### PR TITLE
perf(core): precompute deshaped rhyme inventory (~2.9× faster process_char)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -63,8 +63,8 @@ release build:
 | Component / API | Measured scope | Telex | VNI |
 |---|---|---:|---:|
 | [`funput-core::apply`](crates/funput-core) | Telex/VNI transformation core | 0.230 µs/key | 0.204 µs/key |
-| [`funput-engine::Engine::process_char`](crates/funput-engine) | Full pipeline (boundaries + English restore) | 1.50 µs/key | 1.53 µs/key |
-| [`funput-ffi::{funput_process_char, funput_buffer}`](crates/funput-ffi) | Engine through the C ABI + composed-buffer reads | 1.54 µs/key | 1.53 µs/key |
+| [`funput-engine::Engine::process_char`](crates/funput-engine) | Full pipeline (boundaries + English restore) | 0.52 µs/key | 0.49 µs/key |
+| [`funput-ffi::{funput_process_char, funput_buffer}`](crates/funput-ffi) | Engine through the C ABI + composed-buffer reads | 0.55 µs/key | 0.51 µs/key |
 
 > Measured from a release build on an Apple M-series machine; covers Funput's own
 > processing only (excludes OS keyboard-event delivery and host-app rendering).

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Lõi xử lý viết bằng Rust. Chi phí mỗi phím, đo bằng Criterion tr�
 | Thành phần / API | Phạm vi đo | Telex | VNI |
 |---|---|---:|---:|
 | [`funput-core::apply`](crates/funput-core) | Lõi biến đổi Telex/VNI | 0,230 µs/phím | 0,204 µs/phím |
-| [`funput-engine::Engine::process_char`](crates/funput-engine) | Pipeline đầy đủ (boundary + English restore) | 1,50 µs/phím | 1,53 µs/phím |
-| [`funput-ffi::{funput_process_char, funput_buffer}`](crates/funput-ffi) | Engine qua C ABI + đọc composed buffer | 1,54 µs/phím | 1,53 µs/phím |
+| [`funput-engine::Engine::process_char`](crates/funput-engine) | Pipeline đầy đủ (boundary + English restore) | 0,52 µs/phím | 0,49 µs/phím |
+| [`funput-ffi::{funput_process_char, funput_buffer}`](crates/funput-ffi) | Engine qua C ABI + đọc composed buffer | 0,55 µs/phím | 0,51 µs/phím |
 
 > Đo trên release build, máy Apple M-series; chỉ gồm phần xử lý của Funput (không
 > tính OS chuyển sự kiện bàn phím hay app đích render). Số phụ thuộc phần cứng —

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -28,8 +28,8 @@ their corresponding directories in `target/criterion/`.
 |---|---|
 | Compose latency (core `apply`) | **~0.23 µs / keystroke** (Telex), ~0.22 µs (VNI) |
 | Compose throughput | **> 4 million keystrokes / second** |
-| Full engine path (`process_char`, incl. boundary + English-restore) | ~1.5 µs / keystroke |
-| **End-to-end across the C FFI** (`process_char` + read composed text back) | **~1.5 µs / keystroke** |
+| Full engine path (`process_char`, incl. boundary + English-restore) | **~0.5 µs / keystroke** (~1.9 M/s) |
+| **End-to-end across the C FFI** (`process_char` + read composed text back) | **~0.5 µs / keystroke** |
 | `size_of::<Engine>` (per-field session state) | **112 bytes** |
 | Release FFI shared lib (`libfunput_ffi.dylib`) | ~0.46 MB |
 
@@ -44,7 +44,7 @@ The `latency` bench drives the **real C ABI a platform shell uses** for every ke
 `funput_buffer` (copies the composed text back out to render the marked text). This
 is the layer the pure-core bench skips.
 
-Key finding: it lands at **~1.5 µs/keystroke — essentially identical to the engine
+Key finding: it lands at **~0.5 µs/keystroke — essentially identical to the engine
 alone**, so the FFI boundary (handle indirection + by-value result + UTF-32 copy)
 adds negligible cost.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -26,11 +26,11 @@ their corresponding directories in `target/criterion/`.
 
 | Metric | Result |
 |---|---|
-| Compose latency (core `apply`) | **~0.23 µs / keystroke** (Telex), ~0.22 µs (VNI) |
+| Compose latency (core `apply`) | **~0.23 µs / keystroke** (Telex), ~0.20 µs (VNI) |
 | Compose throughput | **> 4 million keystrokes / second** |
-| Full engine path (`process_char`, incl. boundary + English-restore) | **~0.5 µs / keystroke** (~1.9 M/s) |
-| **End-to-end across the C FFI** (`process_char` + read composed text back) | **~0.5 µs / keystroke** |
-| `size_of::<Engine>` (per-field session state) | **112 bytes** |
+| Full engine path (`process_char`, incl. boundary + English-restore) | **~0.52 µs / keystroke** (~1.9 M/s) |
+| **End-to-end across the C FFI** (`process_char` + read composed text back) | **~0.55 µs / keystroke** |
+| `size_of::<Engine>` (per-field session state) | **136 bytes** |
 | Release FFI shared lib (`libfunput_ffi.dylib`) | ~0.46 MB |
 
 A human types a few keys per second; Funput answers each in **sub-microsecond**
@@ -44,7 +44,7 @@ The `latency` bench drives the **real C ABI a platform shell uses** for every ke
 `funput_buffer` (copies the composed text back out to render the marked text). This
 is the layer the pure-core bench skips.
 
-Key finding: it lands at **~0.5 µs/keystroke — essentially identical to the engine
+Key finding: it lands at **~0.55 µs/keystroke — essentially identical to the engine
 alone**, so the FFI boundary (handle indirection + by-value result + UTF-32 copy)
 adds negligible cost.
 

--- a/crates/funput-core/src/validation/syllable.rs
+++ b/crates/funput-core/src/validation/syllable.rs
@@ -3,6 +3,8 @@
 //! Decides whether a modifier should apply, be ignored, or pass through as a
 //! literal key (non-Vietnamese structure the engine restores later).
 
+use std::sync::LazyLock;
+
 use crate::unicode::marks::{Tone, tone_on_vowel, vowel_stem};
 use crate::validation::parse::{is_valid_onset, parse_syllable};
 use crate::validation::rhyme::{self, is_valid_rhyme};
@@ -188,6 +190,12 @@ fn deshape(s: &str) -> String {
     s.chars().map(plain_base).collect()
 }
 
+/// The rhyme inventory with tone/shape stripped, built once. Lets
+/// [`is_definitely_invalid`] test reachability without re-`deshape`-ing all ~166
+/// rhymes (a `String` allocation each) on every keystroke.
+static DESHAPED_RHYMES: LazyLock<Vec<String>> =
+    LazyLock::new(|| rhyme::all().iter().map(|r| deshape(r)).collect());
+
 /// True when `buffer` can **no longer** become a valid Vietnamese syllable by
 /// typing more — used for *eager* English restore (flip back to the raw
 /// keystrokes the instant a word is unrecoverable, without waiting for a boundary):
@@ -207,9 +215,9 @@ pub fn is_definitely_invalid(buffer: &str) -> bool {
 
     let coda = normalize_ethnic_coda(&parts.coda);
     let rhyme_query = format!("{}{}", deshape(&parts.nucleus), deshape(coda));
-    let reachable = rhyme::all()
+    let reachable = DESHAPED_RHYMES
         .iter()
-        .any(|r| deshape(r).starts_with(&rhyme_query));
+        .any(|r| r.starts_with(&rhyme_query));
     if !reachable {
         return true;
     }

--- a/crates/funput-engine/examples/profile.rs
+++ b/crates/funput-engine/examples/profile.rs
@@ -1,0 +1,141 @@
+//! One-off profiling harness for the keystroke pipeline: counts heap allocations
+//! per keystroke and times `process_char` against its sub-parts, to see where the
+//! ~1.5 µs goes before optimizing. Not a test/bench — run it directly:
+//!
+//!   cargo run --release --example profile -p funput-engine
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+use std::time::Instant;
+
+use funput_core::{InputMethod, ToneStyle, apply_checked, is_definitely_invalid};
+use funput_engine::Engine;
+
+// --- counting global allocator (alloc + realloc count as heap ops) ----------
+struct Counting;
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Relaxed);
+        unsafe { System.alloc(l) }
+    }
+    unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
+        unsafe { System.dealloc(p, l) }
+    }
+    unsafe fn realloc(&self, p: *mut u8, l: Layout, n: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Relaxed);
+        unsafe { System.realloc(p, l, n) }
+    }
+}
+#[global_allocator]
+static GLOBAL: Counting = Counting;
+
+const TELEX: &str =
+    "Tooi yeeu tieesng Vieejt. Hoom nay troiwf nuwowcs ddepj. Ban cos khoeer khoong?";
+
+fn allocs() -> usize {
+    ALLOCS.load(Relaxed)
+}
+fn is_boundary(k: char) -> bool {
+    k == ' ' || k.is_ascii_punctuation()
+}
+
+/// Median-of-a-few wall-clock timing (ns) for one call to `f`.
+fn time(reps: usize, mut f: impl FnMut()) -> f64 {
+    for _ in 0..reps / 10 {
+        f();
+    } // warm up
+    let t = Instant::now();
+    for _ in 0..reps {
+        f();
+    }
+    t.elapsed().as_nanos() as f64 / reps as f64
+}
+
+fn main() {
+    let keys: Vec<char> = TELEX.chars().collect();
+    let n = keys.len();
+    let letters = keys.iter().filter(|k| !is_boundary(**k)).count();
+    let reps = 4000usize;
+
+    // --- allocations: process_char allocs = (construct + type) − construct ---
+    let b = allocs();
+    for _ in 0..reps {
+        let mut e = Engine::new();
+        e.set_method(InputMethod::Telex);
+        black_box(&e);
+    }
+    let ctor = allocs() - b;
+
+    let b = allocs();
+    for _ in 0..reps {
+        let mut e = Engine::new();
+        e.set_method(InputMethod::Telex);
+        for &k in &keys {
+            black_box(e.process_char(black_box(k)));
+        }
+    }
+    let proc = (allocs() - b) - ctor;
+
+    println!("=== allocations (heap ops) ===");
+    println!("Engine::new()+set_method : {:.2} / engine", ctor as f64 / reps as f64);
+    println!(
+        "process_char             : {:.3} allocs/key   ({} keys, {} composing)",
+        proc as f64 / (reps * n) as f64,
+        n,
+        letters
+    );
+
+    // --- timing (ns / keystroke) --------------------------------------------
+    let t = 30_000usize;
+
+    let paragraph_ns = time(t, || {
+        let mut e = Engine::new();
+        e.set_method(InputMethod::Telex);
+        for &k in &keys {
+            black_box(e.process_char(black_box(k)));
+        }
+    }) / n as f64;
+
+    let compose_ns = time(t, || {
+        let mut e = Engine::new();
+        e.set_method(InputMethod::Telex);
+        for &k in &keys {
+            if is_boundary(k) {
+                e.clear();
+            } else {
+                black_box(e.process_char(black_box(k)));
+            }
+        }
+    }) / letters as f64;
+
+    let apply_ns = time(t, || {
+        let mut buf = String::new();
+        for &k in &keys {
+            if is_boundary(k) {
+                buf.clear();
+            } else {
+                buf = apply_checked(&buf, k, InputMethod::Telex, ToneStyle::Traditional, false).text;
+            }
+        }
+        black_box(&buf);
+    }) / letters as f64;
+
+    let composed = ["tôi", "yêu", "tiếng", "việt", "đẹp", "nước", "trời", "không"];
+    let invalid_ns = time(t, || {
+        for b in composed {
+            black_box(is_definitely_invalid(black_box(b)));
+        }
+    }) / composed.len() as f64;
+
+    println!("\n=== timing (ns / keystroke) ===");
+    println!("core apply_checked         : {apply_ns:6.1}  (per composing key)");
+    println!("is_definitely_invalid      : {invalid_ns:6.1}  (per call; pipeline runs it 1×/key)");
+    println!("process_char, compose only : {compose_ns:6.1}  (full pipeline, boundaries excluded)");
+    println!("process_char, paragraph    : {paragraph_ns:6.1}  (avg incl. boundary keys)");
+    println!(
+        "\npipeline overhead / compose key = {:.1} ns  (compose_only − apply_checked)",
+        compose_ns - apply_ns
+    );
+}


### PR DESCRIPTION
## What

`is_definitely_invalid` — the eager English-restore check the engine runs on most keystrokes —
re-`deshape`d **all ~166 rhymes** (a `String` allocation each) on **every call**. Since deshaping is
pure, build the deshaped inventory **once** (`LazyLock<Vec<String>>`) and compare against it.

One line of real change; behavior is identical (deshape is deterministic → precomputed == per-call).

## Why (profiled first)

A profiling harness (added as `crates/funput-engine/examples/profile.rs` — a counting allocator +
sub-part timings) pointed at the real bottleneck, which was **not** the per-key `String` clones I first
suspected, but this whole-inventory re-deshape:

| | before | after |
|---|---:|---:|
| `is_definitely_invalid` | ~4730 ns/call | **~524 ns** |
| heap allocations | ~32 /key | **~13 /key** |
| `process_char` (Telex / VNI) | 1.50 / 1.53 µs | **0.52 / 0.49 µs** |
| end-to-end via C FFI (Telex / VNI) | 1.54 / 1.53 µs | **0.55 / 0.51 µs** |

Criterion confirms **−65 % time / +188 % throughput** on the engine path (≈ 0.67 → 1.9 M keystrokes/s).

## Verification

- `cargo test -p funput-core -p funput-engine` — all green (behavior unchanged).
- `cargo clippy … --all-targets -- -D warnings` — clean.
- `cargo bench -p funput-engine --bench process_char` / `-p funput-ffi --bench latency` — the numbers above.
- Reproduce: `cargo run --release --example profile -p funput-engine`.

README performance tables (`README.md`, `README.en.md`, `benchmarks/README.md`) updated to the new
numbers. The core `apply` transform is untouched (this only fixes an engine-level validity check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
