### PR TITLE
ci: harden cargo network (HTTP/1.1 + retries)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,13 @@ on:
 permissions:
   contents: write
 
+# Cargo network resilience for all jobs that build Rust. CI runners intermittently
+# hit "curl HTTP2 framing layer" (error 16) errors fetching crates from crates.io;
+# forcing HTTP/1.1 avoids the bug, and a higher retry count rides out blips.
+env:
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_RETRY: "5"
+
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
Release builds intermittently fail fetching crates from crates.io with 'curl ... Error in the HTTP2 framing layer' (curl error 16). Force HTTP/1.1 (disable HTTP/2 multiplexing) and raise the network retry count, workflow-wide, so all Rust builds ride out the transient failure.