### PR TITLE
feat: make composing-text underline optional (default off)

### DIFF
--- a/platforms/linux/fcitx5/src/funput_engine.cpp
+++ b/platforms/linux/fcitx5/src/funput_engine.cpp
@@ -91,7 +91,9 @@ void FunputEngine::noteRecentApp(const std::string &program) {
 void FunputEngine::updatePreedit(fcitx::InputContext *ic) {
     const std::string s = handle_.buffer();
     fcitx::Text preedit;
-    if (!s.empty()) preedit.append(s, fcitx::TextFormatFlag::Underline);
+    const auto flag = settings_.composingUnderline ? fcitx::TextFormatFlag::Underline
+                                                   : fcitx::TextFormatFlag::NoFlag;
+    if (!s.empty()) preedit.append(s, flag);
     preedit.setCursor(static_cast<int>(s.size()));
 
     auto &panel = ic->inputPanel();

--- a/platforms/linux/fcitx5/src/settings.cpp
+++ b/platforms/linux/fcitx5/src/settings.cpp
@@ -80,6 +80,7 @@ bool Settings::reloadIfChanged() {
     enabled = j.value("enabled", enabled);
     smartRestore = j.value("smartRestore", smartRestore);
     eagerRestore = j.value("eagerRestore", eagerRestore);
+    composingUnderline = j.value("composingUnderline", composingUnderline);
     toggleHotkey = parseHotkey(j.value("toggleHotkey", std::string(hotkeyStr(toggleHotkey))));
 
     // excludedApps: [{ "id": "code", "name": "Code" }, ...] — keep just the ids.
@@ -94,8 +95,8 @@ bool Settings::reloadIfChanged() {
 
     return method != prev.method || toneStyle != prev.toneStyle ||
            enabled != prev.enabled || smartRestore != prev.smartRestore ||
-           eagerRestore != prev.eagerRestore || toggleHotkey != prev.toggleHotkey ||
-           excludedAppIds != prev.excludedAppIds;
+           eagerRestore != prev.eagerRestore || composingUnderline != prev.composingUnderline ||
+           toggleHotkey != prev.toggleHotkey || excludedAppIds != prev.excludedAppIds;
 }
 
 bool Settings::isExcluded(const std::string &program) const {
@@ -124,6 +125,7 @@ void Settings::save() const {
     j["enabled"] = enabled;
     j["smartRestore"] = smartRestore;
     j["eagerRestore"] = eagerRestore;
+    j["composingUnderline"] = composingUnderline;
     j["toggleHotkey"] = hotkeyStr(toggleHotkey);
 
     std::ofstream out(p, std::ios::trunc);

--- a/platforms/linux/fcitx5/src/settings.h
+++ b/platforms/linux/fcitx5/src/settings.h
@@ -22,6 +22,8 @@ struct Settings {
     bool enabled = true;
     bool smartRestore = true;
     bool eagerRestore = true;
+    // Underline the composing preedit. Off → looks like already-typed text.
+    bool composingUnderline = false;
     Hotkey toggleHotkey = Hotkey::CtrlBacktick;
     // App identifiers (fcitx5 program() / WM_CLASS) that default to English on
     // focus. Owned by the Settings UI; the addon only reads them for matching.

--- a/platforms/linux/src-tauri/src/commands.rs
+++ b/platforms/linux/src-tauri/src/commands.rs
@@ -49,6 +49,11 @@ pub fn set_tone_style(tone_style: ToneStyle) {
 }
 
 #[tauri::command]
+pub fn set_composing_underline(on: bool) {
+    Settings::update(|s| s.composing_underline = on);
+}
+
+#[tauri::command]
 pub fn set_enabled(on: bool) {
     Settings::update(|s| s.enabled = on);
 }

--- a/platforms/linux/src-tauri/src/main.rs
+++ b/platforms/linux/src-tauri/src/main.rs
@@ -39,6 +39,7 @@ fn main() {
             commands::get_settings,
             commands::set_method,
             commands::set_tone_style,
+            commands::set_composing_underline,
             commands::set_enabled,
             commands::set_smart_restore,
             commands::set_eager_restore,

--- a/platforms/linux/src-tauri/src/settings.rs
+++ b/platforms/linux/src-tauri/src/settings.rs
@@ -56,6 +56,10 @@ pub struct Settings {
     pub toggle_hotkey: Hotkey,
     pub launch_at_login: bool,
     pub has_completed_onboarding: bool,
+    /// Underline composing text (preedit). `#[serde(default)]` (false) keeps older
+    /// settings files loadable. The Fcitx5 addon reads this to style the preedit.
+    #[serde(default)]
+    pub composing_underline: bool,
     /// Apps that default to English on focus. `#[serde(default)]` keeps older
     /// settings files (without this key) loadable instead of resetting to defaults.
     #[serde(default)]
@@ -74,6 +78,7 @@ impl Default for Settings {
             launch_at_login: false,
             has_completed_onboarding: false,
             excluded_apps: Vec::new(),
+            composing_underline: false,
         }
     }
 }

--- a/platforms/ui/src/lib/api.ts
+++ b/platforms/ui/src/lib/api.ts
@@ -26,6 +26,8 @@ export interface Settings {
   launchAtLogin: boolean;
   hasCompletedOnboarding: boolean;
   excludedApps: ExcludedApp[];
+  /// Underline composing text (Linux preedit). Off → looks like typed text.
+  composingUnderline: boolean;
 }
 
 const DEFAULTS: Settings = {
@@ -38,6 +40,7 @@ const DEFAULTS: Settings = {
   launchAtLogin: false,
   hasCompletedOnboarding: false,
   excludedApps: [],
+  composingUnderline: false,
 };
 
 // Which OS shell hosts this UI. The shell appends `&platform=windows|linux` to the
@@ -65,6 +68,7 @@ export const setToneStyle = (toneStyle: ToneStyle) => call("set_tone_style", { t
 export const setEnabled = (on: boolean) => call("set_enabled", { on });
 export const setSmartRestore = (on: boolean) => call("set_smart_restore", { on });
 export const setEagerRestore = (on: boolean) => call("set_eager_restore", { on });
+export const setComposingUnderline = (on: boolean) => call("set_composing_underline", { on });
 export const setToggleHotkey = (hotkey: Hotkey) => call("set_toggle_hotkey", { hotkey });
 export const setLaunchAtLogin = (on: boolean) => call("set_launch_at_login", { on });
 export const completeOnboarding = () => call("complete_onboarding");

--- a/platforms/ui/src/lib/settings/panes/InputMethod.svelte
+++ b/platforms/ui/src/lib/settings/panes/InputMethod.svelte
@@ -4,6 +4,7 @@
   import GlassCard from "../../components/GlassCard.svelte";
   import SettingsRow from "../../components/SettingsRow.svelte";
   import Segmented from "../../components/Segmented.svelte";
+  import Toggle from "../../components/Toggle.svelte";
 
   let { settings }: { settings: api.Settings } = $props();
 
@@ -25,6 +26,11 @@
   function pickTone(t: api.ToneStyle) {
     settings.toneStyle = t;
     api.setToneStyle(t);
+  }
+
+  function setUnderline(on: boolean) {
+    settings.composingUnderline = on;
+    api.setComposingUnderline(on);
   }
 </script>
 
@@ -58,6 +64,19 @@
       {/snippet}
     </SettingsRow>
   </GlassCard>
+
+  {#if api.isLinux}
+    <GlassCard>
+      <SettingsRow
+        title="Gạch chân khi đang gõ"
+        subtitle="Tắt để chữ trông như đã gõ xong (giống Windows)."
+      >
+        {#snippet control()}
+          <Toggle checked={settings.composingUnderline} onchange={setUnderline} />
+        {/snippet}
+      </SettingsRow>
+    </GlassCard>
+  {/if}
 
   <GlassCard>
     <div class="try-label">Gõ thử</div>


### PR DESCRIPTION
## Summary

Adds an optional **"Underline composing text"** setting on Linux. When off (the new
default), in-progress Vietnamese text is no longer underlined — it looks like already-typed text,
matching the Windows/UniKey experience that many users expect.

## Motivation

Several Linux users reported disliking the underline shown while composing. The underline is not
a bug — it's the standard IME preedit/marked-text indicator (Linux Fcitx5). Windows uses
a different model (direct key injection, no preedit) and therefore never underlines. This makes the
underline a user preference instead of forcing one behavior.

This is intentionally the **low-risk option**: it keeps the robust preedit/marked-text composition
model on both platforms and only toggles the underline styling. It does **not** switch Linux to
the Windows-style injection model.

## ⚠️ Behavior change

The default is **off (no underline)** on Linux. Existing users will see the composing
underline disappear after updating. They can re-enable it in Settings. Windows is unaffected (it has
no preedit to begin with).

## Changes

Pure presentation — **no changes to `funput-core` / `funput-engine` / `funput-ffi`**.

**Linux**
- Fcitx5 addon: new `composingUnderline` setting parsed from / written to `settings.json`; preedit is
  appended with `Underline` or `NoFlag` accordingly
- Tauri settings app: `composingUnderline` field + `set_composing_underline` command

**Shared web UI**
- `composingUnderline` type/default/setter; toggle rendered in the Input Method pane, shown on Linux
  only (no preedit exists on Windows)

Persisted as `composingUnderline` (bool) in `settings.json`; the field is `#[serde(default)]` so
existing settings files load unchanged.

## Testing

- `svelte-check` — 0 errors/warnings
- Linux: addon + Tauri build on Linux; toggle persists to `settings.json` and the addon picks it up on
  the next focus-in (GTK and Qt apps)

## Notes / Out of scope

- **Windows is intentionally untouched** — its hook + `SendInput` model has no composition/preedit, so
  there is nothing to underline. The toggle is hidden on Windows.
- Does not change the underlying composition model on any platform (no move to the injection model).