### PR TITLE
feat: auto-capitalize at sentence starts (macOS, Windows, Linux)

### DIFF
--- a/crates/funput-engine/src/boundary.rs
+++ b/crates/funput-engine/src/boundary.rs
@@ -63,6 +63,35 @@ fn shortcut_expansion(session: &Session, boundary_key: char) -> Option<ImeResult
     Some(ImeResult::send(backspace, output))
 }
 
+/// Update auto-capitalize state from a boundary key. No-op unless the feature is on.
+/// A sentence-ender (`.`/`!`/`?`) only *arms* once whitespace confirms the break, so
+/// `google.com` is left alone while `End. Next` is capitalized; a newline arms
+/// directly; quotes/brackets are transparent (`He said "Hi." Next`); any other
+/// punctuation cancels a pending capitalization.
+fn update_caps_on_boundary(session: &mut Session, key: char) {
+    if !session.auto_capitalize {
+        return;
+    }
+    match key {
+        '.' | '!' | '?' => session.cap_sentence_ended = true,
+        '\n' | '\r' => {
+            session.cap_armed = true;
+            session.cap_sentence_ended = false;
+        }
+        ' ' | '\t' => {
+            if session.cap_sentence_ended {
+                session.cap_armed = true;
+            }
+        }
+        // Quotes and brackets are transparent — they don't open or end a sentence.
+        '"' | '\'' | '(' | ')' | '[' | ']' | '{' | '}' => {}
+        _ => {
+            session.cap_sentence_ended = false;
+            session.cap_armed = false;
+        }
+    }
+}
+
 /// End-of-word: expand a gõ tắt trigger, else optionally restore English Latin text,
 /// then reset composition state. Text expansion takes priority over English restore.
 pub(crate) fn on_word_boundary(session: &mut Session, boundary_key: char) -> ImeResult {
@@ -73,6 +102,7 @@ pub(crate) fn on_word_boundary(session: &mut Session, boundary_key: char) -> Ime
     } else {
         ImeResult::none()
     };
+    update_caps_on_boundary(session, boundary_key);
     session.clear();
     result
 }
@@ -107,6 +137,9 @@ mod tests {
             smart_restore: true,
             eager_restore: true,
             spell_check: false,
+            auto_capitalize: false,
+            cap_sentence_ended: false,
+            cap_armed: false,
             shortcuts: HashMap::new(),
         };
         assert!(should_restore(&session));
@@ -123,6 +156,9 @@ mod tests {
             smart_restore: true,
             eager_restore: true,
             spell_check: false,
+            auto_capitalize: false,
+            cap_sentence_ended: false,
+            cap_armed: false,
             shortcuts: HashMap::new(),
         };
         assert!(!should_restore(&session));
@@ -139,6 +175,9 @@ mod tests {
             smart_restore: true,
             eager_restore: true,
             spell_check: false,
+            auto_capitalize: false,
+            cap_sentence_ended: false,
+            cap_armed: false,
             shortcuts: HashMap::new(),
         };
         assert!(!should_restore(&session));
@@ -162,6 +201,9 @@ mod tests {
             smart_restore: true,
             eager_restore: true,
             spell_check: false,
+            auto_capitalize: false,
+            cap_sentence_ended: false,
+            cap_armed: false,
             shortcuts: HashMap::new(),
         };
         assert!(!should_restore(&session));
@@ -179,6 +221,9 @@ mod tests {
             smart_restore: true,
             eager_restore: true,
             spell_check: false,
+            auto_capitalize: false,
+            cap_sentence_ended: false,
+            cap_armed: false,
             shortcuts: HashMap::new(),
         };
         assert!(!should_restore(&session));
@@ -195,6 +240,9 @@ mod tests {
             smart_restore: true,
             eager_restore: true,
             spell_check: false,
+            auto_capitalize: false,
+            cap_sentence_ended: false,
+            cap_armed: false,
             shortcuts: HashMap::new(),
         };
         let result = on_word_boundary(&mut session, ' ');
@@ -216,6 +264,9 @@ mod tests {
             smart_restore: true,
             eager_restore: true,
             spell_check: false,
+            auto_capitalize: false,
+            cap_sentence_ended: false,
+            cap_armed: false,
             shortcuts: HashMap::new(),
         };
         let result = on_word_boundary(&mut session, ' ');

--- a/crates/funput-engine/src/lib.rs
+++ b/crates/funput-engine/src/lib.rs
@@ -90,6 +90,26 @@ impl Engine {
         self.session.spell_check = on;
     }
 
+    /// Toggle auto-capitalize ("Tự động viết hoa"): uppercase the first letter of a
+    /// word that starts a sentence (sentence start, after `.`/`!`/`?` + space, after a
+    /// newline). Off by default; when off this is a complete no-op.
+    pub fn set_auto_capitalize(&mut self, on: bool) {
+        self.session.auto_capitalize = on;
+        if !on {
+            self.session.cap_armed = false;
+            self.session.cap_sentence_ended = false;
+        }
+    }
+
+    /// Arm capitalization for the next word — the platform calls this when a text
+    /// field gains focus, so the first letter typed (start of input) is capitalized.
+    /// No-op unless auto-capitalize is on.
+    pub fn arm_capitalization(&mut self) {
+        if self.session.auto_capitalize {
+            self.session.cap_armed = true;
+        }
+    }
+
     /// Reset composition state (buffer and raw keys) without changing enabled/method.
     pub fn clear(&mut self) {
         self.session.clear();
@@ -166,8 +186,27 @@ impl Engine {
         if boundary::is_word_boundary(key) {
             return boundary::on_word_boundary(&mut self.session, key);
         }
+        let key = self.maybe_capitalize(key);
         self.session.keys.push(key);
         pipeline::process(&mut self.session, key)
+    }
+
+    /// Auto-capitalize the first letter of a new word when armed. Consumes the armed
+    /// state at the start of any word (letter or not), so it only ever affects the
+    /// first keystroke. The first keystroke of a Telex/VNI word is an ASCII Latin
+    /// letter, so `to_ascii_uppercase` is sufficient.
+    fn maybe_capitalize(&mut self, key: char) -> char {
+        if !self.session.auto_capitalize || !self.session.buffer.is_empty() {
+            return key;
+        }
+        let armed = self.session.cap_armed;
+        self.session.cap_armed = false;
+        self.session.cap_sentence_ended = false;
+        if armed && key.is_alphabetic() {
+            key.to_ascii_uppercase()
+        } else {
+            key
+        }
     }
 }
 
@@ -233,6 +272,93 @@ mod tests {
         // Real syllables are unaffected.
         assert_eq!(type_word(&mut engine, "mas"), "má");
         assert_eq!(type_word(&mut engine, "tets"), "tét");
+    }
+
+    // ---- Auto-capitalize ("Tự động viết hoa") ----
+
+    fn engine_autocap() -> Engine {
+        let mut e = Engine::new();
+        e.set_auto_capitalize(true);
+        e
+    }
+
+    /// Feed a string keystroke-by-keystroke; return the current composition buffer.
+    fn feed(engine: &mut Engine, s: &str) -> String {
+        for k in s.chars() {
+            engine.process_char(k);
+        }
+        engine.buffer().to_string()
+    }
+
+    #[test]
+    fn autocap_focus_capitalizes_first_word() {
+        let mut e = engine_autocap();
+        e.arm_capitalization();
+        assert_eq!(feed(&mut e, "viet"), "Viet");
+    }
+
+    #[test]
+    fn autocap_first_letter_composes_vietnamese() {
+        let mut e = engine_autocap();
+        e.arm_capitalization();
+        assert_eq!(feed(&mut e, "chaof"), "Chào"); // Telex
+        e.clear();
+        e.arm_capitalization();
+        assert_eq!(feed(&mut e, "dd"), "Đ"); // capital đ
+    }
+
+    #[test]
+    fn autocap_after_sentence_end_and_space() {
+        let mut e = engine_autocap();
+        feed(&mut e, "ok");
+        e.process_char('.'); // commits "ok", marks sentence end
+        e.process_char(' '); // whitespace confirms → arm
+        assert_eq!(feed(&mut e, "lam"), "Lam");
+    }
+
+    #[test]
+    fn autocap_requires_whitespace_after_period() {
+        let mut e = engine_autocap();
+        feed(&mut e, "google");
+        e.process_char('.'); // no whitespace follows
+        assert_eq!(feed(&mut e, "com"), "com"); // google.com stays lower
+    }
+
+    #[test]
+    fn autocap_newline_arms() {
+        let mut e = engine_autocap();
+        feed(&mut e, "ok");
+        e.process_char('\n');
+        assert_eq!(feed(&mut e, "lam"), "Lam");
+    }
+
+    #[test]
+    fn autocap_comma_does_not_arm() {
+        let mut e = engine_autocap();
+        feed(&mut e, "ok");
+        e.process_char(',');
+        e.process_char(' ');
+        assert_eq!(feed(&mut e, "lam"), "lam");
+    }
+
+    #[test]
+    fn autocap_closing_quote_is_transparent() {
+        let mut e = engine_autocap();
+        feed(&mut e, "di");
+        e.process_char('.'); // sentence end
+        e.process_char('"'); // transparent closer
+        e.process_char(' '); // arm
+        assert_eq!(feed(&mut e, "roi"), "Roi");
+    }
+
+    #[test]
+    fn autocap_off_is_noop() {
+        let mut e = Engine::new(); // default off
+        e.arm_capitalization(); // no-op while off
+        assert_eq!(feed(&mut e, "viet"), "viet");
+        e.process_char('.');
+        e.process_char(' ');
+        assert_eq!(feed(&mut e, "lam"), "lam");
     }
 
     #[test]

--- a/crates/funput-engine/src/session.rs
+++ b/crates/funput-engine/src/session.rs
@@ -27,6 +27,17 @@ pub(crate) struct Session {
     /// still become a real Vietnamese syllable, otherwise keep the modifier key as a
     /// literal (UniKey-style strict diacritics). Off by default.
     pub(crate) spell_check: bool,
+    /// Auto-capitalize ("Tự động viết hoa"): uppercase the first letter of a word at
+    /// the start of a sentence. Off by default.
+    pub(crate) auto_capitalize: bool,
+    /// A sentence-ending mark (`.`/`!`/`?`) was just seen; waiting for whitespace to
+    /// confirm the next word starts a new sentence. Survives `clear()` — capitalize
+    /// state spans word commits.
+    pub(crate) cap_sentence_ended: bool,
+    /// The next word's first letter should be capitalized. Set by a confirmed
+    /// sentence start (whitespace after `.`/`!`/`?`, a newline) or focus; consumed
+    /// when a word begins. Survives `clear()`.
+    pub(crate) cap_armed: bool,
     /// Text-expansion table (gõ tắt): raw-keystroke trigger → expansion. Matched
     /// case-sensitively against `keys` at a word boundary, before English restore.
     /// Config that lives for the whole session — `clear()` does not touch it.
@@ -44,6 +55,9 @@ impl Session {
             smart_restore: true,
             eager_restore: true,
             spell_check: false,
+            auto_capitalize: false,
+            cap_sentence_ended: false,
+            cap_armed: false,
             shortcuts: HashMap::new(),
         }
     }

--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -115,6 +115,24 @@ void funput_set_eager_restore(FunputEngine *engine, bool on);
 void funput_set_spell_check(FunputEngine *engine, bool on);
 
 /**
+ * Toggle auto-capitalize ("Tự động viết hoa") — uppercase the first letter of a word
+ * that starts a sentence. Off by default; a no-op while off.
+ *
+ * # Safety
+ * `engine` must be a valid handle or null.
+ */
+void funput_set_auto_capitalize(FunputEngine *engine, bool on);
+
+/**
+ * Arm capitalization for the next word — call on text-field focus so the first
+ * letter typed (start of input) is capitalized. A no-op unless auto-capitalize is on.
+ *
+ * # Safety
+ * `engine` must be a valid handle or null.
+ */
+void funput_arm_capitalization(FunputEngine *engine);
+
+/**
  * Reset composition state (buffer + raw keys), e.g. on focus change.
  *
  * # Safety

--- a/crates/funput-ffi/src/lib.rs
+++ b/crates/funput-ffi/src/lib.rs
@@ -132,6 +132,30 @@ pub unsafe extern "C" fn funput_set_spell_check(engine: *mut FunputEngine, on: b
     }
 }
 
+/// Toggle auto-capitalize ("Tự động viết hoa") — uppercase the first letter of a word
+/// that starts a sentence. Off by default; a no-op while off.
+///
+/// # Safety
+/// `engine` must be a valid handle or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_set_auto_capitalize(engine: *mut FunputEngine, on: bool) {
+    if let Some(engine) = unsafe { engine.as_mut() } {
+        engine.inner.set_auto_capitalize(on);
+    }
+}
+
+/// Arm capitalization for the next word — call on text-field focus so the first
+/// letter typed (start of input) is capitalized. A no-op unless auto-capitalize is on.
+///
+/// # Safety
+/// `engine` must be a valid handle or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_arm_capitalization(engine: *mut FunputEngine) {
+    if let Some(engine) = unsafe { engine.as_mut() } {
+        engine.inner.arm_capitalization();
+    }
+}
+
 /// Reset composition state (buffer + raw keys), e.g. on focus change.
 ///
 /// # Safety

--- a/platforms/linux/common/ffi_handle.h
+++ b/platforms/linux/common/ffi_handle.h
@@ -101,6 +101,8 @@ public:
     void setSmartRestore(bool on) { funput_set_smart_restore(engine_, on); }
     void setEagerRestore(bool on) { funput_set_eager_restore(engine_, on); }
     void setSpellCheck(bool on) { funput_set_spell_check(engine_, on); }
+    void setAutoCapitalize(bool on) { funput_set_auto_capitalize(engine_, on); }
+    void armCapitalization() { funput_arm_capitalization(engine_); }
     void clear() { funput_clear(engine_); }
 
     // Text-expansion shortcuts (gõ tắt). Replace the whole table by clearing then

--- a/platforms/linux/common/settings.cpp
+++ b/platforms/linux/common/settings.cpp
@@ -89,6 +89,7 @@ bool Settings::reload() {
     smartRestore = j.value("smartRestore", smartRestore);
     eagerRestore = j.value("eagerRestore", eagerRestore);
     spellCheck = j.value("spellCheck", spellCheck);
+    autoCapitalize = j.value("autoCapitalize", autoCapitalize);
     toggleHotkey = parseHotkey(j.value("toggleHotkey", std::string(hotkeyStr(toggleHotkey))));
 
     // excludedApps: [{ "id": "code", "name": "Code" }, ...] — keep just the ids.
@@ -116,6 +117,7 @@ bool Settings::reload() {
     return method != prev.method || toneStyle != prev.toneStyle ||
            enabled != prev.enabled || smartRestore != prev.smartRestore ||
            eagerRestore != prev.eagerRestore || spellCheck != prev.spellCheck ||
+           autoCapitalize != prev.autoCapitalize ||
            toggleHotkey != prev.toggleHotkey || excludedAppIds != prev.excludedAppIds ||
            shortcuts != prev.shortcuts;
 }
@@ -147,6 +149,7 @@ void Settings::save() const {
     j["smartRestore"] = smartRestore;
     j["eagerRestore"] = eagerRestore;
     j["spellCheck"] = spellCheck;
+    j["autoCapitalize"] = autoCapitalize;
     j["toggleHotkey"] = hotkeyStr(toggleHotkey);
 
     std::ofstream out(p, std::ios::trunc);

--- a/platforms/linux/common/settings.h
+++ b/platforms/linux/common/settings.h
@@ -27,6 +27,9 @@ struct Settings {
     // Spell-check ("Kiểm tra chính tả"): only place a diacritic that forms a valid
     // Vietnamese syllable. Off by default.
     bool spellCheck = false;
+    // Auto-capitalize ("Tự động viết hoa"): uppercase the first letter at the start of
+    // a sentence. Off by default.
+    bool autoCapitalize = false;
     Hotkey toggleHotkey = Hotkey::CtrlBacktick;
     // App identifiers (fcitx5 program() / WM_CLASS) that default to English on
     // focus. Owned by the Settings UI; the addon only reads them for matching.

--- a/platforms/linux/fcitx5/src/funput_engine.cpp
+++ b/platforms/linux/fcitx5/src/funput_engine.cpp
@@ -62,6 +62,7 @@ void FunputEngine::applySettings() {
     handle_.setSmartRestore(settings_.smartRestore);
     handle_.setEagerRestore(settings_.eagerRestore);
     handle_.setSpellCheck(settings_.spellCheck);
+    handle_.setAutoCapitalize(settings_.autoCapitalize);
     handle_.clearShortcuts();
     for (const auto &[trigger, expansion] : settings_.shortcuts) {
         handle_.addShortcut(trigger, expansion);
@@ -141,7 +142,15 @@ void FunputEngine::commitBuffer(fcitx::InputContext *ic) {
 // with output = rawKeys + boundaryChar; otherwise we keep the composed buffer.
 bool FunputEngine::handleBoundary(fcitx::InputContext *ic, char32_t scalar) {
     const std::string pre = handle_.buffer();
-    if (pre.empty()) return false; // not composing → let the app handle the key
+    if (pre.empty()) {
+        // Not composing: let the app handle the key, but feed it to the engine first so
+        // auto-capitalize can track sentence context across the gap (e.g. the space in
+        // "End. Next" arrives with an empty buffer).
+        if (settings_.autoCapitalize) {
+            handle_.process(static_cast<uint32_t>(scalar));
+        }
+        return false;
+    }
 
     const FunputResult r = handle_.process(static_cast<uint32_t>(scalar));
     std::string word;
@@ -218,6 +227,11 @@ void FunputEngine::keyEvent(const fcitx::InputMethodEntry &, fcitx::KeyEvent &ke
     // carry no Unicode value — end composition and let the app handle them.
     const uint32_t uc = fcitx::Key::keySymToUnicode(key.sym());
     if (uc == 0) {
+        // Enter starts a new line → arm auto-capitalize (the engine never sees the
+        // newline on this no-Unicode path). No-op unless the feature is on.
+        if (settings_.autoCapitalize && key.sym() == FcitxKey_Return) {
+            handle_.armCapitalization();
+        }
         commitBuffer(ic);
         return;
     }
@@ -242,6 +256,8 @@ void FunputEngine::reset(const fcitx::InputMethodEntry &, fcitx::InputContextEve
 void FunputEngine::activate(const fcitx::InputMethodEntry &, fcitx::InputContextEvent &event) {
     // Pick up settings changed while unfocused (fallback to the live watcher).
     if (settings_.reloadIfChanged()) applySettings();
+    // Focus is the start of input: arm so the first letter is capitalized.
+    if (settings_.autoCapitalize) handle_.armCapitalization();
     // Per-app auto-switch on focus-in, mirroring the macOS shell's activateServer.
     const std::string program = event.inputContext()->program();
     lastProgram_ = program; // remembered for live settings reloads

--- a/platforms/linux/ibus/src/engine.cpp
+++ b/platforms/linux/ibus/src/engine.cpp
@@ -52,6 +52,7 @@ void applySettings(EngineState *st) {
     st->handle_.setSmartRestore(st->settings_.smartRestore);
     st->handle_.setEagerRestore(st->settings_.eagerRestore);
     st->handle_.setSpellCheck(st->settings_.spellCheck);
+    st->handle_.setAutoCapitalize(st->settings_.autoCapitalize);
     st->handle_.clearShortcuts();
     for (const auto &[trigger, expansion] : st->settings_.shortcuts) {
         st->handle_.addShortcut(trigger, expansion);
@@ -91,7 +92,15 @@ void commitBuffer(IBusEngine *engine, EngineState *st) {
 // with output = rawKeys + boundaryChar; otherwise we keep the composed buffer.
 bool handleBoundary(IBusEngine *engine, EngineState *st, char32_t scalar) {
     const std::string pre = st->handle_.buffer();
-    if (pre.empty()) return false; // not composing → let the app handle the key
+    if (pre.empty()) {
+        // Not composing: let the app handle the key, but feed it to the engine first so
+        // auto-capitalize can track sentence context across the gap (e.g. the space in
+        // "End. Next" arrives with an empty buffer).
+        if (st->settings_.autoCapitalize) {
+            st->handle_.process(static_cast<uint32_t>(scalar));
+        }
+        return false;
+    }
 
     const FunputResult r = st->handle_.process(static_cast<uint32_t>(scalar));
     std::string word;
@@ -180,6 +189,11 @@ static gboolean ibus_funput_engine_process_key_event(IBusEngine *engine, guint k
     // carry no Unicode value — end composition and let the app handle them.
     const guint32 uc = ibus_keyval_to_unicode(keyval);
     if (uc == 0) {
+        // Enter starts a new line → arm auto-capitalize (the engine never sees the
+        // newline on this no-Unicode path). No-op unless the feature is on.
+        if (st->settings_.autoCapitalize && keyval == IBUS_KEY_Return) {
+            st->handle_.armCapitalization();
+        }
         commitBuffer(engine, st);
         return FALSE;
     }
@@ -201,6 +215,8 @@ static gboolean ibus_funput_engine_process_key_event(IBusEngine *engine, guint k
 static void ibus_funput_engine_focus_in(IBusEngine *engine) {
     EngineState *st = FUNPUT_ENGINE(engine)->state;
     if (st->settings_.reloadIfChanged()) applySettings(st);
+    // Focus is the start of input: arm so the first letter is capitalized.
+    if (st->settings_.autoCapitalize) st->handle_.armCapitalization();
 }
 
 static void ibus_funput_engine_enable(IBusEngine *engine) {

--- a/platforms/linux/settings-gtk/src/settings.rs
+++ b/platforms/linux/settings-gtk/src/settings.rs
@@ -71,6 +71,10 @@ pub struct Settings {
     /// Vietnamese syllable. `#[serde(default)]` keeps older settings files loadable.
     #[serde(default)]
     pub spell_check: bool,
+    /// Auto-capitalize ("Tự động viết hoa"): uppercase the first letter at the start of
+    /// a sentence. `#[serde(default)]` keeps older settings files loadable.
+    #[serde(default)]
+    pub auto_capitalize: bool,
     pub toggle_hotkey: Hotkey,
     pub launch_at_login: bool,
     pub has_completed_onboarding: bool,
@@ -93,6 +97,7 @@ impl Default for Settings {
             smart_restore: true,
             eager_restore: true,
             spell_check: false,
+            auto_capitalize: false,
             toggle_hotkey: Hotkey::CtrlBacktick,
             launch_at_login: false,
             has_completed_onboarding: false,

--- a/platforms/linux/settings-gtk/src/settings_window/smart.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/smart.rs
@@ -44,9 +44,19 @@ pub(super) fn page() -> PreferencesPage {
         let on = row.is_active();
         Settings::update(|s| s.spell_check = on);
     });
+    let auto_cap_row = SwitchRow::builder()
+        .title("Tự động viết hoa")
+        .subtitle("Viết hoa chữ đầu câu, sau dấu chấm và đầu dòng.")
+        .active(s.auto_capitalize)
+        .build();
+    auto_cap_row.connect_active_notify(|row| {
+        let on = row.is_active();
+        Settings::update(|s| s.auto_capitalize = on);
+    });
     group.add(&smart_row);
     group.add(&eager_row);
     group.add(&spell_row);
+    group.add(&auto_cap_row);
     page.add(&group);
 
     // Informational examples (read-only).

--- a/platforms/macos/Funput/IME/FunputComposer.swift
+++ b/platforms/macos/Funput/IME/FunputComposer.swift
@@ -45,6 +45,18 @@ final class FunputComposer {
         funput_set_spell_check(handle, on)
     }
 
+    /// Auto-capitalize ("Tự động viết hoa"): uppercase the first letter at the start
+    /// of a sentence.
+    func setAutoCapitalize(_ on: Bool) {
+        funput_set_auto_capitalize(handle, on)
+    }
+
+    /// Arm capitalization for the next word (call on focus so the first letter typed
+    /// in a field is capitalized). A no-op unless auto-capitalize is on.
+    func armCapitalization() {
+        funput_arm_capitalization(handle)
+    }
+
     func clear() {
         funput_clear(handle)
     }

--- a/platforms/macos/Funput/IME/FunputInputController.swift
+++ b/platforms/macos/Funput/IME/FunputInputController.swift
@@ -105,6 +105,8 @@ final class FunputInputController: IMKInputController {
         super.activateServer(sender)
         applyPerAppDefault()
         syncSettings()
+        // Focus on a field is the start of input: arm so the first letter is capitalized.
+        if AppSettings.shared.autoCapitalizeEnabled { composer.armCapitalization() }
     }
 
     override func deactivateServer(_ sender: Any!) {
@@ -137,7 +139,13 @@ final class FunputInputController: IMKInputController {
     /// Boundary key (space / punctuation / Enter / Tab) while composing.
     private func commitBoundary(_ scalar: Unicode.Scalar, into client: IMKTextInput) -> Bool {
         let pre = composer.buffer()
-        guard !pre.isEmpty else { return false } // not composing → let the app handle the key
+        guard !pre.isEmpty else {
+            // Not composing: the app inserts the key itself. Still feed it to the engine
+            // so auto-capitalize can track sentence context across the gap — e.g. the
+            // space in "End. Next" arrives here with an empty buffer.
+            if AppSettings.shared.autoCapitalizeEnabled { _ = composer.process(scalar) }
+            return false
+        }
 
         // The engine decides English-restore, then clears the session. On restore it
         // returns Action::Send with output = rawKeys + boundaryChar; otherwise keep `pre`.
@@ -197,6 +205,7 @@ final class FunputInputController: IMKInputController {
         composer.setSmartRestore(settings.smartEnglishRestore)
         composer.setEagerRestore(settings.eagerRestore)
         composer.setSpellCheck(settings.spellCheckEnabled)
+        composer.setAutoCapitalize(settings.autoCapitalizeEnabled)
 
         // Re-marshal the gõ tắt table only when it actually changed (cheap on the
         // common keystroke path where nothing changed).

--- a/platforms/macos/Funput/Model/AppSettings.swift
+++ b/platforms/macos/Funput/Model/AppSettings.swift
@@ -51,6 +51,11 @@ final class AppSettings {
     var spellCheckEnabled: Bool {
         didSet { defaults.set(spellCheckEnabled, forKey: Keys.spellCheckEnabled) }
     }
+    /// Auto-capitalize ("Tự động viết hoa"): uppercase the first letter at the start of
+    /// a sentence. Off by default.
+    var autoCapitalizeEnabled: Bool {
+        didSet { defaults.set(autoCapitalizeEnabled, forKey: Keys.autoCapitalizeEnabled) }
+    }
     var toggleShortcut: ToggleShortcut {
         didSet { defaults.set(toggleShortcut.rawValue, forKey: Keys.toggleShortcut) }
     }
@@ -96,6 +101,7 @@ final class AppSettings {
         smartEnglishRestore = defaults.bool(forKey: Keys.smartEnglishRestore)
         eagerRestore = defaults.bool(forKey: Keys.eagerRestore)
         spellCheckEnabled = defaults.bool(forKey: Keys.spellCheckEnabled)
+        autoCapitalizeEnabled = defaults.bool(forKey: Keys.autoCapitalizeEnabled)
         toggleShortcut = defaults.string(forKey: Keys.toggleShortcut)
             .flatMap(ToggleShortcut.init(rawValue:)) ?? .controlBackslash
         launchAtLogin = defaults.bool(forKey: Keys.launchAtLogin)
@@ -145,6 +151,7 @@ final class AppSettings {
         static let smartEnglishRestore = "smartEnglishRestore"
         static let eagerRestore = "eagerRestore"
         static let spellCheckEnabled = "spellCheckEnabled"
+        static let autoCapitalizeEnabled = "autoCapitalizeEnabled"
         static let toggleShortcut = "toggleShortcut"
         static let launchAtLogin = "launchAtLogin"
         static let showMenuBarIcon = "showMenuBarIcon"

--- a/platforms/macos/Funput/Settings/Panes/SmartPane.swift
+++ b/platforms/macos/Funput/Settings/Panes/SmartPane.swift
@@ -39,6 +39,16 @@ struct SmartPane: View {
                             .labelsHidden()
                             .toggleStyle(.switch)
                     }
+                    Divider()
+                    SettingsRow(
+                        title: "Tự động viết hoa",
+                        subtitle: "Viết hoa chữ đầu câu, sau dấu chấm và đầu dòng",
+                        systemImage: "textformat.abc.dottedunderline"
+                    ) {
+                        Toggle("", isOn: $settings.autoCapitalizeEnabled)
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                    }
                 }
             }
 
@@ -49,6 +59,7 @@ struct SmartPane: View {
                     exampleRow("phus", "phú", "âm tiết hợp lệ → có dấu")
                     exampleRow("mixx", "mix", "gõ đúp dấu để ra tiếng Anh")
                     exampleRow("tetf", "tetf", "kiểm tra chính tả → không đặt dấu sai")
+                    exampleRow("xong. roi", "Xong. Rồi", "tự động viết hoa đầu câu")
                 }
             }
         }

--- a/platforms/windows/src/commands.rs
+++ b/platforms/windows/src/commands.rs
@@ -28,6 +28,10 @@ pub fn set_spell_check(on: bool) {
     shell::set_spell_check(on);
 }
 
+pub fn set_auto_capitalize(on: bool) {
+    shell::set_auto_capitalize(on);
+}
+
 pub fn set_toggle_hotkey(hotkey: Hotkey) {
     shell::set_toggle_hotkey(hotkey);
 }

--- a/platforms/windows/src/hook.rs
+++ b/platforms/windows/src/hook.rs
@@ -14,7 +14,7 @@ use windows::Win32::System::Threading::{
     OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION,
 };
 use windows::Win32::UI::Accessibility::{SetWinEventHook, HWINEVENTHOOK};
-use windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY;
+use windows::Win32::UI::Input::KeyboardAndMouse::{VIRTUAL_KEY, VK_RETURN};
 use windows::Win32::UI::WindowsAndMessaging::{
     CallNextHookEx, DispatchMessageW, GetMessageW, GetWindowThreadProcessId, PostQuitMessage,
     SetWindowsHookExW, TranslateMessage, EVENT_SYSTEM_FOREGROUND, HC_ACTION, KBDLLHOOKSTRUCT, MSG,
@@ -104,6 +104,8 @@ unsafe extern "system" fn win_event_proc(
         tray::sync_from_shell();
     }
     shell::note_foreground(id.clone(), name);
+    // Focus on a new app is the start of input: arm so the first letter is capitalized.
+    shell::arm_capitalization();
     if let Some(on) = shell::apply_for_app(&id) {
         if let Some(cb) = ON_TOGGLE.get() {
             cb(on); // keep tray checkmark / tooltip in sync with the auto-switch
@@ -218,6 +220,11 @@ fn handle_keydown(kbd: &KBDLLHOOKSTRUCT) -> bool {
         }
         KeyKind::Flush => {
             shell::clear(); // commit what is shown; nav/Enter/Tab/shortcut passes
+            // Enter starts a new line → arm auto-capitalize (no-op unless the feature
+            // is on). The engine never sees the newline itself on this path.
+            if vk == VK_RETURN {
+                shell::arm_capitalization();
+            }
             false
         }
         KeyKind::PassThrough => false,

--- a/platforms/windows/src/settings.rs
+++ b/platforms/windows/src/settings.rs
@@ -149,6 +149,10 @@ pub struct Settings {
     /// Vietnamese syllable. `#[serde(default)]` keeps older settings files loadable.
     #[serde(default)]
     pub spell_check: bool,
+    /// Auto-capitalize ("Tự động viết hoa"): uppercase the first letter at the start of
+    /// a sentence. `#[serde(default)]` keeps older settings files loadable.
+    #[serde(default)]
+    pub auto_capitalize: bool,
     pub toggle_hotkey: Hotkey,
     pub launch_at_login: bool,
     pub has_completed_onboarding: bool,
@@ -171,6 +175,7 @@ impl Default for Settings {
             smart_restore: true,
             eager_restore: true,
             spell_check: false,
+            auto_capitalize: false,
             toggle_hotkey: Hotkey::CtrlBacktick,
             launch_at_login: false,
             has_completed_onboarding: false,

--- a/platforms/windows/src/shell.rs
+++ b/platforms/windows/src/shell.rs
@@ -44,6 +44,7 @@ fn apply_to_engine(engine: &mut Engine, s: &Settings) {
     engine.set_smart_restore(s.smart_restore);
     engine.set_eager_restore(s.eager_restore);
     engine.set_spell_check(s.spell_check);
+    engine.set_auto_capitalize(s.auto_capitalize);
     push_shortcuts(engine, &s.shortcuts);
     engine.clear();
 }
@@ -239,6 +240,21 @@ pub fn set_spell_check(on: bool) {
         s.engine.set_spell_check(on);
         s.settings.save();
     });
+}
+
+pub fn set_auto_capitalize(on: bool) {
+    with(|s| {
+        s.settings.auto_capitalize = on;
+        s.engine.set_auto_capitalize(on);
+        s.settings.save();
+    });
+}
+
+/// Arm auto-capitalize for the next word (the engine no-ops unless the feature is on).
+/// Called on foreground change so the first letter typed in a newly-focused app is
+/// capitalized, and after Enter for a new line.
+pub fn arm_capitalization() {
+    with(|s| s.engine.arm_capitalization());
 }
 
 pub fn set_toggle_hotkey(hotkey: Hotkey) {

--- a/platforms/windows/src/windows_ui/settings_callbacks.rs
+++ b/platforms/windows/src/windows_ui/settings_callbacks.rs
@@ -49,6 +49,7 @@ pub(super) fn wire(window: &SettingsWindow) {
     window.on_set_smart(commands::set_smart_restore);
     window.on_set_eager(commands::set_eager_restore);
     window.on_set_spell(commands::set_spell_check);
+    window.on_set_auto_cap(commands::set_auto_capitalize);
     window.on_set_launch(commands::set_launch_at_login);
 
     wire_apps(window);

--- a/platforms/windows/src/windows_ui/settings_window.rs
+++ b/platforms/windows/src/windows_ui/settings_window.rs
@@ -39,6 +39,7 @@ fn populate(window: &SettingsWindow) {
     window.set_smart_restore(settings.smart_restore);
     window.set_eager_restore(settings.eager_restore);
     window.set_spell_check(settings.spell_check);
+    window.set_auto_capitalize(settings.auto_capitalize);
     window.set_launch_at_login(settings.launch_at_login);
     window.set_version(env!("CARGO_PKG_VERSION").into());
     window.set_update_state("idle".into());

--- a/platforms/windows/ui/app.slint
+++ b/platforms/windows/ui/app.slint
@@ -33,6 +33,7 @@ export component SettingsWindow inherits Window {
     in-out property <bool> smart-restore;
     in-out property <bool> eager-restore;
     in-out property <bool> spell-check;
+    in-out property <bool> auto-capitalize;
     in-out property <bool> launch-at-login;
     in property <[AppEntry]> excluded-apps;
     in property <[AppEntry]> recent-apps;
@@ -50,6 +51,7 @@ export component SettingsWindow inherits Window {
     callback set-smart(bool);
     callback set-eager(bool);
     callback set-spell(bool);
+    callback set-auto-cap(bool);
     callback set-launch(bool);
     callback add-app(string);
     callback remove-app(string);
@@ -158,9 +160,11 @@ export component SettingsWindow inherits Window {
                     smart-restore <=> root.smart-restore;
                     eager-restore <=> root.eager-restore;
                     spell-check <=> root.spell-check;
+                    auto-capitalize <=> root.auto-capitalize;
                     set-smart(v) => { root.set-smart(v); }
                     set-eager(v) => { root.set-eager(v); }
                     set-spell(v) => { root.set-spell(v); }
+                    set-auto-cap(v) => { root.set-auto-cap(v); }
                 }
 
                 if root.active == "shortcuts": ShortcutsPage {

--- a/platforms/windows/ui/page_smart.slint
+++ b/platforms/windows/ui/page_smart.slint
@@ -7,9 +7,11 @@ export component SmartPage inherits VerticalLayout {
     in-out property <bool> smart-restore;
     in-out property <bool> eager-restore;
     in-out property <bool> spell-check;
+    in-out property <bool> auto-capitalize;
     callback set-smart(bool);
     callback set-eager(bool);
     callback set-spell(bool);
+    callback set-auto-cap(bool);
 
     spacing: Theme.sp-md;
     Text { text: "Gõ thông minh"; font-size: 20px; font-weight: 700; color: Palette.foreground; }
@@ -39,6 +41,15 @@ export component SmartPage inherits VerticalLayout {
             Switch {
                 checked <=> root.spell-check;
                 toggled => { root.set-spell(self.checked); }
+            }
+        }
+        Rectangle { height: 1px; background: Palette.border; }
+        Row {
+            title: "Tự động viết hoa";
+            subtitle: "Viết hoa chữ đầu câu, sau dấu chấm và đầu dòng.";
+            Switch {
+                checked <=> root.auto-capitalize;
+                toggled => { root.set-auto-cap(self.checked); }
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds an optional **Auto-capitalize** feature that uppercases the first letter of a
word at the start of a sentence. It is **off by default** and can be enabled in
**Settings → Smart typing**. The logic lives entirely in the shared `funput-engine`
(no `funput-core` changes), so all three platforms share one implementation and
test suite.

## Behavior

Capitalizes the first letter of the next word when:
- It's the first letter typed in a focused text field (start of input).
- It follows a sentence-ending mark `.` `!` `?` **followed by whitespace**
  (e.g. `xong. lam` → `Xong. Làm`); repeated marks / `...` are handled too.
- It follows a newline (Enter) — start of a new line/paragraph.
- A closing quote/bracket sits between the mark and the space
  (e.g. `nói "Đi." rồi` → `… Rồi`) — quotes/brackets are transparent.

Does **not** capitalize:
- After `,` `;` `:` or any non-sentence-ending punctuation.
- After `.` `!` `?` with **no** whitespace — so `google.com`, `file.txt`, `3.14`,
  `v1.2` are left untouched.
- When the feature is disabled (default) — a complete no-op.

It composes naturally with Vietnamese input (e.g. `Chào`, `Đầu`) because the first
keystroke of the word is uppercased before composition.

## Implementation

- **`funput-engine`**: a small state machine on the session (`auto_capitalize`,
  `cap_sentence_ended`, `cap_armed`) updated on word boundaries and consumed at the
  start of a word. Adds `Engine::set_auto_capitalize` and `Engine::arm_capitalization`.
- **`funput-ffi`**: `funput_set_auto_capitalize` and `funput_arm_capitalization`
  (regenerated `funput.h`).
- **macOS / Windows / Linux (ibus + fcitx5)**: a settings toggle wired through each
  platform's existing settings pattern, plus two per-platform behaviors:
  - forward word boundaries to the engine even when idle (so the space after a
    sentence-ender is seen), and
  - arm capitalization on text-field/app focus.

The settings flag is persisted as `autoCapitalize` consistently across platforms.

## Testing

- Engine unit tests cover the full state machine: focus-arm, sentence-end + space,
  the no-whitespace exception (`google.com`), newline, comma (no-arm), transparent
  closing quote, Vietnamese composition, and the disabled no-op (regression guard).
- `cargo test` + `cargo clippy` pass; macOS app builds and was verified manually.

## Known limitations

- Abbreviations followed by a period + space are over-capitalized (`e.g. The`) —
  no abbreviation dictionary, same as other simple IMEs.
- "Capitalize after Enter" is best-effort on Windows/Linux (the engine doesn't
  receive the newline on those paths); covered via arm-on-focus and arm-on-Enter.
- Re-focusing an app mid-sentence may capitalize the next letter (focus-arming).
