### PR TITLE
chore(windows): bump funput-windows deps to latest majors

### DIFF
--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -25,7 +25,7 @@ slint = "1.17"
 # menu types come from tray-icon's re-exported `muda` (kept version-matched).
 tray-icon = "0.24"
 # Launch-at-login (writes the HKCU\...\Run registry value).
-auto-launch = "0.5"
+auto-launch = "0.6"
 # Open external links in the system browser.
 open = "5"
 # Native Open/Save + message dialogs for config Export/Import (Win32 IFileDialog,
@@ -35,12 +35,12 @@ rfd = "0.17.2"
 image = { version = "0.25", default-features = false, features = ["png"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-dirs = "5"
+dirs = "6"
 # Auto-update (see src/update.rs): fetch a signed JSON manifest from GitHub
 # Releases, verify it with the same Ed25519 key Sparkle uses on macOS, then
 # swap the running .exe in place.
-ureq = "2" # sync HTTP client (rustls, no OpenSSL); runs on its own thread
-ed25519-dalek = "2" # verify the Sparkle-compatible Ed25519 signature
+ureq = "3" # sync HTTP client (rustls, no OpenSSL); runs on its own thread
+ed25519-dalek = "3" # verify the Sparkle-compatible Ed25519 signature
 base64 = "0.22" # decode the public key + signature
 semver = "1" # compare the manifest version against CARGO_PKG_VERSION
 self-replace = "1" # replace the currently running executable (crate `self_replace`)
@@ -49,7 +49,7 @@ funput-engine = { path = "../../crates/funput-engine" }
 funput-desktop = { path = "../../crates/funput-desktop" }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.58", features = [
+windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Input_KeyboardAndMouse",

--- a/platforms/windows/src/hook.rs
+++ b/platforms/windows/src/hook.rs
@@ -8,7 +8,7 @@ use std::sync::OnceLock;
 
 use funput_desktop::{classify, plan_inject, KeyKind};
 use windows::core::PWSTR;
-use windows::Win32::Foundation::{CloseHandle, HINSTANCE, HMODULE, HWND, LPARAM, LRESULT, WPARAM};
+use windows::Win32::Foundation::{CloseHandle, HINSTANCE, HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 use windows::Win32::System::Threading::{
     OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION,
@@ -39,7 +39,7 @@ pub fn set_on_toggle(f: impl Fn(bool) + Send + Sync + 'static) {
 pub fn run() {
     unsafe {
         let hmod = GetModuleHandleW(None).unwrap_or_default();
-        let hook = SetWindowsHookExW(WH_KEYBOARD_LL, Some(keyboard_proc), HINSTANCE(hmod.0), 0);
+        let hook = SetWindowsHookExW(WH_KEYBOARD_LL, Some(keyboard_proc), Some(HINSTANCE(hmod.0)), 0);
         if hook.is_err() {
             eprintln!("Funput: failed to install keyboard hook: {hook:?}");
             return;
@@ -50,7 +50,7 @@ pub fn run() {
         // `KeyKind::Flush` path) — otherwise the next keystroke diffs against a stale
         // word at the new caret and corrupts neighbouring text. Delivered to this
         // thread's message pump, so it shares the engine via `shell` like the others.
-        let mouse_hook = SetWindowsHookExW(WH_MOUSE_LL, Some(mouse_proc), HINSTANCE(hmod.0), 0);
+        let mouse_hook = SetWindowsHookExW(WH_MOUSE_LL, Some(mouse_proc), Some(HINSTANCE(hmod.0)), 0);
         if mouse_hook.is_err() {
             // Non-fatal: typing still works, only mouse-click flush is unavailable.
             eprintln!("Funput: failed to install mouse hook: {mouse_hook:?}");
@@ -61,7 +61,7 @@ pub fn run() {
         let _win_event = SetWinEventHook(
             EVENT_SYSTEM_FOREGROUND,
             EVENT_SYSTEM_FOREGROUND,
-            HMODULE(std::ptr::null_mut()), // OUT_OF_CONTEXT: no DLL module
+            None, // OUT_OF_CONTEXT: no DLL module
             Some(win_event_proc),
             0,
             0,

--- a/platforms/windows/src/keymap.rs
+++ b/platforms/windows/src/keymap.rs
@@ -71,7 +71,7 @@ fn translate_char(kbd: &KBDLLHOOKSTRUCT) -> Option<char> {
     }
     let layout = unsafe { GetKeyboardLayout(0) };
     let mut buf = [0u16; 8];
-    let n = unsafe { ToUnicodeEx(kbd.vkCode, kbd.scanCode, &state, &mut buf, 0, layout) };
+    let n = unsafe { ToUnicodeEx(kbd.vkCode, kbd.scanCode, &state, &mut buf, 0, Some(layout)) };
     if n == 1 {
         char::from_u32(buf[0] as u32)
     } else {

--- a/platforms/windows/src/update.rs
+++ b/platforms/windows/src/update.rs
@@ -98,21 +98,24 @@ fn feed_url() -> String {
 /// A shared HTTP agent with sane timeouts. Built per call (cheap) so the update
 /// thread owns it and nothing lingers on the main app.
 fn agent() -> ureq::Agent {
-    ureq::AgentBuilder::new()
-        .timeout_connect(Duration::from_secs(15))
-        .timeout_read(Duration::from_secs(60))
+    ureq::Agent::config_builder()
+        .timeout_connect(Some(Duration::from_secs(15)))
+        .timeout_recv_response(Some(Duration::from_secs(60)))
         .build()
+        .into()
 }
 
 /// Fetch and parse the update manifest from the GitHub Release feed.
 pub fn fetch_manifest() -> Result<Manifest> {
-    let resp = agent()
+    let mut resp = agent()
         .get(&feed_url())
         .call()
         .map_err(|e| Error::Network(e.to_string()))?;
-    // `into_string` is core ureq (no extra feature), with a built-in size cap.
+    // `read_to_string` caps the body at ureq's default 10MB — ample for a small
+    // JSON manifest and a guard against a runaway feed.
     let body = resp
-        .into_string()
+        .body_mut()
+        .read_to_string()
         .map_err(|e| Error::Network(e.to_string()))?;
     serde_json::from_str(&body).map_err(|e| Error::BadManifest(e.to_string()))
 }
@@ -147,7 +150,8 @@ pub fn download(url: &str, expected_len: u64) -> Result<Vec<u8>> {
         .map_err(|e| Error::Network(e.to_string()))?;
 
     let mut bytes = Vec::with_capacity(expected_len.min(MAX_DOWNLOAD_BYTES) as usize);
-    resp.into_reader()
+    resp.into_body()
+        .into_reader()
         .take(MAX_DOWNLOAD_BYTES)
         .read_to_end(&mut bytes)
         .map_err(|e| Error::Network(e.to_string()))?;


### PR DESCRIPTION
## Purpose

Bump the standalone Windows IME crate (`app/platforms/windows`) dependencies to their **latest major** versions and migrate the breaking APIs.

## Version bumps

| Crate | From | To | Code change |
|--|--|--|--|
| `windows` | 0.58 | 0.62.2 | ✅ optional handle params → `Option<T>` |
| `ureq` | 2 | 3.3 | ✅ `AgentBuilder` removed → config builder + new body API |
| `ed25519-dalek` | 2 | 3 | none (API used unchanged) |
| `dirs` | 5 | 6 | none |
| `auto-launch` | 0.5 | 0.6 | none |

Other deps (slint, tray-icon, rfd, image, serde, base64, semver, self-replace, open, winresource) were already at their latest major; `cargo` resolves their newest patch.

## Migrations

- **`windows` 0.62** — the `Param`/null-handle mechanism was dropped; optional handle args are now explicit `Option<T>`:
  - `SetWindowsHookExW(..)` hmod → `Some(HINSTANCE(..))` (hook.rs, ×2)
  - `SetWinEventHook(..)` module → `None` (hook.rs); drop now-unused `HMODULE` import
  - `ToUnicodeEx(..)` layout → `Some(HKL)` (keymap.rs)
- **`ureq` 3** (update.rs) — `Agent::config_builder().timeout_connect(Some(..)).timeout_recv_response(Some(..)).build().into()`; manifest via `body_mut().read_to_string()` (default 10MB cap); download via `into_body().into_reader().take(..)`.

## Verification

- ✅ **Full compile for `x86_64-pc-windows-gnu`** (mingw) — `cargo check` clean; type-checks the entire `cfg(windows)` tree and every bumped dep.
- ⚠️ The **msvc** target can't be cross-checked on macOS (`ring`'s build script needs the MSVC toolchain), so the release CI's msvc `cargo build --release` is the final gate — flagged since I can't run it here.
- `Cargo.lock` is gitignored for this standalone crate; CI resolves the new versions from `Cargo.toml`.

## Note

`cargo clippy` surfaces some **pre-existing** style lints (`config_transfer.rs`, `dark_mode.rs`, `tray.rs`) unrelated to this bump — this crate's CI builds without clippy, so they're left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)