### PR TITLE
test(telex): specify free-order w permutations

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,6 +24,11 @@ Criterion writes an interactive HTML summary to
 `target/criterion/report/index.html`. Individual benchmark reports live under
 their corresponding directories in `target/criterion/`.
 
+Telex V2 baseline (`telex_v2_w_before`, same machine/toolchain): core Telex
+**19.39 M keys/s**, engine **9.01 M keys/s**, and C FFI **8.23 M keys/s**.
+The V2 suites add equal-length `w-permutation/canonical` and
+`w-permutation/deferred` inputs without renaming these common-path IDs.
+
 | Metric | Result |
 |---|---|
 | Compose latency (core `apply`) | **~0.05 µs / keystroke** (Telex), ~0.05 µs (VNI) |

--- a/crates/funput-core/benches/apply.rs
+++ b/crates/funput-core/benches/apply.rs
@@ -16,6 +16,8 @@ const TELEX: &str = "tooi yeeu tieesng vieejt nam ddaats nuwowcs hoom nay troiwf
 const VNI: &str = "to6i ye6u tie6ng1 vie6t5 nam dda6t1 nu7o7c1 ho6m nay tro7i2 dde9p5";
 const TELEX_CIRCUMFLEX_CANONICAL: &str = "chaan chaanf deem hoom chaats Chaan";
 const TELEX_CIRCUMFLEX_FREE: &str = "chana chanaf deme homo chatas Chana";
+const TELEX_W_CANONICAL: &str = "lawms conw mowif truowngf nguwowif muaw uuw thuowr quowis";
+const TELEX_W_DEFERRED: &str = "lwams cown mwoif trwuongf ngwuoif mwua uwu thwuor quwois";
 
 /// Replay `keys` through `apply_checked`, folding the buffer at each space.
 fn type_through(keys: &str, method: InputMethod, spell_check: bool) -> String {
@@ -51,6 +53,16 @@ fn bench(c: &mut Criterion) {
     ] {
         group.throughput(Throughput::Elements(keys.chars().count() as u64));
         group.bench_function(BenchmarkId::new("circumflex", name), |b| {
+            b.iter(|| type_through(black_box(keys), InputMethod::Telex, false))
+        });
+    }
+
+    for (name, keys) in [
+        ("canonical", TELEX_W_CANONICAL),
+        ("deferred", TELEX_W_DEFERRED),
+    ] {
+        group.throughput(Throughput::Elements(keys.chars().count() as u64));
+        group.bench_function(BenchmarkId::new("w-permutation", name), |b| {
             b.iter(|| type_through(black_box(keys), InputMethod::Telex, false))
         });
     }

--- a/crates/funput-core/tests/telex.rs
+++ b/crates/funput-core/tests/telex.rs
@@ -24,3 +24,7 @@ mod parity;
 mod properties;
 #[path = "telex/regression.rs"]
 mod regression;
+#[path = "telex/w_collisions.rs"]
+mod w_collisions;
+#[path = "telex/w_permutations.rs"]
+mod w_permutations;

--- a/crates/funput-core/tests/telex/w_collisions.rs
+++ b/crates/funput-core/tests/telex/w_collisions.rs
@@ -1,0 +1,25 @@
+use funput_core::InputMethod;
+
+fn type_keys(keys: &str) -> String {
+    crate::support::type_keys(InputMethod::Telex, keys)
+}
+
+#[test]
+fn snapshots_leading_w_and_latin_collisions() {
+    // V2 target: leading w remains literal; post-onset swan becomes Vietnamese
+    // and relies on engine flip as the explicit Latin escape.
+    for literal in ["was", "wow", "win"] {
+        assert_eq!(type_keys(literal), literal);
+    }
+    assert_eq!(type_keys("swift"), "swìt", "engine restores this to swift");
+    assert_eq!(type_keys("swan"), "swan", "V2 target: săn");
+}
+
+#[test]
+fn snapshots_repeated_pending_w_and_boundaries() {
+    assert_eq!(type_keys("lwwa"), "lwwa");
+    assert_eq!(
+        crate::support::type_words(InputMethod::Telex, "lw a"),
+        "lw a"
+    );
+}

--- a/crates/funput-core/tests/telex/w_permutations.rs
+++ b/crates/funput-core/tests/telex/w_permutations.rs
@@ -1,0 +1,132 @@
+use funput_core::{InputMethod, ToneStyle, apply};
+
+struct Case {
+    base: &'static str,
+    target: &'static str,
+    current: &'static [&'static str],
+}
+
+fn insert_w(base: &str, boundary: usize) -> String {
+    let offset = base
+        .char_indices()
+        .nth(boundary)
+        .map_or(base.len(), |p| p.0);
+    format!("{}w{}", &base[..offset], &base[offset..])
+}
+
+fn type_keys(keys: &str, style: ToneStyle) -> String {
+    keys.chars().fold(String::new(), |buffer, key| {
+        apply(&buffer, key, InputMethod::Telex, style).text
+    })
+}
+
+fn assert_baseline(case: &Case, style: ToneStyle) {
+    let count = case.base.chars().count();
+    assert_eq!(case.current.len(), count, "bad snapshot: {}", case.base);
+    for boundary in 1..=count {
+        let keys = insert_w(case.base, boundary);
+        assert_eq!(
+            type_keys(&keys, style),
+            case.current[boundary - 1],
+            "baseline changed for {keys}; V2 target is {}",
+            case.target
+        );
+    }
+}
+
+#[test]
+fn snapshots_breve_and_single_horn_permutations() {
+    for case in [
+        Case {
+            base: "lams",
+            target: "lắm",
+            current: &["lwams", "lắm", "lắm", "lắm"],
+        },
+        Case {
+            base: "con",
+            target: "cơn",
+            current: &["cwon", "cơn", "cơn"],
+        },
+        Case {
+            base: "moif",
+            target: "mời",
+            current: &["mwòi", "mời", "mời", "mời"],
+        },
+    ] {
+        assert_baseline(&case, ToneStyle::Traditional);
+    }
+}
+
+#[test]
+fn snapshots_compound_permutations() {
+    for case in [
+        Case {
+            base: "truongf",
+            target: "trường",
+            current: &[
+                "twruongf",
+                "trwuongf",
+                "trừong",
+                "trường",
+                "trường",
+                "trường",
+                "trưòng",
+            ],
+        },
+        Case {
+            base: "nguoif",
+            target: "người",
+            current: &["nwguoif", "ngwuòi", "ngừoi", "người", "người", "ngưòi"],
+        },
+        Case {
+            base: "mua",
+            target: "mưa",
+            current: &["mwua", "mưa", "mưa"],
+        },
+        Case {
+            base: "uu",
+            target: "ưu",
+            current: &["ưu", "ưu"],
+        },
+        Case {
+            base: "thuor",
+            target: "thuở",
+            current: &["twhuor", "thwủo", "thửo", "thuở", "thửo"],
+        },
+        Case {
+            base: "quois",
+            target: "quới",
+            current: &["qwuois", "quói", "quới", "quới", "qưói"],
+        },
+    ] {
+        assert_baseline(&case, ToneStyle::Traditional);
+    }
+}
+
+#[test]
+fn snapshots_all_tones_case_and_styles() {
+    for (base, target) in [
+        ("lans", "lắn"),
+        ("lanf", "lằn"),
+        ("lanr", "lẳn"),
+        ("lanx", "lẵn"),
+        ("lanj", "lặn"),
+    ] {
+        let current = [
+            insert_w(base, 1),
+            target.into(),
+            target.into(),
+            target.into(),
+        ];
+        for style in [ToneStyle::Traditional, ToneStyle::Modern] {
+            for boundary in 1..=base.chars().count() {
+                assert_eq!(
+                    type_keys(&insert_w(base, boundary), style),
+                    current[boundary - 1]
+                );
+            }
+        }
+    }
+    assert_eq!(type_keys("LWAMS", ToneStyle::Traditional), "LWAMS");
+    assert_eq!(type_keys("LAWMS", ToneStyle::Traditional), "LẮM");
+}

--- a/crates/funput-engine/benches/process_char.rs
+++ b/crates/funput-engine/benches/process_char.rs
@@ -17,6 +17,8 @@ const TELEX: &str =
 const VNI: &str = "To6i ye6u tie6ng1 Vie6t5. Ho6m nay tro7i2 nu7o7c1 dde9p5. Ban co1 khoe3 kho6ng?";
 const TELEX_CIRCUMFLEX_CANONICAL: &str = "Chaan chaanf deem hoom chaats. Chaan!";
 const TELEX_CIRCUMFLEX_FREE: &str = "Chana chanaf deme homo chatas. Chana!";
+const TELEX_W_CANONICAL: &str = "Lawms conw mowif truowngf nguwowif. Muaw uuw thuowr quowis!";
+const TELEX_W_DEFERRED: &str = "Lwams cown mwoif trwuongf ngwuoif. Mwua uwu thwuor quwois!";
 
 fn run(input: &str, method: InputMethod) {
     let mut engine = Engine::new();
@@ -43,6 +45,15 @@ fn bench(c: &mut Criterion) {
     ] {
         group.throughput(Throughput::Elements(input.chars().count() as u64));
         group.bench_function(BenchmarkId::new("circumflex", name), |b| {
+            b.iter(|| run(black_box(input), InputMethod::Telex))
+        });
+    }
+    for (name, input) in [
+        ("canonical", TELEX_W_CANONICAL),
+        ("deferred", TELEX_W_DEFERRED),
+    ] {
+        group.throughput(Throughput::Elements(input.chars().count() as u64));
+        group.bench_function(BenchmarkId::new("w-permutation", name), |b| {
             b.iter(|| run(black_box(input), InputMethod::Telex))
         });
     }


### PR DESCRIPTION
## What changed

- add a generated Telex `w` permutation matrix grouped by breve, single horn, compound vowel, tone style, and case
- lock collision behavior for leading `w`, Latin fallback, repeated pending `w`, word boundaries, and `qu` glide handling
- record the current core, engine, and FFI Criterion baseline without changing existing benchmark IDs

## Why

Free-order `w` affects several overlapping Telex rules. This specification PR captures the current behavior and the intended V2 convergence cases before any production behavior changes, keeping later implementation PRs reviewable and measurable.

## Impact

No runtime behavior or public API changes. This PR adds regression coverage and performance baselines only.

## Dependency

This is the first PR in the Telex V2 stack. It is based on `feat/advanced-telex`, which contains the Telex V1 free-position circumflex work.

## Validation

- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Telex/VNI coverage sample: 100%
- touched-file LOC gate: all files at or below 150 lines
- `git diff --check`
