### PR TITLE
feat(linux): RPM packages + GPG-signed apt/dnf repo (repo.funput.app)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,10 +1,14 @@
 name: Build Linux
 
 # Reusable: builds the shared UI + Settings app + Fcitx5 addon & IBus engine into
-# .debs, natively per arch (no cross-compile) so dpkg-shlibdeps records the right
-# deps. arm64 covers Apple Silicon VMs (Apple Virtualization) and arm servers. Two
-# packages per arch: funput (Fcitx5) and funput-ibus (IBus). Called by release.yml;
-# artifacts (names: linux-<arch>) are picked up by its `publish` job.
+# .debs (Debian/Ubuntu) and .rpms (Fedora/openSUSE), natively per arch (no
+# cross-compile) so the package tool records the right shlib deps. arm64 covers
+# Apple Silicon VMs (Apple Virtualization) and arm servers. Two packages per arch
+# per format: funput (Fcitx5) and funput-ibus (IBus). The `linux` job builds the
+# .debs on Ubuntu; the `linux-rpm` job builds the .rpms in a Fedora container so
+# GNUInstallDirs resolves the rpm-distro libdir (/usr/lib64) and the deps match
+# Fedora package names. Called by release.yml; artifacts (names: linux-<arch> and
+# linux-rpm-<arch>) are picked up by its `publish` job.
 on:
   workflow_call:
     inputs:
@@ -96,4 +100,94 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: linux-${{ matrix.arch }}
+          path: ${{ runner.temp }}/out/*
+
+  # ---- .rpm packages (Fedora container, native per arch) --------------------
+  # Mirrors the `linux` job but on Fedora so the rpm-distro libdir (/usr/lib64),
+  # the Fcitx5/IBus install dirs, and AUTOREQ shlib deps all resolve against
+  # Fedora's layout and package names. Same two packages, .rpm instead of .deb.
+  linux-rpm:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    container: fedora:latest
+    steps:
+      - name: Install build deps
+        run: |
+          # git/tar for actions/checkout; rpm-build so CPack's RPM generator works;
+          # the Fcitx5/IBus/GTK4 -devel packages mirror the apt deps in the `linux`
+          # job. curl (replacing curl-minimal) is for the rustup installer below.
+          dnf install -y --allowerasing --setopt=install_weak_deps=False \
+            git tar gzip which \
+            gcc-c++ cmake make rpm-build pkgconf-pkg-config curl \
+            nlohmann-json-devel \
+            fcitx5-devel \
+            ibus-devel glib2-devel \
+            gtk4-devel libadwaita-devel librsvg2-devel
+
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (rustup, stable)
+        run: |
+          # Pin via rustup rather than Fedora's `rust` package so edition 2024 is
+          # always supported regardless of what `fedora:latest` currently ships.
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Keyed separately from the .deb job (different host/libc) via the suffix.
+          key: rpm-${{ matrix.arch }}
+          workspaces: |
+            . -> target
+            platforms/linux/settings-gtk -> target
+
+      - name: Stamp version from tag
+        if: inputs.version != ''
+        run: |
+          V="${{ inputs.version }}"
+          sed -i -E "0,/^version = \".*\"/s//version = \"$V\"/" platforms/linux/settings-gtk/Cargo.toml
+
+      - name: Build Settings app (GTK4 + libadwaita)
+        working-directory: platforms/linux/settings-gtk
+        run: cargo build --release
+
+      - name: Build addons + .rpms
+        run: |
+          V="${{ inputs.version }}"; V="${V:-1.2026.1}"
+          for fw in fcitx5 ibus; do
+            cmake -S "platforms/linux/$fw" -B "platforms/linux/build/$fw" \
+              -DCMAKE_BUILD_TYPE=Release -DFUNPUT_VERSION="$V"
+            cmake --build "platforms/linux/build/$fw" --parallel
+            ( cd "platforms/linux/build/$fw" && cpack -G RPM )
+          done
+
+      - name: Verify .rpms (rpm can parse them)
+        run: |
+          # Fail fast instead of shipping a broken package: rpm parses the metadata
+          # and we echo the recorded dependencies for the build log.
+          find platforms/linux/build -name '*.rpm' | while read -r f; do
+            echo "== $f =="
+            rpm -qpi "$f" >/dev/null
+            rpm -qp --requires "$f"
+          done
+
+      - name: Stage artifact
+        run: |
+          OUT="$RUNNER_TEMP/out"; mkdir -p "$OUT"
+          find platforms/linux/build -name '*.rpm' | while read -r f; do
+            cp "$f" "$OUT/"
+            sha256sum "$f" | awk '{print $1}' > "$OUT/$(basename "$f").sha256"
+          done
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-rpm-${{ matrix.arch }}
           path: ${{ runner.temp }}/out/*

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -33,7 +33,7 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
           - arch: arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-latest-arm
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
           - arch: arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-latest-arm
     runs-on: ${{ matrix.runner }}
     container: fedora:latest
     steps:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -33,7 +33,7 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
           - arch: arm64
-            runner: ubuntu-latest-arm
+            runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
           - arch: amd64
             runner: ubuntu-latest
           - arch: arm64
-            runner: ubuntu-latest-arm
+            runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     container: fedora:latest
     steps:

--- a/.github/workflows/publish-repo.yml
+++ b/.github/workflows/publish-repo.yml
@@ -1,0 +1,169 @@
+name: Publish package repo
+
+# Phase-2 distribution: take the .deb/.rpm assets of the latest release and serve
+# them as GPG-signed apt + dnf repositories on GitHub Pages, so users get
+# `apt/dnf/zypper upgrade` instead of re-downloading. Stateless: each run rebuilds
+# the whole repo from the current release's assets (the newest version is all a
+# package manager needs to offer an upgrade), so no gh-pages history to maintain.
+#
+# Prerequisites (one-time, see platforms/linux/packaging/repo/README.md):
+#   - Settings → Pages → Source = GitHub Actions.
+#   - Secrets GPG_PRIVATE_KEY (ASCII-armored private key) and GPG_PASSPHRASE.
+#     The key's uid must be `Funput <hello@funput.app>` (matches %_gpg_name below).
+on:
+  release:
+    types: [released]   # fires only for full (non-prerelease) releases
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  # Served under the funput.app brand via a GitHub Pages custom domain. The CNAME
+  # file is written into the Pages artifact (deploy job); DNS needs a CNAME record
+  # repo.funput.app -> <owner>.github.io. Override with the REPO_BASE_URL variable
+  # if the domain ever changes (keep the trailing slash).
+  REPO_URL: ${{ vars.REPO_BASE_URL || 'https://repo.funput.app/' }}
+
+jobs:
+  # ---- apt (flat) repo: signed Packages + InRelease -------------------------
+  apt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install tools
+        run: sudo apt-get update && sudo apt-get install -y apt-utils gnupg jq curl
+
+      - name: Download .deb assets from the release
+        env:
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          mkdir -p tree/deb
+          [ -n "$TAG" ] || TAG="$(curl -fsSL "https://api.github.com/repos/$GH_REPO/releases/latest" | jq -r .tag_name)"
+          curl -fsSL "https://api.github.com/repos/$GH_REPO/releases/tags/$TAG" \
+            | jq -r '.assets[].browser_download_url' | grep '\.deb$' \
+            | while read -r u; do ( cd tree/deb && curl -fsSLO "$u" ); done
+          ls -l tree/deb
+
+      - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+      - name: Build + sign flat apt repo
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          cd tree/deb
+          apt-ftparchive packages . > Packages
+          gzip -kf Packages
+          apt-ftparchive \
+            -o APT::FTPArchive::Release::Origin=Funput \
+            -o APT::FTPArchive::Release::Label=Funput \
+            -o APT::FTPArchive::Release::Suite=stable \
+            -o APT::FTPArchive::Release::Codename=stable \
+            -o APT::FTPArchive::Release::Architectures="amd64 arm64" \
+            -o APT::FTPArchive::Release::Components=main \
+            release . > Release
+          GPG=(gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE")
+          "${GPG[@]}" --clearsign -o InRelease Release
+          "${GPG[@]}" -abs -o Release.gpg Release
+          # Public key users import to trust the repo.
+          gpg --armor --export hello@funput.app > funput.asc
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: apt-tree
+          path: tree/deb
+
+  # ---- dnf/zypper repo: signed packages + signed repomd ---------------------
+  # Runs in Fedora for native rpmsign + createrepo_c.
+  rpm:
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    steps:
+      - name: Install tools
+        run: dnf install -y --setopt=install_weak_deps=False createrepo_c rpm-sign gnupg2 jq curl
+
+      - name: Download .rpm assets from the release
+        env:
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          mkdir -p tree/rpm
+          [ -n "$TAG" ] || TAG="$(curl -fsSL "https://api.github.com/repos/$GH_REPO/releases/latest" | jq -r .tag_name)"
+          curl -fsSL "https://api.github.com/repos/$GH_REPO/releases/tags/$TAG" \
+            | jq -r '.assets[].browser_download_url' | grep '\.rpm$' \
+            | while read -r u; do ( cd tree/rpm && curl -fsSLO "$u" ); done
+          ls -l tree/rpm
+
+      - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+      - name: Sign packages + build + sign repo
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          # rpmsign drives gpg non-interactively via this macro (loopback passphrase).
+          # Written with printf so the macros start at column 0 (rpm ignores indented
+          # ones — a YAML-block heredoc would prepend the run-step indentation).
+          {
+            echo '%_gpg_name hello@funput.app'
+            echo "%__gpg_sign_cmd %{__gpg} gpg --batch --no-armor --pinentry-mode loopback --passphrase $GPG_PASSPHRASE --no-secmem-warning -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}"
+          } > "$HOME/.rpmmacros"
+          rpm --addsign tree/rpm/*.rpm
+          createrepo_c tree/rpm
+          gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" \
+            --detach-sign --armor tree/rpm/repodata/repomd.xml
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rpm-tree
+          path: tree/rpm
+
+  # ---- Assemble + deploy to Pages -------------------------------------------
+  deploy:
+    needs: [apt, rpm]
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with: { name: apt-tree, path: public/deb }
+      - uses: actions/download-artifact@v4
+        with: { name: rpm-tree, path: public/rpm }
+
+      - name: Assemble site (index, .repo, public key)
+        run: |
+          set -euo pipefail
+          # The public key was exported into the apt tree; surface it at the root.
+          mv public/deb/funput.asc public/funput.asc
+          T=platforms/linux/packaging/repo
+          sed "s#@REPO_URL@#${REPO_URL}#g" "$T/index.html.in"  > public/index.html
+          sed "s#@REPO_URL@#${REPO_URL}#g" "$T/funput.repo.in" > public/funput.repo
+          # Custom domain: derive the host from REPO_URL so it tracks the override.
+          echo "${REPO_URL}" | sed -E 's#^https?://([^/]+)/?.*#\1#' > public/CNAME
+          # Stop Pages' Jekyll from eating dotfiles / repodata dirs.
+          touch public/.nojekyll
+          find public -maxdepth 2 -type f | sort
+
+      - uses: actions/upload-pages-artifact@v3
+        with: { path: public }
+
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,10 +119,17 @@ jobs:
             echo "### Windows"
             echo "- \`Funput-*.exe\` — portable, double-click là chạy (nằm ở khay hệ thống). Tự cập nhật trong app (Cài đặt → Giới thiệu → Kiểm tra cập nhật…)."
             echo "### Linux"
-            echo "Chọn gói theo input framework của desktop (chọn đúng kiến trúc — \`dpkg --print-architecture\` — \`amd64\` cho PC x86-64, \`arm64\` cho Apple Silicon VM / máy ARM):"
-            echo "- **GNOME / Ubuntu mặc định (IBus):** \`funput-ibus_*_<arch>.deb\` — \`sudo apt install ./funput-ibus_*_<arch>.deb\`, rồi \`ibus restart\`. **Settings → Keyboard → Input Sources → + → Vietnamese → Funput.**"
-            echo "- **KDE, hoặc muốn đầy đủ (per-app auto-switch) (Fcitx5):** \`funput_*_<arch>.deb\` — \`sudo apt install ./funput_*_<arch>.deb\` (cần Fcitx5), rồi \`fcitx5-configtool\` → thêm **Funput**."
-            echo "  Cả hai: mở **Funput** trong menu ứng dụng để chỉnh Telex/VNI."
+            echo "Chọn gói theo (1) distro — \`.deb\` cho Debian/Ubuntu, \`.rpm\` cho Fedora/openSUSE — và (2) input framework của desktop. Chọn đúng kiến trúc: \`.deb\` dùng \`amd64\`/\`arm64\` (xem \`dpkg --print-architecture\`), \`.rpm\` dùng \`x86_64\`/\`aarch64\` (xem \`uname -m\`)."
+            echo
+            echo "**Debian / Ubuntu (.deb):**"
+            echo "- **GNOME / Ubuntu mặc định (IBus):** \`sudo apt install ./funput-ibus_*_<arch>.deb\`, rồi \`ibus restart\`."
+            echo "- **KDE, hoặc muốn đầy đủ (per-app auto-switch) (Fcitx5):** \`sudo apt install ./funput_*_<arch>.deb\` (cần Fcitx5), rồi \`fcitx5-configtool\` → thêm **Funput**."
+            echo
+            echo "**Fedora / openSUSE (.rpm):**"
+            echo "- **GNOME mặc định (IBus):** \`sudo dnf install ./funput-ibus-*.<arch>.rpm\`, rồi \`ibus restart\`. (openSUSE: \`sudo zypper install\`.)"
+            echo "- **KDE / Fcitx5:** \`sudo dnf install ./funput-*.<arch>.rpm\` (cần Fcitx5), rồi \`fcitx5-configtool\` → thêm **Funput**."
+            echo
+            echo "Sau khi cài (mọi distro): **Settings → Keyboard → Input Sources → + → Vietnamese → Funput**. Mở **Funput** trong menu ứng dụng để chỉnh Telex/VNI."
             echo
             echo "### SHA-256"
             for f in out/*.sha256; do
@@ -140,6 +147,7 @@ jobs:
             out/*.app.zip
             out/*.exe
             out/*.deb
+            out/*.rpm
             out/appcast.xml
             out/*.json
           body_path: notes.md

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -42,9 +42,25 @@ VI–EN bằng hotkey trong addon cũng ghi ngược lại file để UI phản 
 
 Tray + biểu tượng trạng thái dùng luôn của **Fcitx5** (không dựng tray riêng).
 
+## Cài nhanh (mọi distro)
+
+Script tự nhận distro + kiến trúc, tải đúng gói từ GitHub Release mới nhất rồi cài
+bằng package manager bản địa (apt/dnf/zypper; Arch → hướng dẫn AUR):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Funput/Funput/main/platforms/linux/install.sh | bash
+# Mặc định IBus; phiên KDE Plasma mặc định Fcitx5. Ép tay: thêm --ibus hoặc --fcitx5.
+# Ghim phiên bản: --version v1.2026.1
+```
+
+> Đây là lớp "một lệnh" trên **GitHub Releases**, **chưa** có auto-update (chạy lại
+> script để cập nhật). apt và dnf là hai định dạng repo khác nhau → không repo đơn lẻ
+> nào phục vụ mọi distro; chỉ script detect-rồi-tải mới cho trải nghiệm thống nhất.
+> Auto-update qua apt/dnf repo có ký GPG là bước sau (xem mục cuối).
+
 ## Build từ source
 
-Yêu cầu (Debian/Ubuntu):
+Yêu cầu (Debian/Ubuntu — `.deb`):
 
 ```sh
 sudo apt install \
@@ -56,21 +72,38 @@ sudo apt install \
 # Chỉ dựng một shell? Bỏ qua dev-lib của shell kia (fcitx5* hoặc ibus/libibus*).
 ```
 
-Một lệnh dựng cả hai gói `.deb`:
+Yêu cầu (Fedora/openSUSE — `.rpm`):
+
+```sh
+sudo dnf install \
+  gcc-c++ cmake make rpm-build pkgconf-pkg-config nlohmann-json-devel \
+  fcitx5-devel ibus-devel glib2-devel \
+  gtk4-devel libadwaita-devel librsvg2-devel
+# + Rust (rustup). openSUSE: zypper install với tên gói tương đương.
+```
+
+Một lệnh dựng cả hai gói (định dạng tự chọn theo host: `.deb` nếu có `dpkg`, `.rpm`
+nếu có `rpmbuild`; ép tay bằng `FUNPUT_PKG=deb|rpm`):
 
 ```sh
 platforms/linux/build.sh
 # → cargo build -p funput-ffi  (cdylib)
 # → cargo build (Settings app — GTK4 + libadwaita)
 # → cmake + cpack × {fcitx5, ibus}
-# Kết quả:
+# Kết quả (.deb trên Debian/Ubuntu):
 #   platforms/linux/build/fcitx5/funput_<version>_<arch>.deb
 #   platforms/linux/build/ibus/funput-ibus_<version>_<arch>.deb   (arch = host)
+# (.rpm trên Fedora/openSUSE: funput-<version>.<arch>.rpm / funput-ibus-<version>.<arch>.rpm)
 
 # Chỉ một shell:
 FUNPUT_FRAMEWORK=ibus   platforms/linux/build.sh
 FUNPUT_FRAMEWORK=fcitx5 platforms/linux/build.sh
 ```
+
+> **rpm phải build trên distro rpm**, không sinh từ Ubuntu: libdir (`/usr/lib64`),
+> thư mục addon Fcitx5/IBus và dependency đều phải khớp layout + tên gói Fedora. CI
+> dựng `.rpm` trong container `fedora:latest` (xem `.github/workflows/build-linux.yml`,
+> job `linux-rpm`), build native từng kiến trúc — không cross-compile.
 
 Cài thử: `sudo apt install ./platforms/linux/build/fcitx5/funput_*.deb`
 (hoặc `./platforms/linux/build/ibus/funput-ibus_*.deb`).
@@ -92,7 +125,7 @@ Cài thử: `sudo apt install ./platforms/linux/build/fcitx5/funput_*.deb`
 
 ## Cài & bật — IBus (GNOME)
 
-1. Cài gói: `sudo apt install ./.../ibus/funput-ibus_*.deb`.
+1. Cài gói: `sudo apt install ./.../ibus/funput-ibus_*.deb` (Fedora: `sudo dnf install ./.../funput-ibus-*.rpm`).
 2. Nạp lại engine mới đăng ký: `ibus restart` (hoặc đăng nhập lại).
 3. **Settings → Keyboard → Input Sources → +** → **Vietnamese** → **Funput**.
 4. Chuyển nguồn nhập: **`Super + Space`**. Bật/tắt VI–EN khi đang ở Funput: **`Ctrl + `` `**.
@@ -125,8 +158,13 @@ Mở một app GTK (gedit) và một app Qt:
   cấp id app đang focus đáng tin cậy, nhất là trên Wayland. Fcitx5 vẫn hỗ trợ đầy đủ tính năng này.
   App Settings **ẩn hẳn trang "Ứng dụng bỏ qua" khi đang chạy IBus** (phát hiện qua session D-Bus +
   env IM-module), chỉ hiện khi Fcitx5 là IME đang hoạt động.
-- **Chỉ `.deb`** (chưa rpm/AppImage). Hai gói `funput` (Fcitx5) và `funput-ibus` hiện đóng gói riêng,
-  mỗi gói tự bundle `libfunput_ffi.so` + app Settings (gói chung `funput-common` để sau).
+- **`.deb` (Debian/Ubuntu) + `.rpm` (Fedora/openSUSE); Arch qua AUR.** **AppImage không áp dụng** cho
+  bộ gõ: addon Fcitx5/engine IBus phải cài vào thư mục hệ thống mà daemon quét, còn AppImage mount ở
+  path tạm và không cài gì → daemon không thấy. Hai gói `funput` (Fcitx5) và `funput-ibus` hiện đóng gói
+  riêng, mỗi gói tự bundle `libfunput_ffi.so` + app Settings (gói chung `funput-common` để sau).
+- **Auto-update (apt/dnf repo có ký GPG) để sau.** Repo apt + dnf là file tĩnh, host được trên GitHub
+  Pages / R2; mỗi định dạng cần repo + chữ ký GPG riêng (Arch đi đường AUR). Hiện phân phối qua GitHub
+  Release + `install.sh`; chạy lại script để cập nhật.
 - Hotkey `alt_shift` (combo chỉ-modifier) chưa hỗ trợ; UI Linux chỉ hiện `ctrl_backtick`/`ctrl_space`.
 - Settings **áp dụng tức thì** qua theo dõi file (inotify, `common/settings_watch.*`): Fcitx5 wire fd
   vào event loop riêng, IBus qua `g_unix_fd_add` trên GLib loop; vẫn giữ fallback so mtime lúc focus-in.

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -162,9 +162,11 @@ Mở một app GTK (gedit) và một app Qt:
   bộ gõ: addon Fcitx5/engine IBus phải cài vào thư mục hệ thống mà daemon quét, còn AppImage mount ở
   path tạm và không cài gì → daemon không thấy. Hai gói `funput` (Fcitx5) và `funput-ibus` hiện đóng gói
   riêng, mỗi gói tự bundle `libfunput_ffi.so` + app Settings (gói chung `funput-common` để sau).
-- **Auto-update (apt/dnf repo có ký GPG) để sau.** Repo apt + dnf là file tĩnh, host được trên GitHub
-  Pages / R2; mỗi định dạng cần repo + chữ ký GPG riêng (Arch đi đường AUR). Hiện phân phối qua GitHub
-  Release + `install.sh`; chạy lại script để cập nhật.
+- **Auto-update qua kho apt/dnf có ký GPG** tại `repo.funput.app`: kho tĩnh trên GitHub Pages (custom
+  domain), dựng bởi `.github/workflows/publish-repo.yml` mỗi khi có release chính thức — người dùng
+  `apt/dnf/zypper upgrade` như bình thường. Thiết lập (khóa GPG + secrets + Pages + DNS):
+  [`packaging/repo/README.md`](packaging/repo/README.md). GitHub Release + `install.sh` vẫn là kênh
+  tải trực tiếp song song. Kênh *official* của distro (OBS/COPR/PPA) là bước sau.
 - Hotkey `alt_shift` (combo chỉ-modifier) chưa hỗ trợ; UI Linux chỉ hiện `ctrl_backtick`/`ctrl_space`.
 - Settings **áp dụng tức thì** qua theo dõi file (inotify, `common/settings_watch.*`): Fcitx5 wire fd
   vào event loop riêng, IBus qua `g_unix_fd_add` trên GLib loop; vẫn giữ fallback so mtime lúc focus-in.

--- a/platforms/linux/build.sh
+++ b/platforms/linux/build.sh
@@ -1,19 +1,32 @@
 #!/usr/bin/env bash
 # Build the Funput Linux package(s): Rust core + Settings UI + input-method
-# shell(s), bundled into .deb(s). Run on Debian/Ubuntu with the build deps
-# installed (see platforms/linux/README.md).
+# shell(s), bundled into a .deb (Debian/Ubuntu) or .rpm (Fedora/openSUSE). Run on
+# the matching distro with the build deps installed (see platforms/linux/README.md).
 #
 # Usage: platforms/linux/build.sh [build-dir]
 #   FUNPUT_FRAMEWORK=fcitx5|ibus|all   which shell(s) to package (default: all)
+#   FUNPUT_PKG=deb|rpm                 package format (default: auto from host)
 #
-# Each shell builds into <build-dir>/<framework>/ and yields its own .deb:
-# fcitx5 → funput_<ver>_<arch>.deb, ibus → funput-ibus_<ver>_<arch>.deb.
+# Each shell builds into <build-dir>/<framework>/ and yields its own package:
+# fcitx5 → funput_<ver>_<arch>.deb, ibus → funput-ibus_<ver>_<arch>.deb
+# (.rpm on Fedora/openSUSE: funput-<ver>.<arch>.rpm / funput-ibus-<ver>.<arch>.rpm).
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_ROOT="$(cd "${HERE}/../.." && pwd)"
 BUILD_DIR="${1:-${HERE}/build}"
 FRAMEWORK="${FUNPUT_FRAMEWORK:-all}"
+
+# Package format: explicit override, else pick by what's available on the host —
+# dpkg → .deb (Debian/Ubuntu), rpmbuild → .rpm (Fedora/openSUSE).
+PKG="${FUNPUT_PKG:-}"
+if [ -z "${PKG}" ]; then
+    if command -v dpkg >/dev/null 2>&1; then PKG="deb"
+    elif command -v rpmbuild >/dev/null 2>&1; then PKG="rpm"
+    else echo "No dpkg or rpmbuild found; set FUNPUT_PKG=deb|rpm." >&2; exit 1
+    fi
+fi
+CPACK_GEN="$(echo "${PKG}" | tr '[:lower:]' '[:upper:]')"  # deb→DEB, rpm→RPM
 
 # Shared steps (run once, reused by every shell).
 echo "==> [1/2] Rust core (funput-ffi cdylib)"
@@ -24,13 +37,13 @@ echo "==> [2/2] Settings app (GTK4 + libadwaita)"
 # excluded from the root workspace so macOS/Windows `cargo test --workspace` stays green.
 cargo build --release --manifest-path "${HERE}/settings-gtk/Cargo.toml"
 
-# Build one shell into its own subdir and produce a .deb via CPack.
+# Build one shell into its own subdir and produce a package via CPack.
 build_shell() {
     local name="$1" out="${BUILD_DIR}/$1"
-    echo "==> ${name} shell + .deb (CMake/CPack)"
+    echo "==> ${name} shell + .${PKG} (CMake/CPack)"
     cmake -S "${HERE}/${name}" -B "${out}" -DCMAKE_BUILD_TYPE=Release
     cmake --build "${out}" --parallel
-    ( cd "${out}" && cpack -G DEB )
+    ( cd "${out}" && cpack -G "${CPACK_GEN}" )
 }
 
 case "${FRAMEWORK}" in
@@ -41,4 +54,4 @@ case "${FRAMEWORK}" in
 esac
 
 echo "==> Done. Package(s):"
-find "${BUILD_DIR}" -maxdepth 2 -name '*.deb'
+find "${BUILD_DIR}" -maxdepth 2 -name "*.${PKG}"

--- a/platforms/linux/fcitx5/CMakeLists.txt
+++ b/platforms/linux/fcitx5/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 project(funput-fcitx5 VERSION 1.2026.1 LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+# C++20: Fcitx5 5.1+ public headers (log.h, stringutils.h) use std::span and
+# std::string_view::starts_with/ends_with. Fedora ships that newer Fcitx5, so 17
+# fails to compile its headers; Ubuntu's older Fcitx5 builds fine at 20 too.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)

--- a/platforms/linux/fcitx5/CMakeLists.txt
+++ b/platforms/linux/fcitx5/CMakeLists.txt
@@ -91,12 +91,11 @@ else()
                     "packaging the Fcitx5 addon only (no Settings GUI).")
 endif()
 
-# --- .deb packaging (CPack) ------------------------------------------------
+# --- Packaging (CPack: .deb + .rpm) ----------------------------------------
 # CI overrides this from the git tag (-DFUNPUT_VERSION=...); otherwise project().
 set(FUNPUT_VERSION "${PROJECT_VERSION}" CACHE STRING "Package version")
-set(CPACK_GENERATOR "DEB")
 # Lay the relative installs (bin, share/…) under /usr to match the absolute
-# Fcitx5 addon dirs — everything in the .deb lives under /usr.
+# Fcitx5 addon dirs — everything in the package lives under /usr.
 set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
 set(CPACK_PACKAGE_NAME "funput")
 set(CPACK_PACKAGE_VERSION "${FUNPUT_VERSION}")
@@ -121,4 +120,23 @@ else()
 endif()
 set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${FUNPUT_DEB_ARCH}")
 set(CPACK_PACKAGE_FILE_NAME "funput_${FUNPUT_VERSION}_${FUNPUT_DEB_ARCH}")
+
+# --- .rpm packaging (CPack, Fedora/openSUSE) -------------------------------
+# Both generators are listed; CI selects one per host with `cpack -G DEB|RPM`
+# (a Fedora runner produces the .rpm so GNUInstallDirs/FCITX_INSTALL_ADDONDIR
+# resolve the rpm-distro libdir — /usr/lib64 — and shlib deps match Fedora pkgs).
+# The CPACK_RPM_* fields below are ignored when the DEB generator runs.
+set(CPACK_GENERATOR "DEB;RPM")
+set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+set(CPACK_RPM_PACKAGE_GROUP "Applications/System")
+set(CPACK_RPM_PACKAGE_URL "https://github.com/Funput/Funput")
+# fcitx5 must be present; AUTOREQ picks up the shared-lib deps automatically.
+set(CPACK_RPM_PACKAGE_REQUIRES "fcitx5")
+set(CPACK_RPM_PACKAGE_AUTOREQ ON)
+# RPM arch names differ from dpkg's (x86_64/aarch64, not amd64/arm64); take them
+# from the native build host. dpkg is absent on Fedora, so this is independent of
+# FUNPUT_DEB_ARCH above (which falls back to amd64 there but is unused for RPM).
+set(CPACK_RPM_PACKAGE_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}")
+set(CPACK_RPM_FILE_NAME "funput-${FUNPUT_VERSION}.${CMAKE_SYSTEM_PROCESSOR}.rpm")
+
 include(CPack)

--- a/platforms/linux/ibus/CMakeLists.txt
+++ b/platforms/linux/ibus/CMakeLists.txt
@@ -95,10 +95,9 @@ else()
                     "packaging the IBus engine only (no Settings GUI).")
 endif()
 
-# --- .deb packaging (CPack) ------------------------------------------------
+# --- Packaging (CPack: .deb + .rpm) ----------------------------------------
 # FUNPUT_VERSION is defined near the top (project() default; CI overrides with
 # -DFUNPUT_VERSION=<tag>).
-set(CPACK_GENERATOR "DEB")
 set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
 set(CPACK_PACKAGE_NAME "funput-ibus")
 set(CPACK_PACKAGE_VERSION "${FUNPUT_VERSION}")
@@ -121,4 +120,23 @@ else()
 endif()
 set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${FUNPUT_DEB_ARCH}")
 set(CPACK_PACKAGE_FILE_NAME "funput-ibus_${FUNPUT_VERSION}_${FUNPUT_DEB_ARCH}")
+
+# --- .rpm packaging (CPack, Fedora/openSUSE) -------------------------------
+# Both generators are listed; CI selects one per host with `cpack -G DEB|RPM`
+# (a Fedora runner produces the .rpm so GNUInstallDirs/IBUS_LIBEXECDIR resolve
+# the rpm-distro libdir — /usr/lib64 — and shlib deps match Fedora pkgs).
+# The CPACK_RPM_* fields below are ignored when the DEB generator runs.
+set(CPACK_GENERATOR "DEB;RPM")
+set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+set(CPACK_RPM_PACKAGE_GROUP "Applications/System")
+set(CPACK_RPM_PACKAGE_URL "https://github.com/Funput/Funput")
+# ibus must be present; AUTOREQ picks up the shared-lib deps automatically.
+set(CPACK_RPM_PACKAGE_REQUIRES "ibus")
+set(CPACK_RPM_PACKAGE_AUTOREQ ON)
+# RPM arch names differ from dpkg's (x86_64/aarch64, not amd64/arm64); take them
+# from the native build host. dpkg is absent on Fedora, so this is independent of
+# FUNPUT_DEB_ARCH above (which falls back to amd64 there but is unused for RPM).
+set(CPACK_RPM_PACKAGE_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}")
+set(CPACK_RPM_FILE_NAME "funput-ibus-${FUNPUT_VERSION}.${CMAKE_SYSTEM_PROCESSOR}.rpm")
+
 include(CPack)

--- a/platforms/linux/install.sh
+++ b/platforms/linux/install.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Funput Linux installer: detect the distro + arch, pick the matching package from
+# the latest GitHub release, and install it with the native package manager.
+#
+# This is the "one command, auto-detect" front end over GitHub Releases — there is
+# no hosted apt/dnf repo yet, so it downloads a versioned asset and installs it
+# (no automatic upgrades; re-run this script to update). Apt and dnf are different
+# repo formats, so a single repo can never serve every distro — only this kind of
+# detect-then-fetch script gives the unified experience.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/Funput/Funput/main/platforms/linux/install.sh | bash
+#   ./install.sh [--ibus | --fcitx5] [--version vX.Y.Z]
+#
+# Framework: defaults to IBus, except KDE Plasma sessions default to Fcitx5.
+# Override with --ibus / --fcitx5.
+set -euo pipefail
+
+REPO="Funput/Funput"
+FRAMEWORK=""        # "ibus" | "fcitx5"; empty = auto-detect
+VERSION="latest"    # "latest" or a tag like v1.2026.1
+
+die() { echo "Error: $*" >&2; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ibus)    FRAMEWORK="ibus" ;;
+    --fcitx5)  FRAMEWORK="fcitx5" ;;
+    --version) shift; VERSION="${1:?--version needs a tag}" ;;
+    -h|--help)
+      sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) die "unknown argument: $1 (try --help)" ;;
+  esac
+  shift
+done
+
+# --- Distro family ---------------------------------------------------------
+[ -r /etc/os-release ] || die "cannot read /etc/os-release; unsupported system"
+# shellcheck disable=SC1091
+. /etc/os-release
+# Match on ID first, then ID_LIKE so derivatives (Linux Mint, Pop!_OS, Nobara,
+# openSUSE variants, Manjaro/EndeavourOS) resolve to the right family.
+case " ${ID:-} ${ID_LIKE:-} " in
+  *" debian "*|*" ubuntu "*) FAMILY="debian" ;;
+  *" fedora "*|*" rhel "*)   FAMILY="fedora" ;;
+  *" suse "*|*" opensuse "*) FAMILY="suse" ;;
+  *" arch "*)                FAMILY="arch" ;;
+  *) die "unsupported distro (ID=${ID:-?}, ID_LIKE=${ID_LIKE:-?}). Build from source: platforms/linux/build.sh" ;;
+esac
+
+# Arch is community-packaged via the AUR, not a release asset.
+if [ "$FAMILY" = "arch" ]; then
+  cat >&2 <<'EOF'
+Arch Linux is packaged through the AUR, not the GitHub release assets.
+Install with an AUR helper, e.g.:
+  yay -S funput-ibus     # IBus (GNOME)
+  yay -S funput          # Fcitx5 (KDE / full features)
+EOF
+  exit 1
+fi
+
+# --- Framework -------------------------------------------------------------
+if [ -z "$FRAMEWORK" ]; then
+  case " ${XDG_CURRENT_DESKTOP:-} " in
+    *KDE*|*plasma*|*Plasma*) FRAMEWORK="fcitx5" ;;
+    *) FRAMEWORK="ibus" ;;
+  esac
+  echo "Auto-selected framework: $FRAMEWORK (override with --ibus / --fcitx5)"
+fi
+
+# --- Arch + package-name pattern -------------------------------------------
+# .deb uses amd64/arm64; .rpm uses x86_64/aarch64. The CPack file names are:
+#   deb  funput_<v>_<arch>.deb        funput-ibus_<v>_<arch>.deb
+#   rpm  funput-<v>.<arch>.rpm        funput-ibus-<v>.<arch>.rpm
+MACHINE="$(uname -m)"
+if [ "$FAMILY" = "debian" ]; then
+  FORMAT="deb"
+  case "$MACHINE" in
+    x86_64) PKG_ARCH="amd64" ;;
+    aarch64|arm64) PKG_ARCH="arm64" ;;
+    *) die "unsupported CPU arch: $MACHINE" ;;
+  esac
+  if [ "$FRAMEWORK" = "ibus" ]; then
+    PATTERN="funput-ibus_[^/]*_${PKG_ARCH}\.deb"
+  else
+    PATTERN="funput_[^/]*_${PKG_ARCH}\.deb"
+  fi
+else
+  # fedora + suse → .rpm
+  FORMAT="rpm"
+  case "$MACHINE" in
+    x86_64) PKG_ARCH="x86_64" ;;
+    aarch64|arm64) PKG_ARCH="aarch64" ;;
+    *) die "unsupported CPU arch: $MACHINE" ;;
+  esac
+  if [ "$FRAMEWORK" = "ibus" ]; then
+    PATTERN="funput-ibus-[^/]*\.${PKG_ARCH}\.rpm"
+  else
+    # funput- followed by a digit = version, to not match funput-ibus-*.
+    PATTERN="funput-[0-9][^/]*\.${PKG_ARCH}\.rpm"
+  fi
+fi
+
+# --- Resolve the download URL from the GitHub release ----------------------
+have curl || die "curl is required"
+if [ "$VERSION" = "latest" ]; then
+  API="https://api.github.com/repos/${REPO}/releases/latest"
+else
+  API="https://api.github.com/repos/${REPO}/releases/tags/${VERSION}"
+fi
+
+echo "Looking up ${FRAMEWORK} ${FORMAT} (${PKG_ARCH}) in ${REPO} ${VERSION} release…"
+# Pull browser_download_url lines from the API JSON and pick the one matching the
+# package pattern. Avoids a jq dependency on the user's machine.
+URL="$(curl -fsSL "$API" \
+  | grep -Eo '"browser_download_url": *"[^"]*"' \
+  | sed -E 's/.*"(https[^"]*)".*/\1/' \
+  | grep -E "/${PATTERN}$" \
+  | head -n1 || true)"
+[ -n "$URL" ] || die "no matching asset (${PATTERN}) in the ${VERSION} release"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FILE="$TMP/$(basename "$URL")"
+echo "Downloading $(basename "$URL")…"
+curl -fsSL "$URL" -o "$FILE"
+
+# Verify the checksum if the release ships a sibling <file>.sha256.
+if SUM="$(curl -fsSL "${URL}.sha256" 2>/dev/null)" && [ -n "$SUM" ]; then
+  echo "$SUM  $FILE" | sha256sum -c - >/dev/null \
+    && echo "Checksum OK." \
+    || die "checksum mismatch — download corrupt, retry"
+fi
+
+# --- Install ---------------------------------------------------------------
+SUDO=""
+[ "$(id -u)" -eq 0 ] || SUDO="sudo"
+echo "Installing $(basename "$FILE")…"
+case "$FAMILY" in
+  debian) $SUDO apt-get install -y "$FILE" ;;
+  fedora) $SUDO dnf install -y "$FILE" ;;
+  suse)   $SUDO zypper --non-interactive install --allow-unsigned-rpm "$FILE" ;;
+esac
+
+# --- Post-install hint -----------------------------------------------------
+echo
+echo "Installed. Next steps:"
+if [ "$FRAMEWORK" = "ibus" ]; then
+  echo "  1. ibus restart            # load the newly registered engine"
+  echo "  2. Settings → Keyboard → Input Sources → + → Vietnamese → Funput"
+else
+  echo "  1. fcitx5-configtool       # + → add Funput (Vietnamese group)"
+  echo "  2. log out/in if Fcitx5 was not already running"
+fi
+echo "  Open \"Funput\" from the app menu to switch Telex/VNI."

--- a/platforms/linux/packaging/repo/README.md
+++ b/platforms/linux/packaging/repo/README.md
@@ -1,0 +1,77 @@
+# Kho phần mềm Funput — vận hành (maintainer)
+
+> **Đối tượng: maintainer/người vận hành kho**, không phải người dùng cuối.
+> Người dùng cài đặt tại **https://repo.funput.app** (trang `index.html`) hoặc theo
+> mục cài đặt trong [`platforms/linux/README.md`](../../README.md). File này ghi cách
+> *dựng* và *bảo trì* kho (khóa GPG, secrets, Pages, DNS).
+
+Phân phối Phase 2: biến `.deb`/`.rpm` của bản release mới nhất thành **kho apt + dnf
+có ký GPG**, host trên **GitHub Pages**, để người dùng `apt/dnf/zypper upgrade` thay vì
+tải lại tay. Build bởi [`.github/workflows/publish-repo.yml`](../../../../.github/workflows/publish-repo.yml),
+tự chạy mỗi khi có release chính thức (không phải prerelease).
+
+> Đây là kho "bên thứ ba" (như Docker/VS Code): người dùng tin **khóa của bạn** và URL
+> Pages. Khác với kênh *official* của distro (OBS/COPR/PPA) — cái đó để Phase 3.
+
+## Thiết lập một lần
+
+### 1. Tạo khóa ký GPG
+Dùng **RSA 4096** cho tương thích rộng nhất (apt lẫn rpm đều nhận); uid **phải** là
+`Funput <hello@funput.app>` (khớp `%_gpg_name` trong workflow):
+
+```sh
+gpg --batch --full-generate-key <<'EOF'
+Key-Type: RSA
+Key-Length: 4096
+Name-Real: Funput
+Name-Email: hello@funput.app
+Expire-Date: 0
+Passphrase: <đặt-mật-khẩu-mạnh>
+%commit
+EOF
+
+# Xuất khóa BÍ MẬT (dán vào secret GPG_PRIVATE_KEY):
+gpg --armor --export-secret-keys hello@funput.app
+```
+
+> Giữ khóa bí mật an toàn (vault/password manager). Mất khóa = phải phát hành khóa mới
+> và mọi người phải import lại. Khóa công khai do CI tự xuất (`funput.asc`), không cần commit.
+
+### 2. Đặt secrets của repo
+Settings → Secrets and variables → Actions:
+- `GPG_PRIVATE_KEY` — toàn bộ khối `-----BEGIN PGP PRIVATE KEY BLOCK----- … END …`.
+- `GPG_PASSPHRASE` — mật khẩu của khóa trên.
+
+### 3. Bật GitHub Pages + custom domain `repo.funput.app`
+Kho phục vụ dưới thương hiệu funput.app qua subdomain riêng (tách hẳn site marketing —
+**không** nhồi `.deb`/`.rpm` vào image web Angular):
+
+1. Settings → Pages → **Source = GitHub Actions**. (Workflow tự deploy, không cần nhánh `gh-pages`.)
+2. DNS: thêm bản ghi **CNAME `repo` → `<owner>.github.io`** (vd `Funput.github.io`). Để DNS phân giải
+   xong rồi mới chạy workflow.
+3. File `CNAME` (chứa `repo.funput.app`) do workflow tự ghi vào artifact Pages — không cần commit.
+
+Đổi domain khác? Đặt variable `REPO_BASE_URL` = URL mới (vd `https://linux.funput.app/`, **giữ `/`
+cuối**); workflow tự suy host cho `CNAME` từ đó. Không đặt thì mặc định `https://repo.funput.app/`.
+
+### 4. Chạy
+Tự chạy khi release `released`. Chạy tay: Actions → **Publish package repo** → Run workflow.
+Xong, trang cài đặt nằm ở URL Pages (xem mục cuối `index.html.in` để biết các lệnh người dùng).
+
+## Hoạt động thế nào (tóm tắt)
+- **apt** (job `apt`): tải `.deb` của release → `apt-ftparchive` tạo `Packages`/`Release` →
+  ký `InRelease` + `Release.gpg`. Kho **phẳng** (`deb … ./`).
+- **dnf/zypper** (job `rpm`, container Fedora): `rpm --addsign` từng gói → `createrepo_c` →
+  ký `repodata/repomd.xml`. Người dùng đặt `gpgcheck=1` + `repo_gpgcheck=1`.
+- **deploy**: gộp `public/{deb,rpm}` + `funput.asc` + `index.html` + `funput.repo`, đẩy lên Pages.
+
+Mỗi lần chạy **dựng lại toàn bộ** từ release hiện tại (stateless) — package manager chỉ cần
+phiên bản mới nhất để chào upgrade, nên không cần giữ lịch sử gh-pages.
+
+## Giới hạn / lưu ý
+- Người dùng phải tin khóa của bạn (one-time `rpm --import` / `signed-by`). Để có dấu tin cậy
+  của distro thì cần OBS/COPR/PPA (Phase 3).
+- Kho chỉ chứa **bản mới nhất**; không phục vụ cài lại phiên bản cũ qua kho (vẫn tải được từ
+  GitHub Releases).
+- RPM ký gói + ký repomd; APT ký Release. Khóa hết hạn = `Expire-Date: 0` (vô hạn) để khỏi gãy
+  kho; nếu đặt hạn, nhớ gia hạn và chạy lại workflow trước khi hết hạn.

--- a/platforms/linux/packaging/repo/funput.repo.in
+++ b/platforms/linux/packaging/repo/funput.repo.in
@@ -1,0 +1,9 @@
+# dnf/zypper repository for Funput (Vietnamese input method).
+# @REPO_URL@ is substituted by the publish-repo workflow with the Pages base URL.
+[funput]
+name=Funput (Vietnamese input method)
+baseurl=@REPO_URL@rpm/
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=@REPO_URL@funput.asc

--- a/platforms/linux/packaging/repo/index.html.in
+++ b/platforms/linux/packaging/repo/index.html.in
@@ -7,51 +7,224 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Funput — kho phần mềm Linux</title>
 <style>
-  :root { color-scheme: light dark; }
-  body { max-width: 760px; margin: 2rem auto; padding: 0 1rem;
-         font: 16px/1.6 system-ui, sans-serif; }
-  h1 { margin-bottom: .2rem; }
-  p.lead { color: #888; margin-top: 0; }
-  h2 { margin-top: 2rem; }
-  pre { background: #1113; padding: 1rem; border-radius: 8px; overflow-x: auto; }
-  code { font-family: ui-monospace, monospace; }
-  .note { font-size: .9rem; color: #888; }
-  small { color: #888; }
+  :root {
+    color-scheme: light dark;
+    --bg: #fbfbfd; --fg: #1d1d1f; --muted: #6e6e73; --card: #fff;
+    --line: #e6e6eb; --code-bg: #f5f5f7; --code-fg: #1d1d1f;
+    --accent: #6d5efc; --ibus: #2f7de1; --fcitx: #8b5cf6;
+    --radius: 14px;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0c0c0f; --fg: #f5f5f7; --muted: #9a9aa2; --card: #161619;
+      --line: #2a2a31; --code-bg: #1d1d22; --code-fg: #e8e8ea;
+      --ibus: #5ea0f2; --fcitx: #a78bfa;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font: 16px/1.65 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 820px; margin: 0 auto; padding: 3rem 1.25rem 4rem; }
+
+  header { text-align: center; margin-bottom: 2.5rem; }
+  .logo {
+    width: 64px; height: 64px; border-radius: 16px; margin: 0 auto .9rem;
+    background: linear-gradient(135deg, var(--accent), #b06dfc);
+    display: grid; place-items: center; color: #fff; font-size: 30px; font-weight: 700;
+    box-shadow: 0 8px 24px -8px var(--accent);
+  }
+  h1 { font-size: 2rem; margin: 0 0 .3rem; letter-spacing: -.02em; }
+  .lead { color: var(--muted); margin: 0; font-size: 1.05rem; }
+
+  .pick {
+    display: flex; gap: .75rem; flex-wrap: wrap; justify-content: center;
+    margin: 1.6rem 0 2.5rem;
+  }
+  .pick .opt {
+    flex: 1 1 320px; background: var(--card); border: 1px solid var(--line);
+    border-radius: var(--radius); padding: 1rem 1.1rem;
+  }
+  .pick .opt b { display: block; margin-bottom: .15rem; }
+  .pick .opt small { color: var(--muted); }
+  .badge {
+    display: inline-block; font-size: .72rem; font-weight: 700; letter-spacing: .03em;
+    text-transform: uppercase; padding: .15rem .5rem; border-radius: 999px;
+    color: #fff; vertical-align: middle;
+  }
+  .badge.ibus  { background: var(--ibus); }
+  .badge.fcitx { background: var(--fcitx); }
+
+  .card {
+    background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 1.4rem 1.5rem; margin-bottom: 1.5rem;
+  }
+  .card h2 { margin: 0 0 1rem; font-size: 1.25rem; display: flex; align-items: center; gap: .6rem; }
+  .step { font-size: .82rem; font-weight: 700; color: var(--muted);
+          text-transform: uppercase; letter-spacing: .04em; margin: 1.1rem 0 .45rem; }
+  .step:first-of-type { margin-top: 0; }
+
+  .cmd { position: relative; margin: 0 0 .6rem; }
+  pre {
+    margin: 0; background: var(--code-bg); color: var(--code-fg);
+    padding: .85rem 3.2rem .85rem 1rem; border-radius: 10px; overflow-x: auto;
+    font: 13.5px/1.6 ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+  .copy {
+    position: absolute; top: .5rem; right: .5rem; border: 1px solid var(--line);
+    background: var(--card); color: var(--muted); font-size: .72rem; font-weight: 600;
+    padding: .25rem .55rem; border-radius: 7px; cursor: pointer; transition: .15s;
+  }
+  .copy:hover { color: var(--fg); border-color: var(--muted); }
+  .copy.done { color: #fff; background: #34a853; border-color: #34a853; }
+
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem 1.4rem; }
+  @media (max-width: 620px) { .grid { grid-template-columns: 1fr; } }
+  .grid .lbl { margin-bottom: .4rem; }
+
+  .note {
+    background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 1.1rem 1.3rem; color: var(--muted); font-size: .95rem; margin-top: 2rem;
+  }
+  .note b { color: var(--fg); }
+  footer { text-align: center; color: var(--muted); font-size: .85rem; margin-top: 2rem; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code.inline { background: var(--code-bg); padding: .1rem .35rem; border-radius: 5px;
+                font: 13px ui-monospace, monospace; }
 </style>
 </head>
 <body>
-<h1>Funput</h1>
-<p class="lead">Bộ gõ tiếng Việt cho Linux — kho cài đặt &amp; cập nhật tự động.</p>
+<div class="wrap">
 
-<p>Chọn <strong>IBus</strong> (GNOME mặc định) hoặc <strong>Fcitx5</strong> (KDE / đầy đủ tính năng).
-Sau khi thêm kho, cập nhật về sau chỉ là <code>apt/dnf/zypper upgrade</code> bình thường.</p>
+  <header>
+    <div class="logo">F</div>
+    <h1>Funput</h1>
+    <p class="lead">Bộ gõ tiếng Việt cho Linux — kho cài đặt &amp; cập nhật tự động.</p>
+  </header>
 
-<h2>Debian / Ubuntu (.deb)</h2>
-<pre><code>sudo install -d /usr/share/keyrings
+  <div class="pick">
+    <div class="opt">
+      <span class="badge ibus">IBus</span>
+      <b style="margin-top:.4rem">GNOME / Ubuntu mặc định</b>
+      <small>Cài sẵn trên hầu hết desktop. Gói <code class="inline">funput-ibus</code>.</small>
+    </div>
+    <div class="opt">
+      <span class="badge fcitx">Fcitx5</span>
+      <b style="margin-top:.4rem">KDE, hoặc muốn đầy đủ tính năng</b>
+      <small>Per-app auto-switch. Gói <code class="inline">funput</code>.</small>
+    </div>
+  </div>
+
+  <!-- Debian / Ubuntu -->
+  <div class="card">
+    <h2>🐧 Debian / Ubuntu <small style="color:var(--muted);font-weight:400;font-size:.9rem">(.deb)</small></h2>
+
+    <div class="step">1 · Thêm kho (làm một lần)</div>
+    <div class="cmd"><button class="copy">Copy</button><pre><code>sudo install -d /usr/share/keyrings
 curl -fsSL @REPO_URL@funput.asc | sudo tee /usr/share/keyrings/funput.asc >/dev/null
-echo "deb [signed-by=/usr/share/keyrings/funput.asc] @REPO_URL@deb ./" \
-  | sudo tee /etc/apt/sources.list.d/funput.list
-sudo apt update
-sudo apt install funput-ibus    # hoặc: funput  (Fcitx5)</code></pre>
+echo "deb [signed-by=/usr/share/keyrings/funput.asc] @REPO_URL@deb ./" | sudo tee /etc/apt/sources.list.d/funput.list
+sudo apt update</code></pre></div>
 
-<h2>Fedora (.rpm)</h2>
-<pre><code>sudo dnf config-manager --add-repo @REPO_URL@funput.repo
-sudo dnf install funput-ibus    # hoặc: funput  (Fcitx5)</code></pre>
+    <div class="step">2 · Cài đặt</div>
+    <div class="grid">
+      <div>
+        <div class="lbl"><span class="badge ibus">IBus</span></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo apt install funput-ibus</code></pre></div>
+      </div>
+      <div>
+        <div class="lbl"><span class="badge fcitx">Fcitx5</span></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo apt install funput</code></pre></div>
+      </div>
+    </div>
+  </div>
 
-<h2>openSUSE (.rpm)</h2>
-<pre><code>sudo rpm --import @REPO_URL@funput.asc
+  <!-- Fedora -->
+  <div class="card">
+    <h2>🎩 Fedora <small style="color:var(--muted);font-weight:400;font-size:.9rem">(.rpm)</small></h2>
+
+    <div class="step">1 · Thêm kho (làm một lần)</div>
+    <div class="cmd"><button class="copy">Copy</button><pre><code>sudo dnf config-manager --add-repo @REPO_URL@funput.repo</code></pre></div>
+
+    <div class="step">2 · Cài đặt</div>
+    <div class="grid">
+      <div>
+        <div class="lbl"><span class="badge ibus">IBus</span></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo dnf install funput-ibus</code></pre></div>
+      </div>
+      <div>
+        <div class="lbl"><span class="badge fcitx">Fcitx5</span></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo dnf install funput</code></pre></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- openSUSE -->
+  <div class="card">
+    <h2>🦎 openSUSE <small style="color:var(--muted);font-weight:400;font-size:.9rem">(.rpm)</small></h2>
+
+    <div class="step">1 · Thêm kho (làm một lần)</div>
+    <div class="cmd"><button class="copy">Copy</button><pre><code>sudo rpm --import @REPO_URL@funput.asc
 sudo zypper addrepo -gf @REPO_URL@rpm/ funput
-sudo zypper install funput-ibus # hoặc: funput  (Fcitx5)</code></pre>
+sudo zypper refresh</code></pre></div>
 
-<h2>Arch Linux</h2>
-<p>Cài qua AUR: <code>yay -S funput-ibus</code> hoặc <code>yay -S funput</code>.</p>
+    <div class="step">2 · Cài đặt</div>
+    <div class="grid">
+      <div>
+        <div class="lbl"><span class="badge ibus">IBus</span></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo zypper install funput-ibus</code></pre></div>
+      </div>
+      <div>
+        <div class="lbl"><span class="badge fcitx">Fcitx5</span></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo zypper install funput</code></pre></div>
+      </div>
+    </div>
+  </div>
 
-<p class="note">Sau khi cài: <strong>Settings → Keyboard → Input Sources → + → Vietnamese → Funput</strong>
-(IBus cần <code>ibus restart</code>; Fcitx5 dùng <code>fcitx5-configtool</code>). Mở <strong>Funput</strong>
-trong menu ứng dụng để chỉnh Telex/VNI.</p>
+  <!-- Arch -->
+  <div class="card">
+    <h2>🏛️ Arch Linux <small style="color:var(--muted);font-weight:400;font-size:.9rem">(AUR)</small></h2>
+    <div class="step">Cài qua AUR helper (vd <code class="inline">yay</code>)</div>
+    <div class="grid">
+      <div>
+        <div class="lbl"><span class="badge ibus">IBus</span></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>yay -S funput-ibus</code></pre></div>
+      </div>
+      <div>
+        <div class="lbl"><span class="badge fcitx">Fcitx5</span></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>yay -S funput</code></pre></div>
+      </div>
+    </div>
+  </div>
 
-<hr>
-<p><small>Khóa ký công khai: <a href="@REPO_URL@funput.asc">funput.asc</a> ·
-Mã nguồn: <a href="https://github.com/Funput/Funput">github.com/Funput/Funput</a></small></p>
+  <div class="note">
+    <b>Sau khi cài:</b> <span class="badge ibus">IBus</span> chạy <code class="inline">ibus restart</code>
+    rồi <b>Settings → Keyboard → Input Sources → + → Vietnamese → Funput</b>.
+    <span class="badge fcitx">Fcitx5</span> mở <code class="inline">fcitx5-configtool</code> → thêm
+    <b>Funput</b> (nhóm Vietnamese). Mở <b>Funput</b> trong menu ứng dụng để chỉnh Telex/VNI.
+  </div>
+
+  <footer>
+    Khóa ký công khai: <a href="@REPO_URL@funput.asc">funput.asc</a> ·
+    Mã nguồn: <a href="https://github.com/Funput/Funput">github.com/Funput/Funput</a>
+  </footer>
+
+</div>
+
+<script>
+  // Copy-to-clipboard for every command block.
+  document.querySelectorAll('.copy').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var code = btn.parentElement.querySelector('code').innerText;
+      navigator.clipboard.writeText(code).then(function () {
+        btn.textContent = '✓ Đã chép';
+        btn.classList.add('done');
+        setTimeout(function () { btn.textContent = 'Copy'; btn.classList.remove('done'); }, 1500);
+      });
+    });
+  });
+</script>
 </body>
 </html>

--- a/platforms/linux/packaging/repo/index.html.in
+++ b/platforms/linux/packaging/repo/index.html.in
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<!-- Landing page for the Funput Linux package repository.
+     @REPO_URL@ is substituted by the publish-repo workflow with the Pages base URL. -->
+<html lang="vi">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Funput — kho phần mềm Linux</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { max-width: 760px; margin: 2rem auto; padding: 0 1rem;
+         font: 16px/1.6 system-ui, sans-serif; }
+  h1 { margin-bottom: .2rem; }
+  p.lead { color: #888; margin-top: 0; }
+  h2 { margin-top: 2rem; }
+  pre { background: #1113; padding: 1rem; border-radius: 8px; overflow-x: auto; }
+  code { font-family: ui-monospace, monospace; }
+  .note { font-size: .9rem; color: #888; }
+  small { color: #888; }
+</style>
+</head>
+<body>
+<h1>Funput</h1>
+<p class="lead">Bộ gõ tiếng Việt cho Linux — kho cài đặt &amp; cập nhật tự động.</p>
+
+<p>Chọn <strong>IBus</strong> (GNOME mặc định) hoặc <strong>Fcitx5</strong> (KDE / đầy đủ tính năng).
+Sau khi thêm kho, cập nhật về sau chỉ là <code>apt/dnf/zypper upgrade</code> bình thường.</p>
+
+<h2>Debian / Ubuntu (.deb)</h2>
+<pre><code>sudo install -d /usr/share/keyrings
+curl -fsSL @REPO_URL@funput.asc | sudo tee /usr/share/keyrings/funput.asc >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/funput.asc] @REPO_URL@deb ./" \
+  | sudo tee /etc/apt/sources.list.d/funput.list
+sudo apt update
+sudo apt install funput-ibus    # hoặc: funput  (Fcitx5)</code></pre>
+
+<h2>Fedora (.rpm)</h2>
+<pre><code>sudo dnf config-manager --add-repo @REPO_URL@funput.repo
+sudo dnf install funput-ibus    # hoặc: funput  (Fcitx5)</code></pre>
+
+<h2>openSUSE (.rpm)</h2>
+<pre><code>sudo rpm --import @REPO_URL@funput.asc
+sudo zypper addrepo -gf @REPO_URL@rpm/ funput
+sudo zypper install funput-ibus # hoặc: funput  (Fcitx5)</code></pre>
+
+<h2>Arch Linux</h2>
+<p>Cài qua AUR: <code>yay -S funput-ibus</code> hoặc <code>yay -S funput</code>.</p>
+
+<p class="note">Sau khi cài: <strong>Settings → Keyboard → Input Sources → + → Vietnamese → Funput</strong>
+(IBus cần <code>ibus restart</code>; Fcitx5 dùng <code>fcitx5-configtool</code>). Mở <strong>Funput</strong>
+trong menu ứng dụng để chỉnh Telex/VNI.</p>
+
+<hr>
+<p><small>Khóa ký công khai: <a href="@REPO_URL@funput.asc">funput.asc</a> ·
+Mã nguồn: <a href="https://github.com/Funput/Funput">github.com/Funput/Funput</a></small></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Extends Linux distribution beyond `.deb`: adds `.rpm` packages (Fedora/openSUSE),
a distro-detecting installer, and a self-hosted, GPG-signed apt+dnf repository on
GitHub Pages (`repo.funput.app`) so users get `apt/dnf/zypper upgrade` instead of
re-downloading. `.deb` build is unchanged.

## What's added
- **RPM packaging** via CPack (`DEB;RPM`) for both shells — `funput` (Fcitx5) and
  `funput-ibus` (IBus). Independent arch mapping (`x86_64`/`aarch64`) and
  `CPACK_RPM_*` deps (`Requires: fcitx5`/`ibus`, AUTOREQ).
- **`install.sh`** — reads `/etc/os-release`, picks framework (IBus default,
  Fcitx5 on KDE), pulls the matching asset from the latest GitHub Release and
  installs via apt/dnf/zypper (Arch → AUR hint).
- **`publish-repo.yml`** — on each published release, builds signed apt (flat,
  `InRelease`+`Release.gpg`) and dnf (`rpm --addsign` + signed `repomd.xml`) repos
  and deploys them to GitHub Pages under the `repo.funput.app` custom domain.
  Stateless: rebuilt from the latest release each run.
- **Landing page** (`index.html.in`) with per-distro, per-framework install
  commands + copy buttons, and a dnf `funput.repo` template.

## CI
- New `linux-rpm` job builds `.rpm` natively per arch inside a `fedora:latest`
  container (so libdir `/usr/lib64`, Fcitx5/IBus install dirs and shlib deps match
  Fedora). Rust via rustup (edition 2024). `release.yml` now publishes `*.rpm`.

## Fix
- Bump Fcitx5 shell to **C++20** — Fedora's newer Fcitx5 headers use
  `std::span`/`starts_with`/`ends_with`; C++17 failed to compile them. Ubuntu's
  older Fcitx5 builds fine at C++20 too, so the `.deb` build is unaffected.

## One-time setup (already done by maintainer)
GPG key (uid `Funput <hello@funput.app>`) → secrets `GPG_PRIVATE_KEY` /
`GPG_PASSPHRASE`; Pages source = GitHub Actions; DNS `CNAME repo → <owner>.github.io`.
See `platforms/linux/packaging/repo/README.md`.

## Release / test flow
Merge this first (release-triggered `publish-repo.yml` runs from the **default
branch**), then tag `vX.Y.Z` → `release.yml` builds `.deb`+`.rpm` and publishes the
Release → `publish-repo.yml` signs and deploys the repo. The GPG-signing path runs
for the first time on that release — watch the `apt`/`rpm`/`deploy` jobs.

## Not in scope
AppImage (doesn't fit an IM engine — addons must install into system dirs the
daemon scans). Official distro channels (OBS/COPR/PPA) are a later phase.