### PR TITLE
fix(linux): preedit lost on focus change, and per-app exclusion locking out Vietnamese

### DIFF
--- a/platforms/linux/fcitx5/src/funput_engine.cpp
+++ b/platforms/linux/fcitx5/src/funput_engine.cpp
@@ -270,9 +270,14 @@ void FunputEngine::keyEvent(const fcitx::InputMethodEntry &, fcitx::KeyEvent &ke
     keyEvent.filterAndAccept();
 }
 
+// A reset ends the current composition. Commit the in-progress word rather than
+// dropping it: many client toolkits deliver focus-loss to Fcitx5 as reset() instead
+// of deactivate(), so discarding here silently ate whatever the user had typed but
+// not yet committed. Committing mirrors the macOS IMKit shell, which flushes the
+// buffer on commitComposition. commitBuffer() is a no-op on an empty buffer, so a
+// reset right after a commit (e.g. a word boundary) never double-types.
 void FunputEngine::reset(const fcitx::InputMethodEntry &, fcitx::InputContextEvent &event) {
-    handle_.clear();
-    clearPreedit(event.inputContext());
+    commitBuffer(event.inputContext());
 }
 
 void FunputEngine::activate(const fcitx::InputMethodEntry &, fcitx::InputContextEvent &event) {

--- a/platforms/linux/fcitx5/src/funput_engine.cpp
+++ b/platforms/linux/fcitx5/src/funput_engine.cpp
@@ -70,12 +70,19 @@ void FunputEngine::applySettings() {
     handle_.clear();
 }
 
-// excluded app → English; any other app → Vietnamese. No-op when the list is empty
-// (keeps the plain global toggle for users who don't use the feature).
+// Per-app default on focus-in: a positively-excluded app starts in English; every
+// other app follows the user's global VI/EN setting (settings_.enabled).
+//
+// Deliberately fail-safe. On Linux the focused-app id is unreliable — program()
+// is often empty on Wayland (no WM_CLASS exposed to the IME), and the IBus shell
+// skips per-app switching entirely for this reason. So we only force English on a
+// *confident* match: isExcluded() treats an empty/unknown program as "not
+// excluded", meaning an app we can't identify can never silently disable Vietnamese
+// everywhere. The previous `!isExcluded(program)` also ignored the global toggle,
+// forcing Vietnamese on every non-excluded app; deferring to settings_.enabled
+// keeps VI/EN togglable when the exclusion list is non-empty.
 void FunputEngine::applyPerAppDefault(const std::string &program) {
-    const bool eff = settings_.excludedAppIds.empty()
-                         ? settings_.enabled
-                         : !settings_.isExcluded(program);
+    const bool eff = settings_.isExcluded(program) ? false : settings_.enabled;
     if (eff == effectiveEnabled_) return;
     effectiveEnabled_ = eff;
     handle_.setEnabled(eff);

--- a/platforms/linux/ibus/src/engine.cpp
+++ b/platforms/linux/ibus/src/engine.cpp
@@ -254,10 +254,14 @@ static void ibus_funput_engine_disable(IBusEngine *engine) {
     commitBuffer(engine, FUNPUT_ENGINE(engine)->state);
 }
 
+// A reset ends the current composition. Commit the in-progress word rather than
+// dropping it: some clients deliver focus-loss as reset() instead of focus_out(),
+// so discarding here silently ate whatever the user had typed but not yet
+// committed. Committing mirrors the macOS IMKit shell (commit on
+// commitComposition); commitBuffer() no-ops on an empty buffer, so a reset right
+// after a commit never double-types.
 static void ibus_funput_engine_reset(IBusEngine *engine) {
-    EngineState *st = FUNPUT_ENGINE(engine)->state;
-    st->handle_.clear();
-    clearPreedit(engine);
+    commitBuffer(engine, FUNPUT_ENGINE(engine)->state);
 }
 
 // --- Lifecycle -------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two fixes to the Linux IME shells (fcitx5 and ibus) that hurt everyday typing.
Both are localized to the platform shells — the shared engine is untouched.

## Bug 1 — In-progress word is lost on focus change

**Symptom:** typing a word that's still in preedit (no space / navigation key to
commit it yet) and then changing focus (click away, switch window) dropped the
word entirely.

**Cause:** `reset()` discarded the composing buffer (`handle_.clear()` with no
commit). Many client toolkits deliver focus-loss to the IME as `reset()` rather
than `deactivate()`/`focus_out()`, so the commit path that already existed there
never ran and the text was thrown away.

**Fix:** commit the in-progress buffer on `reset()` instead of dropping it —
mirroring the macOS IMKit shell, which flushes the buffer on `commitComposition`.
`commitBuffer()` no-ops on an empty buffer, so a reset right after a commit (e.g. a
word boundary) never double-types.

- `platforms/linux/fcitx5/src/funput_engine.cpp` — `reset()`
- `platforms/linux/ibus/src/engine.cpp` — `ibus_funput_engine_reset()`

## Bug 2 — Per-app exclusion could disable Vietnamese everywhere (fcitx5)

**Symptom:** after adding an app to the exclusion list ("default to English"),
Vietnamese stopped working in every app.

**Cause:** `applyPerAppDefault()` used `!isExcluded(program)`, which (a) ignored the
user's global VI/EN setting — forcing Vietnamese on every non-excluded app — and
(b) was not fail-safe against Linux's unreliable focused-app id (`program()` is
often empty on Wayland; the IBus shell skips per-app switching entirely for this
reason).

**Fix:** `eff = isExcluded(program) ? false : settings_.enabled`. Only a
*confidently* excluded app is forced to English; every other app — including one we
can't identify — follows the user's global setting, so a missing/unreliable app id
can never silently disable Vietnamese. This also restores the global VI/EN toggle
when the exclusion list is non-empty.

- `platforms/linux/fcitx5/src/funput_engine.cpp` — `applyPerAppDefault()`

ibus is unaffected: it intentionally has no per-app auto-switch (no reliable
focused-app id), so there is nothing to fix there.

## Testing

Platform-shell C++ (links libfcitx5 / libibus), so this needs building on the
target distro and manual verification:

- Build: `FUNPUT_FRAMEWORK=all platforms/linux/build.sh`, install the `.deb`,
  restart the IME.
- Bug 1: type a partial word, change focus → the word is committed, not lost.
  Verified across a few app toolkits (terminal, browser, editor).
- Bug 2: exclude one app → Vietnamese still works in other apps; the excluded app
  starts in English; the VI/EN toggle works with the exclusion list non-empty.