### PR TITLE
macOS: make Funput discoverable in Spotlight via an embedded launcher

### DIFF
--- a/platforms/macos/Funput.xcodeproj/project.pbxproj
+++ b/platforms/macos/Funput.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 				5F0EF48A2FE2FEF40036210A /* Sources */,
 				5F0EF48B2FE2FEF40036210A /* Frameworks */,
 				5F0EF48C2FE2FEF40036210A /* Resources */,
+				5FA0000000000000000000B1 /* Embed Launcher */,
 			);
 			buildRules = (
 			);
@@ -170,6 +171,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$SRCROOT/scripts/build-ffi.sh\"\n";
+		};
+		5FA0000000000000000000B1 /* Embed Launcher */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Launcher/main.swift",
+				"$(SRCROOT)/Launcher/Info.plist",
+				"$(SRCROOT)/scripts/build-launcher.sh",
+			);
+			name = "Embed Launcher";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/scripts/embed-launcher.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/platforms/macos/Funput/FunputApp.swift
+++ b/platforms/macos/Funput/FunputApp.swift
@@ -15,6 +15,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let connectionName = Bundle.main.infoDictionary?["InputMethodConnectionName"] as? String
             ?? "Funput_1_Connection"
         server = IMKServer(name: connectionName, bundleIdentifier: Bundle.main.bundleIdentifier)
+        // Make "Funput" findable in Spotlight on no-admin installs (see type docs).
+        LauncherInstaller.ensureInstalled()
     }
 
     /// Handle `funput://` URLs. The /Applications launcher stub opens

--- a/platforms/macos/Funput/FunputApp.swift
+++ b/platforms/macos/Funput/FunputApp.swift
@@ -16,6 +16,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             ?? "Funput_1_Connection"
         server = IMKServer(name: connectionName, bundleIdentifier: Bundle.main.bundleIdentifier)
     }
+
+    /// Handle `funput://` URLs. The /Applications launcher stub opens
+    /// `funput://settings` so users who find "Funput" in Spotlight reach Settings
+    /// (the input method bundle itself isn't surfaced by Spotlight). Bumping the
+    /// request is observed by the menu bar label, which opens the window — this
+    /// works whether we were already running or were just cold-launched by the URL.
+    func application(_ application: NSApplication, open urls: [URL]) {
+        guard urls.contains(where: { $0.scheme == "funput" }) else { return }
+        AppSettings.shared.openSettingsRequest &+= 1
+        NSApp.activate(ignoringOtherApps: true)
+    }
 }
 
 @main
@@ -78,6 +89,14 @@ private struct MenuBarLabel: View {
                 if !settings.hasCompletedOnboarding {
                     openWindow(id: WindowID.onboarding)
                 }
+            }
+            // A funput://settings request (from the /Applications launcher) opens
+            // Settings. `initial: true` also covers a cold launch where the URL
+            // bumped the counter before this label first appeared.
+            .onChange(of: settings.openSettingsRequest, initial: true) { _, count in
+                guard count > 0 else { return }
+                openWindow(id: WindowID.settings)
+                NSApp.activate(ignoringOtherApps: true)
             }
     }
 }

--- a/platforms/macos/Funput/Info.plist
+++ b/platforms/macos/Funput/Info.plist
@@ -18,13 +18,21 @@
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
     <string>$(MARKETING_VERSION)</string>
+    <!-- funput:// — opened by the /Applications launcher stub so users who search
+         "Funput" in Spotlight land on Settings. The input method itself lives in
+         /Library/Input Methods and is invisible to Spotlight; the launcher sends
+         funput://settings here (see scripts/build-launcher.sh, FunputApp.swift). -->
     <key>CFBundleURLTypes</key>
     <array>
         <dict>
-            <key>CFBundleIdentifier</key>
-            <string></string>
+            <key>CFBundleURLName</key>
+            <string>app.funput.url</string>
             <key>CFBundleTypeRole</key>
-            <string>Editor</string>
+            <string>Viewer</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>funput</string>
+            </array>
         </dict>
     </array>
     <key>CFBundleVersion</key>

--- a/platforms/macos/Funput/LauncherInstaller.swift
+++ b/platforms/macos/Funput/LauncherInstaller.swift
@@ -1,0 +1,67 @@
+import AppKit
+
+/// Keeps the Spotlight-findable launcher stub (see Launcher/main.swift) present in
+/// an indexed Applications folder, so users can find "Funput" in Spotlight however
+/// they installed.
+///
+/// The input method lives in (~)/Library/Input Methods, which Spotlight does not
+/// surface as an app. The .pkg installer drops the launcher into /Applications, but
+/// the no-admin .app.zip cannot — so on first launch we copy the launcher embedded
+/// in our Resources (by the Xcode "Embed Launcher" build phase) into ~/Applications
+/// when none is installed. ~/Applications is Spotlight-indexed and writable without
+/// admin rights; the launcher there opens funput://settings back to this process.
+enum LauncherInstaller {
+    private static let bundleName = "Funput.app"
+
+    /// Copy the embedded launcher into ~/Applications if no launcher is installed
+    /// yet. Best-effort and off the main thread — discoverability is a nicety and
+    /// must never delay or fail input-method startup.
+    static func ensureInstalled() {
+        DispatchQueue.global(qos: .utility).async { installIfNeeded() }
+    }
+
+    private static func installIfNeeded() {
+        let fileManager = FileManager.default
+
+        // Already installed system-wide (.pkg) or per-user? Nothing to do.
+        let systemWide = URL(fileURLWithPath: "/Applications/\(bundleName)")
+        let userApps = userApplicationsURL.appendingPathComponent(bundleName)
+        guard !fileManager.fileExists(atPath: systemWide.path),
+              !fileManager.fileExists(atPath: userApps.path)
+        else { return }
+
+        // The launcher we ship inside Resources/Funput.app.
+        guard let embedded = Bundle.main.url(forResource: "Funput", withExtension: "app") else { return }
+
+        do {
+            try fileManager.createDirectory(at: userApplicationsURL, withIntermediateDirectories: true)
+            try fileManager.copyItem(at: embedded, to: userApps)
+            register(userApps)
+        } catch {
+            // Leave discoverability unimproved rather than disrupt the input method.
+        }
+    }
+
+    /// `~/Applications`, falling back to the literal path if the lookup fails.
+    private static var userApplicationsURL: URL {
+        FileManager.default.urls(for: .applicationDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Applications")
+    }
+
+    /// Nudge LaunchServices + Spotlight so the freshly copied launcher is found
+    /// without waiting for the next automatic index pass. Best-effort.
+    private static func register(_ url: URL) {
+        let lsregister = "/System/Library/Frameworks/CoreServices.framework"
+            + "/Frameworks/LaunchServices.framework/Support/lsregister"
+        run(lsregister, ["-f", url.path])
+        run("/usr/bin/mdimport", [url.path])
+    }
+
+    private static func run(_ launchPath: String, _ arguments: [String]) {
+        guard FileManager.default.isExecutableFile(atPath: launchPath) else { return }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: launchPath)
+        process.arguments = arguments
+        try? process.run()
+    }
+}

--- a/platforms/macos/Funput/Model/AppSettings.swift
+++ b/platforms/macos/Funput/Model/AppSettings.swift
@@ -98,6 +98,11 @@ final class AppSettings {
     /// the table to the engine (instead of doing it on every keystroke). Not persisted.
     @ObservationIgnored private(set) var shortcutsRevision = 0
 
+    /// Bumped when an external `funput://settings` request arrives (the /Applications
+    /// launcher, opened from Spotlight). Observed by the menu bar label, which opens
+    /// the Settings window. Not persisted.
+    var openSettingsRequest = 0
+
     @ObservationIgnored private let defaults: UserDefaults
 
     private init(defaults: UserDefaults = .standard) {

--- a/platforms/macos/Launcher/Info.plist
+++ b/platforms/macos/Launcher/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- The launcher carries a distinct bundle id from the input method
+         (app.funput.inputmethod.Funput) so the two bundles never collide in
+         LaunchServices. Version values are stamped at build time by
+         scripts/build-launcher.sh. -->
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>Funput</string>
+    <key>CFBundleExecutable</key>
+    <string>Funput</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
+    <key>CFBundleIdentifier</key>
+    <string>app.funput.Funput</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Funput</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.0.0</string>
+    <key>CFBundleVersion</key>
+    <string>0.0.0</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.productivity</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>26.5</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>

--- a/platforms/macos/Launcher/main.swift
+++ b/platforms/macos/Launcher/main.swift
@@ -1,0 +1,16 @@
+import AppKit
+
+// Funput launcher — a tiny Spotlight-findable stub installed in /Applications.
+//
+// The real input method lives in /Library/Input Methods as an LSUIElement IMK
+// agent, which macOS does not surface in Spotlight's app results. So a user who
+// types "Funput" into Spotlight after installing would otherwise find nothing and
+// not know how to open Funput's Settings. This stub exists only to be findable:
+// launching it asks the input method to show its Settings window via the
+// funput:// URL scheme (handled in FunputApp.swift), then exits. It has no UI.
+//
+// LaunchServices resolves funput:// to the input method bundle regardless of its
+// /Library/Input Methods location, launching it if needed or delivering the URL
+// to the already-running process.
+let url = URL(string: "funput://settings")!
+NSWorkspace.shared.open(url)

--- a/platforms/macos/scripts/build-launcher.sh
+++ b/platforms/macos/scripts/build-launcher.sh
@@ -10,9 +10,13 @@
 #
 #   build-launcher.sh <out-dir> <version> [sign-identity]
 #
-# Writes <out-dir>/Funput.app. sign-identity defaults to "-" (ad-hoc); pass
-# "Developer ID Application" for a release build (adds hardened runtime + timestamp
-# so the bundle can be notarized).
+# Writes <out-dir>/Funput.app. sign-identity defaults to "-" (ad-hoc). Signing
+# adapts to the identity so the launcher is valid as nested code of the app:
+#   "-" / empty          -> ad-hoc (no hardened runtime, no timestamp)
+#   "Developer ID …"     -> hardened runtime + secure timestamp (notarizable)
+#   anything else (dev)  -> hardened runtime, no network timestamp
+# Normally invoked from the Xcode "Embed Launcher" build phase (embed-launcher.sh),
+# which passes the build's own code-signing identity.
 set -eu
 
 OUT="$1"
@@ -55,12 +59,14 @@ if [ -f "$ICON_SRC" ] && command -v iconutil >/dev/null 2>&1; then
     rm -rf "$ICONSET"
 fi
 
-# Sign. Developer ID builds get the hardened runtime + secure timestamp (required
-# to notarize); ad-hoc ("-") builds skip the timestamp.
-if [ "$SIGN_ID" = "-" ]; then
-    codesign --force --sign "-" "$APP"
-else
-    codesign --force --options runtime --timestamp --sign "$SIGN_ID" "$APP"
-fi
+# Sign (see header for the per-identity policy).
+case "$SIGN_ID" in
+    "" | "-")
+        codesign --force --sign "-" "$APP" ;;
+    "Developer ID"*)
+        codesign --force --options runtime --timestamp --sign "$SIGN_ID" "$APP" ;;
+    *)
+        codesign --force --options runtime --sign "$SIGN_ID" "$APP" ;;
+esac
 
 echo "$APP"

--- a/platforms/macos/scripts/build-launcher.sh
+++ b/platforms/macos/scripts/build-launcher.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Build the Funput launcher app.
+#
+# Funput's input method lives in /Library/Input Methods as an LSUIElement IMK
+# agent, which Spotlight does not surface as an app — so a user who types "Funput"
+# into Spotlight finds nothing. This builds a tiny normal app, installed in
+# /Applications, whose only job is to be findable: launching it sends
+# funput://settings to the input method (opening its Settings window) and exits.
+# See Launcher/main.swift.
+#
+#   build-launcher.sh <out-dir> <version> [sign-identity]
+#
+# Writes <out-dir>/Funput.app. sign-identity defaults to "-" (ad-hoc); pass
+# "Developer ID Application" for a release build (adds hardened runtime + timestamp
+# so the bundle can be notarized).
+set -eu
+
+OUT="$1"
+VERSION="$2"
+SIGN_ID="${3:--}"
+
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$DIR/Launcher"
+DEPLOY_TARGET="26.5"
+APP="$OUT/Funput.app"
+
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+
+# Universal binary (arm64 + x86_64), matching the input method.
+TMP="$OUT/.launcher-build"
+rm -rf "$TMP"; mkdir -p "$TMP"
+swiftc -O -target "arm64-apple-macos$DEPLOY_TARGET"  -o "$TMP/launcher-arm64"  "$SRC/main.swift"
+swiftc -O -target "x86_64-apple-macos$DEPLOY_TARGET" -o "$TMP/launcher-x86_64" "$SRC/main.swift"
+lipo -create -output "$APP/Contents/MacOS/Funput" "$TMP/launcher-arm64" "$TMP/launcher-x86_64"
+rm -rf "$TMP"
+
+# Info.plist, version stamped to match the input method.
+cp "$SRC/Info.plist" "$APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION" "$APP/Contents/Info.plist"
+
+# App icon (best-effort): build AppIcon.icns from the 1024px master so Spotlight
+# and Finder show the Funput logo. Skipped quietly if the tools/source are missing.
+ICON_SRC="$DIR/Funput/Assets.xcassets/AppIcon.appiconset/transparent.png"
+if [ -f "$ICON_SRC" ] && command -v iconutil >/dev/null 2>&1; then
+    ICONSET="$OUT/.AppIcon.iconset"
+    rm -rf "$ICONSET"; mkdir -p "$ICONSET"
+    for sz in 16 32 128 256 512; do
+        dbl=$((sz * 2))
+        sips -z "$sz" "$sz" "$ICON_SRC" --out "$ICONSET/icon_${sz}x${sz}.png" >/dev/null 2>&1 || true
+        sips -z "$dbl" "$dbl" "$ICON_SRC" --out "$ICONSET/icon_${sz}x${sz}@2x.png" >/dev/null 2>&1 || true
+    done
+    iconutil -c icns "$ICONSET" -o "$APP/Contents/Resources/AppIcon.icns" 2>/dev/null || true
+    rm -rf "$ICONSET"
+fi
+
+# Sign. Developer ID builds get the hardened runtime + secure timestamp (required
+# to notarize); ad-hoc ("-") builds skip the timestamp.
+if [ "$SIGN_ID" = "-" ]; then
+    codesign --force --sign "-" "$APP"
+else
+    codesign --force --options runtime --timestamp --sign "$SIGN_ID" "$APP"
+fi
+
+echo "$APP"

--- a/platforms/macos/scripts/embed-launcher.sh
+++ b/platforms/macos/scripts/embed-launcher.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Xcode "Embed Launcher" build phase. Builds the launcher stub and embeds it in the
+# app's Resources, so the input method can self-install it into ~/Applications on
+# first launch (see Funput/LauncherInstaller.swift). Runs before Xcode's final code
+# signing, so the embedded launcher is sealed into the notarizable app bundle.
+#
+# The launcher exists only so users can find "Funput" in Spotlight; the input
+# method itself lives in (~)/Library/Input Methods, which Spotlight does not
+# surface. See scripts/build-launcher.sh.
+set -eu
+
+# Nothing to embed for index/preview builds (no real product is produced).
+if [ "${ACTION:-build}" = "indexbuild" ]; then
+    exit 0
+fi
+
+SCRIPTS="$SRCROOT/scripts"
+DEST_RESOURCES="$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
+BUILD_DIR="$DERIVED_FILE_DIR/launcher"
+
+# Sign the launcher with the same identity Xcode is using for this build, so it is
+# valid nested code. With code signing disabled (e.g. CI dry runs) fall back to
+# ad-hoc; Xcode re-signs the whole product afterwards anyway.
+if [ "${CODE_SIGNING_ALLOWED:-YES}" = "NO" ] || [ -z "${EXPANDED_CODE_SIGN_IDENTITY_NAME:-}" ]; then
+    LAUNCHER_SIGN_ID="-"
+else
+    LAUNCHER_SIGN_ID="$EXPANDED_CODE_SIGN_IDENTITY_NAME"
+fi
+
+"$SCRIPTS/build-launcher.sh" "$BUILD_DIR" "${MARKETING_VERSION:-0.0.0}" "$LAUNCHER_SIGN_ID" >/dev/null
+
+mkdir -p "$DEST_RESOURCES"
+rm -rf "$DEST_RESOURCES/Funput.app"
+cp -R "$BUILD_DIR/Funput.app" "$DEST_RESOURCES/Funput.app"

--- a/platforms/macos/scripts/install.sh
+++ b/platforms/macos/scripts/install.sh
@@ -50,15 +50,10 @@ let url = URL(fileURLWithPath: CommandLine.arguments[1]) as CFURL
 exit(TISRegisterInputSource(url) == noErr ? 0 : 1)
 SWIFT
 
-# Build + install the Spotlight launcher stub into /Applications (ad-hoc signed),
-# so "Funput" is findable in Spotlight locally too. It just opens funput://settings.
-LAUNCHER_BUILD="$DERIVED/launcher"
-"$PROJECT_DIR/scripts/build-launcher.sh" "$LAUNCHER_BUILD" "0.0.0" "-" >/dev/null
-rm -rf "/Applications/Funput.app"
-cp -R "$LAUNCHER_BUILD/Funput.app" "/Applications/Funput.app"
-"$LSR" -f "/Applications/Funput.app" 2>/dev/null || true
-
-# Launch so the IMKServer comes up; it then runs as a background agent.
+# Launch so the IMKServer comes up; it then runs as a background agent. On first
+# launch it self-installs the Spotlight launcher stub into ~/Applications (the
+# launcher is embedded in Resources by the Xcode build phase — see
+# LauncherInstaller.swift, scripts/embed-launcher.sh).
 open "$DEST/Funput.app"
 
 echo "Done. If this is the first install, add Funput in"

--- a/platforms/macos/scripts/install.sh
+++ b/platforms/macos/scripts/install.sh
@@ -50,6 +50,14 @@ let url = URL(fileURLWithPath: CommandLine.arguments[1]) as CFURL
 exit(TISRegisterInputSource(url) == noErr ? 0 : 1)
 SWIFT
 
+# Build + install the Spotlight launcher stub into /Applications (ad-hoc signed),
+# so "Funput" is findable in Spotlight locally too. It just opens funput://settings.
+LAUNCHER_BUILD="$DERIVED/launcher"
+"$PROJECT_DIR/scripts/build-launcher.sh" "$LAUNCHER_BUILD" "0.0.0" "-" >/dev/null
+rm -rf "/Applications/Funput.app"
+cp -R "$LAUNCHER_BUILD/Funput.app" "/Applications/Funput.app"
+"$LSR" -f "/Applications/Funput.app" 2>/dev/null || true
+
 # Launch so the IMKServer comes up; it then runs as a background agent.
 open "$DEST/Funput.app"
 

--- a/platforms/macos/scripts/pkg/postinstall
+++ b/platforms/macos/scripts/pkg/postinstall
@@ -10,10 +10,16 @@
 # already in place. So: no `set -e`, every step guarded, always exit 0.
 
 APP="/Library/Input Methods/Funput.app"
+LAUNCHER="/Applications/Funput.app"
 LSR="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
 
 # Register the bundle system-wide (LaunchServices keys input sources by bundle id).
 "$LSR" -f "$APP" 2>/dev/null || true
+
+# Register the /Applications launcher and nudge Spotlight to index it, so a user
+# who searches "Funput" finds it (the input method above is not Spotlight-visible).
+"$LSR" -f "$LAUNCHER" 2>/dev/null || true
+/usr/bin/mdimport "$LAUNCHER" 2>/dev/null || true
 
 # Best-effort: refresh + launch inside the console user's GUI session so it shows
 # up immediately. Skipped cleanly when there is no GUI user (SSH / login window).

--- a/platforms/macos/scripts/release.sh
+++ b/platforms/macos/scripts/release.sh
@@ -165,29 +165,19 @@ if ! codesign -dvv "$APP" 2>&1 | grep -q 'flags=.*runtime'; then
 fi
 lipo -info "$APP/Contents/MacOS/Funput"
 
-# --- 5b. Build the /Applications launcher stub ----------------------------------
-# A tiny normal app so users can find "Funput" in Spotlight — the input method in
-# /Library/Input Methods is an LSUIElement agent that Spotlight does not surface.
-# It just opens funput://settings. Signed with the same Developer ID + hardened
-# runtime so it notarizes alongside the app below.
-echo "Building launcher…"
-LAUNCHER="$OUT/launcher/Funput.app"
-"$PROJECT_DIR/scripts/build-launcher.sh" "$OUT/launcher" "$VERSION" "$SIGN_ID" >/dev/null
-codesign --verify --strict --verbose=2 "$LAUNCHER"
+# The Spotlight launcher stub is embedded in the app's Resources by the Xcode
+# "Embed Launcher" build phase (see scripts/embed-launcher.sh) — already signed
+# with this build's Developer ID + hardened runtime, so it notarizes as nested
+# code below. We reuse that exact bundle for the /Applications payload in step 7.
+LAUNCHER="$APP/Contents/Resources/Funput.app"
 
-# --- 6. Notarize the app + launcher + staple (so they validate offline) ---------
+# --- 6. Notarize the app + staple (so the copied-out app validates offline) -----
 if [ -z "$DRY_RUN" ]; then
     echo "Notarizing app…"
     ditto -c -k --keepParent "$APP" "$OUT/Funput-app.zip"
     notarize "$OUT/Funput-app.zip"
     xcrun stapler staple "$APP"
     rm -f "$OUT/Funput-app.zip"
-
-    echo "Notarizing launcher…"
-    ditto -c -k --keepParent "$LAUNCHER" "$OUT/Funput-launcher.zip"
-    notarize "$OUT/Funput-launcher.zip"
-    xcrun stapler staple "$LAUNCHER"
-    rm -f "$OUT/Funput-launcher.zip"
 fi
 
 # --- 7. Build the signed .pkg installer -----------------------------------------
@@ -206,7 +196,9 @@ COMPONENT="$OUT/Funput-component.pkg"
 rm -rf "$PKGROOT" "$SCRIPTS"
 mkdir -p "$PKGROOT/Library/Input Methods" "$PKGROOT/Applications" "$SCRIPTS"
 cp -R "$APP" "$PKGROOT/Library/Input Methods/Funput.app"
-# Spotlight-findable launcher (step 5b) — installed into /Applications.
+# Spotlight-findable launcher — installed into /Applications system-wide. (The IME
+# also self-installs it into ~/Applications on first launch when absent, which
+# covers the no-admin .app.zip install; here the .pkg places it directly.)
 cp -R "$LAUNCHER" "$PKGROOT/Applications/Funput.app"
 cp "$PROJECT_DIR/scripts/pkg/postinstall" "$SCRIPTS/postinstall"
 chmod +x "$SCRIPTS/postinstall"

--- a/platforms/macos/scripts/release.sh
+++ b/platforms/macos/scripts/release.sh
@@ -165,30 +165,49 @@ if ! codesign -dvv "$APP" 2>&1 | grep -q 'flags=.*runtime'; then
 fi
 lipo -info "$APP/Contents/MacOS/Funput"
 
-# --- 6. Notarize the app + staple (so the copied-out app validates offline) -----
+# --- 5b. Build the /Applications launcher stub ----------------------------------
+# A tiny normal app so users can find "Funput" in Spotlight — the input method in
+# /Library/Input Methods is an LSUIElement agent that Spotlight does not surface.
+# It just opens funput://settings. Signed with the same Developer ID + hardened
+# runtime so it notarizes alongside the app below.
+echo "Building launcher…"
+LAUNCHER="$OUT/launcher/Funput.app"
+"$PROJECT_DIR/scripts/build-launcher.sh" "$OUT/launcher" "$VERSION" "$SIGN_ID" >/dev/null
+codesign --verify --strict --verbose=2 "$LAUNCHER"
+
+# --- 6. Notarize the app + launcher + staple (so they validate offline) ---------
 if [ -z "$DRY_RUN" ]; then
     echo "Notarizing app…"
     ditto -c -k --keepParent "$APP" "$OUT/Funput-app.zip"
     notarize "$OUT/Funput-app.zip"
     xcrun stapler staple "$APP"
     rm -f "$OUT/Funput-app.zip"
+
+    echo "Notarizing launcher…"
+    ditto -c -k --keepParent "$LAUNCHER" "$OUT/Funput-launcher.zip"
+    notarize "$OUT/Funput-launcher.zip"
+    xcrun stapler staple "$LAUNCHER"
+    rm -f "$OUT/Funput-launcher.zip"
 fi
 
 # --- 7. Build the signed .pkg installer -----------------------------------------
 # A double-clickable .pkg replaces the old "Install Funput.command": unlike a flat
 # shell script (which cannot carry a notarization ticket and so always trips
 # Gatekeeper), a .pkg is signed with "Developer ID Installer", notarized, and
-# stapled — Installer.app opens it with no warning. The payload installs Funput.app
-# directly into /Library/Input Methods (a valid, system-wide input-method search
-# location), so the install is correct from the payload alone; the postinstall only
-# does best-effort LaunchServices registration (see scripts/pkg/postinstall).
+# stapled — Installer.app opens it with no warning. The payload installs the input
+# method into /Library/Input Methods (a valid, system-wide input-method search
+# location) and the launcher stub into /Applications, so the install is correct
+# from the payload alone; the postinstall only does best-effort LaunchServices
+# registration (see scripts/pkg/postinstall).
 echo "Building .pkg…"
 PKGROOT="$OUT/pkgroot"
 SCRIPTS="$OUT/pkgscripts"
 COMPONENT="$OUT/Funput-component.pkg"
 rm -rf "$PKGROOT" "$SCRIPTS"
-mkdir -p "$PKGROOT/Library/Input Methods" "$SCRIPTS"
+mkdir -p "$PKGROOT/Library/Input Methods" "$PKGROOT/Applications" "$SCRIPTS"
 cp -R "$APP" "$PKGROOT/Library/Input Methods/Funput.app"
+# Spotlight-findable launcher (step 5b) — installed into /Applications.
+cp -R "$LAUNCHER" "$PKGROOT/Applications/Funput.app"
 cp "$PROJECT_DIR/scripts/pkg/postinstall" "$SCRIPTS/postinstall"
 chmod +x "$SCRIPTS/postinstall"
 

--- a/platforms/macos/scripts/uninstall.sh
+++ b/platforms/macos/scripts/uninstall.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# Uninstall Funput and reset its state so the next install behaves like a
+# brand-new machine (onboarding shows again, no leftover input source or prefs).
+#
+#   ./scripts/uninstall.sh              # remove everything, including preferences
+#   ./scripts/uninstall.sh --keep-prefs # remove the app(s) but keep settings
+#
+# Run as your normal user — NOT `sudo ./uninstall.sh`. The script invokes sudo only
+# for the system-wide locations (/Library, /Applications, the pkg receipt); running
+# the whole thing as root would wipe root's preferences instead of yours.
+#
+# Order: first remove Funput in System Settings -> Keyboard -> Input Sources
+# (select Funput, press the - button), then run this, then log out/in or reboot so
+# the Text Input Sources database forgets the input source completely.
+#
+# Best-effort by design (no `set -e`): every step is guarded so a partial install
+# still cleans up. `set -u` only, to catch unset-variable typos.
+set -u
+
+KEEP_PREFS=
+case "${1:-}" in
+    --keep-prefs) KEEP_PREFS=1 ;;
+    "") ;;
+    *) echo "usage: $0 [--keep-prefs]" >&2; exit 2 ;;
+esac
+
+LSR="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+
+# Every place Funput can live: system-wide (.pkg) and per-user (install.sh) input
+# method bundles, plus the /Applications launcher stub.
+SYSTEM_IME="/Library/Input Methods/Funput.app"
+USER_IME="$HOME/Library/Input Methods/Funput.app"
+LAUNCHER="/Applications/Funput.app"
+
+echo "Stopping Funput…"
+killall Funput 2>/dev/null || true
+
+# Unregister from LaunchServices before deleting, so no dangling records remain.
+for app in "$SYSTEM_IME" "$USER_IME" "$LAUNCHER"; do
+    [ -e "$app" ] && "$LSR" -u "$app" 2>/dev/null
+done
+
+# Dev machines accumulate DerivedData build copies that LaunchServices (and so
+# Spotlight) still know about — unregister any so a "Funput" search on this machine
+# doesn't resurface a stale build. (Only de-registers; build files stay on disk.)
+"$LSR" -dump 2>/dev/null | grep -oE '/Users/[^ ]*DerivedData[^ ]*Funput.app' | sort -u \
+    | while read -r p; do "$LSR" -u "$p" 2>/dev/null || true; done
+
+# Per-user bundle: no privileges needed.
+if [ -e "$USER_IME" ]; then
+    echo "Removing $USER_IME"
+    rm -rf "$USER_IME"
+fi
+
+# System-wide bundle + launcher + pkg receipt need sudo. Only escalate when there
+# is actually something there, so a per-user-only setup never prompts for sudo.
+NEED_SUDO=
+[ -e "$SYSTEM_IME" ] && NEED_SUDO=1
+[ -e "$LAUNCHER" ] && NEED_SUDO=1
+pkgutil --pkg-info com.funput.installer >/dev/null 2>&1 && NEED_SUDO=1
+if [ -n "$NEED_SUDO" ]; then
+    echo "Removing system-wide files (sudo)…"
+    [ -e "$SYSTEM_IME" ] && sudo rm -rf "$SYSTEM_IME"
+    [ -e "$LAUNCHER" ] && sudo rm -rf "$LAUNCHER"
+    sudo pkgutil --forget com.funput.installer 2>/dev/null || true
+fi
+
+# Preferences (skipped with --keep-prefs). `defaults delete` goes through cfprefsd
+# so its in-memory copy is dropped too; also remove the plist in case it lingers.
+if [ -z "$KEEP_PREFS" ]; then
+    echo "Removing preferences…"
+    defaults delete app.funput.inputmethod.Funput 2>/dev/null || true
+    defaults delete app.funput.Funput 2>/dev/null || true
+    rm -f "$HOME/Library/Preferences/app.funput.inputmethod.Funput.plist"
+    rm -f "$HOME/Library/Preferences/app.funput.Funput.plist"
+fi
+
+# Caches and saved window state — always safe to clear.
+echo "Removing caches…"
+rm -rf "$HOME/Library/Caches/app.funput.inputmethod.Funput"
+rm -rf "$HOME/Library/Saved Application State/app.funput.inputmethod.Funput.savedState"
+
+# Make cfprefsd drop any remaining in-memory copy of the deleted preferences.
+[ -z "$KEEP_PREFS" ] && killall cfprefsd 2>/dev/null
+
+echo ""
+echo "Done. Log out and back in (or reboot) so the input source is fully cleared."


### PR DESCRIPTION
## Problem

On a clean install, users can't find Funput in Spotlight when they search
"Funput". The input method lives in `/Library/Input Methods/Funput.app` as an
`LSUIElement` IMK agent, and macOS does not surface that location in Spotlight's
app results. Typing works and the menu bar icon shows, but a first-time user who
reaches for Spotlight to open Settings finds nothing — unlike OpenKey/GoTiengViet,
which ship as normal `/Applications` apps.

## Solution

Ship a tiny **launcher stub** (distinct bundle id `app.funput.Funput`) whose only
job is to be findable in Spotlight. Launching it opens `funput://settings`, which
the input method handles by opening its Settings window, then the stub exits.

To cover **both** install paths, the launcher is embedded and self-installed
rather than only dropped in by the installer:

- **Xcode "Embed Launcher" build phase** (`scripts/embed-launcher.sh` →
  `scripts/build-launcher.sh`) builds the launcher with `swiftc`, signs it with
  the build's own identity (hardened runtime; Developer ID + timestamp for
  release), and embeds it at `Funput.app/Contents/Resources/Funput.app` **before**
  Xcode's final signing — so it's valid, notarizable nested code and the input
  method's auto-generated entitlements are preserved (no script-level re-signing).
- **`LauncherInstaller.ensureInstalled()`** (called on first launch, background,
  best-effort) copies the embedded launcher into `~/Applications` if no launcher
  is present in `/Applications` or `~/Applications`. `~/Applications` is
  Spotlight-indexed and writable without admin; the copy isn't quarantined, so it
  launches without a Gatekeeper prompt.
- **`.pkg`** continues to place the launcher in `/Applications` from the payload
  (admin install); `.app.zip` (no-admin install) relies on the self-install into
  `~/Applications`.

A distinct bundle id + the `/Applications` (or `~/Applications`) location means no
duplicate input source: TIS only scans `(~)/Library/Input Methods` and the
launcher carries none of the `tsInputMode` keys.

## Changes

- New: `Launcher/main.swift`, `Launcher/Info.plist`, `Funput/LauncherInstaller.swift`,
  `scripts/build-launcher.sh`, `scripts/embed-launcher.sh`, `scripts/uninstall.sh`
- `Funput.xcodeproj`: add the "Embed Launcher" build phase
- `Funput/Info.plist`: register the `funput://` URL scheme
- `FunputApp.swift`: handle `funput://settings`; call `LauncherInstaller` on launch
- `AppSettings.swift`: add the (non-persisted) open-Settings request signal
- `release.sh` / `install.sh` / `pkg/postinstall`: package and register the launcher

## Notes

- The Settings-open observer lives on the menu bar label, so it relies on
  `showMenuBarIcon` (on by default).
- The "Embed Launcher" phase runs on every build (like "Build Rust FFI"); the
  `swiftc` step is cheap.