### PR TITLE
refactor(funput-core): panic-proof invariant sites + fmt + docs

### DIFF
--- a/crates/funput-core/Cargo.toml
+++ b/crates/funput-core/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 
 [dev-dependencies]
-criterion = { version = "0.8", features = ["html_reports"] }
+criterion = { version = "0.8.2", features = ["html_reports"] }
 proptest = "1.11.0"
 
 [[bench]]

--- a/crates/funput-core/README.en.md
+++ b/crates/funput-core/README.en.md
@@ -1,0 +1,184 @@
+# funput-core
+
+**English** · [Tiếng Việt](README.md)
+
+The **pure-logic** Vietnamese input crate: given a Latin-character buffer + the key just pressed, per
+Telex/VNI, it returns the new buffer. No keyboard hooks, no I/O, no config files, no knowledge of
+macOS/Windows/Linux.
+
+## What this crate does
+
+It answers exactly one question:
+
+> Current buffer + the key just pressed, per Telex/VNI, becomes what string?
+
+It is the **only** place that holds:
+
+- VNI rules (`1`→sắc, `6`→`â`, `7`→`ơ`/`ư`, `8`→`ă`, `9`→`đ`, …)
+- Telex rules (`s`→sắc, `f`→huyền, `aa`→`â`, `w`→móc/breve, `dd`→`đ`, …)
+- Tone placement (traditional/modern) + the mũ/móc/trần shape marks
+- Revert on a doubled modifier key (`a11` → `a1`)
+- Syllable-structure validation (onset / rhyme / coda)
+- Unicode tables (tones, vowel shapes, vowels)
+
+**Stateless & pure:** no session, no backspace count, no English auto-restore — that is
+`funput-engine`'s job. The engine diffs the before/after buffer to derive the backspace count to send.
+
+## Public API
+
+A small, stable surface for `funput-engine`. Breaking changes require semver coordination with the
+engine.
+
+| Symbol | Description |
+|--------|-------------|
+| `InputMethod` | `Telex` \| `Vni` |
+| `ToneStyle` | `Traditional` (default) \| `Modern` — tone placement (see below) |
+| `TransformKind` | `Pending` \| `Applied` \| `Reverted` \| `Ignored` |
+| `TransformResult` | `{ kind, text }` — state after one key |
+| `apply(buffer, key, method, tone_style) -> TransformResult` | One transform step |
+| `apply_checked(buffer, key, method, tone_style, spell_check) -> TransformResult` | Like `apply` + a **spell-check** gate: when `spell_check` is on, a diacritic is placed only if the result can still become a valid VN syllable, otherwise the modifier key stays a literal (`mix` + ngã → `mĩx` is blocked). `spell_check = false` ≡ `apply` |
+| `is_valid(buffer) -> bool` | Buffer **could** still be a valid VN syllable (lenient) |
+| `is_complete_syllable(buffer) -> bool` | Buffer is a **complete** VN syllable (strict) |
+| `is_definitely_invalid(buffer) -> bool` | Buffer can **definitely** never become a VN syllable |
+
+The three `is_*` functions let `funput-engine` decide whether to keep the Vietnamese text or restore the
+raw Latin: `is_complete_syllable` is used at a word boundary; `is_definitely_invalid` drives eager
+restore (flip back the instant it is certain the word is not Vietnamese).
+
+```rust
+use funput_core::{apply, InputMethod, ToneStyle, TransformKind};
+
+let r = apply("a", '1', InputMethod::Vni, ToneStyle::Traditional);
+assert_eq!(r.kind, TransformKind::Applied);
+assert_eq!(r.text, "á");
+```
+
+### TransformKind
+
+- `Pending` — the key is appended, not transformed yet (waiting for the next key). Also used for a
+  **pass-through** modifier on non-Vietnamese text: `text` + `1` → `"text1"`.
+- `Applied` — a tone / shape / stroke / reposition produced new `text`.
+- `Reverted` — a doubled modifier: strip the diacritic, then re-insert the raw key (`a11` → `a1`, Telex
+  `ass` → `as`).
+- `Ignored` — the modifier was rejected, `text` unchanged (`ng` + `1`, a stroke on a non-`d`).
+
+## Tone placement — `ToneStyle`
+
+The two styles **differ only** on the open glide-initial rhymes: `oa`, `oe`, `uy`.
+
+| Rhyme | `Traditional` (default) | `Modern` |
+|-------|-------------------------|----------|
+| `oa` | hòa (mark on `o`) | hoà (mark on `a`) |
+| `oe` | khỏe | khoẻ |
+| `uy` | thúy | thuý |
+
+Everything else is **identical** in both styles:
+
+- `ia`/`ua` → mark on the first vowel: `mía`, `múa`.
+- With a final consonant: `hoàn`, `toán`, `huýt`.
+- A vowel carrying mũ/móc (`â ê ô ơ ư ă`) always takes the mark: `trường`, `việt`, `người`.
+- Triphthongs: mark on the middle vowel: `ngoài`, `xoáy`.
+
+Placement is **independent of where the tone key is typed** — `hoaf` and `hofa` give the same result for
+the chosen style. Reference: [Quy tắc đặt dấu thanh của chữ Quốc ngữ](https://vi.wikipedia.org/wiki/Quy_t%E1%BA%AFc_%C4%91%E1%BA%B7t_d%E1%BA%A5u_thanh_c%E1%BB%A7a_ch%E1%BB%AF_Qu%E1%BB%91c_ng%E1%BB%AF).
+
+## Module layout
+
+```
+src/
+├── lib.rs                    # Public API + apply()
+├── input_method/             # Key classification → KeyAction. The ONLY place VNI and Telex differ.
+│   ├── vni.rs                # 1–9
+│   └── telex.rs              # s/f/r/x/j, aa/dd/ee/oo, w (buffer-aware)
+├── composition/              # Transform pipeline, shared by VNI + Telex
+│   ├── transform.rs          # Orchestrate: revert → validate → apply
+│   ├── apply.rs              # Apply stroke / tone / shape to the buffer
+│   └── revert.rs             # Strip the diacritic on a doubled modifier key
+├── validation/
+│   ├── parse.rs              # Split onset / nucleus / coda
+│   ├── rhyme.rs              # Valid-rhyme table — the core of "is this Vietnamese?"
+│   └── syllable.rs           # is_valid / is_complete_syllable / is_definitely_invalid + modifier gate
+└── unicode/
+    ├── marks.rs              # Tone-mark table
+    ├── shapes.rs             # mũ / móc / breve table
+    ├── vowels.rs             # Source of truth for vowels
+    └── tone_position.rs      # Pick the vowel that takes the mark (Traditional/Modern) + reposition
+```
+
+## One-keystroke pipeline
+
+```
+key
+ └─ input_method::{vni,telex}::classify_key(buffer, key) → KeyAction (Tone / Shape / Stroke / RemoveTone / Normal)
+     └─ composition::transform::apply_action
+         ├─ try revert (doubled modifier)     → Reverted
+         ├─ validation::syllable (gate)        → Ignored | PassThrough(Pending)
+         └─ composition::apply                 → Applied
+             └─ unicode::{tone_position, marks, shapes}
+```
+
+The `Tone` and `Normal` branches also take a `ToneStyle` to place/reposition the mark. The first stage
+that matches wins.
+
+## Behavior examples
+
+VNI (default `Traditional`):
+
+| Type | Result | Note |
+|------|--------|------|
+| `a1` | `á` | tone |
+| `d9` | `đ` | stroke |
+| `uo7` | `uơ` | open rhyme (`thuo73` → `thuở`) |
+| `hoa2` | `hòa` | tone placement (Traditional) |
+| `vie5t` | `việt` | `ie` → tonal `ê` |
+| `ngu7o7i2` | `người` | mark on `ơ` |
+| `a11` | `a1` | Reverted |
+| `text` + `1` | `text1` | Pending (the engine will restore) |
+
+Telex:
+
+| Type | Result |
+|------|--------|
+| `as` | `á` |
+| `dd` | `đ` |
+| `uow` | `uơ` (`thuowr` → `thuở`) |
+| `nuocws` | `nước` |
+| `hoaf` | `hòa` (Traditional) / `hoà` (Modern) |
+| `ass` | `a` (revert tone) |
+
+Difference between the two tone-placement styles:
+
+| Type (VNI) | `Traditional` | `Modern` |
+|------------|---------------|----------|
+| `hoa2` | `hòa` | `hoà` |
+| `thuy3` | `thủy` | `thuỷ` |
+| `khoe3` | `khỏe` | `khoẻ` |
+| `mua1` | `múa` | `múa` (unchanged) |
+
+## Tests
+
+```bash
+cargo test   -p funput-core
+cargo test   -p funput-core vni_full_regression
+cargo test   -p funput-core telex_full_regression
+cargo clippy -p funput-core -- -D warnings
+cargo doc    -p funput-core --no-deps
+```
+
+Tests are grouped by input method: `tests/telex/` (basic, cases, corpus, parity, `properties` —
+**proptest**, regression) and `tests/vni/` (basic, cases, regression), plus `tests/spellcheck_corpus.rs`
+for the spell-check gate. The Telex corpus is a TSV table loaded at **compile time** (`include_str!` →
+`tests/telex/data/telex_corpus.tsv`); the other cases are **Rust consts** (no serde, no runtime loader).
+Shared helpers in `tests/support/`.
+
+## Dependencies & boundaries
+
+- Depends on **no** other Funput crate; `std` only. **No** `serde`, `libc`, `std::os`.
+- Only `funput-engine` (and tests) call this crate. Platform code (macOS IMKit, Windows hook, Fcitx5
+  addon) does **not** import `funput-core` directly — it goes through `funput-engine`.
+
+| funput-core | funput-engine |
+|-------------|---------------|
+| Pure one-step `apply()` | Holds the session buffer; computes backspace from the diff |
+| Validate syllable structure | Decide English auto-restore at a word boundary |
+| Unicode tables + tone-placement rules | Map hardware keycode → char |

--- a/crates/funput-core/README.md
+++ b/crates/funput-core/README.md
@@ -1,5 +1,7 @@
 # funput-core
 
+[English](README.en.md) · **Tiếng Việt**
+
 Crate **thuần logic** gõ tiếng Việt: cho một buffer ký tự Latin + một phím vừa gõ, theo Telex/VNI,
 trả về buffer mới. Không hook bàn phím, không I/O, không config file, không biết
 macOS/Windows/Linux.
@@ -33,6 +35,7 @@ Bề mặt nhỏ và ổn định cho `funput-engine`. Đổi breaking cần đ�
 | `TransformKind` | `Pending` \| `Applied` \| `Reverted` \| `Ignored` |
 | `TransformResult` | `{ kind, text }` — trạng thái sau một phím |
 | `apply(buffer, key, method, tone_style) -> TransformResult` | Transform một bước |
+| `apply_checked(buffer, key, method, tone_style, spell_check) -> TransformResult` | Như `apply` + cổng **kiểm tra chính tả**: khi `spell_check` bật, chỉ đặt dấu nếu kết quả vẫn có thể thành âm tiết VN hợp lệ, ngược lại giữ phím dấu thành ký tự thường (`mix` + ngã → `mĩx` bị chặn). `spell_check = false` ≡ `apply` |
 | `is_valid(buffer) -> bool` | Buffer **có thể** còn là âm tiết VN hợp lệ (lenient) |
 | `is_complete_syllable(buffer) -> bool` | Buffer là âm tiết VN **hoàn chỉnh** (strict) |
 | `is_definitely_invalid(buffer) -> bool` | Buffer **chắc chắn** không thể thành âm tiết VN |
@@ -159,8 +162,11 @@ cargo clippy -p funput-core -- -D warnings
 cargo doc    -p funput-core --no-deps
 ```
 
-Fixture canonical là **Rust const** (không serde, không JSON loader runtime):
-`tests/fixtures/{vni_cases,telex_cases,telex_parity}.rs`. Helper chung ở `tests/support/`.
+Test gom theo bộ gõ: `tests/telex/` (basic, cases, corpus, parity, `properties` — **proptest**,
+regression) và `tests/vni/` (basic, cases, regression), cùng `tests/spellcheck_corpus.rs` cho cổng
+kiểm tra chính tả. Corpus Telex là bảng TSV nạp **compile-time** (`include_str!` →
+`tests/telex/data/telex_corpus.tsv`); các case khác là **Rust const** (không serde, không loader
+runtime). Helper chung ở `tests/support/`.
 
 ## Phụ thuộc & ranh giới
 

--- a/crates/funput-core/benches/apply.rs
+++ b/crates/funput-core/benches/apply.rs
@@ -8,8 +8,8 @@
 
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use funput_core::{apply_checked, InputMethod, ToneStyle};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use funput_core::{InputMethod, ToneStyle, apply_checked};
 
 // Realistic typing with tones, circumflex/horn/breve and the `đ` stroke.
 const TELEX: &str = "tooi yeeu tieesng vieejt nam ddaats nuwowcs hoom nay troiwf ddepj";

--- a/crates/funput-core/src/composition/apply.rs
+++ b/crates/funput-core/src/composition/apply.rs
@@ -4,8 +4,10 @@
 //! resolved by a classifier, so VNI and Telex share them unchanged.
 
 use crate::composition::replace_char_at;
-use crate::unicode::marks::{apply_tone_to_vowel, is_vowel, stroke_d, tone_on_vowel, vowel_stem, Tone};
-use crate::unicode::shapes::{apply_shape, apply_shape_to_vowel, shape_target_index, VowelShape};
+use crate::unicode::marks::{
+    Tone, apply_tone_to_vowel, is_vowel, stroke_d, tone_on_vowel, vowel_stem,
+};
+use crate::unicode::shapes::{VowelShape, apply_shape, apply_shape_to_vowel, shape_target_index};
 use crate::unicode::tone_position::{tone_target_vowel, tone_vowel_index};
 use crate::{ToneStyle, TransformKind, TransformResult};
 

--- a/crates/funput-core/src/composition/apply.rs
+++ b/crates/funput-core/src/composition/apply.rs
@@ -26,7 +26,10 @@ pub(crate) fn apply_stroke(buffer: &str) -> TransformResult {
     let Some(idx) = chars.iter().rposition(|c| matches!(c, 'd' | 'D')) else {
         return ignored(buffer);
     };
-    chars[idx] = stroke_d(chars[idx]).expect("d/D always strokes");
+    let Some(struck) = stroke_d(chars[idx]) else {
+        return ignored(buffer);
+    };
+    chars[idx] = struck;
     TransformResult {
         kind: TransformKind::Applied,
         text: chars.into_iter().collect(),
@@ -39,7 +42,9 @@ pub(crate) fn apply_tone_key(buffer: &str, tone: Tone, style: ToneStyle) -> Tran
         return ignored(buffer);
     };
 
-    let vowel = buffer.chars().nth(vowel_idx).expect("vowel index in bounds");
+    let Some(vowel) = buffer.chars().nth(vowel_idx) else {
+        return ignored(buffer);
+    };
     let tone_target = tone_target_vowel(buffer, vowel_idx).unwrap_or(vowel);
     let Some(toned) = apply_tone_to_vowel(tone_target, tone) else {
         return ignored(buffer);
@@ -87,7 +92,9 @@ pub(crate) fn apply_shape_key(buffer: &str, shape: VowelShape) -> TransformResul
         return ignored(buffer);
     };
 
-    let vowel = buffer.chars().nth(vowel_idx).expect("vowel index in bounds");
+    let Some(vowel) = buffer.chars().nth(vowel_idx) else {
+        return ignored(buffer);
+    };
     let Some(shaped) = apply_shape_to_vowel(vowel, shape) else {
         return ignored(buffer);
     };

--- a/crates/funput-core/src/composition/revert.rs
+++ b/crates/funput-core/src/composition/revert.rs
@@ -12,7 +12,9 @@ use crate::ToneStyle;
 
 pub(crate) fn replace_char_at(buffer: &str, char_idx: usize, new_ch: char) -> String {
     let mut chars: Vec<char> = buffer.chars().collect();
-    chars[char_idx] = new_ch;
+    if let Some(slot) = chars.get_mut(char_idx) {
+        *slot = new_ch;
+    }
     chars.into_iter().collect()
 }
 

--- a/crates/funput-core/src/composition/revert.rs
+++ b/crates/funput-core/src/composition/revert.rs
@@ -5,10 +5,10 @@
 //!
 //! [`apply_action`]: crate::composition::transform::apply_action
 
-use crate::unicode::marks::{tone_on_vowel, vowel_stem, Tone};
-use crate::unicode::shapes::{shape_on_vowel, shaped_vowel_index, strip_shape, VowelShape};
-use crate::unicode::tone_position::tone_vowel_index;
 use crate::ToneStyle;
+use crate::unicode::marks::{Tone, tone_on_vowel, vowel_stem};
+use crate::unicode::shapes::{VowelShape, shape_on_vowel, shaped_vowel_index, strip_shape};
+use crate::unicode::tone_position::tone_vowel_index;
 
 pub(crate) fn replace_char_at(buffer: &str, char_idx: usize, new_ch: char) -> String {
     let mut chars: Vec<char> = buffer.chars().collect();
@@ -72,7 +72,9 @@ fn try_revert_uo_compound(buffer: &str) -> Option<String> {
 
 /// Revert shape when the same shape key is pressed on the shaped vowel.
 pub fn try_revert_shape(buffer: &str, shape: VowelShape) -> Option<String> {
-    if shape == VowelShape::Horn && let Some(text) = try_revert_uo_compound(buffer) {
+    if shape == VowelShape::Horn
+        && let Some(text) = try_revert_uo_compound(buffer)
+    {
         return Some(text);
     }
 
@@ -95,15 +97,30 @@ mod tests {
 
     #[test]
     fn revert_tone() {
-        assert_eq!(try_revert_tone("á", Tone::Sac, ToneStyle::Traditional),Some("a".into()));
-        assert_eq!(try_revert_tone("hòa", Tone::Huyen, ToneStyle::Traditional), Some("hoa".into()));
-        assert_eq!(try_revert_tone("a", Tone::Sac, ToneStyle::Traditional),None);
-        assert_eq!(try_revert_tone("à", Tone::Sac, ToneStyle::Traditional),None);
+        assert_eq!(
+            try_revert_tone("á", Tone::Sac, ToneStyle::Traditional),
+            Some("a".into())
+        );
+        assert_eq!(
+            try_revert_tone("hòa", Tone::Huyen, ToneStyle::Traditional),
+            Some("hoa".into())
+        );
+        assert_eq!(
+            try_revert_tone("a", Tone::Sac, ToneStyle::Traditional),
+            None
+        );
+        assert_eq!(
+            try_revert_tone("à", Tone::Sac, ToneStyle::Traditional),
+            None
+        );
     }
 
     #[test]
     fn revert_shape() {
-        assert_eq!(try_revert_shape("â", VowelShape::Circumflex), Some("a".into()));
+        assert_eq!(
+            try_revert_shape("â", VowelShape::Circumflex),
+            Some("a".into())
+        );
         assert_eq!(try_revert_shape("ă", VowelShape::Breve), Some("a".into()));
         assert_eq!(try_revert_shape("ươ", VowelShape::Horn), Some("uo".into()));
         assert_eq!(try_revert_shape("a", VowelShape::Circumflex), None);
@@ -111,6 +128,9 @@ mod tests {
 
     #[test]
     fn revert_tone_keeps_shape() {
-        assert_eq!(try_revert_tone("ấ", Tone::Sac, ToneStyle::Traditional),Some("â".into()));
+        assert_eq!(
+            try_revert_tone("ấ", Tone::Sac, ToneStyle::Traditional),
+            Some("â".into())
+        );
     }
 }

--- a/crates/funput-core/src/composition/transform.rs
+++ b/crates/funput-core/src/composition/transform.rs
@@ -7,12 +7,12 @@ use crate::composition::apply::{
     ends_with_open_uo_horn, remove_tone, shape_apply_target_exists,
 };
 use crate::composition::revert::{try_revert_shape, try_revert_stroke, try_revert_tone};
+use crate::input_method::KeyAction;
 use crate::input_method::telex;
 use crate::input_method::vni;
-use crate::input_method::KeyAction;
 use crate::unicode::tone_position::reposition_existing_tone;
 use crate::validation::syllable::{
-    is_definitely_invalid, validate_shape, validate_stroke, validate_tone, ModifierValidation,
+    ModifierValidation, is_definitely_invalid, validate_shape, validate_stroke, validate_tone,
 };
 use crate::{ToneStyle, TransformKind, TransformResult};
 
@@ -42,7 +42,11 @@ fn spell_check_gate(
     result
 }
 
-fn validation_gate(buffer: &str, key: char, validation: ModifierValidation) -> Option<TransformResult> {
+fn validation_gate(
+    buffer: &str,
+    key: char,
+    validation: ModifierValidation,
+) -> Option<TransformResult> {
     match validation {
         ModifierValidation::Allow => None,
         ModifierValidation::Ignored => Some(TransformResult {
@@ -63,7 +67,13 @@ pub(crate) fn apply_vni(
     style: ToneStyle,
     spell_check: bool,
 ) -> TransformResult {
-    apply_action(buffer, key, vni::classify_key(buffer, key), style, spell_check)
+    apply_action(
+        buffer,
+        key,
+        vni::classify_key(buffer, key),
+        style,
+        spell_check,
+    )
 }
 
 /// Apply one Telex keystroke to `buffer`.
@@ -179,7 +189,7 @@ pub(crate) fn apply_action(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{apply, InputMethod};
+    use crate::{InputMethod, apply};
 
     /// VNI keystroke with the default (traditional) tone style.
     fn av(buffer: &str, key: char) -> TransformResult {
@@ -243,7 +253,10 @@ mod tests {
     fn spell_check_does_not_block_revert() {
         // Double modifier to revert (`ass` → `as`) is a deliberate restore, not an
         // applied diacritic, so the spell-check gate must leave it alone.
-        assert_eq!(apply_telex("á", 's', ToneStyle::Traditional, true).text, "as");
+        assert_eq!(
+            apply_telex("á", 's', ToneStyle::Traditional, true).text,
+            "as"
+        );
     }
 
     #[test]
@@ -393,10 +406,13 @@ mod tests {
         assert_eq!(av("", '6').kind, TransformKind::Ignored);
         assert_eq!(av("ng", '7').kind, TransformKind::Ignored);
         assert_eq!(av("", '1').kind, TransformKind::Ignored);
-        assert_eq!(av("a", 'b'), TransformResult {
-            kind: TransformKind::Pending,
-            text: "ab".into(),
-        });
+        assert_eq!(
+            av("a", 'b'),
+            TransformResult {
+                kind: TransformKind::Pending,
+                text: "ab".into(),
+            }
+        );
     }
 
     #[test]

--- a/crates/funput-core/src/input_method/telex.rs
+++ b/crates/funput-core/src/input_method/telex.rs
@@ -24,8 +24,8 @@
 
 use crate::composition::apply::uo_pair_in_vowel_cluster;
 use crate::input_method::KeyAction;
-use crate::unicode::marks::{is_vowel, tone_on_vowel, vowel_stem, Tone};
-use crate::unicode::shapes::{shape_on_vowel, shape_target_index, strip_shape, VowelShape};
+use crate::unicode::marks::{Tone, is_vowel, tone_on_vowel, vowel_stem};
+use crate::unicode::shapes::{VowelShape, shape_on_vowel, shape_target_index, strip_shape};
 
 /// Map Telex tone keys to tone marks.
 pub fn tone_from_key(key: char) -> Option<Tone> {
@@ -47,7 +47,9 @@ pub fn classify_key(buffer: &str, key: char) -> KeyAction {
     if let Some(action) = classify_digraph(buffer, key) {
         return action;
     }
-    if key.eq_ignore_ascii_case(&'w') && let Some(action) = classify_w(buffer) {
+    if key.eq_ignore_ascii_case(&'w')
+        && let Some(action) = classify_w(buffer)
+    {
         return action;
     }
     if let Some(action) = classify_revert_circumflex(buffer, key) {
@@ -274,7 +276,10 @@ mod tests {
         assert_eq!(classify_key("u", 'w'), KeyAction::Shape(VowelShape::Horn));
         assert_eq!(classify_key("uo", 'w'), KeyAction::Shape(VowelShape::Horn));
         assert_eq!(classify_key("tru", 'w'), KeyAction::Shape(VowelShape::Horn));
-        assert_eq!(classify_key("nuoc", 'w'), KeyAction::Shape(VowelShape::Horn));
+        assert_eq!(
+            classify_key("nuoc", 'w'),
+            KeyAction::Shape(VowelShape::Horn)
+        );
     }
 
     #[test]
@@ -310,12 +315,18 @@ mod tests {
     fn classify_w_anywhere_in_syllable() {
         // `w` typed after the coda still shapes the nucleus — `lam` + `w` → breve
         // (→ `lăm`), `con` + `w` → horn (→ `cơn`).
-        assert_eq!(classify_key("lam", 'w'), KeyAction::Shape(VowelShape::Breve));
+        assert_eq!(
+            classify_key("lam", 'w'),
+            KeyAction::Shape(VowelShape::Breve)
+        );
         assert_eq!(classify_key("an", 'w'), KeyAction::Shape(VowelShape::Breve));
         assert_eq!(classify_key("con", 'w'), KeyAction::Shape(VowelShape::Horn));
         assert_eq!(classify_key("tun", 'w'), KeyAction::Shape(VowelShape::Horn));
         // `uo` compound after a coda already worked and still does.
-        assert_eq!(classify_key("nuoc", 'w'), KeyAction::Shape(VowelShape::Horn));
+        assert_eq!(
+            classify_key("nuoc", 'w'),
+            KeyAction::Shape(VowelShape::Horn)
+        );
         // No shapeable nucleus → `w` is a literal.
         assert_eq!(classify_key("eng", 'w'), KeyAction::Normal);
         assert_eq!(classify_key("ng", 'w'), KeyAction::Normal);
@@ -344,13 +355,25 @@ mod tests {
         // `mua` + `w` → `mưa`, `ngua` + `w` → `ngưa`.
         assert_eq!(classify_key("nua", 'w'), KeyAction::Shape(VowelShape::Horn));
         assert_eq!(classify_key("mua", 'w'), KeyAction::Shape(VowelShape::Horn));
-        assert_eq!(classify_key("ngua", 'w'), KeyAction::Shape(VowelShape::Horn));
+        assert_eq!(
+            classify_key("ngua", 'w'),
+            KeyAction::Shape(VowelShape::Horn)
+        );
         assert_eq!(classify_key("ua", 'w'), KeyAction::Shape(VowelShape::Horn));
         // `qu` glide: the `u` is part of the onset, so the `a` takes the breve.
-        assert_eq!(classify_key("qua", 'w'), KeyAction::Shape(VowelShape::Breve));
-        assert_eq!(classify_key("Qua", 'w'), KeyAction::Shape(VowelShape::Breve));
+        assert_eq!(
+            classify_key("qua", 'w'),
+            KeyAction::Shape(VowelShape::Breve)
+        );
+        assert_eq!(
+            classify_key("Qua", 'w'),
+            KeyAction::Shape(VowelShape::Breve)
+        );
         // `oa` still breves the `a` (`xoăn`), unaffected by the `ua` rule.
-        assert_eq!(classify_key("hoa", 'w'), KeyAction::Shape(VowelShape::Breve));
+        assert_eq!(
+            classify_key("hoa", 'w'),
+            KeyAction::Shape(VowelShape::Breve)
+        );
         // Toned `u` still classifies as horn (the apply layer keeps the tone → `ứa`).
         assert_eq!(classify_key("úa", 'w'), KeyAction::Shape(VowelShape::Horn));
         // Already-horned `ưa` classifies as horn too — the transform layer sees no
@@ -361,7 +384,10 @@ mod tests {
 
     #[test]
     fn classify_revert_triggers() {
-        assert_eq!(classify_key("â", 'a'), KeyAction::Shape(VowelShape::Circumflex));
+        assert_eq!(
+            classify_key("â", 'a'),
+            KeyAction::Shape(VowelShape::Circumflex)
+        );
         assert_eq!(classify_key("ơ", 'w'), KeyAction::Shape(VowelShape::Horn));
         assert_eq!(classify_key("đ", 'd'), KeyAction::Stroke);
         assert_eq!(classify_key("á", 's'), KeyAction::Tone(Tone::Sac));

--- a/crates/funput-core/src/input_method/vni.rs
+++ b/crates/funput-core/src/input_method/vni.rs
@@ -39,9 +39,12 @@ pub fn classify_key(_buffer: &str, key: char) -> KeyAction {
     match key {
         '0' => KeyAction::RemoveTone,
         '9' => KeyAction::Stroke,
-        '1'..='5' => KeyAction::Tone(tone_from_digit(key).expect("digit 1-5")),
-        '6'..='8' => KeyAction::Shape(shape_from_digit(key).expect("digit 6-8")),
-        _ => KeyAction::Normal,
+        // Drive the digit ranges off the mapping helpers themselves, so the
+        // classification can never disagree with what they actually cover.
+        _ => tone_from_digit(key)
+            .map(KeyAction::Tone)
+            .or_else(|| shape_from_digit(key).map(KeyAction::Shape))
+            .unwrap_or(KeyAction::Normal),
     }
 }
 

--- a/crates/funput-core/src/input_method/vni.rs
+++ b/crates/funput-core/src/input_method/vni.rs
@@ -67,7 +67,10 @@ mod tests {
 
     #[test]
     fn classify_shapes() {
-        assert_eq!(classify_key("", '6'), KeyAction::Shape(VowelShape::Circumflex));
+        assert_eq!(
+            classify_key("", '6'),
+            KeyAction::Shape(VowelShape::Circumflex)
+        );
         assert_eq!(classify_key("", '7'), KeyAction::Shape(VowelShape::Horn));
         assert_eq!(classify_key("", '8'), KeyAction::Shape(VowelShape::Breve));
     }

--- a/crates/funput-core/src/lib.rs
+++ b/crates/funput-core/src/lib.rs
@@ -87,7 +87,12 @@ pub struct TransformResult {
 /// ```
 pub use validation::syllable::{is_complete_syllable, is_definitely_invalid, is_valid};
 
-pub fn apply(buffer: &str, key: char, method: InputMethod, tone_style: ToneStyle) -> TransformResult {
+pub fn apply(
+    buffer: &str,
+    key: char,
+    method: InputMethod,
+    tone_style: ToneStyle,
+) -> TransformResult {
     apply_checked(buffer, key, method, tone_style, false)
 }
 

--- a/crates/funput-core/src/unicode/shapes.rs
+++ b/crates/funput-core/src/unicode/shapes.rs
@@ -88,11 +88,7 @@ pub(crate) fn strip_shape(vowel: char) -> Option<char> {
 }
 
 fn case_pair(base: char, lower: char, upper: char) -> char {
-    if base.is_uppercase() {
-        upper
-    } else {
-        lower
-    }
+    if base.is_uppercase() { upper } else { lower }
 }
 
 struct ShapedVowel {
@@ -135,8 +131,12 @@ const SHAPED_VOWELS: &[ShapedVowel] = &[
 ];
 
 fn shaped_entry(shaped_stem: char) -> Option<&'static ShapedVowel> {
-    let lower = char::to_lowercase(shaped_stem).next().unwrap_or(shaped_stem);
-    SHAPED_VOWELS.iter().find(|entry| entry.shaped_lower == lower)
+    let lower = char::to_lowercase(shaped_stem)
+        .next()
+        .unwrap_or(shaped_stem);
+    SHAPED_VOWELS
+        .iter()
+        .find(|entry| entry.shaped_lower == lower)
 }
 
 #[cfg(test)]

--- a/crates/funput-core/src/unicode/tone_position.rs
+++ b/crates/funput-core/src/unicode/tone_position.rs
@@ -91,7 +91,7 @@ pub fn tone_vowel_index(buffer: &str, style: ToneStyle) -> Option<usize> {
 
     // No shaped vowel: structural rule. A coda exists when a (consonant) char
     // follows the last vowel of the cluster.
-    let last_vowel = *cluster.indices.last().expect("cluster is non-empty");
+    let last_vowel = *cluster.indices.last()?;
     let has_coda = last_vowel + 1 < chars.len();
 
     // "Kiểu mới": an open `oa`/`oe`/`uy` takes the tone on the second vowel.

--- a/crates/funput-core/src/unicode/tone_position.rs
+++ b/crates/funput-core/src/unicode/tone_position.rs
@@ -1,8 +1,8 @@
 //! Tone mark placement — modern Vietnamese reposition rules.
 
-use crate::unicode::marks::{apply_tone_to_vowel, is_vowel, tone_on_vowel, vowel_stem};
-use crate::unicode::shapes::{apply_shape, shape_on_vowel, VowelShape};
 use crate::ToneStyle;
+use crate::unicode::marks::{apply_tone_to_vowel, is_vowel, tone_on_vowel, vowel_stem};
+use crate::unicode::shapes::{VowelShape, apply_shape, shape_on_vowel};
 
 struct VowelCluster {
     indices: Vec<usize>,
@@ -134,10 +134,10 @@ pub fn tone_target_vowel(buffer: &str, vowel_idx: usize) -> Option<char> {
     // `giế`/`giể`/`giếo`) while leaving `viết`/`giết`/`chiếu` untouched. A cheap char
     // test (no allocation, no rhyme-table scan) keeps `apply` on its hot path.
     let promote = match chars.get(vowel_idx + 1).copied() {
-        None => false,                             // open `ie` → keep `e` (`gié`)
-        Some(c) if is_vowel(c) => vowel_stem(c)    // `ieu` promotes, `ieo` does not
+        None => false, // open `ie` → keep `e` (`gié`)
+        Some(c) if is_vowel(c) => vowel_stem(c) // `ieu` promotes, `ieo` does not
             .is_some_and(|s| s.eq_ignore_ascii_case(&'u')),
-        Some(_) => true,                           // coda consonant → `iê`
+        Some(_) => true, // coda consonant → `iê`
     };
     if !promote {
         return Some(vowel);
@@ -153,7 +153,9 @@ pub fn reposition_existing_tone(buffer: &str, style: ToneStyle) -> Option<String
 
     let mut toned_index: Option<(usize, crate::unicode::marks::Tone)> = None;
     for (i, ch) in buffer.chars().enumerate() {
-        if is_vowel(ch) && let Some(tone) = tone_on_vowel(ch) {
+        if is_vowel(ch)
+            && let Some(tone) = tone_on_vowel(ch)
+        {
             toned_index = Some((i, tone));
             break;
         }

--- a/crates/funput-core/src/validation/rhyme.rs
+++ b/crates/funput-core/src/validation/rhyme.rs
@@ -17,26 +17,21 @@ const VALID_RHYMES: &[&str] = &[
     // Open (no coda)
     "a", "e", "ê", "i", "o", "ô", "ơ", "u", "ư", "y", "ia", "ya", "ai", "ao", "au", "ay", "âu",
     "ây", "eo", "êu", "iu", "oa", "oe", "oi", "ôi", "ơi", "ua", "ui", "uê", "uy", "uơ", "ưa", "ưi",
-    "ưu", "oai", "oay", "oeo", "uôi", "uây", "uya", "uyu", "ươi", "ươu", "iêu", "yêu", "oao", "uêu",
-    // -m
+    "ưu", "oai", "oay", "oeo", "uôi", "uây", "uya", "uyu", "ươi", "ươu", "iêu", "yêu", "oao",
+    "uêu", // -m
     "am", "ăm", "âm", "em", "êm", "im", "om", "ôm", "ơm", "um", "iêm", "yêm", "uôm", "ươm", "oam",
-    "oăm", "oem",
-    // -p
+    "oăm", "oem", // -p
     "ap", "ăp", "âp", "ep", "êp", "ip", "op", "ôp", "ơp", "up", "iêp", "ươp", "oap", "uyp",
     // -n
     "an", "ăn", "ân", "en", "ên", "in", "on", "ôn", "ơn", "un", "ưn", "iên", "yên", "uôn", "ươn",
-    "oan", "oăn", "oen", "uân", "uyên", "uyn",
-    // -t
+    "oan", "oăn", "oen", "uân", "uyên", "uyn", // -t
     "at", "ăt", "ât", "et", "êt", "it", "ot", "ôt", "ơt", "ut", "ưt", "iêt", "yêt", "uôt", "ươt",
-    "oat", "oăt", "oet", "uât", "uyêt", "yt", "uyt",
-    // -ng
+    "oat", "oăt", "oet", "uât", "uyêt", "yt", "uyt", // -ng
     "ang", "ăng", "âng", "eng", "ong", "ông", "ung", "ưng", "iêng", "uông", "ương", "oang", "oăng",
-    "uâng", "oong", "êng", "yêng", "ơng",
-    // -c
+    "uâng", "oong", "êng", "yêng", "ơng", // -c
     "ac", "ăc", "âc", "oc", "ôc", "uc", "ưc", "iêc", "uôc", "ươc", "oac", "oăc", "ec", "ooc",
     // -nh
-    "anh", "ênh", "inh", "ynh", "uynh", "uênh", "oanh",
-    // -ch
+    "anh", "ênh", "inh", "ynh", "uynh", "uênh", "oanh", // -ch
     "ach", "êch", "ich", "uêch", "oach", "uych",
 ];
 

--- a/crates/funput-core/src/validation/syllable.rs
+++ b/crates/funput-core/src/validation/syllable.rs
@@ -3,7 +3,7 @@
 //! Decides whether a modifier should apply, be ignored, or pass through as a
 //! literal key (non-Vietnamese structure the engine restores later).
 
-use crate::unicode::marks::{tone_on_vowel, vowel_stem, Tone};
+use crate::unicode::marks::{Tone, tone_on_vowel, vowel_stem};
 use crate::validation::parse::{is_valid_onset, parse_syllable};
 use crate::validation::rhyme::{self, is_valid_rhyme};
 
@@ -66,7 +66,8 @@ fn violates_ckg_spelling(onset: &str, nucleus: &str) -> bool {
 fn validate_modifier(buffer: &str) -> ModifierValidation {
     let parts = parse_syllable(buffer);
 
-    if parts.invalid_onset || (!parts.onset.is_empty() && !is_valid_onset(&parts.onset.to_lowercase()))
+    if parts.invalid_onset
+        || (!parts.onset.is_empty() && !is_valid_onset(&parts.onset.to_lowercase()))
     {
         return ModifierValidation::PassThrough;
     }
@@ -258,7 +259,18 @@ mod tests {
         // Complete Vietnamese syllables. `k` + `y` (kỳ/ký/kỹ) and the triphthong
         // `ngoài` are regression guards for tone-placement / ckg-spelling fixes.
         for ok in [
-            "má", "ma", "tét", "việt", "trường", "quá", "ăn", "nhanh", "kỳ", "ký", "kỹ", "ngoài",
+            "má",
+            "ma",
+            "tét",
+            "việt",
+            "trường",
+            "quá",
+            "ăn",
+            "nhanh",
+            "kỳ",
+            "ký",
+            "kỹ",
+            "ngoài",
         ] {
             assert!(is_complete_syllable(ok), "{ok} should be complete");
         }
@@ -315,7 +327,8 @@ mod tests {
         // Alive: still typing, already valid, OR a stop coda awaiting its tone
         // (`nuoc`/`nươc`/`côt` → user types the tone after the coda).
         for alive in [
-            "tẽ", "te", "ng", "ngh", "cả", "cản", "việt", "má", "trươ", "nuoc", "nươc", "côt", "tét",
+            "tẽ", "te", "ng", "ngh", "cả", "cản", "việt", "má", "trươ", "nuoc", "nươc", "côt",
+            "tét",
         ] {
             assert!(!is_definitely_invalid(alive), "{alive} should stay alive");
         }

--- a/crates/funput-core/tests/spellcheck_corpus.rs
+++ b/crates/funput-core/tests/spellcheck_corpus.rs
@@ -7,18 +7,57 @@
 //! are never rejected (else spell-check would wrongly block a real word); and
 //! (b) **precision** — structurally-plausible non-syllables are rejected.
 
-use funput_core::{apply_checked, is_complete_syllable, InputMethod, ToneStyle, TransformKind};
+use funput_core::{InputMethod, ToneStyle, TransformKind, apply_checked, is_complete_syllable};
 
 /// Real Vietnamese syllables (incl. established loanwords / onomatopoeia). Each MUST
 /// be accepted as a complete syllable — otherwise spell-check would block a real word.
 const MUST_ACCEPT: &[&str] = &[
     // Everyday vocabulary across the rhyme space.
-    "ăn", "uống", "người", "nghiêng", "được", "trường", "khỏe", "thúy", "quỳnh", "khuỷu", "hươu",
-    "rượu", "khuya", "nghệ", "ngoại", "huỳnh", "quặng", "thoăn", "choắt",
+    "ăn",
+    "uống",
+    "người",
+    "nghiêng",
+    "được",
+    "trường",
+    "khỏe",
+    "thúy",
+    "quỳnh",
+    "khuỷu",
+    "hươu",
+    "rượu",
+    "khuya",
+    "nghệ",
+    "ngoại",
+    "huỳnh",
+    "quặng",
+    "thoăn",
+    "choắt",
     // The loanword / onomatopoeia rhymes added in Mức B (each previously blocked).
-    "buýt", "huýt", "suýt", "quýt", "quỵt", "giêng", "giếng", "giềng", "yểng", "tuýp", "tuyn",
-    "luyn", "xoong", "boong", "soóc", "moóc", "oăm", "khoằm", "huých", "uỵch", "khuều", "ngoao",
-    "ngoém", "héc", "véc",
+    "buýt",
+    "huýt",
+    "suýt",
+    "quýt",
+    "quỵt",
+    "giêng",
+    "giếng",
+    "giềng",
+    "yểng",
+    "tuýp",
+    "tuyn",
+    "luyn",
+    "xoong",
+    "boong",
+    "soóc",
+    "moóc",
+    "oăm",
+    "khoằm",
+    "huých",
+    "uỵch",
+    "khuều",
+    "ngoao",
+    "ngoém",
+    "héc",
+    "véc",
 ];
 
 /// Toned forms that are NOT valid Vietnamese but are structurally close enough to
@@ -33,14 +72,20 @@ const MUST_REJECT: &[&str] = &[
 #[test]
 fn corpus_real_syllables_accepted() {
     for &s in MUST_ACCEPT {
-        assert!(is_complete_syllable(s), "real syllable wrongly rejected: {s}");
+        assert!(
+            is_complete_syllable(s),
+            "real syllable wrongly rejected: {s}"
+        );
     }
 }
 
 #[test]
 fn corpus_nonsyllables_rejected() {
     for &s in MUST_REJECT {
-        assert!(!is_complete_syllable(s), "non-syllable wrongly accepted: {s}");
+        assert!(
+            !is_complete_syllable(s),
+            "non-syllable wrongly accepted: {s}"
+        );
     }
 }
 
@@ -90,7 +135,10 @@ fn tay_nguyen_place_names_accepted() {
         "kông",  // k + ô — loanword/toponym (Hồng Kông, Kông Chro)
         "pơng",  // ơng rhyme (Chư Pơng)
     ] {
-        assert!(is_complete_syllable(s), "Tây Nguyên name wrongly rejected: {s}");
+        assert!(
+            is_complete_syllable(s),
+            "Tây Nguyên name wrongly rejected: {s}"
+        );
     }
 }
 
@@ -119,7 +167,10 @@ fn tay_nguyen_out_of_scope_still_rejected() {
 #[test]
 fn final_k_does_not_overaccept_english() {
     for &s in &["book", "look", "rock", "tank"] {
-        assert!(!is_complete_syllable(s), "English word wrongly accepted: {s}");
+        assert!(
+            !is_complete_syllable(s),
+            "English word wrongly accepted: {s}"
+        );
     }
 }
 

--- a/crates/funput-core/tests/support/mod.rs
+++ b/crates/funput-core/tests/support/mod.rs
@@ -2,7 +2,7 @@
 
 #![allow(dead_code)]
 
-use funput_core::{apply, InputMethod, ToneStyle, TransformKind};
+use funput_core::{InputMethod, ToneStyle, TransformKind, apply};
 
 pub fn type_keys(method: InputMethod, keys: &str) -> String {
     let mut buffer = String::new();

--- a/crates/funput-core/tests/telex/basic.rs
+++ b/crates/funput-core/tests/telex/basic.rs
@@ -1,5 +1,4 @@
-
-use funput_core::{apply, InputMethod, ToneStyle, TransformKind, TransformResult};
+use funput_core::{InputMethod, ToneStyle, TransformKind, TransformResult, apply};
 
 fn type_keys(keys: &str) -> String {
     crate::support::type_keys(InputMethod::Telex, keys)

--- a/crates/funput-core/tests/telex/cases.rs
+++ b/crates/funput-core/tests/telex/cases.rs
@@ -85,10 +85,8 @@ pub const CASES: &[TelexCase] = &[
     },
 ];
 
-pub const WORD_CASES: &[TelexWordCase] = &[
-    TelexWordCase {
-        words: "xins chaof banj",
-        output: "xín chào bạn",
-        label: "multi-word greeting",
-    },
-];
+pub const WORD_CASES: &[TelexWordCase] = &[TelexWordCase {
+    words: "xins chaof banj",
+    output: "xín chào bạn",
+    label: "multi-word greeting",
+}];

--- a/crates/funput-core/tests/telex/parity.rs
+++ b/crates/funput-core/tests/telex/parity.rs
@@ -1,4 +1,3 @@
-
 use funput_core::InputMethod;
 
 #[test]

--- a/crates/funput-core/tests/telex/regression.rs
+++ b/crates/funput-core/tests/telex/regression.rs
@@ -1,4 +1,3 @@
-
 use funput_core::InputMethod;
 
 #[test]

--- a/crates/funput-core/tests/vni/basic.rs
+++ b/crates/funput-core/tests/vni/basic.rs
@@ -1,5 +1,4 @@
-
-use funput_core::{apply, InputMethod, ToneStyle, TransformKind};
+use funput_core::{InputMethod, ToneStyle, TransformKind, apply};
 
 #[test]
 fn vni_stroke_d9() {
@@ -29,19 +28,34 @@ fn vni_syllables_with_tone() {
 
 #[test]
 fn vni_longer_syllables() {
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "trung1"), "trúng");
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "trung1"),
+        "trúng"
+    );
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "ban5"), "bạn");
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "nem1"), "ném");
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "dep1"), "dép");
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "sinh1"), "sính");
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "nuoc1"), "nuóc");
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "dung2"), "dùng");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "thanh1"), "thánh");
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "thanh1"),
+        "thánh"
+    );
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "nghe1"), "nghé");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "phong1"), "phóng");
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "phong1"),
+        "phóng"
+    );
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "dong2"), "dòng");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "thang1"), "tháng");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "d9i5nh"), "định");
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "thang1"),
+        "tháng"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "d9i5nh"),
+        "định"
+    );
 }
 
 #[test]
@@ -83,12 +97,27 @@ fn vni_shape_basic() {
 fn vni_shape_syllables() {
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "uo7"), "uơ");
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "uo73"), "uở");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "thuo73"), "thuở");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "thuo7ng2"), "thường");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "quo7i1"), "quới");
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "thuo73"),
+        "thuở"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "thuo7ng2"),
+        "thường"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "quo7i1"),
+        "quới"
+    );
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "u7o7"), "ươ");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "u7o7ng"), "ương");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "tru7o7ng"), "trương");
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "u7o7ng"),
+        "ương"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "tru7o7ng"),
+        "trương"
+    );
 }
 
 #[test]
@@ -98,7 +127,10 @@ fn vni_reposition() {
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "thuy3"), "thủy");
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "khoe3"), "khỏe");
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "hoaf2"), "hoàf");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "tru7o7n2g"), "trường");
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "tru7o7n2g"),
+        "trường"
+    );
     assert_eq!(
         crate::support::type_words(InputMethod::Vni, "xin1 chao2 ban5"),
         "xín chào bạn"
@@ -122,7 +154,10 @@ fn vni_revert() {
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "a12"), "à"); // different key → re-tone
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "hoa22"), "hoa2");
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "uo77"), "uo7");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "tru7o7n2g2"), "trương2");
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "tru7o7n2g2"),
+        "trương2"
+    );
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "phu11"), "phu1");
 
     let (text, kinds) = crate::support::type_keys_with_kinds(InputMethod::Vni, "a11");
@@ -133,21 +168,57 @@ fn vni_revert() {
 #[test]
 fn vni_complex_syllables() {
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "ngu71"), "ngứ");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "truo7ng"), "trương");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "ngu7o7i2"), "người");
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "truo7ng"),
+        "trương"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "ngu7o7i2"),
+        "người"
+    );
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "vie5t"), "việt");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "nghia4"), "nghĩa");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "phuo7ng"), "phương");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "thuo7ng"), "thương");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "tru7o7n2g"), "trường");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "ngu7o7c1"), "ngước");
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "nghia4"),
+        "nghĩa"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "phuo7ng"),
+        "phương"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "thuo7ng"),
+        "thương"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "tru7o7n2g"),
+        "trường"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "ngu7o7c1"),
+        "ngước"
+    );
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "lien4"), "liễn");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "d9i5nh"), "định");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "nghie5ng"), "nghiệng");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "nuoc71"), "nước");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "khuye6n2"), "khuyền");
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "d9i5nh"),
+        "định"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "nghie5ng"),
+        "nghiệng"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "nuoc71"),
+        "nước"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "khuye6n2"),
+        "khuyền"
+    );
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "hoan2"), "hoàn");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "nghie6ng"), "nghiêng");
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "nghie6ng"),
+        "nghiêng"
+    );
 }
 
 #[test]
@@ -169,9 +240,18 @@ fn vni_qu_gi_onset_tone_placement() {
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "gia1"), "giá");
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "gium2"), "giùm");
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "quy1"), "quý");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "quoc61"), "quốc");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "quyen62"), "quyền");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "giuong72"), "giường");
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "quoc61"),
+        "quốc"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "quyen62"),
+        "quyền"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "giuong72"),
+        "giường"
+    );
 
     // `gi` releases its `i` as the nucleus when no other vowel follows.
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "gi2"), "gì");
@@ -187,10 +267,22 @@ fn vni_shaped_vowel_takes_tone() {
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "to6i2"), "tồi");
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "mo7i1"), "mới");
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "nau61"), "nấu");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "muo6n1"), "muốn");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "tuo6i3"), "tuổi");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "nhie6u2"), "nhiều");
-    assert_eq!(crate::support::type_keys(InputMethod::Vni, "xoan82"), "xoằn");
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "muo6n1"),
+        "muốn"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "tuo6i3"),
+        "tuổi"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "nhie6u2"),
+        "nhiều"
+    );
+    assert_eq!(
+        crate::support::type_keys(InputMethod::Vni, "xoan82"),
+        "xoằn"
+    );
 }
 
 #[test]

--- a/crates/funput-core/tests/vni/regression.rs
+++ b/crates/funput-core/tests/vni/regression.rs
@@ -1,4 +1,3 @@
-
 use funput_core::InputMethod;
 
 #[test]


### PR DESCRIPTION
## What & why

Final crate in the post-Android Rust review pass. The review found `funput-core` **panic-free in practice** — the `unwrap`/`expect`s were either test-only or protected by internal invariants that currently hold (indexing/slicing all guarded; Telex transforms are proptest-fuzzed). So the ffi/jni `catch_unwind` guards are genuine defense-in-depth, not masking an active bug.

This PR makes that guarantee robust to **future** edits, plus housekeeping. **No behavior change for any real input.**

## Commits

1. **`refactor`: make invariant panic sites panic-proof by construction.** Convert the 6 fragile sites to graceful handling so a broken invariant degrades to a no-op instead of panicking across the FFI/JNI boundary (which aborts the IME process):
   - `apply.rs`: `stroke_d(...).expect()` and two `chars().nth(idx).expect()` → `let Some(..) else { return ignored(buffer) }`.
   - `tone_position.rs`: `indices.last().expect("non-empty")` → `?` (the fn already returns `Option`).
   - `vni.rs`: `classify_key` now drives the digit ranges off `tone_from_digit` / `shape_from_digit` directly, so classification can never disagree with what the helpers cover — removing the desync-prone `expect`s.
   - `revert.rs`: `replace_char_at` uses `get_mut` instead of an unchecked index.

   Production code now has **zero** `unwrap`/`expect`.

2. **`chore`: pin criterion dev-dep to 0.8.2.**

3. **`chore`: cargo fmt** — normalize the whole crate so `cargo fmt --check` passes (the crate had pre-existing drift).

4. **`docs`: refresh README + add English `README.en.md`.** The API table was missing `apply_checked` (spell-check gate); the Tests section described a `tests/fixtures/*` layout that no longer exists (tests are grouped under `tests/telex/` + `tests/vni/` with a proptest suite and an `include_str!` TSV corpus).

## Verification

- `cargo test --workspace` — all green; core is **124 tests** incl. proptest, same total as before (behavior unchanged)
- `cargo clippy -p funput-core --all-targets -- -D warnings` — clean
- `cargo fmt -p funput-core --check` — clean
- Production `unwrap`/`expect` count in `funput-core/src`: **0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
