### PR TITLE
fix(windows): Alt+Shift / preset toggle hotkeys never matched in the low-level hook

### DIFF
--- a/platforms/windows/src/keymap.rs
+++ b/platforms/windows/src/keymap.rs
@@ -3,10 +3,10 @@
 
 use funput_desktop::{KeyEvent, Mods};
 use windows::Win32::UI::Input::KeyboardAndMouse::{
-    GetAsyncKeyState, GetKeyState, GetKeyboardLayout, ToUnicodeEx, VIRTUAL_KEY, VK_BACK, VK_CAPITAL,
-    VK_CONTROL, VK_DELETE, VK_DOWN, VK_END, VK_ESCAPE, VK_HOME, VK_INSERT, VK_LEFT, VK_LWIN,
-    VK_MENU, VK_NEXT, VK_OEM_3, VK_PRIOR, VK_RETURN, VK_RIGHT, VK_RWIN, VK_SHIFT, VK_SPACE, VK_TAB,
-    VK_UP,
+    GetAsyncKeyState, GetKeyState, GetKeyboardLayout, ToUnicodeEx, VIRTUAL_KEY, VK_BACK,
+    VK_CAPITAL, VK_CONTROL, VK_DELETE, VK_DOWN, VK_END, VK_ESCAPE, VK_HOME, VK_INSERT, VK_LCONTROL,
+    VK_LEFT, VK_LMENU, VK_LSHIFT, VK_LWIN, VK_MENU, VK_NEXT, VK_OEM_3, VK_PRIOR, VK_RCONTROL,
+    VK_RETURN, VK_RIGHT, VK_RMENU, VK_RSHIFT, VK_RWIN, VK_SHIFT, VK_SPACE, VK_TAB, VK_UP,
 };
 use windows::Win32::UI::WindowsAndMessaging::KBDLLHOOKSTRUCT;
 
@@ -26,19 +26,46 @@ pub fn read_mods() -> Mods {
     }
 }
 
-/// Whether this keydown matches the configured VI/EN toggle hotkey.
+/// Fold side-specific modifier virtual-keys back to their generic codes. The
+/// low-level hook always delivers the side-specific keys (`VK_LSHIFT`,
+/// `VK_RMENU`, …), never the generic `VK_SHIFT`/`VK_MENU`/`VK_CONTROL` an app
+/// sees after message translation — comparing against the generics without this
+/// fold can never match (the original Alt+Shift preset bug).
+fn normalize_vk(vk: VIRTUAL_KEY) -> VIRTUAL_KEY {
+    match vk {
+        VK_LSHIFT | VK_RSHIFT => VK_SHIFT,
+        VK_LCONTROL | VK_RCONTROL => VK_CONTROL,
+        VK_LMENU | VK_RMENU => VK_MENU,
+        VK_RWIN => VK_LWIN,
+        other => other,
+    }
+}
+
+/// Whether this keydown matches the configured VI/EN toggle hotkey. Presets
+/// match their exact modifier set, so nearby combos (e.g. Ctrl+Shift+Space)
+/// still reach the focused app.
 pub fn is_toggle(vk: VIRTUAL_KEY, mods: Mods, hotkey: Hotkey) -> bool {
+    let vk = normalize_vk(vk);
     match hotkey {
-        Hotkey::CtrlBacktick => mods.ctrl && !mods.alt && !mods.win && vk == VK_OEM_3,
-        Hotkey::CtrlSpace => mods.ctrl && !mods.alt && !mods.win && vk == VK_SPACE,
-        // Modifier-only combo: fires on the second modifier's keydown.
-        Hotkey::AltShift => mods.alt && mods.shift && (vk == VK_SHIFT || vk == VK_MENU),
+        Hotkey::CtrlBacktick => {
+            mods.ctrl && !mods.alt && !mods.win && !mods.shift && vk == VK_OEM_3
+        }
+        Hotkey::CtrlSpace => mods.ctrl && !mods.alt && !mods.win && !mods.shift && vk == VK_SPACE,
+        // Modifier-only combo: fires on the second modifier's keydown. The async
+        // key state may not yet include the key this very event is delivering,
+        // so the pressed key itself also counts as held.
+        Hotkey::AltShift => {
+            let alt = mods.alt || vk == VK_MENU;
+            let shift = mods.shift || vk == VK_SHIFT;
+            alt && shift && !mods.ctrl && !mods.win && (vk == VK_SHIFT || vk == VK_MENU)
+        }
     }
 }
 
 /// Whether this keydown matches the configured flip hotkey. Letter virtual-keys are
 /// their ASCII uppercase codes (`Z` = 0x5A, `X` = 0x58).
 pub fn is_flip(vk: VIRTUAL_KEY, mods: Mods, hotkey: FlipHotkey) -> bool {
+    let vk = normalize_vk(vk);
     let ctrl_shift = mods.ctrl && mods.shift && !mods.alt && !mods.win;
     match hotkey {
         FlipHotkey::Off => false,
@@ -50,8 +77,19 @@ pub fn is_flip(vk: VIRTUAL_KEY, mods: Mods, hotkey: FlipHotkey) -> bool {
 fn is_navigation(vk: VIRTUAL_KEY) -> bool {
     if matches!(
         vk,
-        VK_RETURN | VK_TAB | VK_ESCAPE | VK_LEFT | VK_RIGHT | VK_UP | VK_DOWN | VK_HOME | VK_END
-            | VK_PRIOR | VK_NEXT | VK_DELETE | VK_INSERT
+        VK_RETURN
+            | VK_TAB
+            | VK_ESCAPE
+            | VK_LEFT
+            | VK_RIGHT
+            | VK_UP
+            | VK_DOWN
+            | VK_HOME
+            | VK_END
+            | VK_PRIOR
+            | VK_NEXT
+            | VK_DELETE
+            | VK_INSERT
     ) {
         return true;
     }
@@ -88,3 +126,6 @@ pub fn to_key_event(kbd: &KBDLLHOOKSTRUCT) -> KeyEvent {
         is_navigation: is_navigation(vk),
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/platforms/windows/src/keymap/tests.rs
+++ b/platforms/windows/src/keymap/tests.rs
@@ -1,0 +1,106 @@
+use super::*;
+
+fn m(ctrl: bool, alt: bool, shift: bool, win: bool) -> Mods {
+    Mods {
+        ctrl,
+        alt,
+        win,
+        shift,
+    }
+}
+
+#[test]
+fn alt_shift_matches_the_side_specific_vks_the_hook_delivers() {
+    // Alt held, then Shift pressed — the hook reports VK_LSHIFT/VK_RSHIFT, and
+    // the async state may not yet include the Shift being pressed.
+    for vk in [VK_LSHIFT, VK_RSHIFT] {
+        assert!(is_toggle(
+            vk,
+            m(false, true, false, false),
+            Hotkey::AltShift
+        ));
+    }
+    // Shift held, then Alt pressed (either side).
+    for vk in [VK_LMENU, VK_RMENU] {
+        assert!(is_toggle(
+            vk,
+            m(false, false, true, false),
+            Hotkey::AltShift
+        ));
+    }
+}
+
+#[test]
+fn alt_shift_rejects_extra_modifiers_and_other_keys() {
+    // Extra Ctrl / Win held → not the toggle.
+    assert!(!is_toggle(
+        VK_LSHIFT,
+        m(true, true, false, false),
+        Hotkey::AltShift
+    ));
+    assert!(!is_toggle(
+        VK_LMENU,
+        m(false, false, true, true),
+        Hotkey::AltShift
+    ));
+    // A normal key while Alt+Shift are held is not the toggle (it may be an
+    // app shortcut like Alt+Shift+Tab).
+    assert!(!is_toggle(
+        VK_TAB,
+        m(false, true, true, false),
+        Hotkey::AltShift
+    ));
+}
+
+#[test]
+fn ctrl_presets_match_exact_modifiers_only() {
+    assert!(is_toggle(
+        VK_SPACE,
+        m(true, false, false, false),
+        Hotkey::CtrlSpace
+    ));
+    assert!(is_toggle(
+        VK_OEM_3,
+        m(true, false, false, false),
+        Hotkey::CtrlBacktick
+    ));
+    // Ctrl+Shift+Space / Ctrl+Alt+Space belong to the focused app.
+    assert!(!is_toggle(
+        VK_SPACE,
+        m(true, false, true, false),
+        Hotkey::CtrlSpace
+    ));
+    assert!(!is_toggle(
+        VK_SPACE,
+        m(true, true, false, false),
+        Hotkey::CtrlSpace
+    ));
+    // The other preset's key does not toggle.
+    assert!(!is_toggle(
+        VK_SPACE,
+        m(true, false, false, false),
+        Hotkey::CtrlBacktick
+    ));
+}
+
+#[test]
+fn flip_matches_ctrl_shift_letter() {
+    let ctrl_shift = m(true, false, true, false);
+    assert!(is_flip(
+        VIRTUAL_KEY(0x5A),
+        ctrl_shift,
+        FlipHotkey::CtrlShiftZ
+    ));
+    assert!(is_flip(
+        VIRTUAL_KEY(0x58),
+        ctrl_shift,
+        FlipHotkey::CtrlShiftX
+    ));
+    assert!(!is_flip(VIRTUAL_KEY(0x5A), ctrl_shift, FlipHotkey::Off));
+    // Extra Alt held → not the flip.
+    assert!(!is_flip(
+        VIRTUAL_KEY(0x5A),
+        m(true, true, true, false),
+        FlipHotkey::CtrlShiftZ
+    ));
+}


### PR DESCRIPTION
## What

Fixes the user report *"only Ctrl+Space works as the VI/EN toggle on Windows"*.

Two defects in `keymap.rs`:

1. **The `Alt+Shift` preset could never fire.** The `WH_KEYBOARD_LL` hook delivers side-specific modifier virtual-keys (`VK_LSHIFT` 0xA0, `VK_RSHIFT` 0xA1, `VK_LMENU` 0xA4, `VK_RMENU` 0xA5) — never the generic `VK_SHIFT`/`VK_MENU` (0x10/0x12) the matcher compared against. New `normalize_vk()` folds L/R modifier VKs to their generic codes before matching. The pressed key itself also counts as held, since the async key state may not yet include the key whose keydown is being hooked.
2. **Presets over-matched:** `Ctrl+Space` / `Ctrl+\`` fired even with Shift held, swallowing app shortcuts like Ctrl+Shift+Space. Presets now require their exact modifier set.

`Ctrl+\`` remains `VK_OEM_3` (correct on US layouts); non-US layouts will be covered by the upcoming user-recordable hotkeys (records the VK from the user's actual layout).

## Verification

- First unit tests for `is_toggle` / `is_flip` (`src/keymap/tests.rs`): Alt-then-Shift and Shift-then-Alt orders with all four side-specific VKs, extra-modifier rejection, exact-modifier presets, flip combos. They run on a Windows host (`cargo test` in `platforms/windows`).
- From macOS: `cargo check`/`clippy --target x86_64-pc-windows-gnu --all-targets` — clean (no new warnings; the 7 pre-existing clippy warnings in other files are untouched).
- Manual smoke on Windows (maintainer): all three presets toggle VI/EN — especially Alt+Shift, both press orders; Ctrl+Shift+Space reaches the focused app.

Part 1 of the hotkey work — part 2 (user-recordable toggle/flip combos, macOS-style recorder) follows on top of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)