### PR TITLE
fix(windows): extend URL-bar Delete primer to Firefox's address bar

### DIFF
--- a/platforms/windows/src/hook.rs
+++ b/platforms/windows/src/hook.rs
@@ -243,8 +243,8 @@ fn handle_keydown(kbd: &KBDLLHOOKSTRUCT) -> bool {
     if flip_hit {
         let plan = plan_inject(&shell::flip_composing());
         if !plan.is_noop() {
-            if shell::foreground_is_chrome() {
-                inject::send_plan_chrome(&plan);
+            if shell::foreground_has_urlbar_autofill() {
+                inject::send_plan_primed(&plan);
             } else {
                 inject::send_plan(&plan);
             }
@@ -258,11 +258,12 @@ fn handle_keydown(kbd: &KBDLLHOOKSTRUCT) -> bool {
             if plan.is_noop() {
                 false // Action::None — the literal key reaches the app
             } else {
-                // Chrome's omnibox eats a Backspace to clear its autocomplete
-                // selection, so it gets a Delete primer first (see
-                // inject::send_plan_chrome); everything else takes the direct path.
-                if shell::foreground_is_chrome() {
-                    inject::send_plan_chrome(&plan);
+                // Chrome's omnibox and Firefox's address bar eat a Backspace to
+                // clear their autofill selection, so they get a Delete primer
+                // first (see inject::send_plan_primed); everything else takes
+                // the direct path.
+                if shell::foreground_has_urlbar_autofill() {
+                    inject::send_plan_primed(&plan);
                 } else {
                     inject::send_plan(&plan); // delete + retype the composed text
                 }

--- a/platforms/windows/src/inject.rs
+++ b/platforms/windows/src/inject.rs
@@ -77,7 +77,8 @@ fn raw_send(inputs: &[INPUT]) {
 }
 
 /// Send the deletions then the new text as one atomic `SendInput` batch. This is
-/// the default path used for every app except Chrome (see [`send_plan_chrome`]).
+/// the default path used for every app except browsers with URL-bar autofill
+/// (see [`send_plan_primed`]).
 pub fn send_plan(plan: &InjectPlan) {
     if plan.is_noop() {
         return;
@@ -88,25 +89,26 @@ pub fn send_plan(plan: &InjectPlan) {
 }
 
 /// Like [`send_plan`] but prepends a single `Delete` press before the deletions,
-/// for Chrome's omnibox.
+/// for URL bars with inline autofill (Chrome's omnibox, Firefox's address bar).
 ///
-/// The omnibox shows an inline-autocomplete *suffix that is selected* (e.g. after
+/// Those URL bars show an inline-autofill *suffix that is selected* (e.g. after
 /// "bo" it displays "bo[okmarks]"). A Backspace fired against that selection deletes
 /// the **selection**, not the base character, so the vowel we meant to replace
 /// survives and the new glyph piles on top: "bộ" → "boộ". The leading `Delete`
-/// dismisses that autocomplete selection first; the Backspaces then bite real
-/// characters. When there is no autocomplete and the caret sits at the end of the
+/// dismisses that autofill selection first; the Backspaces then bite real
+/// characters. When there is no autofill and the caret sits at the end of the
 /// field (the normal case while typing), `Delete` is a no-op, so this stays safe.
 ///
-/// Sent as one synchronous `SendInput` batch — autocomplete is recomputed
+/// Sent as one synchronous `SendInput` batch — autofill is recomputed
 /// asynchronously, so it will not re-appear between the `Delete` and the Backspaces
 /// within a single burst. Only used when `backspaces > 0` (a pure insert has no
 /// Backspace to lose).
 ///
-/// Caveat: in a Chrome **web** field the omnibox autocomplete does not exist, so the
+/// Caveat: in a **web** field the URL-bar autofill does not exist, so the
 /// `Delete` is wanted only at end-of-text; if the caret is in the middle of existing
-/// text it will eat the following character. See `shell::foreground_is_chrome`.
-pub fn send_plan_chrome(plan: &InjectPlan) {
+/// text it will eat the following character. See
+/// `shell::foreground_has_urlbar_autofill`.
+pub fn send_plan_primed(plan: &InjectPlan) {
     if plan.is_noop() {
         return;
     }

--- a/platforms/windows/src/shell.rs
+++ b/platforms/windows/src/shell.rs
@@ -137,17 +137,22 @@ pub fn method_and_tone() -> (InputMethod, CoreToneStyle) {
     with(|s| (s.settings.method.core(), s.settings.tone_style.core()))
 }
 
-/// True when the most-recently-focused app is Google Chrome. Used to route text
-/// injection through the Delete-primer path that works around Chrome's omnibox
-/// autocomplete eating synthesized Backspaces. `recent[0]` is the current
-/// foreground app (it is pushed there by the foreground hook). Chrome Beta/Dev/
-/// Canary also report `chrome.exe`; Edge (`msedge.exe`) and Brave (`brave.exe`)
+/// Browsers whose URL bar inline-autofills a *selected* suffix that eats a
+/// synthesized Backspace (Chrome's omnibox, Firefox's address bar). Chrome
+/// Beta/Dev/Canary also report `chrome.exe`; Firefox Developer Edition/Nightly
+/// also report `firefox.exe`. Edge (`msedge.exe`) and Brave (`brave.exe`)
 /// deliberately do not match — they are unaffected.
-pub fn foreground_is_chrome() -> bool {
+const URLBAR_AUTOFILL_BROWSERS: [&str; 2] = ["chrome.exe", "firefox.exe"];
+
+/// True when the most-recently-focused app is a browser whose URL bar autofill
+/// swallows synthesized Backspaces. Used to route text injection through the
+/// Delete-primer path (see `inject::send_plan_primed`). `recent[0]` is the
+/// current foreground app (it is pushed there by the foreground hook).
+pub fn foreground_has_urlbar_autofill() -> bool {
     with(|s| {
         s.recent
             .first()
-            .map(|a| a.id == "chrome.exe")
+            .map(|a| URLBAR_AUTOFILL_BROWSERS.contains(&a.id.as_str()))
             .unwrap_or(false)
     })
 }


### PR DESCRIPTION
Firefox's address bar inline-autofills a *selected* suffix exactly like Chrome's omnibox, so a synthesized Backspace deletes the autofill selection instead of the base character and the new glyph piles on top ("go" + w -> "goơ", "d" + d -> "dđ"). Only the word's first transform is hit — after the pile-on the text no longer prefix-matches a URL, the autofill disappears, and later Backspaces bite normally.

Route firefox.exe through the same Delete-primer path as chrome.exe:

- shell: foreground_is_chrome -> foreground_has_urlbar_autofill, matching a browser list (chrome.exe, firefox.exe)
- inject: send_plan_chrome -> send_plan_primed; docs generalized to both URL bars
- hook: route both call sites through the renamed check

The engine itself computes correct backspace counts for the reported sequences (verified via `funput dev run -m telex --steps`); this was never a core regression.