### PR TITLE
perf: zero-alloc keystroke hot path, O(1) vowel table, LTO profiles (0.55 → 0.12 µs/key)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,14 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 authors = ["Funput"]
+
+# Shipped on all five platforms, so the release profile optimizes for speed first
+# and binary size second (measured: libfunput_ffi.dylib 477 KB → 369 KB).
+#
+# Do NOT set `panic = "abort"`: the FFI/JNI boundaries rely on `catch_unwind` to
+# turn an engine panic into a dropped keystroke instead of killing the host IME
+# process (see funput-ffi/src/support.rs).
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = "symbols"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,14 @@ members = [
     "crates/funput-term",
     "crates/funput-desktop",
 ]
-# The Windows shell pulls in `tauri` + the `windows` crate, which only build on a
-# Windows target. Keep it out of the default workspace so `cargo test --workspace`
-# stays green on macOS/Linux dev machines; build it from its own dir on Windows.
+# Platform shells excluded from the default workspace so `cargo test --workspace`
+# stays green on every dev machine; each is built from its own dir on its own OS.
+# NOTE: excluded packages do NOT inherit the [profile.release] below — each keeps
+# an equivalent profile in its own manifest.
 exclude = [
-    "platforms/windows/src-tauri",
-    # GTK4 Settings app: links system gtk4/libadwaita (Linux-only). Build from its
-    # own dir on Linux so `cargo test --workspace` stays green on macOS/Windows.
+    # Windows shell: pulls in slint + the `windows` crate (Windows target only).
+    "platforms/windows",
+    # GTK4 Settings app: links system gtk4/libadwaita (Linux only).
     "platforms/linux/settings-gtk",
 ]
 

--- a/README.en.md
+++ b/README.en.md
@@ -63,9 +63,9 @@ release build:
 
 | Component / API | Measured scope | Telex | VNI |
 |---|---|---:|---:|
-| [`funput-core::apply`](crates/funput-core) | Telex/VNI transformation core | 0.230 µs/key | 0.204 µs/key |
-| [`funput-engine::Engine::process_char`](crates/funput-engine) | Full pipeline (boundaries + English restore) | 0.52 µs/key | 0.49 µs/key |
-| [`funput-ffi::{funput_process_char, funput_buffer}`](crates/funput-ffi) | Engine through the C ABI + composed-buffer reads | 0.55 µs/key | 0.51 µs/key |
+| [`funput-core::apply`](crates/funput-core) | Telex/VNI transformation core | 0.054 µs/key | 0.047 µs/key |
+| [`funput-engine::Engine::process_char`](crates/funput-engine) | Full pipeline (boundaries + English restore) | 0.11 µs/key | 0.10 µs/key |
+| [`funput-ffi::{funput_process_char, funput_buffer}`](crates/funput-ffi) | Engine through the C ABI + composed-buffer reads | 0.12 µs/key | 0.11 µs/key |
 
 > Measured from a release build on an Apple M-series machine; covers Funput's own
 > processing only (excludes OS keyboard-event delivery and host-app rendering).

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Lõi xử lý viết bằng Rust. Chi phí mỗi phím, đo bằng Criterion tr�
 
 | Thành phần / API | Phạm vi đo | Telex | VNI |
 |---|---|---:|---:|
-| [`funput-core::apply`](crates/funput-core) | Lõi biến đổi Telex/VNI | 0,230 µs/phím | 0,204 µs/phím |
-| [`funput-engine::Engine::process_char`](crates/funput-engine) | Pipeline đầy đủ (boundary + English restore) | 0,52 µs/phím | 0,49 µs/phím |
-| [`funput-ffi::{funput_process_char, funput_buffer}`](crates/funput-ffi) | Engine qua C ABI + đọc composed buffer | 0,55 µs/phím | 0,51 µs/phím |
+| [`funput-core::apply`](crates/funput-core) | Lõi biến đổi Telex/VNI | 0,054 µs/phím | 0,047 µs/phím |
+| [`funput-engine::Engine::process_char`](crates/funput-engine) | Pipeline đầy đủ (boundary + English restore) | 0,11 µs/phím | 0,10 µs/phím |
+| [`funput-ffi::{funput_process_char, funput_buffer}`](crates/funput-ffi) | Engine qua C ABI + đọc composed buffer | 0,12 µs/phím | 0,11 µs/phím |
 
 > Đo trên release build, máy Apple M-series; chỉ gồm phần xử lý của Funput (không
 > tính OS chuyển sự kiện bàn phím hay app đích render). Số phụ thuộc phần cứng —

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -31,7 +31,8 @@ their corresponding directories in `target/criterion/`.
 | Full engine path (`process_char`, incl. boundary + English-restore) | **~0.52 µs / keystroke** (~1.9 M/s) |
 | **End-to-end across the C FFI** (`process_char` + read composed text back) | **~0.55 µs / keystroke** |
 | `size_of::<Engine>` (per-field session state) | **136 bytes** |
-| Release FFI shared lib (`libfunput_ffi.dylib`) | ~0.46 MB |
+| Heap allocations per keystroke (default / spell-check on) | **~12 / ~14** (~134 / ~148 B) |
+| Release FFI shared lib (`libfunput_ffi.dylib`, LTO + stripped) | ~0.37 MB |
 
 A human types a few keys per second; Funput answers each in **sub-microsecond**
 time, i.e. millions of times faster than needed — composition is never the
@@ -59,8 +60,13 @@ Footprint check:
 
 ```sh
 cargo test -p funput-engine -- --nocapture engine_struct_size   # prints size_of::<Engine>
+cargo test -p funput-engine --test alloc_budget -- --nocapture  # heap allocs per keystroke (budget-guarded)
 ls -lh target/release/libfunput_ffi.dylib                       # after: cargo build --release -p funput-ffi
 ```
+
+The `alloc_budget` test doubles as a regression guard: it fails if a change adds
+heap allocations to the keystroke hot path beyond the committed budget, and its
+budgets are ratcheted down as allocation-removal work lands.
 
 ## B2 — Coverage (round-trip)
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -31,7 +31,7 @@ their corresponding directories in `target/criterion/`.
 | Full engine path (`process_char`, incl. boundary + English-restore) | **~0.52 µs / keystroke** (~1.9 M/s) |
 | **End-to-end across the C FFI** (`process_char` + read composed text back) | **~0.55 µs / keystroke** |
 | `size_of::<Engine>` (per-field session state) | **136 bytes** |
-| Heap allocations per keystroke (default / spell-check on) | **~12 / ~14** (~134 / ~148 B) |
+| Heap allocations per keystroke (with or without spell-check) | **~4** (~39 B) |
 | Release FFI shared lib (`libfunput_ffi.dylib`, LTO + stripped) | ~0.37 MB |
 
 A human types a few keys per second; Funput answers each in **sub-microsecond**

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -26,12 +26,12 @@ their corresponding directories in `target/criterion/`.
 
 | Metric | Result |
 |---|---|
-| Compose latency (core `apply`) | **~0.23 µs / keystroke** (Telex), ~0.20 µs (VNI) |
-| Compose throughput | **> 4 million keystrokes / second** |
-| Full engine path (`process_char`, incl. boundary + English-restore) | **~0.52 µs / keystroke** (~1.9 M/s) |
-| **End-to-end across the C FFI** (`process_char` + read composed text back) | **~0.55 µs / keystroke** |
+| Compose latency (core `apply`) | **~0.05 µs / keystroke** (Telex), ~0.05 µs (VNI) |
+| Compose throughput | **> 18 million keystrokes / second** |
+| Full engine path (`process_char`, incl. boundary + English-restore) | **~0.11 µs / keystroke** (~8.9 M/s) |
+| **End-to-end across the C FFI** (`process_char` + read composed text back) | **~0.12 µs / keystroke** |
 | `size_of::<Engine>` (per-field session state) | **136 bytes** |
-| Heap allocations per keystroke (with or without spell-check) | **~4** (~39 B) |
+| Heap allocations per keystroke (with or without spell-check) | **~1** (~7 B) |
 | Release FFI shared lib (`libfunput_ffi.dylib`, LTO + stripped) | ~0.37 MB |
 
 A human types a few keys per second; Funput answers each in **sub-microsecond**
@@ -45,7 +45,7 @@ The `latency` bench drives the **real C ABI a platform shell uses** for every ke
 `funput_buffer` (copies the composed text back out to render the marked text). This
 is the layer the pure-core bench skips.
 
-Key finding: it lands at **~0.55 µs/keystroke — essentially identical to the engine
+Key finding: it lands at **~0.12 µs/keystroke — essentially identical to the engine
 alone**, so the FFI boundary (handle indirection + by-value result + UTF-32 copy)
 adds negligible cost.
 

--- a/crates/funput-core/src/composition/apply.rs
+++ b/crates/funput-core/src/composition/apply.rs
@@ -1,13 +1,14 @@
 //! Per-action buffer transforms (stroke, tone, shape).
 //!
 //! Method-agnostic: these operate on a [`crate::input_method::KeyAction`] already
-//! resolved by a classifier, so VNI and Telex share them unchanged.
+//! resolved by a classifier, so VNI and Telex share them unchanged. Hot path:
+//! each transform builds its result `String` in one pass — no intermediate
+//! `Vec<char>` collections.
 
 use crate::composition::replace_char_at;
-use crate::unicode::marks::{
-    Tone, apply_tone_to_vowel, is_vowel, stroke_d, tone_on_vowel, vowel_stem,
-};
-use crate::unicode::shapes::{VowelShape, apply_shape, apply_shape_to_vowel, shape_target_index};
+use crate::composition::uo_horn::{apply_uo_compound, uo_pair_in_vowel_cluster};
+use crate::unicode::marks::{Tone, apply_tone_to_vowel, stroke_d, tone_on_vowel, vowel_stem};
+use crate::unicode::shapes::{VowelShape, apply_shape_to_vowel, shape_target_index};
 use crate::unicode::tone_position::{tone_target_vowel, tone_vowel_index};
 use crate::{ToneStyle, TransformKind, TransformResult};
 
@@ -18,24 +19,35 @@ fn ignored(buffer: &str) -> TransformResult {
     }
 }
 
+fn applied(text: String) -> TransformResult {
+    TransformResult {
+        kind: TransformKind::Applied,
+        text,
+    }
+}
+
 /// Turn a `d`/`D` into `đ`/`Đ` so the key works wherever it is typed: `dang` + `9`
 /// → `đang`, not only `d` + `9`. Targets the **last** `d` in the buffer — a
 /// Vietnamese syllable has at most one `d` (always the onset), and in an
 /// abbreviation run the last one is the most recent onset (`GD` + `9` → `GĐ`,
 /// `GDD` → `GĐ`).
 pub(crate) fn apply_stroke(buffer: &str) -> TransformResult {
-    let mut chars: Vec<char> = buffer.chars().collect();
-    let Some(idx) = chars.iter().rposition(|c| matches!(c, 'd' | 'D')) else {
+    let Some((offset, d)) = buffer
+        .char_indices()
+        .rev()
+        .find(|&(_, c)| matches!(c, 'd' | 'D'))
+    else {
         return ignored(buffer);
     };
-    let Some(struck) = stroke_d(chars[idx]) else {
+    let Some(struck) = stroke_d(d) else {
         return ignored(buffer);
     };
-    chars[idx] = struck;
-    TransformResult {
-        kind: TransformKind::Applied,
-        text: chars.into_iter().collect(),
-    }
+
+    let mut text = String::with_capacity(buffer.len() + struck.len_utf8());
+    text.push_str(&buffer[..offset]);
+    text.push(struck);
+    text.push_str(&buffer[offset + d.len_utf8()..]);
+    applied(text)
 }
 
 /// Place `tone` on the nucleus vowel (handles reposition and `ie`/`gie` → `ê`).
@@ -52,19 +64,17 @@ pub(crate) fn apply_tone_key(buffer: &str, tone: Tone, style: ToneStyle) -> Tran
         return ignored(buffer);
     };
 
-    TransformResult {
-        kind: TransformKind::Applied,
-        text: replace_char_at(buffer, vowel_idx, toned),
-    }
+    applied(replace_char_at(buffer, vowel_idx, toned))
 }
 
 /// Remove the tone mark from the syllable, keeping any shape (`việt` → `viêt`,
 /// `toán` → `toan`, `được` → `đươc`). Returns `None` when there is no tone.
 pub(crate) fn remove_tone(buffer: &str) -> Option<String> {
-    let mut chars: Vec<char> = buffer.chars().collect();
-    let idx = chars.iter().position(|&c| tone_on_vowel(c).is_some())?;
-    chars[idx] = vowel_stem(chars[idx])?; // strips tone, keeps shape
-    Some(chars.into_iter().collect())
+    let (idx, stem) = buffer.chars().enumerate().find_map(|(i, ch)| {
+        tone_on_vowel(ch)?;
+        Some((i, vowel_stem(ch)?)) // strips tone, keeps shape
+    })?;
+    Some(replace_char_at(buffer, idx, stem))
 }
 
 /// True if `shape` can still be applied to some vowel in `buffer` (the horn
@@ -78,16 +88,13 @@ pub(crate) fn shape_apply_target_exists(buffer: &str, shape: VowelShape) -> bool
 
 /// Apply a vowel shape. For an adjacent plain `uo`, initially horn only the `o`
 /// (`uơ`): that is the completed open rhyme in `thuở`/`huơ`/`quơ`. If another
-/// vowel or coda arrives, [`complete_uo_horn_for_continuation`] turns it into
-/// `ươ` (`thương`, `hươu`).
+/// vowel or coda arrives, [`crate::composition::uo_horn::complete_uo_horn_for_continuation`]
+/// turns it into `ươ` (`thương`, `hươu`).
 pub(crate) fn apply_shape_key(buffer: &str, shape: VowelShape) -> TransformResult {
     if shape == VowelShape::Horn
         && let Some(text) = apply_uo_compound(buffer)
     {
-        return TransformResult {
-            kind: TransformKind::Applied,
-            text,
-        };
+        return applied(text);
     }
 
     let Some(vowel_idx) = shape_target_index(buffer, shape) else {
@@ -110,87 +117,5 @@ pub(crate) fn apply_shape_key(buffer: &str, shape: VowelShape) -> TransformResul
         None => shaped,
     };
 
-    TransformResult {
-        kind: TransformKind::Applied,
-        text: replace_char_at(buffer, vowel_idx, shaped),
-    }
-}
-
-/// Char indices of an adjacent plain `uo` pair inside the vowel cluster.
-pub(crate) fn uo_pair_in_vowel_cluster(buffer: &str) -> Option<(usize, usize)> {
-    let chars: Vec<char> = buffer.chars().collect();
-    let start = chars.iter().position(|c| is_vowel(*c))?;
-    let mut indices = Vec::new();
-    for (i, ch) in chars.iter().enumerate().skip(start) {
-        if is_vowel(*ch) {
-            indices.push(i);
-        } else {
-            break;
-        }
-    }
-
-    // A plain (untoned, unshaped) `u` followed by a plain `o`. The ASCII match
-    // already excludes `ư`, `ơ`, and any toned variants.
-    for pair in indices.windows(2) {
-        let (u_idx, o_idx) = (pair[0], pair[1]);
-        if chars[u_idx].eq_ignore_ascii_case(&'u') && chars[o_idx].eq_ignore_ascii_case(&'o') {
-            return Some((u_idx, o_idx));
-        }
-    }
-    None
-}
-
-fn apply_uo_compound(buffer: &str) -> Option<String> {
-    let (u_idx, o_idx) = uo_pair_in_vowel_cluster(buffer)?;
-    let mut chars: Vec<char> = buffer.chars().collect();
-    let has_continuation = o_idx + 1 < chars.len();
-    let is_qu_glide = u_idx > 0 && chars[u_idx - 1].eq_ignore_ascii_case(&'q');
-    if has_continuation && !is_qu_glide {
-        chars[u_idx] = apply_shape(chars[u_idx], VowelShape::Horn)?;
-    }
-    chars[o_idx] = apply_shape(chars[o_idx], VowelShape::Horn)?;
-    Some(chars.into_iter().collect())
-}
-
-/// Return the byte offset and character of the plain `u` when `buffer` ends in
-/// ambiguous `uơ` (including a tone on `ơ`), plus the character before `u`.
-/// The ASCII-byte guard makes the overwhelmingly common path constant-time.
-fn open_uo_horn_suffix(buffer: &str) -> Option<(usize, char, Option<char>)> {
-    if buffer.as_bytes().last().is_none_or(u8::is_ascii) {
-        return None;
-    }
-
-    let mut chars = buffer.char_indices().rev();
-    let (_, o) = chars.next()?;
-    let (u_offset, u) = chars.next()?;
-    let before_u = chars.next().map(|(_, ch)| ch);
-    let is_plain_u = vowel_stem(u).is_some_and(|stem| stem.eq_ignore_ascii_case(&'u'))
-        && crate::unicode::shapes::shape_on_vowel(u).is_none();
-    let is_horned_o = vowel_stem(o).is_some_and(|stem| stem.eq_ignore_ascii_case(&'ơ'));
-    (is_plain_u && is_horned_o).then_some((u_offset, u, before_u))
-}
-
-/// Complete an ambiguous open `uơ` as `ươ` once another character proves that
-/// the rhyme continues (`thuơ` + `n` → `thươn`, `huơ` + `u` → `hươu`). The `u`
-/// in a `qu` onset is a glide, not part of the nucleus, so `quơi` stays `quơi`.
-pub(crate) fn complete_uo_horn_for_continuation(buffer: &str, key: char) -> Option<String> {
-    let (u_offset, u, before_u) = open_uo_horn_suffix(buffer)?;
-    if before_u.is_some_and(|ch| ch.eq_ignore_ascii_case(&'q')) {
-        return None;
-    }
-
-    let shaped_u = apply_shape(u, VowelShape::Horn)?;
-    let after_u = u_offset + u.len_utf8();
-    let mut completed = String::with_capacity(buffer.len() + key.len_utf8() + 1);
-    completed.push_str(&buffer[..u_offset]);
-    completed.push(shaped_u);
-    completed.push_str(&buffer[after_u..]);
-    completed.push(key);
-    Some(completed)
-}
-
-/// Whether the buffer ends in the ambiguous open `uơ` form. A repeated horn key
-/// must revert this form (`uo77` → `uo7`) rather than horn the remaining `u`.
-pub(crate) fn ends_with_open_uo_horn(buffer: &str) -> bool {
-    open_uo_horn_suffix(buffer).is_some()
+    applied(replace_char_at(buffer, vowel_idx, shaped))
 }

--- a/crates/funput-core/src/composition/mod.rs
+++ b/crates/funput-core/src/composition/mod.rs
@@ -1,5 +1,6 @@
 pub mod apply;
 pub mod revert;
 pub mod transform;
+pub mod uo_horn;
 
 pub(crate) use revert::replace_char_at;

--- a/crates/funput-core/src/composition/revert.rs
+++ b/crates/funput-core/src/composition/revert.rs
@@ -6,16 +6,19 @@
 //! [`apply_action`]: crate::composition::transform::apply_action
 
 use crate::ToneStyle;
+use crate::composition::uo_horn::try_revert_uo_compound;
 use crate::unicode::marks::{Tone, tone_on_vowel, vowel_stem};
-use crate::unicode::shapes::{VowelShape, shape_on_vowel, shaped_vowel_index, strip_shape};
+use crate::unicode::shapes::{VowelShape, shaped_vowel_index, strip_shape};
 use crate::unicode::tone_position::tone_vowel_index;
 
+/// Copy of `buffer` with the char at `char_idx` replaced (single allocation).
+/// An out-of-range index returns the buffer unchanged.
 pub(crate) fn replace_char_at(buffer: &str, char_idx: usize, new_ch: char) -> String {
-    let mut chars: Vec<char> = buffer.chars().collect();
-    if let Some(slot) = chars.get_mut(char_idx) {
-        *slot = new_ch;
+    let mut replaced = String::with_capacity(buffer.len() + new_ch.len_utf8());
+    for (i, ch) in buffer.chars().enumerate() {
+        replaced.push(if i == char_idx { new_ch } else { ch });
     }
-    chars.into_iter().collect()
+    replaced
 }
 
 /// Revert `đ`/`Đ` back to `d`/`D` when stroke key `9` is pressed again, matching
@@ -23,10 +26,17 @@ pub(crate) fn replace_char_at(buffer: &str, char_idx: usize, new_ch: char) -> St
 ///
 /// [`apply_stroke`]: crate::composition::apply::apply_stroke
 pub fn try_revert_stroke(buffer: &str) -> Option<String> {
-    let mut chars: Vec<char> = buffer.chars().collect();
-    let idx = chars.iter().rposition(|c| matches!(c, 'đ' | 'Đ'))?;
-    chars[idx] = if chars[idx] == 'đ' { 'd' } else { 'D' };
-    Some(chars.into_iter().collect())
+    let (offset, struck) = buffer
+        .char_indices()
+        .rev()
+        .find(|&(_, c)| matches!(c, 'đ' | 'Đ'))?;
+    let plain = if struck == 'đ' { 'd' } else { 'D' };
+
+    let mut reverted = String::with_capacity(buffer.len());
+    reverted.push_str(&buffer[..offset]);
+    reverted.push(plain);
+    reverted.push_str(&buffer[offset + struck.len_utf8()..]);
+    Some(reverted)
 }
 
 /// Revert tone when the same tone key is pressed on the toned vowel. Uses the
@@ -39,35 +49,6 @@ pub fn try_revert_tone(buffer: &str, tone: Tone, style: ToneStyle) -> Option<Str
     }
     let unstemmed = vowel_stem(vowel)?;
     Some(replace_char_at(buffer, vowel_idx, unstemmed))
-}
-
-fn ends_with_plain_shaped_uo(buffer: &str) -> bool {
-    let chars: Vec<char> = buffer.chars().collect();
-    if chars.len() < 2 {
-        return false;
-    }
-    let u = chars[chars.len() - 2];
-    let o = chars[chars.len() - 1];
-    shape_on_vowel(u) == Some(VowelShape::Horn)
-        && shape_on_vowel(o) == Some(VowelShape::Horn)
-        && tone_on_vowel(u).is_none()
-        && tone_on_vowel(o).is_none()
-        && strip_shape(u).is_some_and(|c| c.eq_ignore_ascii_case(&'u'))
-        && strip_shape(o).is_some_and(|c| c.eq_ignore_ascii_case(&'o'))
-}
-
-fn try_revert_uo_compound(buffer: &str) -> Option<String> {
-    if !ends_with_plain_shaped_uo(buffer) {
-        return None;
-    }
-
-    let mut chars: Vec<char> = buffer.chars().collect();
-    let len = chars.len();
-    let u = chars[len - 2];
-    let o = chars[len - 1];
-    chars[len - 2] = strip_shape(u)?;
-    chars[len - 1] = strip_shape(o)?;
-    Some(chars.into_iter().collect())
 }
 
 /// Revert shape when the same shape key is pressed on the shaped vowel.

--- a/crates/funput-core/src/composition/transform.rs
+++ b/crates/funput-core/src/composition/transform.rs
@@ -3,16 +3,17 @@
 //! [`apply_action`] is method-agnostic; only the input-method classifier differs.
 
 use crate::composition::apply::{
-    apply_shape_key, apply_stroke, apply_tone_key, complete_uo_horn_for_continuation,
-    ends_with_open_uo_horn, remove_tone, shape_apply_target_exists,
+    apply_shape_key, apply_stroke, apply_tone_key, remove_tone, shape_apply_target_exists,
 };
 use crate::composition::revert::{try_revert_shape, try_revert_stroke, try_revert_tone};
+use crate::composition::uo_horn::{complete_uo_horn_for_continuation, ends_with_open_uo_horn};
 use crate::input_method::KeyAction;
 use crate::input_method::telex;
 use crate::input_method::vni;
 use crate::unicode::tone_position::reposition_existing_tone;
+use crate::validation::reachability::is_definitely_invalid;
 use crate::validation::syllable::{
-    ModifierValidation, is_definitely_invalid, validate_shape, validate_stroke, validate_tone,
+    ModifierValidation, validate_shape, validate_stroke, validate_tone,
 };
 use crate::{ToneStyle, TransformKind, TransformResult};
 

--- a/crates/funput-core/src/composition/uo_horn.rs
+++ b/crates/funput-core/src/composition/uo_horn.rs
@@ -1,0 +1,121 @@
+//! The `uo` → `ươ` horn-compound rules (apply, complete, revert).
+//!
+//! For an adjacent plain `uo`, the horn initially lands only on the `o` (`uơ`):
+//! that is the completed open rhyme in `thuở`/`huơ`/`quơ`. If another vowel or
+//! coda arrives, the compound completes to `ươ` (`thương`, `hươu`). All
+//! helpers here are allocation-free except the ones that build the new buffer.
+
+use crate::unicode::marks::{is_vowel, tone_on_vowel, vowel_stem};
+use crate::unicode::shapes::{VowelShape, apply_shape, shape_on_vowel, strip_shape};
+
+/// Char indices of the first adjacent plain `uo` pair inside the vowel cluster.
+/// The ASCII match already excludes `ư`, `ơ`, and any toned variants.
+pub(crate) fn uo_pair_in_vowel_cluster(buffer: &str) -> Option<(usize, usize)> {
+    let mut in_cluster = false;
+    let mut prev: Option<(usize, char)> = None; // previous cluster vowel
+    for (i, ch) in buffer.chars().enumerate() {
+        if is_vowel(ch) {
+            if let Some((u_idx, u)) = prev
+                && u.eq_ignore_ascii_case(&'u')
+                && ch.eq_ignore_ascii_case(&'o')
+            {
+                return Some((u_idx, i));
+            }
+            in_cluster = true;
+            prev = Some((i, ch));
+        } else if in_cluster {
+            break;
+        }
+    }
+    None
+}
+
+/// Horn the `uo` pair: only the `o` for the open rhyme (`uơ`), both vowels once
+/// something follows — unless the `u` is a `qu` onset glide, which never horns.
+pub(crate) fn apply_uo_compound(buffer: &str) -> Option<String> {
+    let (u_idx, o_idx) = uo_pair_in_vowel_cluster(buffer)?;
+    let has_continuation = o_idx + 1 < buffer.chars().count();
+    let is_qu_glide = u_idx > 0
+        && buffer
+            .chars()
+            .nth(u_idx - 1)
+            .is_some_and(|c| c.eq_ignore_ascii_case(&'q'));
+    let horn_u = has_continuation && !is_qu_glide;
+
+    let mut horned = String::with_capacity(buffer.len() + 2);
+    for (i, ch) in buffer.chars().enumerate() {
+        let ch = if i == o_idx || (i == u_idx && horn_u) {
+            apply_shape(ch, VowelShape::Horn)?
+        } else {
+            ch
+        };
+        horned.push(ch);
+    }
+    Some(horned)
+}
+
+/// Return the byte offset and character of the plain `u` when `buffer` ends in
+/// ambiguous `uơ` (including a tone on `ơ`), plus the character before `u`.
+/// The ASCII-byte guard makes the overwhelmingly common path constant-time.
+fn open_uo_horn_suffix(buffer: &str) -> Option<(usize, char, Option<char>)> {
+    if buffer.as_bytes().last().is_none_or(u8::is_ascii) {
+        return None;
+    }
+
+    let mut chars = buffer.char_indices().rev();
+    let (_, o) = chars.next()?;
+    let (u_offset, u) = chars.next()?;
+    let before_u = chars.next().map(|(_, ch)| ch);
+    let is_plain_u = vowel_stem(u).is_some_and(|stem| stem.eq_ignore_ascii_case(&'u'))
+        && shape_on_vowel(u).is_none();
+    let is_horned_o = vowel_stem(o).is_some_and(|stem| stem.eq_ignore_ascii_case(&'ơ'));
+    (is_plain_u && is_horned_o).then_some((u_offset, u, before_u))
+}
+
+/// Complete an ambiguous open `uơ` as `ươ` once another character proves that
+/// the rhyme continues (`thuơ` + `n` → `thươn`, `huơ` + `u` → `hươu`). The `u`
+/// in a `qu` onset is a glide, not part of the nucleus, so `quơi` stays `quơi`.
+pub(crate) fn complete_uo_horn_for_continuation(buffer: &str, key: char) -> Option<String> {
+    let (u_offset, u, before_u) = open_uo_horn_suffix(buffer)?;
+    if before_u.is_some_and(|ch| ch.eq_ignore_ascii_case(&'q')) {
+        return None;
+    }
+
+    let shaped_u = apply_shape(u, VowelShape::Horn)?;
+    let after_u = u_offset + u.len_utf8();
+    let mut completed = String::with_capacity(buffer.len() + key.len_utf8() + 1);
+    completed.push_str(&buffer[..u_offset]);
+    completed.push(shaped_u);
+    completed.push_str(&buffer[after_u..]);
+    completed.push(key);
+    Some(completed)
+}
+
+/// Whether the buffer ends in the ambiguous open `uơ` form. A repeated horn key
+/// must revert this form (`uo77` → `uo7`) rather than horn the remaining `u`.
+pub(crate) fn ends_with_open_uo_horn(buffer: &str) -> bool {
+    open_uo_horn_suffix(buffer).is_some()
+}
+
+/// Revert a trailing plain (untoned) `ươ` back to `uo` when the horn key is
+/// pressed again. `None` when the buffer does not end in that compound.
+pub(crate) fn try_revert_uo_compound(buffer: &str) -> Option<String> {
+    let mut chars = buffer.char_indices().rev();
+    let (_, o) = chars.next()?;
+    let (u_offset, u) = chars.next()?;
+
+    let plain_horned = |ch: char, base: char| {
+        shape_on_vowel(ch) == Some(VowelShape::Horn)
+            && tone_on_vowel(ch).is_none()
+            && strip_shape(ch).is_some_and(|c| c.eq_ignore_ascii_case(&base))
+    };
+    if !plain_horned(u, 'u') || !plain_horned(o, 'o') {
+        return None;
+    }
+
+    let mut reverted = String::with_capacity(buffer.len());
+    reverted.push_str(&buffer[..u_offset]);
+    reverted.push(strip_shape(u)?);
+    reverted.push(strip_shape(o)?);
+    Some(reverted)
+}

--- a/crates/funput-core/src/input_method/telex.rs
+++ b/crates/funput-core/src/input_method/telex.rs
@@ -22,7 +22,7 @@
 //! 5. Tone keys `s` / `f` / `r` / `x` / `j`
 //! 6. Normal character
 
-use crate::composition::apply::uo_pair_in_vowel_cluster;
+use crate::composition::uo_horn::uo_pair_in_vowel_cluster;
 use crate::input_method::KeyAction;
 use crate::unicode::marks::{Tone, is_vowel, tone_on_vowel, vowel_stem};
 use crate::unicode::shapes::{VowelShape, shape_on_vowel, shape_target_index, strip_shape};

--- a/crates/funput-core/src/lib.rs
+++ b/crates/funput-core/src/lib.rs
@@ -85,7 +85,8 @@ pub struct TransformResult {
 ///     }
 /// );
 /// ```
-pub use validation::syllable::{is_complete_syllable, is_definitely_invalid, is_valid};
+pub use validation::reachability::is_definitely_invalid;
+pub use validation::syllable::{is_complete_syllable, is_valid};
 
 pub fn apply(
     buffer: &str,

--- a/crates/funput-core/src/unicode/tone_position.rs
+++ b/crates/funput-core/src/unicode/tone_position.rs
@@ -1,110 +1,38 @@
 //! Tone mark placement — modern Vietnamese reposition rules.
+//!
+//! Hot path: runs on every normal keystroke, so the cluster analysis is a
+//! single allocation-free pass; only an actual reposition builds a `String`.
+
+mod cluster;
+
+use cluster::{modern_open_pair_takes_second, scan_cluster, tone_offset_in_cluster};
 
 use crate::ToneStyle;
 use crate::unicode::marks::{apply_tone_to_vowel, is_vowel, tone_on_vowel, vowel_stem};
-use crate::unicode::shapes::{VowelShape, apply_shape, shape_on_vowel};
-
-struct VowelCluster {
-    indices: Vec<usize>,
-}
-
-/// True if the vowel at `idx` is the onset glide of `qu`/`gi` (the `u`/`i` belongs
-/// to the leading consonant, not the tonal nucleus).
-fn is_onset_glide(chars: &[char], idx: usize) -> bool {
-    if idx == 0 {
-        return false;
-    }
-    let vowel = chars[idx];
-    let prev = chars[idx - 1];
-    (vowel.eq_ignore_ascii_case(&'u') && prev.eq_ignore_ascii_case(&'q'))
-        || (vowel.eq_ignore_ascii_case(&'i') && prev.eq_ignore_ascii_case(&'g'))
-}
-
-fn vowel_cluster(buffer: &str) -> Option<VowelCluster> {
-    let chars: Vec<char> = buffer.chars().collect();
-    let start = chars.iter().position(|c| is_vowel(*c))?;
-    let mut indices = Vec::new();
-
-    for (i, ch) in chars.iter().enumerate().skip(start) {
-        if is_vowel(*ch) {
-            indices.push(i);
-        } else {
-            break;
-        }
-    }
-
-    if indices.is_empty() {
-        return None;
-    }
-
-    // Drop the onset glide of `qu`/`gi` when a real nucleus vowel follows
-    // (e.g. `qua` → tone on `a`, `gia` → tone on `a`), but keep it when it is
-    // the only vowel (e.g. `gì`, `gìn`).
-    if indices.len() >= 2 && is_onset_glide(&chars, indices[0]) {
-        indices.remove(0);
-    }
-
-    Some(VowelCluster { indices })
-}
-
-/// Which vowel in the cluster receives the tone (0-based within cluster) — the
-/// **traditional** ("kiểu cũ") rule. Only consulted for clusters with no shaped
-/// vowel (those take priority and are handled in [`tone_vowel_index`]):
-///
-/// - 1 vowel → on it.
-/// - 2 vowels, **open** (no final consonant) → first vowel: `hòa`, `ùy`, `mía`.
-/// - 2 vowels **+ final consonant**, or 3 vowels → second vowel: `toán`, `ngoài`.
-fn tone_offset_in_cluster(cluster_len: usize, has_coda: bool) -> usize {
-    match cluster_len {
-        1 => 0,
-        2 if has_coda => 1,
-        2 => 0,
-        _ => 1, // triphthong → middle vowel
-    }
-}
-
-/// True for the open glide-initial diphthongs where "kiểu mới" moves the tone onto
-/// the second (main) vowel: `oa`, `oe`, `uy` — the only syllables on which the
-/// modern and traditional styles disagree. Compared on the stem so a vowel that
-/// already carries a tone (reposition) still matches (`hoà` → `o`, `à`→stem `a`).
-fn modern_open_pair_takes_second(first: char, second: char) -> bool {
-    let f = vowel_stem(first).unwrap_or(first).to_ascii_lowercase();
-    let s = vowel_stem(second).unwrap_or(second).to_ascii_lowercase();
-    matches!((f, s), ('o', 'a') | ('o', 'e') | ('u', 'y'))
-}
+use crate::unicode::shapes::{VowelShape, apply_shape};
 
 /// Char index where a tone mark should be placed, for the given placement `style`.
 pub fn tone_vowel_index(buffer: &str, style: ToneStyle) -> Option<usize> {
-    let cluster = vowel_cluster(buffer)?;
-    let chars: Vec<char> = buffer.chars().collect();
+    let cluster = scan_cluster(buffer)?;
 
     // A vowel carrying mũ/móc/trần (â ê ô ơ ư ă) takes the tone. For `ươ` (two
     // horned vowels) the tone sits on the second one (`ơ`): trường, được, rượu.
-    let last_shaped = cluster
-        .indices
-        .iter()
-        .copied()
-        .rfind(|&i| shape_on_vowel(chars[i]).is_some());
-    if let Some(i) = last_shaped {
+    if let Some(i) = cluster.last_shaped {
         return Some(i);
     }
 
-    // No shaped vowel: structural rule. A coda exists when a (consonant) char
-    // follows the last vowel of the cluster.
-    let last_vowel = *cluster.indices.last()?;
-    let has_coda = last_vowel + 1 < chars.len();
-
     // "Kiểu mới": an open `oa`/`oe`/`uy` takes the tone on the second vowel.
     if style == ToneStyle::Modern
-        && cluster.indices.len() == 2
-        && !has_coda
-        && modern_open_pair_takes_second(chars[cluster.indices[0]], chars[cluster.indices[1]])
+        && cluster.len == 2
+        && !cluster.has_coda
+        && let Some(second) = cluster.second
+        && modern_open_pair_takes_second(cluster.first, second)
     {
-        return Some(cluster.indices[1]);
+        return Some(cluster.start + 1);
     }
 
-    let offset = tone_offset_in_cluster(cluster.indices.len(), has_coda);
-    Some(cluster.indices[offset.min(cluster.indices.len() - 1)])
+    let offset = tone_offset_in_cluster(cluster.len, cluster.has_coda);
+    Some(cluster.start + offset.min(cluster.len - 1))
 }
 
 /// Vowel character used when applying a tone (handles `ie`/`gie` → tonal base `ê`).
@@ -113,16 +41,29 @@ pub fn tone_vowel_index(buffer: &str, style: ToneStyle) -> Option<usize> {
 /// (`viết`, `giết`), so the tone lands on `ê`. This covers both the `i` nucleus of
 /// `viet` and the `i` that is part of the `gi` onset of `giet`.
 pub fn tone_target_vowel(buffer: &str, vowel_idx: usize) -> Option<char> {
-    let chars: Vec<char> = buffer.chars().collect();
-    let vowel = *chars.get(vowel_idx)?;
+    // Chars at vowel_idx - 1, vowel_idx, vowel_idx + 1, in one pass.
+    let (mut prev, mut vowel, mut next) = (None, None, None);
+    for (i, ch) in buffer.chars().enumerate() {
+        if i + 1 == vowel_idx {
+            prev = Some(ch);
+        } else if i == vowel_idx {
+            vowel = Some(ch);
+        } else if i == vowel_idx + 1 {
+            next = Some(ch);
+            break;
+        }
+    }
+
+    let vowel = vowel?;
     let stem = vowel_stem(vowel)?;
     if !stem.eq_ignore_ascii_case(&'e') {
         return Some(vowel);
     }
     // The preceding `i` may already carry a tone (`vịe` + `t` → `việt`), so compare
     // its stem, not the raw char.
-    let prev_is_i = vowel_idx > 0
-        && vowel_stem(chars[vowel_idx - 1]).is_some_and(|s| s.eq_ignore_ascii_case(&'i'));
+    let prev_is_i = prev
+        .and_then(vowel_stem)
+        .is_some_and(|s| s.eq_ignore_ascii_case(&'i'));
     if !prev_is_i {
         return Some(vowel);
     }
@@ -131,9 +72,8 @@ pub fn tone_target_vowel(buffer: &str, vowel_idx: usize) -> Option<char> {
     // triphthong `iêu`; open `ie`/`ieo` do not (open /iə/ is written `ia`). So promote
     // only when `e` is followed by a coda consonant or the glide `u` — otherwise keep
     // plain `e`. This fixes the gi-onset words `gié`/`giẻ`/`giẹo` (previously
-    // `giế`/`giể`/`giếo`) while leaving `viết`/`giết`/`chiếu` untouched. A cheap char
-    // test (no allocation, no rhyme-table scan) keeps `apply` on its hot path.
-    let promote = match chars.get(vowel_idx + 1).copied() {
+    // `giế`/`giể`/`giếo`) while leaving `viết`/`giết`/`chiếu` untouched.
+    let promote = match next {
         None => false, // open `ie` → keep `e` (`gié`)
         Some(c) if is_vowel(c) => vowel_stem(c) // `ieu` promotes, `ieo` does not
             .is_some_and(|s| s.eq_ignore_ascii_case(&'u')),
@@ -149,150 +89,33 @@ pub fn tone_target_vowel(buffer: &str, vowel_idx: usize) -> Option<char> {
 
 /// If a tone exists on the wrong vowel, move it to the correct position for `style`.
 pub fn reposition_existing_tone(buffer: &str, style: ToneStyle) -> Option<String> {
+    // Cheap scan first: most keystrokes carry no tone yet, and this runs on
+    // every normal key — bail out without any cluster analysis or allocation.
+    let (current, current_ch, tone) = buffer
+        .chars()
+        .enumerate()
+        .find_map(|(i, ch)| tone_on_vowel(ch).map(|t| (i, ch, t)))?;
+
     let desired = tone_vowel_index(buffer, style)?;
-
-    let mut toned_index: Option<(usize, crate::unicode::marks::Tone)> = None;
-    for (i, ch) in buffer.chars().enumerate() {
-        if is_vowel(ch)
-            && let Some(tone) = tone_on_vowel(ch)
-        {
-            toned_index = Some((i, tone));
-            break;
-        }
-    }
-
-    let (current, tone) = toned_index?;
     if current == desired {
         return None;
     }
 
-    let mut chars: Vec<char> = buffer.chars().collect();
-    let old_stem = vowel_stem(chars[current])?;
-    chars[current] = old_stem;
+    let old_stem = vowel_stem(current_ch)?;
+    let desired_ch = buffer.chars().nth(desired)?;
+    let tone_base = tone_target_vowel(buffer, desired).unwrap_or(desired_ch);
+    let toned = apply_tone_to_vowel(tone_base, tone)?;
 
-    let new_vowel = chars[desired];
-    let tone_base = tone_target_vowel(buffer, desired).unwrap_or(new_vowel);
-    let new_stem = vowel_stem(tone_base)?;
-    let toned = apply_tone_to_vowel(new_stem, tone)?;
-    chars[desired] = toned;
-
-    Some(chars.into_iter().collect())
+    let mut moved = String::with_capacity(buffer.len() + toned.len_utf8());
+    for (i, ch) in buffer.chars().enumerate() {
+        moved.push(match i {
+            _ if i == current => old_stem,
+            _ if i == desired => toned,
+            _ => ch,
+        });
+    }
+    Some(moved)
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn char_at(buffer: &str, index: usize) -> char {
-        buffer.chars().nth(index).expect("char at index")
-    }
-
-    /// `tone_vowel_index` with the default (traditional) style.
-    fn trad(buffer: &str) -> usize {
-        tone_vowel_index(buffer, ToneStyle::Traditional).unwrap()
-    }
-
-    /// `tone_vowel_index` with the modern ("kiểu mới") style.
-    fn modern(buffer: &str) -> usize {
-        tone_vowel_index(buffer, ToneStyle::Modern).unwrap()
-    }
-
-    #[test]
-    fn tone_vowel_index_open_diphthong_first_vowel() {
-        // Traditional rule: open 2-vowel cluster → tone on the first vowel.
-        assert_eq!(char_at("hoa", trad("hoa")), 'o'); // hòa
-        assert_eq!(char_at("chao", trad("chao")), 'a'); // chào
-        assert_eq!(char_at("hoe", trad("hoe")), 'o'); // hòe
-    }
-
-    #[test]
-    fn tone_vowel_index_uy_open_is_first_vowel() {
-        // Open `uy` → tone on `u` (ùy/úy), traditional style.
-        assert_eq!(char_at("thuy", trad("thuy")), 'u');
-    }
-
-    #[test]
-    fn tone_vowel_index_oa_with_coda_is_second_vowel() {
-        // 2 vowels + final consonant → second vowel: hoàn, toán.
-        assert_eq!(char_at("hoan", trad("hoan")), 'a');
-        assert_eq!(char_at("toan", trad("toan")), 'a');
-    }
-
-    #[test]
-    fn tone_vowel_index_single_vowel() {
-        assert_eq!(char_at("ma", trad("ma")), 'a');
-        assert_eq!(char_at("ho", trad("ho")), 'o');
-    }
-
-    #[test]
-    fn tone_vowel_index_uo_horn_cluster() {
-        assert_eq!(char_at("trương", trad("trương")), 'ơ');
-        assert_eq!(char_at("thuơ", trad("thuơ")), 'ơ');
-    }
-
-    #[test]
-    fn tone_vowel_index_open_diphthongs_ia_ua() {
-        assert_eq!(char_at("mia", trad("mia")), 'i');
-        assert_eq!(char_at("mua", trad("mua")), 'u');
-        assert_eq!(char_at("cua", trad("cua")), 'u');
-        assert_eq!(char_at("lua", trad("lua")), 'u');
-    }
-
-    #[test]
-    fn tone_vowel_index_uoi_cluster() {
-        assert_eq!(char_at("ngươi", trad("ngươi")), 'ơ');
-    }
-
-    #[test]
-    fn tone_vowel_index_plain_triphthong_is_middle() {
-        // Plain triphthongs take the tone on the middle vowel, not the last.
-        assert_eq!(char_at("ngoai", trad("ngoai")), 'a'); // ngoài
-        assert_eq!(char_at("xoay", trad("xoay")), 'a'); // xoáy
-        assert_eq!(char_at("khuyu", trad("khuyu")), 'y'); // khuỷu
-    }
-
-    #[test]
-    fn tone_vowel_index_modern_moves_oa_oe_uy_to_second() {
-        // "Kiểu mới": open oa/oe/uy → tone on the second (main) vowel.
-        assert_eq!(char_at("hoa", modern("hoa")), 'a'); // hoà
-        assert_eq!(char_at("hoe", modern("hoe")), 'e'); // hoè
-        assert_eq!(char_at("thuy", modern("thuy")), 'y'); // thuý
-    }
-
-    #[test]
-    fn tone_vowel_index_modern_leaves_other_clusters_unchanged() {
-        // Only oa/oe/uy differ — everything else matches the traditional rule.
-        assert_eq!(char_at("mia", modern("mia")), 'i'); // mía
-        assert_eq!(char_at("mua", modern("mua")), 'u'); // múa
-        assert_eq!(char_at("chao", modern("chao")), 'a'); // chào
-        assert_eq!(char_at("hoan", modern("hoan")), 'a'); // hoàn (coda)
-        assert_eq!(char_at("ngoai", modern("ngoai")), 'a'); // ngoài (triphthong)
-        assert_eq!(char_at("trương", modern("trương")), 'ơ'); // shaped vowel wins
-    }
-
-    #[test]
-    fn tone_target_vowel_ie_uses_circumflex_e() {
-        assert_eq!(tone_target_vowel("viet", 2), Some('ê'));
-        assert_eq!(tone_target_vowel("lien", 2), Some('ê'));
-    }
-
-    #[test]
-    fn reposition_moves_tone_to_first_vowel_of_open_diphthong() {
-        // Traditional: an open `oa` takes the tone on `o`, so `hoà` → `hòa`.
-        assert_eq!(
-            reposition_existing_tone("hoà", ToneStyle::Traditional).as_deref(),
-            Some("hòa")
-        );
-    }
-
-    #[test]
-    fn reposition_modern_moves_tone_to_second_vowel() {
-        // Modern: an open `oa` takes the tone on `a`, so `hòa` → `hoà`.
-        assert_eq!(
-            reposition_existing_tone("hòa", ToneStyle::Modern).as_deref(),
-            Some("hoà")
-        );
-        // Already correct for the style → no change.
-        assert_eq!(reposition_existing_tone("hoà", ToneStyle::Modern), None);
-    }
-}
+mod tests;

--- a/crates/funput-core/src/unicode/tone_position/cluster.rs
+++ b/crates/funput-core/src/unicode/tone_position/cluster.rs
@@ -1,0 +1,103 @@
+//! One-pass, allocation-free scan of the nucleus vowel cluster.
+
+use crate::unicode::marks::{is_vowel, vowel_stem};
+use crate::unicode::shapes::shape_on_vowel;
+
+/// Summary of the nucleus vowel cluster (a contiguous vowel run, so its char
+/// positions are simply `start..start + len`).
+pub(super) struct ClusterScan {
+    /// Char index of the first cluster vowel (onset glide already dropped).
+    pub(super) start: usize,
+    pub(super) len: usize,
+    /// First two cluster vowels (after the glide drop).
+    pub(super) first: char,
+    pub(super) second: Option<char>,
+    /// Char index of the last shaped (mũ/móc/trần) vowel in the cluster.
+    pub(super) last_shaped: Option<usize>,
+    /// A consonant follows the cluster.
+    pub(super) has_coda: bool,
+}
+
+/// True if `vowel`, preceded by `prev`, is the onset glide of `qu`/`gi` (the
+/// `u`/`i` belongs to the leading consonant, not the tonal nucleus).
+fn is_onset_glide(prev: Option<char>, vowel: char) -> bool {
+    let Some(prev) = prev else {
+        return false;
+    };
+    (vowel.eq_ignore_ascii_case(&'u') && prev.eq_ignore_ascii_case(&'q'))
+        || (vowel.eq_ignore_ascii_case(&'i') && prev.eq_ignore_ascii_case(&'g'))
+}
+
+pub(super) fn scan_cluster(buffer: &str) -> Option<ClusterScan> {
+    let mut before = None; // char immediately before the cluster
+    let mut start = 0;
+    let mut len = 0;
+    let mut vowels = [None; 3]; // first three cluster vowels
+    let mut last_shaped = None;
+    let mut has_coda = false;
+
+    for (i, ch) in buffer.chars().enumerate() {
+        if is_vowel(ch) {
+            if len == 0 {
+                start = i;
+            }
+            if len < vowels.len() {
+                vowels[len] = Some(ch);
+            }
+            if shape_on_vowel(ch).is_some() {
+                last_shaped = Some(i);
+            }
+            len += 1;
+        } else if len > 0 {
+            has_coda = true;
+            break;
+        } else {
+            before = Some(ch);
+        }
+    }
+
+    // Drop the onset glide of `qu`/`gi` when a real nucleus vowel follows
+    // (e.g. `qua` → tone on `a`, `gia` → tone on `a`), but keep it when it is
+    // the only vowel (e.g. `gì`, `gìn`). A glide is a plain `u`/`i` — never
+    // shaped — so `last_shaped` is unaffected.
+    if len >= 2 && is_onset_glide(before, vowels[0]?) {
+        start += 1;
+        len -= 1;
+        vowels = [vowels[1], vowels[2], None];
+    }
+
+    Some(ClusterScan {
+        start,
+        len,
+        first: vowels[0]?,
+        second: vowels[1],
+        last_shaped,
+        has_coda,
+    })
+}
+
+/// True for the open glide-initial diphthongs where "kiểu mới" moves the tone onto
+/// the second (main) vowel: `oa`, `oe`, `uy` — the only syllables on which the
+/// modern and traditional styles disagree. Compared on the stem so a vowel that
+/// already carries a tone (reposition) still matches (`hoà` → `o`, `à`→stem `a`).
+pub(super) fn modern_open_pair_takes_second(first: char, second: char) -> bool {
+    let f = vowel_stem(first).unwrap_or(first).to_ascii_lowercase();
+    let s = vowel_stem(second).unwrap_or(second).to_ascii_lowercase();
+    matches!((f, s), ('o', 'a') | ('o', 'e') | ('u', 'y'))
+}
+
+/// Which vowel in the cluster receives the tone (0-based within cluster) — the
+/// **traditional** ("kiểu cũ") rule. Only consulted for clusters with no shaped
+/// vowel (those take priority in [`super::tone_vowel_index`]):
+///
+/// - 1 vowel → on it.
+/// - 2 vowels, **open** (no final consonant) → first vowel: `hòa`, `ùy`, `mía`.
+/// - 2 vowels **+ final consonant**, or 3 vowels → second vowel: `toán`, `ngoài`.
+pub(super) fn tone_offset_in_cluster(cluster_len: usize, has_coda: bool) -> usize {
+    match cluster_len {
+        1 => 0,
+        2 if has_coda => 1,
+        2 => 0,
+        _ => 1, // triphthong → middle vowel
+    }
+}

--- a/crates/funput-core/src/unicode/tone_position/tests.rs
+++ b/crates/funput-core/src/unicode/tone_position/tests.rs
@@ -1,0 +1,114 @@
+use super::*;
+
+fn char_at(buffer: &str, index: usize) -> char {
+    buffer.chars().nth(index).expect("char at index")
+}
+
+/// `tone_vowel_index` with the default (traditional) style.
+fn trad(buffer: &str) -> usize {
+    tone_vowel_index(buffer, ToneStyle::Traditional).unwrap()
+}
+
+/// `tone_vowel_index` with the modern ("kiểu mới") style.
+fn modern(buffer: &str) -> usize {
+    tone_vowel_index(buffer, ToneStyle::Modern).unwrap()
+}
+
+#[test]
+fn tone_vowel_index_open_diphthong_first_vowel() {
+    // Traditional rule: open 2-vowel cluster → tone on the first vowel.
+    assert_eq!(char_at("hoa", trad("hoa")), 'o'); // hòa
+    assert_eq!(char_at("chao", trad("chao")), 'a'); // chào
+    assert_eq!(char_at("hoe", trad("hoe")), 'o'); // hòe
+}
+
+#[test]
+fn tone_vowel_index_uy_open_is_first_vowel() {
+    // Open `uy` → tone on `u` (ùy/úy), traditional style.
+    assert_eq!(char_at("thuy", trad("thuy")), 'u');
+}
+
+#[test]
+fn tone_vowel_index_oa_with_coda_is_second_vowel() {
+    // 2 vowels + final consonant → second vowel: hoàn, toán.
+    assert_eq!(char_at("hoan", trad("hoan")), 'a');
+    assert_eq!(char_at("toan", trad("toan")), 'a');
+}
+
+#[test]
+fn tone_vowel_index_single_vowel() {
+    assert_eq!(char_at("ma", trad("ma")), 'a');
+    assert_eq!(char_at("ho", trad("ho")), 'o');
+}
+
+#[test]
+fn tone_vowel_index_uo_horn_cluster() {
+    assert_eq!(char_at("trương", trad("trương")), 'ơ');
+    assert_eq!(char_at("thuơ", trad("thuơ")), 'ơ');
+}
+
+#[test]
+fn tone_vowel_index_open_diphthongs_ia_ua() {
+    assert_eq!(char_at("mia", trad("mia")), 'i');
+    assert_eq!(char_at("mua", trad("mua")), 'u');
+    assert_eq!(char_at("cua", trad("cua")), 'u');
+    assert_eq!(char_at("lua", trad("lua")), 'u');
+}
+
+#[test]
+fn tone_vowel_index_uoi_cluster() {
+    assert_eq!(char_at("ngươi", trad("ngươi")), 'ơ');
+}
+
+#[test]
+fn tone_vowel_index_plain_triphthong_is_middle() {
+    // Plain triphthongs take the tone on the middle vowel, not the last.
+    assert_eq!(char_at("ngoai", trad("ngoai")), 'a'); // ngoài
+    assert_eq!(char_at("xoay", trad("xoay")), 'a'); // xoáy
+    assert_eq!(char_at("khuyu", trad("khuyu")), 'y'); // khuỷu
+}
+
+#[test]
+fn tone_vowel_index_modern_moves_oa_oe_uy_to_second() {
+    // "Kiểu mới": open oa/oe/uy → tone on the second (main) vowel.
+    assert_eq!(char_at("hoa", modern("hoa")), 'a'); // hoà
+    assert_eq!(char_at("hoe", modern("hoe")), 'e'); // hoè
+    assert_eq!(char_at("thuy", modern("thuy")), 'y'); // thuý
+}
+
+#[test]
+fn tone_vowel_index_modern_leaves_other_clusters_unchanged() {
+    // Only oa/oe/uy differ — everything else matches the traditional rule.
+    assert_eq!(char_at("mia", modern("mia")), 'i'); // mía
+    assert_eq!(char_at("mua", modern("mua")), 'u'); // múa
+    assert_eq!(char_at("chao", modern("chao")), 'a'); // chào
+    assert_eq!(char_at("hoan", modern("hoan")), 'a'); // hoàn (coda)
+    assert_eq!(char_at("ngoai", modern("ngoai")), 'a'); // ngoài (triphthong)
+    assert_eq!(char_at("trương", modern("trương")), 'ơ'); // shaped vowel wins
+}
+
+#[test]
+fn tone_target_vowel_ie_uses_circumflex_e() {
+    assert_eq!(tone_target_vowel("viet", 2), Some('ê'));
+    assert_eq!(tone_target_vowel("lien", 2), Some('ê'));
+}
+
+#[test]
+fn reposition_moves_tone_to_first_vowel_of_open_diphthong() {
+    // Traditional: an open `oa` takes the tone on `o`, so `hoà` → `hòa`.
+    assert_eq!(
+        reposition_existing_tone("hoà", ToneStyle::Traditional).as_deref(),
+        Some("hòa")
+    );
+}
+
+#[test]
+fn reposition_modern_moves_tone_to_second_vowel() {
+    // Modern: an open `oa` takes the tone on `a`, so `hòa` → `hoà`.
+    assert_eq!(
+        reposition_existing_tone("hòa", ToneStyle::Modern).as_deref(),
+        Some("hoà")
+    );
+    // Already correct for the style → no change.
+    assert_eq!(reposition_existing_tone("hoà", ToneStyle::Modern), None);
+}

--- a/crates/funput-core/src/unicode/vowels.rs
+++ b/crates/funput-core/src/unicode/vowels.rs
@@ -1,124 +1,54 @@
-//! Single source of truth for Vietnamese vowel glyphs (base + tone variants).
+//! Vietnamese vowel queries (base + tone variants), O(1) per call.
+//!
+//! These run on every keystroke — often once per buffer character — so each
+//! query is a single lookup in the compile-time table built in [`table`]: no
+//! family-list scan, no case folding, no allocation. The human-readable vowel
+//! inventory lives in [`table`] as the single source of truth.
 
-/// One vowel family: base (no tone) + five tone marks (sắc, huyền, hỏi, ngã, nặng).
-struct VowelFamily {
-    base: char,
-    tones: [char; 5],
-}
+mod table;
 
-const VOWEL_FAMILIES: &[VowelFamily] = &[
-    VowelFamily {
-        base: 'a',
-        tones: ['á', 'à', 'ả', 'ã', 'ạ'],
-    },
-    VowelFamily {
-        base: 'ă',
-        tones: ['ắ', 'ằ', 'ẳ', 'ẵ', 'ặ'],
-    },
-    VowelFamily {
-        base: 'â',
-        tones: ['ấ', 'ầ', 'ẩ', 'ẫ', 'ậ'],
-    },
-    VowelFamily {
-        base: 'e',
-        tones: ['é', 'è', 'ẻ', 'ẽ', 'ẹ'],
-    },
-    VowelFamily {
-        base: 'ê',
-        tones: ['ế', 'ề', 'ể', 'ễ', 'ệ'],
-    },
-    VowelFamily {
-        base: 'i',
-        tones: ['í', 'ì', 'ỉ', 'ĩ', 'ị'],
-    },
-    VowelFamily {
-        base: 'o',
-        tones: ['ó', 'ò', 'ỏ', 'õ', 'ọ'],
-    },
-    VowelFamily {
-        base: 'ô',
-        tones: ['ố', 'ồ', 'ổ', 'ỗ', 'ộ'],
-    },
-    VowelFamily {
-        base: 'ơ',
-        tones: ['ớ', 'ờ', 'ở', 'ỡ', 'ợ'],
-    },
-    VowelFamily {
-        base: 'u',
-        tones: ['ú', 'ù', 'ủ', 'ũ', 'ụ'],
-    },
-    VowelFamily {
-        base: 'ư',
-        tones: ['ứ', 'ừ', 'ử', 'ữ', 'ự'],
-    },
-    VowelFamily {
-        base: 'y',
-        tones: ['ý', 'ỳ', 'ỷ', 'ỹ', 'ỵ'],
-    },
-];
-
-fn fold_lower(c: char) -> char {
-    char::to_lowercase(c).next().unwrap_or(c)
-}
-
-fn with_case(template: char, reference: char) -> char {
-    if reference.is_uppercase() {
-        char::to_uppercase(template).next().unwrap_or(template)
-    } else {
-        template
-    }
-}
-
-fn family_of(c: char) -> Option<&'static VowelFamily> {
-    let lower = fold_lower(c);
-    VOWEL_FAMILIES
-        .iter()
-        .find(|family| family.base == lower || family.tones.contains(&lower))
-}
+use table::{entry, glyph};
 
 /// Returns true if `c` is a vowel (ASCII or precomposed Vietnamese).
 pub fn is_vowel(c: char) -> bool {
-    family_of(c).is_some()
+    entry(c).is_some()
 }
 
 /// Strip tone from a vowel, keeping shape (e.g. `á` → `a`, `ấ` → `â`).
 pub fn vowel_stem(c: char) -> Option<char> {
-    let family = family_of(c)?;
-    Some(with_case(family.base, c))
+    let e = entry(c)?;
+    Some(glyph(e.family, 0, e.upper))
 }
 
-/// Apply tone by index: 0 = sắc … 4 = nặng.
+/// Apply tone by index: 0 = sắc … 4 = nặng. `base` must be toneless (`a`, `ơ`,
+/// …); a vowel already carrying a tone yields `None`.
 pub fn toned_vowel(base: char, tone_index: usize) -> Option<char> {
-    let lower = fold_lower(base);
-    let family = VOWEL_FAMILIES.iter().find(|f| f.base == lower)?;
-    let toned = *family.tones.get(tone_index)?;
-    Some(with_case(toned, base))
+    let e = entry(base)?;
+    if e.index != 0 || tone_index >= 5 {
+        return None;
+    }
+    Some(glyph(e.family, tone_index + 1, e.upper))
 }
 
 /// Tone index on a vowel, if any (0 = sắc … 4 = nặng).
 pub fn tone_index_on_vowel(c: char) -> Option<usize> {
-    let lower = fold_lower(c);
-    let family = family_of(c)?;
-    if lower == family.base {
-        return None;
-    }
-    family.tones.iter().position(|&t| t == lower)
+    entry(c)?.index.checked_sub(1)
 }
 
 #[cfg(test)]
 mod tests {
+    use super::table::VOWEL_FAMILIES;
     use super::*;
 
     #[test]
     fn table_covers_all_stems_and_tones() {
         for family in VOWEL_FAMILIES {
-            assert!(is_vowel(family.base));
-            for &toned in &family.tones {
+            let (base, tones) = (family[0], &family[1..]);
+            assert!(is_vowel(base));
+            for (i, &toned) in tones.iter().enumerate() {
                 assert!(is_vowel(toned));
-                assert_eq!(vowel_stem(toned), Some(family.base));
-            }
-            for (i, &toned) in family.tones.iter().enumerate() {
-                assert_eq!(toned_vowel(family.base, i), Some(toned));
+                assert_eq!(vowel_stem(toned), Some(base));
+                assert_eq!(toned_vowel(base, i), Some(toned));
                 assert_eq!(tone_index_on_vowel(toned), Some(i));
             }
         }
@@ -129,5 +59,22 @@ mod tests {
         assert_eq!(toned_vowel('A', 0), Some('Á'));
         assert_eq!(vowel_stem('Ắ'), Some('Ă'));
         assert_eq!(tone_index_on_vowel('Ứ'), Some(0));
+    }
+
+    #[test]
+    fn toned_input_rejected_by_toned_vowel() {
+        // `toned_vowel` takes a toneless base; re-toning goes through
+        // `vowel_stem` first (see `marks::apply_tone_to_vowel`).
+        assert_eq!(toned_vowel('á', 1), None);
+        assert_eq!(toned_vowel('a', 5), None); // tone index out of range
+    }
+
+    #[test]
+    fn non_vowels_rejected() {
+        for ch in ['b', 'đ', 'Đ', '9', ' '] {
+            assert!(!is_vowel(ch), "{ch}");
+            assert_eq!(vowel_stem(ch), None, "{ch}");
+            assert_eq!(tone_index_on_vowel(ch), None, "{ch}");
+        }
     }
 }

--- a/crates/funput-core/src/unicode/vowels/table.rs
+++ b/crates/funput-core/src/unicode/vowels/table.rs
@@ -1,0 +1,139 @@
+//! Compile-time codepoint → vowel table behind the O(1) queries in [`super`].
+//!
+//! [`VOWEL_FAMILIES`] stays the single human-readable source of truth. At
+//! compile time it is flattened into a dense byte table indexed by codepoint,
+//! so per-keystroke lookups never scan the family list or case-fold.
+
+/// The 12 vowel families, lowercase. Per row, index 0 is the toneless base and
+/// 1–5 carry the tone marks in order: sắc, huyền, hỏi, ngã, nặng.
+pub(super) const VOWEL_FAMILIES: [[char; 6]; 12] = [
+    ['a', 'á', 'à', 'ả', 'ã', 'ạ'],
+    ['ă', 'ắ', 'ằ', 'ẳ', 'ẵ', 'ặ'],
+    ['â', 'ấ', 'ầ', 'ẩ', 'ẫ', 'ậ'],
+    ['e', 'é', 'è', 'ẻ', 'ẽ', 'ẹ'],
+    ['ê', 'ế', 'ề', 'ể', 'ễ', 'ệ'],
+    ['i', 'í', 'ì', 'ỉ', 'ĩ', 'ị'],
+    ['o', 'ó', 'ò', 'ỏ', 'õ', 'ọ'],
+    ['ô', 'ố', 'ồ', 'ổ', 'ỗ', 'ộ'],
+    ['ơ', 'ớ', 'ờ', 'ở', 'ỡ', 'ợ'],
+    ['u', 'ú', 'ù', 'ủ', 'ũ', 'ụ'],
+    ['ư', 'ứ', 'ừ', 'ử', 'ữ', 'ự'],
+    ['y', 'ý', 'ỳ', 'ỷ', 'ỹ', 'ỵ'],
+];
+
+// Vietnamese precomposed vowels span three Unicode blocks: Basic Latin +
+// Latin-1 (plain vowels, acute/grave/circumflex/tilde), Latin Extended-A/B
+// (ă ĩ ũ ơ ư), and Latin Extended Additional (the rest). Two dense ranges
+// cover all of them.
+const BASIC_END: usize = 0x1B1; // one past 'ư' (U+01B0)
+const EXTRA_START: usize = 0x1EA0; // 'Ạ'
+const EXTRA_END: usize = 0x1EFA; // one past 'ỹ' (U+1EF9)
+const SLOTS: usize = BASIC_END + (EXTRA_END - EXTRA_START);
+
+static TABLE: [u8; SLOTS] = build();
+
+/// A vowel's coordinates: family, index within it (0 = base, 1–5 = tone), case.
+pub(super) struct Entry {
+    pub(super) family: usize,
+    pub(super) index: usize,
+    pub(super) upper: bool,
+}
+
+/// Decode the table entry for `c`, or `None` when it is not a Vietnamese vowel.
+pub(super) fn entry(c: char) -> Option<Entry> {
+    let packed = match slot(c as usize) {
+        Some(s) => TABLE[s],
+        None => return None,
+    };
+    let v = packed.checked_sub(1)? as usize;
+    Some(Entry {
+        family: v / 12,
+        index: (v % 12) / 2,
+        upper: v % 2 == 1,
+    })
+}
+
+/// The glyph at (family, index) in the requested case.
+pub(super) fn glyph(family: usize, index: usize, upper: bool) -> char {
+    let lower = VOWEL_FAMILIES[family][index];
+    if upper { to_upper(lower) } else { lower }
+}
+
+/// Table slot for a codepoint, or `None` outside the two mapped ranges.
+const fn slot(cp: usize) -> Option<usize> {
+    if cp < BASIC_END {
+        Some(cp)
+    } else if cp >= EXTRA_START && cp < EXTRA_END {
+        Some(BASIC_END + (cp - EXTRA_START))
+    } else {
+        None
+    }
+}
+
+/// Uppercase counterpart of a [`VOWEL_FAMILIES`] char (not general Unicode):
+/// Latin-1 uppers sit 0x20 below their lower; in the extended blocks the upper
+/// is the direct predecessor. Cross-checked against `char::to_uppercase` in tests.
+const fn to_upper(lower: char) -> char {
+    let cp = lower as u32;
+    let up = if cp < 0x100 { cp - 0x20 } else { cp - 1 };
+    match char::from_u32(up) {
+        Some(upper) => upper,
+        None => lower,
+    }
+}
+
+/// Pack (family, index, case) into a non-zero byte; 0 means "not a vowel".
+const fn pack(family: usize, index: usize, upper: bool) -> u8 {
+    1 + (family * 12 + index * 2 + upper as usize) as u8
+}
+
+const fn build() -> [u8; SLOTS] {
+    let mut table = [0u8; SLOTS];
+    let mut family = 0;
+    while family < VOWEL_FAMILIES.len() {
+        let mut index = 0;
+        while index < 6 {
+            let lower = VOWEL_FAMILIES[family][index];
+            store(&mut table, lower, pack(family, index, false));
+            store(&mut table, to_upper(lower), pack(family, index, true));
+            index += 1;
+        }
+        family += 1;
+    }
+    table
+}
+
+const fn store(table: &mut [u8; SLOTS], ch: char, value: u8) {
+    match slot(ch as usize) {
+        Some(s) => table[s] = value,
+        // Unreachable for the current inventory; a bad edit fails the build.
+        None => panic!("vowel outside the mapped Unicode ranges"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_glyph_round_trips_and_uppercases_correctly() {
+        for (family, glyphs) in VOWEL_FAMILIES.iter().enumerate() {
+            for (index, &ch) in glyphs.iter().enumerate() {
+                let upper = to_upper(ch);
+                assert_eq!(Some(upper), ch.to_uppercase().next(), "{ch}");
+                for (want, case) in [(ch, false), (upper, true)] {
+                    let e = entry(want).expect("vowel missing from table");
+                    assert_eq!((e.family, e.index, e.upper), (family, index, case));
+                    assert_eq!(glyph(family, index, case), want);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn non_vowels_have_no_entry() {
+        for ch in ['b', 'Z', 'đ', 'Đ', '1', ' ', 'ǎ', '漢'] {
+            assert!(entry(ch).is_none(), "{ch}");
+        }
+    }
+}

--- a/crates/funput-core/src/validation/coda.rs
+++ b/crates/funput-core/src/validation/coda.rs
@@ -1,0 +1,60 @@
+//! Coda inventory and the nucleus/coda helpers shared by syllable validation
+//! and rhyme reachability. Everything here is allocation-free except
+//! [`toneless_rhyme`], which builds the boundary-time rhyme string.
+
+use crate::unicode::marks::{Tone, tone_on_vowel, vowel_stem};
+use crate::validation::parse::SyllableParts;
+
+pub(crate) const VALID_CODAS: &[&str] = &["", "c", "ch", "m", "n", "ng", "nh", "p", "t"];
+
+/// Stop (oral plosive) codas. A syllable ending in one of these may only carry
+/// the sắc or nặng tone — a Vietnamese phonotactic rule. This is what tells
+/// English `text` (→ `tẽt`, ngã + `t`) apart from real syllables like `tét`.
+pub(crate) const STOP_CODAS: &[&str] = &["c", "ch", "p", "t"];
+
+/// Longest valid Vietnamese coda (`ch` / `ng` / `nh`).
+pub(crate) const MAX_CODA: usize = 2;
+
+/// The tone carried by the nucleus (at most one toned vowel), if any.
+pub(crate) fn nucleus_tone(mut nucleus: impl Iterator<Item = char>) -> Option<Tone> {
+    nucleus.find_map(tone_on_vowel)
+}
+
+/// The coda lowercased into a fixed buffer, or `None` when it is longer than
+/// any Vietnamese coda. A lone `k` is normalized to `c`: Central Highlands
+/// (Tây Nguyên) toponyms write the final /k/ stop as `k` (`Đắk`, `Lắk`), which
+/// is allophonic with final `c` — while a multi-letter coda (`ck`) stays
+/// untouched, so English `rock`/`back` are unaffected.
+pub(crate) fn normalized_coda(parts: &SyllableParts) -> Option<([char; MAX_CODA], usize)> {
+    let mut coda = ['\0'; MAX_CODA];
+    let mut len = 0;
+    for ch in parts.coda_chars() {
+        if len == MAX_CODA {
+            return None;
+        }
+        coda[len] = ch.to_ascii_lowercase();
+        len += 1;
+    }
+    if len == 1 && coda[0] == 'k' {
+        coda[0] = 'c';
+    }
+    Some((coda, len))
+}
+
+/// True if `coda` (lowercase chars) is an entry of `list`.
+pub(crate) fn coda_in(list: &[&str], coda: &[char]) -> bool {
+    list.iter()
+        .any(|entry| entry.chars().eq(coda.iter().copied()))
+}
+
+/// Toneless rhyme (vần) = nucleus with tones stripped (shape kept) + coda,
+/// lowercase: `tiền` → `iên`, `trường` → `ương`.
+pub(crate) fn toneless_rhyme(parts: &SyllableParts, coda: &[char]) -> String {
+    let mut rhyme = String::with_capacity(8);
+    for ch in parts.nucleus_chars() {
+        let stem = vowel_stem(ch).unwrap_or(ch);
+        rhyme.extend(stem.to_lowercase());
+    }
+    rhyme.extend(coda.iter().copied());
+    rhyme
+}

--- a/crates/funput-core/src/validation/mod.rs
+++ b/crates/funput-core/src/validation/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod coda;
 pub mod parse;
+pub mod reachability;
 pub mod rhyme;
 pub mod syllable;

--- a/crates/funput-core/src/validation/parse.rs
+++ b/crates/funput-core/src/validation/parse.rs
@@ -1,20 +1,38 @@
 //! Split a syllable chunk into onset + vowel nucleus + coda.
+//!
+//! Runs on the keystroke hot path, so parsing borrows the buffer and never
+//! allocates: the onset is a prefix slice; nucleus and coda are filtering
+//! iterators over the remainder.
 
 use crate::unicode::marks::is_vowel;
 
-/// Parsed components of a single syllable chunk.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SyllableParts {
-    pub onset: String,
-    pub nucleus: String,
-    pub coda: String,
+/// Parsed view of a single syllable chunk. The nucleus and coda are
+/// *interleaved* selections of the post-onset text — a vowel after a consonant
+/// still counts as nucleus (`mixa` → nucleus `ia`, coda `x`) — so they are
+/// exposed as iterators rather than slices.
+#[derive(Debug, Clone, Copy)]
+pub struct SyllableParts<'a> {
+    pub onset: &'a str,
+    rest: &'a str,
     /// Leading consonants do not form a valid Vietnamese onset.
     pub invalid_onset: bool,
 }
 
+impl<'a> SyllableParts<'a> {
+    /// The vowel nucleus, in buffer order.
+    pub fn nucleus_chars(&self) -> impl Iterator<Item = char> + Clone + 'a {
+        self.rest.chars().filter(|&c| is_vowel(c))
+    }
+
+    /// The consonant coda, in buffer order.
+    pub fn coda_chars(&self) -> impl Iterator<Item = char> + Clone + 'a {
+        self.rest.chars().filter(|&c| !is_vowel(c))
+    }
+}
+
 const VALID_ONSETS: &[&str] = &[
-    "", "b", "c", "ch", "d", "g", "gh", "gi", "h", "k", "kh", "l", "m", "n", "ng", "ngh", "nh",
-    "p", "ph", "qu", "r", "s", "t", "th", "tr", "v", "x",
+    "b", "c", "ch", "d", "g", "gh", "gi", "h", "k", "kh", "l", "m", "n", "ng", "ngh", "nh", "p",
+    "ph", "qu", "r", "s", "t", "th", "tr", "v", "x",
 ];
 
 /// Consonant-cluster onsets that occur only in Central Highlands (Tây Nguyên)
@@ -24,109 +42,104 @@ const VALID_ONSETS: &[&str] = &[
 /// the onset, so this barely affects English auto-restore.
 const ETHNIC_ONSETS: &[&str] = &["bl", "br", "dr", "gl", "gr", "kl", "kr", "pl", "pr"];
 
-/// True if `onset_lower` is a valid Vietnamese onset (`đ` included), or a Tây
-/// Nguyên toponym cluster ([`ETHNIC_ONSETS`]).
-pub(crate) fn is_valid_onset(onset_lower: &str) -> bool {
-    onset_lower.is_empty()
-        || onset_lower == "đ"
-        || VALID_ONSETS.contains(&onset_lower)
-        || ETHNIC_ONSETS.contains(&onset_lower)
+/// True if `onset` is a valid Vietnamese onset (`đ` included, any case), or a
+/// Tây Nguyên toponym cluster ([`ETHNIC_ONSETS`]).
+pub(crate) fn is_valid_onset(onset: &str) -> bool {
+    onset.is_empty()
+        || onset == "đ"
+        || onset == "Đ"
+        || VALID_ONSETS.iter().any(|o| onset.eq_ignore_ascii_case(o))
+        || ETHNIC_ONSETS.iter().any(|o| onset.eq_ignore_ascii_case(o))
 }
 
 /// Parse one syllable chunk into onset, vowel nucleus, and coda.
-pub fn parse_syllable(buffer: &str) -> SyllableParts {
-    if buffer.is_empty() {
-        return SyllableParts {
-            onset: String::new(),
-            nucleus: String::new(),
-            coda: String::new(),
-            invalid_onset: false,
-        };
-    }
-
+pub fn parse_syllable(buffer: &str) -> SyllableParts<'_> {
     let (onset, rest, invalid_onset) = match_onset(buffer);
-    let mut nucleus = String::new();
-    let mut coda = String::new();
-    for ch in rest.chars() {
-        if is_vowel(ch) {
-            nucleus.push(ch);
-        } else {
-            coda.push(ch);
-        }
-    }
-
     SyllableParts {
         onset,
-        nucleus,
-        coda,
+        rest,
         invalid_onset,
     }
 }
 
-fn match_onset(buffer: &str) -> (String, &str, bool) {
-    if let Some(first) = buffer.chars().next()
-        && (first == 'đ' || first == 'Đ')
-    {
-        let rest = buffer.strip_prefix(first).unwrap_or("");
-        return (first.to_string(), rest, false);
+/// Byte offset just past the first `n` chars of `s`, or `None` if `s` is shorter.
+fn after_n_chars(s: &str, n: usize) -> Option<usize> {
+    let mut chars = s.chars();
+    for _ in 0..n {
+        chars.next()?;
+    }
+    Some(s.len() - chars.as_str().len())
+}
+
+fn match_onset(buffer: &str) -> (&str, &str, bool) {
+    let Some(first) = buffer.chars().next() else {
+        return ("", buffer, false);
+    };
+    if first == 'đ' || first == 'Đ' {
+        let (onset, rest) = buffer.split_at(first.len_utf8());
+        return (onset, rest, false);
     }
 
-    let lower_chars: Vec<char> = buffer.to_lowercase().chars().collect();
-
+    // Longest onset first (3 chars: `ngh`), then shorter.
     for len in (1..=3).rev() {
-        if lower_chars.len() < len {
+        let Some(split) = after_n_chars(buffer, len) else {
+            continue;
+        };
+        let (prefix, rest) = buffer.split_at(split);
+        if prefix.is_empty() || !is_valid_onset(prefix) {
             continue;
         }
-        let prefix_lower: String = lower_chars[..len].iter().collect();
-        if !is_valid_onset(&prefix_lower) {
-            continue;
-        }
-        let prefix: String = buffer.chars().take(len).collect();
-        let rest = &buffer[prefix.len()..];
 
         // In `gi`, the `i` is part of the onset only when another vowel follows
         // (`gia`, `giết`). When `i` is the lone vowel it is the nucleus (`gì`,
         // `gìn`), so fall back to the shorter `g` onset.
-        if prefix_lower == "gi" && !rest.chars().next().is_some_and(is_vowel) {
+        if prefix.eq_ignore_ascii_case("gi") && !rest.chars().next().is_some_and(is_vowel) {
             continue;
         }
 
         return (prefix, rest, false);
     }
 
-    if let Some(first) = buffer.chars().next()
-        && is_vowel(first)
-    {
-        return (String::new(), buffer, false);
+    if is_vowel(first) {
+        return ("", buffer, false);
     }
 
-    (String::new(), buffer, true)
+    ("", buffer, true)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn parts(onset: &str, nucleus: &str, coda: &str) -> SyllableParts {
-        SyllableParts {
-            onset: onset.into(),
-            nucleus: nucleus.into(),
-            coda: coda.into(),
-            invalid_onset: false,
-        }
+    /// (onset, nucleus, coda, invalid_onset) with the iterators materialized.
+    fn parts(buffer: &str) -> (String, String, String, bool) {
+        let p = parse_syllable(buffer);
+        (
+            p.onset.into(),
+            p.nucleus_chars().collect(),
+            p.coda_chars().collect(),
+            p.invalid_onset,
+        )
+    }
+
+    fn ok(onset: &str, nucleus: &str, coda: &str) -> (String, String, String, bool) {
+        (onset.into(), nucleus.into(), coda.into(), false)
     }
 
     #[test]
     fn parse_syllable_cases() {
-        assert_eq!(parse_syllable("tr"), parts("tr", "", ""));
-        assert_eq!(parse_syllable("ng"), parts("ng", "", ""));
-        assert_eq!(parse_syllable("ma"), parts("m", "a", ""));
-        assert_eq!(parse_syllable("text"), parts("t", "e", "xt"));
-        assert_eq!(parse_syllable("mix"), parts("m", "i", "x"));
-        assert_eq!(parse_syllable("trung"), parts("tr", "u", "ng"));
-        assert_eq!(parse_syllable("đ"), parts("đ", "", ""));
+        assert_eq!(parts("tr"), ok("tr", "", ""));
+        assert_eq!(parts("ng"), ok("ng", "", ""));
+        assert_eq!(parts("ma"), ok("m", "a", ""));
+        assert_eq!(parts("text"), ok("t", "e", "xt"));
+        assert_eq!(parts("mix"), ok("m", "i", "x"));
+        assert_eq!(parts("trung"), ok("tr", "u", "ng"));
+        assert_eq!(parts("đ"), ok("đ", "", ""));
         // `gi` releases its `i` as the nucleus when no vowel follows.
-        assert_eq!(parse_syllable("gi"), parts("g", "i", ""));
-        assert_eq!(parse_syllable("gia"), parts("gi", "a", ""));
+        assert_eq!(parts("gi"), ok("g", "i", ""));
+        assert_eq!(parts("gia"), ok("gi", "a", ""));
+        // No valid onset → the leading consonants flag the chunk.
+        assert_eq!(parts("zt"), ("".into(), "".into(), "zt".into(), true));
+        assert_eq!(parts(""), ok("", "", ""));
     }
 }

--- a/crates/funput-core/src/validation/reachability.rs
+++ b/crates/funput-core/src/validation/reachability.rs
@@ -1,0 +1,91 @@
+//! Eager English-restore: can the buffer still become a Vietnamese syllable?
+//!
+//! Runs on every composed keystroke, so the check is allocation-free: the
+//! deshaped rhyme-so-far goes into a stack buffer and is prefix-matched against
+//! the cached deshaped rhyme inventory.
+
+use std::sync::LazyLock;
+
+use crate::unicode::marks::{Tone, vowel_stem};
+use crate::validation::coda::{STOP_CODAS, coda_in, normalized_coda, nucleus_tone};
+use crate::validation::parse::parse_syllable;
+use crate::validation::rhyme;
+
+/// Longer than every deshaped rhyme (max is 4 chars, e.g. `uong`), so a query
+/// that overflows this buffer can never be a rhyme prefix.
+const MAX_QUERY: usize = 8;
+
+/// Plain base of a vowel — tone **and** shape stripped (`ớ`→`o`, `ẽ`→`e`,
+/// `ư`→`u`). Non-vowels pass through lowercased.
+fn plain_base(c: char) -> char {
+    let stem = vowel_stem(c).unwrap_or(c);
+    match char::to_lowercase(stem).next().unwrap_or(stem) {
+        'ă' | 'â' => 'a',
+        'ê' => 'e',
+        'ô' | 'ơ' => 'o',
+        'ư' => 'u',
+        other => other,
+    }
+}
+
+/// The rhyme inventory with tone/shape stripped, built once. Lets
+/// [`is_definitely_invalid`] test reachability without re-deshaping all ~166
+/// rhymes on every keystroke.
+static DESHAPED_RHYMES: LazyLock<Vec<String>> = LazyLock::new(|| {
+    rhyme::all()
+        .iter()
+        .map(|r| r.chars().map(plain_base).collect())
+        .collect()
+});
+
+fn starts_with(rhyme: &str, prefix: &[char]) -> bool {
+    let mut chars = rhyme.chars();
+    prefix.iter().all(|&p| chars.next() == Some(p))
+}
+
+/// True when `buffer` can **no longer** become a valid Vietnamese syllable by
+/// typing more — used for *eager* English restore (flip back to the raw
+/// keystrokes the instant a word is unrecoverable, without waiting for a boundary):
+/// `tẽt`→`text` on the closing `t`, `caé`→`case` on the `e`, `luuỷ`→`luxury`.
+///
+/// Conservative. The rhyme so far is compared **deshaped** against the deshaped
+/// rhyme inventory, so a plain vowel still awaiting its shape stays alive (`ưo`
+/// matches `ươ…`, so typing `nước` via `nuwowcs` is never interrupted). Dead when:
+/// 1. The deshaped nucleus+coda is not a prefix of any rhyme: `ae`, `uuy`, `ad`.
+/// 2. A **stop** coda already carries a *wrong* tone — huyền / hỏi / ngã: `tẽt`.
+///    (A stop coda with no tone yet stays alive — the tone follows the coda.)
+pub fn is_definitely_invalid(buffer: &str) -> bool {
+    let parts = parse_syllable(buffer);
+    if parts.nucleus_chars().next().is_none() {
+        return false; // still building the onset
+    }
+    let Some((coda, coda_len)) = normalized_coda(&parts) else {
+        return true; // longer than any Vietnamese coda — no rhyme can match
+    };
+    let coda = &coda[..coda_len];
+
+    let mut query = ['\0'; MAX_QUERY];
+    let mut len = 0;
+    for ch in parts.nucleus_chars().chain(coda.iter().copied()) {
+        if len == MAX_QUERY {
+            return true; // longer than any rhyme — dead end
+        }
+        query[len] = plain_base(ch);
+        len += 1;
+    }
+
+    if !DESHAPED_RHYMES
+        .iter()
+        .any(|r| starts_with(r, &query[..len]))
+    {
+        return true;
+    }
+
+    if coda_in(STOP_CODAS, coda) {
+        return matches!(
+            nucleus_tone(parts.nucleus_chars()),
+            Some(Tone::Huyen | Tone::Hoi | Tone::Nga)
+        );
+    }
+    false
+}

--- a/crates/funput-core/src/validation/reachability.rs
+++ b/crates/funput-core/src/validation/reachability.rs
@@ -28,19 +28,31 @@ fn plain_base(c: char) -> char {
     }
 }
 
-/// The rhyme inventory with tone/shape stripped, built once. Lets
-/// [`is_definitely_invalid`] test reachability without re-deshaping all ~166
-/// rhymes on every keystroke.
+/// The rhyme inventory with tone/shape stripped, deshaped and sorted once.
+/// Lets [`is_definitely_invalid`] test reachability in O(log n) without
+/// re-deshaping all ~166 rhymes on every keystroke.
 static DESHAPED_RHYMES: LazyLock<Vec<String>> = LazyLock::new(|| {
-    rhyme::all()
+    let mut deshaped: Vec<String> = rhyme::all()
         .iter()
         .map(|r| r.chars().map(plain_base).collect())
-        .collect()
+        .collect();
+    deshaped.sort_unstable();
+    deshaped
 });
 
 fn starts_with(rhyme: &str, prefix: &[char]) -> bool {
     let mut chars = rhyme.chars();
     prefix.iter().all(|&p| chars.next() == Some(p))
+}
+
+/// True if some rhyme starts with `prefix`. The inventory is sorted, so all
+/// candidates form a contiguous range beginning at the first entry ≥ `prefix`;
+/// checking that single entry suffices.
+fn any_rhyme_with_prefix(prefix: &[char]) -> bool {
+    let rhymes = &*DESHAPED_RHYMES;
+    let first = rhymes
+        .partition_point(|r| r.chars().cmp(prefix.iter().copied()) == std::cmp::Ordering::Less);
+    rhymes.get(first).is_some_and(|r| starts_with(r, prefix))
 }
 
 /// True when `buffer` can **no longer** become a valid Vietnamese syllable by
@@ -74,10 +86,7 @@ pub fn is_definitely_invalid(buffer: &str) -> bool {
         len += 1;
     }
 
-    if !DESHAPED_RHYMES
-        .iter()
-        .any(|r| starts_with(r, &query[..len]))
-    {
+    if !any_rhyme_with_prefix(&query[..len]) {
         return true;
     }
 

--- a/crates/funput-core/src/validation/rhyme.rs
+++ b/crates/funput-core/src/validation/rhyme.rs
@@ -35,9 +35,18 @@ const VALID_RHYMES: &[&str] = &[
     "ach", "êch", "ich", "uêch", "oach", "uych",
 ];
 
+/// The inventory sorted once for O(log n) membership checks. [`VALID_RHYMES`]
+/// itself stays grouped by coda — that grouping is the human-readable
+/// documentation of the inventory.
+static SORTED_RHYMES: std::sync::LazyLock<Vec<&'static str>> = std::sync::LazyLock::new(|| {
+    let mut sorted = VALID_RHYMES.to_vec();
+    sorted.sort_unstable();
+    sorted
+});
+
 /// True if `rhyme` (toneless, lowercase) is a valid Vietnamese rhyme.
 pub fn is_valid_rhyme(rhyme: &str) -> bool {
-    VALID_RHYMES.contains(&rhyme)
+    SORTED_RHYMES.binary_search(&rhyme).is_ok()
 }
 
 /// The full toneless rhyme inventory (for prefix/reachability checks).
@@ -65,6 +74,14 @@ mod tests {
     fn nonexistent_rhymes_absent() {
         for bad in ["eg", "id", "ub", "az", "onk", "erf"] {
             assert!(!is_valid_rhyme(bad), "{bad} should not be a rhyme");
+        }
+    }
+
+    #[test]
+    fn binary_search_covers_the_whole_inventory() {
+        // The sorted view must agree with the source table for every entry.
+        for rhyme in all() {
+            assert!(is_valid_rhyme(rhyme), "{rhyme} missing from sorted view");
         }
     }
 }

--- a/crates/funput-core/src/validation/syllable.rs
+++ b/crates/funput-core/src/validation/syllable.rs
@@ -1,13 +1,16 @@
 //! Syllable-structure validation for modifier keys (tone / shape / stroke).
 //!
 //! Decides whether a modifier should apply, be ignored, or pass through as a
-//! literal key (non-Vietnamese structure the engine restores later).
+//! literal key (non-Vietnamese structure the engine restores later). Hot path:
+//! everything works on the borrowed [`SyllableParts`] view — the only
+//! allocation left is the rhyme string built at a word boundary.
 
-use std::sync::LazyLock;
-
-use crate::unicode::marks::{Tone, tone_on_vowel, vowel_stem};
-use crate::validation::parse::{is_valid_onset, parse_syllable};
-use crate::validation::rhyme::{self, is_valid_rhyme};
+use crate::unicode::marks::{Tone, vowel_stem};
+use crate::validation::coda::{
+    STOP_CODAS, VALID_CODAS, coda_in, normalized_coda, nucleus_tone, toneless_rhyme,
+};
+use crate::validation::parse::{SyllableParts, is_valid_onset, parse_syllable};
+use crate::validation::rhyme::is_valid_rhyme;
 
 /// Result of validating a modifier keystroke against the current buffer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -20,76 +23,50 @@ pub enum ModifierValidation {
     PassThrough,
 }
 
-const VALID_CODAS: &[&str] = &["", "c", "ch", "m", "n", "ng", "nh", "p", "t"];
-
-/// Stop (oral plosive) codas. A syllable ending in one of these may only carry
-/// the sắc or nặng tone — a Vietnamese phonotactic rule. This is what tells
-/// English `text` (→ `tẽt`, ngã + `t`) apart from real syllables like `tét`.
-const STOP_CODAS: &[&str] = &["c", "ch", "p", "t"];
-
-/// The tone carried by the nucleus (at most one toned vowel), if any.
-fn nucleus_tone(nucleus: &str) -> Option<Tone> {
-    nucleus.chars().find_map(tone_on_vowel)
-}
-
-/// Toneless rhyme (vần) = nucleus with tones stripped (shape kept) + coda, lowercased.
-/// `tiền` → `iên`, `trường` → `ương`.
-fn toneless_rhyme(nucleus: &str, coda: &str) -> String {
-    let mut rhyme = String::new();
-    for ch in nucleus.chars() {
-        let stem = vowel_stem(ch).unwrap_or(ch);
-        rhyme.extend(char::to_lowercase(stem));
-    }
-    rhyme.push_str(&coda.to_lowercase());
-    rhyme
-}
-
-fn violates_ckg_spelling(onset: &str, nucleus: &str) -> bool {
-    let Some(first) = nucleus.chars().next().and_then(vowel_stem) else {
+fn violates_ckg_spelling(onset: &str, parts: &SyllableParts) -> bool {
+    let Some(first) = parts.nucleus_chars().next().and_then(vowel_stem) else {
         return false;
     };
-    let stem = char::to_lowercase(first).next().unwrap_or(first);
+    let stem = first.to_lowercase().next().unwrap_or(first);
 
-    match onset.to_lowercase().as_str() {
-        "c" => !matches!(stem, 'a' | 'ă' | 'â' | 'o' | 'ô' | 'ơ' | 'u' | 'ư'),
-        // Native `k` precedes only front vowels (kẻ, kê, kim, kỳ), but loanwords and
-        // toponyms break this freely — `Kông` (Hồng Kông), `Kenya`, `Kang` — and a
-        // back-vowel `k` is distinct enough from English that allowing it costs little.
-        // So `k` is exempt from the pairing rule (the rhyme check still applies).
-        "k" => false,
+    if onset.eq_ignore_ascii_case("c") {
+        !matches!(stem, 'a' | 'ă' | 'â' | 'o' | 'ô' | 'ơ' | 'u' | 'ư')
+    } else if onset.eq_ignore_ascii_case("g") {
         // `g` + `i` is the valid `gi` digraph (gì, gìn); `g` + e/ê uses `gh`.
-        "g" => !matches!(stem, 'a' | 'ă' | 'â' | 'o' | 'ô' | 'ơ' | 'u' | 'ư' | 'i'),
-        "gh" => !matches!(stem, 'e' | 'ê' | 'i'),
-        "ngh" => !matches!(stem, 'e' | 'ê' | 'i'),
-        _ => false,
+        !matches!(stem, 'a' | 'ă' | 'â' | 'o' | 'ô' | 'ơ' | 'u' | 'ư' | 'i')
+    } else if onset.eq_ignore_ascii_case("gh") || onset.eq_ignore_ascii_case("ngh") {
+        !matches!(stem, 'e' | 'ê' | 'i')
+    } else {
+        // Native `k` precedes only front vowels (kẻ, kê, kim, kỳ), but loanwords
+        // and toponyms break this freely — `Kông` (Hồng Kông), `Kenya` — and a
+        // back-vowel `k` is distinct enough from English that allowing it costs
+        // little. So `k` is exempt (the rhyme check still applies).
+        false
     }
 }
 
 fn validate_modifier(buffer: &str) -> ModifierValidation {
     let parts = parse_syllable(buffer);
 
-    if parts.invalid_onset
-        || (!parts.onset.is_empty() && !is_valid_onset(&parts.onset.to_lowercase()))
-    {
+    if parts.invalid_onset || !is_valid_onset(parts.onset) {
         return ModifierValidation::PassThrough;
     }
-
-    if parts.nucleus.is_empty() {
+    if parts.nucleus_chars().next().is_none() {
         return ModifierValidation::Ignored;
     }
-
-    if violates_ckg_spelling(&parts.onset, &parts.nucleus) {
+    if violates_ckg_spelling(parts.onset, &parts) {
         return ModifierValidation::PassThrough;
     }
 
     // Two or more trailing consonants can't form a Vietnamese coda → likely an
     // English word, pass the key through. A single trailing consonant is allowed
     // (the user may still be typing, e.g. "mix" → "mĩx").
-    let coda_lower = parts.coda.to_lowercase();
-    if parts.coda.chars().count() >= 2 && !VALID_CODAS.contains(&coda_lower.as_str()) {
-        return ModifierValidation::PassThrough;
+    if parts.coda_chars().nth(1).is_some() {
+        match normalized_coda(&parts) {
+            Some((coda, len)) if coda_in(VALID_CODAS, &coda[..len]) => {}
+            _ => return ModifierValidation::PassThrough,
+        }
     }
-
     ModifierValidation::Allow
 }
 
@@ -123,20 +100,6 @@ pub fn is_valid(buffer: &str) -> bool {
     matches!(validate_modifier(buffer), ModifierValidation::Allow)
 }
 
-/// Central Highlands (Tây Nguyên) toponyms borrowed from Ê Đê / Jarai / Bahnar /
-/// M'Nông write the final /k/ stop as `k` (`Đắk`, `Lắk`, `Plắk`), which is
-/// allophonic with Vietnamese final `c`. Treat a lone trailing `k` as `c` for
-/// validation so these names pass without broadening the general coda inventory
-/// (which would wrongly accept English `book`, `look`, …). A multi-letter coda
-/// (`ck`) is left untouched, so `rock`/`back` are unaffected.
-fn normalize_ethnic_coda(coda: &str) -> &str {
-    if coda.eq_ignore_ascii_case("k") {
-        "c"
-    } else {
-        coda
-    }
-}
-
 /// Returns true if `buffer` is a *complete* valid Vietnamese syllable.
 ///
 /// **Strict**: the coda must be a real Vietnamese final (`c ch m n ng nh p t`),
@@ -146,229 +109,36 @@ fn normalize_ethnic_coda(coda: &str) -> &str {
 /// `côl` (cool), `tẽt` (text).
 pub fn is_complete_syllable(buffer: &str) -> bool {
     let parts = parse_syllable(buffer);
-    let coda = normalize_ethnic_coda(&parts.coda);
+    let Some((coda, coda_len)) = normalized_coda(&parts) else {
+        return false;
+    };
+    let coda = &coda[..coda_len];
 
     let structure_ok = !parts.invalid_onset
-        && (parts.onset.is_empty() || is_valid_onset(&parts.onset.to_lowercase()))
-        && !parts.nucleus.is_empty()
-        && !violates_ckg_spelling(&parts.onset, &parts.nucleus)
-        && VALID_CODAS.contains(&coda.to_lowercase().as_str());
+        && is_valid_onset(parts.onset)
+        && parts.nucleus_chars().next().is_some()
+        && !violates_ckg_spelling(parts.onset, &parts)
+        && coda_in(VALID_CODAS, coda);
     if !structure_ok {
         return false;
     }
 
     // The nucleus+coda must be a real Vietnamese rhyme (Level 2): keeps `việt`,
     // `trường` … but reverts structurally-ok-but-nonexistent rhymes.
-    if !is_valid_rhyme(&toneless_rhyme(&parts.nucleus, coda)) {
+    if !is_valid_rhyme(&toneless_rhyme(&parts, coda)) {
         return false;
     }
 
     // Phonotactics: a stop coda only allows sắc / nặng. Flags `tẽt` (English
     // "text"), `bèct`, etc. as not-a-syllable so the engine restores the raw word.
-    if STOP_CODAS.contains(&coda.to_lowercase().as_str()) {
-        return matches!(nucleus_tone(&parts.nucleus), Some(Tone::Sac | Tone::Nang));
+    if coda_in(STOP_CODAS, coda) {
+        return matches!(
+            nucleus_tone(parts.nucleus_chars()),
+            Some(Tone::Sac | Tone::Nang)
+        );
     }
-
     true
 }
 
-/// Plain base of a vowel — tone **and** shape stripped (`ớ`→`o`, `ẽ`→`e`, `ư`→`u`).
-/// Non-vowels pass through lowercased.
-fn plain_base(c: char) -> char {
-    let stem = vowel_stem(c).unwrap_or(c);
-    match char::to_lowercase(stem).next().unwrap_or(stem) {
-        'ă' | 'â' => 'a',
-        'ê' => 'e',
-        'ô' | 'ơ' => 'o',
-        'ư' => 'u',
-        other => other,
-    }
-}
-
-/// Strip tone and shape from every char (`ướng` → `uong`).
-fn deshape(s: &str) -> String {
-    s.chars().map(plain_base).collect()
-}
-
-/// The rhyme inventory with tone/shape stripped, built once. Lets
-/// [`is_definitely_invalid`] test reachability without re-`deshape`-ing all ~166
-/// rhymes (a `String` allocation each) on every keystroke.
-static DESHAPED_RHYMES: LazyLock<Vec<String>> =
-    LazyLock::new(|| rhyme::all().iter().map(|r| deshape(r)).collect());
-
-/// True when `buffer` can **no longer** become a valid Vietnamese syllable by
-/// typing more — used for *eager* English restore (flip back to the raw
-/// keystrokes the instant a word is unrecoverable, without waiting for a boundary):
-/// `tẽt`→`text` on the closing `t`, `caé`→`case` on the `e`, `luuỷ`→`luxury`.
-///
-/// Conservative. The rhyme so far is compared **deshaped** against the deshaped
-/// rhyme inventory, so a plain vowel still awaiting its shape stays alive (`ưo`
-/// matches `ươ…`, so typing `nước` via `nuwowcs` is never interrupted). Dead when:
-/// 1. The deshaped nucleus+coda is not a prefix of any rhyme: `ae`, `uuy`, `ad`.
-/// 2. A **stop** coda already carries a *wrong* tone — huyền / hỏi / ngã: `tẽt`.
-///    (A stop coda with no tone yet stays alive — the tone follows the coda.)
-pub fn is_definitely_invalid(buffer: &str) -> bool {
-    let parts = parse_syllable(buffer);
-    if parts.nucleus.is_empty() {
-        return false; // still building the onset
-    }
-
-    let coda = normalize_ethnic_coda(&parts.coda);
-    let rhyme_query = format!("{}{}", deshape(&parts.nucleus), deshape(coda));
-    let reachable = DESHAPED_RHYMES
-        .iter()
-        .any(|r| r.starts_with(&rhyme_query));
-    if !reachable {
-        return true;
-    }
-
-    if STOP_CODAS.contains(&coda.to_lowercase().as_str()) {
-        return matches!(
-            nucleus_tone(&parts.nucleus),
-            Some(Tone::Huyen | Tone::Hoi | Tone::Nga)
-        );
-    }
-    false
-}
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn validate_tone_cases() {
-        assert_eq!(validate_tone("ng"), ModifierValidation::Ignored);
-        assert_eq!(validate_tone("text"), ModifierValidation::PassThrough);
-        assert_eq!(validate_tone("mix"), ModifierValidation::Allow);
-        assert_eq!(validate_tone("ma"), ModifierValidation::Allow);
-        assert_eq!(validate_tone("zt"), ModifierValidation::PassThrough);
-    }
-
-    #[test]
-    fn validate_stroke_cases() {
-        assert_eq!(validate_stroke("d"), ModifierValidation::Allow);
-        // A d anywhere in the buffer allows the stroke: dang9 → đang, GD9 → GĐ.
-        assert_eq!(validate_stroke("dang"), ModifierValidation::Allow);
-        assert_eq!(validate_stroke("GD"), ModifierValidation::Allow);
-        assert_eq!(validate_stroke("x"), ModifierValidation::Ignored);
-        assert_eq!(validate_stroke("bag"), ModifierValidation::Ignored);
-    }
-
-    #[test]
-    fn is_valid_cases() {
-        assert!(is_valid("má"));
-        assert!(is_valid("ma"));
-        assert!(!is_valid("ábc"));
-        assert!(!is_valid("text"));
-    }
-
-    #[test]
-    fn is_complete_syllable_cases() {
-        // Complete Vietnamese syllables. `k` + `y` (kỳ/ký/kỹ) and the triphthong
-        // `ngoài` are regression guards for tone-placement / ckg-spelling fixes.
-        for ok in [
-            "má",
-            "ma",
-            "tét",
-            "việt",
-            "trường",
-            "quá",
-            "ăn",
-            "nhanh",
-            "kỳ",
-            "ký",
-            "kỹ",
-            "ngoài",
-        ] {
-            assert!(is_complete_syllable(ok), "{ok} should be complete");
-        }
-        // Invalid finals — a finished word ending in a non-Vietnamese coda.
-        for bad in ["cảd", "côl", "máz", "hảd", "ng", "abc", "text"] {
-            assert!(!is_complete_syllable(bad), "{bad} should be incomplete");
-        }
-        // Stricter than `is_valid`: single trailing `d`/`z` is lenient-valid but
-        // not a complete syllable.
-        assert!(is_valid("cảd"));
-        assert!(!is_complete_syllable("cảd"));
-    }
-
-    #[test]
-    fn real_syllables_are_complete() {
-        // Broad battery of real Vietnamese syllables (incl. hard rhymes). A failure
-        // means the rhyme table is missing an entry — add it to `rhyme.rs`.
-        let words = "\
-            a ba cá chè dê đi em gà gh ghê gì hoa khô là mẹ nó ô phở quà rể sữa tô \
-            uô(no) việt nghĩa người trường nước được rượu hươu khuya khuỷu quýnh quyên \
-            nguyệt khuếch doanh hoạch bâng khuâng ngoằn ngoèo tuềnh toàng xoèn xoẹt \
-            muốn muống thuốc nhuộm tuốt cướp lướt mượn đường riêng tiếng chuông \
-            anh ánh ách inh tính kịch lệnh xanh sạch huỳnh quỳnh xoong(no) \
-            hoàng khoảng nguyên nguyền quyết tuyết duyên xuân xuất bâng khuâng \
-            ngoắt ngoéo ngoạm ngoạp ngoạc ngoắc loắt choắt \
-            cằn nhằn lẳng lặng phưng phức nưng nửng \
-            tay hai cao sau cau mây đây kẹo kêu cừu mưu líu xíu";
-        for w in words.split_whitespace() {
-            if w.ends_with("(no)") {
-                continue;
-            }
-            // skip onset-only fragments used as spacers
-            if w == "gh" {
-                continue;
-            }
-            assert!(
-                is_complete_syllable(w),
-                "{w} (rhyme {:?}) should be a complete syllable",
-                {
-                    let p = parse_syllable(w);
-                    toneless_rhyme(&p.nucleus, &p.coda)
-                }
-            );
-        }
-    }
-
-    #[test]
-    fn definitely_invalid_detects_dead_ends() {
-        // Dead ends — unreachable rhyme (incl. open clusters), or stop coda +
-        // wrong (huyền/hỏi/ngã) tone.
-        for dead in ["tẽt", "tèt", "cảd", "máz", "pèect", "ábc", "caé", "luuỷ"] {
-            assert!(is_definitely_invalid(dead), "{dead} should be a dead end");
-        }
-        // Alive: still typing, already valid, OR a stop coda awaiting its tone
-        // (`nuoc`/`nươc`/`côt` → user types the tone after the coda).
-        for alive in [
-            "tẽ", "te", "ng", "ngh", "cả", "cản", "việt", "má", "trươ", "nuoc", "nươc", "côt",
-            "tét",
-        ] {
-            assert!(!is_definitely_invalid(alive), "{alive} should stay alive");
-        }
-    }
-
-    #[test]
-    fn stop_coda_only_allows_sac_or_nang() {
-        // Legal: stop coda with sắc or nặng.
-        for ok in ["tét", "tẹt", "sách", "học", "đẹp", "việt", "nước"] {
-            assert!(is_complete_syllable(ok), "{ok} should be complete");
-        }
-        // Illegal: stop coda with ngang / huyền / hỏi / ngã — the signal that
-        // catches English words like `text` (→ `tẽt`) or `coot` (→ `côt`).
-        for bad in ["tẽt", "tèt", "tẻt", "côt", "sàch", "mãc"] {
-            assert!(!is_complete_syllable(bad), "{bad} should be incomplete");
-        }
-        // Sonorant codas keep all tones legal.
-        for ok in ["làng", "mển", "ngã", "cũng"] {
-            assert!(is_complete_syllable(ok), "{ok} should be complete");
-        }
-    }
-
-    #[test]
-    fn ckg_spelling() {
-        assert_eq!(validate_tone("ke"), ModifierValidation::Allow);
-        // `k` is exempt from the pairing rule for loanwords/toponyms (Kông, Kenya).
-        assert_eq!(validate_tone("ka"), ModifierValidation::Allow);
-        assert_eq!(validate_tone("ca"), ModifierValidation::Allow);
-        // `c`+front still needs `k`; `ge` would need `gh` — these stay restricted.
-        assert_eq!(validate_tone("ce"), ModifierValidation::PassThrough);
-        assert_eq!(validate_tone("ge"), ModifierValidation::PassThrough);
-        // `gi` digraph stays valid.
-        assert_eq!(validate_tone("gi"), ModifierValidation::Allow);
-    }
-}
+mod tests;

--- a/crates/funput-core/src/validation/syllable/tests.rs
+++ b/crates/funput-core/src/validation/syllable/tests.rs
@@ -1,0 +1,140 @@
+use super::*;
+use crate::validation::coda::{MAX_CODA, normalized_coda, toneless_rhyme};
+use crate::validation::reachability::is_definitely_invalid;
+
+#[test]
+fn validate_tone_cases() {
+    assert_eq!(validate_tone("ng"), ModifierValidation::Ignored);
+    assert_eq!(validate_tone("text"), ModifierValidation::PassThrough);
+    assert_eq!(validate_tone("mix"), ModifierValidation::Allow);
+    assert_eq!(validate_tone("ma"), ModifierValidation::Allow);
+    assert_eq!(validate_tone("zt"), ModifierValidation::PassThrough);
+}
+
+#[test]
+fn validate_stroke_cases() {
+    assert_eq!(validate_stroke("d"), ModifierValidation::Allow);
+    // A d anywhere in the buffer allows the stroke: dang9 → đang, GD9 → GĐ.
+    assert_eq!(validate_stroke("dang"), ModifierValidation::Allow);
+    assert_eq!(validate_stroke("GD"), ModifierValidation::Allow);
+    assert_eq!(validate_stroke("x"), ModifierValidation::Ignored);
+    assert_eq!(validate_stroke("bag"), ModifierValidation::Ignored);
+}
+
+#[test]
+fn is_valid_cases() {
+    assert!(is_valid("má"));
+    assert!(is_valid("ma"));
+    assert!(!is_valid("ábc"));
+    assert!(!is_valid("text"));
+}
+
+#[test]
+fn is_complete_syllable_cases() {
+    // Complete Vietnamese syllables. `k` + `y` (kỳ/ký/kỹ) and the triphthong
+    // `ngoài` are regression guards for tone-placement / ckg-spelling fixes.
+    for ok in [
+        "má",
+        "ma",
+        "tét",
+        "việt",
+        "trường",
+        "quá",
+        "ăn",
+        "nhanh",
+        "kỳ",
+        "ký",
+        "kỹ",
+        "ngoài",
+    ] {
+        assert!(is_complete_syllable(ok), "{ok} should be complete");
+    }
+    // Invalid finals — a finished word ending in a non-Vietnamese coda.
+    for bad in ["cảd", "côl", "máz", "hảd", "ng", "abc", "text"] {
+        assert!(!is_complete_syllable(bad), "{bad} should be incomplete");
+    }
+    // Stricter than `is_valid`: single trailing `d`/`z` is lenient-valid but
+    // not a complete syllable.
+    assert!(is_valid("cảd"));
+    assert!(!is_complete_syllable("cảd"));
+}
+
+#[test]
+fn real_syllables_are_complete() {
+    // Broad battery of real Vietnamese syllables (incl. hard rhymes). A failure
+    // means the rhyme table is missing an entry — add it to `rhyme.rs`.
+    let words = "\
+        a ba cá chè dê đi em gà gh ghê gì hoa khô là mẹ nó ô phở quà rể sữa tô \
+        uô(no) việt nghĩa người trường nước được rượu hươu khuya khuỷu quýnh quyên \
+        nguyệt khuếch doanh hoạch bâng khuâng ngoằn ngoèo tuềnh toàng xoèn xoẹt \
+        muốn muống thuốc nhuộm tuốt cướp lướt mượn đường riêng tiếng chuông \
+        anh ánh ách inh tính kịch lệnh xanh sạch huỳnh quỳnh xoong(no) \
+        hoàng khoảng nguyên nguyền quyết tuyết duyên xuân xuất bâng khuâng \
+        ngoắt ngoéo ngoạm ngoạp ngoạc ngoắc loắt choắt \
+        cằn nhằn lẳng lặng phưng phức nưng nửng \
+        tay hai cao sau cau mây đây kẹo kêu cừu mưu líu xíu";
+    for w in words.split_whitespace() {
+        if w.ends_with("(no)") {
+            continue;
+        }
+        // skip onset-only fragments used as spacers
+        if w == "gh" {
+            continue;
+        }
+        assert!(
+            is_complete_syllable(w),
+            "{w} (rhyme {:?}) should be a complete syllable",
+            {
+                let p = parse_syllable(w);
+                let (coda, len) = normalized_coda(&p).unwrap_or((['\0'; MAX_CODA], 0));
+                toneless_rhyme(&p, &coda[..len])
+            }
+        );
+    }
+}
+
+#[test]
+fn definitely_invalid_detects_dead_ends() {
+    // Dead ends — unreachable rhyme (incl. open clusters), or stop coda +
+    // wrong (huyền/hỏi/ngã) tone.
+    for dead in ["tẽt", "tèt", "cảd", "máz", "pèect", "ábc", "caé", "luuỷ"] {
+        assert!(is_definitely_invalid(dead), "{dead} should be a dead end");
+    }
+    // Alive: still typing, already valid, OR a stop coda awaiting its tone
+    // (`nuoc`/`nươc`/`côt` → user types the tone after the coda).
+    for alive in [
+        "tẽ", "te", "ng", "ngh", "cả", "cản", "việt", "má", "trươ", "nuoc", "nươc", "côt", "tét",
+    ] {
+        assert!(!is_definitely_invalid(alive), "{alive} should stay alive");
+    }
+}
+
+#[test]
+fn stop_coda_only_allows_sac_or_nang() {
+    // Legal: stop coda with sắc or nặng.
+    for ok in ["tét", "tẹt", "sách", "học", "đẹp", "việt", "nước"] {
+        assert!(is_complete_syllable(ok), "{ok} should be complete");
+    }
+    // Illegal: stop coda with ngang / huyền / hỏi / ngã — the signal that
+    // catches English words like `text` (→ `tẽt`) or `coot` (→ `côt`).
+    for bad in ["tẽt", "tèt", "tẻt", "côt", "sàch", "mãc"] {
+        assert!(!is_complete_syllable(bad), "{bad} should be incomplete");
+    }
+    // Sonorant codas keep all tones legal.
+    for ok in ["làng", "mển", "ngã", "cũng"] {
+        assert!(is_complete_syllable(ok), "{ok} should be complete");
+    }
+}
+
+#[test]
+fn ckg_spelling() {
+    assert_eq!(validate_tone("ke"), ModifierValidation::Allow);
+    // `k` is exempt from the pairing rule for loanwords/toponyms (Kông, Kenya).
+    assert_eq!(validate_tone("ka"), ModifierValidation::Allow);
+    assert_eq!(validate_tone("ca"), ModifierValidation::Allow);
+    // `c`+front still needs `k`; `ge` would need `gh` — these stay restricted.
+    assert_eq!(validate_tone("ce"), ModifierValidation::PassThrough);
+    assert_eq!(validate_tone("ge"), ModifierValidation::PassThrough);
+    // `gi` digraph stays valid.
+    assert_eq!(validate_tone("gi"), ModifierValidation::Allow);
+}

--- a/crates/funput-engine/examples/profile.rs
+++ b/crates/funput-engine/examples/profile.rs
@@ -79,7 +79,10 @@ fn main() {
     let proc = (allocs() - b) - ctor;
 
     println!("=== allocations (heap ops) ===");
-    println!("Engine::new()+set_method : {:.2} / engine", ctor as f64 / reps as f64);
+    println!(
+        "Engine::new()+set_method : {:.2} / engine",
+        ctor as f64 / reps as f64
+    );
     println!(
         "process_char             : {:.3} allocs/key   ({} keys, {} composing)",
         proc as f64 / (reps * n) as f64,
@@ -116,13 +119,16 @@ fn main() {
             if is_boundary(k) {
                 buf.clear();
             } else {
-                buf = apply_checked(&buf, k, InputMethod::Telex, ToneStyle::Traditional, false).text;
+                buf =
+                    apply_checked(&buf, k, InputMethod::Telex, ToneStyle::Traditional, false).text;
             }
         }
         black_box(&buf);
     }) / letters as f64;
 
-    let composed = ["tôi", "yêu", "tiếng", "việt", "đẹp", "nước", "trời", "không"];
+    let composed = [
+        "tôi", "yêu", "tiếng", "việt", "đẹp", "nước", "trời", "không",
+    ];
     let invalid_ns = time(t, || {
         for b in composed {
             black_box(is_definitely_invalid(black_box(b)));

--- a/crates/funput-engine/src/diff.rs
+++ b/crates/funput-engine/src/diff.rs
@@ -1,22 +1,25 @@
 //! Buffer diff → backspace count + output suffix for platform inject.
 
+/// Byte length of the longest common char prefix of `old` and `new`.
+pub(crate) fn common_prefix_bytes(old: &str, new: &str) -> usize {
+    let mut prefix = 0;
+    for (o, n) in old.chars().zip(new.chars()) {
+        if o != n {
+            break;
+        }
+        prefix += o.len_utf8();
+    }
+    prefix
+}
+
 /// Compare composed text before and after a transform.
 ///
 /// Returns `(backspace, output)` where the platform deletes `backspace` chars
-/// then injects `output`.
+/// then injects `output`. Allocates only the output suffix.
 pub(crate) fn diff(old: &str, new: &str) -> (usize, String) {
-    let old_chars: Vec<char> = old.chars().collect();
-    let new_chars: Vec<char> = new.chars().collect();
-
-    let prefix_len = old_chars
-        .iter()
-        .zip(&new_chars)
-        .take_while(|(a, b)| a == b)
-        .count();
-
-    let backspace = old_chars.len() - prefix_len;
-    let output: String = new_chars.into_iter().skip(prefix_len).collect();
-    (backspace, output)
+    let prefix = common_prefix_bytes(old, new);
+    let backspace = old[prefix..].chars().count();
+    (backspace, new[prefix..].to_string())
 }
 
 #[cfg(test)]
@@ -41,5 +44,14 @@ mod tests {
     #[test]
     fn diff_unchanged() {
         assert_eq!(diff("x", "x"), (0, String::new()));
+    }
+
+    #[test]
+    fn common_prefix_is_char_aligned() {
+        // `â` vs `á` share a UTF-8 lead byte but differ as chars — the prefix
+        // must stay on the char boundary before them.
+        assert_eq!(common_prefix_bytes("â", "á"), 0);
+        assert_eq!(common_prefix_bytes("viê", "việ"), "vi".len());
+        assert_eq!(common_prefix_bytes("ab", "abc"), 2);
     }
 }

--- a/crates/funput-engine/src/pipeline.rs
+++ b/crates/funput-engine/src/pipeline.rs
@@ -1,8 +1,12 @@
 //! Key → funput-core → ImeResult orchestration.
+//!
+//! Hot path: the common keystroke (a pure append the app echoes itself) takes
+//! the zero-allocation pass-through exit; session strings (`vn_form`, `keys`)
+//! are refilled in place so their capacity is reused across keystrokes.
 
 use funput_core::{TransformKind, apply_checked, is_definitely_invalid};
 
-use crate::diff::diff;
+use crate::diff::common_prefix_bytes;
 use crate::flip::RestoreOverride;
 use crate::result::ImeResult;
 use crate::session::Session;
@@ -27,7 +31,8 @@ pub(crate) fn process(session: &mut Session, key: char) -> ImeResult {
 
     // Remember the Vietnamese composition before an eager restore can collapse the
     // buffer to raw keys, so the flip hotkey can recover it after a restore.
-    session.vn_form = composed.clone();
+    session.vn_form.clear();
+    session.vn_form.push_str(&composed);
 
     // A manual flip pins which form is displayed for the rest of the word, overriding
     // the automatic restore decision below.
@@ -52,22 +57,28 @@ pub(crate) fn process(session: &mut Session, key: char) -> ImeResult {
         }
     };
 
-    let (backspace, output) = diff(&session.buffer, &new_buffer);
+    // A pure append of the typed key passes through — the app echoes it itself,
+    // so there is nothing to inject (and nothing to allocate).
+    let prefix = common_prefix_bytes(&session.buffer, &new_buffer);
+    let pass_through =
+        prefix == session.buffer.len() && new_buffer[prefix..].chars().eq(std::iter::once(key));
+    let instruction = if pass_through {
+        ImeResult::none()
+    } else {
+        let backspace = session.buffer[prefix..].chars().count();
+        ImeResult::send(backspace, new_buffer[prefix..].to_string())
+    };
     session.buffer = new_buffer;
 
     // A revert is itself a restore to raw, so keep `keys` in sync — otherwise a
     // later word boundary sees `keys != buffer` and re-restores the stale original
     // keystrokes (e.g. `mixx` revert → `mix`, then Space → wrongly `mixx`).
     if result.kind == TransformKind::Reverted {
-        session.keys = session.buffer.clone();
+        session.keys.clear();
+        session.keys.push_str(&session.buffer);
     }
 
-    // A pure append of the typed key passes through — the app echoes it itself.
-    if backspace == 0 && output.chars().eq(std::iter::once(key)) {
-        ImeResult::none()
-    } else {
-        ImeResult::send(backspace, output)
-    }
+    instruction
 }
 
 #[cfg(test)]

--- a/crates/funput-engine/tests/alloc_budget.rs
+++ b/crates/funput-engine/tests/alloc_budget.rs
@@ -1,0 +1,107 @@
+//! Heap-allocation budget for the per-keystroke hot path.
+//!
+//! Counts every allocation the engine makes while typing a realistic Vietnamese
+//! sentence, and fails if the average per keystroke exceeds the budget. This is
+//! the regression guard for "least memory possible" work: optimizations ratchet
+//! the budgets down; a change that silently adds allocations to the hot path
+//! trips the test.
+//!
+//! Print the current numbers with:
+//! `cargo test -p funput-engine --test alloc_budget -- --nocapture`
+//!
+//! The counting allocator is process-global, so this file must stay its own
+//! integration-test binary and hold exactly one `#[test]` — a second test running
+//! in parallel would pollute the counters.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use funput_engine::Engine;
+
+/// Measured baseline (2026-07): 12.2 allocs / 134 B per keystroke with default
+/// settings, 13.9 / 148 B with spell-check on (identical in debug and release).
+/// Budgets leave a little headroom for legitimate feature work; ratchet them
+/// down as hot-path optimizations land.
+const MAX_ALLOCS_PER_KEY: f64 = 16.0;
+const MAX_BYTES_PER_KEY: f64 = 192.0;
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static BYTES: AtomicUsize = AtomicUsize::new(0);
+
+/// Counts allocations and requested bytes, then defers to the system allocator.
+struct CountingAlloc;
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // A grow-in-place still hits the allocator, so it counts as one event.
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(new_size, Ordering::Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAlloc = CountingAlloc;
+
+/// Realistic Telex input: tones, circumflex/horn/breve, the `đ` stroke, word
+/// boundaries, and an English word (`text`) to exercise eager restore.
+const TELEX_TEXT: &str =
+    "Tooi yeeu tieesng Vieejt. Hoom nay troiwf nuwowcs ddepj. Go~ text nhanh! ";
+
+/// Type `text` through `engine`, returning (allocs, bytes) attributed to it.
+fn measure(engine: &mut Engine, text: &str) -> (usize, usize) {
+    let before_allocs = ALLOCS.load(Ordering::Relaxed);
+    let before_bytes = BYTES.load(Ordering::Relaxed);
+    for key in text.chars() {
+        std::hint::black_box(engine.process_char(key));
+    }
+    (
+        ALLOCS.load(Ordering::Relaxed) - before_allocs,
+        BYTES.load(Ordering::Relaxed) - before_bytes,
+    )
+}
+
+fn assert_within_budget(label: &str, engine: &mut Engine) {
+    let keys = TELEX_TEXT.chars().count() as f64;
+    let (allocs, bytes) = measure(engine, TELEX_TEXT);
+    let allocs_per_key = allocs as f64 / keys;
+    let bytes_per_key = bytes as f64 / keys;
+    println!("{label}: {allocs_per_key:.1} allocs/key, {bytes_per_key:.0} bytes/key");
+    assert!(
+        allocs_per_key <= MAX_ALLOCS_PER_KEY,
+        "{label}: {allocs_per_key:.1} allocs/key exceeds the {MAX_ALLOCS_PER_KEY} budget \
+         — a change added heap allocations to the keystroke hot path"
+    );
+    assert!(
+        bytes_per_key <= MAX_BYTES_PER_KEY,
+        "{label}: {bytes_per_key:.0} bytes/key exceeds the {MAX_BYTES_PER_KEY} budget \
+         — a change added heap traffic to the keystroke hot path"
+    );
+}
+
+#[test]
+fn keystroke_alloc_budget() {
+    let mut engine = Engine::new();
+
+    // Warm-up: populate lazy statics (the deshaped-rhyme table behind eager
+    // restore) so one-time init is not billed to the steady-state measurement.
+    for key in TELEX_TEXT.chars() {
+        engine.process_char(key);
+    }
+    engine.clear();
+
+    assert_within_budget("default settings", &mut engine);
+
+    engine.set_spell_check(true);
+    assert_within_budget("spell-check on", &mut engine);
+}

--- a/crates/funput-engine/tests/alloc_budget.rs
+++ b/crates/funput-engine/tests/alloc_budget.rs
@@ -18,12 +18,13 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use funput_engine::Engine;
 
-/// Measured baseline (2026-07, after the zero-alloc core rewrite): 3.9 allocs /
-/// 39 B per keystroke, with or without spell-check (identical in debug and
-/// release). Budgets leave a little headroom for legitimate feature work;
-/// ratchet them down as hot-path optimizations land.
-const MAX_ALLOCS_PER_KEY: f64 = 6.0;
-const MAX_BYTES_PER_KEY: f64 = 64.0;
+/// Measured baseline (2026-07, after the zero-alloc core + engine rewrite):
+/// 1.1 allocs / 7 B per keystroke, with or without spell-check (identical in
+/// debug and release) — essentially just the composed-text `String` the core
+/// API returns. Budgets leave a little headroom for legitimate feature work;
+/// ratchet them down if the hot path sheds its last allocation.
+const MAX_ALLOCS_PER_KEY: f64 = 2.0;
+const MAX_BYTES_PER_KEY: f64 = 24.0;
 
 static ALLOCS: AtomicUsize = AtomicUsize::new(0);
 static BYTES: AtomicUsize = AtomicUsize::new(0);

--- a/crates/funput-engine/tests/alloc_budget.rs
+++ b/crates/funput-engine/tests/alloc_budget.rs
@@ -18,12 +18,12 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use funput_engine::Engine;
 
-/// Measured baseline (2026-07): 12.2 allocs / 134 B per keystroke with default
-/// settings, 13.9 / 148 B with spell-check on (identical in debug and release).
-/// Budgets leave a little headroom for legitimate feature work; ratchet them
-/// down as hot-path optimizations land.
-const MAX_ALLOCS_PER_KEY: f64 = 16.0;
-const MAX_BYTES_PER_KEY: f64 = 192.0;
+/// Measured baseline (2026-07, after the zero-alloc core rewrite): 3.9 allocs /
+/// 39 B per keystroke, with or without spell-check (identical in debug and
+/// release). Budgets leave a little headroom for legitimate feature work;
+/// ratchet them down as hot-path optimizations land.
+const MAX_ALLOCS_PER_KEY: f64 = 6.0;
+const MAX_BYTES_PER_KEY: f64 = 64.0;
 
 static ALLOCS: AtomicUsize = AtomicUsize::new(0);
 static BYTES: AtomicUsize = AtomicUsize::new(0);

--- a/crates/funput-engine/tests/engine_api.rs
+++ b/crates/funput-engine/tests/engine_api.rs
@@ -358,7 +358,11 @@ fn word_start_digit_passes_through() {
         engine.set_method(method);
         let result = engine.process_char('1');
         assert_eq!(result.action, Action::None, "{method:?}");
-        assert_eq!(engine.buffer(), "", "{method:?}: a leading digit must not compose");
+        assert_eq!(
+            engine.buffer(),
+            "",
+            "{method:?}: a leading digit must not compose"
+        );
     }
 }
 

--- a/platforms/linux/settings-gtk/Cargo.toml
+++ b/platforms/linux/settings-gtk/Cargo.toml
@@ -20,3 +20,12 @@ adw = { package = "libadwaita", version = "0.7", features = ["v1_5"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "5"
+
+# Pure settings UI — no IME hot path links here, so optimize for size. Matches
+# the root workspace profile (excluded packages do not inherit it). Do NOT set
+# `panic = "abort"` — repo-wide rule, see the root workspace Cargo.toml.
+[profile.release]
+opt-level = "s"
+lto = "fat"
+codegen-units = 1
+strip = "symbols"

--- a/platforms/macos/scripts/build-launcher.sh
+++ b/platforms/macos/scripts/build-launcher.sh
@@ -8,20 +8,23 @@
 # funput://settings to the input method (opening its Settings window) and exits.
 # See Launcher/main.swift.
 #
-#   build-launcher.sh <out-dir> <version> [sign-identity]
+#   build-launcher.sh <out-dir> <version> [sign-identity] [sign-name]
 #
-# Writes <out-dir>/Funput.app. sign-identity defaults to "-" (ad-hoc). Signing
-# adapts to the identity so the launcher is valid as nested code of the app:
+# Writes <out-dir>/Funput.app. sign-identity defaults to "-" (ad-hoc) and may be a
+# certificate hash (never ambiguous) or a name. sign-name defaults to
+# sign-identity and only selects the signing *policy*, so the launcher is valid
+# as nested code of the app:
 #   "-" / empty          -> ad-hoc (no hardened runtime, no timestamp)
 #   "Developer ID …"     -> hardened runtime + secure timestamp (notarizable)
 #   anything else (dev)  -> hardened runtime, no network timestamp
 # Normally invoked from the Xcode "Embed Launcher" build phase (embed-launcher.sh),
-# which passes the build's own code-signing identity.
+# which passes the build's own code-signing identity hash + name.
 set -eu
 
 OUT="$1"
 VERSION="$2"
 SIGN_ID="${3:--}"
+SIGN_NAME="${4:-$SIGN_ID}"
 
 DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SRC="$DIR/Launcher"
@@ -59,8 +62,9 @@ if [ -f "$ICON_SRC" ] && command -v iconutil >/dev/null 2>&1; then
     rm -rf "$ICONSET"
 fi
 
-# Sign (see header for the per-identity policy).
-case "$SIGN_ID" in
+# Sign — policy picked from the identity *name*, signing done with $SIGN_ID
+# (see header for the per-identity policy).
+case "$SIGN_NAME" in
     "" | "-")
         codesign --force --sign "-" "$APP" ;;
     "Developer ID"*)

--- a/platforms/macos/scripts/embed-launcher.sh
+++ b/platforms/macos/scripts/embed-launcher.sh
@@ -19,15 +19,20 @@ DEST_RESOURCES="$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
 BUILD_DIR="$DERIVED_FILE_DIR/launcher"
 
 # Sign the launcher with the same identity Xcode is using for this build, so it is
-# valid nested code. With code signing disabled (e.g. CI dry runs) fall back to
-# ad-hoc; Xcode re-signs the whole product afterwards anyway.
-if [ "${CODE_SIGNING_ALLOWED:-YES}" = "NO" ] || [ -z "${EXPANDED_CODE_SIGN_IDENTITY_NAME:-}" ]; then
+# valid nested code. Sign by the certificate *hash* (EXPANDED_CODE_SIGN_IDENTITY):
+# the human-readable name is ambiguous when the keychain holds two certs with the
+# same subject (e.g. a renewed "Apple Development" cert) and codesign then refuses
+# it. The name is still passed so build-launcher.sh can pick the per-identity
+# signing policy (hardened runtime / timestamp). With code signing disabled (e.g.
+# CI dry runs) fall back to ad-hoc; Xcode re-signs the whole product afterwards.
+if [ "${CODE_SIGNING_ALLOWED:-YES}" = "NO" ] || [ -z "${EXPANDED_CODE_SIGN_IDENTITY:-}" ]; then
     LAUNCHER_SIGN_ID="-"
 else
-    LAUNCHER_SIGN_ID="$EXPANDED_CODE_SIGN_IDENTITY_NAME"
+    LAUNCHER_SIGN_ID="$EXPANDED_CODE_SIGN_IDENTITY"
 fi
 
-"$SCRIPTS/build-launcher.sh" "$BUILD_DIR" "${MARKETING_VERSION:-0.0.0}" "$LAUNCHER_SIGN_ID" >/dev/null
+"$SCRIPTS/build-launcher.sh" "$BUILD_DIR" "${MARKETING_VERSION:-0.0.0}" \
+    "$LAUNCHER_SIGN_ID" "${EXPANDED_CODE_SIGN_IDENTITY_NAME:-}" >/dev/null
 
 mkdir -p "$DEST_RESOURCES"
 rm -rf "$DEST_RESOURCES/Funput.app"

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -58,7 +58,23 @@ windows = { version = "0.62", features = [
     "Win32_System_Threading",
 ] }
 
+# Size-first for the shell (the slint UI dominates the binary), speed-first for
+# the shared IME crates below — the per-keystroke hot path keeps full
+# optimization. Matches the root workspace profile (excluded packages do not
+# inherit it). Do NOT set `panic = "abort"` — repo-wide rule, see the root
+# workspace Cargo.toml.
 [profile.release]
 opt-level = "s"
-lto = true
-strip = true
+lto = "fat"
+codegen-units = 1
+strip = "symbols"
+
+# The shared engine hot path (funput-core/engine/desktop) stays speed-optimized.
+[profile.release.package.funput-core]
+opt-level = 3
+
+[profile.release.package.funput-engine]
+opt-level = 3
+
+[profile.release.package.funput-desktop]
+opt-level = 3


### PR DESCRIPTION
## What

A five-part performance and memory pass over the shared Rust hot path (`crates/`), plus release-profile hygiene for every shipped binary. Public APIs are untouched — `funput-core` / `funput-engine` frozen surfaces keep their exact signatures and behavior.

1. **Release profile** (root workspace): `lto = "fat"`, `codegen-units = 1`, `strip = "symbols"`. `panic = "abort"` is deliberately **not** set — the FFI/JNI boundaries rely on `catch_unwind` to keep host IME processes alive (documented in the manifest).
2. **O(1) vowel table** (`unicode/vowels/table.rs`): the per-char vowel queries (`is_vowel`, `vowel_stem`, …) now hit a 523-byte packed codepoint table built by a `const fn` at compile time, instead of scanning 12 families with case folding on every call. `VOWEL_FAMILIES` stays the single human-readable source of truth; a bad edit fails the build.
3. **Zero-alloc parse/validation**: `SyllableParts` borrows the buffer (onset slice + nucleus/coda iterators, interleaved semantics preserved); tone-position cluster analysis is one allocation-free pass with a no-tone fast path; every transform builds its result `String` in a single pass; `is_definitely_invalid` deshapes into a stack buffer. New themed modules keep files ≤150 LOC: `validation/coda.rs`, `validation/reachability.rs`, `composition/uo_horn.rs`, `tone_position/cluster.rs`.
4. **Engine hot path**: the common pass-through keystroke is detected *before* building output (zero allocation); `vn_form`/`keys` are refilled in place to reuse capacity; `diff` computes the common prefix on byte offsets instead of collecting two `Vec<char>`.
5. **O(log n) rhyme lookups**: sorted views of the rhyme inventory built once (`LazyLock`), membership via `binary_search`, prefix reachability via `partition_point`. The source table keeps its by-coda grouping as documentation.

The excluded platform manifests (`platforms/windows`, `platforms/linux/settings-gtk`) now carry equivalent profiles — size-first for the shells, with `opt-level = 3` package overrides keeping the shared IME crates speed-first inside the Windows exe. The stale `platforms/windows/src-tauri` exclude path is fixed.

## Measurements (Criterion + counting allocator, Apple M-series)

| | before | after |
|---|---:|---:|
| `funput-core::apply` (Telex) | 14.2 µs/run | **3.5 µs** |
| `process_char` engine path (Telex) | ~0.52 µs/key | **~0.11 µs** (8.9 M keys/s) |
| end-to-end via C FFI (Telex / VNI) | 0.55 / 0.51 µs/key | **0.12 / 0.11 µs** (8.5 M keys/s) |
| heap allocations per keystroke | 13.7 (~146 B) | **1.1 (~7 B)** — just the composed-text `String` the core API returns |
| spell-check overhead | +14 % time, +2 allocs | **none measurable** |
| `libfunput_ffi.dylib` (release) | 477 KB | **369 KB** |

`crates/funput-engine/tests/alloc_budget.rs` (new) turns the allocation count into a regression guard: a counting global allocator types a realistic Telex sentence and fails if the average exceeds **2 allocs / 24 B per keystroke**. Budgets are ratcheted down as optimizations land.

## Verification

- `cargo test --workspace` — all green (behavior unchanged; the full diacritics/methods/restore/words suites and the spell-check corpus test pass).
- Round-trip coverage through the real engine: `cargo run --release -p funput-cli -- dev coverage benchmarks/sample.txt` → **Telex 100 %, VNI 100 %** (137/137).
- `cargo clippy --workspace --all-targets` — clean; `cargo fmt --check` — clean; every new/rewritten file ≤150 LOC.
- Excluded manifests validated with `cargo metadata` (they only compile on their own OS); CI builds them from their own dirs with plain `cargo build --release`, so the profiles apply as-is. First `build-windows` / `build-linux` runs will be somewhat slower (fat LTO + one codegen unit); if a job ever times out, dropping that shell to `lto = "thin"` keeps most of the win.
- One deliberate nuance: `is_vowel('İ')` (Turkish dotted capital I) was accidentally `true` via full case folding; the table correctly returns `false`. Unreachable from Telex/VNI input.

Performance tables in `README.md`, `README.en.md`, and `benchmarks/README.md` updated to the new numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)