### PR TITLE
feat(telex): resolve deferred w modifiers

### DIFF
--- a/crates/funput-core/src/composition/intent/mod.rs
+++ b/crates/funput-core/src/composition/intent/mod.rs
@@ -4,6 +4,7 @@
 mod candidate;
 mod circumflex;
 mod target;
+mod w;
 
 use crate::input_method::CircumflexStem;
 use crate::{ToneStyle, TransformKind, TransformResult};
@@ -11,13 +12,13 @@ use crate::{ToneStyle, TransformKind, TransformResult};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ModifierIntent {
     Circumflex { stem: CircumflexStem, key: char },
+    DeferredW { key: char },
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum IntentResolution {
     Applied(String),
     Reverted(String),
-    #[expect(dead_code, reason = "reserved for the deferred-w V2 client")]
     Deferred(String),
     Literal(String),
 }
@@ -27,8 +28,11 @@ pub(crate) fn resolve(buffer: &str, intent: ModifierIntent, style: ToneStyle) ->
         ModifierIntent::Circumflex { stem, key } => {
             circumflex::resolve(buffer, char::from(stem), key, style)
         }
+        ModifierIntent::DeferredW { key } => w::resolve(buffer, key),
     }
 }
+
+pub(crate) use w::has_pending;
 
 impl IntentResolution {
     pub(crate) fn into_result(self) -> TransformResult {

--- a/crates/funput-core/src/composition/intent/w.rs
+++ b/crates/funput-core/src/composition/intent/w.rs
@@ -1,0 +1,103 @@
+use crate::composition::apply::apply_shape_key;
+use crate::composition::uo_horn::uo_pair_in_vowel_cluster;
+use crate::input_method::KeyAction;
+use crate::input_method::telex::classify_w;
+use crate::unicode::marks::{apply_tone_to_vowel, is_vowel, tone_on_vowel};
+use crate::unicode::shapes::{apply_shape_to_vowel, shape_target_index};
+use crate::validation::syllable::is_viable_shape_candidate;
+
+use super::IntentResolution;
+
+/// Exactly one non-leading `w` before the first vowel is a deferred modifier.
+pub(crate) fn has_pending(buffer: &str) -> bool {
+    let mut count = 0;
+    for (index, ch) in buffer.chars().enumerate() {
+        if is_vowel(ch) {
+            break;
+        }
+        if index > 0 && ch.eq_ignore_ascii_case(&'w') {
+            count += 1;
+        }
+    }
+    count == 1
+}
+
+pub(super) fn resolve(buffer: &str, key: char) -> IntentResolution {
+    let Some(w_offset) = pending_offset(buffer) else {
+        return IntentResolution::Literal(appended(buffer, key));
+    };
+    let mut candidate = String::with_capacity(buffer.len() + key.len_utf8() + 2);
+    candidate.push_str(&buffer[..w_offset]);
+    candidate.push_str(&buffer[w_offset + 1..]);
+    candidate.push(key);
+
+    let Some(KeyAction::Shape(shape)) = classify_w(&candidate) else {
+        return raw(buffer, key, candidate);
+    };
+    if apply_in_place(&mut candidate, shape) && is_viable_shape_candidate(&candidate) {
+        return IntentResolution::Applied(candidate);
+    }
+    raw(buffer, key, candidate)
+}
+
+fn apply_in_place(text: &mut String, shape: crate::unicode::shapes::VowelShape) -> bool {
+    if uo_pair_in_vowel_cluster(text).is_some() {
+        *text = apply_shape_key(text, shape).text;
+        return true;
+    }
+    let Some(index) = shape_target_index(text, shape) else {
+        return false;
+    };
+    let Some((offset, vowel)) = text.char_indices().nth(index) else {
+        return false;
+    };
+    let Some(bare) = apply_shape_to_vowel(vowel, shape) else {
+        return false;
+    };
+    let shaped = tone_on_vowel(vowel)
+        .and_then(|tone| apply_tone_to_vowel(bare, tone))
+        .unwrap_or(bare);
+    text.replace_range(
+        offset..offset + vowel.len_utf8(),
+        shaped.encode_utf8(&mut [0; 4]),
+    );
+    true
+}
+
+fn pending_offset(buffer: &str) -> Option<usize> {
+    if !has_pending(buffer) {
+        return None;
+    }
+    buffer
+        .char_indices()
+        .find(|&(offset, ch)| offset > 0 && ch.eq_ignore_ascii_case(&'w'))
+        .map(|(offset, _)| offset)
+}
+
+fn raw(buffer: &str, key: char, mut reusable: String) -> IntentResolution {
+    reusable.clear();
+    reusable.push_str(buffer);
+    reusable.push(key);
+    IntentResolution::Deferred(reusable)
+}
+
+fn appended(buffer: &str, key: char) -> String {
+    let mut text = String::with_capacity(buffer.len() + key.len_utf8());
+    text.push_str(buffer);
+    text.push(key);
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn marker_is_non_leading_unique_and_before_nucleus() {
+        assert!(has_pending("lw"));
+        assert!(has_pending("trw"));
+        assert!(!has_pending("w"));
+        assert!(!has_pending("lww"));
+        assert!(!has_pending("law"));
+    }
+}

--- a/crates/funput-core/src/composition/transform/normal.rs
+++ b/crates/funput-core/src/composition/transform/normal.rs
@@ -1,3 +1,4 @@
+use crate::composition::intent::{ModifierIntent, has_pending, resolve};
 use crate::composition::uo_horn::complete_uo_horn_for_continuation;
 use crate::unicode::tone_position::reposition_existing_tone;
 use crate::{ToneStyle, TransformKind, TransformResult};
@@ -5,6 +6,9 @@ use crate::{ToneStyle, TransformKind, TransformResult};
 use super::append;
 
 pub(super) fn apply(buffer: &str, key: char, style: ToneStyle) -> TransformResult {
+    if has_pending(buffer) {
+        return resolve(buffer, ModifierIntent::DeferredW { key }, style).into_result();
+    }
     if let Some(completed) = complete_uo_horn_for_continuation(buffer, key) {
         return repositioned_or(completed, style, TransformKind::Applied);
     }

--- a/crates/funput-core/src/input_method/telex/mod.rs
+++ b/crates/funput-core/src/input_method/telex/mod.rs
@@ -12,6 +12,9 @@ pub use tone::tone_from_key;
 
 /// Classify a Telex keystroke into a method-agnostic action.
 pub fn classify_key(buffer: &str, key: char) -> KeyAction {
+    if crate::composition::intent::has_pending(buffer) {
+        return KeyAction::Normal;
+    }
     if let Some(action) = stroke::classify(buffer, key) {
         return action;
     }
@@ -27,6 +30,10 @@ pub fn classify_key(buffer: &str, key: char) -> KeyAction {
         return KeyAction::RemoveTone;
     }
     tone::classify(buffer, key).unwrap_or(KeyAction::Normal)
+}
+
+pub(crate) fn classify_w(buffer: &str) -> Option<KeyAction> {
+    w::classify(buffer)
 }
 
 pub(super) fn last_char(buffer: &str) -> Option<char> {

--- a/crates/funput-core/tests/telex/w_collisions.rs
+++ b/crates/funput-core/tests/telex/w_collisions.rs
@@ -11,8 +11,8 @@ fn snapshots_leading_w_and_latin_collisions() {
     for literal in ["was", "wow", "win"] {
         assert_eq!(type_keys(literal), literal);
     }
-    assert_eq!(type_keys("swift"), "swìt", "engine restores this to swift");
-    assert_eq!(type_keys("swan"), "swan", "V2 target: săn");
+    assert_eq!(type_keys("swift"), "swift");
+    assert_eq!(type_keys("swan"), "săn");
 }
 
 #[test]

--- a/crates/funput-core/tests/telex/w_permutations.rs
+++ b/crates/funput-core/tests/telex/w_permutations.rs
@@ -34,6 +34,17 @@ fn assert_baseline(case: &Case, style: ToneStyle) {
     }
 }
 
+fn assert_converges(case: &Case, style: ToneStyle) {
+    for boundary in 1..=case.base.chars().count() {
+        let keys = insert_w(case.base, boundary);
+        assert_eq!(
+            type_keys(&keys, style),
+            case.target,
+            "did not converge: {keys}"
+        );
+    }
+}
+
 #[test]
 fn snapshots_breve_and_single_horn_permutations() {
     for case in [
@@ -53,7 +64,7 @@ fn snapshots_breve_and_single_horn_permutations() {
             current: &["mwòi", "mời", "mời", "mời"],
         },
     ] {
-        assert_baseline(&case, ToneStyle::Traditional);
+        assert_converges(&case, ToneStyle::Traditional);
     }
 }
 
@@ -64,8 +75,8 @@ fn snapshots_compound_permutations() {
             base: "truongf",
             target: "trường",
             current: &[
-                "twruongf",
-                "trwuongf",
+                "trừong",
+                "trừong",
                 "trừong",
                 "trường",
                 "trường",
@@ -76,12 +87,12 @@ fn snapshots_compound_permutations() {
         Case {
             base: "nguoif",
             target: "người",
-            current: &["nwguoif", "ngwuòi", "ngừoi", "người", "người", "ngưòi"],
+            current: &["ngừoi", "ngừoi", "ngừoi", "người", "người", "ngưòi"],
         },
         Case {
             base: "mua",
             target: "mưa",
-            current: &["mwua", "mưa", "mưa"],
+            current: &["mưa", "mưa", "mưa"],
         },
         Case {
             base: "uu",
@@ -91,12 +102,12 @@ fn snapshots_compound_permutations() {
         Case {
             base: "thuor",
             target: "thuở",
-            current: &["twhuor", "thwủo", "thửo", "thuở", "thửo"],
+            current: &["thửo", "thửo", "thửo", "thuở", "thửo"],
         },
         Case {
             base: "quois",
             target: "quới",
-            current: &["qwuois", "quói", "quới", "quới", "qưói"],
+            current: &["quới", "quói", "quới", "quới", "qưói"],
         },
     ] {
         assert_baseline(&case, ToneStyle::Traditional);
@@ -112,21 +123,12 @@ fn snapshots_all_tones_case_and_styles() {
         ("lanx", "lẵn"),
         ("lanj", "lặn"),
     ] {
-        let current = [
-            insert_w(base, 1),
-            target.into(),
-            target.into(),
-            target.into(),
-        ];
         for style in [ToneStyle::Traditional, ToneStyle::Modern] {
             for boundary in 1..=base.chars().count() {
-                assert_eq!(
-                    type_keys(&insert_w(base, boundary), style),
-                    current[boundary - 1]
-                );
+                assert_eq!(type_keys(&insert_w(base, boundary), style), target);
             }
         }
     }
-    assert_eq!(type_keys("LWAMS", ToneStyle::Traditional), "LWAMS");
+    assert_eq!(type_keys("LWAMS", ToneStyle::Traditional), "LẮM");
     assert_eq!(type_keys("LAWMS", ToneStyle::Traditional), "LẮM");
 }

--- a/crates/funput-engine/tests/alloc_budget.rs
+++ b/crates/funput-engine/tests/alloc_budget.rs
@@ -63,6 +63,8 @@ const TELEX_TEXT: &str =
 /// changing the number of processed keys.
 const CANONICAL_CIRCUMFLEX: &str = "chaan chaanf deem hoom chaats Chaan ";
 const FREE_CIRCUMFLEX: &str = "chana chanaf deme homo chatas Chana ";
+const CANONICAL_W: &str = "lawms cown mowif muaw ";
+const DEFERRED_W: &str = "lwams cwon mwoif mwua ";
 
 /// Type `text` through `engine`, returning (allocs, bytes) attributed to it.
 fn measure(engine: &mut Engine, text: &str) -> (usize, usize) {
@@ -126,4 +128,14 @@ fn keystroke_alloc_budget() {
         "free-position circumflex added allocation events: canonical={canonical:?}, free={free:?}"
     );
     assert_counts_within_budget("free-position circumflex", FREE_CIRCUMFLEX, free.0, free.1);
+
+    engine.clear();
+    let canonical_w = measure(&mut engine, CANONICAL_W);
+    engine.clear();
+    let deferred_w = measure(&mut engine, DEFERRED_W);
+    assert!(
+        deferred_w.0 <= canonical_w.0,
+        "w allocs: {canonical_w:?} vs {deferred_w:?}"
+    );
+    assert_counts_within_budget("deferred w", DEFERRED_W, deferred_w.0, deferred_w.1);
 }

--- a/crates/funput-engine/tests/methods.rs
+++ b/crates/funput-engine/tests/methods.rs
@@ -4,5 +4,7 @@ mod support;
 
 #[path = "methods/telex.rs"]
 mod telex;
+#[path = "methods/telex_deferred_w.rs"]
+mod telex_deferred_w;
 #[path = "methods/vni.rs"]
 mod vni;

--- a/crates/funput-engine/tests/methods/telex_deferred_w.rs
+++ b/crates/funput-engine/tests/methods/telex_deferred_w.rs
@@ -1,0 +1,47 @@
+use funput_core::InputMethod;
+use funput_engine::{Action, Engine};
+
+#[test]
+fn resolves_with_minimal_diff_and_preserves_raw_keys() {
+    let (buffer, results) = crate::support::type_keys(InputMethod::Telex, "lwa");
+    assert_eq!(buffer, "lă");
+    assert_eq!(results[2].action, Action::Send);
+    assert_eq!(results[2].backspace, 1);
+    assert_eq!(results[2].output, "ă");
+
+    let mut engine = Engine::new();
+    for key in "swan".chars() {
+        engine.process_char(key);
+    }
+    assert_eq!(engine.buffer(), "săn");
+    assert_eq!(engine.keys(), "swan");
+}
+
+#[test]
+fn flip_is_the_sticky_latin_escape() {
+    let mut engine = Engine::new();
+    for key in "swan".chars() {
+        engine.process_char(key);
+    }
+    engine.flip_composing();
+    assert_eq!(engine.buffer(), "swan");
+    let boundary = engine.process_char(' ');
+    assert_eq!(boundary.action, Action::None);
+    assert!(engine.buffer().is_empty());
+}
+
+#[test]
+fn literal_and_boundary_cases_do_not_leak() {
+    assert_eq!(
+        crate::support::app_text(InputMethod::Telex, "was wow win swift "),
+        "was wow win swift "
+    );
+    assert_eq!(
+        crate::support::app_text(InputMethod::Telex, "lwwa "),
+        "lwwa "
+    );
+    assert_eq!(
+        crate::support::app_text(InputMethod::Telex, "lw a "),
+        "lw a "
+    );
+}


### PR DESCRIPTION
## What changed

- represent one non-leading unresolved `w` directly in the composition buffer and resolve it when a viable vowel target arrives
- keep leading `w`, repeated pending `w`, dead candidates, and boundary-crossing cases literal
- preserve `qu` glide behavior and apply Vietnamese-first collision handling after a valid onset
- keep raw session keys unchanged so flip restores Latin input such as `swan`
- emit minimal Unicode diffs when the deferred modifier resolves

## Why

Telex users can physically overlap or reorder key presses. A modifier typed after the onset but before its vowel should converge with canonical Telex input without replaying the entire session or adding engine state.

## Impact

Sequences such as deferred breve and horn forms now converge when the candidate remains structurally viable. `swan` becomes `săn`, with the existing flip action restoring and preserving `swan`. Leading and invalid Latin words remain literal.

## Dependency

This is the third PR in the Telex V2 stack. It is based on `agent/telex-v2-intent-refactor` and should be merged after the internal intent refactor.

## Validation

- core permutation and collision matrix passed
- engine raw-key, minimal-diff, flip, sticky-Latin, restore, and boundary tests passed
- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- allocation budget and 136-byte `Engine` size preserved
- touched-file LOC gate: all files at or below 150 lines
- `git diff --check`
