### PR TITLE
fix(telex): free mark placement — horn/breve anywhere, ưa rhyme, keep tone across shapes

### DIFF
--- a/crates/funput-core/src/composition/apply.rs
+++ b/crates/funput-core/src/composition/apply.rs
@@ -92,6 +92,15 @@ pub(crate) fn apply_shape_key(buffer: &str, shape: VowelShape) -> TransformResul
         return ignored(buffer);
     };
 
+    // Carry any tone already on the vowel across the shape change — `apply_shape_to_vowel`
+    // drops it (it shapes the bare stem). This makes the mark order free: shaping a
+    // toned vowel keeps the tone (`asw` → `ắ`, not `ă`; `uasw` → `ứa`), matching the
+    // usual shape-then-tone order and VNI's position-free modifiers.
+    let shaped = match tone_on_vowel(vowel) {
+        Some(tone) => apply_tone_to_vowel(shaped, tone).unwrap_or(shaped),
+        None => shaped,
+    };
+
     TransformResult {
         kind: TransformKind::Applied,
         text: replace_char_at(buffer, vowel_idx, shaped),

--- a/crates/funput-core/src/composition/transform.rs
+++ b/crates/funput-core/src/composition/transform.rs
@@ -335,6 +335,21 @@ mod tests {
     }
 
     #[test]
+    fn telex_ua_horn_keeps_tone_and_reverts() {
+        // #2: a tone already on the `u` is kept when the horn lands (`úa` → `ứa`),
+        // so `ua` + tone + `w` composes the same as `ua` + `w` + tone.
+        assert_eq!(type_telex("uasw", false), "ứa");
+        assert_eq!(type_telex("uaws", false), "ứa");
+        assert_eq!(type_telex("cuawr", false), "cửa"); // cửa (door)
+        // #1: a repeat `w` reverts the horn even when it sits on `ư` (not the last
+        // char), giving back `ua` plus the literal `w`, not a stray breve on `a`.
+        assert_eq!(type_telex("nuaww", false), "nuaw");
+        assert_eq!(type_telex("muaww", false), "muaw");
+        // `qu` glide is still breve-and-revert on the `a`, untouched by the `ua` rule.
+        assert_eq!(type_telex("quaww", false), "quaw");
+    }
+
+    #[test]
     fn reposition_and_complex() {
         assert_eq!(type_keys("hoa2"), "hòa");
         assert_eq!(type_keys("thuy3"), "thủy");

--- a/crates/funput-core/src/composition/transform.rs
+++ b/crates/funput-core/src/composition/transform.rs
@@ -307,6 +307,20 @@ mod tests {
     }
 
     #[test]
+    fn telex_ua_rhyme_horns_u() {
+        // `w` after a plain `ua` forms the `ưa` rhyme (horn on `u`), so the horn can
+        // be placed last: `nuawx` → `nữa`, same as `nuwax`.
+        assert_eq!(type_telex("nuawx", false), "nữa");
+        assert_eq!(type_telex("nuwax", false), "nữa");
+        assert_eq!(type_telex("muaw", false), "mưa");
+        assert_eq!(type_telex("dduaw", false), "đưa");
+        // `qu` glide is untouched: `a` takes the breve (`quăng`).
+        assert_eq!(type_telex("quawng", false), "quăng");
+        // The plain `ua` rhyme (no `w`) still composes normally (`múa`, not `mứa`).
+        assert_eq!(type_telex("muas", false), "múa");
+    }
+
+    #[test]
     fn reposition_and_complex() {
         assert_eq!(type_keys("hoa2"), "hòa");
         assert_eq!(type_keys("thuy3"), "thủy");

--- a/crates/funput-core/src/composition/transform.rs
+++ b/crates/funput-core/src/composition/transform.rs
@@ -307,6 +307,20 @@ mod tests {
     }
 
     #[test]
+    fn shape_after_tone_keeps_tone() {
+        // Applying a shape to an already-toned vowel must keep the tone, so the mark
+        // order is free (shape-then-tone and tone-then-shape agree).
+        // Telex:
+        assert_eq!(type_telex("asw", false), "ắ"); // á + breve → ắ (not ă)
+        assert_eq!(type_telex("aws", false), "ắ"); // breve + á → ắ (same result)
+        assert_eq!(type_telex("osw", false), "ớ"); // ó + horn → ớ (keeps sắc)
+        // VNI (position-free digits) gets the same benefit:
+        assert_eq!(type_keys("a18"), "ắ"); // á + 8 (breve) → ắ
+        assert_eq!(type_keys("o17"), "ớ"); // ó + 7 (horn) → ớ
+        assert_eq!(type_keys("a16"), "ấ"); // á + 6 (circumflex) → ấ
+    }
+
+    #[test]
     fn telex_ua_rhyme_horns_u() {
         // `w` after a plain `ua` forms the `ưa` rhyme (horn on `u`), so the horn can
         // be placed last: `nuawx` → `nữa`, same as `nuwax`.

--- a/crates/funput-core/src/input_method/telex.rs
+++ b/crates/funput-core/src/input_method/telex.rs
@@ -69,17 +69,28 @@ fn is_plain_vowel(c: char, base: char) -> bool {
         && shape_on_vowel(c).is_none()
 }
 
-/// Whether the buffer ends in a plain `ua` whose `u` should take the horn, forming
-/// the `ưa` rhyme (`mua` + `w` → `mưa`, `nua` + `w` → `nưa`). Vietnamese has no
-/// `uă` rhyme, so `w` after `ua` horns the `u` rather than putting a breve on the
-/// `a`. The `u` in a `qu` glide is excluded — there it is part of the onset and the
-/// `a` takes the breve (`qua` + `w` → `quă`), mirroring the `uo` → `ươ` rule.
-fn ends_with_hornable_ua(buffer: &str) -> bool {
+/// Whether the buffer ends in a `ua`-family cluster (`u`/`ú`/`ư` + `a`) on which a
+/// `w` should act on the `u` slot rather than putting a breve on the `a` — there is
+/// no `uă` rhyme. All three cases resolve through the shared apply/revert layer once
+/// `classify_w` returns [`VowelShape::Horn`]:
+///
+/// - plain `ua` → horn the `u`, forming `ưa` (`mua` + `w` → `mưa`, `nua` → `nưa`)
+/// - toned `úa` → horn the `u`, keeping the tone (`úa` + `w` → `ứa`)
+/// - already-horned `ưa` → a repeat `w` reverts it (`nưa` + `w` → `nua`)
+///
+/// The `qu` glide is excluded: there the `u` belongs to the onset and the `a` takes
+/// the breve (`qua` + `w` → `quă`), mirroring the `uo` → `ươ` compound rule.
+fn ends_with_ua_horn_target(buffer: &str) -> bool {
     let mut rev = buffer.chars().rev();
     if !rev.next().is_some_and(|a| is_plain_vowel(a, 'a')) {
         return false;
     }
-    if !rev.next().is_some_and(|u| is_plain_vowel(u, 'u')) {
+    // The `u` slot: any `u`- or `ư`-based vowel (plain, toned, or already horned).
+    let is_u_slot = rev
+        .next()
+        .and_then(vowel_stem)
+        .is_some_and(|stem| matches!(stem, 'u' | 'U' | 'ư' | 'Ư'));
+    if !is_u_slot {
         return false;
     }
     !matches!(rev.next(), Some('q' | 'Q'))
@@ -104,8 +115,9 @@ fn classify_w(buffer: &str) -> Option<KeyAction> {
             };
         }
         if is_plain_vowel(last, 'a') {
-            // Plain `ua` horns the `u` (→ `ưa`); a bare/`oa` `a` takes the breve.
-            let shape = if ends_with_hornable_ua(buffer) {
+            // A `ua`-family cluster horns the `u` (→ `ưa`, and a repeat `w` reverts
+            // it); a bare or `oa` `a` takes the breve.
+            let shape = if ends_with_ua_horn_target(buffer) {
                 VowelShape::Horn
             } else {
                 VowelShape::Breve
@@ -339,6 +351,12 @@ mod tests {
         assert_eq!(classify_key("Qua", 'w'), KeyAction::Shape(VowelShape::Breve));
         // `oa` still breves the `a` (`xoăn`), unaffected by the `ua` rule.
         assert_eq!(classify_key("hoa", 'w'), KeyAction::Shape(VowelShape::Breve));
+        // Toned `u` still classifies as horn (the apply layer keeps the tone → `ứa`).
+        assert_eq!(classify_key("úa", 'w'), KeyAction::Shape(VowelShape::Horn));
+        // Already-horned `ưa` classifies as horn too — the transform layer sees no
+        // apply target and reverts it (`nưa` + `w` → `nua`).
+        assert_eq!(classify_key("nưa", 'w'), KeyAction::Shape(VowelShape::Horn));
+        assert_eq!(classify_key("ưa", 'w'), KeyAction::Shape(VowelShape::Horn));
     }
 
     #[test]

--- a/crates/funput-core/src/input_method/telex.rs
+++ b/crates/funput-core/src/input_method/telex.rs
@@ -69,6 +69,22 @@ fn is_plain_vowel(c: char, base: char) -> bool {
         && shape_on_vowel(c).is_none()
 }
 
+/// Whether the buffer ends in a plain `ua` whose `u` should take the horn, forming
+/// the `ưa` rhyme (`mua` + `w` → `mưa`, `nua` + `w` → `nưa`). Vietnamese has no
+/// `uă` rhyme, so `w` after `ua` horns the `u` rather than putting a breve on the
+/// `a`. The `u` in a `qu` glide is excluded — there it is part of the onset and the
+/// `a` takes the breve (`qua` + `w` → `quă`), mirroring the `uo` → `ươ` rule.
+fn ends_with_hornable_ua(buffer: &str) -> bool {
+    let mut rev = buffer.chars().rev();
+    if !rev.next().is_some_and(|a| is_plain_vowel(a, 'a')) {
+        return false;
+    }
+    if !rev.next().is_some_and(|u| is_plain_vowel(u, 'u')) {
+        return false;
+    }
+    !matches!(rev.next(), Some('q' | 'Q'))
+}
+
 fn classify_w(buffer: &str) -> Option<KeyAction> {
     if uo_pair_in_vowel_cluster(buffer).is_some() {
         return Some(KeyAction::Shape(VowelShape::Horn));
@@ -88,7 +104,13 @@ fn classify_w(buffer: &str) -> Option<KeyAction> {
             };
         }
         if is_plain_vowel(last, 'a') {
-            return Some(KeyAction::Shape(VowelShape::Breve));
+            // Plain `ua` horns the `u` (→ `ưa`); a bare/`oa` `a` takes the breve.
+            let shape = if ends_with_hornable_ua(buffer) {
+                VowelShape::Horn
+            } else {
+                VowelShape::Breve
+            };
+            return Some(KeyAction::Shape(shape));
         }
         if is_plain_vowel(last, 'o') || is_plain_vowel(last, 'u') {
             return Some(KeyAction::Shape(VowelShape::Horn));
@@ -301,6 +323,22 @@ mod tests {
         assert_eq!(classify_key("mo", 'w'), KeyAction::Shape(VowelShape::Horn));
         // `i` alone has no shapeable vowel → literal.
         assert_eq!(classify_key("mi", 'w'), KeyAction::Normal);
+    }
+
+    #[test]
+    fn classify_w_on_ua_horns_the_u() {
+        // Plain `ua` + `w` forms the `ưa` rhyme by horning the `u`, not a breve on
+        // the `a` (there is no `uă` rhyme): `nua` + `w` → `nưa` (→ `nữa`),
+        // `mua` + `w` → `mưa`, `ngua` + `w` → `ngưa`.
+        assert_eq!(classify_key("nua", 'w'), KeyAction::Shape(VowelShape::Horn));
+        assert_eq!(classify_key("mua", 'w'), KeyAction::Shape(VowelShape::Horn));
+        assert_eq!(classify_key("ngua", 'w'), KeyAction::Shape(VowelShape::Horn));
+        assert_eq!(classify_key("ua", 'w'), KeyAction::Shape(VowelShape::Horn));
+        // `qu` glide: the `u` is part of the onset, so the `a` takes the breve.
+        assert_eq!(classify_key("qua", 'w'), KeyAction::Shape(VowelShape::Breve));
+        assert_eq!(classify_key("Qua", 'w'), KeyAction::Shape(VowelShape::Breve));
+        // `oa` still breves the `a` (`xoăn`), unaffected by the `ua` rule.
+        assert_eq!(classify_key("hoa", 'w'), KeyAction::Shape(VowelShape::Breve));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

In Telex, tone keys and the `đ` stroke could already be typed anywhere in a
syllable, but the horn/breve key `w` and shape/tone ordering were positional. This
made several natural typing orders produce wrong output. This PR makes mark
placement position-free in Telex (matching VNI, where dedicated keys are already
position-free), all in the shared engine so every platform benefits.

## Fixes

| Sequence | Before | After | Word |
|----------|--------|-------|------|
| `moiwf` (horn typed after the rhyme) | literal `moiwf` | `mời` | mời |
| `nuawx` (`ua` → `ưa` rhyme) | wrong / `nuawx` | `nữa` | nữa |
| `asw` (tone typed before the shape) | `ă` (tone lost) | `ắ` | — |
| `uasw` (toned `u` in `ua`) | `úă` | `ứa` | ứa |
| `nuaww` (repeat `w` to undo the horn) | `nưă` | `nuaw` | — |

The canonical orders (`mowif`, `nuwax`, `aws`, `muonws`) already worked and still do.

## What changed

- **`classify_w` (`input_method/telex.rs`)** — the horn/breve key is now
  position-free:
  - After a coda or a trailing vowel that can't take the shape, place the
    breve/horn on whichever nucleus vowel can receive it (`con` + `w` → `cơn`,
    `moi` + `w` → `mơi`).
  - A `ua`-family cluster horns the `u` (the `ưa` rhyme), not the `a` — there is no
    `uă` rhyme. This covers plain `ua` → `ưa`, toned `úa` → `ứa`, and a repeat `w`
    that reverts an existing `ư`. The `qu` glide is excluded (`qua` + `w` → `quă`),
    mirroring the existing `uo` → `ươ` rule.
  - Apply-vs-revert is left to the shared transform layer (no new special cases).

- **`apply_shape_key` (`composition/apply.rs`)** — carry an existing tone across a
  shape change (shaping previously dropped it via `vowel_stem`). This makes
  shape-after-tone equal shape-before-tone and also benefits VNI (`a18` → `ắ`,
  `o17` → `ớ`).

## Not changed (intentional)

Telex circumflex (`aa`/`ee`/`oo`) stays adjacent-only. Its "key" is a vowel letter,
so a position-free version would be ambiguous and would corrupt English / mixed
words and syllables with non-adjacent vowels. This matches UniKey/OpenKey.

## Testing

- New unit tests (`classify_w_after_trailing_vowel`, `classify_w_on_ua_horns_the_u`)
  and end-to-end tests (`telex_horn_placed_after_trailing_vowel`,
  `telex_ua_rhyme_horns_u`, `telex_ua_horn_keeps_tone_and_reverts`,
  `shape_after_tone_keeps_tone`, covering Telex and VNI).
- Full `funput-core` / `funput-engine` / `funput-ffi` suites pass.
- Corpus round-trip coverage unchanged at 100% for both Telex and VNI.