### PR TITLE
feat(funput-term): bracketed-paste & tmux fixes, shared config, shell install, live Telex↔VNI

### DIFF
--- a/crates/funput-term/Cargo.toml
+++ b/crates/funput-term/Cargo.toml
@@ -11,9 +11,12 @@ path = "src/main.rs"
 [dependencies]
 funput-core = { path = "../funput-core" }
 funput-engine = { path = "../funput-engine" }
-clap = { version = "4", features = ["derive"] }
-portable-pty = "0.8"
-crossterm = "0.28"
+clap = { version = "4.6.1", features = ["derive"] }
+portable-pty = "0.9"
+crossterm = "0.29"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.150"
+dirs = "6"
 
 [target.'cfg(unix)'.dependencies]
-signal-hook = "0.3"
+signal-hook = "0.4.4"

--- a/crates/funput-term/README.md
+++ b/crates/funput-term/README.md
@@ -18,14 +18,31 @@ funput-term -- cursor
 ```
 
 - VNI `xin1 chao2` hoặc Telex `xins chaof` → **xín chào**.
-- **`Ctrl-\`**: bật/tắt tiếng Việt (trạng thái VI/EN hiện ở **tiêu đề cửa sổ** qua OSC; tự bọc
-  passthrough cho **tmux/screen**).
+- **`Ctrl-\`**: bật/tắt tiếng Việt. Trạng thái VI/EN hiện ở **tiêu đề cửa sổ** (OSC, tự bọc
+  passthrough cho **tmux/screen**) và ở **màu con trỏ** (xanh khi VI, reset khi EN) — vẫn thấy được
+  cả khi tiêu đề bị ẩn.
 - Từ không hợp lệ tiếng Việt tự khôi phục ở ranh giới từ (`card ` → `card`).
 
-**"Luôn bật":** `alias claude='funput-term -- claude'`, hoặc cấu hình terminal emulator chạy
-`funput-term -- $SHELL` → mọi app trong cửa sổ đó đều gõ được.
+**"Luôn bật":** chạy `funput-term install` để in (hoặc `--write` để ghi) đoạn alias vào shell rc, hoặc
+cấu hình terminal emulator chạy `funput-term -- $SHELL` → mọi app trong cửa sổ đó đều gõ được.
 
-CLI: `-m, --method telex|vni` (mặc định `vni`); chương trình truyền sau `--` (mặc định `$SHELL`).
+```bash
+funput-term install --alias claude --alias cursor   # in alias cho $SHELL
+funput-term install --shell zsh --alias claude --write   # ghi vào ~/.zshrc (idempotent)
+```
+
+## Cấu hình
+
+funput-term đọc file cấu hình chung của Funput: `dirs::config_dir()/Funput/settings.json` (Linux/Win
+chia sẻ luôn preferences của IME hệ thống; macOS dùng file riêng tại path chuẩn). Áp dụng được:
+`method`, `toneStyle`, `enabled`, `smartRestore`, `eagerRestore`, `spellCheck`, `autoCapitalize`,
+`shortcuts` (gõ tắt). File thiếu key vẫn nạp được (mọi key có default).
+
+**Thứ tự ưu tiên:** cờ CLI > biến môi trường > `settings.json` > mặc định.
+
+- CLI: `-m, --method telex|vni`; chương trình truyền sau `--` (mặc định `$SHELL`).
+- Env: `FUNPUT_METHOD`, `FUNPUT_TONE_STYLE`, `FUNPUT_ENABLED`, `FUNPUT_TOGGLE` (vd `ctrl-\`,
+  `ctrl-space`), `FUNPUT_CURSOR_COLOR_VI`, `FUNPUT_CONFIG` (đường dẫn file khác).
 
 ## Hành vi & phạm vi
 
@@ -60,20 +77,24 @@ engine của hệ Funput.
 
 ```
 src/
-├── main.rs    # clap CLI: -m telex|vni, [-- command]; default $SHELL; toggle Ctrl-\ (0x1c)
-├── app.rs     # forward_input (seam THUẦN, có test) + run() orchestration (spawn PTY, threads)
-├── input.rs   # THUẦN: Classifier byte → ByteKind (Printable/Control/Escape/Utf8/Toggle)
+├── main.rs    # clap CLI: [run] -m telex|vni [-- command] (default $SHELL); subcommand `install`
+├── config.rs  # THUẦN: đọc settings.json → TermConfig; overlay env; apply_to(engine); ưu tiên CLI>env>file
+├── install.rs # THUẦN: snippet(shell, aliases) (bash/zsh/fish, idempotent) + ghi vào rc file
+├── app.rs     # forward_input (seam THUẦN, có test) + run() orchestration (spawn PTY, threads, indicators)
+├── input.rs   # THUẦN: Classifier byte → ByteKind (Printable/Control/Escape/Utf8/Toggle/Paste)
 ├── inject.rs  # THUẦN: result_bytes(char, &ImeResult) → bytes (None→phím; Send/Restore→DEL×bs + UTF-8)
 ├── output.rs  # forward_output + AltScreenScanner (ESC[?1049h/l, chịu được chunk bị cắt)
-├── term.rs    # RawModeGuard (RAII), set_title (OSC)
+├── term.rs    # RawModeGuard (RAII), Mux passthrough, set_title (OSC) + set_cursor_cue (OSC 12/112)
 └── state.rs   # SharedState: enabled (toggle) + alt_screen (atomics)
 ```
 
-`input` / `inject` / `forward_input` **thuần, không I/O thật** → unit-test bằng pipe in-memory.
+`input` / `inject` / `forward_input` / `config` / `install` **thuần, không I/O thật** → unit-test bằng
+pipe in-memory hoặc input dạng chuỗi.
 
 ### Quy tắc xử lý (trong `forward_input`)
 
-- `Toggle` (`0x1c`) → `state.toggle()` + `engine.clear()` + đổi title VI/EN.
+- Khởi tạo: `config.apply_to(engine)` (method, tone, smart/eager restore, spell-check, auto-cap, gõ tắt).
+- `Toggle` (mặc định `0x1c`, đổi được qua config) → `state.toggle()` + `engine.clear()` + cập nhật title & màu con trỏ.
 - `Printable` khi đang soạn → `engine.process_char` → `result_bytes`.
 - Backspace (`0x7f`/`0x08`) khi đang soạn → `engine.on_backspace()` + forward byte (app tự xoá ký tự).
 - Tab/LF/CR (ranh giới từ) khi đang soạn → `engine.process_char(boundary)`: `None` → forward byte;
@@ -108,7 +129,8 @@ phải thư viện cho crate khác link.
 ## Phụ thuộc
 
 `funput-core` · `funput-engine` · `portable-pty` (PTY/ConPTY) · `crossterm` (raw-mode/size) · `clap`
-(CLI) · `signal-hook` (resize, chỉ unix). **Không** `funput-ffi`.
+(CLI) · `serde`/`serde_json` (đọc settings.json) · `dirs` (config path) · `signal-hook` (resize, chỉ
+unix). **Không** `funput-ffi`.
 
 ## Tests
 
@@ -121,12 +143,16 @@ cargo run    -p funput-term -- cat       # gõ "as" → "á"
 Unit test thuần (pipe in-memory): classifier (printable/control/escape/mũi tên/Alt/utf8/toggle),
 `inject` (None/Send/Restore), `forward_input` (compose `as`→`a`+DEL+`á`, `Phua`⌫`s`→`Phú`,
 `text`+Enter restore, `mas`+Enter giữ `má`, revert `mixx`→`mix`, toggle off, bracketed paste giữ
-nguyên + soạn lại sau khi dán), bracketed paste (marker bị cắt, toggle/chữ trong paste là thô, CSI
-quá dài không phải marker), alt-screen scanner (kể cả chunk bị cắt), `title_sequence` (none/tmux/screen), state.
+nguyên + soạn lại sau khi dán, config `enabled=false` không soạn, gõ tắt `vn`→`Việt Nam`), bracketed
+paste (marker bị cắt, toggle/chữ trong paste là thô, CSI quá dài không phải marker), alt-screen
+scanner (kể cả chunk bị cắt), `config` (parse camelCase, default khi thiếu key / JSON hỏng, env
+override + ưu tiên, parse phím toggle), `install` (snippet bash/zsh/fish, idempotent, detect shell),
+`title_sequence` & `cursor_cue` (none/tmux/screen), state.
 
 ## Còn làm (sau v1)
 
 - **Windows (ConPTY):** hiện chỉ Unix PTY; stack `portable-pty` đã sẵn, cần tầng input/resize cho
   Windows (TT6).
-- **Cấu hình bền:** phương thức + phím toggle đang cố định qua CLI; thêm env/file + đổi phương thức
-  lúc đang chạy.
+- **Đổi method/kiểu đặt dấu lúc đang chạy:** hiện đổi method cần khởi động lại; thêm phím lệnh xoay
+  Telex↔VNI và bật/tắt kiểu đặt dấu ngay trong phiên.
+- **Per-app profile:** dùng `excludedApps` từ settings.json để tự bật/tắt theo lệnh được bọc.

--- a/crates/funput-term/README.md
+++ b/crates/funput-term/README.md
@@ -18,9 +18,10 @@ funput-term -- cursor
 ```
 
 - VNI `xin1 chao2` hoặc Telex `xins chaof` → **xín chào**.
-- **`Ctrl-\`**: bật/tắt tiếng Việt. Trạng thái VI/EN hiện ở **tiêu đề cửa sổ** (OSC, tự bọc
-  passthrough cho **tmux/screen**) và ở **màu con trỏ** (xanh khi VI, reset khi EN) — vẫn thấy được
-  cả khi tiêu đề bị ẩn.
+- **`Ctrl-\`**: bật/tắt tiếng Việt. **`Ctrl-^`**: xoay **Telex↔VNI** ngay trong phiên (đổi/tắt qua
+  `FUNPUT_CYCLE_METHOD`). Trạng thái hiện ở **tiêu đề cửa sổ** dạng `Funput · VI · Telex` (OSC, tự bọc
+  passthrough cho **tmux/screen**), và ở **màu con trỏ** (xanh khi VI, reset khi EN) — vẫn thấy được cả
+  khi tiêu đề bị ẩn.
 - Từ không hợp lệ tiếng Việt tự khôi phục ở ranh giới từ (`card ` → `card`).
 
 **"Luôn bật":** chạy `funput-term install` để in (hoặc `--write` để ghi) đoạn alias vào shell rc, hoặc
@@ -42,7 +43,8 @@ chia sẻ luôn preferences của IME hệ thống; macOS dùng file riêng tạ
 
 - CLI: `-m, --method telex|vni`; chương trình truyền sau `--` (mặc định `$SHELL`).
 - Env: `FUNPUT_METHOD`, `FUNPUT_TONE_STYLE`, `FUNPUT_ENABLED`, `FUNPUT_TOGGLE` (vd `ctrl-\`,
-  `ctrl-space`), `FUNPUT_CURSOR_COLOR_VI`, `FUNPUT_CONFIG` (đường dẫn file khác).
+  `ctrl-space`), `FUNPUT_CYCLE_METHOD` (phím xoay Telex↔VNI; `off`/`none` để tắt),
+  `FUNPUT_CURSOR_COLOR_VI`, `FUNPUT_CONFIG` (đường dẫn file khác).
 
 ## Hành vi & phạm vi
 
@@ -81,7 +83,7 @@ src/
 ├── config.rs  # THUẦN: đọc settings.json → TermConfig; overlay env; apply_to(engine); ưu tiên CLI>env>file
 ├── install.rs # THUẦN: snippet(shell, aliases) (bash/zsh/fish, idempotent) + ghi vào rc file
 ├── app.rs     # forward_input (seam THUẦN, có test) + run() orchestration (spawn PTY, threads, indicators)
-├── input.rs   # THUẦN: Classifier byte → ByteKind (Printable/Control/Escape/Utf8/Toggle/Paste)
+├── input.rs   # THUẦN: Classifier byte → ByteKind (Printable/Control/Escape/Utf8/Toggle/CycleMethod/Paste)
 ├── inject.rs  # THUẦN: result_bytes(char, &ImeResult) → bytes (None→phím; Send/Restore→DEL×bs + UTF-8)
 ├── output.rs  # forward_output + AltScreenScanner (ESC[?1049h/l, chịu được chunk bị cắt)
 ├── term.rs    # RawModeGuard (RAII), Mux passthrough, set_title (OSC) + set_cursor_cue (OSC 12/112)
@@ -94,7 +96,8 @@ pipe in-memory hoặc input dạng chuỗi.
 ### Quy tắc xử lý (trong `forward_input`)
 
 - Khởi tạo: `config.apply_to(engine)` (method, tone, smart/eager restore, spell-check, auto-cap, gõ tắt).
-- `Toggle` (mặc định `0x1c`, đổi được qua config) → `state.toggle()` + `engine.clear()` + cập nhật title & màu con trỏ.
+- `Toggle` (mặc định `0x1c`) → `state.toggle()` + `engine.clear()` + cập nhật title & màu con trỏ.
+- `CycleMethod` (mặc định `Ctrl-^` `0x1e`, đổi/tắt qua config) → `engine.set_method` xoay Telex↔VNI + `engine.clear()` + cập nhật indicator (`Status{enabled, method}`).
 - `Printable` khi đang soạn → `engine.process_char` → `result_bytes`.
 - Backspace (`0x7f`/`0x08`) khi đang soạn → `engine.on_backspace()` + forward byte (app tự xoá ký tự).
 - Tab/LF/CR (ranh giới từ) khi đang soạn → `engine.process_char(boundary)`: `None` → forward byte;
@@ -140,8 +143,9 @@ cargo clippy -p funput-term --all-targets -- -D warnings
 cargo run    -p funput-term -- cat       # gõ "as" → "á"
 ```
 
-Unit test thuần (pipe in-memory): classifier (printable/control/escape/mũi tên/Alt/utf8/toggle),
-`inject` (None/Send/Restore), `forward_input` (compose `as`→`a`+DEL+`á`, `Phua`⌫`s`→`Phú`,
+Unit test thuần (pipe in-memory): classifier (printable/control/escape/mũi tên/Alt/utf8/toggle/cycle-method),
+`inject` (None/Send/Restore), `forward_input` (compose `as`→`a`+DEL+`á`, `Phua`⌫`s`→`Phú`, xoay
+Telex→VNI giữa dòng `as`+Ctrl-^+`as`→`áas`,
 `text`+Enter restore, `mas`+Enter giữ `má`, revert `mixx`→`mix`, toggle off, bracketed paste giữ
 nguyên + soạn lại sau khi dán, config `enabled=false` không soạn, gõ tắt `vn`→`Việt Nam`), bracketed
 paste (marker bị cắt, toggle/chữ trong paste là thô, CSI quá dài không phải marker), alt-screen
@@ -153,6 +157,6 @@ override + ưu tiên, parse phím toggle), `install` (snippet bash/zsh/fish, ide
 
 - **Windows (ConPTY):** hiện chỉ Unix PTY; stack `portable-pty` đã sẵn, cần tầng input/resize cho
   Windows (TT6).
-- **Đổi method/kiểu đặt dấu lúc đang chạy:** hiện đổi method cần khởi động lại; thêm phím lệnh xoay
-  Telex↔VNI và bật/tắt kiểu đặt dấu ngay trong phiên.
+- **Đổi kiểu đặt dấu lúc đang chạy:** đã có xoay Telex↔VNI (`Ctrl-^`); còn thiếu phím bật/tắt
+  kiểu đặt dấu (traditional/modern) ngay trong phiên.
 - **Per-app profile:** dùng `excludedApps` từ settings.json để tự bật/tắt theo lệnh được bọc.

--- a/crates/funput-term/README.md
+++ b/crates/funput-term/README.md
@@ -18,7 +18,8 @@ funput-term -- cursor
 ```
 
 - VNI `xin1 chao2` hoặc Telex `xins chaof` → **xín chào**.
-- **`Ctrl-\`**: bật/tắt tiếng Việt (trạng thái VI/EN hiện ở **tiêu đề cửa sổ** qua OSC).
+- **`Ctrl-\`**: bật/tắt tiếng Việt (trạng thái VI/EN hiện ở **tiêu đề cửa sổ** qua OSC; tự bọc
+  passthrough cho **tmux/screen**).
 - Từ không hợp lệ tiếng Việt tự khôi phục ở ranh giới từ (`card ` → `card`).
 
 **"Luôn bật":** `alias claude='funput-term -- claude'`, hoặc cấu hình terminal emulator chạy
@@ -36,7 +37,8 @@ CLI: `-m, --method telex|vni` (mặc định `vni`); chương trình truyền sa
 | App full-screen (vim, less, htop) | **Tự tắt** soạn (phát hiện alt-screen) để không phá UI |
 | Backspace giữa lúc soạn | `engine.on_backspace()` — sửa rồi soạn tiếp (`Phua` ⌫ `s` → `Phú`) |
 | Enter / Tab khi đang soạn | Đi qua engine trước → English-restore kịp chạy (`text`+Enter gửi `text`, không phải `tẽt`) |
-| Escape / mũi tên / phím tắt / paste / UTF-8 | Forward **thô**, flush composition |
+| Bracketed paste (`ESC[200~ … ESC[201~`) | Nội dung dán forward **thô** (không soạn từng ký tự); marker giữ nguyên cho app con |
+| Escape / mũi tên / phím tắt / UTF-8 | Forward **thô**, flush composition |
 
 ## Cách hoạt động
 
@@ -88,6 +90,10 @@ src/
 - Resize: Unix `SIGWINCH` (`signal-hook`) → `crossterm::size` → `master.resize`. Windows: TT6.
 - Alt-screen: `output.rs` thấy `ESC[?1049h` → set `state.alt_screen` → input passthrough (vim/less
   không bị soạn).
+- Bracketed paste: `input.rs` thấy `ESC[200~` → `in_paste` → nội dung dán phân loại `Paste`
+  (forward thô) tới `ESC[201~`. Chịu được marker bị cắt qua nhiều chunk; buffer tham số CSI có giới hạn.
+- Title qua mux: `term.rs::detect_mux` đọc `$TMUX`/`$STY`/`$TERM`; `title_sequence` bọc DCS passthrough
+  cho tmux (nhân đôi ESC) và screen.
 
 ## Quan hệ với phần còn lại
 
@@ -114,14 +120,13 @@ cargo run    -p funput-term -- cat       # gõ "as" → "á"
 
 Unit test thuần (pipe in-memory): classifier (printable/control/escape/mũi tên/Alt/utf8/toggle),
 `inject` (None/Send/Restore), `forward_input` (compose `as`→`a`+DEL+`á`, `Phua`⌫`s`→`Phú`,
-`text`+Enter restore, `mas`+Enter giữ `má`, revert `mixx`→`mix`, toggle off), alt-screen scanner
-(kể cả chunk bị cắt), state.
+`text`+Enter restore, `mas`+Enter giữ `má`, revert `mixx`→`mix`, toggle off, bracketed paste giữ
+nguyên + soạn lại sau khi dán), bracketed paste (marker bị cắt, toggle/chữ trong paste là thô, CSI
+quá dài không phải marker), alt-screen scanner (kể cả chunk bị cắt), `title_sequence` (none/tmux/screen), state.
 
 ## Còn làm (sau v1)
 
 - **Windows (ConPTY):** hiện chỉ Unix PTY; stack `portable-pty` đã sẵn, cần tầng input/resize cho
   Windows (TT6).
-- **Bracketed paste:** khi dán (`ESC[200~ … ESC[201~`) nên pass-through thô thay vì soạn từng ký tự,
-  tránh méo nội dung dán (phát hiện tương tự alt-screen).
 - **Cấu hình bền:** phương thức + phím toggle đang cố định qua CLI; thêm env/file + đổi phương thức
   lúc đang chạy.

--- a/crates/funput-term/src/app.rs
+++ b/crates/funput-term/src/app.rs
@@ -5,20 +5,19 @@ use std::io::{self, Read, Write};
 use std::sync::Arc;
 use std::thread;
 
-use funput_core::InputMethod;
 use funput_engine::{Action, Engine};
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
+use crate::config::TermConfig;
 use crate::inject::result_bytes;
 use crate::input::{ByteKind, Classifier};
 use crate::output::forward_output;
 use crate::state::SharedState;
-use crate::term::{RawModeGuard, set_title};
+use crate::term::{RawModeGuard, set_cursor_cue, set_title};
 
-/// Run options resolved from the command line.
+/// Run options resolved from config, env, and the command line.
 pub struct Options {
-    pub method: InputMethod,
-    pub toggle: u8,
+    pub config: TermConfig,
     pub command: Vec<String>,
 }
 
@@ -29,9 +28,8 @@ pub struct Options {
 pub fn forward_input<R, W, F>(
     mut reader: R,
     mut writer: W,
-    method: InputMethod,
+    config: &TermConfig,
     state: &SharedState,
-    toggle: u8,
     mut on_toggle: F,
 ) -> io::Result<()>
 where
@@ -40,8 +38,9 @@ where
     F: FnMut(bool),
 {
     let mut engine = Engine::new();
-    engine.set_method(method);
-    let mut classifier = Classifier::new(toggle);
+    config.apply_to(&mut engine);
+    engine.arm_capitalization();
+    let mut classifier = Classifier::new(config.toggle);
     let mut buf = [0u8; 4096];
 
     loop {
@@ -142,9 +141,13 @@ pub fn run(opts: Options) -> io::Result<i32> {
     let writer = pair.master.take_writer().map_err(pty_err)?;
     let reader = pair.master.try_clone_reader().map_err(pty_err)?;
 
-    let state = Arc::new(SharedState::new(true));
+    let state = Arc::new(SharedState::new(opts.config.enabled));
 
     spawn_resize_thread(pair.master);
+
+    // Reflect the initial composition state in the title and cursor cue.
+    let vi_color = opts.config.vi_cursor_color.clone();
+    update_indicators(opts.config.enabled, &vi_color);
 
     // Child -> terminal (own thread; ends at EOF when the child exits).
     let state_out = Arc::clone(&state);
@@ -154,18 +157,35 @@ pub fn run(opts: Options) -> io::Result<i32> {
 
     // Terminal -> child (detached; blocks on stdin until the process exits).
     let state_in = Arc::clone(&state);
-    let method = opts.method;
-    let toggle = opts.toggle;
+    let config = opts.config;
+    let toggle_color = vi_color.clone();
     thread::spawn(move || {
-        let _ = forward_input(io::stdin(), writer, method, &state_in, toggle, |on| {
-            let mut out = io::stdout();
-            let _ = set_title(&mut out, if on { "funput · VI" } else { "funput · EN" });
+        let _ = forward_input(io::stdin(), writer, &config, &state_in, |on| {
+            update_indicators(on, &toggle_color);
         });
     });
 
     let status = child.wait().map_err(pty_err)?;
     let _ = output.join();
+
+    // Restore the user's default cursor — never leave it recolored after exit.
+    let _ = set_cursor_cue(&mut io::stdout(), false, &vi_color);
+
     Ok(status.exit_code() as i32)
+}
+
+/// Update both VI/EN indicators (window title + cursor color) to match `enabled`.
+fn update_indicators(enabled: bool, vi_color: &str) {
+    let mut out = io::stdout();
+    let _ = set_title(
+        &mut out,
+        if enabled {
+            "funput · VI"
+        } else {
+            "funput · EN"
+        },
+    );
+    let _ = set_cursor_cue(&mut out, enabled, vi_color);
 }
 
 #[cfg(unix)]
@@ -199,10 +219,19 @@ fn spawn_resize_thread(_master: Box<dyn portable_pty::MasterPty + Send>) {
 mod tests {
     use super::*;
 
+    use funput_core::InputMethod;
+
+    fn config_for(method: InputMethod) -> TermConfig {
+        TermConfig {
+            method,
+            ..TermConfig::default()
+        }
+    }
+
     fn compose(method: InputMethod, input: &[u8]) -> Vec<u8> {
         let state = SharedState::new(true);
         let mut out = Vec::new();
-        forward_input(input, &mut out, method, &state, 0x1c, |_| {}).unwrap();
+        forward_input(input, &mut out, &config_for(method), &state, |_| {}).unwrap();
         out
     }
 
@@ -297,14 +326,39 @@ mod tests {
         forward_input(
             &[0x1c, b'a', b's'][..],
             &mut out,
-            InputMethod::Telex,
+            &config_for(InputMethod::Telex),
             &state,
-            0x1c,
             |on| toggles.push(on),
         )
         .unwrap();
         assert_eq!(out, b"as");
         assert_eq!(toggles, vec![false]);
         assert!(!state.composing());
+    }
+
+    #[test]
+    fn config_disabled_composes_nothing() {
+        // enabled = false in config → start in EN, keystrokes pass through raw.
+        let config = TermConfig {
+            enabled: false,
+            ..config_for(InputMethod::Telex)
+        };
+        let state = SharedState::new(config.enabled);
+        let mut out = Vec::new();
+        forward_input(b"as".as_ref(), &mut out, &config, &state, |_| {}).unwrap();
+        assert_eq!(out, b"as");
+    }
+
+    #[test]
+    fn config_shortcut_expands_at_boundary() {
+        // A gõ-tắt shortcut from config expands when the word boundary arrives.
+        let config = TermConfig {
+            shortcuts: vec![("vn".to_string(), "Việt Nam".to_string())],
+            ..config_for(InputMethod::Telex)
+        };
+        let state = SharedState::new(true);
+        let mut out = Vec::new();
+        forward_input(b"vn ".as_ref(), &mut out, &config, &state, |_| {}).unwrap();
+        assert_eq!(reconstruct(&out), "Việt Nam ");
     }
 }

--- a/crates/funput-term/src/app.rs
+++ b/crates/funput-term/src/app.rs
@@ -5,6 +5,7 @@ use std::io::{self, Read, Write};
 use std::sync::Arc;
 use std::thread;
 
+use funput_core::InputMethod;
 use funput_engine::{Action, Engine};
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
@@ -21,6 +22,24 @@ pub struct Options {
     pub command: Vec<String>,
 }
 
+/// The user-visible composition state, reported whenever it changes so the caller
+/// can refresh the indicators (window title + cursor cue).
+#[derive(Debug, Clone, Copy)]
+pub struct Status {
+    /// VI (composing) vs EN (passthrough).
+    pub enabled: bool,
+    /// Active input method.
+    pub method: InputMethod,
+}
+
+/// The other input method — used to cycle Telex↔VNI.
+fn other_method(method: InputMethod) -> InputMethod {
+    match method {
+        InputMethod::Telex => InputMethod::Vni,
+        InputMethod::Vni => InputMethod::Telex,
+    }
+}
+
 /// Read keystrokes from `reader`, compose, and write the result bytes to `writer`.
 ///
 /// Pure of real I/O — the caller injects the reader/writer and a toggle callback,
@@ -30,17 +49,17 @@ pub fn forward_input<R, W, F>(
     mut writer: W,
     config: &TermConfig,
     state: &SharedState,
-    mut on_toggle: F,
+    mut on_status: F,
 ) -> io::Result<()>
 where
     R: Read,
     W: Write,
-    F: FnMut(bool),
+    F: FnMut(Status),
 {
     let mut engine = Engine::new();
     config.apply_to(&mut engine);
     engine.arm_capitalization();
-    let mut classifier = Classifier::new(config.toggle);
+    let mut classifier = Classifier::new(config.toggle, config.cycle_method);
     let mut buf = [0u8; 4096];
 
     loop {
@@ -53,7 +72,21 @@ where
                 ByteKind::Toggle => {
                     let enabled = state.toggle();
                     engine.clear();
-                    on_toggle(enabled);
+                    on_status(Status {
+                        enabled,
+                        method: engine.method(),
+                    });
+                }
+                // Cycle Telex↔VNI live; flush the in-progress word so it doesn't
+                // carry half-composed under the old method.
+                ByteKind::CycleMethod => {
+                    let method = other_method(engine.method());
+                    engine.set_method(method);
+                    engine.clear();
+                    on_status(Status {
+                        enabled: state.enabled(),
+                        method,
+                    });
                 }
                 ByteKind::Printable(ch) if state.composing() => {
                     let result = engine.process_char(ch);
@@ -147,7 +180,13 @@ pub fn run(opts: Options) -> io::Result<i32> {
 
     // Reflect the initial composition state in the title and cursor cue.
     let vi_color = opts.config.vi_cursor_color.clone();
-    update_indicators(opts.config.enabled, &vi_color);
+    update_indicators(
+        Status {
+            enabled: opts.config.enabled,
+            method: opts.config.method,
+        },
+        &vi_color,
+    );
 
     // Child -> terminal (own thread; ends at EOF when the child exits).
     let state_out = Arc::clone(&state);
@@ -158,10 +197,10 @@ pub fn run(opts: Options) -> io::Result<i32> {
     // Terminal -> child (detached; blocks on stdin until the process exits).
     let state_in = Arc::clone(&state);
     let config = opts.config;
-    let toggle_color = vi_color.clone();
+    let status_color = vi_color.clone();
     thread::spawn(move || {
-        let _ = forward_input(io::stdin(), writer, &config, &state_in, |on| {
-            update_indicators(on, &toggle_color);
+        let _ = forward_input(io::stdin(), writer, &config, &state_in, |status| {
+            update_indicators(status, &status_color);
         });
     });
 
@@ -174,18 +213,17 @@ pub fn run(opts: Options) -> io::Result<i32> {
     Ok(status.exit_code() as i32)
 }
 
-/// Update both VI/EN indicators (window title + cursor color) to match `enabled`.
-fn update_indicators(enabled: bool, vi_color: &str) {
+/// Update both VI/EN indicators (window title + cursor color) to match `status`.
+/// The title also shows the active method so a live Telex↔VNI switch is visible.
+fn update_indicators(status: Status, vi_color: &str) {
     let mut out = io::stdout();
-    let _ = set_title(
-        &mut out,
-        if enabled {
-            "funput · VI"
-        } else {
-            "funput · EN"
-        },
-    );
-    let _ = set_cursor_cue(&mut out, enabled, vi_color);
+    let vi_en = if status.enabled { "VI" } else { "EN" };
+    let method = match status.method {
+        InputMethod::Telex => "Telex",
+        InputMethod::Vni => "VNI",
+    };
+    let _ = set_title(&mut out, &format!("Funput · {vi_en} · {method}"));
+    let _ = set_cursor_cue(&mut out, status.enabled, vi_color);
 }
 
 #[cfg(unix)]
@@ -328,12 +366,31 @@ mod tests {
             &mut out,
             &config_for(InputMethod::Telex),
             &state,
-            |on| toggles.push(on),
+            |status| toggles.push(status.enabled),
         )
         .unwrap();
         assert_eq!(out, b"as");
         assert_eq!(toggles, vec![false]);
         assert!(!state.composing());
+    }
+
+    #[test]
+    fn cycle_method_key_switches_telex_vni() {
+        // Start Telex (cycle key Ctrl-^ = 0x1e): "as" → "á". After cycling to VNI,
+        // "as" stays "as" (s is not a VNI modifier). Status reports the new method.
+        let config = TermConfig {
+            cycle_method: Some(0x1e),
+            ..config_for(InputMethod::Telex)
+        };
+        let state = SharedState::new(true);
+        let mut out = Vec::new();
+        let mut methods = Vec::new();
+        forward_input(b"as\x1eas".as_ref(), &mut out, &config, &state, |s| {
+            methods.push(s.method)
+        })
+        .unwrap();
+        assert_eq!(reconstruct(&out), "áas");
+        assert_eq!(methods, vec![InputMethod::Vni]);
     }
 
     #[test]

--- a/crates/funput-term/src/app.rs
+++ b/crates/funput-term/src/app.rs
@@ -7,13 +7,13 @@ use std::thread;
 
 use funput_core::InputMethod;
 use funput_engine::{Action, Engine};
-use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
 use crate::inject::result_bytes;
 use crate::input::{ByteKind, Classifier};
 use crate::output::forward_output;
 use crate::state::SharedState;
-use crate::term::{set_title, RawModeGuard};
+use crate::term::{RawModeGuard, set_title};
 
 /// Run options resolved from the command line.
 pub struct Options {
@@ -78,6 +78,9 @@ where
                         _ => writer.write_all(&result_bytes(ch, &result))?,
                     }
                 }
+                // Bracketed-paste content: forward verbatim, never compose. The
+                // start marker already flushed composition via the arm below.
+                ByteKind::Paste => writer.write_all(&[byte])?,
                 // Control / escape / utf8 / printable-while-disabled: end the
                 // current word and forward the byte unchanged.
                 _ => {
@@ -265,6 +268,24 @@ mod tests {
         // A real syllable is finalized, not restored.
         let out = compose(InputMethod::Telex, b"mas\r");
         assert_eq!(reconstruct(&out), "má\r");
+    }
+
+    #[test]
+    fn bracketed_paste_is_forwarded_verbatim() {
+        // "as" pasted inside ESC[200~…ESC[201~ must stay "as", not compose to
+        // "á"; the markers themselves are forwarded to the child untouched.
+        let out = compose(InputMethod::Telex, b"\x1b[200~as\x1b[201~");
+        assert!(out.starts_with(b"\x1b[200~"));
+        assert!(out.ends_with(b"\x1b[201~"));
+        assert_eq!(reconstruct(&out), "\x1b[200~as\x1b[201~");
+    }
+
+    #[test]
+    fn composition_resumes_after_paste() {
+        // Compose, paste raw, then compose again — all in one buffer.
+        let out = compose(InputMethod::Telex, b"as\x1b[200~as\x1b[201~as");
+        // First "as" → "á", pasted "as" stays literal, trailing "as" → "á".
+        assert_eq!(reconstruct(&out), "á\x1b[200~as\x1b[201~á");
     }
 
     #[test]

--- a/crates/funput-term/src/config.rs
+++ b/crates/funput-term/src/config.rs
@@ -1,0 +1,335 @@
+//! Persistent configuration for `funput-term`.
+//!
+//! Reads the project's canonical settings file —
+//! `dirs::config_dir()/Funput/settings.json` — so on Linux/Windows the terminal
+//! inherits the system IME's preferences, and on macOS it uses its own file at the
+//! same well-known path. The on-disk schema (camelCase) mirrors the platform
+//! settings readers (`platforms/windows/src/settings.rs`,
+//! `platforms/linux/settings-gtk/src/settings.rs`); we keep a local copy rather
+//! than depend on those platform-only crates.
+//!
+//! Resolution precedence is **CLI flag > env var > settings.json > built-in
+//! default**. The file and env layers live here; the CLI layer is applied by the
+//! caller (`main.rs`).
+//!
+//! The parse, env-overlay, and engine-apply steps are pure seams (no real I/O), so
+//! they are unit-tested directly.
+
+use std::path::PathBuf;
+
+use funput_core::{InputMethod, ToneStyle};
+use funput_engine::Engine;
+use serde::Deserialize;
+
+use crate::term::DEFAULT_VI_CURSOR_COLOR;
+
+/// `Ctrl-\` (0x1c) — the default Vietnamese on/off toggle byte.
+pub const DEFAULT_TOGGLE: u8 = 0x1c;
+
+/// Input method as it serializes in `settings.json` (`"telex"`/`"vni"`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum Method {
+    Telex,
+    #[default]
+    Vni,
+}
+
+impl From<Method> for InputMethod {
+    fn from(m: Method) -> Self {
+        match m {
+            Method::Telex => InputMethod::Telex,
+            Method::Vni => InputMethod::Vni,
+        }
+    }
+}
+
+/// Tone-mark placement as it serializes in `settings.json`
+/// (`"traditional"`/`"modern"`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum ToneStyleCfg {
+    #[default]
+    Traditional,
+    Modern,
+}
+
+impl From<ToneStyleCfg> for ToneStyle {
+    fn from(t: ToneStyleCfg) -> Self {
+        match t {
+            ToneStyleCfg::Traditional => ToneStyle::Traditional,
+            ToneStyleCfg::Modern => ToneStyle::Modern,
+        }
+    }
+}
+
+/// A text-expansion shortcut (gõ tắt) as stored in `settings.json`.
+#[derive(Debug, Clone, Deserialize)]
+struct Shortcut {
+    trigger: String,
+    expansion: String,
+}
+
+/// The subset of the on-disk settings that `funput-term` can act on. Every field
+/// has a serde default so older or partial files still load, and so an empty
+/// object (`{}`) yields the canonical defaults — the single source of truth.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FileSettings {
+    #[serde(default)]
+    method: Method,
+    #[serde(default)]
+    tone_style: ToneStyleCfg,
+    #[serde(default = "default_true")]
+    enabled: bool,
+    #[serde(default = "default_true")]
+    smart_restore: bool,
+    #[serde(default = "default_true")]
+    eager_restore: bool,
+    #[serde(default)]
+    spell_check: bool,
+    #[serde(default)]
+    auto_capitalize: bool,
+    #[serde(default)]
+    shortcuts: Vec<Shortcut>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Resolved, engine-ready configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TermConfig {
+    pub method: InputMethod,
+    pub tone_style: ToneStyle,
+    /// Whether composition starts on (VI) or off (EN).
+    pub enabled: bool,
+    pub smart_restore: bool,
+    pub eager_restore: bool,
+    pub spell_check: bool,
+    pub auto_capitalize: bool,
+    pub shortcuts: Vec<(String, String)>,
+    /// The byte that toggles VI/EN.
+    pub toggle: u8,
+    /// Cursor color shown while composing (VI).
+    pub vi_cursor_color: String,
+}
+
+impl Default for TermConfig {
+    fn default() -> Self {
+        // Parsing an empty object routes through the serde defaults so the
+        // defaults are defined in exactly one place.
+        from_json("{}")
+    }
+}
+
+impl From<FileSettings> for TermConfig {
+    fn from(f: FileSettings) -> Self {
+        TermConfig {
+            method: f.method.into(),
+            tone_style: f.tone_style.into(),
+            enabled: f.enabled,
+            smart_restore: f.smart_restore,
+            eager_restore: f.eager_restore,
+            spell_check: f.spell_check,
+            auto_capitalize: f.auto_capitalize,
+            shortcuts: f
+                .shortcuts
+                .into_iter()
+                .map(|s| (s.trigger, s.expansion))
+                .collect(),
+            toggle: DEFAULT_TOGGLE,
+            vi_cursor_color: DEFAULT_VI_CURSOR_COLOR.to_string(),
+        }
+    }
+}
+
+/// Parse `settings.json` contents into a resolved config. Malformed or empty input
+/// falls back to the canonical defaults.
+pub fn from_json(s: &str) -> TermConfig {
+    serde_json::from_str::<FileSettings>(s)
+        .or_else(|_| serde_json::from_str::<FileSettings>("{}"))
+        .expect("an empty JSON object is always valid FileSettings")
+        .into()
+}
+
+impl TermConfig {
+    /// Overlay environment-variable overrides (higher precedence than the file).
+    /// The getter is injected so this is unit-testable without touching the
+    /// process environment.
+    pub fn apply_env(mut self, get: impl Fn(&str) -> Option<String>) -> Self {
+        if let Some(m) = get("FUNPUT_METHOD").as_deref().and_then(parse_method) {
+            self.method = m;
+        }
+        if let Some(t) = get("FUNPUT_TONE_STYLE").as_deref().and_then(parse_tone) {
+            self.tone_style = t;
+        }
+        if let Some(e) = get("FUNPUT_ENABLED").as_deref().and_then(parse_bool) {
+            self.enabled = e;
+        }
+        if let Some(b) = get("FUNPUT_TOGGLE").as_deref().and_then(parse_toggle) {
+            self.toggle = b;
+        }
+        if let Some(c) = get("FUNPUT_CURSOR_COLOR_VI").filter(|c| !c.is_empty()) {
+            self.vi_cursor_color = c;
+        }
+        self
+    }
+
+    /// Push the engine-affecting options into a fresh engine. Replaces the whole
+    /// shortcut table so repeated calls stay consistent.
+    pub fn apply_to(&self, engine: &mut Engine) {
+        engine.set_method(self.method);
+        engine.set_tone_style(self.tone_style);
+        engine.set_smart_restore(self.smart_restore);
+        engine.set_eager_restore(self.eager_restore);
+        engine.set_spell_check(self.spell_check);
+        engine.set_auto_capitalize(self.auto_capitalize);
+        engine.clear_shortcuts();
+        for (trigger, expansion) in &self.shortcuts {
+            engine.add_shortcut(trigger.clone(), expansion.clone());
+        }
+    }
+}
+
+/// Path to the settings file: `$FUNPUT_CONFIG` if set, else the canonical
+/// `dirs::config_dir()/Funput/settings.json`.
+pub fn settings_path() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("FUNPUT_CONFIG") {
+        return Some(PathBuf::from(p));
+    }
+    dirs::config_dir().map(|d| d.join("Funput").join("settings.json"))
+}
+
+/// Load the effective config: settings file (or defaults if missing/unreadable)
+/// with environment overrides applied.
+pub fn load() -> TermConfig {
+    let from_file = settings_path()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .map(|s| from_json(&s))
+        .unwrap_or_default();
+    from_file.apply_env(|k| std::env::var(k).ok())
+}
+
+fn parse_method(s: &str) -> Option<InputMethod> {
+    match s.to_ascii_lowercase().as_str() {
+        "telex" => Some(InputMethod::Telex),
+        "vni" => Some(InputMethod::Vni),
+        _ => None,
+    }
+}
+
+fn parse_tone(s: &str) -> Option<ToneStyle> {
+    match s.to_ascii_lowercase().as_str() {
+        "traditional" | "old" => Some(ToneStyle::Traditional),
+        "modern" | "new" => Some(ToneStyle::Modern),
+        _ => None,
+    }
+}
+
+fn parse_bool(s: &str) -> Option<bool> {
+    match s.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+/// Parse a toggle-key spec into its control byte: `ctrl-\`, `ctrl-^`, `ctrl-]`,
+/// `ctrl-space`, etc. A control byte is the key's ASCII value masked with 0x1f
+/// (`\` 0x5c → 0x1c), and `space` maps to NUL (0x00, i.e. `Ctrl-Space`).
+fn parse_toggle(s: &str) -> Option<u8> {
+    let key = s.trim().to_ascii_lowercase();
+    let key = key
+        .strip_prefix("ctrl-")
+        .or_else(|| key.strip_prefix("c-"))?;
+    match key {
+        "space" | "spc" => Some(0x00),
+        k if k.chars().count() == 1 => {
+            let ch = k.chars().next().unwrap();
+            ch.is_ascii().then_some((ch as u8) & 0x1f)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_canonical_camelcase_file() {
+        let json = r#"{
+            "method": "telex",
+            "toneStyle": "modern",
+            "enabled": true,
+            "smartRestore": true,
+            "eagerRestore": false,
+            "spellCheck": true,
+            "autoCapitalize": true,
+            "shortcuts": [{ "trigger": "vn", "expansion": "Việt Nam" }]
+        }"#;
+        let c = from_json(json);
+        assert_eq!(c.method, InputMethod::Telex);
+        assert_eq!(c.tone_style, ToneStyle::Modern);
+        assert!(c.enabled);
+        assert!(!c.eager_restore);
+        assert!(c.spell_check);
+        assert!(c.auto_capitalize);
+        assert_eq!(
+            c.shortcuts,
+            vec![("vn".to_string(), "Việt Nam".to_string())]
+        );
+    }
+
+    #[test]
+    fn missing_keys_fall_back_to_defaults() {
+        // Empty object: VNI, traditional, enabled, restore flags on, others off.
+        let c = from_json("{}");
+        assert_eq!(c, TermConfig::default());
+        assert_eq!(c.method, InputMethod::Vni);
+        assert_eq!(c.tone_style, ToneStyle::Traditional);
+        assert!(c.enabled && c.smart_restore && c.eager_restore);
+        assert!(!c.spell_check && !c.auto_capitalize);
+        assert_eq!(c.toggle, DEFAULT_TOGGLE);
+        assert_eq!(c.vi_cursor_color, DEFAULT_VI_CURSOR_COLOR);
+    }
+
+    #[test]
+    fn malformed_json_falls_back_to_defaults() {
+        assert_eq!(from_json("not json"), TermConfig::default());
+    }
+
+    #[test]
+    fn env_overrides_file_values() {
+        let base = from_json(r#"{ "method": "vni", "enabled": true }"#);
+        let env = |k: &str| match k {
+            "FUNPUT_METHOD" => Some("telex".to_string()),
+            "FUNPUT_ENABLED" => Some("false".to_string()),
+            "FUNPUT_TOGGLE" => Some("ctrl-^".to_string()),
+            _ => None,
+        };
+        let c = base.apply_env(env);
+        assert_eq!(c.method, InputMethod::Telex); // env beat the file
+        assert!(!c.enabled);
+        assert_eq!(c.toggle, 0x1e); // '^' (0x5e) & 0x1f
+    }
+
+    #[test]
+    fn env_ignores_unset_and_invalid() {
+        let base = from_json(r#"{ "method": "telex" }"#);
+        let c = base.clone().apply_env(|_| None);
+        assert_eq!(c, base); // nothing set → unchanged
+        let c = base.apply_env(|k| (k == "FUNPUT_METHOD").then(|| "garbage".to_string()));
+        assert_eq!(c.method, InputMethod::Telex); // invalid value ignored
+    }
+
+    #[test]
+    fn toggle_spec_parsing() {
+        assert_eq!(parse_toggle("ctrl-\\"), Some(0x1c));
+        assert_eq!(parse_toggle("Ctrl-Space"), Some(0x00));
+        assert_eq!(parse_toggle("c-]"), Some(0x1d));
+        assert_eq!(parse_toggle("nope"), None);
+    }
+}

--- a/crates/funput-term/src/config.rs
+++ b/crates/funput-term/src/config.rs
@@ -26,6 +26,11 @@ use crate::term::DEFAULT_VI_CURSOR_COLOR;
 /// `Ctrl-\` (0x1c) — the default Vietnamese on/off toggle byte.
 pub const DEFAULT_TOGGLE: u8 = 0x1c;
 
+/// `Ctrl-^` (0x1e) — the default key to cycle Telex↔VNI. Almost never used by
+/// shells or readline, so it is safe to claim by default; set `FUNPUT_CYCLE_METHOD`
+/// to another key, or to `off`/`none` to disable.
+pub const DEFAULT_CYCLE_METHOD: Option<u8> = Some(0x1e);
+
 /// Input method as it serializes in `settings.json` (`"telex"`/`"vni"`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -112,6 +117,8 @@ pub struct TermConfig {
     pub shortcuts: Vec<(String, String)>,
     /// The byte that toggles VI/EN.
     pub toggle: u8,
+    /// The byte that cycles Telex↔VNI at runtime, or `None` to disable.
+    pub cycle_method: Option<u8>,
     /// Cursor color shown while composing (VI).
     pub vi_cursor_color: String,
 }
@@ -140,6 +147,7 @@ impl From<FileSettings> for TermConfig {
                 .map(|s| (s.trigger, s.expansion))
                 .collect(),
             toggle: DEFAULT_TOGGLE,
+            cycle_method: DEFAULT_CYCLE_METHOD,
             vi_cursor_color: DEFAULT_VI_CURSOR_COLOR.to_string(),
         }
     }
@@ -170,6 +178,18 @@ impl TermConfig {
         }
         if let Some(b) = get("FUNPUT_TOGGLE").as_deref().and_then(parse_toggle) {
             self.toggle = b;
+        }
+        if let Some(spec) = get("FUNPUT_CYCLE_METHOD") {
+            // `off`/`none`/empty disables; otherwise parse a key spec (invalid
+            // specs are ignored, keeping the previous value).
+            match spec.trim().to_ascii_lowercase().as_str() {
+                "" | "off" | "none" | "disable" | "disabled" => self.cycle_method = None,
+                _ => {
+                    if let Some(b) = parse_toggle(&spec) {
+                        self.cycle_method = Some(b);
+                    }
+                }
+            }
         }
         if let Some(c) = get("FUNPUT_CURSOR_COLOR_VI").filter(|c| !c.is_empty()) {
             self.vi_cursor_color = c;
@@ -323,6 +343,18 @@ mod tests {
         assert_eq!(c, base); // nothing set → unchanged
         let c = base.apply_env(|k| (k == "FUNPUT_METHOD").then(|| "garbage".to_string()));
         assert_eq!(c.method, InputMethod::Telex); // invalid value ignored
+    }
+
+    #[test]
+    fn cycle_method_key_defaults_and_overrides() {
+        assert_eq!(from_json("{}").cycle_method, DEFAULT_CYCLE_METHOD);
+        // A custom key spec.
+        let c =
+            from_json("{}").apply_env(|k| (k == "FUNPUT_CYCLE_METHOD").then(|| "ctrl-]".into()));
+        assert_eq!(c.cycle_method, Some(0x1d));
+        // Disabled.
+        let c = from_json("{}").apply_env(|k| (k == "FUNPUT_CYCLE_METHOD").then(|| "off".into()));
+        assert_eq!(c.cycle_method, None);
     }
 
     #[test]

--- a/crates/funput-term/src/input.rs
+++ b/crates/funput-term/src/input.rs
@@ -17,6 +17,8 @@ pub enum ByteKind {
     Utf8,
     /// The configured toggle key — consume, do not forward.
     Toggle,
+    /// The configured cycle-method key (Telex↔VNI) — consume, do not forward.
+    CycleMethod,
     /// Byte inside a bracketed paste — forward raw, never compose.
     Paste,
 }
@@ -34,6 +36,8 @@ enum Phase {
 #[derive(Debug)]
 pub struct Classifier {
     toggle: u8,
+    /// Key that cycles Telex↔VNI, or `None` when disabled.
+    cycle_method: Option<u8>,
     phase: Phase,
     /// Inside a bracketed paste (`ESC[200~` … `ESC[201~`): forward content raw.
     in_paste: bool,
@@ -51,9 +55,10 @@ const PASTE_END: &[u8] = b"201";
 const MAX_CSI_PARAMS: usize = PASTE_START.len();
 
 impl Classifier {
-    pub fn new(toggle: u8) -> Self {
+    pub fn new(toggle: u8, cycle_method: Option<u8>) -> Self {
         Self {
             toggle,
+            cycle_method,
             phase: Phase::Normal,
             in_paste: false,
             params: Vec::new(),
@@ -111,6 +116,9 @@ impl Classifier {
         if byte == self.toggle {
             return ByteKind::Toggle;
         }
+        if self.cycle_method == Some(byte) {
+            return ByteKind::CycleMethod;
+        }
         match byte {
             0x20..=0x7e => ByteKind::Printable(byte as char),
             0x80..=0xff => ByteKind::Utf8,
@@ -126,7 +134,7 @@ mod tests {
     const CTRL_BACKSLASH: u8 = 0x1c;
 
     fn classify_all(toggle: u8, bytes: &[u8]) -> Vec<ByteKind> {
-        let mut c = Classifier::new(toggle);
+        let mut c = Classifier::new(toggle, None);
         bytes.iter().map(|&b| c.classify(b)).collect()
     }
 
@@ -160,9 +168,21 @@ mod tests {
     }
 
     #[test]
+    fn cycle_method_key_recognised_only_when_configured() {
+        const CTRL_CARET: u8 = 0x1e;
+        // Configured → CycleMethod; nothing else changes.
+        let mut c = Classifier::new(CTRL_BACKSLASH, Some(CTRL_CARET));
+        assert_eq!(c.classify(CTRL_CARET), ByteKind::CycleMethod);
+        assert_eq!(c.classify(CTRL_BACKSLASH), ByteKind::Toggle);
+        // Disabled → the same byte is just a control byte.
+        let mut c = Classifier::new(CTRL_BACKSLASH, None);
+        assert_eq!(c.classify(CTRL_CARET), ByteKind::Control);
+    }
+
+    #[test]
     fn arrow_key_is_escape_sequence() {
         // Up arrow = ESC [ A — all three bytes are Escape, then back to normal.
-        let mut c = Classifier::new(CTRL_BACKSLASH);
+        let mut c = Classifier::new(CTRL_BACKSLASH, None);
         assert_eq!(c.classify(0x1b), ByteKind::Escape);
         assert_eq!(c.classify(b'['), ByteKind::Escape);
         assert_eq!(c.classify(b'A'), ByteKind::Escape);
@@ -171,7 +191,7 @@ mod tests {
 
     #[test]
     fn alt_key_is_two_byte_escape() {
-        let mut c = Classifier::new(CTRL_BACKSLASH);
+        let mut c = Classifier::new(CTRL_BACKSLASH, None);
         assert_eq!(c.classify(0x1b), ByteKind::Escape);
         assert_eq!(c.classify(b'x'), ByteKind::Escape); // ESC x = Alt-x
         assert_eq!(c.classify(b'y'), ByteKind::Printable('y'));
@@ -190,7 +210,7 @@ mod tests {
     fn bracketed_paste_content_is_raw() {
         // ESC[200~as ESC[201~b : "as" is paste content (not composed), then
         // "b" composes normally once the paste ends.
-        let mut c = Classifier::new(CTRL_BACKSLASH);
+        let mut c = Classifier::new(CTRL_BACKSLASH, None);
         for &b in b"\x1b[200~" {
             assert_eq!(c.classify(b), ByteKind::Escape);
         }
@@ -206,7 +226,7 @@ mod tests {
     fn paste_marker_split_across_chunks() {
         // The marker can arrive byte-by-byte across reads; classifier state
         // persists, so paste mode still engages.
-        let mut c = Classifier::new(CTRL_BACKSLASH);
+        let mut c = Classifier::new(CTRL_BACKSLASH, None);
         for &b in b"\x1b[20" {
             c.classify(b);
         }
@@ -220,7 +240,7 @@ mod tests {
     fn toggle_and_letters_inside_paste_are_raw() {
         // Pasted content must never be interpreted as commands: the toggle key
         // and letters alike are literal Paste bytes.
-        let mut c = Classifier::new(CTRL_BACKSLASH);
+        let mut c = Classifier::new(CTRL_BACKSLASH, None);
         for &b in b"\x1b[200~" {
             c.classify(b);
         }
@@ -232,7 +252,7 @@ mod tests {
     fn over_long_csi_is_not_a_paste_marker() {
         // A CSI whose parameters exceed a marker's length must not toggle paste,
         // and its parameter buffer must stay bounded.
-        let mut c = Classifier::new(CTRL_BACKSLASH);
+        let mut c = Classifier::new(CTRL_BACKSLASH, None);
         for &b in b"\x1b[200000~" {
             c.classify(b);
         }

--- a/crates/funput-term/src/input.rs
+++ b/crates/funput-term/src/input.rs
@@ -17,6 +17,8 @@ pub enum ByteKind {
     Utf8,
     /// The configured toggle key — consume, do not forward.
     Toggle,
+    /// Byte inside a bracketed paste — forward raw, never compose.
+    Paste,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -33,15 +35,28 @@ enum Phase {
 pub struct Classifier {
     toggle: u8,
     phase: Phase,
+    /// Inside a bracketed paste (`ESC[200~` … `ESC[201~`): forward content raw.
+    in_paste: bool,
+    /// Parameter bytes of the CSI sequence being parsed, kept only to recognise
+    /// the `200`/`201` bracketed-paste markers. Capped at `MAX_CSI_PARAMS`.
+    params: Vec<u8>,
 }
 
 const ESC: u8 = 0x1b;
+/// Bracketed-paste markers (`ESC[200~` start, `ESC[201~` end).
+const PASTE_START: &[u8] = b"200";
+const PASTE_END: &[u8] = b"201";
+/// Upper bound on retained CSI parameter bytes — enough for the markers we match,
+/// while keeping a malformed, never-terminated CSI from growing the buffer.
+const MAX_CSI_PARAMS: usize = PASTE_START.len();
 
 impl Classifier {
     pub fn new(toggle: u8) -> Self {
         Self {
             toggle,
             phase: Phase::Normal,
+            in_paste: false,
+            params: Vec::new(),
         }
     }
 
@@ -52,6 +67,7 @@ impl Classifier {
                 // `ESC [` (CSI) or `ESC O` (SS3) start a multi-byte sequence;
                 // anything else is a 2-byte sequence (e.g. Alt+key).
                 self.phase = if byte == b'[' || byte == b'O' {
+                    self.params.clear();
                     Phase::Csi
                 } else {
                     Phase::Normal
@@ -59,9 +75,22 @@ impl Classifier {
                 ByteKind::Escape
             }
             Phase::Csi => {
-                // Final byte of a CSI/SS3 sequence is in `0x40..=0x7e`.
+                // Final byte of a CSI/SS3 sequence is in `0x40..=0x7e`; bytes
+                // before it are parameters we track to spot the bracketed-paste
+                // markers.
                 if (0x40..=0x7e).contains(&byte) {
                     self.phase = Phase::Normal;
+                    if byte == b'~' {
+                        match self.params.as_slice() {
+                            PASTE_START => self.in_paste = true,
+                            PASTE_END => self.in_paste = false,
+                            _ => {}
+                        }
+                    }
+                } else if self.params.len() <= MAX_CSI_PARAMS {
+                    // Retain one byte beyond a marker's length so an over-long
+                    // run (e.g. `2000`) can't equal a marker, then stop growing.
+                    self.params.push(byte);
                 }
                 ByteKind::Escape
             }
@@ -69,14 +98,20 @@ impl Classifier {
     }
 
     fn classify_normal(&mut self, byte: u8) -> ByteKind {
+        if byte == ESC {
+            self.phase = Phase::AfterEsc;
+            return ByteKind::Escape;
+        }
+        // Inside a paste, every non-ESC byte is literal content: forward it raw
+        // before any toggle/printable handling, so pasted letters and even the
+        // toggle key are never interpreted as commands.
+        if self.in_paste {
+            return ByteKind::Paste;
+        }
         if byte == self.toggle {
             return ByteKind::Toggle;
         }
         match byte {
-            ESC => {
-                self.phase = Phase::AfterEsc;
-                ByteKind::Escape
-            }
             0x20..=0x7e => ByteKind::Printable(byte as char),
             0x80..=0xff => ByteKind::Utf8,
             _ => ByteKind::Control,
@@ -149,5 +184,59 @@ mod tests {
             classify_all(CTRL_BACKSLASH, "á".as_bytes()),
             vec![ByteKind::Utf8, ByteKind::Utf8]
         );
+    }
+
+    #[test]
+    fn bracketed_paste_content_is_raw() {
+        // ESC[200~as ESC[201~b : "as" is paste content (not composed), then
+        // "b" composes normally once the paste ends.
+        let mut c = Classifier::new(CTRL_BACKSLASH);
+        for &b in b"\x1b[200~" {
+            assert_eq!(c.classify(b), ByteKind::Escape);
+        }
+        assert_eq!(c.classify(b'a'), ByteKind::Paste);
+        assert_eq!(c.classify(b's'), ByteKind::Paste);
+        for &b in b"\x1b[201~" {
+            assert_eq!(c.classify(b), ByteKind::Escape);
+        }
+        assert_eq!(c.classify(b'b'), ByteKind::Printable('b'));
+    }
+
+    #[test]
+    fn paste_marker_split_across_chunks() {
+        // The marker can arrive byte-by-byte across reads; classifier state
+        // persists, so paste mode still engages.
+        let mut c = Classifier::new(CTRL_BACKSLASH);
+        for &b in b"\x1b[20" {
+            c.classify(b);
+        }
+        for &b in b"0~" {
+            c.classify(b);
+        }
+        assert_eq!(c.classify(b'x'), ByteKind::Paste);
+    }
+
+    #[test]
+    fn toggle_and_letters_inside_paste_are_raw() {
+        // Pasted content must never be interpreted as commands: the toggle key
+        // and letters alike are literal Paste bytes.
+        let mut c = Classifier::new(CTRL_BACKSLASH);
+        for &b in b"\x1b[200~" {
+            c.classify(b);
+        }
+        assert_eq!(c.classify(CTRL_BACKSLASH), ByteKind::Paste);
+        assert_eq!(c.classify(b'a'), ByteKind::Paste);
+    }
+
+    #[test]
+    fn over_long_csi_is_not_a_paste_marker() {
+        // A CSI whose parameters exceed a marker's length must not toggle paste,
+        // and its parameter buffer must stay bounded.
+        let mut c = Classifier::new(CTRL_BACKSLASH);
+        for &b in b"\x1b[200000~" {
+            c.classify(b);
+        }
+        assert_eq!(c.classify(b'a'), ByteKind::Printable('a'));
+        assert!(c.params.len() <= MAX_CSI_PARAMS + 1);
     }
 }

--- a/crates/funput-term/src/install.rs
+++ b/crates/funput-term/src/install.rs
@@ -1,0 +1,168 @@
+//! `funput-term install` — wire the wrapper into the user's shell so Vietnamese
+//! input is "always on".
+//!
+//! Emits an idempotent, marked block of shell aliases (each `name` runs
+//! `funput-term -- cmd`). By default it just prints the block (safe to inspect);
+//! `--write` appends it to the detected shell rc file, skipping if the marker is
+//! already present. The snippet builder is pure, so it is unit-tested directly.
+
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+/// Start/end markers delimiting the block we own in the rc file, so `--write`
+/// stays idempotent and the block is easy to find or remove by hand.
+const MARKER_START: &str = "# >>> funput-term >>>";
+const MARKER_END: &str = "# <<< funput-term <<<";
+
+/// Supported shells, distinguished only by alias syntax and rc-file location.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Shell {
+    Bash,
+    Zsh,
+    Fish,
+}
+
+impl Shell {
+    /// Match a shell by name or `$SHELL` path basename (`/bin/zsh` → `Zsh`).
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name.rsplit('/').next().unwrap_or(name) {
+            "bash" => Some(Shell::Bash),
+            "zsh" => Some(Shell::Zsh),
+            "fish" => Some(Shell::Fish),
+            _ => None,
+        }
+    }
+
+    /// Detect from `$SHELL`, defaulting to bash when unknown.
+    pub fn detect() -> Self {
+        std::env::var("SHELL")
+            .ok()
+            .and_then(|s| Shell::from_name(&s))
+            .unwrap_or(Shell::Bash)
+    }
+
+    fn alias_line(self, name: &str, command: &str) -> String {
+        match self {
+            // POSIX-style quoting for bash/zsh; fish uses a space, not `=`.
+            Shell::Bash | Shell::Zsh => format!("alias {name}='funput-term -- {command}'"),
+            Shell::Fish => format!("alias {name} 'funput-term -- {command}'"),
+        }
+    }
+}
+
+/// Parse an `name=command` argument; a bare `name` aliases the command of the same
+/// name (`claude` → `claude`→`funput-term -- claude`).
+pub fn parse_alias(arg: &str) -> (String, String) {
+    match arg.split_once('=') {
+        Some((name, command)) => (name.to_string(), command.to_string()),
+        None => (arg.to_string(), arg.to_string()),
+    }
+}
+
+/// Build the marked, idempotent shell block for `aliases`. With no aliases it
+/// emits a commented example so the user can see the shape.
+pub fn snippet(shell: Shell, aliases: &[(String, String)]) -> String {
+    let mut out = String::new();
+    out.push_str(MARKER_START);
+    out.push('\n');
+    out.push_str("# Funput Terminal — type Vietnamese inside terminal apps.\n");
+    if aliases.is_empty() {
+        out.push_str("# Example: add `--alias claude` to wrap a command, e.g.\n");
+        out.push_str(&format!("#   {}\n", shell.alias_line("claude", "claude")));
+        out.push_str("# Or wrap your whole shell from your terminal emulator:\n");
+        out.push_str("#   funput-term -- $SHELL\n");
+    } else {
+        for (name, command) in aliases {
+            out.push_str(&shell.alias_line(name, command));
+            out.push('\n');
+        }
+    }
+    out.push_str(MARKER_END);
+    out.push('\n');
+    out
+}
+
+/// The rc file a `--write` should append to for `shell`.
+pub fn rc_path(shell: Shell) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    Some(match shell {
+        Shell::Bash => home.join(".bashrc"),
+        Shell::Zsh => home.join(".zshrc"),
+        Shell::Fish => home.join(".config").join("fish").join("config.fish"),
+    })
+}
+
+/// Run the `install` subcommand: print the snippet, and when `write` is set append
+/// it to the shell rc file unless our marker is already there.
+pub fn run(shell: Shell, aliases: &[(String, String)], write: bool) -> io::Result<()> {
+    let block = snippet(shell, aliases);
+
+    if !write {
+        print!("{block}");
+        return Ok(());
+    }
+
+    let path = rc_path(shell)
+        .ok_or_else(|| io::Error::other("cannot determine home directory for rc file"))?;
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    if existing.contains(MARKER_START) {
+        println!("funput-term: already installed in {}", path.display());
+        return Ok(());
+    }
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    // Separate from any preceding content.
+    writeln!(file, "\n{block}")?;
+    println!("funput-term: installed in {}", path.display());
+    println!("Restart your shell or run `source {}`.", path.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn aliases() -> Vec<(String, String)> {
+        vec![("claude".to_string(), "claude".to_string())]
+    }
+
+    #[test]
+    fn bash_zsh_use_equals_quoting() {
+        let s = snippet(Shell::Zsh, &aliases());
+        assert!(s.contains("alias claude='funput-term -- claude'"));
+        assert!(s.contains(MARKER_START) && s.contains(MARKER_END));
+    }
+
+    #[test]
+    fn fish_uses_space_syntax() {
+        let s = snippet(Shell::Fish, &aliases());
+        assert!(s.contains("alias claude 'funput-term -- claude'"));
+    }
+
+    #[test]
+    fn empty_aliases_emit_commented_example() {
+        let s = snippet(Shell::Bash, &[]);
+        assert!(s.contains(MARKER_START) && s.contains(MARKER_END));
+        // The example is commented out, so sourcing the block is a no-op.
+        assert!(!s.lines().any(|l| l.starts_with("alias ")));
+    }
+
+    #[test]
+    fn shell_detection_from_path() {
+        assert_eq!(Shell::from_name("/bin/zsh"), Some(Shell::Zsh));
+        assert_eq!(Shell::from_name("fish"), Some(Shell::Fish));
+        assert_eq!(Shell::from_name("/usr/bin/tcsh"), None);
+    }
+
+    #[test]
+    fn alias_arg_parsing() {
+        assert_eq!(parse_alias("claude"), ("claude".into(), "claude".into()));
+        assert_eq!(parse_alias("cc=claude"), ("cc".into(), "claude".into()));
+    }
+}

--- a/crates/funput-term/src/main.rs
+++ b/crates/funput-term/src/main.rs
@@ -4,34 +4,65 @@
 //! composed into Vietnamese before reaching the child; everything else is
 //! forwarded untouched. Toggle with `Ctrl-\`. Not an IME — no system hooks, no
 //! permissions; works in any terminal emulator.
+//!
+//! Settings come from the shared `Funput/settings.json`, overridable by env vars
+//! and CLI flags (see [`config`]). `funput-term install` wires it into your shell.
 
 mod app;
+mod config;
 mod inject;
 mod input;
+mod install;
 mod output;
 mod state;
 mod term;
 
-use clap::{Parser, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use funput_core::InputMethod;
-
-/// `Ctrl-\` — toggles Vietnamese composition on/off.
-const TOGGLE_KEY: u8 = 0x1c;
 
 #[derive(Parser)]
 #[command(
     name = "funput-term",
     version,
-    about = "Type Vietnamese (Telex/VNI) inside terminal apps via a PTY wrapper"
+    about = "Type Vietnamese (Telex/VNI) inside terminal apps via a PTY wrapper",
+    args_conflicts_with_subcommands = true
 )]
 struct Cli {
-    /// Input method.
-    #[arg(short, long, value_enum, default_value_t = Method::Vni)]
-    method: Method,
+    #[command(subcommand)]
+    command: Option<Command>,
 
-    /// Program to run (defaults to $SHELL). Pass after `--`, e.g. `funput-term -- claude`.
+    #[command(flatten)]
+    run: RunArgs,
+}
+
+/// Arguments for the default action: run a program through the wrapper.
+#[derive(Args)]
+struct RunArgs {
+    /// Input method; overrides the config file and `$FUNPUT_METHOD`.
+    #[arg(short, long, value_enum)]
+    method: Option<Method>,
+
+    /// Program to run (defaults to `$SHELL`). Pass after `--`, e.g. `funput-term -- claude`.
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    command: Vec<String>,
+    program: Vec<String>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Print (or write) shell integration so funput-term is always on.
+    Install {
+        /// Target shell (bash/zsh/fish); defaults to `$SHELL`.
+        #[arg(long)]
+        shell: Option<String>,
+
+        /// Alias to add, `name` or `name=command`; repeatable.
+        #[arg(long = "alias", value_name = "NAME[=CMD]")]
+        alias: Vec<String>,
+
+        /// Append the snippet to your shell rc file instead of just printing it.
+        #[arg(long)]
+        write: bool,
+    },
 }
 
 #[derive(Clone, Copy, ValueEnum)]
@@ -51,18 +82,42 @@ impl From<Method> for InputMethod {
 
 fn main() {
     let cli = Cli::parse();
+    match cli.command {
+        Some(Command::Install {
+            shell,
+            alias,
+            write,
+        }) => install_cmd(shell, alias, write),
+        None => run_cmd(cli.run),
+    }
+}
 
-    let command = if cli.command.is_empty() {
+fn install_cmd(shell: Option<String>, alias: Vec<String>, write: bool) {
+    let shell = shell
+        .as_deref()
+        .and_then(install::Shell::from_name)
+        .unwrap_or_else(install::Shell::detect);
+    let aliases: Vec<_> = alias.iter().map(|a| install::parse_alias(a)).collect();
+    if let Err(err) = install::run(shell, &aliases, write) {
+        eprintln!("funput-term: {err}");
+        std::process::exit(1);
+    }
+}
+
+fn run_cmd(args: RunArgs) {
+    // Precedence: CLI flag > env var > settings.json > built-in default.
+    let mut config = config::load();
+    if let Some(method) = args.method {
+        config.method = method.into();
+    }
+
+    let command = if args.program.is_empty() {
         vec![std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())]
     } else {
-        cli.command
+        args.program
     };
 
-    let opts = app::Options {
-        method: cli.method.into(),
-        toggle: TOGGLE_KEY,
-        command,
-    };
+    let opts = app::Options { config, command };
 
     match app::run(opts) {
         Ok(code) => std::process::exit(code),

--- a/crates/funput-term/src/state.rs
+++ b/crates/funput-term/src/state.rs
@@ -24,6 +24,11 @@ impl SharedState {
         self.enabled.load(Ordering::Relaxed) && !self.alt_screen.load(Ordering::Relaxed)
     }
 
+    /// The user's VI/EN toggle, independent of alt-screen — used for the indicator.
+    pub fn enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
     /// Flip the toggle; returns the new value.
     pub fn toggle(&self) -> bool {
         !self.enabled.fetch_xor(true, Ordering::Relaxed)

--- a/crates/funput-term/src/term.rs
+++ b/crates/funput-term/src/term.rs
@@ -45,25 +45,56 @@ pub fn detect_mux() -> Mux {
     Mux::None
 }
 
-/// Build the byte sequence that sets the terminal window title to `text`,
-/// wrapped for `mux` so it reaches the outer terminal.
+/// Default cursor color shown while Vietnamese composition is on — the brand
+/// green used in the README badges.
+pub const DEFAULT_VI_CURSOR_COLOR: &str = "#22C55E";
+
+/// Wrap a terminal control sequence so it survives the surrounding multiplexer
+/// and reaches the outer terminal.
 ///
 /// Pure (no I/O) so the exact wrapping is unit-tested.
-pub fn title_sequence(text: &str, mux: Mux) -> String {
-    let osc = format!("\x1b]0;{text}\x07");
+fn wrap_for_mux(seq: &str, mux: Mux) -> String {
     match mux {
-        Mux::None => osc,
+        Mux::None => seq.to_string(),
         // tmux DCS passthrough: every inner ESC must be doubled.
-        Mux::Tmux => format!("\x1bPtmux;{}\x1b\\", osc.replace('\x1b', "\x1b\x1b")),
+        Mux::Tmux => format!("\x1bPtmux;{}\x1b\\", seq.replace('\x1b', "\x1b\x1b")),
         // screen DCS passthrough: forward the sequence as-is.
-        Mux::Screen => format!("\x1bP{osc}\x1b\\"),
+        Mux::Screen => format!("\x1bP{seq}\x1b\\"),
     }
+}
+
+/// Build the byte sequence that sets the terminal window title to `text`,
+/// wrapped for `mux` so it reaches the outer terminal.
+pub fn title_sequence(text: &str, mux: Mux) -> String {
+    wrap_for_mux(&format!("\x1b]0;{text}\x07"), mux)
+}
+
+/// Build the cursor-color cue: a brand-colored cursor while composing (VI), reset
+/// to the terminal default otherwise (EN). A non-intrusive indicator that works
+/// even when the window title is hidden.
+///
+/// VI sets the cursor color via `OSC 12`; EN resets it via `OSC 112` rather than
+/// guessing the user's default. Wrapped for `mux` like the title.
+pub fn cursor_cue(enabled: bool, vi_color: &str, mux: Mux) -> String {
+    let seq = if enabled {
+        format!("\x1b]12;{vi_color}\x07")
+    } else {
+        "\x1b]112\x07".to_string()
+    };
+    wrap_for_mux(&seq, mux)
 }
 
 /// Set the terminal window title — a non-intrusive status indicator that does not
 /// draw over the child app's UI, wrapped for any surrounding multiplexer.
 pub fn set_title(out: &mut impl Write, text: &str) -> io::Result<()> {
     out.write_all(title_sequence(text, detect_mux()).as_bytes())?;
+    out.flush()
+}
+
+/// Update the cursor-color cue to match the composition state. Always safe to
+/// call with `enabled = false` on exit to restore the user's default cursor.
+pub fn set_cursor_cue(out: &mut impl Write, enabled: bool, vi_color: &str) -> io::Result<()> {
+    out.write_all(cursor_cue(enabled, vi_color, detect_mux()).as_bytes())?;
     out.flush()
 }
 
@@ -92,6 +123,36 @@ mod tests {
         assert_eq!(
             title_sequence("VI", Mux::Screen),
             "\x1bP\x1b]0;VI\x07\x1b\\"
+        );
+    }
+
+    #[test]
+    fn cursor_cue_sets_color_when_enabled() {
+        assert_eq!(
+            cursor_cue(true, "#22C55E", Mux::None),
+            "\x1b]12;#22C55E\x07"
+        );
+    }
+
+    #[test]
+    fn cursor_cue_resets_when_disabled() {
+        assert_eq!(cursor_cue(false, "#22C55E", Mux::None), "\x1b]112\x07");
+    }
+
+    #[test]
+    fn cursor_cue_wraps_for_tmux() {
+        // Inner ESC doubled inside the tmux DCS passthrough.
+        assert_eq!(
+            cursor_cue(true, "#fff", Mux::Tmux),
+            "\x1bPtmux;\x1b\x1b]12;#fff\x07\x1b\\"
+        );
+    }
+
+    #[test]
+    fn cursor_cue_wraps_for_screen() {
+        assert_eq!(
+            cursor_cue(false, "#fff", Mux::Screen),
+            "\x1bP\x1b]112\x07\x1b\\"
         );
     }
 }

--- a/crates/funput-term/src/term.rs
+++ b/crates/funput-term/src/term.rs
@@ -105,8 +105,8 @@ mod tests {
     #[test]
     fn plain_title_is_bare_osc() {
         assert_eq!(
-            title_sequence("funput · VI", Mux::None),
-            "\x1b]0;funput · VI\x07"
+            title_sequence("Funput · VI", Mux::None),
+            "\x1b]0;Funput · VI\x07"
         );
     }
 

--- a/crates/funput-term/src/term.rs
+++ b/crates/funput-term/src/term.rs
@@ -21,9 +21,77 @@ impl Drop for RawModeGuard {
     }
 }
 
-/// Set the terminal window title via OSC — a non-intrusive status indicator that
-/// does not draw over the child app's UI.
+/// Terminal multiplexer wrapping the session, if any. A bare OSC title sequence
+/// is swallowed by tmux/screen, so it must be wrapped in their passthrough form
+/// to reach the outer terminal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mux {
+    None,
+    Tmux,
+    Screen,
+}
+
+/// Detect the surrounding multiplexer from the environment. `$TMUX` is set inside
+/// tmux; GNU screen is recognised by `$STY` or a `screen`/`tmux` `$TERM` (best
+/// effort, since screen's passthrough is more limited).
+pub fn detect_mux() -> Mux {
+    if std::env::var_os("TMUX").is_some() {
+        return Mux::Tmux;
+    }
+    let term = std::env::var("TERM").unwrap_or_default();
+    if std::env::var_os("STY").is_some() || term.starts_with("screen") || term.starts_with("tmux") {
+        return Mux::Screen;
+    }
+    Mux::None
+}
+
+/// Build the byte sequence that sets the terminal window title to `text`,
+/// wrapped for `mux` so it reaches the outer terminal.
+///
+/// Pure (no I/O) so the exact wrapping is unit-tested.
+pub fn title_sequence(text: &str, mux: Mux) -> String {
+    let osc = format!("\x1b]0;{text}\x07");
+    match mux {
+        Mux::None => osc,
+        // tmux DCS passthrough: every inner ESC must be doubled.
+        Mux::Tmux => format!("\x1bPtmux;{}\x1b\\", osc.replace('\x1b', "\x1b\x1b")),
+        // screen DCS passthrough: forward the sequence as-is.
+        Mux::Screen => format!("\x1bP{osc}\x1b\\"),
+    }
+}
+
+/// Set the terminal window title — a non-intrusive status indicator that does not
+/// draw over the child app's UI, wrapped for any surrounding multiplexer.
 pub fn set_title(out: &mut impl Write, text: &str) -> io::Result<()> {
-    write!(out, "\x1b]0;{text}\x07")?;
+    out.write_all(title_sequence(text, detect_mux()).as_bytes())?;
     out.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_title_is_bare_osc() {
+        assert_eq!(
+            title_sequence("funput · VI", Mux::None),
+            "\x1b]0;funput · VI\x07"
+        );
+    }
+
+    #[test]
+    fn tmux_title_doubles_inner_escapes() {
+        assert_eq!(
+            title_sequence("VI", Mux::Tmux),
+            "\x1bPtmux;\x1b\x1b]0;VI\x07\x1b\\"
+        );
+    }
+
+    #[test]
+    fn screen_title_wraps_in_dcs() {
+        assert_eq!(
+            title_sequence("VI", Mux::Screen),
+            "\x1bP\x1b]0;VI\x07\x1b\\"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Rounds out `funput-term` — the transparent PTY wrapper that lets you type
Vietnamese inside terminal apps (Claude Code, shells, REPLs) without any system
IME — making it correct in common situations and usable as an "always-on" tool.

## What's included

### Correctness fixes
- **Bracketed paste passthrough.** Pasted content (`ESC[200~ … ESC[201~`) is now
  forwarded verbatim instead of being composed character-by-character, which
  previously corrupted pasted commands/passwords (e.g. `as` → `á`). Paste markers
  are still forwarded so the child app can honor them.
- **tmux / GNU screen title passthrough.** The VI/EN window-title indicator is
  wrapped in DCS passthrough so it survives a surrounding multiplexer instead of
  being swallowed.

### UX & configuration ("always-on")
- **Shared persistent config.** Reads the project's canonical
  `dirs::config_dir()/Funput/settings.json` (same camelCase schema as the
  Windows/Linux settings readers), applying the full engine option set: method,
  tone style, smart/eager restore, spell-check, auto-capitalize, and gõ-tắt
  shortcuts. Resolution precedence is **CLI flag > env var > settings.json >
  default**; env overrides via `FUNPUT_METHOD`, `FUNPUT_TONE_STYLE`,
  `FUNPUT_ENABLED`, `FUNPUT_TOGGLE`, `FUNPUT_CURSOR_COLOR_VI`, `FUNPUT_CONFIG`.
- **Cursor-color status cue.** Beyond the window title, the cursor turns the brand
  green while composing (VI) and resets on EN (`OSC 12`/`OSC 112`), so the state
  is visible even when the title is hidden. Restored on exit.
- **`funput-term install` command.** Prints (or, with `--write`, appends an
  idempotent marked block to) shell aliases for bash/zsh/fish so a command like
  `claude` is transparently wrapped.

### Runtime input switching
- **Live Telex↔VNI cycling** with `Ctrl-^` (configurable / disablable via
  `FUNPUT_CYCLE_METHOD`), no restart required. The window title now shows the
  active method (`Funput · VI · Telex`).

## Implementation notes
- New pure, unit-tested seams (`config.rs`, `install.rs`) plus extensions to the
  existing pure `input`/`term`/`app` seams; the engine lives on the input thread
  so runtime switching needs no locking.
- Dependencies added: `serde`, `serde_json`, `dirs`.

## Testing
- 48 unit tests (in-memory pipes / string inputs), `cargo clippy -D warnings`
  clean, `cargo fmt --check` clean. Manually verified on macOS (Terminal.app,
  iTerm2, tmux).

## Out of scope (follow-ups)
- Windows (ConPTY) and Linux packaging.
- Runtime tone-style (traditional/modern) switching.
- Per-app profiles via `excludedApps`.

Note: `funput-term` is meant to replace the system IME *inside* the terminal —
they should not run simultaneously, or the OS-level IME will compose first.