### PR TITLE
feat: add Traditional/Modern tone placement style

### DIFF
--- a/crates/funput-core/src/composition/apply.rs
+++ b/crates/funput-core/src/composition/apply.rs
@@ -7,7 +7,7 @@ use crate::composition::replace_char_at;
 use crate::unicode::marks::{apply_tone_to_vowel, is_vowel, stroke_d, tone_on_vowel, vowel_stem, Tone};
 use crate::unicode::shapes::{apply_shape, apply_shape_to_vowel, shape_target_index, VowelShape};
 use crate::unicode::tone_position::{tone_target_vowel, tone_vowel_index};
-use crate::{TransformKind, TransformResult};
+use crate::{ToneStyle, TransformKind, TransformResult};
 
 fn ignored(buffer: &str) -> TransformResult {
     TransformResult {
@@ -34,8 +34,8 @@ pub(crate) fn apply_stroke(buffer: &str) -> TransformResult {
 }
 
 /// Place `tone` on the nucleus vowel (handles reposition and `ie`/`gie` → `ê`).
-pub(crate) fn apply_tone_key(buffer: &str, tone: Tone) -> TransformResult {
-    let Some(vowel_idx) = tone_vowel_index(buffer) else {
+pub(crate) fn apply_tone_key(buffer: &str, tone: Tone, style: ToneStyle) -> TransformResult {
+    let Some(vowel_idx) = tone_vowel_index(buffer, style) else {
         return ignored(buffer);
     };
 

--- a/crates/funput-core/src/composition/revert.rs
+++ b/crates/funput-core/src/composition/revert.rs
@@ -8,6 +8,7 @@
 use crate::unicode::marks::{tone_on_vowel, vowel_stem, Tone};
 use crate::unicode::shapes::{shape_on_vowel, shaped_vowel_index, strip_shape, VowelShape};
 use crate::unicode::tone_position::tone_vowel_index;
+use crate::ToneStyle;
 
 pub(crate) fn replace_char_at(buffer: &str, char_idx: usize, new_ch: char) -> String {
     let mut chars: Vec<char> = buffer.chars().collect();
@@ -26,9 +27,10 @@ pub fn try_revert_stroke(buffer: &str) -> Option<String> {
     Some(chars.into_iter().collect())
 }
 
-/// Revert tone when the same tone key is pressed on the toned vowel.
-pub fn try_revert_tone(buffer: &str, tone: Tone) -> Option<String> {
-    let vowel_idx = tone_vowel_index(buffer)?;
+/// Revert tone when the same tone key is pressed on the toned vowel. Uses the
+/// active placement `style` so it looks for the tone where that style put it.
+pub fn try_revert_tone(buffer: &str, tone: Tone, style: ToneStyle) -> Option<String> {
+    let vowel_idx = tone_vowel_index(buffer, style)?;
     let vowel = buffer.chars().nth(vowel_idx)?;
     if tone_on_vowel(vowel) != Some(tone) {
         return None;
@@ -91,10 +93,10 @@ mod tests {
 
     #[test]
     fn revert_tone() {
-        assert_eq!(try_revert_tone("á", Tone::Sac), Some("a".into()));
-        assert_eq!(try_revert_tone("hòa", Tone::Huyen), Some("hoa".into()));
-        assert_eq!(try_revert_tone("a", Tone::Sac), None);
-        assert_eq!(try_revert_tone("à", Tone::Sac), None);
+        assert_eq!(try_revert_tone("á", Tone::Sac, ToneStyle::Traditional),Some("a".into()));
+        assert_eq!(try_revert_tone("hòa", Tone::Huyen, ToneStyle::Traditional), Some("hoa".into()));
+        assert_eq!(try_revert_tone("a", Tone::Sac, ToneStyle::Traditional),None);
+        assert_eq!(try_revert_tone("à", Tone::Sac, ToneStyle::Traditional),None);
     }
 
     #[test]
@@ -107,6 +109,6 @@ mod tests {
 
     #[test]
     fn revert_tone_keeps_shape() {
-        assert_eq!(try_revert_tone("ấ", Tone::Sac), Some("â".into()));
+        assert_eq!(try_revert_tone("ấ", Tone::Sac, ToneStyle::Traditional),Some("â".into()));
     }
 }

--- a/crates/funput-core/src/composition/transform.rs
+++ b/crates/funput-core/src/composition/transform.rs
@@ -13,7 +13,7 @@ use crate::unicode::tone_position::reposition_existing_tone;
 use crate::validation::syllable::{
     validate_shape, validate_stroke, validate_tone, ModifierValidation,
 };
-use crate::{TransformKind, TransformResult};
+use crate::{ToneStyle, TransformKind, TransformResult};
 
 fn reverted(text: String) -> TransformResult {
     TransformResult {
@@ -37,13 +37,13 @@ fn validation_gate(buffer: &str, key: char, validation: ModifierValidation) -> O
 }
 
 /// Apply one VNI keystroke to `buffer`.
-pub(crate) fn apply_vni(buffer: &str, key: char) -> TransformResult {
-    apply_action(buffer, key, vni::classify_key(buffer, key))
+pub(crate) fn apply_vni(buffer: &str, key: char, style: ToneStyle) -> TransformResult {
+    apply_action(buffer, key, vni::classify_key(buffer, key), style)
 }
 
 /// Apply one Telex keystroke to `buffer`.
-pub(crate) fn apply_telex(buffer: &str, key: char) -> TransformResult {
-    apply_action(buffer, key, telex::classify_key(buffer, key))
+pub(crate) fn apply_telex(buffer: &str, key: char, style: ToneStyle) -> TransformResult {
+    apply_action(buffer, key, telex::classify_key(buffer, key), style)
 }
 
 /// Apply a classified key action to `buffer`.
@@ -52,7 +52,12 @@ pub(crate) fn apply_telex(buffer: &str, key: char) -> TransformResult {
 /// [`KeyAction`] — the revert → validate → apply orchestration here is shared.
 /// `key` is the literal character to append for [`KeyAction::Normal`] and
 /// pass-through.
-pub(crate) fn apply_action(buffer: &str, key: char, action: KeyAction) -> TransformResult {
+pub(crate) fn apply_action(
+    buffer: &str,
+    key: char,
+    action: KeyAction,
+    style: ToneStyle,
+) -> TransformResult {
     match action {
         KeyAction::Stroke => {
             if let Some(text) = try_revert_stroke(buffer) {
@@ -62,11 +67,11 @@ pub(crate) fn apply_action(buffer: &str, key: char, action: KeyAction) -> Transf
                 .unwrap_or_else(|| apply_stroke(buffer))
         }
         KeyAction::Tone(tone) => {
-            if let Some(text) = try_revert_tone(buffer, tone) {
+            if let Some(text) = try_revert_tone(buffer, tone, style) {
                 return reverted(format!("{text}{key}"));
             }
             validation_gate(buffer, key, validate_tone(buffer))
-                .unwrap_or_else(|| apply_tone_key(buffer, tone))
+                .unwrap_or_else(|| apply_tone_key(buffer, tone, style))
         }
         KeyAction::Shape(shape) => {
             // Apply takes priority when an unshaped target exists, so the second
@@ -97,7 +102,7 @@ pub(crate) fn apply_action(buffer: &str, key: char, action: KeyAction) -> Transf
         },
         KeyAction::Normal => {
             let text = format!("{buffer}{key}");
-            match reposition_existing_tone(&text) {
+            match reposition_existing_tone(&text, style) {
                 Some(repositioned) => TransformResult {
                     kind: TransformKind::Applied,
                     text: repositioned,
@@ -116,29 +121,48 @@ mod tests {
     use super::*;
     use crate::{apply, InputMethod};
 
+    /// VNI keystroke with the default (traditional) tone style.
+    fn av(buffer: &str, key: char) -> TransformResult {
+        apply_vni(buffer, key, ToneStyle::Traditional)
+    }
+
+    /// Telex keystroke with the default (traditional) tone style.
+    fn at(buffer: &str, key: char) -> TransformResult {
+        apply_telex(buffer, key, ToneStyle::Traditional)
+    }
+
     fn type_keys(keys: &str) -> String {
         let mut buf = String::new();
         for key in keys.chars() {
-            buf = apply_vni(&buf, key).text;
+            buf = av(&buf, key).text;
+        }
+        buf
+    }
+
+    /// Type a VNI sequence with the modern ("kiểu mới") tone style.
+    fn type_keys_modern(keys: &str) -> String {
+        let mut buf = String::new();
+        for key in keys.chars() {
+            buf = apply_vni(&buf, key, ToneStyle::Modern).text;
         }
         buf
     }
 
     #[test]
     fn stroke_and_tone_basics() {
-        assert_eq!(apply_vni("d", '9').text, "đ");
-        assert_eq!(apply_vni("D", '9').text, "Đ");
+        assert_eq!(av("d", '9').text, "đ");
+        assert_eq!(av("D", '9').text, "Đ");
         for (key, expected) in [('1', "á"), ('2', "à"), ('3', "ả"), ('4', "ã"), ('5', "ạ")] {
-            assert_eq!(apply_vni("a", key).text, expected, "key {key}");
+            assert_eq!(av("a", key).text, expected, "key {key}");
         }
     }
 
     #[test]
     fn shape_basics_and_compound() {
-        assert_eq!(apply_vni("a", '6').text, "â");
-        assert_eq!(apply_vni("o", '7').text, "ơ");
-        assert_eq!(apply_vni("a", '8').text, "ă");
-        assert_eq!(apply_vni("uo", '7').text, "ươ");
+        assert_eq!(av("a", '6').text, "â");
+        assert_eq!(av("o", '7').text, "ơ");
+        assert_eq!(av("a", '8').text, "ă");
+        assert_eq!(av("uo", '7').text, "ươ");
     }
 
     #[test]
@@ -162,7 +186,7 @@ mod tests {
         let telex = |keys: &str| {
             let mut buf = String::new();
             for key in keys.chars() {
-                buf = apply_telex(&buf, key).text;
+                buf = at(&buf, key).text;
             }
             buf
         };
@@ -184,12 +208,27 @@ mod tests {
     }
 
     #[test]
+    fn modern_tone_style_oa_oe_uy() {
+        // "Kiểu mới": tone on the second vowel for open oa/oe/uy, regardless of
+        // where the tone key is typed.
+        assert_eq!(type_keys_modern("hoa2"), "hoà"); // tone after both vowels
+        assert_eq!(type_keys_modern("ho2a"), "hoà"); // tone typed before `a` (reposition)
+        assert_eq!(type_keys_modern("thuy3"), "thuỷ");
+        assert_eq!(type_keys_modern("khoe3"), "khoẻ");
+        // Unchanged from traditional: ia/ua, coda, triphthong, shaped vowel.
+        assert_eq!(type_keys_modern("mua1"), "múa");
+        assert_eq!(type_keys_modern("hoan2"), "hoàn");
+        assert_eq!(type_keys_modern("ngoai2"), "ngoài");
+        assert_eq!(type_keys_modern("tru7o7n2g"), "trường");
+    }
+
+    #[test]
     fn revert_cases() {
         // Double modifier restores raw keystrokes: strip diacritic + append the key.
-        assert_eq!(apply_vni("á", '1'), reverted("a1".into()));
-        assert_eq!(apply_vni("â", '6'), reverted("a6".into()));
-        assert_eq!(apply_vni("đ", '9'), reverted("d9".into()));
-        assert_eq!(apply_vni("ấ", '1'), reverted("â1".into()));
+        assert_eq!(av("á", '1'), reverted("a1".into()));
+        assert_eq!(av("â", '6'), reverted("a6".into()));
+        assert_eq!(av("đ", '9'), reverted("d9".into()));
+        assert_eq!(av("ấ", '1'), reverted("â1".into()));
         assert_eq!(type_keys("a12"), "à"); // different tone key → re-tone, not revert
         assert_eq!(type_keys("a11"), "a1");
         assert_eq!(type_keys("a66"), "a6");
@@ -199,10 +238,10 @@ mod tests {
 
     #[test]
     fn ignored_and_pending() {
-        assert_eq!(apply_vni("", '6').kind, TransformKind::Ignored);
-        assert_eq!(apply_vni("ng", '7').kind, TransformKind::Ignored);
-        assert_eq!(apply_vni("", '1').kind, TransformKind::Ignored);
-        assert_eq!(apply_vni("a", 'b'), TransformResult {
+        assert_eq!(av("", '6').kind, TransformKind::Ignored);
+        assert_eq!(av("ng", '7').kind, TransformKind::Ignored);
+        assert_eq!(av("", '1').kind, TransformKind::Ignored);
+        assert_eq!(av("a", 'b'), TransformResult {
             kind: TransformKind::Pending,
             text: "ab".into(),
         });
@@ -212,7 +251,7 @@ mod tests {
     fn dispatches_through_public_api() {
         let mut buf = String::new();
         for key in "ma1".chars() {
-            buf = apply(&buf, key, InputMethod::Vni).text;
+            buf = apply(&buf, key, InputMethod::Vni, ToneStyle::Traditional).text;
         }
         assert_eq!(buf, "má");
     }

--- a/crates/funput-core/src/lib.rs
+++ b/crates/funput-core/src/lib.rs
@@ -33,6 +33,18 @@ pub enum InputMethod {
     Telex,
 }
 
+/// Tone-mark placement style — where the tone lands on an open glide-initial
+/// diphthong (`oa`, `oe`, `uy`). The only syllables on which the two styles
+/// disagree; everything else is identical.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ToneStyle {
+    /// "Kiểu cũ": tone on the first vowel — `hòa`, `khỏe`, `thúy`.
+    #[default]
+    Traditional,
+    /// "Kiểu mới": tone on the main (second) vowel — `hoà`, `khoẻ`, `thuý`.
+    Modern,
+}
+
 /// Result kind for a single keystroke transform.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransformKind {
@@ -62,9 +74,9 @@ pub struct TransformResult {
 /// # Examples
 ///
 /// ```
-/// use funput_core::{apply, InputMethod, TransformKind, TransformResult};
+/// use funput_core::{apply, InputMethod, ToneStyle, TransformKind, TransformResult};
 ///
-/// let r = apply("a", '1', InputMethod::Vni);
+/// let r = apply("a", '1', InputMethod::Vni, ToneStyle::Traditional);
 /// assert_eq!(
 ///     r,
 ///     TransformResult {
@@ -75,10 +87,10 @@ pub struct TransformResult {
 /// ```
 pub use validation::syllable::{is_complete_syllable, is_definitely_invalid, is_valid};
 
-pub fn apply(buffer: &str, key: char, method: InputMethod) -> TransformResult {
+pub fn apply(buffer: &str, key: char, method: InputMethod, tone_style: ToneStyle) -> TransformResult {
     match method {
-        InputMethod::Vni => composition::transform::apply_vni(buffer, key),
-        InputMethod::Telex => composition::transform::apply_telex(buffer, key),
+        InputMethod::Vni => composition::transform::apply_vni(buffer, key, tone_style),
+        InputMethod::Telex => composition::transform::apply_telex(buffer, key, tone_style),
     }
 }
 
@@ -88,7 +100,7 @@ mod tests {
 
     #[test]
     fn apply_vni_appends_normal_key() {
-        let result = apply("", 'a', InputMethod::Vni);
+        let result = apply("", 'a', InputMethod::Vni, ToneStyle::Traditional);
         assert_eq!(
             result,
             TransformResult {
@@ -100,7 +112,7 @@ mod tests {
 
     #[test]
     fn apply_telex_tone() {
-        let result = apply("a", 's', InputMethod::Telex);
+        let result = apply("a", 's', InputMethod::Telex, ToneStyle::Modern);
         assert_eq!(
             result,
             TransformResult {

--- a/crates/funput-core/src/unicode/marks.rs
+++ b/crates/funput-core/src/unicode/marks.rs
@@ -61,10 +61,10 @@ pub fn is_vowel(c: char) -> bool {
     vowels::is_vowel(c)
 }
 
-/// Index of the vowel where a tone mark should be placed (modern Vietnamese rules).
+/// Index of the vowel where a tone mark should be placed, for the given `style`.
 #[allow(dead_code)] // Public API — used by engine and external callers.
-pub fn main_vowel_index(syllable: &str) -> Option<usize> {
-    crate::unicode::tone_position::tone_vowel_index(syllable)
+pub fn main_vowel_index(syllable: &str, style: crate::ToneStyle) -> Option<usize> {
+    crate::unicode::tone_position::tone_vowel_index(syllable, style)
 }
 
 /// Detect tone on a vowel character, if any.
@@ -116,9 +116,11 @@ mod tests {
 
     #[test]
     fn main_vowel_index_delegates_to_tone_rules() {
-        assert_eq!(main_vowel_index("hoa"), Some(1)); // hòa — tone on `o`
-        assert_eq!(main_vowel_index("chao"), Some(2));
-        assert_eq!(main_vowel_index("ma"), Some(1));
-        assert_eq!(main_vowel_index("ng"), None);
+        use crate::ToneStyle::{Modern, Traditional};
+        assert_eq!(main_vowel_index("hoa", Traditional), Some(1)); // hòa — tone on `o`
+        assert_eq!(main_vowel_index("hoa", Modern), Some(2)); // hoà — tone on `a`
+        assert_eq!(main_vowel_index("chao", Traditional), Some(2));
+        assert_eq!(main_vowel_index("ma", Traditional), Some(1));
+        assert_eq!(main_vowel_index("ng", Traditional), None);
     }
 }

--- a/crates/funput-core/src/unicode/tone_position.rs
+++ b/crates/funput-core/src/unicode/tone_position.rs
@@ -2,6 +2,7 @@
 
 use crate::unicode::marks::{apply_tone_to_vowel, is_vowel, tone_on_vowel, vowel_stem};
 use crate::unicode::shapes::{apply_shape, shape_on_vowel, VowelShape};
+use crate::ToneStyle;
 
 struct VowelCluster {
     indices: Vec<usize>,
@@ -62,8 +63,18 @@ fn tone_offset_in_cluster(cluster_len: usize, has_coda: bool) -> usize {
     }
 }
 
-/// Char index where a tone mark should be placed.
-pub fn tone_vowel_index(buffer: &str) -> Option<usize> {
+/// True for the open glide-initial diphthongs where "kiểu mới" moves the tone onto
+/// the second (main) vowel: `oa`, `oe`, `uy` — the only syllables on which the
+/// modern and traditional styles disagree. Compared on the stem so a vowel that
+/// already carries a tone (reposition) still matches (`hoà` → `o`, `à`→stem `a`).
+fn modern_open_pair_takes_second(first: char, second: char) -> bool {
+    let f = vowel_stem(first).unwrap_or(first).to_ascii_lowercase();
+    let s = vowel_stem(second).unwrap_or(second).to_ascii_lowercase();
+    matches!((f, s), ('o', 'a') | ('o', 'e') | ('u', 'y'))
+}
+
+/// Char index where a tone mark should be placed, for the given placement `style`.
+pub fn tone_vowel_index(buffer: &str, style: ToneStyle) -> Option<usize> {
     let cluster = vowel_cluster(buffer)?;
     let chars: Vec<char> = buffer.chars().collect();
 
@@ -82,6 +93,16 @@ pub fn tone_vowel_index(buffer: &str) -> Option<usize> {
     // follows the last vowel of the cluster.
     let last_vowel = *cluster.indices.last().expect("cluster is non-empty");
     let has_coda = last_vowel + 1 < chars.len();
+
+    // "Kiểu mới": an open `oa`/`oe`/`uy` takes the tone on the second vowel.
+    if style == ToneStyle::Modern
+        && cluster.indices.len() == 2
+        && !has_coda
+        && modern_open_pair_takes_second(chars[cluster.indices[0]], chars[cluster.indices[1]])
+    {
+        return Some(cluster.indices[1]);
+    }
+
     let offset = tone_offset_in_cluster(cluster.indices.len(), has_coda);
     Some(cluster.indices[offset.min(cluster.indices.len() - 1)])
 }
@@ -110,9 +131,9 @@ pub fn tone_target_vowel(buffer: &str, vowel_idx: usize) -> Option<char> {
     apply_shape(stem, VowelShape::Circumflex)
 }
 
-/// If a tone exists on the wrong vowel, move it to the correct position.
-pub fn reposition_existing_tone(buffer: &str) -> Option<String> {
-    let desired = tone_vowel_index(buffer)?;
+/// If a tone exists on the wrong vowel, move it to the correct position for `style`.
+pub fn reposition_existing_tone(buffer: &str, style: ToneStyle) -> Option<String> {
+    let desired = tone_vowel_index(buffer, style)?;
 
     let mut toned_index: Option<(usize, crate::unicode::marks::Tone)> = None;
     for (i, ch) in buffer.chars().enumerate() {
@@ -148,58 +169,86 @@ mod tests {
         buffer.chars().nth(index).expect("char at index")
     }
 
+    /// `tone_vowel_index` with the default (traditional) style.
+    fn trad(buffer: &str) -> usize {
+        tone_vowel_index(buffer, ToneStyle::Traditional).unwrap()
+    }
+
+    /// `tone_vowel_index` with the modern ("kiểu mới") style.
+    fn modern(buffer: &str) -> usize {
+        tone_vowel_index(buffer, ToneStyle::Modern).unwrap()
+    }
+
     #[test]
     fn tone_vowel_index_open_diphthong_first_vowel() {
         // Traditional rule: open 2-vowel cluster → tone on the first vowel.
-        assert_eq!(char_at("hoa", tone_vowel_index("hoa").unwrap()), 'o'); // hòa
-        assert_eq!(char_at("chao", tone_vowel_index("chao").unwrap()), 'a'); // chào
-        assert_eq!(char_at("hoe", tone_vowel_index("hoe").unwrap()), 'o'); // hòe
+        assert_eq!(char_at("hoa", trad("hoa")), 'o'); // hòa
+        assert_eq!(char_at("chao", trad("chao")), 'a'); // chào
+        assert_eq!(char_at("hoe", trad("hoe")), 'o'); // hòe
     }
 
     #[test]
     fn tone_vowel_index_uy_open_is_first_vowel() {
         // Open `uy` → tone on `u` (ùy/úy), traditional style.
-        assert_eq!(char_at("thuy", tone_vowel_index("thuy").unwrap()), 'u');
+        assert_eq!(char_at("thuy", trad("thuy")), 'u');
     }
 
     #[test]
     fn tone_vowel_index_oa_with_coda_is_second_vowel() {
         // 2 vowels + final consonant → second vowel: hoàn, toán.
-        assert_eq!(char_at("hoan", tone_vowel_index("hoan").unwrap()), 'a');
-        assert_eq!(char_at("toan", tone_vowel_index("toan").unwrap()), 'a');
+        assert_eq!(char_at("hoan", trad("hoan")), 'a');
+        assert_eq!(char_at("toan", trad("toan")), 'a');
     }
 
     #[test]
     fn tone_vowel_index_single_vowel() {
-        assert_eq!(char_at("ma", tone_vowel_index("ma").unwrap()), 'a');
-        assert_eq!(char_at("ho", tone_vowel_index("ho").unwrap()), 'o');
+        assert_eq!(char_at("ma", trad("ma")), 'a');
+        assert_eq!(char_at("ho", trad("ho")), 'o');
     }
 
     #[test]
     fn tone_vowel_index_uo_horn_cluster() {
-        let buffer = "trương";
-        assert_eq!(char_at(buffer, tone_vowel_index(buffer).unwrap()), 'ơ');
+        assert_eq!(char_at("trương", trad("trương")), 'ơ');
     }
 
     #[test]
     fn tone_vowel_index_open_diphthongs_ia_ua() {
-        assert_eq!(char_at("mia", tone_vowel_index("mia").unwrap()), 'i');
-        assert_eq!(char_at("mua", tone_vowel_index("mua").unwrap()), 'u');
-        assert_eq!(char_at("cua", tone_vowel_index("cua").unwrap()), 'u');
-        assert_eq!(char_at("lua", tone_vowel_index("lua").unwrap()), 'u');
+        assert_eq!(char_at("mia", trad("mia")), 'i');
+        assert_eq!(char_at("mua", trad("mua")), 'u');
+        assert_eq!(char_at("cua", trad("cua")), 'u');
+        assert_eq!(char_at("lua", trad("lua")), 'u');
     }
 
     #[test]
     fn tone_vowel_index_uoi_cluster() {
-        assert_eq!(char_at("ngươi", tone_vowel_index("ngươi").unwrap()), 'ơ');
+        assert_eq!(char_at("ngươi", trad("ngươi")), 'ơ');
     }
 
     #[test]
     fn tone_vowel_index_plain_triphthong_is_middle() {
         // Plain triphthongs take the tone on the middle vowel, not the last.
-        assert_eq!(char_at("ngoai", tone_vowel_index("ngoai").unwrap()), 'a'); // ngoài
-        assert_eq!(char_at("xoay", tone_vowel_index("xoay").unwrap()), 'a'); // xoáy
-        assert_eq!(char_at("khuyu", tone_vowel_index("khuyu").unwrap()), 'y'); // khuỷu
+        assert_eq!(char_at("ngoai", trad("ngoai")), 'a'); // ngoài
+        assert_eq!(char_at("xoay", trad("xoay")), 'a'); // xoáy
+        assert_eq!(char_at("khuyu", trad("khuyu")), 'y'); // khuỷu
+    }
+
+    #[test]
+    fn tone_vowel_index_modern_moves_oa_oe_uy_to_second() {
+        // "Kiểu mới": open oa/oe/uy → tone on the second (main) vowel.
+        assert_eq!(char_at("hoa", modern("hoa")), 'a'); // hoà
+        assert_eq!(char_at("hoe", modern("hoe")), 'e'); // hoè
+        assert_eq!(char_at("thuy", modern("thuy")), 'y'); // thuý
+    }
+
+    #[test]
+    fn tone_vowel_index_modern_leaves_other_clusters_unchanged() {
+        // Only oa/oe/uy differ — everything else matches the traditional rule.
+        assert_eq!(char_at("mia", modern("mia")), 'i'); // mía
+        assert_eq!(char_at("mua", modern("mua")), 'u'); // múa
+        assert_eq!(char_at("chao", modern("chao")), 'a'); // chào
+        assert_eq!(char_at("hoan", modern("hoan")), 'a'); // hoàn (coda)
+        assert_eq!(char_at("ngoai", modern("ngoai")), 'a'); // ngoài (triphthong)
+        assert_eq!(char_at("trương", modern("trương")), 'ơ'); // shaped vowel wins
     }
 
     #[test]
@@ -211,7 +260,20 @@ mod tests {
     #[test]
     fn reposition_moves_tone_to_first_vowel_of_open_diphthong() {
         // Traditional: an open `oa` takes the tone on `o`, so `hoà` → `hòa`.
-        let result = reposition_existing_tone("hoà");
-        assert_eq!(result.as_deref(), Some("hòa"));
+        assert_eq!(
+            reposition_existing_tone("hoà", ToneStyle::Traditional).as_deref(),
+            Some("hòa")
+        );
+    }
+
+    #[test]
+    fn reposition_modern_moves_tone_to_second_vowel() {
+        // Modern: an open `oa` takes the tone on `a`, so `hòa` → `hoà`.
+        assert_eq!(
+            reposition_existing_tone("hòa", ToneStyle::Modern).as_deref(),
+            Some("hoà")
+        );
+        // Already correct for the style → no change.
+        assert_eq!(reposition_existing_tone("hoà", ToneStyle::Modern), None);
     }
 }

--- a/crates/funput-core/tests/support/mod.rs
+++ b/crates/funput-core/tests/support/mod.rs
@@ -2,12 +2,12 @@
 
 #![allow(dead_code)]
 
-use funput_core::{apply, InputMethod, TransformKind};
+use funput_core::{apply, InputMethod, ToneStyle, TransformKind};
 
 pub fn type_keys(method: InputMethod, keys: &str) -> String {
     let mut buffer = String::new();
     for key in keys.chars() {
-        buffer = apply(&buffer, key, method).text;
+        buffer = apply(&buffer, key, method, ToneStyle::Traditional).text;
     }
     buffer
 }
@@ -24,7 +24,7 @@ pub fn type_keys_with_kinds(method: InputMethod, keys: &str) -> (String, Vec<Tra
     let mut buffer = String::new();
     let mut kinds = Vec::new();
     for key in keys.chars() {
-        let result = apply(&buffer, key, method);
+        let result = apply(&buffer, key, method, ToneStyle::Traditional);
         kinds.push(result.kind);
         buffer = result.text;
     }

--- a/crates/funput-core/tests/telex_basic.rs
+++ b/crates/funput-core/tests/telex_basic.rs
@@ -1,6 +1,6 @@
 mod support;
 
-use funput_core::{apply, InputMethod, TransformKind, TransformResult};
+use funput_core::{apply, InputMethod, ToneStyle, TransformKind, TransformResult};
 
 fn type_keys(keys: &str) -> String {
     support::type_keys(InputMethod::Telex, keys)
@@ -72,14 +72,14 @@ fn telex_complex_syllables() {
 fn telex_validation_and_pass_through() {
     // A tone letter with no vowel to land on is kept literally, not dropped.
     assert_eq!(
-        apply("ng", 's', InputMethod::Telex),
+        apply("ng", 's', InputMethod::Telex, ToneStyle::Traditional),
         TransformResult {
             kind: TransformKind::Pending,
             text: "ngs".into(),
         }
     );
     assert_eq!(
-        apply("text", 's', InputMethod::Telex),
+        apply("text", 's', InputMethod::Telex, ToneStyle::Traditional),
         TransformResult {
             kind: TransformKind::Pending,
             text: "texts".into(),
@@ -90,7 +90,7 @@ fn telex_validation_and_pass_through() {
     assert_eq!(type_keys("from"), "from");
     assert_eq!(type_keys("just"), "just");
     assert_eq!(
-        apply("a", 'b', InputMethod::Telex),
+        apply("a", 'b', InputMethod::Telex, ToneStyle::Traditional),
         TransformResult {
             kind: TransformKind::Pending,
             text: "ab".into(),

--- a/crates/funput-core/tests/vni_basic.rs
+++ b/crates/funput-core/tests/vni_basic.rs
@@ -1,6 +1,6 @@
 mod support;
 
-use funput_core::{apply, InputMethod, TransformKind};
+use funput_core::{apply, InputMethod, ToneStyle, TransformKind};
 
 #[test]
 fn vni_stroke_d9() {
@@ -149,7 +149,7 @@ fn vni_complex_syllables() {
 
 #[test]
 fn vni_complex_syllable_step_kinds() {
-    let result = apply("ng", '1', InputMethod::Vni);
+    let result = apply("ng", '1', InputMethod::Vni, ToneStyle::Traditional);
     assert_eq!(result.kind, TransformKind::Ignored);
     assert_eq!(result.text, "ng");
 
@@ -201,21 +201,21 @@ fn vni_shape_targets_receiving_vowel() {
 
 #[test]
 fn vni_validation() {
-    let result = apply("ng", '1', InputMethod::Vni);
+    let result = apply("ng", '1', InputMethod::Vni, ToneStyle::Traditional);
     assert_eq!(result.kind, TransformKind::Ignored);
     assert_eq!(result.text, "ng");
 
-    let result = apply("text", '1', InputMethod::Vni);
+    let result = apply("text", '1', InputMethod::Vni, ToneStyle::Traditional);
     assert_eq!(result.kind, TransformKind::Pending);
     assert_eq!(result.text, "text1");
 
     assert_eq!(support::type_keys(InputMethod::Vni, "ma1"), "má");
 
-    let result = apply("mix", '1', InputMethod::Vni);
+    let result = apply("mix", '1', InputMethod::Vni, ToneStyle::Traditional);
     assert_eq!(result.kind, TransformKind::Applied);
     assert_eq!(result.text, "míx");
 
-    let result = apply("zt", '1', InputMethod::Vni);
+    let result = apply("zt", '1', InputMethod::Vni, ToneStyle::Traditional);
     assert_eq!(result.kind, TransformKind::Pending);
     assert_eq!(result.text, "zt1");
 }

--- a/crates/funput-engine/src/boundary.rs
+++ b/crates/funput-engine/src/boundary.rs
@@ -63,7 +63,7 @@ pub(crate) fn on_word_boundary(session: &mut Session, boundary_key: char) -> Ime
 mod tests {
     use super::*;
     use crate::result::Action;
-    use funput_core::InputMethod;
+    use funput_core::{InputMethod, ToneStyle};
 
     #[test]
     fn word_boundary_chars() {
@@ -84,6 +84,7 @@ mod tests {
             method: InputMethod::Telex,
             buffer: "ábc".into(),
             keys: "absc".into(),
+            tone_style: ToneStyle::Traditional,
             smart_restore: true,
             eager_restore: true,
         };
@@ -97,6 +98,7 @@ mod tests {
             method: InputMethod::Telex,
             buffer: "má".into(),
             keys: "mas".into(),
+            tone_style: ToneStyle::Traditional,
             smart_restore: true,
             eager_restore: true,
         };
@@ -110,6 +112,7 @@ mod tests {
             method: InputMethod::Telex,
             buffer: "text".into(),
             keys: "text".into(),
+            tone_style: ToneStyle::Traditional,
             smart_restore: true,
             eager_restore: true,
         };
@@ -130,6 +133,7 @@ mod tests {
             method: InputMethod::Vni,
             buffer: "đc".into(),
             keys: "d9c".into(),
+            tone_style: ToneStyle::Traditional,
             smart_restore: true,
             eager_restore: true,
         };
@@ -144,6 +148,7 @@ mod tests {
             method: InputMethod::Telex,
             buffer: "GĐ".into(),
             keys: "GDD".into(),
+            tone_style: ToneStyle::Traditional,
             smart_restore: true,
             eager_restore: true,
         };
@@ -157,6 +162,7 @@ mod tests {
             method: InputMethod::Telex,
             buffer: "ábc".into(),
             keys: "absc".into(),
+            tone_style: ToneStyle::Traditional,
             smart_restore: true,
             eager_restore: true,
         };
@@ -175,6 +181,7 @@ mod tests {
             method: InputMethod::Telex,
             buffer: "má".into(),
             keys: "mas".into(),
+            tone_style: ToneStyle::Traditional,
             smart_restore: true,
             eager_restore: true,
         };

--- a/crates/funput-engine/src/lib.rs
+++ b/crates/funput-engine/src/lib.rs
@@ -59,6 +59,16 @@ impl Engine {
         self.session.method
     }
 
+    /// Set the tone-mark placement style (traditional `hòa` vs modern `hoà`).
+    pub fn set_tone_style(&mut self, style: funput_core::ToneStyle) {
+        self.session.tone_style = style;
+    }
+
+    /// Current tone-mark placement style.
+    pub fn tone_style(&self) -> funput_core::ToneStyle {
+        self.session.tone_style
+    }
+
     /// Toggle auto-restore of non-Vietnamese words to their raw Latin keystrokes
     /// (`card` stays `card` instead of composing `cảd`). When off, the composed
     /// buffer is always kept.

--- a/crates/funput-engine/src/pipeline.rs
+++ b/crates/funput-engine/src/pipeline.rs
@@ -10,7 +10,7 @@ use crate::session::Session;
 ///
 /// `session.keys` already includes `key` (pushed by the caller).
 pub(crate) fn process(session: &mut Session, key: char) -> ImeResult {
-    let result = apply(&session.buffer, key, session.method);
+    let result = apply(&session.buffer, key, session.method, session.tone_style);
 
     // Buffer after composing this key (the engine appends literally on Ignored).
     let composed = match result.kind {

--- a/crates/funput-engine/src/session.rs
+++ b/crates/funput-engine/src/session.rs
@@ -1,12 +1,14 @@
 //! IME session state — enabled flag, input method, composition buffer.
 
-use funput_core::InputMethod;
+use funput_core::{InputMethod, ToneStyle};
 
 /// Mutable session held by [`crate::Engine`]. Internal — not part of the public API.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Session {
     pub(crate) enabled: bool,
     pub(crate) method: InputMethod,
+    /// Tone-mark placement style (traditional `hòa` vs modern `hoà`).
+    pub(crate) tone_style: ToneStyle,
     /// Composed text currently shown in the app (the composition span).
     pub(crate) buffer: String,
     /// Raw keystrokes since the last word boundary. Lets English restore
@@ -26,6 +28,7 @@ impl Session {
         Self {
             enabled: true,
             method: InputMethod::Telex,
+            tone_style: ToneStyle::Traditional,
             buffer: String::new(),
             keys: String::new(),
             smart_restore: true,

--- a/crates/funput-engine/tests/tone_placement.rs
+++ b/crates/funput-engine/tests/tone_placement.rs
@@ -1,9 +1,14 @@
 //! End-to-end tone placement: `k`+`y` words and triphthong (kiểu truyền thống).
 
 use funput_engine::Engine;
-use funput_core::InputMethod;
+use funput_core::{InputMethod, ToneStyle};
 fn run(m: InputMethod, keys: &str) -> String {
     let mut e = Engine::new(); e.set_method(m);
+    for k in keys.chars() { e.process_char(k); }
+    e.buffer().to_string()
+}
+fn run_modern(m: InputMethod, keys: &str) -> String {
+    let mut e = Engine::new(); e.set_method(m); e.set_tone_style(ToneStyle::Modern);
     for k in keys.chars() { e.process_char(k); }
     e.buffer().to_string()
 }
@@ -14,6 +19,31 @@ fn traditional_tone_placement_and_ky_words() {
     assert_eq!(run(InputMethod::Telex, "ngoaif"), "ngoài");
     assert_eq!(run(InputMethod::Vni, "ngoai2"), "ngoài");
     assert_eq!(run(InputMethod::Telex, "kyx"), "kỹ"); // kỹ
+}
+
+#[test]
+fn modern_tone_style_oa_oe_uy() {
+    // "Kiểu mới": tone on the second vowel of open oa/oe/uy, independent of where
+    // the tone key is typed.
+    assert_eq!(run_modern(InputMethod::Telex, "hoaf"), "hoà");
+    assert_eq!(run_modern(InputMethod::Telex, "hofa"), "hoà"); // tone before the `a`
+    assert_eq!(run_modern(InputMethod::Telex, "thuyr"), "thuỷ");
+    assert_eq!(run_modern(InputMethod::Telex, "khoer"), "khoẻ");
+    assert_eq!(run_modern(InputMethod::Vni, "hoa2"), "hoà");
+    assert_eq!(run_modern(InputMethod::Vni, "thuy3"), "thuỷ");
+    // Unchanged between styles: ia/ua, coda, triphthong, shaped vowel.
+    assert_eq!(run_modern(InputMethod::Telex, "muaf"), "mùa");
+    assert_eq!(run_modern(InputMethod::Telex, "hoanf"), "hoàn");
+    assert_eq!(run_modern(InputMethod::Telex, "ngoaif"), "ngoài");
+    assert_eq!(run_modern(InputMethod::Vni, "tru7o7n2g"), "trường");
+}
+
+#[test]
+fn traditional_keeps_oa_oe_uy_on_first_vowel() {
+    // Same words in the default style stay on the first vowel.
+    assert_eq!(run(InputMethod::Telex, "hoaf"), "hòa");
+    assert_eq!(run(InputMethod::Telex, "thuyr"), "thủy");
+    assert_eq!(run(InputMethod::Telex, "khoer"), "khỏe");
 }
 
 #[test]

--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -70,6 +70,15 @@ void funput_engine_free(FunputEngine *engine);
 void funput_set_method(FunputEngine *engine, uint8_t method);
 
 /**
+ * Set the tone-mark placement style: `0 = Traditional` (`hòa`), `1 = Modern`
+ * (`hoà`) — any other value = Traditional.
+ *
+ * # Safety
+ * `engine` must be a valid handle or null.
+ */
+void funput_set_tone_style(FunputEngine *engine, uint8_t style);
+
+/**
  * Enable or disable Vietnamese composition.
  *
  * # Safety

--- a/crates/funput-ffi/src/lib.rs
+++ b/crates/funput-ffi/src/lib.rs
@@ -18,12 +18,13 @@
 
 mod types;
 
-use funput_core::InputMethod;
+use funput_core::{InputMethod, ToneStyle};
 use funput_engine::Engine;
 
 pub use types::{FunputResult, ACTION_NONE, ACTION_RESTORE, ACTION_SEND, CHARS_CAP};
 
 const METHOD_VNI: u8 = 1;
+const TONE_STYLE_MODERN: u8 = 1;
 
 /// Opaque IME engine handle for C callers. Create with [`funput_engine_new`],
 /// release with [`funput_engine_free`]. cbindgen emits this as an opaque struct.
@@ -63,6 +64,23 @@ pub unsafe extern "C" fn funput_set_method(engine: *mut FunputEngine, method: u8
             InputMethod::Telex
         };
         engine.inner.set_method(method);
+    }
+}
+
+/// Set the tone-mark placement style: `0 = Traditional` (`hòa`), `1 = Modern`
+/// (`hoà`) — any other value = Traditional.
+///
+/// # Safety
+/// `engine` must be a valid handle or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_set_tone_style(engine: *mut FunputEngine, style: u8) {
+    if let Some(engine) = unsafe { engine.as_mut() } {
+        let style = if style == TONE_STYLE_MODERN {
+            ToneStyle::Modern
+        } else {
+            ToneStyle::Traditional
+        };
+        engine.inner.set_tone_style(style);
     }
 }
 

--- a/platforms/linux/fcitx5/CMakeLists.txt
+++ b/platforms/linux/fcitx5/CMakeLists.txt
@@ -112,7 +112,7 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Vietnamese input method (Telex & VNI) —
 set(CPACK_PACKAGE_CONTACT "PulseFu <hello@pulsefu.com>")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "PulseFu <hello@pulsefu.com>")
 set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
-set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/pcodedynamics/Funput")
+set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/PulseFu/Funput")
 # fcitx5 must be present; the rest are picked up automatically.
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "fcitx5")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)

--- a/platforms/linux/fcitx5/src/ffi_handle.h
+++ b/platforms/linux/fcitx5/src/ffi_handle.h
@@ -50,6 +50,7 @@ public:
     }
 
     void setMethod(uint8_t method) { funput_set_method(engine_, method); }
+    void setToneStyle(uint8_t style) { funput_set_tone_style(engine_, style); }
     void setEnabled(bool on) { funput_set_enabled(engine_, on); }
     void setSmartRestore(bool on) { funput_set_smart_restore(engine_, on); }
     void setEagerRestore(bool on) { funput_set_eager_restore(engine_, on); }

--- a/platforms/linux/fcitx5/src/funput_engine.cpp
+++ b/platforms/linux/fcitx5/src/funput_engine.cpp
@@ -44,6 +44,7 @@ FunputEngine::FunputEngine(fcitx::Instance *instance) : instance_(instance) {
 
 void FunputEngine::applySettings() {
     handle_.setMethod(static_cast<uint8_t>(settings_.method));
+    handle_.setToneStyle(static_cast<uint8_t>(settings_.toneStyle));
     effectiveEnabled_ = settings_.enabled; // baseline; activate() refines it per-app
     handle_.setEnabled(effectiveEnabled_);
     handle_.setSmartRestore(settings_.smartRestore);

--- a/platforms/linux/fcitx5/src/settings.cpp
+++ b/platforms/linux/fcitx5/src/settings.cpp
@@ -33,6 +33,14 @@ static const char *methodStr(Method m) {
     return m == Method::Telex ? "telex" : "vni";
 }
 
+static ToneStyle parseToneStyle(const std::string &s) {
+    return s == "modern" ? ToneStyle::Modern : ToneStyle::Traditional;
+}
+
+static const char *toneStyleStr(ToneStyle t) {
+    return t == ToneStyle::Modern ? "modern" : "traditional";
+}
+
 static Hotkey parseHotkey(const std::string &s) {
     if (s == "ctrl_space") return Hotkey::CtrlSpace;
     if (s == "alt_shift") return Hotkey::AltShift;
@@ -68,6 +76,7 @@ bool Settings::reloadIfChanged() {
 
     const Settings prev = *this;
     method = parseMethod(j.value("method", std::string(methodStr(method))));
+    toneStyle = parseToneStyle(j.value("toneStyle", std::string(toneStyleStr(toneStyle))));
     enabled = j.value("enabled", enabled);
     smartRestore = j.value("smartRestore", smartRestore);
     eagerRestore = j.value("eagerRestore", eagerRestore);
@@ -83,9 +92,10 @@ bool Settings::reloadIfChanged() {
         }
     }
 
-    return method != prev.method || enabled != prev.enabled ||
-           smartRestore != prev.smartRestore || eagerRestore != prev.eagerRestore ||
-           toggleHotkey != prev.toggleHotkey || excludedAppIds != prev.excludedAppIds;
+    return method != prev.method || toneStyle != prev.toneStyle ||
+           enabled != prev.enabled || smartRestore != prev.smartRestore ||
+           eagerRestore != prev.eagerRestore || toggleHotkey != prev.toggleHotkey ||
+           excludedAppIds != prev.excludedAppIds;
 }
 
 bool Settings::isExcluded(const std::string &program) const {
@@ -110,6 +120,7 @@ void Settings::save() const {
         if (existing.is_object()) j = std::move(existing);
     }
     j["method"] = methodStr(method);
+    j["toneStyle"] = toneStyleStr(toneStyle);
     j["enabled"] = enabled;
     j["smartRestore"] = smartRestore;
     j["eagerRestore"] = eagerRestore;

--- a/platforms/linux/fcitx5/src/settings.h
+++ b/platforms/linux/fcitx5/src/settings.h
@@ -13,10 +13,12 @@
 namespace funput {
 
 enum class Method : uint8_t { Telex = 0, Vni = 1 };
+enum class ToneStyle : uint8_t { Traditional = 0, Modern = 1 };
 enum class Hotkey { CtrlBacktick, CtrlSpace, AltShift };
 
 struct Settings {
     Method method = Method::Vni;
+    ToneStyle toneStyle = ToneStyle::Traditional;
     bool enabled = true;
     bool smartRestore = true;
     bool eagerRestore = true;

--- a/platforms/linux/src-tauri/src/commands.rs
+++ b/platforms/linux/src-tauri/src/commands.rs
@@ -7,7 +7,7 @@
 use tauri::AppHandle;
 use tauri_plugin_opener::OpenerExt;
 
-use crate::settings::{self, ExcludedApp, Hotkey, Method, Settings};
+use crate::settings::{self, ExcludedApp, Hotkey, Method, Settings, ToneStyle};
 
 #[tauri::command]
 pub fn get_settings() -> Settings {
@@ -41,6 +41,11 @@ pub fn list_recent_apps() -> Vec<ExcludedApp> {
 #[tauri::command]
 pub fn set_method(method: Method) {
     Settings::update(|s| s.method = method);
+}
+
+#[tauri::command]
+pub fn set_tone_style(tone_style: ToneStyle) {
+    Settings::update(|s| s.tone_style = tone_style);
 }
 
 #[tauri::command]

--- a/platforms/linux/src-tauri/src/main.rs
+++ b/platforms/linux/src-tauri/src/main.rs
@@ -38,6 +38,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             commands::get_settings,
             commands::set_method,
+            commands::set_tone_style,
             commands::set_enabled,
             commands::set_smart_restore,
             commands::set_eager_restore,

--- a/platforms/linux/src-tauri/src/settings.rs
+++ b/platforms/linux/src-tauri/src/settings.rs
@@ -15,6 +15,16 @@ pub enum Method {
     Vni,
 }
 
+/// Tone-mark placement style (traditional `hòa` vs modern `hoà`). This process only
+/// persists it to settings.json; the Fcitx5 addon reads it and drives the engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ToneStyle {
+    #[default]
+    Traditional,
+    Modern,
+}
+
 /// VI/EN toggle hotkey presets. The Fcitx5 addon maps these to keysyms.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -37,6 +47,9 @@ pub struct ExcludedApp {
 #[serde(rename_all = "camelCase")]
 pub struct Settings {
     pub method: Method,
+    /// `#[serde(default)]` keeps older settings files (without this key) loadable.
+    #[serde(default)]
+    pub tone_style: ToneStyle,
     pub enabled: bool,
     pub smart_restore: bool,
     pub eager_restore: bool,
@@ -53,6 +66,7 @@ impl Default for Settings {
     fn default() -> Self {
         Self {
             method: Method::Vni,
+            tone_style: ToneStyle::Traditional,
             enabled: true,
             smart_restore: true,
             eager_restore: true,

--- a/platforms/macos/Funput/IME/FunputComposer.swift
+++ b/platforms/macos/Funput/IME/FunputComposer.swift
@@ -20,6 +20,11 @@ final class FunputComposer {
         funput_set_method(handle, UInt8(method.rawValue))
     }
 
+    /// Tone-mark placement style (traditional `hòa` vs modern `hoà`).
+    func setToneStyle(_ style: ToneStyle) {
+        funput_set_tone_style(handle, UInt8(style.rawValue))
+    }
+
     func setEnabled(_ enabled: Bool) {
         funput_set_enabled(handle, enabled)
     }

--- a/platforms/macos/Funput/IME/FunputInputController.swift
+++ b/platforms/macos/Funput/IME/FunputInputController.swift
@@ -189,6 +189,7 @@ final class FunputInputController: IMKInputController {
     private func syncSettings() {
         let settings = AppSettings.shared
         composer.setMethod(settings.inputMethod)
+        composer.setToneStyle(settings.toneStyle)
         composer.setEnabled(settings.vietnameseEnabled)
         composer.setSmartRestore(settings.smartEnglishRestore)
         composer.setEagerRestore(settings.eagerRestore)

--- a/platforms/macos/Funput/Model/AppSettings.swift
+++ b/platforms/macos/Funput/Model/AppSettings.swift
@@ -19,6 +19,11 @@ final class AppSettings {
     var inputMethod: InputMethod {
         didSet { defaults.set(inputMethod.rawValue, forKey: Keys.inputMethod) }
     }
+    /// Tone-mark placement style (traditional `hòa` vs modern `hoà`). Read live by
+    /// `FunputInputController` and pushed to the engine.
+    var toneStyle: ToneStyle {
+        didSet { defaults.set(toneStyle.rawValue, forKey: Keys.toneStyle) }
+    }
     /// Whether Vietnamese composition is active (vs. English pass-through). Flipped by
     /// the toggle shortcut and the menu bar; read live by `FunputInputController`.
     var vietnameseEnabled: Bool {
@@ -61,6 +66,7 @@ final class AppSettings {
             Keys.vietnameseEnabled: true,
         ])
         inputMethod = InputMethod(rawValue: defaults.integer(forKey: Keys.inputMethod)) ?? .telex
+        toneStyle = ToneStyle(rawValue: defaults.integer(forKey: Keys.toneStyle)) ?? .traditional
         vietnameseEnabled = defaults.bool(forKey: Keys.vietnameseEnabled)
         smartEnglishRestore = defaults.bool(forKey: Keys.smartEnglishRestore)
         eagerRestore = defaults.bool(forKey: Keys.eagerRestore)
@@ -94,6 +100,7 @@ final class AppSettings {
 
     private enum Keys {
         static let inputMethod = "inputMethod"
+        static let toneStyle = "toneStyle"
         static let vietnameseEnabled = "vietnameseEnabled"
         static let smartEnglishRestore = "smartEnglishRestore"
         static let eagerRestore = "eagerRestore"

--- a/platforms/macos/Funput/Model/InputMethod.swift
+++ b/platforms/macos/Funput/Model/InputMethod.swift
@@ -23,6 +23,29 @@ enum InputMethod: Int, CaseIterable, Identifiable, Codable {
     }
 }
 
+/// Tone-mark placement style. Raw value matches `funput_core`
+/// (`Traditional = 0`, `Modern = 1`), so it passes straight to `funput_set_tone_style`.
+enum ToneStyle: Int, CaseIterable, Identifiable, Codable {
+    case traditional = 0
+    case modern = 1
+
+    var id: Int { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .traditional: "Truyền thống"
+        case .modern: "Hiện đại"
+        }
+    }
+
+    var blurb: String {
+        switch self {
+        case .traditional: "Dấu kiểu cũ — hòa, khỏe, thúy"
+        case .modern: "Dấu kiểu mới — hoà, khoẻ, thuý"
+        }
+    }
+}
+
 /// Hotkey that switches between Vietnamese and English (pass-through) typing.
 enum ToggleShortcut: String, CaseIterable, Identifiable, Codable {
     case controlBackslash

--- a/platforms/macos/Funput/Settings/Panes/AboutPane.swift
+++ b/platforms/macos/Funput/Settings/Panes/AboutPane.swift
@@ -17,7 +17,7 @@ struct AboutPane: View {
                         .foregroundStyle(.secondary)
 
                     HStack(spacing: Theme.Spacing.md) {
-                        Link("GitHub", destination: URL(string: "https://github.com/pcodedynamics/Funput")!)
+                        Link("GitHub", destination: URL(string: "https://github.com/PulseFu/Funput")!)
                         Link("Website", destination: URL(string: "https://funput.pulsefu.com/")!)
                     }
                     .buttonStyle(.glass)

--- a/platforms/macos/Funput/Settings/Panes/InputMethodPane.swift
+++ b/platforms/macos/Funput/Settings/Panes/InputMethodPane.swift
@@ -25,6 +25,23 @@ struct InputMethodPane: View {
             }
 
             GlassCard {
+                VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+                    SectionHeader(title: "Kiểu đặt dấu")
+                    Picker("Kiểu đặt dấu", selection: $settings.toneStyle) {
+                        ForEach(ToneStyle.allCases) { style in
+                            Text(style.displayName).tag(style)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+
+                    Text(settings.toneStyle.blurb)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            GlassCard {
                 VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
                     SectionHeader(title: "Gõ thử")
                     TextField("Gõ ở đây…", text: $demoText, axis: .vertical)

--- a/platforms/ui/src/lib/api.ts
+++ b/platforms/ui/src/lib/api.ts
@@ -85,7 +85,7 @@ export const HOTKEYS: { id: Hotkey; caps: string[] }[] = [
 
 // Canonical Funput links, shared by every platform's About screen.
 export const LINKS = {
-  github: "https://github.com/pcodedynamics/Funput",
+  github: "https://github.com/PulseFu/Funput",
   website: "https://funput.pulsefu.com/",
 };
 

--- a/platforms/ui/src/lib/api.ts
+++ b/platforms/ui/src/lib/api.ts
@@ -6,6 +6,7 @@
 import { invoke } from "@tauri-apps/api/core";
 
 export type Method = "telex" | "vni";
+export type ToneStyle = "traditional" | "modern";
 export type Hotkey = "ctrl_backtick" | "ctrl_space" | "alt_shift";
 
 /// An app excluded from Vietnamese input. `id` is the platform-specific identifier
@@ -17,6 +18,7 @@ export interface ExcludedApp {
 
 export interface Settings {
   method: Method;
+  toneStyle: ToneStyle;
   enabled: boolean;
   smartRestore: boolean;
   eagerRestore: boolean;
@@ -28,6 +30,7 @@ export interface Settings {
 
 const DEFAULTS: Settings = {
   method: "vni",
+  toneStyle: "traditional",
   enabled: true,
   smartRestore: true,
   eagerRestore: true,
@@ -58,6 +61,7 @@ export async function getSettings(): Promise<Settings> {
 }
 
 export const setMethod = (method: Method) => call("set_method", { method });
+export const setToneStyle = (toneStyle: ToneStyle) => call("set_tone_style", { toneStyle });
 export const setEnabled = (on: boolean) => call("set_enabled", { on });
 export const setSmartRestore = (on: boolean) => call("set_smart_restore", { on });
 export const setEagerRestore = (on: boolean) => call("set_eager_restore", { on });

--- a/platforms/ui/src/lib/settings/panes/InputMethod.svelte
+++ b/platforms/ui/src/lib/settings/panes/InputMethod.svelte
@@ -12,9 +12,19 @@
     vni: "Dấu bằng chữ số — a6→â, o7→ơ, a1→á, d9→đ",
   };
 
+  const toneBlurb: Record<api.ToneStyle, string> = {
+    traditional: "Dấu kiểu cũ — hòa, khỏe, thúy",
+    modern: "Dấu kiểu mới — hoà, khoẻ, thuý",
+  };
+
   function pick(m: api.Method) {
     settings.method = m;
     api.setMethod(m);
+  }
+
+  function pickTone(t: api.ToneStyle) {
+    settings.toneStyle = t;
+    api.setToneStyle(t);
   }
 </script>
 
@@ -29,6 +39,21 @@
           ]}
           value={settings.method}
           onchange={pick}
+        />
+      {/snippet}
+    </SettingsRow>
+  </GlassCard>
+
+  <GlassCard>
+    <SettingsRow title="Kiểu đặt dấu" subtitle={toneBlurb[settings.toneStyle]}>
+      {#snippet control()}
+        <Segmented
+          options={[
+            { id: "traditional", label: "Truyền thống" },
+            { id: "modern", label: "Hiện đại" },
+          ]}
+          value={settings.toneStyle}
+          onchange={pickTone}
         />
       {/snippet}
     </SettingsRow>

--- a/platforms/windows/src-tauri/src/commands.rs
+++ b/platforms/windows/src-tauri/src/commands.rs
@@ -6,7 +6,7 @@ use tauri::AppHandle;
 use tauri_plugin_autostart::ManagerExt;
 use tauri_plugin_opener::OpenerExt;
 
-use crate::settings::{ExcludedApp, Hotkey, Method, Settings};
+use crate::settings::{ExcludedApp, Hotkey, Method, Settings, ToneStyle};
 use crate::shell;
 
 #[tauri::command]
@@ -37,6 +37,11 @@ pub fn list_recent_apps() -> Vec<ExcludedApp> {
 #[tauri::command]
 pub fn set_method(method: Method) {
     shell::set_method(method.core());
+}
+
+#[tauri::command]
+pub fn set_tone_style(tone_style: ToneStyle) {
+    shell::set_tone_style(tone_style.core());
 }
 
 #[tauri::command]

--- a/platforms/windows/src-tauri/src/main.rs
+++ b/platforms/windows/src-tauri/src/main.rs
@@ -25,6 +25,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             commands::get_settings,
             commands::set_method,
+            commands::set_tone_style,
             commands::set_enabled,
             commands::set_smart_restore,
             commands::set_eager_restore,

--- a/platforms/windows/src-tauri/src/settings.rs
+++ b/platforms/windows/src-tauri/src/settings.rs
@@ -4,7 +4,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use funput_core::InputMethod;
+use funput_core::{InputMethod, ToneStyle as CoreToneStyle};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -25,6 +25,31 @@ impl Method {
         match m {
             InputMethod::Telex => Method::Telex,
             InputMethod::Vni => Method::Vni,
+        }
+    }
+}
+
+/// Tone-mark placement style (traditional `hòa` vs modern `hoà`). Mirrors `Method`:
+/// a serde-friendly enum bridged to the engine's `funput_core::ToneStyle`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ToneStyle {
+    #[default]
+    Traditional,
+    Modern,
+}
+
+impl ToneStyle {
+    pub fn core(self) -> CoreToneStyle {
+        match self {
+            ToneStyle::Traditional => CoreToneStyle::Traditional,
+            ToneStyle::Modern => CoreToneStyle::Modern,
+        }
+    }
+    pub fn from_core(ts: CoreToneStyle) -> Self {
+        match ts {
+            CoreToneStyle::Traditional => ToneStyle::Traditional,
+            CoreToneStyle::Modern => ToneStyle::Modern,
         }
     }
 }
@@ -51,6 +76,9 @@ pub struct ExcludedApp {
 #[serde(rename_all = "camelCase")]
 pub struct Settings {
     pub method: Method,
+    /// `#[serde(default)]` keeps older settings files (without this key) loadable.
+    #[serde(default)]
+    pub tone_style: ToneStyle,
     pub enabled: bool,
     pub smart_restore: bool,
     pub eager_restore: bool,
@@ -67,6 +95,7 @@ impl Default for Settings {
     fn default() -> Self {
         Self {
             method: Method::Vni,
+            tone_style: ToneStyle::Traditional,
             enabled: true,
             smart_restore: true,
             eager_restore: true,

--- a/platforms/windows/src-tauri/src/shell.rs
+++ b/platforms/windows/src-tauri/src/shell.rs
@@ -5,10 +5,10 @@
 
 use std::sync::{Mutex, OnceLock};
 
-use funput_core::InputMethod;
+use funput_core::{InputMethod, ToneStyle as CoreToneStyle};
 use funput_engine::{Engine, ImeResult};
 
-use crate::settings::{ExcludedApp, Hotkey, Method, Settings};
+use crate::settings::{ExcludedApp, Hotkey, Method, Settings, ToneStyle};
 
 /// Tag stamped into `dwExtraInfo` of every event we synthesize via `SendInput`, so
 /// the hook can recognize and ignore its own injected keystrokes (no re-entrancy).
@@ -29,6 +29,7 @@ static SHELL: OnceLock<Mutex<Shell>> = OnceLock::new();
 
 fn apply_to_engine(engine: &mut Engine, s: &Settings) {
     engine.set_method(s.method.core());
+    engine.set_tone_style(s.tone_style.core());
     engine.set_enabled(s.enabled);
     engine.set_smart_restore(s.smart_restore);
     engine.set_eager_restore(s.eager_restore);
@@ -69,6 +70,9 @@ pub fn enabled() -> bool {
 }
 pub fn method() -> InputMethod {
     with(|s| s.settings.method.core())
+}
+pub fn tone_style() -> CoreToneStyle {
+    with(|s| s.settings.tone_style.core())
 }
 pub fn toggle_hotkey() -> Hotkey {
     with(|s| s.settings.toggle_hotkey)
@@ -119,6 +123,14 @@ pub fn set_method(method: InputMethod) {
         s.settings.method = Method::from_core(method);
         s.engine.set_method(method);
         s.engine.clear();
+        s.settings.save();
+    });
+}
+
+pub fn set_tone_style(style: CoreToneStyle) {
+    with(|s| {
+        s.settings.tone_style = ToneStyle::from_core(style);
+        s.engine.set_tone_style(style);
         s.settings.save();
     });
 }


### PR DESCRIPTION
## Summary

Adds a user-selectable **tone-mark placement style** for Vietnamese input:

- **Traditional ("kiểu cũ")** — tone on the first vowel: `hòa`, `khỏe`, `thúy` (current behavior, default)
- **Modern ("kiểu mới")** — tone on the main vowel of open `oa`/`oe`/`uy`: `hoà`, `khoẻ`, `thuý`

The setting is exposed in Settings on all platforms and defaults to **Traditional**, so existing
users see no change unless they opt in.

## Motivation

Many users expect the "new style" tone placement (`hoà` rather than `hòa`). Funput previously
hard-coded the traditional rule. This makes it configurable without touching anyone's current
experience.

## Behavior

The two styles differ **only** for open, glide-initial diphthongs `oa`, `oe`, `uy`. Everything else
is identical between styles and unchanged:

- `ia`/`ua` stay on the first vowel (`mía`, `múa`)
- syllables with a final consonant (`hoàn`, `toán`, `huýt`)
- vowels carrying a diacritic shape, which always take the tone (`trường`, `việt`, `người`)
- triphthongs (`ngoài`, `xoáy`, `khuỷu`)

Placement is **rule-based and position-independent** — the tone lands in the same place regardless of
where the tone key is typed (`hoaf` and `hofa` both produce `hoà` in Modern). Reference:
[Quy tắc đặt dấu thanh của chữ Quốc ngữ](https://vi.wikipedia.org/wiki/Quy_t%E1%BA%AFc_%C4%91%E1%BA%B7t_d%E1%BA%A5u_thanh_c%E1%BB%A7a_ch%E1%BB%AF_Qu%E1%BB%91c_ng%E1%BB%AF).

## Changes

**Engine (shared, platform-agnostic)**
- `funput-core`: new `ToneStyle { Traditional, Modern }` enum; placement logic in
  `tone_vowel_index` / `reposition_existing_tone` threaded through `apply(...)`
- `funput-engine`: `Session.tone_style` + `Engine::set_tone_style` / `tone_style`
- `funput-ffi`: `funput_set_tone_style(engine, u8)` (`0=Traditional`, `1=Modern`); header regenerated

**Platforms (settings plumbing + UI; no logic — all decisions live in the engine)**
- **macOS**: `ToneStyle` model, `AppSettings.toneStyle`, composer setter wired in `syncSettings`,
  segmented picker in the Input Method pane
- **Windows**: `ToneStyle` settings enum, shell setter/getter + `apply_to_engine`, Tauri command
- **Linux**: Tauri command writes `settings.json`; the Fcitx5 addon reads the new `toneStyle` key and
  applies it to the engine on focus-in
- **Shared web UI**: `toneStyle` type/default/setter + a tone-style picker in the existing pane

Persisted as the `toneStyle` key (`"traditional"` / `"modern"`) in `settings.json`. The new field is
`#[serde(default)]` so pre-existing settings files load unchanged.

## Testing

- `cargo test --workspace` — green, including new unit/integration tests for Modern placement,
  reposition, and Traditional regressions
- `svelte-check` — 0 errors/warnings on the shared UI
- macOS app builds and the setting works end-to-end (typed in TextEdit)

## Notes / Out of scope

- `qu`/`gi` onset handling is unchanged: `quy` → `quý` in both styles (the medial `u` is already
  dropped as an onset glide). Not part of this change.
- Default is **Traditional** at every layer, so no behavior change for users who don't opt in.

## Reviewer verification

- **macOS**: Settings → Input Method → Tone style → Modern; type `hoaf`/`hofa` → `hoà`, `thuyr` →
  `thuỷ`; switch back → `hòa`/`thủy`.
- **Windows / Linux**: build the respective shell, toggle the setting, confirm the same words and
  that `settings.json` contains `"toneStyle"`. On Linux the addon picks up the change on the next
  focus-in.