### PR TITLE
fix(linux): clear preedit before commit — Chromium/Electron duplication + focus-out loss

### DIFF
--- a/platforms/linux/fcitx5/src/funput_engine.cpp
+++ b/platforms/linux/fcitx5/src/funput_engine.cpp
@@ -139,9 +139,15 @@ void FunputEngine::clearPreedit(fcitx::InputContext *ic) {
 
 void FunputEngine::commitBuffer(fcitx::InputContext *ic) {
     const std::string s = handle_.buffer();
-    if (!s.empty()) ic->commitString(s);
     handle_.clear();
+    // Clear the preedit *before* committing. With client-side (on-the-spot)
+    // preedit, Chromium/Electron apps (VS Code, Cursor) otherwise finalize the
+    // still-active composing region *and* apply our commit — duplicating the word
+    // when the commit is followed by Enter, or dropping both when the commit races
+    // a focus change (the word is lost on focus-out). Resetting the composing
+    // region first turns the commit into a plain, atomic insertion.
     clearPreedit(ic);
+    if (!s.empty()) ic->commitString(s);
 }
 
 // Boundary key (space / punctuation) while composing. The engine decides
@@ -170,9 +176,9 @@ bool FunputEngine::handleBoundary(fcitx::InputContext *ic, char32_t scalar) {
 
     std::string boundary;
     funput::appendUtf8(boundary, static_cast<uint32_t>(scalar));
-    ic->commitString(word + boundary);
     handle_.clear();
-    clearPreedit(ic);
+    clearPreedit(ic); // reset the composing region before commit (see commitBuffer)
+    ic->commitString(word + boundary);
     return true;
 }
 

--- a/platforms/linux/ibus/src/engine.cpp
+++ b/platforms/linux/ibus/src/engine.cpp
@@ -80,11 +80,16 @@ void updatePreedit(IBusEngine *engine, EngineState *st) {
 // Commit buffer() and end composition.
 void commitBuffer(IBusEngine *engine, EngineState *st) {
     const std::string s = st->handle_.buffer();
+    st->handle_.clear();
+    // Hide the preedit *before* committing. With client-side (on-the-spot) preedit,
+    // Chromium/Electron apps (VS Code, Cursor) otherwise finalize the still-active
+    // composing region *and* apply our commit — duplicating the word when followed
+    // by Enter, or dropping both when the commit races a focus change (word lost on
+    // focus-out). Hiding it first turns the commit into a plain, atomic insertion.
+    clearPreedit(engine);
     if (!s.empty()) {
         ibus_engine_commit_text(engine, ibus_text_new_from_string(s.c_str()));
     }
-    st->handle_.clear();
-    clearPreedit(engine);
 }
 
 // Boundary key (space / punctuation) while composing. The engine decides
@@ -114,9 +119,9 @@ bool handleBoundary(IBusEngine *engine, EngineState *st, char32_t scalar) {
     std::string boundary;
     funput::appendUtf8(boundary, static_cast<uint32_t>(scalar));
     const std::string full = word + boundary;
-    ibus_engine_commit_text(engine, ibus_text_new_from_string(full.c_str()));
     st->handle_.clear();
-    clearPreedit(engine);
+    clearPreedit(engine); // hide the composing region before commit (see commitBuffer)
+    ibus_engine_commit_text(engine, ibus_text_new_from_string(full.c_str()));
     return true;
 }
 


### PR DESCRIPTION
## Symptoms (Fcitx5)

1. **Focus-out loses the word** — while a word is composing (underlined), clicking away commits
   nothing; the word is lost.
2. **Enter duplicates the word in Cursor/VS Code** — composing a word then pressing Enter leaves one
   copy on the original line and another on the new line.

## Root cause

Both the Fcitx5 and IBus shells committed the composing buffer **before** clearing the preedit
(`commitString`/`commit_text`, then `clearPreedit`). With **client-side (on-the-spot) preedit**,
Chromium/Electron apps handle a commit while the composing region is still active by:

- finalizing the still-active composing region **and** applying our commit → **duplicate** (most
  visible on Enter); or
- discarding the composing region and dropping the commit when it races a focus change → **word lost
  on focus-out**.

macOS doesn't hit this because IMKit's `insertText` replaces the marked text atomically.

## Fix

Reset/hide the preedit **before** committing at every commit-while-composing site — `commitBuffer`
and `handleBoundary` — in **both** shells (`platforms/linux/fcitx5/src/funput_engine.cpp`,
`platforms/linux/ibus/src/engine.cpp`). The commit then lands as a plain, atomic insertion with no
active composition for the app to double-apply or drop.

IBus had the same latent bug and is fixed symmetrically.

## ⚠️ Not verified on a live session

Developed on macOS — I could not build or run Fcitx5/IBus locally. **Please test on Linux before
merging.**

### Test plan

1. Rebuild the Fcitx5 addon and restart (`fcitx5 -r`).
2. **Bug 2**: in Cursor/VS Code, type Telex `tieengs` → `tiếng` (underlined), press **Enter** →
   expect a single `tiếng` then a newline (no duplicate).
3. **Bug 1**: type a word so it's underlined (no space/Enter), then click another window/field →
   expect the word to be **committed** (kept), not lost.
4. **No regression**: normal typing, space/punctuation boundaries, and Backspace still work; also try
   a non-Electron app (gedit/Firefox).
5. Optionally repeat for the IBus build.

Confidence: bug 2 (Enter duplicate) is the classic Chromium/on-the-spot commit issue and this is the
standard fix — high. Bug 1 (focus-out) should also be resolved (the commit becomes a plain
insertion), but if it persists the next step is to confirm Fcitx5 actually fires `deactivate`/`reset`
on that focus-out path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
