### PR TITLE
feat(ci): distribute Windows funput CLI via Scoop

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -57,6 +57,49 @@ jobs:
           name: windows
           path: ${{ runner.temp }}/out/*
 
+  # Build the `funput` umbrella CLI (crates/funput-cli, which hosts `funput term`)
+  # for Windows and package it as a zip for the Scoop bucket. This is a DIFFERENT
+  # binary from the Slint IME GUI above, even though both are named funput.exe — so
+  # the release asset is the distinctly-named zip below, never `Funput-<v>.exe`.
+  windows-cli:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Workspace root is the tarball root (app/), so the CLI target is `-> target`.
+          workspaces: . -> target
+
+      - name: Stamp version from tag
+        if: inputs.version != ''
+        run: |
+          V="${{ inputs.version }}"
+          # funput-cli inherits [workspace.package] version; stamp it so `funput
+          # --version` reports the release version (single source of truth = tag).
+          node -e "const fs=require('fs');const f='Cargo.toml';let s=fs.readFileSync(f,'utf8');s=s.replace(/^version = \".*\"/m,'version = \"'+process.argv[1]+'\"');fs.writeFileSync(f,s)" "$V"
+
+      - name: Build funput CLI
+        run: cargo build --release -p funput-cli
+
+      - name: Stage artifact
+        run: |
+          V="${{ inputs.version }}"; V="${V:-dev}"
+          OUT="$RUNNER_TEMP/out"; mkdir -p "$OUT"
+          ZIP="funput-term-$V-x86_64-pc-windows-msvc.zip"
+          # Package just the CLI exe; Scoop shims funput.exe from inside the zip.
+          7z a -tzip "$OUT/$ZIP" "./target/release/funput.exe" >/dev/null
+          (cd "$OUT" && sha256sum "$ZIP" | awk '{print $1}' > "$ZIP.sha256")
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: windows-cli
+          path: ${{ runner.temp }}/out/*
+
   # Sign the .exe with the shared Sparkle EdDSA key and emit funput-windows.json.
   # The in-app updater (platforms/windows/src/update.rs) fetches it from
   # releases/latest/download and verifies the .exe against the *same* Ed25519 key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
           mkdir -p out
           cp artifacts/macos/* out/ 2>/dev/null || true
           cp artifacts/windows/* out/ 2>/dev/null || true
+          cp artifacts/windows-cli/* out/ 2>/dev/null || true
           cp artifacts/windows-feed/* out/ 2>/dev/null || true
           cp artifacts/linux-*/* out/ 2>/dev/null || true
           ls -l out
@@ -117,6 +118,7 @@ jobs:
             echo "### Tải về"
             echo "- **macOS:** \`Funput-*.pkg\` (có quyền admin) hoặc \`Funput-*.app.zip\` (không cần admin)."
             echo "- **Windows:** \`Funput-*.exe\` — portable, chạy ngay, tự cập nhật trong app."
+            echo "- **Funput Term (CLI, Windows):** \`scoop bucket add funput https://github.com/Funput/scoop-funput && scoop install funput\`, hoặc tải \`funput-term-*-x86_64-pc-windows-msvc.zip\`."
             echo "- **Linux:** \`.deb\` (Debian/Ubuntu) hoặc \`.rpm\` (Fedora/openSUSE); mỗi loại có bản **IBus** (\`funput-ibus-*\`) và **Fcitx5** (\`funput-*\`). Chọn đúng kiến trúc CPU."
           } > notes.md
 
@@ -129,6 +131,7 @@ jobs:
             out/*.pkg
             out/*.app.zip
             out/*.exe
+            out/*.zip
             out/*.deb
             out/*.rpm
             out/appcast.xml
@@ -185,4 +188,31 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${TOKEN}" \
             https://api.github.com/repos/Funput/homebrew-tap/dispatches \
+            -d "{\"event_type\":\"release\",\"client_payload\":{\"version\":\"${VERSION}\"}}"
+
+  # ---- Trigger the Scoop bucket to bump its manifest ------------------------
+  # Windows analogue of `homebrew`. Fires only for a real public release. The
+  # bucket's `bump.yml` points funput.json at the new release zip + sha256 and
+  # commits it — instant, no community review (unlike winget public). Requires a
+  # `SCOOP_BUCKET_TOKEN` secret (a PAT with `contents: write` on
+  # Funput/scoop-funput); skipped automatically if absent.
+  scoop:
+    needs: [version, publish]
+    if: needs.version.outputs.prerelease == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch manifest bump to Funput/scoop-funput
+        env:
+          TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${TOKEN:-}" ]]; then
+            echo "SCOOP_BUCKET_TOKEN not set — skipping bucket update." >&2
+            exit 0
+          fi
+          curl -fsS -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            https://api.github.com/repos/Funput/scoop-funput/dispatches \
             -d "{\"event_type\":\"release\",\"client_payload\":{\"version\":\"${VERSION}\"}}"


### PR DESCRIPTION
## Purpose

Distribute **Funput Term** on Windows via **Scoop** — the Windows counterpart of the Homebrew tap. Homebrew has no native Windows install, and Scoop is per-user (no admin), matching funput-term's no-system-permissions design. This is the distribution channel only, using the same `funput` umbrella binary and its `funput term` subcommand.

## Changes

- **`build-windows.yml`** — add a `windows-cli` job: build `funput-cli` for `x86_64-pc-windows-msvc` and package it as `funput-term-<v>-x86_64-pc-windows-msvc.zip` (+ `.sha256`). The asset name is deliberately distinct so it never collides with the IME GUI's `Funput-<v>.exe`, even though both binaries are named `funput.exe`.
- **`release.yml`** — the `publish` job gathers the `windows-cli` artifact and adds `out/*.zip` to the release; a new `scoop` job dispatches `repository_dispatch` to `Funput/scoop-funput` (mirrors the existing `homebrew` job; gated to non-prereleases; requires the `SCOOP_BUCKET_TOKEN` secret).

## Verification

- ✅ `cargo check -p funput-cli --target x86_64-pc-windows-msvc` compiles cleanly.
- ✅ Workflow YAML parses.
- Bucket created & pushed: [Funput/scoop-funput](https://github.com/Funput/scoop-funput). Windows docs in a separate PR on [Funput/Docs](https://github.com/Funput/Docs).

## Out of scope

ConPTY runtime for funput-term on Windows (phase TT6) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)