### PR TITLE
feat: pass word-start digits through (numeric fields / OTP / phone numbers)

### DIFF
--- a/crates/funput-engine/src/lib.rs
+++ b/crates/funput-engine/src/lib.rs
@@ -203,6 +203,8 @@ impl Engine {
     /// - **Word boundary** (whitespace / ASCII punctuation): optionally restore Latin
     ///   via [`Action::Send`] when `keys != buffer` and buffer is not a complete
     ///   Vietnamese syllable; then clear session. Otherwise pass the boundary key.
+    /// - **Word-start digit** (a digit with an empty buffer): [`Action::None`], passed
+    ///   through untouched — a number, never a Vietnamese syllable.
     /// - **Normal key:** append to `keys`, call `funput-core`, map
     ///   `TransformKind` → `ImeResult` (see the README).
     pub fn process_char(&mut self, key: char) -> ImeResult {
@@ -213,6 +215,13 @@ impl Engine {
             return boundary::on_word_boundary(&mut self.session, key);
         }
         let key = self.maybe_capitalize(key);
+        // A digit at the start of a word is a number, never the start of a Vietnamese
+        // syllable — and a VNI tone/shape digit needs a vowel before it. Pass it
+        // straight through without opening a composition (numeric fields, OTP codes,
+        // phone numbers), keeping `buffer` and `keys` clean for the next real word.
+        if self.session.buffer.is_empty() && key.is_ascii_digit() {
+            return ImeResult::none();
+        }
         self.session.keys.push(key);
         pipeline::process(&mut self.session, key)
     }

--- a/crates/funput-engine/tests/engine_api.rs
+++ b/crates/funput-engine/tests/engine_api.rs
@@ -346,3 +346,55 @@ fn flip_choice_resets_after_the_word_commits() {
     type_word(&mut engine, "card"); // a new word
     assert_eq!(engine.buffer(), "card"); // eager-restored again, override gone
 }
+
+// --- Word-start digits (numeric fields / OTP codes / phone numbers) ----------
+
+/// A digit typed with an empty buffer is a number, not the start of a Vietnamese
+/// syllable, so the engine passes it through untouched in either method.
+#[test]
+fn word_start_digit_passes_through() {
+    for method in [InputMethod::Telex, InputMethod::Vni] {
+        let mut engine = Engine::new();
+        engine.set_method(method);
+        let result = engine.process_char('1');
+        assert_eq!(result.action, Action::None, "{method:?}");
+        assert_eq!(engine.buffer(), "", "{method:?}: a leading digit must not compose");
+    }
+}
+
+/// A whole number never opens a composition — including in VNI, where digits are the
+/// tone/shape keys (they only modify a preceding vowel, which a bare number lacks).
+#[test]
+fn full_number_never_composes() {
+    for method in [InputMethod::Telex, InputMethod::Vni] {
+        let mut engine = Engine::new();
+        engine.set_method(method);
+        for key in "0912345678".chars() {
+            assert_eq!(engine.process_char(key).action, Action::None, "{method:?}");
+        }
+        assert_eq!(engine.buffer(), "", "{method:?}");
+    }
+}
+
+/// The rule is word-start only: a VNI tone digit *after* a vowel still applies.
+#[test]
+fn digit_after_vowel_still_modifies_in_vni() {
+    let mut engine = Engine::new();
+    engine.set_method(InputMethod::Vni);
+    engine.process_char('a');
+    let result = engine.process_char('1'); // á
+    assert_eq!(result.action, Action::Send);
+    assert_eq!(engine.buffer(), "á");
+}
+
+/// A real word typed right after a leading number composes normally.
+#[test]
+fn word_after_leading_digit_still_composes() {
+    let mut engine = Engine::new(); // Telex by default
+    engine.process_char('3'); // passthrough — buffer stays empty
+    assert_eq!(engine.buffer(), "");
+    for key in "meof".chars() {
+        engine.process_char(key);
+    }
+    assert_eq!(engine.buffer(), "mèo");
+}

--- a/platforms/linux/fcitx5/src/funput_engine.cpp
+++ b/platforms/linux/fcitx5/src/funput_engine.cpp
@@ -273,6 +273,10 @@ void FunputEngine::keyEvent(const fcitx::InputMethodEntry &, fcitx::KeyEvent &ke
 
     // Compose: feed the scalar and show the updated buffer as underlined preedit.
     handle_.process(static_cast<uint32_t>(scalar));
+    // Nothing composing → the engine passed the key through (e.g. a digit starting a
+    // word: a number, not Vietnamese). Let the app insert it instead of swallowing it
+    // as (empty) preedit.
+    if (handle_.buffer().empty()) return;
     updatePreedit(ic);
     keyEvent.filterAndAccept();
 }

--- a/platforms/linux/ibus/src/engine.cpp
+++ b/platforms/linux/ibus/src/engine.cpp
@@ -227,6 +227,9 @@ static gboolean ibus_funput_engine_process_key_event(IBusEngine *engine, guint k
 
     // Compose: feed the scalar and show the updated buffer as preedit.
     st->handle_.process(static_cast<uint32_t>(scalar));
+    // Nothing composing → the engine passed the key through (e.g. a digit starting a
+    // word: a number, not Vietnamese). Let the app insert it instead of swallowing it.
+    if (st->handle_.buffer().empty()) return FALSE;
     updatePreedit(engine, st);
     return TRUE;
 }

--- a/platforms/macos/Funput/IME/FunputInputController.swift
+++ b/platforms/macos/Funput/IME/FunputInputController.swift
@@ -87,6 +87,11 @@ final class FunputInputController: IMKInputController {
         }
 
         composer.process(scalar)
+        // Nothing composing after this key → the engine passed it through (e.g. a
+        // digit starting a word: a number, not Vietnamese). Let the app insert it.
+        if composer.buffer().isEmpty {
+            return false
+        }
         setMarked(composer.buffer(), client)
         return true
     }

--- a/platforms/windows/src/compose.rs
+++ b/platforms/windows/src/compose.rs
@@ -54,6 +54,12 @@ impl FieldComposer {
             self.engine.clear();
         } else {
             self.engine.process_char(c);
+            if self.engine.buffer().is_empty() {
+                // The engine passed the key through (e.g. a digit starting a word — a
+                // number, not Vietnamese). It won't show up in the buffer, so fold it
+                // into the committed text directly.
+                self.committed.push(c);
+            }
         }
         self.current()
     }


### PR DESCRIPTION
## What

A digit typed at the **start of a word** is a number, never the start of a Vietnamese syllable — and
a VNI tone/shape digit (`1`–`9`) only modifies a *preceding* vowel, which a bare number lacks. So
typing into **numeric fields, OTP codes, and phone numbers** no longer opens a pointless composition
(an underlined preedit that could even be lost on a focus change).

## How

- **Engine (single source)** — `Engine::process_char`: a digit with an empty buffer returns
  `Action::None` and is not buffered.
- **Inject-model shells (Windows, funput-term) + CLI**: already treat `Action::None` as passthrough →
  they get this for free.
- **Preedit-model shells (macOS, fcitx5, ibus)**: these render `buffer()` and consume the key, so each
  gets a one-line guard — *if nothing is composing after the keystroke, forward the raw key to the app*
  instead of swallowing it as empty preedit. Required in all three: without it, the shared engine
  change would make them drop word-start digits.

Mid-word digits are unchanged: VNI `a1` still composes `á`; a digit after a non-empty buffer is still
literal (`toi3` → `toi3`).

## Verification

Engine logic is covered by tests and the CLI (runs on any platform):

- `cargo test -p funput-engine` — 4 new tests (Telex/VNI passthrough, whole number, VNI `a1`→`á`, a
  word after a leading digit); full workspace green; clippy `-D warnings` clean.
- `funput dev run "0912345678"` → `0912345678`; `dev run -m vni "a1"` → `á`;
  `dev run -m telex "xins chaof"` → `xín chào`; `dev run -m telex "toi3"` → `toi3`.

⚠️ The macOS/fcitx5/ibus **shell wiring** (3–5 lines each) needs a build on each platform to confirm
end-to-end. Independent of #44 (this touches the `keyEvent`/`process_char` compose tail, not
`commitBuffer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
