### PR TITLE
feat(ios): repeat spaces while holding spacebar

### DIFF
--- a/platforms/ios/FunputTests/SpaceRepeatSurfaceTests.swift
+++ b/platforms/ios/FunputTests/SpaceRepeatSurfaceTests.swift
@@ -1,0 +1,78 @@
+import KeyboardLayout
+import KeyboardRenderer
+import XCTest
+
+@MainActor
+final class SpaceRepeatSurfaceTests: XCTestCase {
+    func testHoldingSpaceRepeatsAndSuppressesRelease() async throws {
+        let subject = try makeSubject()
+
+        subject.interaction.sendActions(for: .touchDown)
+        try await Task.sleep(for: .milliseconds(460))
+        subject.interaction.sendActions(for: .touchUpInside)
+
+        let spaceEvents = subject.events.value.filter { $0.key.role == .space }
+        XCTAssertEqual(spaceEvents.first?.phase, .pressed)
+        XCTAssertTrue(spaceEvents.contains { $0.phase == .repeated })
+        XCTAssertFalse(spaceEvents.contains { $0.phase == .released })
+    }
+
+    func testTappingSpaceCommitsOnceAndDoesNotRepeatLater() async throws {
+        let subject = try makeSubject()
+
+        subject.interaction.sendActions(for: .touchDown)
+        subject.interaction.sendActions(for: .touchUpInside)
+        try await Task.sleep(for: .milliseconds(460))
+
+        let phases = subject.events.value.filter { $0.key.role == .space }.map(\.phase)
+        XCTAssertEqual(phases, [.pressed, .released])
+    }
+
+    func testCancellingSpaceStopsPendingRepeat() async throws {
+        let subject = try makeSubject()
+
+        subject.interaction.sendActions(for: .touchDown)
+        subject.interaction.sendActions(for: .touchCancel)
+        try await Task.sleep(for: .milliseconds(460))
+
+        let phases = subject.events.value.filter { $0.key.role == .space }.map(\.phase)
+        XCTAssertEqual(phases, [.pressed, .cancelled])
+    }
+
+    private final class EventBox {
+        var value: [KeyboardKeyEvent] = []
+    }
+
+    private final class Subject {
+        let surface: KeyboardSurfaceView
+        let interaction: UIControl
+        let events: EventBox
+
+        init(surface: KeyboardSurfaceView, interaction: UIControl, events: EventBox) {
+            self.surface = surface
+            self.interaction = interaction
+            self.events = events
+        }
+    }
+
+    private func makeSubject() throws -> Subject {
+        var presentation = KeyboardPresentation()
+        presentation.layout = StandardKeyboardLayouts.letters(.vni)
+        presentation.isHapticFeedbackEnabled = false
+        presentation.showsKeyPreviews = false
+        let surface = KeyboardSurfaceView(presentation: presentation)
+        let events = EventBox()
+        surface.onKeyEvent = { events.value.append($0) }
+
+        let spaceKey = try XCTUnwrap(
+            accessibleControls(in: surface).first {
+                $0.accessibilityLabel?.hasPrefix("Dấu cách") == true
+            }
+        )
+        let interaction = try XCTUnwrap(
+            spaceKey.subviews.compactMap { $0 as? UIControl }.first
+        )
+
+        return Subject(surface: surface, interaction: interaction, events: events)
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyRepeatController.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyRepeatController.swift
@@ -16,7 +16,7 @@ final class KeyboardScheduledAction {
 }
 
 @MainActor
-final class BackspaceRepeatController {
+final class KeyRepeatController {
     typealias Scheduler = @MainActor (
         _ delay: TimeInterval,
         _ action: @escaping @MainActor () -> Void
@@ -33,7 +33,7 @@ final class BackspaceRepeatController {
     init(
         initialDelay: TimeInterval = 0.4,
         repeatInterval: TimeInterval = 0.05,
-        schedule: @escaping Scheduler = BackspaceRepeatController.schedule,
+        schedule: @escaping Scheduler = KeyRepeatController.schedule,
         onRepeat: @escaping () -> Void
     ) {
         precondition(initialDelay > 0)
@@ -72,9 +72,7 @@ final class BackspaceRepeatController {
     }
 
     private func scheduleNext(after delay: TimeInterval) {
-        scheduledAction = schedule(delay) { [weak self] in
-            self?.tick()
-        }
+        scheduledAction = schedule(delay) { [weak self] in self?.tick() }
     }
 
     static func schedule(

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardRepeatCoordinator.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardRepeatCoordinator.swift
@@ -1,0 +1,42 @@
+#if canImport(UIKit)
+import KeyboardLayout
+
+/// Owns one repeat timer per held repeatable key.
+@MainActor
+final class KeyboardRepeatCoordinator {
+    private let schedule: KeyRepeatController.Scheduler
+    private let onRepeat: (KeySpec) -> Void
+    private var controllers: [String: KeyRepeatController] = [:]
+
+    init(
+        schedule: @escaping KeyRepeatController.Scheduler,
+        onRepeat: @escaping (KeySpec) -> Void
+    ) {
+        self.schedule = schedule
+        self.onRepeat = onRepeat
+    }
+
+    func start(_ key: KeySpec) {
+        guard key.role == .backspace || key.role == .space else { return }
+        controllers.removeValue(forKey: key.id)?.cancel()
+        let controller = KeyRepeatController(schedule: schedule) { [weak self] in
+            self?.onRepeat(key)
+        }
+        controllers[key.id] = controller
+        controller.start()
+    }
+
+    func finish(_ key: KeySpec) -> Bool {
+        controllers.removeValue(forKey: key.id)?.finish() ?? false
+    }
+
+    func cancel(_ key: KeySpec) {
+        controllers.removeValue(forKey: key.id)?.cancel()
+    }
+
+    func cancelAll() {
+        controllers.values.forEach { $0.cancel() }
+        controllers.removeAll()
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController.swift
@@ -11,14 +11,13 @@ final class KeyboardSurfaceInteractionController {
     private let haptics: KeyboardHaptics
     private let onEvent: (KeyboardKeyEvent) -> Void
     private let onPreview: PreviewHandler
-    private let repeatScheduler: BackspaceRepeatController.Scheduler
-    private lazy var repeatController = BackspaceRepeatController(
+    private let repeatScheduler: KeyRepeatController.Scheduler
+    private lazy var repeatCoordinator = KeyboardRepeatCoordinator(
         schedule: repeatScheduler
-    ) { [weak self] in
-        self?.repeatBackspace()
+    ) { [weak self] key in
+        self?.repeatKey(key)
     }
     private var commitQueue = KeyboardPressCommitQueue()
-    private var backspaceKeyID: String?
     private var previewKeyID: String?
     private var hapticsEnabled = true
     var activeKey: KeySpec? { commitQueue.activeKey }
@@ -27,8 +26,8 @@ final class KeyboardSurfaceInteractionController {
         feedbackView: UIView = UIView(),
         onEvent: @escaping (KeyboardKeyEvent) -> Void,
         onPreview: @escaping PreviewHandler,
-        repeatScheduler: @escaping BackspaceRepeatController.Scheduler =
-            BackspaceRepeatController.schedule
+        repeatScheduler: @escaping KeyRepeatController.Scheduler =
+            KeyRepeatController.schedule
     ) {
         haptics = KeyboardHaptics(view: feedbackView)
         self.onEvent = onEvent
@@ -59,7 +58,7 @@ final class KeyboardSurfaceInteractionController {
 
     func cancelAll() {
         commitQueue.cancelAll()
-        clearBackspaceRepeat()
+        repeatCoordinator.cancelAll()
         clearPreview()
         flushCompletedKeys()
     }
@@ -78,17 +77,13 @@ final class KeyboardSurfaceInteractionController {
             previewKeyID = key.id
             onPreview(key, sourceFrame)
         }
-        if key.role == .backspace {
-            backspaceKeyID = key.id
-            repeatController.start()
-        }
+        repeatCoordinator.start(key)
         onEvent(KeyboardKeyEvent(key: key, phase: .pressed))
     }
 
     private func finish(_ key: KeySpec) {
         guard commitQueue.hasPendingKey(id: key.id) else { return }
-        let wasRepeating = key.role == .backspace && repeatController.finish()
-        if key.role == .backspace { backspaceKeyID = nil }
+        let wasRepeating = repeatCoordinator.finish(key)
         commitQueue.complete(id: key.id, as: wasRepeating ? .suppressed : .released)
         if key.id == previewKeyID { clearPreview() }
         flushCompletedKeys()
@@ -96,7 +91,7 @@ final class KeyboardSurfaceInteractionController {
 
     private func cancel(_ key: KeySpec) {
         guard commitQueue.complete(id: key.id, as: .cancelled) else { return }
-        if key.role == .backspace { clearBackspaceRepeat() }
+        repeatCoordinator.cancel(key)
         if key.id == previewKeyID { clearPreview() }
         flushCompletedKeys()
     }
@@ -105,7 +100,7 @@ final class KeyboardSurfaceInteractionController {
         if commitQueue.hasPendingKey(id: event.key.id) {
             guard case let .swiped(action) = event.phase else { return }
             commitQueue.complete(id: event.key.id, as: .swiped(action))
-            if event.key.id == backspaceKeyID { clearBackspaceRepeat() }
+            repeatCoordinator.cancel(event.key)
             if event.key.id == previewKeyID { clearPreview() }
         } else if !commitQueue.isEmpty {
             return
@@ -119,10 +114,12 @@ final class KeyboardSurfaceInteractionController {
         flushCompletedKeys()
     }
 
-    private func repeatBackspace() {
-        guard let id = backspaceKeyID,
-              commitQueue.bufferRepeat(for: id) else { return }
-        if hapticsEnabled { haptics.perform(.deleteRepeat) }
+    private func repeatKey(_ key: KeySpec) {
+        guard commitQueue.bufferRepeat(for: key.id) else {
+            repeatCoordinator.cancel(key)
+            return
+        }
+        if hapticsEnabled, key.role == .backspace { haptics.perform(.deleteRepeat) }
         flushCompletedKeys()
     }
 
@@ -135,11 +132,6 @@ final class KeyboardSurfaceInteractionController {
                 continue
             }
         }
-    }
-
-    private func clearBackspaceRepeat() {
-        repeatController.cancel()
-        backspaceKeyID = nil
     }
 
     private func clearPreview() {

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyRepeatControllerTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyRepeatControllerTests.swift
@@ -4,8 +4,8 @@ import Foundation
 import Testing
 
 @MainActor
-struct BackspaceRepeatControllerTests {
-    @Test("Quick tap keeps one release action")
+struct KeyRepeatControllerTests {
+    @Test("Quick tap does not enter repeat mode")
     func quickTap() {
         let scheduler = TestRepeatScheduler()
         var repeats = 0
@@ -52,8 +52,8 @@ struct BackspaceRepeatControllerTests {
     private func makeController(
         scheduler: TestRepeatScheduler,
         onRepeat: @escaping () -> Void
-    ) -> BackspaceRepeatController {
-        BackspaceRepeatController(
+    ) -> KeyRepeatController {
+        KeyRepeatController(
             initialDelay: 0.4,
             repeatInterval: 0.05,
             schedule: scheduler.schedule,

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardSpaceRepeatTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardSpaceRepeatTests.swift
@@ -1,0 +1,105 @@
+#if canImport(UIKit)
+@testable import KeyboardRenderer
+import KeyboardLayout
+import Testing
+
+@MainActor
+struct KeyboardSpaceRepeatTests {
+    @Test("Holding Space repeats and suppresses its release")
+    func holdSpace() {
+        let (controller, scheduler, events) = makeController()
+        let space = key(id: "space", role: .space)
+
+        controller.handle(event(space, .pressed), sourceFrame: nil, presentation: presentation())
+        scheduler.runNext()
+        controller.handle(event(space, .released), sourceFrame: nil, presentation: presentation())
+
+        #expect(events.value.map(\.phase) == [.pressed, .repeated])
+    }
+
+    @Test("Tapping Space still emits exactly one release")
+    func tapSpace() {
+        let (controller, scheduler, events) = makeController()
+        let space = key(id: "space", role: .space)
+
+        controller.handle(event(space, .pressed), sourceFrame: nil, presentation: presentation())
+        controller.handle(event(space, .released), sourceFrame: nil, presentation: presentation())
+        scheduler.runNext()
+
+        #expect(events.value.map(\.phase) == [.pressed, .released])
+    }
+
+    @Test("Swiping Space cancels repeat")
+    func swipeCancelsRepeat() {
+        let (controller, scheduler, events) = makeController()
+        let space = KeySpec(
+            id: "space",
+            label: "Space",
+            role: .space,
+            horizontalSwipeAction: .toggleLanguage
+        )
+
+        controller.handle(event(space, .pressed), sourceFrame: nil, presentation: presentation())
+        controller.handle(
+            event(space, .swiped(.toggleLanguage)),
+            sourceFrame: nil,
+            presentation: presentation()
+        )
+        scheduler.runNext()
+        controller.handle(event(space, .released), sourceFrame: nil, presentation: presentation())
+
+        #expect(events.value.map(\.phase) == [.pressed, .swiped(.toggleLanguage)])
+    }
+
+    @Test("Repeated Space waits behind an earlier press")
+    func repeatPreservesPressOrder() {
+        let (controller, scheduler, events) = makeController()
+        let character = key(id: "a", role: .character)
+        let space = key(id: "space", role: .space)
+
+        controller.handle(event(character, .pressed), sourceFrame: nil, presentation: presentation())
+        controller.handle(event(space, .pressed), sourceFrame: nil, presentation: presentation())
+        scheduler.runNext()
+        #expect(!events.value.contains { $0.phase == .repeated })
+        controller.handle(event(space, .released), sourceFrame: nil, presentation: presentation())
+        controller.handle(event(character, .released), sourceFrame: nil, presentation: presentation())
+
+        let mutations = events.value.filter { $0.phase == .released || $0.phase == .repeated }
+        #expect(mutations.map(\.key.id) == [character.id, space.id])
+        #expect(mutations.map(\.phase) == [.released, .repeated])
+    }
+
+    private final class EventBox {
+        var value: [KeyboardKeyEvent] = []
+    }
+
+    private func makeController() -> (
+        KeyboardSurfaceInteractionController,
+        TestRepeatScheduler,
+        EventBox
+    ) {
+        let scheduler = TestRepeatScheduler()
+        let events = EventBox()
+        let controller = KeyboardSurfaceInteractionController(
+            onEvent: { events.value.append($0) },
+            onPreview: { _, _ in },
+            repeatScheduler: scheduler.schedule
+        )
+        return (controller, scheduler, events)
+    }
+
+    private func presentation() -> KeyboardPresentation {
+        var value = KeyboardPresentation()
+        value.isHapticFeedbackEnabled = false
+        return value
+    }
+
+    private func key(id: String, role: KeyRole) -> KeySpec {
+        KeySpec(id: id, label: id, role: role)
+    }
+
+    private func event(_ key: KeySpec, _ phase: KeyboardKeyEvent.Phase) -> KeyboardKeyEvent {
+        KeyboardKeyEvent(key: key, phase: phase)
+    }
+}
+#endif


### PR DESCRIPTION
## What changed

- generalize the Backspace repeat timer into a reusable key-repeat controller
- give each held repeatable key an independent timer
- make Space repeat after a 0.4-second hold at 0.05-second intervals
- suppress the final Space release after repeating, while preserving one Space for a quick tap
- cancel pending Space repeat on touch cancellation or language swipe
- route repeated Space events through the existing press-order commit queue

## Why

Holding Backspace already supports continuous input, but holding Space did nothing until release. This adds matching hold behavior without bypassing the rollover ordering guarantees introduced by #57.

## Impact

Users can hold the Space bar to insert spaces continuously. Quick taps, cancellation, language swipe, Backspace repeat, and two-thumb rollover retain their existing behavior.

## Dependency

This is a stacked PR based on `test/ios-typing-uitest` and should be merged after #57. Its diff contains only the Space-repeat feature.

## Validation

- FunputKit: 85 tests passed
- FunputTests: 64 tests passed
- real-timer tests cover hold, quick tap, and cancellation
- rollover and reverse-release regressions passed
- Swift LOC check passed
- `git diff --check` passed
