### PR TITLE
fix(telex): allow the horn/breve (w) to be placed anywhere in the syllable

### DIFF
--- a/crates/funput-core/src/composition/transform.rs
+++ b/crates/funput-core/src/composition/transform.rs
@@ -296,6 +296,17 @@ mod tests {
     }
 
     #[test]
+    fn telex_horn_placed_after_trailing_vowel() {
+        // The horn (`w`) can be placed anywhere, including after the whole rhyme:
+        // `moiwf` → `mời` works the same as `mowif`. Likewise the tone key is
+        // already position-free, so both orders land the huyền on the right vowel.
+        assert_eq!(type_telex("moiwf", false), "mời");
+        assert_eq!(type_telex("mowif", false), "mời");
+        assert_eq!(type_telex("doiwf", false), "dời");
+        assert_eq!(type_telex("nguoiwf", false), "người");
+    }
+
+    #[test]
     fn reposition_and_complex() {
         assert_eq!(type_keys("hoa2"), "hòa");
         assert_eq!(type_keys("thuy3"), "thủy");

--- a/crates/funput-core/src/input_method/telex.rs
+++ b/crates/funput-core/src/input_method/telex.rs
@@ -76,33 +76,37 @@ fn classify_w(buffer: &str) -> Option<KeyAction> {
 
     let last = last_char(buffer)?;
 
-    // `w` typed after the coda (last char is a consonant): place the shape on the
-    // nucleus wherever it sits, so the breve/horn key works anywhere in the
-    // syllable (`lam` + `w` → `lăm`, `con` + `w` → `cơn`), mirroring free-position
-    // `đ`. A Vietnamese syllable never has a `w` after the coda, so this is
-    // unambiguous. The `uo` horn compound is already handled above; breve (only
-    // `a` takes it) is tried before horn (`o`/`u`).
-    if !is_vowel(last) {
-        if shape_target_index(buffer, VowelShape::Breve).is_some() {
+    // Adjacent rules on the last vowel, tried first so an immediately-preceding
+    // vowel still wins: revert a shaped vowel (`ơ` + `w` → `o`), or shape a plain
+    // `a`/`o`/`u` typed right before `w`. Circumflex is never reverted by `w` and
+    // returns early so an `ô` is left literal rather than re-horned below.
+    if is_vowel(last) {
+        if let Some(shape) = shape_on_vowel(last) {
+            return match shape {
+                VowelShape::Breve | VowelShape::Horn => Some(KeyAction::Shape(shape)),
+                VowelShape::Circumflex => None,
+            };
+        }
+        if is_plain_vowel(last, 'a') {
             return Some(KeyAction::Shape(VowelShape::Breve));
         }
-        if shape_target_index(buffer, VowelShape::Horn).is_some() {
+        if is_plain_vowel(last, 'o') || is_plain_vowel(last, 'u') {
             return Some(KeyAction::Shape(VowelShape::Horn));
         }
-        return None;
     }
 
-    if let Some(shape) = shape_on_vowel(last) {
-        return match shape {
-            VowelShape::Breve | VowelShape::Horn => Some(KeyAction::Shape(shape)),
-            VowelShape::Circumflex => None,
-        };
-    }
-
-    if is_plain_vowel(last, 'a') {
+    // Free position: place the breve/horn on whichever nucleus vowel can receive
+    // it, wherever it sits — so the key works after the coda (`con` + `w` → `cơn`)
+    // or after a trailing vowel that can't itself take the shape (`moi` + `w` →
+    // `mơi`, `doi` + `w` → `dơi`), not only on a plain `a`/`o`/`u` typed right
+    // before `w`. This lets the user place the horn/breve at any point in the
+    // syllable, like VNI's position-free 7/8. A Vietnamese syllable never holds a
+    // literal `w`, so this is unambiguous; with no shapeable nucleus (`eng`) it
+    // returns None and `w` stays literal. Breve (only `a` takes it) before horn.
+    if shape_target_index(buffer, VowelShape::Breve).is_some() {
         return Some(KeyAction::Shape(VowelShape::Breve));
     }
-    if is_plain_vowel(last, 'o') || is_plain_vowel(last, 'u') {
+    if shape_target_index(buffer, VowelShape::Horn).is_some() {
         return Some(KeyAction::Shape(VowelShape::Horn));
     }
 
@@ -281,6 +285,22 @@ mod tests {
         // No shapeable nucleus → `w` is a literal.
         assert_eq!(classify_key("eng", 'w'), KeyAction::Normal);
         assert_eq!(classify_key("ng", 'w'), KeyAction::Normal);
+    }
+
+    #[test]
+    fn classify_w_after_trailing_vowel() {
+        // `w` typed after a trailing vowel that can't take the shape still horns the
+        // earlier nucleus vowel — so the horn can be placed last, `moi` + `w` →
+        // `mơi` (the user types `moiwf` for `mời`, not only `mowif`).
+        assert_eq!(classify_key("moi", 'w'), KeyAction::Shape(VowelShape::Horn));
+        assert_eq!(classify_key("doi", 'w'), KeyAction::Shape(VowelShape::Horn));
+        assert_eq!(classify_key("coi", 'w'), KeyAction::Shape(VowelShape::Horn));
+        // Breve target wins over horn when present (only `a` takes the breve).
+        assert_eq!(classify_key("oa", 'w'), KeyAction::Shape(VowelShape::Breve));
+        // A plain vowel typed right before `w` still shapes itself (adjacent rule).
+        assert_eq!(classify_key("mo", 'w'), KeyAction::Shape(VowelShape::Horn));
+        // `i` alone has no shapeable vowel → literal.
+        assert_eq!(classify_key("mi", 'w'), KeyAction::Normal);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In Telex, the tone mark (`w`'s sibling keys) and the `đ` stroke can already be
typed at any point in a syllable, but the horn/breve key `w` could not. It was
only recognized as a modifier when the character right before it was a vowel that
takes the shape (`o`/`u`/`a`) or the coda. So a user had to place `w` *before*
finishing the rhyme:

- `mowif` → `mời` ✓
- `moiwf` → ✗ (the `w` after `oi` was treated as a literal letter, since the last
  char `i` can't take a horn)

This is inconsistent with VNI, where `7`/`8` are position-free, and with the
existing free-position behavior of tones and `đ`.

## Fix

`classify_w` (Telex key classifier) keeps the existing adjacent-vowel rules so an
immediately-preceding vowel still wins, then falls back to a free-position search:
if no adjacent rule matches, place the breve/horn on whichever nucleus vowel can
receive it, wherever it sits — mirroring VNI's `8`/`7`. The apply layer already
targets the correct vowel via `shape_target_index`, so this is purely a
classification fix.

- `moi` + `w` → `mơi` (→ `moiwf` = `mời`)
- `doi` + `w` → `dơi`, `coi` + `w` → `cơi`
- `eng` + `w` → still literal (no shapeable nucleus)
- `ô` + `w` → still literal (an existing circumflex is not re-horned)

Tones (`s/f/r/x/j`) and the `đ` stroke were already position-free; only `w` was
constrained. Telex circumflex (`aa`/`ee`/`oo`) is the double-letter mechanism and
is intentionally left unchanged.

Because the engine is the single source of truth via `funput-ffi`, this applies to
all platforms (macOS / Windows / Linux).

## Changes

- `crates/funput-core/src/input_method/telex.rs`: restructure `classify_w` to add
  the free-position fallback

## Testing

- New `classify_w_after_trailing_vowel` (unit) and
  `telex_horn_placed_after_trailing_vowel` (end-to-end) tests; the latter asserts
  both `moiwf` and `mowif` → `mời`, plus `doiwf` → `dời`, `nguoiwf` → `người`.
- Full `funput-core`, `funput-engine`, and `funput-ffi` test suites pass with no
  regressions (existing Telex parity / step-case fixtures included).