### PR TITLE
refactor: remove composingUnderline setting and related functionality

### DIFF
--- a/platforms/linux/common/settings.cpp
+++ b/platforms/linux/common/settings.cpp
@@ -80,7 +80,6 @@ bool Settings::reloadIfChanged() {
     enabled = j.value("enabled", enabled);
     smartRestore = j.value("smartRestore", smartRestore);
     eagerRestore = j.value("eagerRestore", eagerRestore);
-    composingUnderline = j.value("composingUnderline", composingUnderline);
     toggleHotkey = parseHotkey(j.value("toggleHotkey", std::string(hotkeyStr(toggleHotkey))));
 
     // excludedApps: [{ "id": "code", "name": "Code" }, ...] — keep just the ids.
@@ -95,7 +94,7 @@ bool Settings::reloadIfChanged() {
 
     return method != prev.method || toneStyle != prev.toneStyle ||
            enabled != prev.enabled || smartRestore != prev.smartRestore ||
-           eagerRestore != prev.eagerRestore || composingUnderline != prev.composingUnderline ||
+           eagerRestore != prev.eagerRestore ||
            toggleHotkey != prev.toggleHotkey || excludedAppIds != prev.excludedAppIds;
 }
 
@@ -125,7 +124,6 @@ void Settings::save() const {
     j["enabled"] = enabled;
     j["smartRestore"] = smartRestore;
     j["eagerRestore"] = eagerRestore;
-    j["composingUnderline"] = composingUnderline;
     j["toggleHotkey"] = hotkeyStr(toggleHotkey);
 
     std::ofstream out(p, std::ios::trunc);

--- a/platforms/linux/common/settings.h
+++ b/platforms/linux/common/settings.h
@@ -22,8 +22,6 @@ struct Settings {
     bool enabled = true;
     bool smartRestore = true;
     bool eagerRestore = true;
-    // Underline the composing preedit. Off → looks like already-typed text.
-    bool composingUnderline = false;
     Hotkey toggleHotkey = Hotkey::CtrlBacktick;
     // App identifiers (fcitx5 program() / WM_CLASS) that default to English on
     // focus. Owned by the Settings UI; the addon only reads them for matching.

--- a/platforms/linux/fcitx5/src/funput_engine.cpp
+++ b/platforms/linux/fcitx5/src/funput_engine.cpp
@@ -83,9 +83,9 @@ void FunputEngine::noteRecentApp(const std::string &program) {
 void FunputEngine::updatePreedit(fcitx::InputContext *ic) {
     const std::string s = handle_.buffer();
     fcitx::Text preedit;
-    const auto flag = settings_.composingUnderline ? fcitx::TextFormatFlag::Underline
-                                                   : fcitx::TextFormatFlag::NoFlag;
-    if (!s.empty()) preedit.append(s, flag);
+    // Mark the composing buffer with the standard underline. How (or whether)
+    // this is drawn is ultimately up to the client app.
+    if (!s.empty()) preedit.append(s, fcitx::TextFormatFlag::Underline);
     preedit.setCursor(static_cast<int>(s.size()));
 
     auto &panel = ic->inputPanel();

--- a/platforms/linux/ibus/src/engine.cpp
+++ b/platforms/linux/ibus/src/engine.cpp
@@ -51,21 +51,14 @@ void clearPreedit(IBusEngine *engine) {
     ibus_engine_hide_preedit_text(engine);
 }
 
-// Show buffer() as preedit, optionally underlined, cursor at the end.
+// Show buffer() as preedit, cursor at the end. We don't set any underline
+// attribute: how preedit is drawn is up to the client app, which renders its
+// default composing style (typically underlined). Trying to override it isn't
+// reliable since many clients ignore the attribute.
 void updatePreedit(IBusEngine *engine, EngineState *st) {
     const std::string s = st->handle_.buffer();
     IBusText *text = ibus_text_new_from_string(s.c_str());
     const glong len = g_utf8_strlen(s.c_str(), -1);
-    if (!s.empty()) {
-        // IBus clients (GTK/Qt) underline preedit by *default*, so omitting the
-        // attribute does NOT turn it off — we must send an explicit UNDERLINE_NONE
-        // when composingUnderline is off. SINGLE when on.
-        const guint underline = st->settings_.composingUnderline
-                                    ? IBUS_ATTR_UNDERLINE_SINGLE
-                                    : IBUS_ATTR_UNDERLINE_NONE;
-        ibus_text_append_attribute(text, IBUS_ATTR_TYPE_UNDERLINE, underline, 0,
-                                   static_cast<gint>(len));
-    }
     // ibus_engine_update_preedit_text sinks the floating ref on `text`.
     ibus_engine_update_preedit_text(engine, text, static_cast<guint>(len),
                                     s.empty() ? FALSE : TRUE);

--- a/platforms/linux/src-tauri/src/commands.rs
+++ b/platforms/linux/src-tauri/src/commands.rs
@@ -49,11 +49,6 @@ pub fn set_tone_style(tone_style: ToneStyle) {
 }
 
 #[tauri::command]
-pub fn set_composing_underline(on: bool) {
-    Settings::update(|s| s.composing_underline = on);
-}
-
-#[tauri::command]
 pub fn set_enabled(on: bool) {
     Settings::update(|s| s.enabled = on);
 }

--- a/platforms/linux/src-tauri/src/main.rs
+++ b/platforms/linux/src-tauri/src/main.rs
@@ -39,7 +39,6 @@ fn main() {
             commands::get_settings,
             commands::set_method,
             commands::set_tone_style,
-            commands::set_composing_underline,
             commands::set_enabled,
             commands::set_smart_restore,
             commands::set_eager_restore,

--- a/platforms/linux/src-tauri/src/settings.rs
+++ b/platforms/linux/src-tauri/src/settings.rs
@@ -56,10 +56,6 @@ pub struct Settings {
     pub toggle_hotkey: Hotkey,
     pub launch_at_login: bool,
     pub has_completed_onboarding: bool,
-    /// Underline composing text (preedit). `#[serde(default)]` (false) keeps older
-    /// settings files loadable. The Fcitx5 addon reads this to style the preedit.
-    #[serde(default)]
-    pub composing_underline: bool,
     /// Apps that default to English on focus. `#[serde(default)]` keeps older
     /// settings files (without this key) loadable instead of resetting to defaults.
     #[serde(default)]
@@ -78,7 +74,6 @@ impl Default for Settings {
             launch_at_login: false,
             has_completed_onboarding: false,
             excluded_apps: Vec::new(),
-            composing_underline: false,
         }
     }
 }

--- a/platforms/ui/src/lib/api.ts
+++ b/platforms/ui/src/lib/api.ts
@@ -26,8 +26,6 @@ export interface Settings {
   launchAtLogin: boolean;
   hasCompletedOnboarding: boolean;
   excludedApps: ExcludedApp[];
-  /// Underline composing text (Linux preedit). Off → looks like typed text.
-  composingUnderline: boolean;
 }
 
 const DEFAULTS: Settings = {
@@ -40,7 +38,6 @@ const DEFAULTS: Settings = {
   launchAtLogin: false,
   hasCompletedOnboarding: false,
   excludedApps: [],
-  composingUnderline: false,
 };
 
 // Which OS shell hosts this UI. The shell appends `&platform=windows|linux` to the
@@ -68,7 +65,6 @@ export const setToneStyle = (toneStyle: ToneStyle) => call("set_tone_style", { t
 export const setEnabled = (on: boolean) => call("set_enabled", { on });
 export const setSmartRestore = (on: boolean) => call("set_smart_restore", { on });
 export const setEagerRestore = (on: boolean) => call("set_eager_restore", { on });
-export const setComposingUnderline = (on: boolean) => call("set_composing_underline", { on });
 export const setToggleHotkey = (hotkey: Hotkey) => call("set_toggle_hotkey", { hotkey });
 export const setLaunchAtLogin = (on: boolean) => call("set_launch_at_login", { on });
 export const completeOnboarding = () => call("complete_onboarding");

--- a/platforms/ui/src/lib/settings/panes/InputMethod.svelte
+++ b/platforms/ui/src/lib/settings/panes/InputMethod.svelte
@@ -4,7 +4,6 @@
   import GlassCard from "../../components/GlassCard.svelte";
   import SettingsRow from "../../components/SettingsRow.svelte";
   import Segmented from "../../components/Segmented.svelte";
-  import Toggle from "../../components/Toggle.svelte";
 
   let { settings }: { settings: api.Settings } = $props();
 
@@ -26,11 +25,6 @@
   function pickTone(t: api.ToneStyle) {
     settings.toneStyle = t;
     api.setToneStyle(t);
-  }
-
-  function setUnderline(on: boolean) {
-    settings.composingUnderline = on;
-    api.setComposingUnderline(on);
   }
 </script>
 
@@ -64,19 +58,6 @@
       {/snippet}
     </SettingsRow>
   </GlassCard>
-
-  {#if api.isLinux}
-    <GlassCard>
-      <SettingsRow
-        title="Gạch chân khi đang gõ"
-        subtitle="Tắt để chữ trông như đã gõ xong (giống Windows)."
-      >
-        {#snippet control()}
-          <Toggle checked={settings.composingUnderline} onchange={setUnderline} />
-        {/snippet}
-      </SettingsRow>
-    </GlassCard>
-  {/if}
 
   <GlassCard>
     <div class="try-label">Gõ thử</div>


### PR DESCRIPTION
The composingUnderline setting has been removed from the Settings structure and its associated methods. This change simplifies the codebase by eliminating the handling of composing text underlining, as it is now managed by client applications. All references to composingUnderline in the settings interface and commands have been removed, ensuring a cleaner and more maintainable implementation.