### PR TITLE
chore: cargo fmt funput-cli and funput-ffi test/bench

### DIFF
--- a/crates/funput-cli/src/cli.rs
+++ b/crates/funput-cli/src/cli.rs
@@ -12,7 +12,11 @@ use funput_core::InputMethod;
 use crate::sim::Method;
 
 #[derive(Debug, Parser)]
-#[command(name = "funput", version, about = "Funput — Vietnamese input, from the terminal")]
+#[command(
+    name = "funput",
+    version,
+    about = "Funput — Vietnamese input, from the terminal"
+)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Command,

--- a/crates/funput-cli/src/coverage.rs
+++ b/crates/funput-cli/src/coverage.rs
@@ -21,10 +21,28 @@ use crate::sim::{Method, SimConfig, simulate_with};
 /// than silently guessed at runtime.
 const CORPUS_NOISE: &[&str] = &[
     // Two tone marks in one syllable.
-    "chưởì", "cướì", "cưỡì", "dướỉ", "dịệp", "lèõ", "lưỡì", "lưỡí", "lưỡỉ", "lạị",
-    "ngườì", "ngườí", "ngồí", "phổí",
+    "chưởì",
+    "cướì",
+    "cưỡì",
+    "dướỉ",
+    "dịệp",
+    "lèõ",
+    "lưỡì",
+    "lưỡí",
+    "lưỡỉ",
+    "lạị",
+    "ngườì",
+    "ngườí",
+    "ngồí",
+    "phổí",
     // Tone on the wrong vowel (engine produces the correctly-placed spelling).
-    "ngươí", "ngóeo", "quoắt", "rià", "sóoc", "tơì", "tươì",
+    "ngươí",
+    "ngóeo",
+    "quoắt",
+    "rià",
+    "sóoc",
+    "tơì",
+    "tươì",
 ];
 
 /// A token is a testable Vietnamese syllable when (a) it is not a known-malformed

--- a/crates/funput-cli/src/encode.rs
+++ b/crates/funput-cli/src/encode.rs
@@ -131,7 +131,7 @@ fn tone_key(method: Method, tone: Tone) -> char {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sim::{simulate_with, SimConfig};
+    use crate::sim::{SimConfig, simulate_with};
     use funput_core::ToneStyle;
 
     /// The meaningful property: encoding a word and typing it back reproduces it.
@@ -150,8 +150,8 @@ mod tests {
     // Words chosen to be tone-style-invariant (no oa/oe/uy glide) so both Telex and
     // VNI round-trip exactly under the traditional style.
     const WORDS: &[&str] = &[
-        "đầu", "việt", "nước", "Đắk", "nam", "tiếng", "người", "được", "rượu", "nghiêng",
-        "Ô", "khuỷu",
+        "đầu", "việt", "nước", "Đắk", "nam", "tiếng", "người", "được", "rượu", "nghiêng", "Ô",
+        "khuỷu",
         // `oo` loanwords: the double-o escapes the Telex `oo`→`ô` digraph.
         "boong", "xoong", "soóc", "moóc", "voọc", "coong",
     ];

--- a/crates/funput-cli/src/render.rs
+++ b/crates/funput-cli/src/render.rs
@@ -58,7 +58,7 @@ fn show_str(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sim::{simulate, Method};
+    use crate::sim::{Method, simulate};
 
     #[test]
     fn table_has_header_rows_and_summary() {

--- a/crates/funput-cli/src/repl.rs
+++ b/crates/funput-cli/src/repl.rs
@@ -6,7 +6,7 @@
 use std::io::{self, BufRead, Write};
 
 use crate::render::steps_table;
-use crate::sim::{simulate, Method};
+use crate::sim::{Method, simulate};
 
 pub fn run(method: Method, steps: bool) {
     let name = match method {

--- a/crates/funput-ffi/benches/latency.rs
+++ b/crates/funput-ffi/benches/latency.rs
@@ -16,10 +16,10 @@
 
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use funput_ffi::{
-    funput_buffer, funput_clear, funput_engine_free, funput_engine_new, funput_process_char,
-    funput_set_method, CHARS_CAP, FunputEngine,
+    CHARS_CAP, FunputEngine, funput_buffer, funput_clear, funput_engine_free, funput_engine_new,
+    funput_process_char, funput_set_method,
 };
 
 const TELEX: &str =

--- a/crates/funput-ffi/tests/round_trip.rs
+++ b/crates/funput-ffi/tests/round_trip.rs
@@ -1,9 +1,9 @@
 //! Round-trip tests: drive the `extern "C"` API exactly like a C caller would.
 
 use funput_ffi::{
-    funput_add_shortcut, funput_backspace, funput_buffer, funput_clear, funput_clear_shortcuts,
-    funput_engine_free, funput_engine_new, funput_process_char, funput_set_method, FunputResult,
-    ACTION_NONE, ACTION_SEND,
+    ACTION_NONE, ACTION_SEND, FunputResult, funput_add_shortcut, funput_backspace, funput_buffer,
+    funput_clear, funput_clear_shortcuts, funput_engine_free, funput_engine_new,
+    funput_process_char, funput_set_method,
 };
 
 fn output(result: &FunputResult) -> String {
@@ -142,7 +142,10 @@ fn buffer_reflects_marked_text() {
 fn buffer_null_safe() {
     let mut out = [0u32; 8];
     unsafe {
-        assert_eq!(funput_buffer(std::ptr::null(), out.as_mut_ptr(), out.len()), 0);
+        assert_eq!(
+            funput_buffer(std::ptr::null(), out.as_mut_ptr(), out.len()),
+            0
+        );
         let engine = funput_engine_new();
         assert_eq!(funput_buffer(engine, std::ptr::null_mut(), 8), 0);
         funput_engine_free(engine);
@@ -218,7 +221,13 @@ fn shortcut_null_safe() {
         // Null handle: must not crash.
         funput_clear_shortcuts(std::ptr::null_mut());
         let t = [b'v' as u32, b'n' as u32];
-        funput_add_shortcut(std::ptr::null_mut(), t.as_ptr(), t.len(), t.as_ptr(), t.len());
+        funput_add_shortcut(
+            std::ptr::null_mut(),
+            t.as_ptr(),
+            t.len(),
+            t.as_ptr(),
+            t.len(),
+        );
 
         // Null string pointers are treated as empty (empty trigger is ignored).
         let engine = funput_engine_new();


### PR DESCRIPTION
## What & why

`cargo fmt --all --check` did not pass on the workspace due to pre-existing rustfmt drift. Most of it is already fixed by the in-flight review PRs (#38 funput-ffi src, #39 funput-engine, #40 funput-core). This PR closes the remaining gap — the files **no open PR touches**:

- `funput-cli/src/{cli,encode,render,repl,coverage}.rs`
- `funput-ffi/tests/round_trip.rs`, `funput-ffi/benches/latency.rs`

## Coordination

Scope is deliberately limited to those files so it **merges cleanly in any order** relative to #38/#39/#40 (no overlap). Once this plus the three review PRs land, `cargo fmt --all --check` is clean across the workspace.

Verified: on this branch, the only remaining `cargo fmt --all --check` drift is inside `funput-core` and `funput-engine` — exactly what #40 and #39 fix.

## Verification

- `rustfmt --check` on all touched files — clean
- `cargo test -p funput-cli` — green (formatting only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
