### PR TITLE
feat(windows): in-app auto-update + dark tray menu; split release CI into reusable workflows

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,99 @@
+name: Build Linux
+
+# Reusable: builds the shared UI + Settings app + Fcitx5 addon & IBus engine into
+# .debs, natively per arch (no cross-compile) so dpkg-shlibdeps records the right
+# deps. arm64 covers Apple Silicon VMs (Apple Virtualization) and arm servers. Two
+# packages per arch: funput (Fcitx5) and funput-ibus (IBus). Called by release.yml;
+# artifacts (names: linux-<arch>) are picked up by its `publish` job.
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version (empty for a non-tag smoke test)."
+        required: false
+        type: string
+        default: ""
+
+# Cargo network resilience (see release.yml). Workflow-level env does not cross the
+# workflow_call boundary, so each build workflow repeats it.
+env:
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_RETRY: "5"
+
+jobs:
+  linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          # Fcitx5 + IBus shell toolchains + JSON, and the GTK4/libadwaita Settings deps.
+          sudo apt-get install -y \
+            cmake nlohmann-json3-dev \
+            fcitx5 libfcitx5core-dev libfcitx5utils-dev libfcitx5config-dev \
+            ibus libibus-1.0-dev libglib2.0-dev \
+            libgtk-4-dev libadwaita-1-dev librsvg2-dev
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            platforms/linux/settings-gtk -> target
+
+      - name: Stamp version from tag
+        if: inputs.version != ''
+        run: |
+          V="${{ inputs.version }}"
+          # Stamp the GUI crate version (shown in the Settings "Giới thiệu" page via
+          # CARGO_PKG_VERSION). The .deb version comes separately from -DFUNPUT_VERSION.
+          sed -i -E "0,/^version = \".*\"/s//version = \"$V\"/" platforms/linux/settings-gtk/Cargo.toml
+
+      - name: Build Settings app (GTK4 + libadwaita)
+        working-directory: platforms/linux/settings-gtk
+        run: cargo build --release
+
+      - name: Build addons + .debs
+        run: |
+          V="${{ inputs.version }}"; V="${V:-1.2026.1}"
+          # Each shell is its own CMake project; build into a separate dir so the
+          # two CPack runs don't clobber each other.
+          for fw in fcitx5 ibus; do
+            cmake -S "platforms/linux/$fw" -B "platforms/linux/build/$fw" \
+              -DCMAKE_BUILD_TYPE=Release -DFUNPUT_VERSION="$V"
+            cmake --build "platforms/linux/build/$fw" --parallel
+            ( cd "platforms/linux/build/$fw" && cpack -G DEB )
+          done
+
+      - name: Verify .debs (apt can parse them)
+        run: |
+          # Fail fast instead of shipping a broken package. `--simulate` forces apt
+          # to parse the .deb metadata through its own reader.
+          find platforms/linux/build -name '*.deb' | while read -r f; do
+            echo "== $f =="
+            dpkg-deb --info "$f" >/dev/null
+            sudo apt-get install --simulate "./$f" >/dev/null
+          done
+
+      - name: Stage artifact
+        run: |
+          OUT="$RUNNER_TEMP/out"; mkdir -p "$OUT"
+          find platforms/linux/build -name '*.deb' | while read -r f; do
+            cp "$f" "$OUT/"
+            sha256sum "$f" | awk '{print $1}' > "$OUT/$(basename "$f").sha256"
+          done
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-${{ matrix.arch }}
+          path: ${{ runner.temp }}/out/*

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,116 @@
+name: Build macOS
+
+# Reusable: builds the universal app, signs (Developer ID) + notarizes into a
+# .pkg / .app.zip, and emits the signed Sparkle appcast.xml. Called by release.yml;
+# artifacts (name: macos) are picked up by its `publish` job.
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version (empty for a non-tag smoke test)."
+        required: false
+        type: string
+        default: ""
+
+# Cargo network resilience (see release.yml). Workflow-level env does not cross the
+# workflow_call boundary, so each build workflow repeats it.
+env:
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_RETRY: "5"
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Rust targets (universal)
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Import Developer ID certificate
+        env:
+          CERT_P12: ${{ secrets.DEVELOPER_ID_CERT_P12 }}
+          CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/funput-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          echo "$CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          # The p12 must contain BOTH "Developer ID Application" (signs the app) and
+          # "Developer ID Installer" (signs the .pkg). productbuild/productsign need
+          # key access too, hence the extra -T entries.
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/xcodebuild \
+            -T /usr/bin/productbuild -T /usr/bin/productsign -T /usr/bin/pkgbuild
+          security set-key-partition-list -S apple-tool:,apple:,codesign:,productsign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN" \
+            $(security list-keychains -d user | sed 's/["[:space:]]//g')
+          security default-keychain -s "$KEYCHAIN"
+          rm -f "$RUNNER_TEMP/cert.p12"
+
+      - name: Build, sign, notarize, package
+        working-directory: platforms/macos
+        env:
+          VERSION: ${{ inputs.version }}
+          NOTARY_APPLE_ID: ${{ secrets.NOTARY_APPLE_ID }}
+          NOTARY_PASSWORD: ${{ secrets.NOTARY_PASSWORD }}
+          TEAM_ID: ${{ secrets.NOTARY_TEAM_ID || 'RSARFZ5CD3' }}
+        run: ./scripts/release.sh
+
+      - name: Stage artifact
+        working-directory: platforms/macos
+        run: |
+          OUT="$RUNNER_TEMP/out"; mkdir -p "$OUT"
+          for f in build/release/Funput-*.pkg build/release/Funput-*.app.zip; do
+            cp "$f" "$OUT/"
+            shasum -a 256 "$f" | awk '{print $1}' > "$OUT/$(basename "$f").sha256"
+          done
+
+      # Sparkle auto-update feed: sign the .app.zip with the EdDSA key and emit an
+      # appcast.xml whose enclosure points at this tag's GitHub Release asset. The
+      # app's SUFeedURL reads releases/latest/download/appcast.xml, so publishing
+      # appcast.xml as a release asset is enough — no separate host needed.
+      - name: Generate + sign Sparkle appcast
+        if: inputs.version != ''
+        working-directory: platforms/macos
+        env:
+          VERSION: ${{ inputs.version }}
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+          # Keep the CLI tools in lockstep with the framework SPM resolves (~> 2.6).
+          SPARKLE_VERSION: "2.9.3"
+        run: |
+          set -euo pipefail
+          # Fetch Sparkle's command-line tools (generate_appcast / sign_update).
+          TOOLS="$RUNNER_TEMP/sparkle"; mkdir -p "$TOOLS"
+          curl -fsSL "https://github.com/sparkle-project/Sparkle/releases/download/$SPARKLE_VERSION/Sparkle-$SPARKLE_VERSION.tar.xz" \
+            | tar -xJ -C "$TOOLS"
+          # generate_appcast reads CFBundleVersion/CFBundleShortVersionString from the
+          # app inside the archive, so feed it a clean dir with just the .app.zip.
+          ARCHIVES="$RUNNER_TEMP/appcast"; mkdir -p "$ARCHIVES"
+          cp build/release/Funput-*.app.zip "$ARCHIVES/"
+          KEYFILE="$RUNNER_TEMP/sparkle_ed_key"
+          printf '%s' "$SPARKLE_ED_PRIVATE_KEY" > "$KEYFILE"
+          "$TOOLS/bin/generate_appcast" \
+            --ed-key-file "$KEYFILE" \
+            --download-url-prefix "https://github.com/Funput/Funput/releases/download/v$VERSION/" \
+            -o "$ARCHIVES/appcast.xml" \
+            "$ARCHIVES"
+          rm -f "$KEYFILE"
+          cp "$ARCHIVES/appcast.xml" "$RUNNER_TEMP/out/appcast.xml"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos
+          path: ${{ runner.temp }}/out/*

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -45,6 +45,13 @@ jobs:
         working-directory: platforms/windows
         run: cargo build --release
 
+      # This crate is excluded from the workspace, so its unit tests (the Ed25519
+      # signature-verify + version-compare logic in update.rs) only run here.
+      # --release reuses the build above instead of compiling a second time.
+      - name: Run tests
+        working-directory: platforms/windows
+        run: cargo test --release
+
       - name: Stage artifact
         run: |
           V="${{ inputs.version }}"; V="${V:-dev}"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,112 @@
+name: Build Windows
+
+# Reusable: builds the native Slint portable .exe (job `windows`), then signs it
+# with the shared Sparkle EdDSA key and emits the in-app update feed
+# `funput-windows.json` (job `windows-feed`). Called by release.yml; artifacts
+# (names: windows, windows-feed) are picked up by its `publish` job.
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version (empty for a non-tag smoke test)."
+        required: false
+        type: string
+        default: ""
+
+# Cargo network resilience (see release.yml). Workflow-level env does not cross the
+# workflow_call boundary, so each build workflow repeats it.
+env:
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_RETRY: "5"
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: platforms/windows -> target
+
+      - name: Stamp version from tag
+        if: inputs.version != ''
+        run: |
+          V="${{ inputs.version }}"
+          # Crate version is the single source of truth: cargo logs, the exe's
+          # embedded version resource, and the About pane (CARGO_PKG_VERSION).
+          node -e "const fs=require('fs');const f='platforms/windows/Cargo.toml';let s=fs.readFileSync(f,'utf8');s=s.replace(/^version = \".*\"/m,'version = \"'+process.argv[1]+'\"');fs.writeFileSync(f,s)" "$V"
+
+      - name: Build Funput.exe
+        working-directory: platforms/windows
+        run: cargo build --release
+
+      - name: Stage artifact
+        run: |
+          V="${{ inputs.version }}"; V="${V:-dev}"
+          OUT="$RUNNER_TEMP/out"; mkdir -p "$OUT"
+          cp platforms/windows/target/release/funput.exe "$OUT/Funput-$V.exe"
+          sha256sum "$OUT/Funput-$V.exe" | awk '{print $1}' > "$OUT/Funput-$V.exe.sha256"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows
+          path: ${{ runner.temp }}/out/*
+
+  # Sign the .exe with the shared Sparkle EdDSA key and emit funput-windows.json.
+  # The in-app updater (platforms/windows/src/update.rs) fetches it from
+  # releases/latest/download and verifies the .exe against the *same* Ed25519 key
+  # macOS uses. Sparkle's sign_update is macOS-only, so this runs on a macOS runner;
+  # it just needs the built .exe, hence `needs: windows`.
+  windows-feed:
+    needs: windows
+    if: inputs.version != ''
+    runs-on: macos-latest
+    steps:
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: windows
+          path: win
+
+      - name: Sign .exe + emit funput-windows.json
+        env:
+          VERSION: ${{ inputs.version }}
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+          # Keep the CLI tools in lockstep with the macOS job (and the framework).
+          SPARKLE_VERSION: "2.9.3"
+        run: |
+          set -euo pipefail
+          EXE="win/Funput-$VERSION.exe"
+          # Fetch Sparkle's command-line tools (sign_update).
+          TOOLS="$RUNNER_TEMP/sparkle"; mkdir -p "$TOOLS"
+          curl -fsSL "https://github.com/sparkle-project/Sparkle/releases/download/$SPARKLE_VERSION/Sparkle-$SPARKLE_VERSION.tar.xz" \
+            | tar -xJ -C "$TOOLS"
+          KEYFILE="$RUNNER_TEMP/sparkle_ed_key"
+          printf '%s' "$SPARKLE_ED_PRIVATE_KEY" > "$KEYFILE"
+          # sign_update prints one line: sparkle:edSignature="<base64>" length="<bytes>"
+          SIGLINE="$("$TOOLS/bin/sign_update" "$EXE" -f "$KEYFILE")"
+          rm -f "$KEYFILE"
+          ED_SIG="$(printf '%s' "$SIGLINE" | sed -E 's/.*edSignature="([^"]+)".*/\1/')"
+          LENGTH="$(printf '%s' "$SIGLINE" | sed -E 's/.*length="([^"]+)".*/\1/')"
+          OUT="$RUNNER_TEMP/out"; mkdir -p "$OUT"
+          cat > "$OUT/funput-windows.json" <<EOF
+          {
+            "version": "$VERSION",
+            "url": "https://github.com/Funput/Funput/releases/download/v$VERSION/Funput-$VERSION.exe",
+            "ed_signature": "$ED_SIG",
+            "length": $LENGTH,
+            "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "notes_url": "https://github.com/Funput/Funput/releases/tag/v$VERSION"
+          }
+          EOF
+          cat "$OUT/funput-windows.json"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-feed
+          path: ${{ runner.temp }}/out/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,9 @@ jobs:
       - name: Publish the draft release
         env:
           GH_TOKEN: ${{ github.token }}
+          # The publish job has no checkout, so tell gh which repo to act on instead
+          # of letting it look for a local .git.
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', needs.version.outputs.version) }}
           PRERELEASE: ${{ needs.version.outputs.prerelease }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 
-# One tag → both platforms. Pushing a tag like v1.2026.1 builds the macOS .pkg and
-# the Windows .exe, both stamped with the **tag version** (single source of truth),
-# and publishes them to one GitHub Release. workflow_dispatch builds without
-# publishing (verify secrets / smoke test).
+# One tag → all platforms. Pushing a tag like v1.2026.1 builds the macOS .pkg, the
+# Windows .exe, and the Linux .debs — all stamped with the **tag version** (single
+# source of truth) — and publishes them to one GitHub Release. workflow_dispatch
+# builds without publishing (verify secrets / smoke test).
+#
+# The per-platform build steps live in reusable workflows (build-*.yml) and are
+# called below; artifacts they upload are gathered by `publish` in the same run.
 on:
   push:
     tags: ["v*"]
@@ -11,13 +14,6 @@ on:
 
 permissions:
   contents: write
-
-# Cargo network resilience for all jobs that build Rust. CI runners intermittently
-# hit "curl HTTP2 framing layer" (error 16) errors fetching crates from crates.io;
-# forcing HTTP/1.1 avoids the bug, and a higher retry count rides out blips.
-env:
-  CARGO_HTTP_MULTIPLEXING: "false"
-  CARGO_NET_RETRY: "5"
 
 concurrency:
   group: release-${{ github.ref }}
@@ -41,224 +37,28 @@ jobs:
             echo "is_release=false" >> "$GITHUB_OUTPUT"
           fi
 
-  # ---- macOS: Developer ID + notarize + .pkg --------------------------------
+  # ---- Per-platform builds (reusable workflows) -----------------------------
+  # `secrets: inherit` forwards the signing/notarization secrets each build needs.
   macos:
     needs: version
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
+    uses: ./.github/workflows/build-macos.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+    secrets: inherit
 
-      - name: Select latest stable Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
-
-      - name: Rust targets (universal)
-        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
-
-      - name: Cache cargo build
-        uses: Swatinem/rust-cache@v2
-
-      - name: Import Developer ID certificate
-        env:
-          CERT_P12: ${{ secrets.DEVELOPER_ID_CERT_P12 }}
-          CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
-        run: |
-          set -euo pipefail
-          KEYCHAIN="$RUNNER_TEMP/funput-signing.keychain-db"
-          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          echo "$CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
-          # The p12 must contain BOTH "Developer ID Application" (signs the app) and
-          # "Developer ID Installer" (signs the .pkg). productbuild/productsign need
-          # key access too, hence the extra -T entries.
-          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$CERT_PASSWORD" \
-            -T /usr/bin/codesign -T /usr/bin/xcodebuild \
-            -T /usr/bin/productbuild -T /usr/bin/productsign -T /usr/bin/pkgbuild
-          security set-key-partition-list -S apple-tool:,apple:,codesign:,productsign: \
-            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
-          security list-keychains -d user -s "$KEYCHAIN" \
-            $(security list-keychains -d user | sed 's/["[:space:]]//g')
-          security default-keychain -s "$KEYCHAIN"
-          rm -f "$RUNNER_TEMP/cert.p12"
-
-      - name: Build, sign, notarize, package
-        working-directory: platforms/macos
-        env:
-          VERSION: ${{ needs.version.outputs.version }}
-          NOTARY_APPLE_ID: ${{ secrets.NOTARY_APPLE_ID }}
-          NOTARY_PASSWORD: ${{ secrets.NOTARY_PASSWORD }}
-          TEAM_ID: ${{ secrets.NOTARY_TEAM_ID || 'RSARFZ5CD3' }}
-        run: ./scripts/release.sh
-
-      - name: Stage artifact
-        working-directory: platforms/macos
-        run: |
-          OUT="$RUNNER_TEMP/out"; mkdir -p "$OUT"
-          for f in build/release/Funput-*.pkg build/release/Funput-*.app.zip; do
-            cp "$f" "$OUT/"
-            shasum -a 256 "$f" | awk '{print $1}' > "$OUT/$(basename "$f").sha256"
-          done
-
-      # Sparkle auto-update feed: sign the .app.zip with the EdDSA key and emit an
-      # appcast.xml whose enclosure points at this tag's GitHub Release asset. The
-      # app's SUFeedURL reads releases/latest/download/appcast.xml, so publishing
-      # appcast.xml as a release asset is enough — no separate host needed.
-      - name: Generate + sign Sparkle appcast
-        if: needs.version.outputs.version != ''
-        working-directory: platforms/macos
-        env:
-          VERSION: ${{ needs.version.outputs.version }}
-          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
-          # Keep the CLI tools in lockstep with the framework SPM resolves (~> 2.6).
-          SPARKLE_VERSION: "2.9.3"
-        run: |
-          set -euo pipefail
-          # Fetch Sparkle's command-line tools (generate_appcast / sign_update).
-          TOOLS="$RUNNER_TEMP/sparkle"; mkdir -p "$TOOLS"
-          curl -fsSL "https://github.com/sparkle-project/Sparkle/releases/download/$SPARKLE_VERSION/Sparkle-$SPARKLE_VERSION.tar.xz" \
-            | tar -xJ -C "$TOOLS"
-          # generate_appcast reads CFBundleVersion/CFBundleShortVersionString from the
-          # app inside the archive, so feed it a clean dir with just the .app.zip.
-          ARCHIVES="$RUNNER_TEMP/appcast"; mkdir -p "$ARCHIVES"
-          cp build/release/Funput-*.app.zip "$ARCHIVES/"
-          KEYFILE="$RUNNER_TEMP/sparkle_ed_key"
-          printf '%s' "$SPARKLE_ED_PRIVATE_KEY" > "$KEYFILE"
-          "$TOOLS/bin/generate_appcast" \
-            --ed-key-file "$KEYFILE" \
-            --download-url-prefix "https://github.com/Funput/Funput/releases/download/v$VERSION/" \
-            -o "$ARCHIVES/appcast.xml" \
-            "$ARCHIVES"
-          rm -f "$KEYFILE"
-          cp "$ARCHIVES/appcast.xml" "$RUNNER_TEMP/out/appcast.xml"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: macos
-          path: ${{ runner.temp }}/out/*
-
-  # ---- Windows: native Slint portable .exe ----------------------------------
   windows:
     needs: version
-    runs-on: windows-latest
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v4
+    uses: ./.github/workflows/build-windows.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+    secrets: inherit
 
-      - name: Cache cargo build
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: platforms/windows -> target
-
-      - name: Stamp version from tag
-        if: needs.version.outputs.version != ''
-        run: |
-          V="${{ needs.version.outputs.version }}"
-          # Crate version is the single source of truth: cargo logs, the exe's
-          # embedded version resource, and the About pane (CARGO_PKG_VERSION).
-          node -e "const fs=require('fs');const f='platforms/windows/Cargo.toml';let s=fs.readFileSync(f,'utf8');s=s.replace(/^version = \".*\"/m,'version = \"'+process.argv[1]+'\"');fs.writeFileSync(f,s)" "$V"
-
-      - name: Build Funput.exe
-        working-directory: platforms/windows
-        run: cargo build --release
-
-      - name: Stage artifact
-        run: |
-          V="${{ needs.version.outputs.version }}"; V="${V:-dev}"
-          OUT="$RUNNER_TEMP/out"; mkdir -p "$OUT"
-          cp platforms/windows/target/release/funput.exe "$OUT/Funput-$V.exe"
-          sha256sum "$OUT/Funput-$V.exe" | awk '{print $1}' > "$OUT/Funput-$V.exe.sha256"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: windows
-          path: ${{ runner.temp }}/out/*
-
-  # ---- Linux: shared UI + Settings app + Fcitx5 addon & IBus engine → .debs -
-  # Built natively per arch (no cross-compile) so dpkg-shlibdeps records the right
-  # deps. arm64 covers Apple Silicon VMs (Apple Virtualization) and arm servers.
-  # Two packages per arch: funput (Fcitx5) and funput-ibus (IBus).
   linux:
     needs: version
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            runner: ubuntu-latest
-          - arch: arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install build deps
-        run: |
-          sudo apt-get update
-          # Fcitx5 + IBus shell toolchains + JSON, and the GTK4/libadwaita Settings deps.
-          sudo apt-get install -y \
-            cmake nlohmann-json3-dev \
-            fcitx5 libfcitx5core-dev libfcitx5utils-dev libfcitx5config-dev \
-            ibus libibus-1.0-dev libglib2.0-dev \
-            libgtk-4-dev libadwaita-1-dev librsvg2-dev
-
-      - name: Cache cargo build
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            . -> target
-            platforms/linux/settings-gtk -> target
-
-      - name: Stamp version from tag
-        if: needs.version.outputs.version != ''
-        run: |
-          V="${{ needs.version.outputs.version }}"
-          # Stamp the GUI crate version (shown in the Settings "Giới thiệu" page via
-          # CARGO_PKG_VERSION). The .deb version comes separately from -DFUNPUT_VERSION.
-          sed -i -E "0,/^version = \".*\"/s//version = \"$V\"/" platforms/linux/settings-gtk/Cargo.toml
-
-      - name: Build Settings app (GTK4 + libadwaita)
-        working-directory: platforms/linux/settings-gtk
-        run: cargo build --release
-
-      - name: Build addons + .debs
-        run: |
-          V="${{ needs.version.outputs.version }}"; V="${V:-1.2026.1}"
-          # Each shell is its own CMake project; build into a separate dir so the
-          # two CPack runs don't clobber each other.
-          for fw in fcitx5 ibus; do
-            cmake -S "platforms/linux/$fw" -B "platforms/linux/build/$fw" \
-              -DCMAKE_BUILD_TYPE=Release -DFUNPUT_VERSION="$V"
-            cmake --build "platforms/linux/build/$fw" --parallel
-            ( cd "platforms/linux/build/$fw" && cpack -G DEB )
-          done
-
-      - name: Verify .debs (apt can parse them)
-        run: |
-          # Fail fast instead of shipping a broken package. `--simulate` forces apt
-          # to parse the .deb metadata through its own reader.
-          find platforms/linux/build -name '*.deb' | while read -r f; do
-            echo "== $f =="
-            dpkg-deb --info "$f" >/dev/null
-            sudo apt-get install --simulate "./$f" >/dev/null
-          done
-
-      - name: Stage artifact
-        run: |
-          OUT="$RUNNER_TEMP/out"; mkdir -p "$OUT"
-          find platforms/linux/build -name '*.deb' | while read -r f; do
-            cp "$f" "$OUT/"
-            sha256sum "$f" | awk '{print $1}' > "$OUT/$(basename "$f").sha256"
-          done
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: linux-${{ matrix.arch }}
-          path: ${{ runner.temp }}/out/*
+    uses: ./.github/workflows/build-linux.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+    secrets: inherit
 
   # ---- Publish one release with all artifacts -------------------------------
   publish:
@@ -275,6 +75,7 @@ jobs:
           mkdir -p out
           cp artifacts/macos/* out/ 2>/dev/null || true
           cp artifacts/windows/* out/ 2>/dev/null || true
+          cp artifacts/windows-feed/* out/ 2>/dev/null || true
           cp artifacts/linux-*/* out/ 2>/dev/null || true
           ls -l out
           {
@@ -285,7 +86,7 @@ jobs:
             echo "- \`Funput-*.app.zip\` — **không có quyền admin:** giải nén, rồi kéo \`Funput.app\` vào \`~/Library/Input Methods\` (Finder → \`Cmd+Shift+G\` → gõ đường dẫn đó, tạo nếu chưa có). App đã notarized nên không bị chặn; không cần admin."
             echo "  Sau khi cài (cả hai cách): **System Settings → Keyboard → Input Sources → + → Vietnamese → Funput**. Chưa thấy thì log out/in một lần."
             echo "### Windows"
-            echo "- \`Funput-*.exe\` — portable, double-click là chạy (nằm ở khay hệ thống). Cần WebView2 (có sẵn trên Win10/11)."
+            echo "- \`Funput-*.exe\` — portable, double-click là chạy (nằm ở khay hệ thống). Tự cập nhật trong app (Cài đặt → Giới thiệu → Kiểm tra cập nhật…)."
             echo "### Linux"
             echo "Chọn gói theo input framework của desktop (chọn đúng kiến trúc — \`dpkg --print-architecture\` — \`amd64\` cho PC x86-64, \`arm64\` cho Apple Silicon VM / máy ARM):"
             echo "- **GNOME / Ubuntu mặc định (IBus):** \`funput-ibus_*_<arch>.deb\` — \`sudo apt install ./funput-ibus_*_<arch>.deb\`, rồi \`ibus restart\`. **Settings → Keyboard → Input Sources → + → Vietnamese → Funput.**"
@@ -306,5 +107,6 @@ jobs:
             out/*.exe
             out/*.deb
             out/appcast.xml
+            out/*.json
           body_path: notes.md
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,9 @@ jobs:
             done
           } > notes.md
 
+      # Create the release as a DRAFT with all assets attached. This repo has
+      # "immutable releases" enabled: a published release rejects asset uploads, so
+      # we must attach everything while it is still a mutable draft, then publish.
       - uses: softprops/action-gh-release@v2
         with:
           files: |
@@ -141,8 +144,25 @@ jobs:
             out/*.json
           body_path: notes.md
           generate_release_notes: true
+          draft: true
           # Dispatch runs have no pushed tag, so name it explicitly (the action
           # creates the tag); tag pushes reuse the pushed ref. Dispatch publishes
           # are always prereleases.
           prerelease: ${{ needs.version.outputs.prerelease }}
           tag_name: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', needs.version.outputs.version) }}
+
+      # Flip the draft to published. This fires `release.published` and bakes the
+      # already-attached assets into the now-immutable release.
+      - name: Publish the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', needs.version.outputs.version) }}
+          PRERELEASE: ${{ needs.version.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          if [[ "$PRERELEASE" == "true" ]]; then
+            # Prerelease must NOT become the `latest` the auto-updater serves.
+            gh release edit "$TAG" --draft=false --prerelease --latest=false
+          else
+            gh release edit "$TAG" --draft=false --latest
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,32 @@ name: Release
 
 # One tag → all platforms. Pushing a tag like v1.2026.1 builds the macOS .pkg, the
 # Windows .exe, and the Linux .debs — all stamped with the **tag version** (single
-# source of truth) — and publishes them to one GitHub Release. workflow_dispatch
-# builds without publishing (verify secrets / smoke test).
+# source of truth) — and publishes them to one public GitHub Release.
+#
+# workflow_dispatch is for testing the *full* pipeline (incl. EdDSA signing + the
+# update feeds) without disturbing users:
+#   - version empty            → compile-only smoke test (no signing/feed/publish).
+#   - version set, publish off → build + sign + emit feeds; artifacts only, no Release.
+#   - version set, publish on  → same, plus a **prerelease** (never becomes the
+#                                `latest` the auto-updater serves).
 #
 # The per-platform build steps live in reusable workflows (build-*.yml) and are
 # called below; artifacts they upload are gathered by `publish` in the same run.
 on:
   push:
     tags: ["v*"]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Build version, e.g. 1.2026.2-rc1. Empty = compile-only smoke test (no signing/feed)."
+        required: false
+        type: string
+        default: ""
+      publish:
+        description: "Publish a GitHub prerelease with the built artifacts (never becomes `latest`)."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -25,16 +42,30 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.v.outputs.version }}
-      is_release: ${{ steps.v.outputs.is_release }}
+      publish: ${{ steps.v.outputs.publish }}
+      prerelease: ${{ steps.v.outputs.prerelease }}
     steps:
       - id: v
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+          DISPATCH_PUBLISH: ${{ inputs.publish }}
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            # Tag push → full public release.
             echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
           else
-            echo "version=" >> "$GITHUB_OUTPUT"
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            # Manual dispatch → use the provided version (may be empty for a
+            # compile-only smoke test). Any publish here is always a prerelease, so
+            # it never becomes the `latest` the auto-updater serves.
+            echo "version=${DISPATCH_VERSION}" >> "$GITHUB_OUTPUT"
+            if [[ "${DISPATCH_PUBLISH}" == "true" && -n "${DISPATCH_VERSION}" ]]; then
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+            fi
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
           fi
 
   # ---- Per-platform builds (reusable workflows) -----------------------------
@@ -63,7 +94,7 @@ jobs:
   # ---- Publish one release with all artifacts -------------------------------
   publish:
     needs: [version, macos, windows, linux]
-    if: needs.version.outputs.is_release == 'true'
+    if: needs.version.outputs.publish == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -79,7 +110,7 @@ jobs:
           cp artifacts/linux-*/* out/ 2>/dev/null || true
           ls -l out
           {
-            echo "## Funput ${{ github.ref_name }}"
+            echo "## Funput v${{ needs.version.outputs.version }}"
             echo
             echo "### macOS"
             echo "- \`Funput-*.pkg\` — **cách thường (có quyền admin):** double-click để cài (mở Installer.app), nhập mật khẩu. Đã ký Developer ID Installer + notarized, không bị Gatekeeper chặn."
@@ -110,3 +141,8 @@ jobs:
             out/*.json
           body_path: notes.md
           generate_release_notes: true
+          # Dispatch runs have no pushed tag, so name it explicitly (the action
+          # creates the tag); tag pushes reuse the pushed ref. Dispatch publishes
+          # are always prereleases.
+          prerelease: ${{ needs.version.outputs.prerelease }}
+          tag_name: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', needs.version.outputs.version) }}

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -40,7 +40,7 @@ ureq = "2" # sync HTTP client (rustls, no OpenSSL); runs on its own thread
 ed25519-dalek = "2" # verify the Sparkle-compatible Ed25519 signature
 base64 = "0.22" # decode the public key + signature
 semver = "1" # compare the manifest version against CARGO_PKG_VERSION
-self_replace = "1" # replace the currently running executable
+self-replace = "1" # replace the currently running executable (crate `self_replace`)
 funput-core = { path = "../../crates/funput-core" }
 funput-engine = { path = "../../crates/funput-engine" }
 funput-desktop = { path = "../../crates/funput-desktop" }

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -33,6 +33,14 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "5"
+# Auto-update (see src/update.rs): fetch a signed JSON manifest from GitHub
+# Releases, verify it with the same Ed25519 key Sparkle uses on macOS, then
+# swap the running .exe in place.
+ureq = "2" # sync HTTP client (rustls, no OpenSSL); runs on its own thread
+ed25519-dalek = "2" # verify the Sparkle-compatible Ed25519 signature
+base64 = "0.22" # decode the public key + signature
+semver = "1" # compare the manifest version against CARGO_PKG_VERSION
+self_replace = "1" # replace the currently running executable
 funput-core = { path = "../../crates/funput-core" }
 funput-engine = { path = "../../crates/funput-engine" }
 funput-desktop = { path = "../../crates/funput-desktop" }

--- a/platforms/windows/README.md
+++ b/platforms/windows/README.md
@@ -17,9 +17,11 @@ Funput.exe (Rust, Slint) — khởi động ẩn, tray-only
 ├─ keymap.rs      vkCode + modifier → funput_desktop::KeyEvent (ToUnicodeEx)
 ├─ inject.rs      InjectPlan → SendInput (VK_BACK ×n, KEYEVENTF_UNICODE), gắn INJECT_TAG
 ├─ shell.rs       state toàn cục: Engine + settings + per-app override (mutex)
-├─ tray.rs        tray-icon + muda: VI/EN, VNI/Telex, Cài đặt…, Hướng dẫn, Thoát
+├─ tray.rs        tray-icon + muda: VI/EN, VNI/Telex, Cài đặt…, Hướng dẫn, Kiểm tra cập nhật…, Thoát
 ├─ windows_ui.rs  mở cửa sổ Slint (Settings/Onboarding) + áp Mica theo sáng/tối hệ thống
-├─ commands.rs    glue: persist settings + autostart (auto-launch) + mở link (open)
+├─ commands.rs    glue: persist settings + autostart (auto-launch) + mở link + auto-update
+├─ update.rs      auto-update: tải manifest JSON + verify chữ ký Ed25519 + tráo exe + relaunch
+├─ dark_mode.rs   bật preferred-app-mode để context menu của tray theo dark/light hệ thống
 └─ ui/*.slint     SettingsWindow + OnboardingWindow (style Fluent)
 ```
 
@@ -62,6 +64,20 @@ Hiện build ra **`funput.exe` portable** (icon + manifest DPI/asInvoker nhúng 
 Bản Tauri trước lo luôn bundler; nếu cần MSI/NSIS, thêm bước riêng (`cargo-wix` hoặc script NSIS)
 — **chưa** nằm trong crate này.
 
+## Tự cập nhật (auto-update)
+
+Giống bản macOS (Sparkle) hết mức có thể, **dùng chung cặp khóa EdDSA** với macOS:
+
+- **Manifest** `funput-windows.json` (tương đương `appcast.xml`) đính kèm GitHub Release; app đọc ở
+  URL cố định `releases/latest/download/funput-windows.json` (redirect tải thẳng — không đụng REST
+  API nên không dính rate-limit).
+- **Kiểm tra thủ công** (không tự poll nền): tray "Kiểm tra cập nhật…" hoặc Cài đặt → Giới thiệu.
+- Khi có bản mới: tải `.exe` → **verify chữ ký Ed25519** bằng cùng public key macOS (`update.rs`) →
+  `self-replace` exe đang chạy → relaunch (tray process nên **không cần logout** như macOS).
+- **Ký** bằng `sign_update` của Sparkle trong CI (`secret SPARKLE_ED_PRIVATE_KEY`); xem job
+  `windows-feed` trong [`.github/workflows/build-windows.yml`](../../.github/workflows/build-windows.yml).
+- Test cục bộ: đặt `FUNPUT_UPDATE_FEED=<url manifest>` (chỉ có tác dụng ở **debug build**).
+
 ## Hạn chế đã biết
 
 - **Không gõ được vào app chạy quyền Admin** (trừ khi `funput.exe` cũng chạy Admin) — bản chất của
@@ -81,5 +97,8 @@ Notepad/WordPad/trình duyệt:
   từ chữ kế; "Thoát" để thoát.
 - `Ctrl+` ``` bật/tắt nhanh (đổi được trong Settings).
 - Settings: đổi kiểu gõ / phím tắt / smart-eager có hiệu lực ngay; **giữ qua restart**.
-- Đổi Windows sang Dark/Light → cửa sổ đổi nền gradient + màu chữ theo.
+- Đổi Windows sang Dark/Light → cửa sổ đổi nền gradient + màu chữ theo; right-click tray ở Dark mode
+  → context menu cũng nền tối.
 - Bật "Khởi động cùng Windows" → có registry `HKCU\…\Run`.
+- Auto-update: đặt `FUNPUT_UPDATE_FEED` trỏ manifest có version cao hơn (debug build) → tray/Settings
+  "Kiểm tra cập nhật…" → tải + verify + tráo exe + relaunch; chữ ký sai thì báo lỗi, không tráo.

--- a/platforms/windows/build.rs
+++ b/platforms/windows/build.rs
@@ -11,6 +11,14 @@ fn main() {
         let mut res = winresource::WindowsResource::new();
         res.set_icon("icons/icon.ico");
         res.set_manifest(MANIFEST);
+        // Version-info strings shown by Windows. Without these, winresource derives
+        // them from the crate name ("funput-windows"); Task Manager surfaces
+        // FileDescription as the process "Name". Pin them to "Funput" so the
+        // displayed name matches the macOS/Linux apps.
+        res.set("FileDescription", "Funput");
+        res.set("ProductName", "Funput");
+        res.set("InternalName", "Funput");
+        res.set("OriginalFilename", "Funput.exe");
         if let Err(e) = res.compile() {
             println!("cargo:warning=winresource failed: {e}");
         }

--- a/platforms/windows/src/commands.rs
+++ b/platforms/windows/src/commands.rs
@@ -2,8 +2,11 @@
 //! mutates the shared `shell` state (which applies to the engine + persists); a
 //! couple also apply an OS side effect (autostart registry, opening a link).
 
+use std::sync::Mutex;
+
 use crate::settings::{ExcludedApp, Hotkey, Method, ToneStyle};
-use crate::shell;
+use crate::update::{self, Manifest};
+use crate::{shell, windows_ui};
 
 pub fn set_method(method: Method) {
     shell::set_method(method.core());
@@ -63,4 +66,66 @@ fn autolaunch() -> Option<auto_launch::AutoLaunch> {
 /// Open an external link (GitHub / Website) in the system browser.
 pub fn open_url(url: &str) {
     let _ = open::that(url);
+}
+
+// --- Auto-update ------------------------------------------------------------
+//
+// All three steps run off the main thread (network + file I/O must not block the
+// Slint loop or the keyboard hook) and report progress back to the About pane via
+// `windows_ui::set_update_state` marshalled onto the event loop. The available
+// update is stashed between "check" and "install" so the UI callback can stay
+// argument-free.
+
+/// The update found by the last check, awaiting the user's "Tải và cài đặt".
+static PENDING_UPDATE: Mutex<Option<Manifest>> = Mutex::new(None);
+
+/// Check the GitHub Release feed for a newer build. Drives the About pane through
+/// `checking` → `available`/`uptodate`/`error`.
+pub fn check_for_updates() {
+    set_update_ui("checking", "", "");
+    std::thread::spawn(|| match update::fetch_manifest() {
+        Ok(manifest) if update::is_newer(&manifest.version) => {
+            let version = manifest.version.clone();
+            *PENDING_UPDATE.lock().unwrap() = Some(manifest);
+            set_update_ui("available", &version, "");
+        }
+        Ok(_) => {
+            *PENDING_UPDATE.lock().unwrap() = None;
+            set_update_ui("uptodate", "", "");
+        }
+        Err(e) => set_update_ui("error", "", &e.to_string()),
+    });
+}
+
+/// Download, verify, and swap in the pending update. Drives the About pane through
+/// `downloading` → `ready`/`error`. The relaunch waits for the user's confirmation.
+pub fn install_update() {
+    let Some(manifest) = PENDING_UPDATE.lock().unwrap().clone() else {
+        return;
+    };
+    set_update_ui("downloading", &manifest.version, "");
+    std::thread::spawn(move || {
+        let outcome = update::download(&manifest.url, manifest.length).and_then(|bytes| {
+            update::verify(&bytes, &manifest.ed_signature)?;
+            update::stage_and_replace(&bytes)
+        });
+        match outcome {
+            Ok(()) => set_update_ui("ready", &manifest.version, ""),
+            Err(e) => set_update_ui("error", "", &e.to_string()),
+        }
+    });
+}
+
+/// Relaunch into the freshly installed build (no log-out needed — it is a plain
+/// tray process). Never returns.
+pub fn relaunch_after_update() {
+    update::relaunch();
+}
+
+/// Push an update state onto the Settings window from any thread.
+fn set_update_ui(state: &str, version: &str, message: &str) {
+    let (state, version, message) = (state.to_owned(), version.to_owned(), message.to_owned());
+    let _ = slint::invoke_from_event_loop(move || {
+        windows_ui::set_update_state(&state, &version, &message);
+    });
 }

--- a/platforms/windows/src/dark_mode.rs
+++ b/platforms/windows/src/dark_mode.rs
@@ -1,0 +1,35 @@
+//! Make the tray's right-click menu follow the Windows light/dark setting.
+//!
+//! Win32 popup menus — drawn by `TrackPopupMenu`, which is what `tray-icon`/`muda`
+//! use for the tray menu — ignore the system dark theme unless the process opts in
+//! via two *undocumented* `uxtheme.dll` exports: `SetPreferredAppMode` (ordinal
+//! 135) and `FlushMenuThemes` (ordinal 136), the same trick win32-darkmode uses.
+//! muda themes the menu *bar* but explicitly not popups, so we do this ourselves.
+
+use windows::core::{s, PCSTR};
+use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
+
+/// Opt the process into dark menus when Windows is in dark mode (and light when
+/// light). Call once at startup, before the tray menu is first shown. No-op on
+/// Windows builds that lack these exports.
+pub fn allow_dark_menus() {
+    // PreferredAppMode::AllowDark — menus track the system light/dark setting.
+    const ALLOW_DARK: i32 = 1;
+
+    unsafe {
+        let Ok(uxtheme) = LoadLibraryA(s!("uxtheme.dll")) else {
+            return;
+        };
+        // The two uxtheme functions are exported by ordinal only (no public names),
+        // so look them up via MAKEINTRESOURCE-style ordinal pointers.
+        if let Some(proc) = GetProcAddress(uxtheme, PCSTR(135 as *const u8)) {
+            let set_preferred_app_mode: extern "system" fn(i32) -> i32 =
+                std::mem::transmute(proc);
+            set_preferred_app_mode(ALLOW_DARK);
+        }
+        if let Some(proc) = GetProcAddress(uxtheme, PCSTR(136 as *const u8)) {
+            let flush_menu_themes: extern "system" fn() = std::mem::transmute(proc);
+            flush_menu_themes();
+        }
+    }
+}

--- a/platforms/windows/src/dark_mode.rs
+++ b/platforms/windows/src/dark_mode.rs
@@ -6,7 +6,7 @@
 //! 135) and `FlushMenuThemes` (ordinal 136), the same trick win32-darkmode uses.
 //! muda themes the menu *bar* but explicitly not popups, so we do this ourselves.
 
-use windows::core::{s, PCSTR};
+use windows::core::PCSTR;
 use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
 
 /// Opt the process into dark menus when Windows is in dark mode (and light when
@@ -17,7 +17,8 @@ pub fn allow_dark_menus() {
     const ALLOW_DARK: i32 = 1;
 
     unsafe {
-        let Ok(uxtheme) = LoadLibraryA(s!("uxtheme.dll")) else {
+        // Null-terminated literal → PCSTR, without relying on the `s!` macro path.
+        let Ok(uxtheme) = LoadLibraryA(PCSTR(b"uxtheme.dll\0".as_ptr())) else {
             return;
         };
         // The two uxtheme functions are exported by ordinal only (no public names),

--- a/platforms/windows/src/main.rs
+++ b/platforms/windows/src/main.rs
@@ -10,6 +10,7 @@ compile_error!("funput-windows builds only on Windows (global keyboard hook + Se
 slint::include_modules!();
 
 mod commands;
+mod dark_mode;
 mod hook;
 mod inject;
 mod keymap;
@@ -20,6 +21,10 @@ mod update;
 mod windows_ui;
 
 fn main() {
+    // Let Windows draw the tray's right-click menu dark when the system is dark.
+    // Process-global, so set it before the tray (on the hook thread) is created.
+    dark_mode::allow_dark_menus();
+
     // Touch the shell to load persisted settings + apply them to the engine.
     let settings = shell::snapshot();
 

--- a/platforms/windows/src/main.rs
+++ b/platforms/windows/src/main.rs
@@ -16,6 +16,7 @@ mod keymap;
 mod settings;
 mod shell;
 mod tray;
+mod update;
 mod windows_ui;
 
 fn main() {

--- a/platforms/windows/src/tray.rs
+++ b/platforms/windows/src/tray.rs
@@ -39,6 +39,7 @@ pub fn install() {
     let telex = CheckMenuItem::with_id("telex", "Telex", true, method == InputMethod::Telex, None);
     let settings = MenuItem::with_id("settings", "Cài đặt…", true, None);
     let guide = MenuItem::with_id("guide", "Hướng dẫn", true, None);
+    let update = MenuItem::with_id("check-update", "Kiểm tra cập nhật…", true, None);
     let quit = MenuItem::with_id("quit", "Thoát", true, None);
 
     let menu = Menu::new();
@@ -48,6 +49,7 @@ pub fn install() {
         &PredefinedMenuItem::separator(),
         &settings,
         &guide,
+        &update,
         &PredefinedMenuItem::separator(),
         &quit,
     ])
@@ -99,6 +101,9 @@ pub fn drain_events() {
             }
             "guide" => {
                 let _ = slint::invoke_from_event_loop(windows_ui::open_onboarding);
+            }
+            "check-update" => {
+                let _ = slint::invoke_from_event_loop(windows_ui::open_settings_and_check_updates);
             }
             "quit" => {
                 let _ = slint::invoke_from_event_loop(|| {

--- a/platforms/windows/src/update.rs
+++ b/platforms/windows/src/update.rs
@@ -1,0 +1,261 @@
+//! Auto-update, mirroring the macOS Sparkle setup as closely as Windows allows.
+//!
+//! The release pipeline publishes a small JSON manifest (`funput-windows.json`)
+//! next to the `.exe` on the GitHub Release, signed with the **same Ed25519 key
+//! Sparkle uses for macOS**. We fetch the manifest from a fixed
+//! `releases/latest/download/…` URL (a redirect to the asset, not the REST API,
+//! so there is no rate limit), compare versions, then — if newer — download the
+//! new `.exe`, verify its signature against the embedded public key, swap the
+//! running executable in place, and relaunch.
+//!
+//! Checks are manual-only (parity with macOS `SUEnableAutomaticChecks=false`):
+//! nothing here runs unless the user clicks "Kiểm tra cập nhật…".
+//!
+//! Because Funput on Windows is just a tray process (not a system-loaded input
+//! method like on macOS), the relaunch needs no log-out — we spawn the new
+//! binary and exit. And since our own process writes the new file, it carries no
+//! Mark-of-the-Web, so the relaunch does not trip SmartScreen.
+
+use std::io::Read;
+use std::time::Duration;
+
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::Deserialize;
+
+/// Ed25519 public key used to verify update signatures. This MUST stay identical
+/// to `SUPublicEDKey` in the macOS `Info.plist` — both platforms are signed with
+/// the one `SPARKLE_ED_PRIVATE_KEY` secret in CI.
+const PUBLIC_ED_KEY: &str = "wDWk569Lmn9WmjPn1ZwHMTp/KW+nfaaNIvtrYSV9nHU=";
+
+/// Fixed update feed. The `latest/download` path always redirects to the asset on
+/// the most recent (non-prerelease) GitHub Release.
+const FEED_URL: &str = "https://github.com/Funput/Funput/releases/latest/download/funput-windows.json";
+
+/// The version this build reports — the single source of truth stamped from the
+/// release tag into `Cargo.toml`.
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Upper bound on the downloaded `.exe` size, so a bogus feed cannot make us read
+/// unboundedly. The real binary is a few tens of MB.
+const MAX_DOWNLOAD_BYTES: u64 = 200 * 1024 * 1024;
+
+/// One parsed entry of the update feed. Unknown fields (e.g. `pub_date`) are
+/// ignored by serde.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Manifest {
+    /// Marketing version of the available build, e.g. `1.2026.2`.
+    pub version: String,
+    /// Direct download URL of the new `.exe` on the GitHub Release.
+    pub url: String,
+    /// Base64 Ed25519 signature of the `.exe` bytes (Sparkle `sign_update` output).
+    pub ed_signature: String,
+    /// Expected size of the `.exe` in bytes; a cheap integrity pre-check.
+    pub length: u64,
+    /// Optional link to the release notes (shown as "Xem thay đổi").
+    #[serde(default)]
+    pub notes_url: Option<String>,
+}
+
+/// Errors surfaced to the About pane. `Display` is the user-facing Vietnamese
+/// text — the whole UI is Vietnamese.
+#[derive(Debug)]
+pub enum Error {
+    Network(String),
+    BadManifest(String),
+    SizeMismatch { expected: u64, actual: u64 },
+    BadSignature,
+    Replace(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Network(_) => write!(f, "Không kết nối được máy chủ cập nhật."),
+            Error::BadManifest(_) => write!(f, "Dữ liệu cập nhật không hợp lệ."),
+            Error::SizeMismatch { .. } => write!(f, "Tải bản cập nhật bị lỗi, vui lòng thử lại."),
+            Error::BadSignature => write!(f, "Chữ ký bản cập nhật không hợp lệ — đã huỷ."),
+            Error::Replace(_) => write!(f, "Không thay được tệp chương trình. Hãy tải thủ công."),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// The feed URL, allowing a debug-build override (`FUNPUT_UPDATE_FEED`) so the
+/// end-to-end flow can be tested against a local manifest before tagging.
+fn feed_url() -> String {
+    #[cfg(debug_assertions)]
+    if let Ok(url) = std::env::var("FUNPUT_UPDATE_FEED") {
+        return url;
+    }
+    FEED_URL.to_string()
+}
+
+/// A shared HTTP agent with sane timeouts. Built per call (cheap) so the update
+/// thread owns it and nothing lingers on the main app.
+fn agent() -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(15))
+        .timeout_read(Duration::from_secs(60))
+        .build()
+}
+
+/// Fetch and parse the update manifest from the GitHub Release feed.
+pub fn fetch_manifest() -> Result<Manifest> {
+    let resp = agent()
+        .get(&feed_url())
+        .call()
+        .map_err(|e| Error::Network(e.to_string()))?;
+    // `into_string` is core ureq (no extra feature), with a built-in size cap.
+    let body = resp
+        .into_string()
+        .map_err(|e| Error::Network(e.to_string()))?;
+    serde_json::from_str(&body).map_err(|e| Error::BadManifest(e.to_string()))
+}
+
+/// Whether `candidate` is a strictly newer version than this build.
+pub fn is_newer(candidate: &str) -> bool {
+    version_is_newer(candidate, CURRENT_VERSION)
+}
+
+/// The marketing version this build reports.
+pub fn current_version() -> &'static str {
+    CURRENT_VERSION
+}
+
+/// Pure version comparison, split out so it can be unit-tested without a build.
+/// Treats unparseable versions as "not newer" (fail safe — never offers junk).
+fn version_is_newer(candidate: &str, current: &str) -> bool {
+    match (
+        semver::Version::parse(candidate),
+        semver::Version::parse(current),
+    ) {
+        (Ok(c), Ok(cur)) => c > cur,
+        _ => false,
+    }
+}
+
+/// Download the `.exe` bytes, enforcing the manifest's expected length.
+pub fn download(url: &str, expected_len: u64) -> Result<Vec<u8>> {
+    let resp = agent()
+        .get(url)
+        .call()
+        .map_err(|e| Error::Network(e.to_string()))?;
+
+    let mut bytes = Vec::with_capacity(expected_len.min(MAX_DOWNLOAD_BYTES) as usize);
+    resp.into_reader()
+        .take(MAX_DOWNLOAD_BYTES)
+        .read_to_end(&mut bytes)
+        .map_err(|e| Error::Network(e.to_string()))?;
+
+    let actual = bytes.len() as u64;
+    if actual != expected_len {
+        return Err(Error::SizeMismatch {
+            expected: expected_len,
+            actual,
+        });
+    }
+    Ok(bytes)
+}
+
+/// Verify the downloaded bytes against the embedded public key. Sparkle signs the
+/// raw file with Ed25519 (libsodium), which is byte-compatible with `ed25519-dalek`.
+pub fn verify(bytes: &[u8], ed_signature: &str) -> Result<()> {
+    verify_with_key(bytes, ed_signature, PUBLIC_ED_KEY)
+}
+
+/// Inner verify that takes the public key explicitly, so tests can use their own
+/// keypair instead of the production one.
+fn verify_with_key(bytes: &[u8], ed_signature: &str, public_key_b64: &str) -> Result<()> {
+    let key_bytes = BASE64
+        .decode(public_key_b64)
+        .ok()
+        .and_then(|b| <[u8; 32]>::try_from(b).ok())
+        .ok_or(Error::BadSignature)?;
+    let verifying_key = VerifyingKey::from_bytes(&key_bytes).map_err(|_| Error::BadSignature)?;
+
+    let sig_bytes = BASE64.decode(ed_signature).map_err(|_| Error::BadSignature)?;
+    let signature = Signature::from_slice(&sig_bytes).map_err(|_| Error::BadSignature)?;
+
+    verifying_key
+        .verify(bytes, &signature)
+        .map_err(|_| Error::BadSignature)
+}
+
+/// Write the verified bytes to a temp file and swap them in for the running
+/// executable. After this returns, `current_exe()` points at the new build.
+pub fn stage_and_replace(bytes: &[u8]) -> Result<()> {
+    let staged = std::env::temp_dir().join("Funput-update.exe");
+    std::fs::write(&staged, bytes).map_err(|e| Error::Replace(e.to_string()))?;
+    let result = self_replace::self_replace(&staged).map_err(|e| Error::Replace(e.to_string()));
+    // Best-effort cleanup; the swap already copied the bytes into place.
+    let _ = std::fs::remove_file(&staged);
+    result
+}
+
+/// Relaunch the (now updated) executable and exit this process. Never returns.
+pub fn relaunch() -> ! {
+    if let Ok(exe) = std::env::current_exe() {
+        let _ = std::process::Command::new(exe).spawn();
+    }
+    std::process::exit(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    #[test]
+    fn newer_version_detected() {
+        assert!(version_is_newer("1.2026.2", "1.2026.1"));
+        assert!(version_is_newer("2.0.0", "1.2026.1"));
+    }
+
+    #[test]
+    fn same_or_older_is_not_newer() {
+        assert!(!version_is_newer("1.2026.1", "1.2026.1"));
+        assert!(!version_is_newer("1.2026.0", "1.2026.1"));
+    }
+
+    #[test]
+    fn unparseable_version_is_not_newer() {
+        assert!(!version_is_newer("not-a-version", "1.2026.1"));
+        assert!(!version_is_newer("1.2026.2", "garbage"));
+    }
+
+    #[test]
+    fn manifest_parses_and_ignores_unknown_fields() {
+        let json = r#"{
+            "version": "1.2026.2",
+            "url": "https://example.com/Funput-1.2026.2.exe",
+            "ed_signature": "AAAA",
+            "length": 1234,
+            "pub_date": "2026-06-26T10:00:00Z",
+            "notes_url": "https://example.com/notes"
+        }"#;
+        let m: Manifest = serde_json::from_str(json).expect("parse");
+        assert_eq!(m.version, "1.2026.2");
+        assert_eq!(m.length, 1234);
+        assert_eq!(m.notes_url.as_deref(), Some("https://example.com/notes"));
+    }
+
+    #[test]
+    fn verify_accepts_good_signature_and_rejects_tampering() {
+        // Deterministic keypair (no RNG dependency) standing in for the CI key.
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let pubkey_b64 = BASE64.encode(signing.verifying_key().to_bytes());
+        let payload = b"funput release bytes";
+        let sig_b64 = BASE64.encode(signing.sign(payload).to_bytes());
+
+        assert!(verify_with_key(payload, &sig_b64, &pubkey_b64).is_ok());
+        // Flip one byte of the payload → verification must fail.
+        assert!(verify_with_key(b"funput release bytez", &sig_b64, &pubkey_b64).is_err());
+        // Garbage signature → fail, not panic.
+        assert!(verify_with_key(payload, "!!!notbase64!!!", &pubkey_b64).is_err());
+    }
+}

--- a/platforms/windows/src/windows_ui.rs
+++ b/platforms/windows/src/windows_ui.rs
@@ -42,6 +42,10 @@ fn populate_settings(win: &SettingsWindow) {
     win.set_eager_restore(s.eager_restore);
     win.set_launch_at_login(s.launch_at_login);
     win.set_version(env!("CARGO_PKG_VERSION").into());
+    // Reset the updater UI each time the window is (re)shown.
+    win.set_update_state("idle".into());
+    win.set_update_version("".into());
+    win.set_update_message("".into());
     refresh_apps(win);
 }
 
@@ -102,6 +106,36 @@ fn wire_settings(win: &SettingsWindow) {
     });
 
     win.on_open_link(|url| commands::open_url(url.as_str()));
+
+    // Auto-update: the buttons are argument-free; state flows back through
+    // `set_update_state`. `commands` runs the work off the main thread.
+    win.on_check_update(commands::check_for_updates);
+    win.on_install_update(commands::install_update);
+    win.on_relaunch_now(commands::relaunch_after_update);
+}
+
+/// Reflect an update step on the Settings window (no-op if it is not open).
+/// Called on the main thread via `slint::invoke_from_event_loop`.
+pub fn set_update_state(state: &str, version: &str, message: &str) {
+    SETTINGS.with(|c| {
+        if let Some(win) = c.borrow().as_ref() {
+            win.set_update_state(state.into());
+            win.set_update_version(version.into());
+            win.set_update_message(message.into());
+        }
+    });
+}
+
+/// Open Settings on the "Giới thiệu" tab and immediately check for updates — the
+/// tray's "Kiểm tra cập nhật…" entry point.
+pub fn open_settings_and_check_updates() {
+    open_settings();
+    SETTINGS.with(|c| {
+        if let Some(win) = c.borrow().as_ref() {
+            win.set_active("about".into());
+        }
+    });
+    commands::check_for_updates();
 }
 
 /// Refresh the excluded list and the "recent" picker (recent minus already-excluded).

--- a/platforms/windows/ui/app.slint
+++ b/platforms/windows/ui/app.slint
@@ -346,12 +346,6 @@ export component SettingsWindow inherits Window {
                             Text { text: "Funput"; font-size: 18px; font-weight: 700; horizontal-alignment: center; color: Palette.foreground; }
                             Text { text: "Bộ gõ tiếng Việt — miễn phí, mã nguồn mở."; font-size: 13px; horizontal-alignment: center; color: Theme.subtle; }
                             Text { text: "Phiên bản \{root.version}"; font-size: 12px; horizontal-alignment: center; color: Theme.subtle; }
-                            HorizontalLayout {
-                                alignment: center;
-                                spacing: Theme.sp-sm;
-                                Button { text: "GitHub"; clicked => { root.open-link("https://github.com/Funput/Funput"); } }
-                                Button { text: "Website"; clicked => { root.open-link("https://funput.app/"); } }
-                            }
 
                             // --- Cập nhật ---
                             if root.update-state != "idle": Text {
@@ -388,6 +382,12 @@ export component SettingsWindow inherits Window {
                                     text: "Khởi động lại";
                                     clicked => { root.relaunch-now(); }
                                 }
+                            }
+                            HorizontalLayout {
+                                alignment: center;
+                                spacing: Theme.sp-sm;
+                                Button { text: "GitHub"; clicked => { root.open-link("https://github.com/Funput/Funput"); } }
+                                Button { text: "Website"; clicked => { root.open-link("https://funput.app/"); } }
                             }
                         }
                     }

--- a/platforms/windows/ui/app.slint
+++ b/platforms/windows/ui/app.slint
@@ -59,6 +59,10 @@ export component SettingsWindow inherits Window {
     in property <[AppEntry]> excluded-apps;
     in property <[AppEntry]> recent-apps;
     in property <string> version;
+    // Auto-update: idle | checking | uptodate | available | downloading | ready | error
+    in property <string> update-state: "idle";
+    in property <string> update-version;
+    in property <string> update-message;
 
     // --- events to Rust ---
     callback pick-method(string);
@@ -70,8 +74,12 @@ export component SettingsWindow inherits Window {
     callback add-app(string);
     callback remove-app(string);
     callback open-link(string);
+    callback check-update();
+    callback install-update();
+    callback relaunch-now();
 
-    private property <string> active: "input";
+    // `in-out` so the tray's "Kiểm tra cập nhật…" can jump straight to the About tab.
+    in-out property <string> active: "input";
     property <[{id: string, label: string, icon: image}]> nav: [
         { id: "input", label: "Kiểu gõ", icon: @image-url("icons/keyboard.svg") },
         { id: "keyboard", label: "Phím chuyển", icon: @image-url("icons/switch.svg") },
@@ -343,6 +351,43 @@ export component SettingsWindow inherits Window {
                                 spacing: Theme.sp-sm;
                                 Button { text: "GitHub"; clicked => { root.open-link("https://github.com/Funput/Funput"); } }
                                 Button { text: "Website"; clicked => { root.open-link("https://funput.app/"); } }
+                            }
+
+                            // --- Cập nhật ---
+                            if root.update-state != "idle": Text {
+                                text: root.update-state == "checking" ? "Đang kiểm tra…"
+                                    : root.update-state == "uptodate" ? "Bạn đang dùng bản mới nhất."
+                                    : root.update-state == "available" ? "Có bản mới \{root.update-version}."
+                                    : root.update-state == "downloading" ? "Đang tải bản cập nhật…"
+                                    : root.update-state == "ready" ? "Đã cập nhật Funput. Khởi động lại để áp dụng."
+                                    : root.update-message;
+                                font-size: 12px;
+                                horizontal-alignment: center;
+                                wrap: word-wrap;
+                                color: root.update-state == "error" ? #e5484d : Theme.subtle;
+                            }
+                            HorizontalLayout {
+                                alignment: center;
+                                spacing: Theme.sp-sm;
+                                // Re-checkable from idle / up-to-date / error.
+                                if root.update-state != "available" && root.update-state != "downloading" && root.update-state != "ready": Button {
+                                    text: "Kiểm tra cập nhật…";
+                                    enabled: root.update-state != "checking";
+                                    clicked => { root.check-update(); }
+                                }
+                                if root.update-state == "available" || root.update-state == "downloading": Button {
+                                    text: "Tải và cài đặt";
+                                    enabled: root.update-state != "downloading";
+                                    clicked => { root.install-update(); }
+                                }
+                                if root.update-state == "available": Button {
+                                    text: "Xem thay đổi";
+                                    clicked => { root.open-link("https://github.com/Funput/Funput/releases/latest"); }
+                                }
+                                if root.update-state == "ready": Button {
+                                    text: "Khởi động lại";
+                                    clicked => { root.relaunch-now(); }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## What

Brings the macOS Sparkle auto-update experience to the Windows (Slint) build, plus
two polish fixes, and refactors the release pipeline.

### Windows auto-update (`platforms/windows/src/update.rs`)
- Manual "Kiểm tra cập nhật…" in the tray menu and Settings → Giới thiệu (parity with
  macOS; no background polling).
- Reuses the **same EdDSA key as macOS** (`SPARKLE_ED_PRIVATE_KEY` / public key in the
  macOS `Info.plist`); the `.exe` is verified with `ed25519-dalek` before install.
- Fetches a JSON manifest `funput-windows.json` from the fixed
  `releases/latest/download/…` URL (a redirect, so no REST rate limit) — the Windows
  equivalent of the Sparkle appcast, fully hosted on GitHub Releases.
- On a newer version: download → verify signature → `self-replace` the running exe →
  relaunch. No log-out needed (it is a plain tray process, unlike the macOS IME), and
  since our process writes the file there is no Mark-of-the-Web, so the relaunch does
  not trip SmartScreen.
- Pure logic (version compare, manifest parse, signature verify) is unit-tested; the
  Windows CI job now runs `cargo test`.

### Tray context menu follows the system theme (`src/dark_mode.rs`)
- Opt the process into dark menus via the undocumented `uxtheme` exports
  (`SetPreferredAppMode` / `FlushMenuThemes`). muda themes the menu bar but not popups,
  so the tray's right-click menu now matches Windows light/dark.

### Process display name (`build.rs`)
- Pin the version-resource fields to **"Funput"** so Task Manager shows `Funput`
  instead of `funput-windows`, consistent with macOS/Linux.

### Release CI
- Split the monolithic `release.yml` into reusable workflows: `build-macos.yml`,
  `build-windows.yml` (build + sign feed), `build-linux.yml`. `release.yml` is now a
  thin orchestrator (version → builds → publish).
- New `windows-feed` job signs the `.exe` with Sparkle's `sign_update` (macOS-only
  tool) and emits `funput-windows.json`.
- `workflow_dispatch` gains a `version` input + a `publish` flag for testing the full
  signing/feed pipeline as a **prerelease** without disturbing the `latest` channel.
- Publish now creates a **draft** with assets then flips it to published, to satisfy
  this repo's immutable-releases setting.

## Test plan
- CI smoke test: `gh workflow run release.yml --ref <branch>` (compile only).
- Full pipeline incl. signing: `… -f version=X.Y.Z-rc1` (artifacts only) or
  `… -f version=X.Y.Z-rc1 -f publish=true` (prerelease).
- Local E2E: set `FUNPUT_UPDATE_FEED` (debug build) to a manifest with a higher
  version → check → download → verify → swap → relaunch; tampered signature errors out
  without swapping.
- Dark mode: system dark → right-click tray → menu renders dark.