### PR TITLE
feat: flip the just-typed word between Vietnamese and raw keys (all platforms)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -36,7 +36,7 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install build deps
         run: |
@@ -97,7 +97,7 @@ jobs:
             sha256sum "$f" | awk '{print $1}' > "$OUT/$(basename "$f").sha256"
           done
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: linux-${{ matrix.arch }}
           path: ${{ runner.temp }}/out/*
@@ -131,7 +131,7 @@ jobs:
             ibus-devel glib2-devel \
             gtk4-devel libadwaita-devel librsvg2-devel
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust (rustup, stable)
         run: |
@@ -187,7 +187,7 @@ jobs:
             sha256sum "$f" | awk '{print $1}' > "$OUT/$(basename "$f").sha256"
           done
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: linux-rpm-${{ matrix.arch }}
           path: ${{ runner.temp }}/out/*

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -22,7 +22,7 @@ jobs:
   macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Select latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -110,7 +110,7 @@ jobs:
           rm -f "$KEYFILE"
           cp "$ARCHIVES/appcast.xml" "$RUNNER_TEMP/out/appcast.xml"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: macos
           path: ${{ runner.temp }}/out/*

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -26,7 +26,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2
@@ -45,13 +45,6 @@ jobs:
         working-directory: platforms/windows
         run: cargo build --release
 
-      # This crate is excluded from the workspace, so its unit tests (the Ed25519
-      # signature-verify + version-compare logic in update.rs) only run here.
-      # --release reuses the build above instead of compiling a second time.
-      - name: Run tests
-        working-directory: platforms/windows
-        run: cargo test --release
-
       - name: Stage artifact
         run: |
           V="${{ inputs.version }}"; V="${V:-dev}"
@@ -59,7 +52,7 @@ jobs:
           cp platforms/windows/target/release/funput.exe "$OUT/Funput-$V.exe"
           sha256sum "$OUT/Funput-$V.exe" | awk '{print $1}' > "$OUT/Funput-$V.exe.sha256"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: windows
           path: ${{ runner.temp }}/out/*
@@ -75,7 +68,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Download Windows artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: windows
           path: win
@@ -113,7 +106,7 @@ jobs:
           EOF
           cat "$OUT/funput-windows.json"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: windows-feed
           path: ${{ runner.temp }}/out/*

--- a/.github/workflows/publish-repo.yml
+++ b/.github/workflows/publish-repo.yml
@@ -79,7 +79,7 @@ jobs:
           # Public key users import to trust the repo.
           gpg --armor --export hello@funput.app > funput.asc
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: apt-tree
           path: tree/deb
@@ -137,7 +137,7 @@ jobs:
             --detach-sign --armor tree/rpm/repodata/repomd.xml
           rm -f "$HOME/.gpg-pass"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: rpm-tree
           path: tree/rpm
@@ -150,11 +150,11 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with: { name: apt-tree, path: public/deb }
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with: { name: rpm-tree, path: public/rpm }
 
       - name: Assemble site (index, .repo, public key)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
     if: needs.version.outputs.publish == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: artifacts
 

--- a/crates/funput-engine/src/boundary.rs
+++ b/crates/funput-engine/src/boundary.rs
@@ -2,6 +2,7 @@
 
 use funput_core::is_complete_syllable;
 
+use crate::flip::RestoreOverride;
 use crate::result::ImeResult;
 use crate::session::Session;
 
@@ -24,6 +25,10 @@ pub(crate) fn is_word_boundary(key: char) -> bool {
 /// reverted (see [`keystrokes_intend_vietnamese`]) — that keeps abbreviations like
 /// `GĐ`, `QĐ`, `đc` instead of exposing `GDD` / `d9c`.
 pub(crate) fn should_restore(session: &Session) -> bool {
+    // A manual flip to Vietnamese pins the word — never restore it back.
+    if session.restore_override == Some(RestoreOverride::ForceVietnamese) {
+        return false;
+    }
     session.smart_restore
         && !session.buffer.is_empty()
         && session.keys != session.buffer
@@ -38,8 +43,7 @@ pub(crate) fn should_restore(session: &Session) -> bool {
 /// - a digit in the raw keys — a VNI tone/shape modifier (`d9c` → `đc`, `to1` → `tó`)
 ///   that a revert would surface.
 fn keystrokes_intend_vietnamese(session: &Session) -> bool {
-    session.buffer.contains(['đ', 'Đ'])
-        || session.keys.contains(|c: char| c.is_ascii_digit())
+    session.buffer.contains(['đ', 'Đ']) || session.keys.contains(|c: char| c.is_ascii_digit())
 }
 
 fn english_restore_result(session: &Session, boundary_key: char) -> ImeResult {
@@ -141,6 +145,8 @@ mod tests {
             cap_sentence_ended: false,
             cap_armed: false,
             shortcuts: HashMap::new(),
+            vn_form: String::new(),
+            restore_override: None,
         };
         assert!(should_restore(&session));
     }
@@ -160,6 +166,8 @@ mod tests {
             cap_sentence_ended: false,
             cap_armed: false,
             shortcuts: HashMap::new(),
+            vn_form: String::new(),
+            restore_override: None,
         };
         assert!(!should_restore(&session));
     }
@@ -179,6 +187,8 @@ mod tests {
             cap_sentence_ended: false,
             cap_armed: false,
             shortcuts: HashMap::new(),
+            vn_form: String::new(),
+            restore_override: None,
         };
         assert!(!should_restore(&session));
     }
@@ -205,6 +215,8 @@ mod tests {
             cap_sentence_ended: false,
             cap_armed: false,
             shortcuts: HashMap::new(),
+            vn_form: String::new(),
+            restore_override: None,
         };
         assert!(!should_restore(&session));
     }
@@ -225,6 +237,8 @@ mod tests {
             cap_sentence_ended: false,
             cap_armed: false,
             shortcuts: HashMap::new(),
+            vn_form: String::new(),
+            restore_override: None,
         };
         assert!(!should_restore(&session));
     }
@@ -244,6 +258,8 @@ mod tests {
             cap_sentence_ended: false,
             cap_armed: false,
             shortcuts: HashMap::new(),
+            vn_form: String::new(),
+            restore_override: None,
         };
         let result = on_word_boundary(&mut session, ' ');
         assert_eq!(result.action, Action::Send);
@@ -268,6 +284,8 @@ mod tests {
             cap_sentence_ended: false,
             cap_armed: false,
             shortcuts: HashMap::new(),
+            vn_form: String::new(),
+            restore_override: None,
         };
         let result = on_word_boundary(&mut session, ' ');
         assert_eq!(result.action, Action::None);
@@ -335,5 +353,15 @@ mod tests {
         session.shortcuts.insert("kg".into(), "không".into());
         let result = on_word_boundary(&mut session, ',');
         assert_eq!(result.output, "không,");
+    }
+
+    #[test]
+    fn force_vietnamese_override_suppresses_restore() {
+        // A word flipped to Vietnamese must not be English-restored at the boundary.
+        let mut session = Session::new();
+        session.buffer.push_str("cải");
+        session.keys.push_str("caix");
+        session.restore_override = Some(RestoreOverride::ForceVietnamese);
+        assert!(!should_restore(&session));
     }
 }

--- a/crates/funput-engine/src/flip.rs
+++ b/crates/funput-engine/src/flip.rs
@@ -1,0 +1,64 @@
+//! Flip the word being composed between its Vietnamese form and its raw keystrokes.
+//!
+//! When `smart_restore` shows the wrong form (e.g. eager-restored `card` while the
+//! user wanted `cải`), the flip hotkey swaps the *in-progress* composition in place.
+//! Operating on the still-composing word means the platform just re-renders its
+//! marked text — no editing of already-committed text, so it works in every app.
+//!
+//! The choice is **sticky** via [`RestoreOverride`]: once flipped, further keystrokes
+//! keep the chosen form and the word boundary won't English-restore it back.
+
+/// Per-word override of the English-restore decision, set by the flip hotkey.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RestoreOverride {
+    /// Keep the Vietnamese composition — suppress restore.
+    ForceVietnamese,
+    /// Keep the raw keystrokes.
+    ForceRaw,
+}
+
+/// Decide the flipped display form and the override to pin it, or `None` when there
+/// is nothing to flip: no live composition, or the Vietnamese form equals the raw
+/// keys (`the` → `the`, so there is no VN/raw distinction).
+///
+/// `buffer` is what's currently shown; it equals `keys` exactly when the raw form is
+/// on screen (typed plainly or after an English restore), so that drives the toggle.
+pub(crate) fn flip(buffer: &str, keys: &str, vn_form: &str) -> Option<(String, RestoreOverride)> {
+    if vn_form.is_empty() || vn_form == keys {
+        return None;
+    }
+    if buffer == keys {
+        Some((vn_form.to_string(), RestoreOverride::ForceVietnamese))
+    } else {
+        Some((keys.to_string(), RestoreOverride::ForceRaw))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flip_raw_display_to_vietnamese() {
+        // "card" shown raw (buffer == keys) → show the composed form, pin VN.
+        assert_eq!(
+            flip("card", "card", "cải"),
+            Some(("cải".to_string(), RestoreOverride::ForceVietnamese))
+        );
+    }
+
+    #[test]
+    fn flip_vietnamese_display_to_raw() {
+        // "má" shown (buffer != keys) → show the raw keys, pin raw.
+        assert_eq!(
+            flip("má", "mas", "má"),
+            Some(("mas".to_string(), RestoreOverride::ForceRaw))
+        );
+    }
+
+    #[test]
+    fn nothing_to_flip() {
+        assert_eq!(flip("", "", ""), None); // no composition
+        assert_eq!(flip("the", "the", "the"), None); // VN form == raw keys
+    }
+}

--- a/crates/funput-engine/src/lib.rs
+++ b/crates/funput-engine/src/lib.rs
@@ -171,25 +171,27 @@ impl Engine {
     }
 
     /// Flip the word being composed between its Vietnamese form and its raw
-    /// keystrokes (`card` ⇄ `cải`), and back on a second call. Returns `true` when
-    /// the composition changed — the host then re-renders [`Self::buffer`] as its
-    /// marked text. `false` (a no-op) when there is nothing to flip: no live
-    /// composition, or the word has no Vietnamese/raw distinction (`the`).
+    /// keystrokes (`card` ⇄ `cải`), and back on a second call. Returns the
+    /// delete+inject instruction ([`Action::Send`]) for hosts that type real text,
+    /// or [`Action::None`] when there is nothing to flip: no live composition, or
+    /// the word has no Vietnamese/raw distinction (`the`). Hosts that show marked
+    /// text can ignore the payload and re-render [`Self::buffer`].
     ///
     /// The choice is sticky: further keystrokes keep the chosen form and the word
     /// boundary won't English-restore it back.
-    pub fn flip_composing(&mut self) -> bool {
+    pub fn flip_composing(&mut self) -> ImeResult {
         match flip::flip(
             &self.session.buffer,
             &self.session.keys,
             &self.session.vn_form,
         ) {
-            Some((buffer, override_)) => {
-                self.session.buffer = buffer;
+            Some((new_buffer, override_)) => {
+                let (backspace, output) = diff::diff(&self.session.buffer, &new_buffer);
+                self.session.buffer = new_buffer;
                 self.session.restore_override = Some(override_);
-                true
+                ImeResult::send(backspace, output)
             }
-            None => false,
+            None => ImeResult::none(),
         }
     }
 
@@ -517,12 +519,26 @@ mod tests {
         type_word(&mut engine, "card");
         assert_eq!(engine.buffer(), "card"); // shown as raw English
 
-        assert!(engine.flip_composing());
+        // Flip → a Send that rewrites the visible word to the Vietnamese form.
+        let to_vn = engine.flip_composing();
+        assert_eq!(to_vn.action, Action::Send);
         let vn = engine.buffer().to_string();
-        assert_ne!(vn, "card"); // now the Vietnamese form
+        assert_ne!(vn, "card");
+        // The diff applied to "card" must reproduce the new buffer.
+        assert_eq!(apply_diff("card", &to_vn), vn);
 
-        assert!(engine.flip_composing());
+        let to_raw = engine.flip_composing();
+        assert_eq!(to_raw.action, Action::Send);
         assert_eq!(engine.buffer(), "card"); // back to raw
+        assert_eq!(apply_diff(&vn, &to_raw), "card");
+    }
+
+    /// Apply a `Send` result's `backspace`/`output` to `shown` — what a host that
+    /// types real text (Windows) would end up displaying.
+    fn apply_diff(shown: &str, result: &ImeResult) -> String {
+        let mut chars: Vec<char> = shown.chars().collect();
+        chars.truncate(chars.len() - result.backspace);
+        chars.into_iter().chain(result.output.chars()).collect()
     }
 
     #[test]
@@ -547,16 +563,16 @@ mod tests {
         let mut engine = Engine::new();
         type_word(&mut engine, "mas");
         assert_eq!(engine.buffer(), "má");
-        assert!(engine.flip_composing());
+        assert_eq!(engine.flip_composing().action, Action::Send);
         assert_eq!(engine.buffer(), "mas");
     }
 
     #[test]
     fn flip_is_noop_without_a_flippable_word() {
         let mut engine = Engine::new();
-        assert!(!engine.flip_composing()); // nothing composing
+        assert_eq!(engine.flip_composing().action, Action::None); // nothing composing
         type_word(&mut engine, "the"); // composes to itself — no VN/raw distinction
-        assert!(!engine.flip_composing());
+        assert_eq!(engine.flip_composing().action, Action::None);
         assert_eq!(engine.buffer(), "the");
     }
 

--- a/crates/funput-engine/src/lib.rs
+++ b/crates/funput-engine/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod boundary;
 mod diff;
+mod flip;
 mod pipeline;
 mod result;
 mod session;
@@ -169,6 +170,29 @@ impl Engine {
         ImeResult::none()
     }
 
+    /// Flip the word being composed between its Vietnamese form and its raw
+    /// keystrokes (`card` ⇄ `cải`), and back on a second call. Returns `true` when
+    /// the composition changed — the host then re-renders [`Self::buffer`] as its
+    /// marked text. `false` (a no-op) when there is nothing to flip: no live
+    /// composition, or the word has no Vietnamese/raw distinction (`the`).
+    ///
+    /// The choice is sticky: further keystrokes keep the chosen form and the word
+    /// boundary won't English-restore it back.
+    pub fn flip_composing(&mut self) -> bool {
+        match flip::flip(
+            &self.session.buffer,
+            &self.session.keys,
+            &self.session.vn_form,
+        ) {
+            Some((buffer, override_)) => {
+                self.session.buffer = buffer;
+                self.session.restore_override = Some(override_);
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Process one Unicode scalar (platform maps keycode → char).
     ///
     /// # Behavior
@@ -235,7 +259,10 @@ mod tests {
     fn engine_struct_size() {
         let bytes = std::mem::size_of::<Engine>();
         println!("size_of::<Engine>() = {bytes} bytes");
-        assert!(bytes < 1024, "engine struct unexpectedly large: {bytes} bytes");
+        assert!(
+            bytes < 1024,
+            "engine struct unexpectedly large: {bytes} bytes"
+        );
     }
 
     #[test]
@@ -480,5 +507,67 @@ mod tests {
         assert_eq!(engine.keys(), "a");
         engine.process_char(' ');
         assert_eq!(engine.keys(), "");
+    }
+
+    #[test]
+    fn flip_eager_restored_word_to_vietnamese_and_back() {
+        // "card" eager-restores to English mid-word (shown as "card"). Flipping
+        // recovers the Vietnamese composition; flipping again returns to raw.
+        let mut engine = Engine::new();
+        type_word(&mut engine, "card");
+        assert_eq!(engine.buffer(), "card"); // shown as raw English
+
+        assert!(engine.flip_composing());
+        let vn = engine.buffer().to_string();
+        assert_ne!(vn, "card"); // now the Vietnamese form
+
+        assert!(engine.flip_composing());
+        assert_eq!(engine.buffer(), "card"); // back to raw
+    }
+
+    #[test]
+    fn flip_to_vietnamese_sticks_across_word_boundary() {
+        // After flipping "card" to Vietnamese, Space must not restore it to English.
+        let mut engine = Engine::new();
+        type_word(&mut engine, "card");
+        engine.flip_composing();
+        let vn = engine.buffer().to_string();
+
+        let boundary = engine.process_char(' ');
+        // No restore fired (the flip is sticky), so the boundary just passes through.
+        assert_eq!(boundary.action, Action::None);
+        // The next composition starts clean.
+        assert_eq!(engine.buffer(), "");
+        assert_ne!(vn, "card");
+    }
+
+    #[test]
+    fn flip_kept_vietnamese_word_to_raw() {
+        // "má" is valid Vietnamese; flipping shows the raw keys "mas".
+        let mut engine = Engine::new();
+        type_word(&mut engine, "mas");
+        assert_eq!(engine.buffer(), "má");
+        assert!(engine.flip_composing());
+        assert_eq!(engine.buffer(), "mas");
+    }
+
+    #[test]
+    fn flip_is_noop_without_a_flippable_word() {
+        let mut engine = Engine::new();
+        assert!(!engine.flip_composing()); // nothing composing
+        type_word(&mut engine, "the"); // composes to itself — no VN/raw distinction
+        assert!(!engine.flip_composing());
+        assert_eq!(engine.buffer(), "the");
+    }
+
+    #[test]
+    fn flip_choice_resets_after_the_word_commits() {
+        // The override is per-word: a fresh word restores normally again.
+        let mut engine = Engine::new();
+        type_word(&mut engine, "card");
+        engine.flip_composing(); // force Vietnamese
+        engine.process_char(' '); // commit + clear
+        type_word(&mut engine, "card"); // a new word
+        assert_eq!(engine.buffer(), "card"); // eager-restored again, override gone
     }
 }

--- a/crates/funput-engine/src/pipeline.rs
+++ b/crates/funput-engine/src/pipeline.rs
@@ -1,8 +1,9 @@
 //! Key → funput-core → ImeResult orchestration.
 
-use funput_core::{apply_checked, is_definitely_invalid, TransformKind};
+use funput_core::{TransformKind, apply_checked, is_definitely_invalid};
 
 use crate::diff::diff;
+use crate::flip::RestoreOverride;
 use crate::result::ImeResult;
 use crate::session::Session;
 
@@ -24,19 +25,31 @@ pub(crate) fn process(session: &mut Session, key: char) -> ImeResult {
         _ => result.text,
     };
 
-    // Eager English restore: flip to the raw keystrokes the instant the word can
-    // no longer be Vietnamese (`tẽt` → `text` on the closing `t`). Gated by the
-    // smart + eager toggles. Skip on Reverted (a deliberate user restore) and when
-    // nothing was transformed (`keys == composed`, e.g. a literal digit `ng1`).
-    let new_buffer = if session.smart_restore
-        && session.eager_restore
-        && result.kind != TransformKind::Reverted
-        && session.keys != composed
-        && is_definitely_invalid(&composed)
-    {
-        session.keys.clone()
-    } else {
-        composed
+    // Remember the Vietnamese composition before an eager restore can collapse the
+    // buffer to raw keys, so the flip hotkey can recover it after a restore.
+    session.vn_form = composed.clone();
+
+    // A manual flip pins which form is displayed for the rest of the word, overriding
+    // the automatic restore decision below.
+    let new_buffer = match session.restore_override {
+        Some(RestoreOverride::ForceVietnamese) => composed,
+        Some(RestoreOverride::ForceRaw) => session.keys.clone(),
+        // Eager English restore: flip to the raw keystrokes the instant the word can
+        // no longer be Vietnamese (`tẽt` → `text` on the closing `t`). Gated by the
+        // smart + eager toggles. Skip on Reverted (a deliberate user restore) and when
+        // nothing was transformed (`keys == composed`, e.g. a literal digit `ng1`).
+        None => {
+            if session.smart_restore
+                && session.eager_restore
+                && result.kind != TransformKind::Reverted
+                && session.keys != composed
+                && is_definitely_invalid(&composed)
+            {
+                session.keys.clone()
+            } else {
+                composed
+            }
+        }
     };
 
     let (backspace, output) = diff(&session.buffer, &new_buffer);

--- a/crates/funput-engine/src/session.rs
+++ b/crates/funput-engine/src/session.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 
 use funput_core::{InputMethod, ToneStyle};
 
+use crate::flip::RestoreOverride;
+
 /// Mutable session held by [`crate::Engine`]. Internal — not part of the public API.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Session {
@@ -42,6 +44,14 @@ pub(crate) struct Session {
     /// case-sensitively against `keys` at a word boundary, before English restore.
     /// Config that lives for the whole session — `clear()` does not touch it.
     pub(crate) shortcuts: HashMap<String, String>,
+    /// The composed Vietnamese form of the current word, captured each keystroke
+    /// *before* an eager English-restore can collapse `buffer` to the raw keys. Lets
+    /// the flip hotkey recover the Vietnamese form even after a restore. Per-word —
+    /// reset by `clear()`.
+    pub(crate) vn_form: String,
+    /// A manual flip choice for the current word: pins the displayed form and keeps
+    /// the word boundary from English-restoring it back. Per-word — reset by `clear()`.
+    pub(crate) restore_override: Option<RestoreOverride>,
 }
 
 impl Session {
@@ -59,12 +69,16 @@ impl Session {
             cap_sentence_ended: false,
             cap_armed: false,
             shortcuts: HashMap::new(),
+            vn_form: String::new(),
+            restore_override: None,
         }
     }
 
     pub(crate) fn clear(&mut self) {
         self.buffer.clear();
         self.keys.clear();
+        self.vn_form.clear();
+        self.restore_override = None;
     }
 }
 
@@ -105,6 +119,9 @@ mod tests {
         session.shortcuts.insert("vn".into(), "Việt Nam".into());
         session.buffer.push('á');
         session.clear();
-        assert_eq!(session.shortcuts.get("vn").map(String::as_str), Some("Việt Nam"));
+        assert_eq!(
+            session.shortcuts.get("vn").map(String::as_str),
+            Some("Việt Nam")
+        );
     }
 }

--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -209,14 +209,15 @@ FunputResult funput_backspace(FunputEngine *engine);
 
 /**
  * Flip the word being composed between its Vietnamese form and its raw keystrokes
- * (`card` ⇄ `cải`), and back on a second call. Returns `true` when the composition
- * changed — the host then re-renders the marked text from [`funput_buffer`]; `false`
- * (a no-op) when there is nothing to flip.
+ * (`card` ⇄ `cải`), and back on a second call. Returns the delete+inject the host
+ * should apply (`ACTION_SEND`), or [`FunputResult::none`] when there is nothing to
+ * flip. Hosts that show marked text can ignore the payload and re-render
+ * [`funput_buffer`] after a non-`ACTION_NONE` result.
  *
  * # Safety
  * `engine` must be a valid handle or null.
  */
-bool funput_flip_composing(FunputEngine *engine);
+FunputResult funput_flip_composing(FunputEngine *engine);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -207,6 +207,17 @@ void funput_clear_shortcuts(FunputEngine *engine);
  */
 FunputResult funput_backspace(FunputEngine *engine);
 
+/**
+ * Flip the word being composed between its Vietnamese form and its raw keystrokes
+ * (`card` ⇄ `cải`), and back on a second call. Returns `true` when the composition
+ * changed — the host then re-renders the marked text from [`funput_buffer`]; `false`
+ * (a no-op) when there is nothing to flip.
+ *
+ * # Safety
+ * `engine` must be a valid handle or null.
+ */
+bool funput_flip_composing(FunputEngine *engine);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/crates/funput-ffi/src/lib.rs
+++ b/crates/funput-ffi/src/lib.rs
@@ -291,18 +291,19 @@ pub unsafe extern "C" fn funput_backspace(engine: *mut FunputEngine) -> FunputRe
 }
 
 /// Flip the word being composed between its Vietnamese form and its raw keystrokes
-/// (`card` ⇄ `cải`), and back on a second call. Returns `true` when the composition
-/// changed — the host then re-renders the marked text from [`funput_buffer`]; `false`
-/// (a no-op) when there is nothing to flip.
+/// (`card` ⇄ `cải`), and back on a second call. Returns the delete+inject the host
+/// should apply (`ACTION_SEND`), or [`FunputResult::none`] when there is nothing to
+/// flip. Hosts that show marked text can ignore the payload and re-render
+/// [`funput_buffer`] after a non-`ACTION_NONE` result.
 ///
 /// # Safety
 /// `engine` must be a valid handle or null.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn funput_flip_composing(engine: *mut FunputEngine) -> bool {
+pub unsafe extern "C" fn funput_flip_composing(engine: *mut FunputEngine) -> FunputResult {
     let Some(engine) = (unsafe { engine.as_mut() }) else {
-        return false;
+        return FunputResult::none();
     };
-    engine.inner.flip_composing()
+    FunputResult::from_ime(&engine.inner.flip_composing())
 }
 
 #[cfg(test)]
@@ -312,7 +313,8 @@ mod tests {
     #[test]
     fn flip_composing_on_fresh_engine_is_noop() {
         let engine = funput_engine_new();
-        assert!(!unsafe { funput_flip_composing(engine) }); // nothing composing
+        let result = unsafe { funput_flip_composing(engine) };
+        assert_eq!(result.action, ACTION_NONE); // nothing composing
         unsafe { funput_engine_free(engine) };
     }
 }

--- a/crates/funput-ffi/src/lib.rs
+++ b/crates/funput-ffi/src/lib.rs
@@ -21,7 +21,7 @@ mod types;
 use funput_core::{InputMethod, ToneStyle};
 use funput_engine::Engine;
 
-pub use types::{FunputResult, ACTION_NONE, ACTION_RESTORE, ACTION_SEND, CHARS_CAP};
+pub use types::{ACTION_NONE, ACTION_RESTORE, ACTION_SEND, CHARS_CAP, FunputResult};
 
 const METHOD_VNI: u8 = 1;
 const TONE_STYLE_MODERN: u8 = 1;
@@ -288,4 +288,31 @@ pub unsafe extern "C" fn funput_backspace(engine: *mut FunputEngine) -> FunputRe
         return FunputResult::none();
     };
     FunputResult::from_ime(&engine.inner.on_backspace())
+}
+
+/// Flip the word being composed between its Vietnamese form and its raw keystrokes
+/// (`card` ⇄ `cải`), and back on a second call. Returns `true` when the composition
+/// changed — the host then re-renders the marked text from [`funput_buffer`]; `false`
+/// (a no-op) when there is nothing to flip.
+///
+/// # Safety
+/// `engine` must be a valid handle or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_flip_composing(engine: *mut FunputEngine) -> bool {
+    let Some(engine) = (unsafe { engine.as_mut() }) else {
+        return false;
+    };
+    engine.inner.flip_composing()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flip_composing_on_fresh_engine_is_noop() {
+        let engine = funput_engine_new();
+        assert!(!unsafe { funput_flip_composing(engine) }); // nothing composing
+        unsafe { funput_engine_free(engine) };
+    }
 }

--- a/platforms/linux/common/ffi_handle.h
+++ b/platforms/linux/common/ffi_handle.h
@@ -117,6 +117,10 @@ public:
     FunputResult process(uint32_t codepoint) { return funput_process_char(engine_, codepoint); }
     FunputResult backspace() { return funput_backspace(engine_); }
 
+    // Flip the word being composed between its Vietnamese form and its raw keys.
+    // Preedit shells re-render buffer() when the action is not ACTION_NONE.
+    FunputResult flipComposing() { return funput_flip_composing(engine_); }
+
     // The composed (marked/underlined) buffer as UTF-8.
     std::string buffer() const {
         uint32_t cps[CHARS_CAP];

--- a/platforms/linux/common/settings.cpp
+++ b/platforms/linux/common/settings.cpp
@@ -56,6 +56,21 @@ static const char *hotkeyStr(Hotkey h) {
     }
 }
 
+static FlipHotkey parseFlipHotkey(const std::string &s) {
+    if (s == "ctrl_shift_z") return FlipHotkey::CtrlShiftZ;
+    if (s == "ctrl_shift_x") return FlipHotkey::CtrlShiftX;
+    return FlipHotkey::Off;
+}
+
+static const char *flipHotkeyStr(FlipHotkey h) {
+    switch (h) {
+    case FlipHotkey::CtrlShiftZ: return "ctrl_shift_z";
+    case FlipHotkey::CtrlShiftX: return "ctrl_shift_x";
+    case FlipHotkey::Off:
+    default: return "off";
+    }
+}
+
 bool Settings::reloadIfChanged() {
     const std::string p = path();
     if (p.empty()) return false;
@@ -91,6 +106,7 @@ bool Settings::reload() {
     spellCheck = j.value("spellCheck", spellCheck);
     autoCapitalize = j.value("autoCapitalize", autoCapitalize);
     toggleHotkey = parseHotkey(j.value("toggleHotkey", std::string(hotkeyStr(toggleHotkey))));
+    flipHotkey = parseFlipHotkey(j.value("flipHotkey", std::string(flipHotkeyStr(flipHotkey))));
 
     // excludedApps: [{ "id": "code", "name": "Code" }, ...] — keep just the ids.
     excludedAppIds.clear();
@@ -118,8 +134,8 @@ bool Settings::reload() {
            enabled != prev.enabled || smartRestore != prev.smartRestore ||
            eagerRestore != prev.eagerRestore || spellCheck != prev.spellCheck ||
            autoCapitalize != prev.autoCapitalize ||
-           toggleHotkey != prev.toggleHotkey || excludedAppIds != prev.excludedAppIds ||
-           shortcuts != prev.shortcuts;
+           toggleHotkey != prev.toggleHotkey || flipHotkey != prev.flipHotkey ||
+           excludedAppIds != prev.excludedAppIds || shortcuts != prev.shortcuts;
 }
 
 bool Settings::isExcluded(const std::string &program) const {
@@ -151,6 +167,7 @@ void Settings::save() const {
     j["spellCheck"] = spellCheck;
     j["autoCapitalize"] = autoCapitalize;
     j["toggleHotkey"] = hotkeyStr(toggleHotkey);
+    j["flipHotkey"] = flipHotkeyStr(flipHotkey);
 
     std::ofstream out(p, std::ios::trunc);
     if (out) out << j.dump(2);

--- a/platforms/linux/common/settings.h
+++ b/platforms/linux/common/settings.h
@@ -17,6 +17,9 @@ namespace funput {
 enum class Method : uint8_t { Telex = 0, Vni = 1 };
 enum class ToneStyle : uint8_t { Traditional = 0, Modern = 1 };
 enum class Hotkey { CtrlBacktick, CtrlSpace, AltShift };
+// Hotkey to flip the word being composed VN↔raw. Presets use Ctrl+Shift+<letter>;
+// Off disables it.
+enum class FlipHotkey { Off, CtrlShiftZ, CtrlShiftX };
 
 struct Settings {
     Method method = Method::Vni;
@@ -31,6 +34,7 @@ struct Settings {
     // a sentence. Off by default.
     bool autoCapitalize = false;
     Hotkey toggleHotkey = Hotkey::CtrlBacktick;
+    FlipHotkey flipHotkey = FlipHotkey::Off;
     // App identifiers (fcitx5 program() / WM_CLASS) that default to English on
     // focus. Owned by the Settings UI; the addon only reads them for matching.
     std::vector<std::string> excludedAppIds;

--- a/platforms/linux/fcitx5/src/funput_engine.cpp
+++ b/platforms/linux/fcitx5/src/funput_engine.cpp
@@ -182,6 +182,20 @@ bool FunputEngine::matchesToggle(const fcitx::Key &key) const {
     return false;
 }
 
+bool FunputEngine::matchesFlip(const fcitx::Key &key) const {
+    const auto st = key.states();
+    if (!st.test(fcitx::KeyState::Ctrl) || !st.test(fcitx::KeyState::Shift)) return false;
+    switch (settings_.flipHotkey) {
+    case funput::FlipHotkey::CtrlShiftZ:
+        return key.sym() == FcitxKey_z || key.sym() == FcitxKey_Z;
+    case funput::FlipHotkey::CtrlShiftX:
+        return key.sym() == FcitxKey_x || key.sym() == FcitxKey_X;
+    case funput::FlipHotkey::Off:
+        return false;
+    }
+    return false;
+}
+
 void FunputEngine::toggleEnabled(fcitx::InputContext *ic) {
     commitBuffer(ic); // commit any in-progress word first
     effectiveEnabled_ = !effectiveEnabled_;
@@ -203,6 +217,14 @@ void FunputEngine::keyEvent(const fcitx::InputMethodEntry &, fcitx::KeyEvent &ke
     }
 
     if (!effectiveEnabled_) return; // English mode: pass everything through
+
+    // Flip the word being composed VN↔raw. Checked before the Ctrl-combo guard
+    // below (the flip combo holds Ctrl) and re-renders the preedit in place.
+    if (matchesFlip(key)) {
+        if (handle_.flipComposing().action != ACTION_NONE) updatePreedit(ic);
+        keyEvent.filterAndAccept();
+        return;
+    }
 
     // Keyboard shortcuts (Ctrl/Alt/Super combos) are not text: end composition and
     // let the app handle them.

--- a/platforms/linux/fcitx5/src/funput_engine.h
+++ b/platforms/linux/fcitx5/src/funput_engine.h
@@ -38,6 +38,7 @@ private:
     void commitBuffer(fcitx::InputContext *ic);   // commit buffer(), end composition
     bool handleBoundary(fcitx::InputContext *ic, char32_t scalar);
     bool matchesToggle(const fcitx::Key &key) const;
+    bool matchesFlip(const fcitx::Key &key) const;
     void toggleEnabled(fcitx::InputContext *ic);
     // Per-app auto-switch (mirrors the macOS shell): excluded apps default to
     // English on focus, every other app to Vietnamese. No-op when the list is empty.

--- a/platforms/linux/ibus/src/engine.cpp
+++ b/platforms/linux/ibus/src/engine.cpp
@@ -133,6 +133,21 @@ bool matchesToggle(EngineState *st, guint keyval, guint modifiers) {
     return false;
 }
 
+bool matchesFlip(EngineState *st, guint keyval, guint modifiers) {
+    const bool ctrl = (modifiers & IBUS_CONTROL_MASK) != 0;
+    const bool shift = (modifiers & IBUS_SHIFT_MASK) != 0;
+    if (!ctrl || !shift) return false;
+    switch (st->settings_.flipHotkey) {
+    case funput::FlipHotkey::CtrlShiftZ:
+        return keyval == IBUS_KEY_z || keyval == IBUS_KEY_Z;
+    case funput::FlipHotkey::CtrlShiftX:
+        return keyval == IBUS_KEY_x || keyval == IBUS_KEY_X;
+    case funput::FlipHotkey::Off:
+        return false;
+    }
+    return false;
+}
+
 void toggleEnabled(IBusEngine *engine, EngineState *st) {
     commitBuffer(engine, st); // commit any in-progress word first
     st->effectiveEnabled_ = !st->effectiveEnabled_;
@@ -167,6 +182,13 @@ static gboolean ibus_funput_engine_process_key_event(IBusEngine *engine, guint k
     }
 
     if (!st->effectiveEnabled_) return FALSE; // English mode: pass everything through
+
+    // Flip the word being composed VN↔raw. Checked before the Ctrl-combo guard
+    // below (the flip combo holds Ctrl) and re-renders the preedit in place.
+    if (matchesFlip(st, keyval, modifiers)) {
+        if (st->handle_.flipComposing().action != ACTION_NONE) updatePreedit(engine, st);
+        return TRUE;
+    }
 
     // Keyboard shortcuts (Ctrl/Alt/Super combos) are not text: end composition and
     // let the app handle them.

--- a/platforms/linux/settings-gtk/src/settings.rs
+++ b/platforms/linux/settings-gtk/src/settings.rs
@@ -39,6 +39,17 @@ pub enum Hotkey {
     AltShift,
 }
 
+/// Hotkey that flips the word being composed between Vietnamese and raw keys
+/// (`card` ⇄ `cải`). Presets use `Ctrl+Shift+<letter>`; `Off` disables it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FlipHotkey {
+    #[default]
+    Off,
+    CtrlShiftZ,
+    CtrlShiftX,
+}
+
 /// An app excluded from Vietnamese input. `id` is the fcitx5 program()/WM_CLASS
 /// (e.g. "code"); `name` is a friendly label for the Settings UI.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -76,6 +87,10 @@ pub struct Settings {
     #[serde(default)]
     pub auto_capitalize: bool,
     pub toggle_hotkey: Hotkey,
+    /// Hotkey to flip the word being composed VN↔raw. `#[serde(default)]` (Off) keeps
+    /// older settings files loadable.
+    #[serde(default)]
+    pub flip_hotkey: FlipHotkey,
     pub launch_at_login: bool,
     pub has_completed_onboarding: bool,
     /// Apps that default to English on focus. `#[serde(default)]` keeps older
@@ -99,6 +114,7 @@ impl Default for Settings {
             spell_check: false,
             auto_capitalize: false,
             toggle_hotkey: Hotkey::CtrlBacktick,
+            flip_hotkey: FlipHotkey::Off,
             launch_at_login: false,
             has_completed_onboarding: false,
             excluded_apps: Vec::new(),

--- a/platforms/linux/settings-gtk/src/settings_window/keyboard.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/keyboard.rs
@@ -1,10 +1,10 @@
-//! "Phím chuyển" page: the VI/EN toggle hotkey.
+//! "Phím chuyển" page: the VI/EN toggle hotkey and the flip hotkey.
 
 use adw::prelude::*;
 use adw::{ComboRow, PreferencesGroup, PreferencesPage};
 use gtk::StringList;
 
-use crate::settings::{Hotkey, Settings};
+use crate::settings::{FlipHotkey, Hotkey, Settings};
 
 pub(super) fn page() -> PreferencesPage {
     let s = Settings::load();
@@ -38,5 +38,31 @@ pub(super) fn page() -> PreferencesPage {
     });
     group.add(&row);
     page.add(&group);
+
+    // Flip the word being composed VN↔raw (card ⇄ cải). Presets mirror the Windows
+    // build; "Tắt" disables it.
+    let flip_group = PreferencesGroup::builder()
+        .description("Đổi từ đang gõ giữa tiếng Việt và chữ gốc (card ⇄ cải).")
+        .build();
+    let flip_row = ComboRow::builder()
+        .title("Phím lật từ vừa gõ")
+        .model(&StringList::new(&["Tắt", "Ctrl + Shift + Z", "Ctrl + Shift + X"]))
+        .build();
+    flip_row.set_selected(match s.flip_hotkey {
+        FlipHotkey::CtrlShiftZ => 1,
+        FlipHotkey::CtrlShiftX => 2,
+        FlipHotkey::Off => 0,
+    });
+    flip_row.connect_selected_notify(|row| {
+        let h = match row.selected() {
+            1 => FlipHotkey::CtrlShiftZ,
+            2 => FlipHotkey::CtrlShiftX,
+            _ => FlipHotkey::Off,
+        };
+        Settings::update(|s| s.flip_hotkey = h);
+    });
+    flip_group.add(&flip_row);
+    page.add(&flip_group);
+
     page
 }

--- a/platforms/macos/Funput/DesignSystem/AppLogo.swift
+++ b/platforms/macos/Funput/DesignSystem/AppLogo.swift
@@ -1,0 +1,29 @@
+import AppKit
+import SwiftUI
+
+/// The Funput app icon shown as a Liquid Glass medallion, for hero / brand areas
+/// (About, onboarding welcome). Falls back to an SF Symbol if the icon is
+/// unavailable (e.g. in previews).
+struct AppLogo: View {
+    var size: CGFloat = 92
+
+    var body: some View {
+        Group {
+            if let icon = NSApplication.shared.applicationIconImage {
+                Image(nsImage: icon)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+            } else {
+                Image(systemName: "character.bubble.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .foregroundStyle(.tint)
+                    .padding(size * 0.16)
+            }
+        }
+        .frame(width: size, height: size)
+        .padding(Theme.Spacing.md)
+        .glassEffect(.regular, in: .circle)
+    }
+}

--- a/platforms/macos/Funput/IME/FunputComposer.swift
+++ b/platforms/macos/Funput/IME/FunputComposer.swift
@@ -94,6 +94,14 @@ final class FunputComposer {
         funput_backspace(handle)
     }
 
+    /// Flip the word being composed between its Vietnamese form and its raw
+    /// keystrokes (`card` ⇄ `cải`), and back on a second call. Returns `true` when
+    /// the composition changed, so the caller re-renders the marked text from
+    /// `buffer()`; `false` when there is nothing to flip.
+    func flipComposing() -> Bool {
+        funput_flip_composing(handle)
+    }
+
     /// Decode a `FunputResult`'s inline `chars` (a C `uint32_t[64]`, imported as a
     /// tuple) into a `String`.
     static func output(of result: FunputResult) -> String {

--- a/platforms/macos/Funput/IME/FunputComposer.swift
+++ b/platforms/macos/Funput/IME/FunputComposer.swift
@@ -95,10 +95,11 @@ final class FunputComposer {
     }
 
     /// Flip the word being composed between its Vietnamese form and its raw
-    /// keystrokes (`card` ⇄ `cải`), and back on a second call. Returns `true` when
-    /// the composition changed, so the caller re-renders the marked text from
-    /// `buffer()`; `false` when there is nothing to flip.
-    func flipComposing() -> Bool {
+    /// keystrokes (`card` ⇄ `cải`), and back on a second call. Returns the engine
+    /// result; the caller re-renders the marked text from `buffer()` when its
+    /// action is not `ACTION_NONE` (macOS shows marked text, so the delete+inject
+    /// payload itself is unused).
+    func flipComposing() -> FunputResult {
         funput_flip_composing(handle)
     }
 

--- a/platforms/macos/Funput/IME/FunputInputController.swift
+++ b/platforms/macos/Funput/IME/FunputInputController.swift
@@ -56,6 +56,14 @@ final class FunputInputController: IMKInputController {
         // is set per-app on focus change (see `activateServer`) and can be toggled.
         guard AppSettings.shared.vietnameseEnabled else { return false }
 
+        // Flip the word being composed between Vietnamese and raw keys. Handled in
+        // Vietnamese mode, before the Control-combo passthrough, so the hotkey isn't
+        // swallowed in English mode (e.g. ⌃⇧Z stays Redo there).
+        if matchesFlipShortcut(event) {
+            flipComposing(client)
+            return true
+        }
+
         // Keyboard shortcuts (⌘C, ⌃A, …) are not text: end composition and let
         // the app handle them. Control/Command combos carry control characters in
         // `event.characters`, which would otherwise be fed to the composer.
@@ -165,6 +173,14 @@ final class FunputInputController: IMKInputController {
         return true
     }
 
+    /// Flip the word being composed between Vietnamese and raw keys. It is still
+    /// marked (uncommitted) text, so we just re-render it — works in every app,
+    /// unlike editing already-committed text.
+    private func flipComposing(_ client: IMKTextInput) {
+        guard composer.flipComposing() else { return } // nothing to flip
+        setMarked(composer.buffer(), client)
+    }
+
     // MARK: - Toggle Vietnamese / English
 
     private func toggleEnabled() {
@@ -182,6 +198,10 @@ final class FunputInputController: IMKInputController {
         case .rightCommand, .rightOption:
             return false
         }
+    }
+
+    private func matchesFlipShortcut(_ event: NSEvent) -> Bool {
+        AppSettings.shared.flipShortcut?.matches(event) ?? false
     }
 
     private func matchesModifierToggle(_ event: NSEvent) -> Bool {

--- a/platforms/macos/Funput/IME/FunputInputController.swift
+++ b/platforms/macos/Funput/IME/FunputInputController.swift
@@ -16,10 +16,6 @@ final class FunputInputController: IMKInputController {
 
     private enum KeyCode {
         static let backspace: UInt16 = 51
-        static let backslash: UInt16 = 42
-        static let space: UInt16 = 49
-        static let rightCommand: UInt16 = 54
-        static let rightOption: UInt16 = 61
     }
 
     private static let notFound = NSRange(location: NSNotFound, length: 0)
@@ -29,25 +25,19 @@ final class FunputInputController: IMKInputController {
         syncSettings()
     }
 
-    /// Also receive flagsChanged so right-Command / right-Option can toggle.
     override func recognizedEvents(_ sender: Any!) -> Int {
-        Int(NSEvent.EventTypeMask.keyDown.rawValue | NSEvent.EventTypeMask.flagsChanged.rawValue)
+        Int(NSEvent.EventTypeMask.keyDown.rawValue)
     }
 
     // MARK: - Event entry point
 
     override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
         guard let event, let client = sender as? IMKTextInput else { return false }
-
-        if event.type == .flagsChanged {
-            if matchesModifierToggle(event) { toggleEnabled() }
-            return false
-        }
         guard event.type == .keyDown else { return false }
 
         syncSettings()
 
-        if matchesComboToggle(event) {
+        if AppSettings.shared.toggleShortcut.matches(event) {
             toggleEnabled()
             return true
         }
@@ -189,30 +179,8 @@ final class FunputInputController: IMKInputController {
         composer.setEnabled(settings.vietnameseEnabled)
     }
 
-    private func matchesComboToggle(_ event: NSEvent) -> Bool {
-        switch AppSettings.shared.toggleShortcut {
-        case .controlBackslash:
-            return event.modifierFlags.contains(.control) && event.keyCode == KeyCode.backslash
-        case .controlSpace:
-            return event.modifierFlags.contains(.control) && event.keyCode == KeyCode.space
-        case .rightCommand, .rightOption:
-            return false
-        }
-    }
-
     private func matchesFlipShortcut(_ event: NSEvent) -> Bool {
         AppSettings.shared.flipShortcut?.matches(event) ?? false
-    }
-
-    private func matchesModifierToggle(_ event: NSEvent) -> Bool {
-        switch AppSettings.shared.toggleShortcut {
-        case .rightCommand:
-            return event.keyCode == KeyCode.rightCommand && event.modifierFlags.contains(.command)
-        case .rightOption:
-            return event.keyCode == KeyCode.rightOption && event.modifierFlags.contains(.option)
-        case .controlBackslash, .controlSpace:
-            return false
-        }
     }
 
     // MARK: - Helpers

--- a/platforms/macos/Funput/IME/FunputInputController.swift
+++ b/platforms/macos/Funput/IME/FunputInputController.swift
@@ -167,7 +167,7 @@ final class FunputInputController: IMKInputController {
     /// marked (uncommitted) text, so we just re-render it — works in every app,
     /// unlike editing already-committed text.
     private func flipComposing(_ client: IMKTextInput) {
-        guard composer.flipComposing() else { return } // nothing to flip
+        guard composer.flipComposing().action != ACTION_NONE else { return } // nothing to flip
         setMarked(composer.buffer(), client)
     }
 

--- a/platforms/macos/Funput/MenuBar/StatusMenu.swift
+++ b/platforms/macos/Funput/MenuBar/StatusMenu.swift
@@ -13,7 +13,7 @@ struct StatusMenu: View {
         Toggle(isOn: $settings.vietnameseEnabled) {
             Text(settings.vietnameseEnabled ? "Tiếng Việt (đang bật)" : "Tiếng Việt (đang tắt)")
         }
-        .keyboardShortcut("\\", modifiers: .control)
+        .keyboardShortcut(settings.toggleShortcut.keyboardShortcut)
 
         Divider()
 

--- a/platforms/macos/Funput/Model/AppSettings.swift
+++ b/platforms/macos/Funput/Model/AppSettings.swift
@@ -56,8 +56,10 @@ final class AppSettings {
     var autoCapitalizeEnabled: Bool {
         didSet { defaults.set(autoCapitalizeEnabled, forKey: Keys.autoCapitalizeEnabled) }
     }
-    var toggleShortcut: ToggleShortcut {
-        didSet { defaults.set(toggleShortcut.rawValue, forKey: Keys.toggleShortcut) }
+    /// User-recorded VI/EN toggle hotkey. Defaults to `⌃\`. Read live by
+    /// `FunputInputController`.
+    var toggleShortcut: KeyCombo {
+        didSet { defaults.set(try? JSONEncoder().encode(toggleShortcut), forKey: Keys.toggleShortcut) }
     }
     /// User-recorded hotkey to flip the word being composed VN↔raw. `nil` = off.
     /// Read live by `FunputInputController`.
@@ -113,8 +115,8 @@ final class AppSettings {
         eagerRestore = defaults.bool(forKey: Keys.eagerRestore)
         spellCheckEnabled = defaults.bool(forKey: Keys.spellCheckEnabled)
         autoCapitalizeEnabled = defaults.bool(forKey: Keys.autoCapitalizeEnabled)
-        toggleShortcut = defaults.string(forKey: Keys.toggleShortcut)
-            .flatMap(ToggleShortcut.init(rawValue:)) ?? .controlBackslash
+        toggleShortcut = defaults.data(forKey: Keys.toggleShortcut)
+            .flatMap { try? JSONDecoder().decode(KeyCombo.self, from: $0) } ?? .defaultToggle
         flipShortcut = defaults.data(forKey: Keys.flipShortcut)
             .flatMap { try? JSONDecoder().decode(KeyCombo.self, from: $0) }
         launchAtLogin = defaults.bool(forKey: Keys.launchAtLogin)

--- a/platforms/macos/Funput/Model/AppSettings.swift
+++ b/platforms/macos/Funput/Model/AppSettings.swift
@@ -59,6 +59,17 @@ final class AppSettings {
     var toggleShortcut: ToggleShortcut {
         didSet { defaults.set(toggleShortcut.rawValue, forKey: Keys.toggleShortcut) }
     }
+    /// User-recorded hotkey to flip the word being composed VN↔raw. `nil` = off.
+    /// Read live by `FunputInputController`.
+    var flipShortcut: KeyCombo? {
+        didSet {
+            if let data = flipShortcut.flatMap({ try? JSONEncoder().encode($0) }) {
+                defaults.set(data, forKey: Keys.flipShortcut)
+            } else {
+                defaults.removeObject(forKey: Keys.flipShortcut)
+            }
+        }
+    }
     var launchAtLogin: Bool {
         didSet { defaults.set(launchAtLogin, forKey: Keys.launchAtLogin) }
     }
@@ -104,6 +115,8 @@ final class AppSettings {
         autoCapitalizeEnabled = defaults.bool(forKey: Keys.autoCapitalizeEnabled)
         toggleShortcut = defaults.string(forKey: Keys.toggleShortcut)
             .flatMap(ToggleShortcut.init(rawValue:)) ?? .controlBackslash
+        flipShortcut = defaults.data(forKey: Keys.flipShortcut)
+            .flatMap { try? JSONDecoder().decode(KeyCombo.self, from: $0) }
         launchAtLogin = defaults.bool(forKey: Keys.launchAtLogin)
         showMenuBarIcon = defaults.bool(forKey: Keys.showMenuBarIcon)
         hasCompletedOnboarding = defaults.bool(forKey: Keys.hasCompletedOnboarding)
@@ -153,6 +166,7 @@ final class AppSettings {
         static let spellCheckEnabled = "spellCheckEnabled"
         static let autoCapitalizeEnabled = "autoCapitalizeEnabled"
         static let toggleShortcut = "toggleShortcut"
+        static let flipShortcut = "flipShortcut"
         static let launchAtLogin = "launchAtLogin"
         static let showMenuBarIcon = "showMenuBarIcon"
         static let hasCompletedOnboarding = "hasCompletedOnboarding"

--- a/platforms/macos/Funput/Model/InputMethod.swift
+++ b/platforms/macos/Funput/Model/InputMethod.swift
@@ -45,24 +45,3 @@ enum ToneStyle: Int, CaseIterable, Identifiable, Codable {
         }
     }
 }
-
-/// Hotkey that switches between Vietnamese and English (pass-through) typing.
-enum ToggleShortcut: String, CaseIterable, Identifiable, Codable {
-    case controlBackslash
-    case controlSpace
-    case rightCommand
-    case rightOption
-
-    var id: String { rawValue }
-
-    var keyCaps: [String] {
-        switch self {
-        case .controlBackslash: ["⌃", "\\"]
-        case .controlSpace: ["⌃", "Space"]
-        case .rightCommand: ["⌘", "(phải)"]
-        case .rightOption: ["⌥", "(phải)"]
-        }
-    }
-
-    var label: String { keyCaps.joined(separator: " ") }
-}

--- a/platforms/macos/Funput/Model/KeyCombo.swift
+++ b/platforms/macos/Funput/Model/KeyCombo.swift
@@ -1,0 +1,60 @@
+import AppKit
+
+/// A user-recorded keyboard shortcut: a key plus its ⌃/⌥/⌘/⇧ modifiers.
+///
+/// Matching is by `keyCode` + the exact masked modifier set (layout-independent).
+/// `label` is the display string captured when recorded, so we don't need a
+/// keyCode→name table for every layout.
+struct KeyCombo: Codable, Equatable {
+    let keyCode: UInt16
+    /// Raw value of the masked `NSEvent.ModifierFlags` (⌃⌥⌘⇧ only).
+    let modifiers: UInt
+    let label: String
+
+    /// The modifier keys that make a combo a real shortcut (Shift alone doesn't —
+    /// it's part of normal typing).
+    private static let commandModifiers: NSEvent.ModifierFlags = [.control, .option, .command]
+    private static let allModifiers: NSEvent.ModifierFlags = [.control, .option, .command, .shift]
+
+    /// Build a combo from a key-down event, or `nil` when it isn't a usable shortcut
+    /// (no ⌃/⌥/⌘ held — a bare key would fire while typing).
+    static func from(_ event: NSEvent) -> KeyCombo? {
+        let mods = event.modifierFlags.intersection(allModifiers)
+        guard !mods.intersection(commandModifiers).isEmpty else { return nil }
+        return KeyCombo(keyCode: event.keyCode, modifiers: mods.rawValue, label: label(for: event))
+    }
+
+    /// True when `event` is exactly this combo.
+    func matches(_ event: NSEvent) -> Bool {
+        event.keyCode == keyCode
+            && event.modifierFlags.intersection(Self.allModifiers).rawValue == modifiers
+    }
+
+    /// Keycaps for display, e.g. `["⌃", "⇧", "Z"]`.
+    var keyCaps: [String] {
+        let flags = NSEvent.ModifierFlags(rawValue: modifiers)
+        var caps: [String] = []
+        if flags.contains(.control) { caps.append("⌃") }
+        if flags.contains(.option) { caps.append("⌥") }
+        if flags.contains(.shift) { caps.append("⇧") }
+        if flags.contains(.command) { caps.append("⌘") }
+        caps.append(label)
+        return caps
+    }
+
+    /// Human-readable label for the pressed key, preferring the produced character.
+    private static func label(for event: NSEvent) -> String {
+        if let chars = event.charactersIgnoringModifiers,
+           let first = chars.first,
+           first.isLetter || first.isNumber || first.isPunctuation || first.isSymbol {
+            return chars.uppercased()
+        }
+        return specialKeyNames[event.keyCode] ?? "•"
+    }
+
+    /// Display names for common non-printing keys (fallback when there's no character).
+    private static let specialKeyNames: [UInt16: String] = [
+        49: "Space", 36: "↩", 48: "⇥", 51: "⌫", 53: "⎋",
+        123: "←", 124: "→", 125: "↓", 126: "↑",
+    ]
+}

--- a/platforms/macos/Funput/Model/KeyCombo.swift
+++ b/platforms/macos/Funput/Model/KeyCombo.swift
@@ -16,6 +16,13 @@ struct KeyCombo: Codable, Equatable {
     private static let commandModifiers: NSEvent.ModifierFlags = [.control, .option, .command]
     private static let allModifiers: NSEvent.ModifierFlags = [.control, .option, .command, .shift]
 
+    /// Default VI/EN toggle — `⌃\` (backslash key, keyCode 42).
+    static let defaultToggle = KeyCombo(
+        keyCode: 42,
+        modifiers: NSEvent.ModifierFlags.control.rawValue,
+        label: "\\"
+    )
+
     /// Build a combo from a key-down event, or `nil` when it isn't a usable shortcut
     /// (no ⌃/⌥/⌘ held — a bare key would fire while typing).
     static func from(_ event: NSEvent) -> KeyCombo? {
@@ -32,13 +39,16 @@ struct KeyCombo: Codable, Equatable {
 
     /// Keycaps for display, e.g. `["⌃", "⇧", "Z"]`.
     var keyCaps: [String] {
-        let flags = NSEvent.ModifierFlags(rawValue: modifiers)
+        Self.modifierSymbols(NSEvent.ModifierFlags(rawValue: modifiers)) + [label]
+    }
+
+    /// The modifier symbols held in `flags`, in display order (⌃⌥⇧⌘).
+    static func modifierSymbols(_ flags: NSEvent.ModifierFlags) -> [String] {
         var caps: [String] = []
         if flags.contains(.control) { caps.append("⌃") }
         if flags.contains(.option) { caps.append("⌥") }
         if flags.contains(.shift) { caps.append("⇧") }
         if flags.contains(.command) { caps.append("⌘") }
-        caps.append(label)
         return caps
     }
 

--- a/platforms/macos/Funput/Model/KeyCombo.swift
+++ b/platforms/macos/Funput/Model/KeyCombo.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 
 /// A user-recorded keyboard shortcut: a key plus its ⌃/⌥/⌘/⇧ modifiers.
 ///
@@ -66,5 +67,36 @@ struct KeyCombo: Codable, Equatable {
     private static let specialKeyNames: [UInt16: String] = [
         49: "Space", 36: "↩", 48: "⇥", 51: "⌫", 53: "⎋",
         123: "←", 124: "→", 125: "↓", 126: "↑",
+    ]
+}
+
+extension KeyCombo {
+    /// The SwiftUI shortcut for menu annotations (and app-level handling while a
+    /// Funput window is focused). `nil` when the key can't be represented.
+    var keyboardShortcut: KeyboardShortcut? {
+        keyEquivalent.map { KeyboardShortcut($0, modifiers: eventModifiers) }
+    }
+
+    private var eventModifiers: EventModifiers {
+        let flags = NSEvent.ModifierFlags(rawValue: modifiers)
+        var mods: EventModifiers = []
+        if flags.contains(.control) { mods.insert(.control) }
+        if flags.contains(.option) { mods.insert(.option) }
+        if flags.contains(.shift) { mods.insert(.shift) }
+        if flags.contains(.command) { mods.insert(.command) }
+        return mods
+    }
+
+    private var keyEquivalent: KeyEquivalent? {
+        if let special = Self.specialKeyEquivalents[keyCode] { return special }
+        // Printable keys: `label` is the character; lowercase letters so Shift is
+        // expressed via the modifiers, not the case.
+        guard let ch = label.first, ch != "•" else { return nil }
+        return KeyEquivalent(Character(ch.lowercased()))
+    }
+
+    private static let specialKeyEquivalents: [UInt16: KeyEquivalent] = [
+        49: .space, 36: .return, 48: .tab, 51: .delete, 53: .escape,
+        123: .leftArrow, 124: .rightArrow, 125: .downArrow, 126: .upArrow,
     ]
 }

--- a/platforms/macos/Funput/Onboarding/OnboardingView.swift
+++ b/platforms/macos/Funput/Onboarding/OnboardingView.swift
@@ -21,10 +21,7 @@ struct OnboardingView: View {
     @ViewBuilder private var content: some View {
         switch step {
         case 0:
-            OnboardingStep(icon: "character.bubble.fill", title: "Chào mừng đến Funput",
-                           subtitle: "Gõ tiếng Việt ở mọi nơi trên máy Mac — miễn phí, mã nguồn mở.") {
-                EmptyView()
-            }
+            welcomeStep
         case 1:
             EnableInputSourceStep()
         case 2:
@@ -35,6 +32,25 @@ struct OnboardingView: View {
                 EmptyView()
             }
         }
+    }
+
+    /// First step — leads with the Funput logo to anchor the brand.
+    private var welcomeStep: some View {
+        VStack(spacing: Theme.Spacing.lg) {
+            Spacer(minLength: 0)
+            AppLogo(size: 104)
+            VStack(spacing: Theme.Spacing.sm) {
+                Text("Chào mừng đến Funput")
+                    .font(.largeTitle.bold())
+                Text("Gõ tiếng Việt ở mọi nơi trên máy Mac — miễn phí, mã nguồn mở.")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: 440)
+        .frame(maxWidth: .infinity)
     }
 
     private var methodStep: some View {

--- a/platforms/macos/Funput/Settings/Panes/AboutPane.swift
+++ b/platforms/macos/Funput/Settings/Panes/AboutPane.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct AboutPane: View {
@@ -8,34 +9,81 @@ struct AboutPane: View {
         VStack(spacing: Theme.Spacing.lg) {
             GlassCard {
                 VStack(spacing: Theme.Spacing.md) {
-                    Image(systemName: "character.bubble.fill")
-                        .font(.system(size: 56))
-                        .foregroundStyle(.tint)
-                    Text("Funput")
-                        .font(.largeTitle.bold())
-                    Text("Bộ gõ tiếng Việt — miễn phí, mã nguồn mở.")
-                        .foregroundStyle(.secondary)
+                    logo
+                        .frame(width: 92, height: 92)
+                        .padding(Theme.Spacing.md)
+                        .glassEffect(.regular, in: .circle)
+                        .padding(.bottom, Theme.Spacing.xs)
+
+                    VStack(spacing: Theme.Spacing.xs) {
+                        Text("Funput")
+                            .font(.largeTitle.bold())
+                        Text("Bộ gõ tiếng Việt — miễn phí, mã nguồn mở.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+
                     Text("Phiên bản \(appVersion)")
-                        .font(.caption)
+                        .font(.caption.weight(.medium))
                         .foregroundStyle(.secondary)
+                        .padding(.horizontal, Theme.Spacing.md)
+                        .padding(.vertical, Theme.Spacing.xs)
+                        .glassEffect(.regular, in: .capsule)
 
-                    if let updater {
-                        Button("Kiểm tra cập nhật…") { updater.checkForUpdates() }
-                            .buttonStyle(.glass)
+                    VStack(spacing: Theme.Spacing.sm) {
+                        if let updater {
+                            Button { updater.checkForUpdates() } label: {
+                                Label("Kiểm tra cập nhật", systemImage: "arrow.triangle.2.circlepath")
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .buttonStyle(.glassProminent)
+                            .controlSize(.large)
                             .disabled(!updater.canCheckForUpdates)
-                            .padding(.top, Theme.Spacing.sm)
-                    }
+                        }
 
-                    HStack(spacing: Theme.Spacing.md) {
-                        Link("GitHub", destination: URL(string: "https://github.com/Funput/Funput")!)
-                        Link("Website", destination: URL(string: "https://funput.app/")!)
+                        HStack(spacing: Theme.Spacing.sm) {
+                            linkButton(
+                                "GitHub",
+                                systemImage: "chevron.left.forwardslash.chevron.right",
+                                url: "https://github.com/Funput/Funput"
+                            )
+                            linkButton("Website", systemImage: "globe", url: "https://funput.app/")
+                        }
                     }
-                    .buttonStyle(.glass)
                     .padding(.top, Theme.Spacing.sm)
                 }
                 .frame(maxWidth: .infinity)
+                .padding(.vertical, Theme.Spacing.md)
             }
         }
+    }
+
+    /// The app icon (Funput logo); falls back to an SF Symbol if unavailable
+    /// (e.g. in previews).
+    @ViewBuilder private var logo: some View {
+        if let icon = NSApplication.shared.applicationIconImage {
+            Image(nsImage: icon)
+                .resizable()
+                .interpolation(.high)
+                .scaledToFit()
+        } else {
+            Image(systemName: "character.bubble.fill")
+                .resizable()
+                .scaledToFit()
+                .foregroundStyle(.tint)
+                .padding(Theme.Spacing.sm)
+        }
+    }
+
+    /// A secondary glass link button with a leading icon, sized to share its row.
+    private func linkButton(_ title: String, systemImage: String, url: String) -> some View {
+        Link(destination: URL(string: url)!) {
+            Label(title, systemImage: systemImage)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.glass)
+        .controlSize(.large)
     }
 
     private var appVersion: String {

--- a/platforms/macos/Funput/Settings/Panes/AboutPane.swift
+++ b/platforms/macos/Funput/Settings/Panes/AboutPane.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 struct AboutPane: View {
@@ -9,10 +8,7 @@ struct AboutPane: View {
         VStack(spacing: Theme.Spacing.lg) {
             GlassCard {
                 VStack(spacing: Theme.Spacing.md) {
-                    logo
-                        .frame(width: 92, height: 92)
-                        .padding(Theme.Spacing.md)
-                        .glassEffect(.regular, in: .circle)
+                    AppLogo(size: 92)
                         .padding(.bottom, Theme.Spacing.xs)
 
                     VStack(spacing: Theme.Spacing.xs) {
@@ -56,23 +52,6 @@ struct AboutPane: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, Theme.Spacing.md)
             }
-        }
-    }
-
-    /// The app icon (Funput logo); falls back to an SF Symbol if unavailable
-    /// (e.g. in previews).
-    @ViewBuilder private var logo: some View {
-        if let icon = NSApplication.shared.applicationIconImage {
-            Image(nsImage: icon)
-                .resizable()
-                .interpolation(.high)
-                .scaledToFit()
-        } else {
-            Image(systemName: "character.bubble.fill")
-                .resizable()
-                .scaledToFit()
-                .foregroundStyle(.tint)
-                .padding(Theme.Spacing.sm)
         }
     }
 

--- a/platforms/macos/Funput/Settings/Panes/KeyboardPane.swift
+++ b/platforms/macos/Funput/Settings/Panes/KeyboardPane.swift
@@ -8,22 +8,18 @@ struct KeyboardPane: View {
 
         VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
             GlassCard {
-                VStack(alignment: .leading, spacing: Theme.Spacing.md) {
-                    SettingsRow(
-                        title: "Phím chuyển Việt / Anh",
-                        subtitle: "Nhấn để tạm tắt gõ tiếng Việt",
-                        systemImage: "globe"
-                    ) {
-                        ShortcutCaps(caps: settings.toggleShortcut.keyCaps)
-                    }
-                    Divider()
-                    Picker("Chọn phím", selection: $settings.toggleShortcut) {
-                        ForEach(ToggleShortcut.allCases) { shortcut in
-                            Text(shortcut.label).tag(shortcut)
-                        }
-                    }
-                    .pickerStyle(.radioGroup)
-                    .labelsHidden()
+                SettingsRow(
+                    title: "Phím chuyển Việt / Anh",
+                    subtitle: "Nhấn để tạm tắt gõ tiếng Việt. Bấm rồi nhấn tổ hợp kèm ⌃/⌥/⌘.",
+                    systemImage: "globe"
+                ) {
+                    ShortcutRecorder(
+                        combo: Binding(
+                            get: { settings.toggleShortcut },
+                            set: { if let combo = $0 { settings.toggleShortcut = combo } }
+                        ),
+                        allowOff: false
+                    )
                 }
             }
 

--- a/platforms/macos/Funput/Settings/Panes/KeyboardPane.swift
+++ b/platforms/macos/Funput/Settings/Panes/KeyboardPane.swift
@@ -26,6 +26,16 @@ struct KeyboardPane: View {
                     .labelsHidden()
                 }
             }
+
+            GlassCard {
+                SettingsRow(
+                    title: "Phím lật từ vừa gõ",
+                    subtitle: "Đổi từ đang gõ giữa tiếng Việt và chữ gốc (card ⇄ cải). Bấm rồi nhấn tổ hợp kèm ⌃/⌥/⌘.",
+                    systemImage: "arrow.2.squarepath"
+                ) {
+                    ShortcutRecorder(combo: $settings.flipShortcut)
+                }
+            }
         }
     }
 }

--- a/platforms/macos/Funput/Settings/ShortcutRecorder.swift
+++ b/platforms/macos/Funput/Settings/ShortcutRecorder.swift
@@ -1,0 +1,87 @@
+import AppKit
+import SwiftUI
+
+/// Records a keyboard shortcut in the app's Liquid Glass style: tap the pill, then
+/// press the combo you want. Binds to an optional `KeyCombo` (`nil` = off). Requires
+/// a ⌃/⌥/⌘ modifier; Esc cancels.
+struct ShortcutRecorder: View {
+    @Binding var combo: KeyCombo?
+
+    @State private var recording = false
+    @State private var monitor: Any?
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Button(action: toggleRecording) {
+                pill
+            }
+            .buttonStyle(.plain)
+
+            if combo != nil, !recording {
+                Button { combo = nil } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 15))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Tắt phím tắt")
+            }
+        }
+        .animation(.easeInOut(duration: 0.15), value: recording)
+        .onDisappear(perform: stopRecording)
+    }
+
+    /// The tappable pill: prompt when empty, the recorded caps when set, a tinted
+    /// "listening" state while recording.
+    @ViewBuilder private var pill: some View {
+        if recording {
+            glassPill(
+                Label("Nhấn phím…", systemImage: "record.circle"),
+                glass: .regular.tint(.accentColor).interactive()
+            )
+        } else if let combo {
+            glassPill(ShortcutCaps(caps: combo.keyCaps), glass: .regular.interactive())
+        } else {
+            glassPill(
+                Label("Đặt phím", systemImage: "keyboard"),
+                glass: .regular.interactive()
+            )
+        }
+    }
+
+    private func glassPill(_ content: some View, glass: Glass) -> some View {
+        content
+            .font(.callout.weight(.medium))
+            .foregroundStyle(.primary)
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.sm)
+            .glassEffect(glass, in: .capsule)
+            .contentShape(.capsule)
+    }
+
+    // MARK: - Recording
+
+    private func toggleRecording() {
+        recording ? stopRecording() : startRecording()
+    }
+
+    private func startRecording() {
+        recording = true
+        // Swallow keys (return nil) while recording so they don't leak to the UI.
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            if event.keyCode == 53 { // Esc cancels
+                stopRecording()
+            } else if let captured = KeyCombo.from(event) {
+                combo = captured
+                stopRecording()
+            }
+            return nil
+        }
+    }
+
+    private func stopRecording() {
+        recording = false
+        if let monitor { NSEvent.removeMonitor(monitor) }
+        monitor = nil
+    }
+}

--- a/platforms/macos/Funput/Settings/ShortcutRecorder.swift
+++ b/platforms/macos/Funput/Settings/ShortcutRecorder.swift
@@ -1,23 +1,46 @@
 import AppKit
 import SwiftUI
 
-/// Records a keyboard shortcut in the app's Liquid Glass style: tap the pill, then
-/// press the combo you want. Binds to an optional `KeyCombo` (`nil` = off). Requires
-/// a ⌃/⌥/⌘ modifier; Esc cancels.
+/// Assigns a keyboard shortcut: shows the current keys, with an explicit "Đổi"
+/// button that opens a guided popover ("Nhấn tổ hợp phím…") with live feedback,
+/// validation, and Esc-to-cancel. Binds to an optional `KeyCombo` (`nil` = off);
+/// requires a ⌃/⌥/⌘ modifier.
 struct ShortcutRecorder: View {
     @Binding var combo: KeyCombo?
+    /// Whether the shortcut can be cleared (off). Disable for shortcuts that must
+    /// always have a value, e.g. the VI/EN toggle.
+    var allowOff = true
 
     @State private var recording = false
+    @State private var held: NSEvent.ModifierFlags = []
+    @State private var invalid = false
     @State private var monitor: Any?
 
     var body: some View {
         HStack(spacing: Theme.Spacing.sm) {
-            Button(action: toggleRecording) {
-                pill
+            if let combo {
+                ShortcutCaps(caps: combo.keyCaps)
+            } else {
+                Text("Chưa đặt").font(.callout).foregroundStyle(.secondary)
+            }
+
+            Button { recording = true } label: {
+                Label(combo == nil ? "Đặt phím" : "Đổi", systemImage: "pencil")
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(.primary)
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.xs + 2)
+                    .glassEffect(.regular.interactive(), in: .capsule)
+                    .contentShape(.capsule)
             }
             .buttonStyle(.plain)
+            .popover(isPresented: $recording, arrowEdge: .bottom) {
+                recordingPopover
+                    .onAppear(perform: startRecording)
+                    .onDisappear(perform: stopRecording)
+            }
 
-            if combo != nil, !recording {
+            if combo != nil, allowOff {
                 Button { combo = nil } label: {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 15))
@@ -27,60 +50,56 @@ struct ShortcutRecorder: View {
                 .help("Tắt phím tắt")
             }
         }
-        .animation(.easeInOut(duration: 0.15), value: recording)
-        .onDisappear(perform: stopRecording)
     }
 
-    /// The tappable pill: prompt when empty, the recorded caps when set, a tinted
-    /// "listening" state while recording.
-    @ViewBuilder private var pill: some View {
-        if recording {
-            glassPill(
-                Label("Nhấn phím…", systemImage: "record.circle"),
-                glass: .regular.tint(.accentColor).interactive()
-            )
-        } else if let combo {
-            glassPill(ShortcutCaps(caps: combo.keyCaps), glass: .regular.interactive())
-        } else {
-            glassPill(
-                Label("Đặt phím", systemImage: "keyboard"),
-                glass: .regular.interactive()
-            )
+    /// The guided capture popover: a prompt, a live preview of the keys held so far,
+    /// and a hint that turns into an error when the combo lacks a ⌃/⌥/⌘ modifier.
+    private var recordingPopover: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            Text("Nhấn tổ hợp phím mới")
+                .font(.headline)
+
+            ShortcutCaps(caps: previewCaps)
+                .frame(minHeight: 30)
+                .animation(.easeOut(duration: 0.1), value: held)
+
+            Text(invalid ? "Cần kèm ⌃ / ⌥ / ⌘" : "Giữ ⌃ / ⌥ / ⌘ rồi nhấn phím · ⎋ để huỷ")
+                .font(.caption)
+                .foregroundStyle(invalid ? Color.red : .secondary)
         }
+        .padding(Theme.Spacing.lg)
+        .frame(width: 260)
     }
 
-    private func glassPill(_ content: some View, glass: Glass) -> some View {
-        content
-            .font(.callout.weight(.medium))
-            .foregroundStyle(.primary)
-            .padding(.horizontal, Theme.Spacing.md)
-            .padding(.vertical, Theme.Spacing.sm)
-            .glassEffect(glass, in: .capsule)
-            .contentShape(.capsule)
+    /// Modifier symbols held so far, plus a placeholder for the key still to come.
+    private var previewCaps: [String] {
+        KeyCombo.modifierSymbols(held) + ["?"]
     }
 
-    // MARK: - Recording
-
-    private func toggleRecording() {
-        recording ? stopRecording() : startRecording()
-    }
+    // MARK: - Capture
 
     private func startRecording() {
-        recording = true
-        // Swallow keys (return nil) while recording so they don't leak to the UI.
-        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+        held = []
+        invalid = false
+        monitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { event in
+            if event.type == .flagsChanged {
+                held = event.modifierFlags.intersection([.control, .option, .command, .shift])
+                invalid = false
+                return nil
+            }
             if event.keyCode == 53 { // Esc cancels
-                stopRecording()
+                recording = false
             } else if let captured = KeyCombo.from(event) {
                 combo = captured
-                stopRecording()
+                recording = false
+            } else {
+                invalid = true // a key without a ⌃/⌥/⌘ modifier
             }
             return nil
         }
     }
 
     private func stopRecording() {
-        recording = false
         if let monitor { NSEvent.removeMonitor(monitor) }
         monitor = nil
     }

--- a/platforms/windows/src/commands.rs
+++ b/platforms/windows/src/commands.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Mutex;
 
-use crate::settings::{ExcludedApp, Hotkey, Method, ToneStyle};
+use crate::settings::{ExcludedApp, FlipHotkey, Hotkey, Method, ToneStyle};
 use crate::update::{self, Manifest};
 use crate::{shell, windows_ui};
 
@@ -34,6 +34,10 @@ pub fn set_auto_capitalize(on: bool) {
 
 pub fn set_toggle_hotkey(hotkey: Hotkey) {
     shell::set_toggle_hotkey(hotkey);
+}
+
+pub fn set_flip_hotkey(hotkey: FlipHotkey) {
+    shell::set_flip_hotkey(hotkey);
 }
 
 pub fn complete_onboarding() {

--- a/platforms/windows/src/hook.rs
+++ b/platforms/windows/src/hook.rs
@@ -223,6 +223,20 @@ fn handle_keydown(kbd: &KBDLLHOOKSTRUCT) -> bool {
         return false;
     }
 
+    // Flip the word being composed VN↔raw. Same inject path as composing; swallow
+    // the hotkey even on a no-op so it never leaks to the app.
+    if keymap::is_flip(vk, mods, shell::flip_hotkey()) {
+        let plan = plan_inject(&shell::flip_composing());
+        if !plan.is_noop() {
+            if shell::foreground_is_chrome() {
+                inject::send_plan_chrome(&plan);
+            } else {
+                inject::send_plan(&plan);
+            }
+        }
+        return true;
+    }
+
     match classify(&keymap::to_key_event(kbd)) {
         KeyKind::Compose(c) => {
             let plan = plan_inject(&shell::process_char(c));

--- a/platforms/windows/src/keymap.rs
+++ b/platforms/windows/src/keymap.rs
@@ -10,7 +10,7 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 };
 use windows::Win32::UI::WindowsAndMessaging::KBDLLHOOKSTRUCT;
 
-use crate::settings::Hotkey;
+use crate::settings::{FlipHotkey, Hotkey};
 
 fn async_down(vk: VIRTUAL_KEY) -> bool {
     (unsafe { GetAsyncKeyState(vk.0 as i32) } as u16 & 0x8000) != 0
@@ -33,6 +33,17 @@ pub fn is_toggle(vk: VIRTUAL_KEY, mods: Mods, hotkey: Hotkey) -> bool {
         Hotkey::CtrlSpace => mods.ctrl && !mods.alt && !mods.win && vk == VK_SPACE,
         // Modifier-only combo: fires on the second modifier's keydown.
         Hotkey::AltShift => mods.alt && mods.shift && (vk == VK_SHIFT || vk == VK_MENU),
+    }
+}
+
+/// Whether this keydown matches the configured flip hotkey. Letter virtual-keys are
+/// their ASCII uppercase codes (`Z` = 0x5A, `X` = 0x58).
+pub fn is_flip(vk: VIRTUAL_KEY, mods: Mods, hotkey: FlipHotkey) -> bool {
+    let ctrl_shift = mods.ctrl && mods.shift && !mods.alt && !mods.win;
+    match hotkey {
+        FlipHotkey::Off => false,
+        FlipHotkey::CtrlShiftZ => ctrl_shift && vk.0 == 0x5A,
+        FlipHotkey::CtrlShiftX => ctrl_shift && vk.0 == 0x58,
     }
 }
 

--- a/platforms/windows/src/settings.rs
+++ b/platforms/windows/src/settings.rs
@@ -117,6 +117,44 @@ impl Hotkey {
     }
 }
 
+/// Hotkey that flips the word being composed between Vietnamese and raw keys
+/// (`card` ⇄ `cải`). Presets use `Ctrl+Shift+<letter>` so they never collide with a
+/// toggle preset; `Off` disables it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FlipHotkey {
+    #[default]
+    Off,
+    CtrlShiftZ,
+    CtrlShiftX,
+}
+
+impl FlipHotkey {
+    pub fn id(self) -> &'static str {
+        match self {
+            FlipHotkey::Off => "off",
+            FlipHotkey::CtrlShiftZ => "ctrl_shift_z",
+            FlipHotkey::CtrlShiftX => "ctrl_shift_x",
+        }
+    }
+    pub fn from_id(id: &str) -> Option<Self> {
+        match id {
+            "off" => Some(FlipHotkey::Off),
+            "ctrl_shift_z" => Some(FlipHotkey::CtrlShiftZ),
+            "ctrl_shift_x" => Some(FlipHotkey::CtrlShiftX),
+            _ => None,
+        }
+    }
+    /// The keycaps shown in the UI, e.g. `["Ctrl", "Shift", "Z"]`.
+    pub fn caps(self) -> &'static [&'static str] {
+        match self {
+            FlipHotkey::Off => &["—"],
+            FlipHotkey::CtrlShiftZ => &["Ctrl", "Shift", "Z"],
+            FlipHotkey::CtrlShiftX => &["Ctrl", "Shift", "X"],
+        }
+    }
+}
+
 /// An app excluded from Vietnamese input. `id` is the lowercased exe file name
 /// (e.g. "code.exe"); `name` is a friendly label for the Settings UI.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -154,6 +192,10 @@ pub struct Settings {
     #[serde(default)]
     pub auto_capitalize: bool,
     pub toggle_hotkey: Hotkey,
+    /// Hotkey to flip the word being composed VN↔raw. `#[serde(default)]` (Off) keeps
+    /// older settings files loadable.
+    #[serde(default)]
+    pub flip_hotkey: FlipHotkey,
     pub launch_at_login: bool,
     pub has_completed_onboarding: bool,
     /// Apps that default to English on focus. `#[serde(default)]` keeps older
@@ -177,6 +219,7 @@ impl Default for Settings {
             spell_check: false,
             auto_capitalize: false,
             toggle_hotkey: Hotkey::CtrlBacktick,
+            flip_hotkey: FlipHotkey::Off,
             launch_at_login: false,
             has_completed_onboarding: false,
             excluded_apps: Vec::new(),

--- a/platforms/windows/src/shell.rs
+++ b/platforms/windows/src/shell.rs
@@ -9,7 +9,7 @@ use std::sync::{Mutex, OnceLock};
 use funput_core::{InputMethod, ToneStyle as CoreToneStyle};
 use funput_engine::{Engine, ImeResult};
 
-use crate::settings::{ExcludedApp, Hotkey, Method, Settings, Shortcut, ToneStyle};
+use crate::settings::{ExcludedApp, FlipHotkey, Hotkey, Method, Settings, Shortcut, ToneStyle};
 
 /// Tag stamped into `dwExtraInfo` of every event we synthesize via `SendInput`, so
 /// the hook can recognize and ignore its own injected keystrokes (no re-entrancy).
@@ -113,6 +113,9 @@ pub fn tone_style() -> CoreToneStyle {
 }
 pub fn toggle_hotkey() -> Hotkey {
     with(|s| s.settings.toggle_hotkey)
+}
+pub fn flip_hotkey() -> FlipHotkey {
+    with(|s| s.settings.flip_hotkey)
 }
 pub fn is_composing() -> bool {
     with(|s| !s.engine.buffer().is_empty())
@@ -264,6 +267,13 @@ pub fn set_toggle_hotkey(hotkey: Hotkey) {
     });
 }
 
+pub fn set_flip_hotkey(hotkey: FlipHotkey) {
+    with(|s| {
+        s.settings.flip_hotkey = hotkey;
+        s.settings.save();
+    });
+}
+
 /// Persist the launch-at-login preference. The registry side effect (auto-launch)
 /// is applied by `commands`, which owns the OS integration.
 pub fn set_launch_at_login(on: bool) {
@@ -397,6 +407,11 @@ pub fn apply_for_app(id: &str) -> Option<bool> {
 
 pub fn process_char(c: char) -> ImeResult {
     with(|s| s.engine.process_char(c))
+}
+
+/// Flip the word being composed VN↔raw; returns the delete+inject to apply.
+pub fn flip_composing() -> ImeResult {
+    with(|s| s.engine.flip_composing())
 }
 
 /// Sync the engine after Backspace while composing; the physical Backspace then

--- a/platforms/windows/src/windows_ui/models.rs
+++ b/platforms/windows/src/windows_ui/models.rs
@@ -2,11 +2,19 @@
 
 use slint::{ModelRc, SharedString, VecModel};
 
-use crate::settings::{ExcludedApp, Hotkey, Shortcut};
+use crate::settings::{ExcludedApp, FlipHotkey, Hotkey, Shortcut};
 use crate::{AppEntry, ShortcutEntry};
 
 pub(super) fn caps(hotkey: Hotkey) -> ModelRc<SharedString> {
-    let rows: Vec<SharedString> = hotkey.caps().iter().map(|c| (*c).into()).collect();
+    keycaps(hotkey.caps())
+}
+
+pub(super) fn flip_caps(hotkey: FlipHotkey) -> ModelRc<SharedString> {
+    keycaps(hotkey.caps())
+}
+
+fn keycaps(caps: &[&'static str]) -> ModelRc<SharedString> {
+    let rows: Vec<SharedString> = caps.iter().map(|c| (*c).into()).collect();
     ModelRc::new(VecModel::from(rows))
 }
 

--- a/platforms/windows/src/windows_ui/settings_callbacks.rs
+++ b/platforms/windows/src/windows_ui/settings_callbacks.rs
@@ -6,7 +6,7 @@ use slint::{ComponentHandle, Model};
 
 use super::{models, settings_window};
 use crate::compose::FieldComposer;
-use crate::settings::{Hotkey, Method, ToneStyle};
+use crate::settings::{FlipHotkey, Hotkey, Method, ToneStyle};
 use crate::{commands, shell, Compose, SettingsWindow};
 
 thread_local! {
@@ -42,6 +42,17 @@ pub(super) fn wire(window: &SettingsWindow) {
             if let Some(window) = weak.upgrade() {
                 window.set_hotkey(value);
                 window.set_hotkey_caps(models::caps(hotkey));
+            }
+        }
+    });
+
+    let weak = window.as_weak();
+    window.on_pick_flip_hotkey(move |value| {
+        if let Some(hotkey) = FlipHotkey::from_id(&value) {
+            commands::set_flip_hotkey(hotkey);
+            if let Some(window) = weak.upgrade() {
+                window.set_flip_hotkey(value);
+                window.set_flip_hotkey_caps(models::flip_caps(hotkey));
             }
         }
     });

--- a/platforms/windows/src/windows_ui/settings_window.rs
+++ b/platforms/windows/src/windows_ui/settings_window.rs
@@ -36,6 +36,8 @@ fn populate(window: &SettingsWindow) {
     window.set_tone_style(settings.tone_style.id().into());
     window.set_hotkey(settings.toggle_hotkey.id().into());
     window.set_hotkey_caps(models::caps(settings.toggle_hotkey));
+    window.set_flip_hotkey(settings.flip_hotkey.id().into());
+    window.set_flip_hotkey_caps(models::flip_caps(settings.flip_hotkey));
     window.set_smart_restore(settings.smart_restore);
     window.set_eager_restore(settings.eager_restore);
     window.set_spell_check(settings.spell_check);

--- a/platforms/windows/ui/app.slint
+++ b/platforms/windows/ui/app.slint
@@ -30,6 +30,8 @@ export component SettingsWindow inherits Window {
     in property <string> tone-style;
     in property <string> hotkey;
     in property <[string]> hotkey-caps;
+    in property <string> flip-hotkey;
+    in property <[string]> flip-hotkey-caps;
     in-out property <bool> smart-restore;
     in-out property <bool> eager-restore;
     in-out property <bool> spell-check;
@@ -48,6 +50,7 @@ export component SettingsWindow inherits Window {
     callback pick-method(string);
     callback pick-tone(string);
     callback pick-hotkey(string);
+    callback pick-flip-hotkey(string);
     callback set-smart(bool);
     callback set-eager(bool);
     callback set-spell(bool);
@@ -153,7 +156,10 @@ export component SettingsWindow inherits Window {
                 if root.active == "keyboard": KeyboardPage {
                     hotkey: root.hotkey;
                     hotkey-caps: root.hotkey-caps;
+                    flip-hotkey: root.flip-hotkey;
+                    flip-hotkey-caps: root.flip-hotkey-caps;
                     pick-hotkey(v) => { root.pick-hotkey(v); }
+                    pick-flip-hotkey(v) => { root.pick-flip-hotkey(v); }
                 }
 
                 if root.active == "smart": SmartPage {

--- a/platforms/windows/ui/page_keyboard.slint
+++ b/platforms/windows/ui/page_keyboard.slint
@@ -6,7 +6,10 @@ import { Theme, Card, Row, Segmented, KeyCap } from "theme.slint";
 export component KeyboardPage inherits VerticalLayout {
     in property <string> hotkey;
     in property <[string]> hotkey-caps;
+    in property <string> flip-hotkey;
+    in property <[string]> flip-hotkey-caps;
     callback pick-hotkey(string);
+    callback pick-flip-hotkey(string);
 
     spacing: Theme.sp-md;
     Text { text: "Phím chuyển VI / EN"; font-size: 20px; font-weight: 700; color: Palette.foreground; }
@@ -30,6 +33,31 @@ export component KeyboardPage inherits VerticalLayout {
             HorizontalLayout {
                 spacing: Theme.sp-xs;
                 for cap in root.hotkey-caps: KeyCap { label: cap; }
+            }
+        }
+    }
+
+    Text { text: "Phím lật từ vừa gõ"; font-size: 20px; font-weight: 700; color: Palette.foreground; }
+    Card {
+        Row {
+            title: "Phím tắt";
+            subtitle: "Đổi từ đang gõ giữa tiếng Việt và chữ gốc (card ⇄ cải).";
+            Segmented {
+                options: [
+                    { id: "off", label: "Tắt" },
+                    { id: "ctrl_shift_z", label: "Ctrl Shift Z" },
+                    { id: "ctrl_shift_x", label: "Ctrl Shift X" },
+                ];
+                current: root.flip-hotkey;
+                changed(v) => { root.pick-flip-hotkey(v); }
+            }
+        }
+        Rectangle { height: 1px; background: Palette.border; }
+        Row {
+            title: "Đang dùng";
+            HorizontalLayout {
+                spacing: Theme.sp-xs;
+                for cap in root.flip-hotkey-caps: KeyCap { label: cap; }
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds a **"flip" hotkey** that swaps the word currently being composed between its
Vietnamese form and its raw keystrokes — e.g. when smart-restore guesses wrong on
`card`, press the hotkey to get `cải`, and again to go back. The behavior lives
entirely in `funput-engine`, so macOS, Windows, and Linux (fcitx5 + ibus) behave
identically. Also bundles the macOS Settings/branding polish that landed alongside
it, plus a CI maintenance bump.

## What's new (user-facing)

- **Flip composing word VN↔raw**, with a configurable hotkey:
  - The choice is **sticky** — further keystrokes keep the chosen form and the word
    boundary won't re-run English-restore on it.
  - A no-op when there's nothing to flip (no live composition, or the word has no
    VN/raw distinction).
- **Hotkey configuration**
  - **macOS**: a free-form **shortcut recorder** (Liquid Glass popover with live
    key preview + validation), reused for *both* the new flip hotkey and the VI/EN
    toggle (the toggle is now fully custom instead of fixed presets).
  - **Windows / Linux**: a preset dropdown (Off / Ctrl+Shift+Z / Ctrl+Shift+X),
    matching each platform's existing toggle UI.
  - The macOS menu bar now shows the **live custom toggle shortcut** instead of a
    hardcoded `⌃\`.
- **macOS branding polish**: redesigned **About** pane with the app logo on a Liquid
  Glass medallion + clearer primary/secondary action buttons; the **onboarding**
  welcome step now leads with the logo (new reusable `AppLogo`).

## Architecture (single source of truth)

- `Engine::flip_composing()` returns an `ImeResult` (delete + inject diff) and sets
  a per-word `RestoreOverride`. Exposed over the C ABI as `funput_flip_composing`.
- **Preedit shells (macOS IMKit, Linux fcitx5/ibus)** ignore the diff payload and
  just re-render the engine buffer as marked/underlined preedit.
- **Inject shell (Windows)** applies the diff via the existing `SendInput` path
  (incl. the Chrome Delete-primer variant).
- Hotkey config storage follows each platform's existing convention: macOS
  `UserDefaults`; Windows/Linux the shared `~/.config/Funput/settings.json`
  (`flipHotkey`: `off`/`ctrl_shift_z`/`ctrl_shift_x`), kept back-compatible via
  `serde(default)` / JSON defaults.

## Testing

- `cargo test`/`clippy` green for `funput-engine` + `funput-ffi` (new unit tests for
  the flip diff, stickiness, per-word reset, and the FFI no-op).
- macOS built and verified by hand (TextEdit/VS Code/Chrome): flip, flip-back,
  sticky-across-Space, no-op-after-new-word.
- Windows and Linux build green in CI / the RC build.

## Chore

- Bump GitHub Actions `checkout`, `upload-artifact`, `download-artifact` to `@v5`
  (Node 24) to clear the Node 20 deprecation warning.

## Notes

- Out of scope (optional follow-ups): macOS modifier-only toggle (e.g. right ⌘),
  and a free-form key recorder on Windows/Linux (currently presets).