### PR TITLE
feat(telex): support free-position circumflex modifiers

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -27,9 +27,11 @@ their corresponding directories in `target/criterion/`.
 | Metric | Result |
 |---|---|
 | Compose latency (core `apply`) | **~0.05 µs / keystroke** (Telex), ~0.05 µs (VNI) |
-| Compose throughput | **> 18 million keystrokes / second** |
-| Full engine path (`process_char`, incl. boundary + English-restore) | **~0.11 µs / keystroke** (~8.9 M/s) |
-| **End-to-end across the C FFI** (`process_char` + read composed text back) | **~0.12 µs / keystroke** |
+| Compose throughput | **~19.0 million keystrokes / second** |
+| Free-position `aa/ee/oo` compose throughput | **~18.4 million keystrokes / second** |
+| Full engine path (`process_char`, incl. boundary + English-restore) | **~0.12 µs / keystroke** (~8.5 M/s) |
+| Free-position `aa/ee/oo` through the full engine | **~0.09 µs / keystroke** (~10.6 M/s) |
+| **End-to-end across the C FFI** (`process_char` + read composed text back) | **~0.12 µs / keystroke** (~8.5 M/s) |
 | `size_of::<Engine>` (per-field session state) | **136 bytes** |
 | Heap allocations per keystroke (with or without spell-check) | **~1** (~7 B) |
 | Release FFI shared lib (`libfunput_ffi.dylib`, LTO + stripped) | ~0.37 MB |
@@ -37,6 +39,10 @@ their corresponding directories in `target/criterion/`.
 A human types a few keys per second; Funput answers each in **sub-microsecond**
 time, i.e. millions of times faster than needed — composition is never the
 bottleneck.
+
+The core and engine suites also contain equal-length canonical/free-position
+circumflex pairs (`chaan`/`chana`, `hoom`/`homo`, …). They keep the ordinary
+typing benchmark stable while measuring the extra candidate validation directly.
 
 ### What "end-to-end" measures (and what it doesn't)
 

--- a/crates/funput-core/benches/apply.rs
+++ b/crates/funput-core/benches/apply.rs
@@ -14,6 +14,8 @@ use funput_core::{InputMethod, ToneStyle, apply_checked};
 // Realistic typing with tones, circumflex/horn/breve and the `đ` stroke.
 const TELEX: &str = "tooi yeeu tieesng vieejt nam ddaats nuwowcs hoom nay troiwf ddepj";
 const VNI: &str = "to6i ye6u tie6ng1 vie6t5 nam dda6t1 nu7o7c1 ho6m nay tro7i2 dde9p5";
+const TELEX_CIRCUMFLEX_CANONICAL: &str = "chaan chaanf deem hoom chaats Chaan";
+const TELEX_CIRCUMFLEX_FREE: &str = "chana chanaf deme homo chatas Chana";
 
 /// Replay `keys` through `apply_checked`, folding the buffer at each space.
 fn type_through(keys: &str, method: InputMethod, spell_check: bool) -> String {
@@ -40,6 +42,16 @@ fn bench(c: &mut Criterion) {
         });
         group.bench_function(BenchmarkId::new("spellcheck", name), |b| {
             b.iter(|| type_through(black_box(keys), method, true))
+        });
+    }
+
+    for (name, keys) in [
+        ("canonical", TELEX_CIRCUMFLEX_CANONICAL),
+        ("free-position", TELEX_CIRCUMFLEX_FREE),
+    ] {
+        group.throughput(Throughput::Elements(keys.chars().count() as u64));
+        group.bench_function(BenchmarkId::new("circumflex", name), |b| {
+            b.iter(|| type_through(black_box(keys), InputMethod::Telex, false))
         });
     }
     group.finish();

--- a/crates/funput-core/src/composition/free_circumflex.rs
+++ b/crates/funput-core/src/composition/free_circumflex.rs
@@ -1,0 +1,212 @@
+//! Free-position Telex circumflex (`aa` / `ee` / `oo`).
+//!
+//! The adjacent digraph stays on the established fast path. This module handles
+//! only a repeated vowel that arrives after a tone or coda (`chana` → `chân`).
+//! It targets an exact vowel stem, validates the resulting Vietnamese candidate,
+//! and reuses one allocation for both the candidate and literal fallback.
+
+use crate::composition::replace_char_at;
+use crate::input_method::telex::tone_from_key;
+use crate::unicode::marks::{Tone, apply_tone_to_vowel, tone_on_vowel, vowel_stem};
+use crate::unicode::shapes::{VowelShape, apply_shape_to_vowel, shape_on_vowel, strip_shape};
+use crate::unicode::tone_position::{tone_target_vowel, tone_vowel_index};
+use crate::validation::syllable::is_viable_shape_candidate;
+use crate::{ToneStyle, TransformKind, TransformResult};
+
+#[derive(Debug, Clone, Copy)]
+struct Target {
+    char_index: usize,
+    byte_offset: usize,
+    vowel: char,
+}
+
+/// Apply or revert a free-position circumflex for the exact ASCII `stem`.
+pub(crate) fn apply_free_circumflex(
+    buffer: &str,
+    key: char,
+    stem: char,
+    style: ToneStyle,
+) -> TransformResult {
+    let Some(target) = matching_target(buffer, stem) else {
+        return literal(buffer, key, None);
+    };
+
+    if shape_on_vowel(target.vowel) == Some(VowelShape::Circumflex) {
+        let Some(plain) = strip_shape(target.vowel) else {
+            return literal(buffer, key, None);
+        };
+        let mut text = replace_char_at(buffer, target.char_index, plain);
+        text.push(key);
+        return TransformResult {
+            kind: TransformKind::Reverted,
+            text,
+        };
+    }
+
+    let mut candidate = String::with_capacity(buffer.len() + 2);
+    build_candidate(&mut candidate, buffer, target, None);
+    if is_viable_shape_candidate(&candidate) {
+        return applied(candidate);
+    }
+
+    // A tone typed before the first vowel is literal on the normal Telex path.
+    // When the later repeated vowel makes the intended syllable unambiguous,
+    // reinterpret that one pending tone without changing tone classification in
+    // general (`chfana` → `chần`).
+    if let Some((tone_offset, tone)) = pending_tone_before_target(buffer, target.byte_offset) {
+        candidate.clear();
+        build_candidate(&mut candidate, buffer, target, Some(tone_offset));
+        if apply_tone_in_place(&mut candidate, tone, style) && is_viable_shape_candidate(&candidate)
+        {
+            return applied(candidate);
+        }
+    }
+
+    literal(buffer, key, Some(candidate))
+}
+
+fn matching_target(buffer: &str, stem: char) -> Option<Target> {
+    let mut target = None;
+    for (char_index, (byte_offset, vowel)) in buffer.char_indices().enumerate() {
+        if !vowel.is_alphabetic() {
+            target = None;
+            continue;
+        }
+        if !matches!(shape_on_vowel(vowel), None | Some(VowelShape::Circumflex)) {
+            continue;
+        }
+        let plain = strip_shape(vowel).unwrap_or(vowel);
+        if vowel_stem(plain).is_some_and(|target| target.eq_ignore_ascii_case(&stem)) {
+            target = Some(Target {
+                char_index,
+                byte_offset,
+                vowel,
+            });
+        }
+    }
+    target
+}
+
+fn build_candidate(
+    candidate: &mut String,
+    buffer: &str,
+    target: Target,
+    skipped_byte: Option<usize>,
+) {
+    for (byte_offset, ch) in buffer.char_indices() {
+        if skipped_byte == Some(byte_offset) {
+            continue;
+        }
+        if byte_offset != target.byte_offset {
+            candidate.push(ch);
+            continue;
+        }
+
+        let Some(shaped) = apply_shape_to_vowel(ch, VowelShape::Circumflex) else {
+            candidate.push(ch);
+            continue;
+        };
+        candidate.push(match tone_on_vowel(ch) {
+            Some(tone) => apply_tone_to_vowel(shaped, tone).unwrap_or(shaped),
+            None => shaped,
+        });
+    }
+}
+
+fn pending_tone_before_target(buffer: &str, target_offset: usize) -> Option<(usize, Tone)> {
+    buffer[..target_offset]
+        .char_indices()
+        .rev()
+        .find_map(|(offset, ch)| tone_from_key(ch).map(|tone| (offset, tone)))
+}
+
+fn apply_tone_in_place(text: &mut String, tone: Tone, style: ToneStyle) -> bool {
+    let Some(vowel_index) = tone_vowel_index(text, style) else {
+        return false;
+    };
+    let Some(vowel) = text.chars().nth(vowel_index) else {
+        return false;
+    };
+    let target = tone_target_vowel(text, vowel_index).unwrap_or(vowel);
+    let Some(toned) = apply_tone_to_vowel(target, tone) else {
+        return false;
+    };
+    let Some((offset, current)) = text.char_indices().nth(vowel_index) else {
+        return false;
+    };
+    text.replace_range(
+        offset..offset + current.len_utf8(),
+        toned.encode_utf8(&mut [0; 4]),
+    );
+    true
+}
+
+fn applied(text: String) -> TransformResult {
+    TransformResult {
+        kind: TransformKind::Applied,
+        text,
+    }
+}
+
+fn literal(buffer: &str, key: char, reusable: Option<String>) -> TransformResult {
+    let mut text = reusable.unwrap_or_else(|| String::with_capacity(buffer.len() + key.len_utf8()));
+    text.clear();
+    text.push_str(buffer);
+    text.push(key);
+    TransformResult {
+        kind: TransformKind::Pending,
+        text,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn apply(buffer: &str, key: char) -> TransformResult {
+        apply_free_circumflex(
+            buffer,
+            key,
+            key.to_ascii_lowercase(),
+            ToneStyle::Traditional,
+        )
+    }
+
+    #[test]
+    fn applies_to_exact_stem_and_preserves_tone_and_case() {
+        assert_eq!(apply("chan", 'a').text, "chân");
+        assert_eq!(apply("chàn", 'a').text, "chần");
+        assert_eq!(apply("ChAn", 'A').text, "ChÂn");
+        assert_eq!(apply("hom", 'o').text, "hôm");
+        assert_eq!(apply("dem", 'e').text, "dêm");
+    }
+
+    #[test]
+    fn rejects_invalid_candidate_and_reuses_literal_key() {
+        let result = apply("camer", 'a');
+        assert_eq!(result.kind, TransformKind::Pending);
+        assert_eq!(result.text, "camera");
+        assert_eq!(apply("ngoe", 'o').text, "ngoeo");
+        assert_eq!(apply("oao", 'o').text, "oaoo");
+        assert_eq!(apply("â ", 'a').text, "â a");
+    }
+
+    #[test]
+    fn reinterprets_early_tone_only_when_candidate_is_viable() {
+        assert_eq!(apply("chfan", 'a').text, "chần");
+    }
+
+    #[test]
+    fn reverts_non_adjacent_circumflex() {
+        let result = apply("chân", 'a');
+        assert_eq!(result.kind, TransformKind::Reverted);
+        assert_eq!(result.text, "chana");
+    }
+
+    #[test]
+    fn selects_the_rightmost_matching_stem() {
+        let target = matching_target("oao", 'o').expect("matching o target");
+        assert_eq!(target.char_index, 2);
+        assert_eq!(target.byte_offset, 2);
+    }
+}

--- a/crates/funput-core/src/composition/mod.rs
+++ b/crates/funput-core/src/composition/mod.rs
@@ -1,4 +1,5 @@
 pub mod apply;
+pub mod free_circumflex;
 pub mod revert;
 pub mod transform;
 pub mod uo_horn;

--- a/crates/funput-core/src/composition/transform.rs
+++ b/crates/funput-core/src/composition/transform.rs
@@ -5,6 +5,7 @@
 use crate::composition::apply::{
     apply_shape_key, apply_stroke, apply_tone_key, remove_tone, shape_apply_target_exists,
 };
+use crate::composition::free_circumflex::apply_free_circumflex;
 use crate::composition::revert::{try_revert_shape, try_revert_stroke, try_revert_tone};
 use crate::composition::uo_horn::{complete_uo_horn_for_continuation, ends_with_open_uo_horn};
 use crate::input_method::KeyAction;
@@ -145,6 +146,9 @@ pub(crate) fn apply_action(
             let result = validation_gate(buffer, key, validate_shape(buffer))
                 .unwrap_or_else(|| apply_shape_key(buffer, shape));
             spell_check_gate(buffer, key, spell_check, result)
+        }
+        KeyAction::FreeCircumflex(stem) => {
+            apply_free_circumflex(buffer, key, stem.as_char(), style)
         }
         KeyAction::RemoveTone => match remove_tone(buffer) {
             // Tone stripped (keeps shape): `viết` + `z`/`0` → `viêt`.

--- a/crates/funput-core/src/input_method/mod.rs
+++ b/crates/funput-core/src/input_method/mod.rs
@@ -14,6 +14,37 @@ pub mod vni;
 use crate::unicode::marks::Tone;
 use crate::unicode::shapes::VowelShape;
 
+/// Exact Telex vowel stem targeted by a free-position circumflex.
+///
+/// A compact enum keeps [`KeyAction`] at its original small size on the hot path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CircumflexStem {
+    A,
+    E,
+    O,
+}
+
+impl CircumflexStem {
+    #[inline]
+    pub(crate) fn from_key(key: char) -> Option<Self> {
+        match key.to_ascii_lowercase() {
+            'a' => Some(Self::A),
+            'e' => Some(Self::E),
+            'o' => Some(Self::O),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn as_char(self) -> char {
+        match self {
+            Self::A => 'a',
+            Self::E => 'e',
+            Self::O => 'o',
+        }
+    }
+}
+
 /// What a keystroke means, independent of input method.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyAction {
@@ -23,6 +54,11 @@ pub enum KeyAction {
     Tone(Tone),
     /// Vowel shape (mũ / móc / trần).
     Shape(VowelShape),
+    /// A circumflex requested by a repeated Telex vowel away from its target.
+    ///
+    /// Carries the exact ASCII stem so composition never guesses between several
+    /// shapeable vowels in the nucleus (`a`, `e`, and `o` all accept a circumflex).
+    FreeCircumflex(CircumflexStem),
     /// Remove the tone mark from the syllable, keeping shapes (VNI `0`, Telex `z`).
     RemoveTone,
     /// Ordinary character — appended as-is.

--- a/crates/funput-core/src/input_method/telex.rs
+++ b/crates/funput-core/src/input_method/telex.rs
@@ -7,7 +7,7 @@
 //! | `s` / `f` / `r` / `x` / `j` | sắc / huyền / hỏi / ngã / nặng |
 //! | `z` | remove tone mark (xóa dấu) |
 //! | `dd` | stroke `đ` |
-//! | `aa` / `ee` / `oo` | circumflex on `a` / `e` / `o` |
+//! | repeated `a` / `e` / `o` | circumflex, adjacent or later in the syllable |
 //! | `w` after `a` | breve `ă` |
 //! | `w` after `o` / `u` | horn `ơ` / `ư` |
 //! | `w` after `uo` | horn compound `ươ` |
@@ -16,14 +16,13 @@
 //!
 //! 1. Stroke `đ` — adjacent `dd`, `đ`+`d` revert, or a `d`/`đ` already past the
 //!    nucleus so the `d` can be typed anywhere in the syllable (`dược`+`d` → `được`)
-//! 2. Digraph shape (`aa`, `ee`, `oo`) on plain vowels
+//! 2. Circumflex (`aa`, `ee`, `oo`), adjacent or later in the syllable
 //! 3. `w` — `uo` compound before single `o` / `u` / `a`; shaped-vowel revert
-//! 4. Shape revert (`â`+`a`, …)
-//! 5. Tone keys `s` / `f` / `r` / `x` / `j`
-//! 6. Normal character
+//! 4. Tone keys `s` / `f` / `r` / `x` / `j`
+//! 5. Normal character
 
 use crate::composition::uo_horn::uo_pair_in_vowel_cluster;
-use crate::input_method::KeyAction;
+use crate::input_method::{CircumflexStem, KeyAction};
 use crate::unicode::marks::{Tone, is_vowel, tone_on_vowel, vowel_stem};
 use crate::unicode::shapes::{VowelShape, shape_on_vowel, shape_target_index, strip_shape};
 
@@ -44,7 +43,7 @@ pub fn classify_key(buffer: &str, key: char) -> KeyAction {
     if let Some(action) = classify_stroke(buffer, key) {
         return action;
     }
-    if let Some(action) = classify_digraph(buffer, key) {
+    if let Some(action) = classify_circumflex(buffer, key) {
         return action;
     }
     if key.eq_ignore_ascii_case(&'w')
@@ -52,13 +51,74 @@ pub fn classify_key(buffer: &str, key: char) -> KeyAction {
     {
         return action;
     }
-    if let Some(action) = classify_revert_circumflex(buffer, key) {
-        return action;
-    }
     if key.eq_ignore_ascii_case(&'z') {
         return KeyAction::RemoveTone;
     }
     classify_tone(buffer, key).unwrap_or(KeyAction::Normal)
+}
+
+/// Classify adjacent, revert, and free-position `aa`/`ee`/`oo` in one pass.
+/// Returning early for non-vowel keys makes the added capability free on the
+/// consonant/tone hot path and avoids scanning the buffer twice for vowel keys.
+#[inline]
+fn classify_circumflex(buffer: &str, key: char) -> Option<KeyAction> {
+    let stem = CircumflexStem::from_key(key)?;
+    let stem_char = stem.as_char();
+
+    if let Some(last) = last_char(buffer) {
+        if is_plain_vowel(last, stem_char) {
+            return Some(KeyAction::Shape(VowelShape::Circumflex));
+        }
+        if shape_on_vowel(last) == Some(VowelShape::Circumflex) {
+            let plain = strip_shape(last).unwrap_or(last);
+            if vowel_stem(plain).is_some_and(|base| base.eq_ignore_ascii_case(&stem_char)) {
+                return Some(KeyAction::Shape(VowelShape::Circumflex));
+            }
+        }
+    }
+
+    classify_free_circumflex(buffer, stem)
+}
+
+/// A repeated `a`/`e`/`o` may modify the matching nucleus vowel even after a
+/// tone or coda (`chan` + `a` → `chân`). Classification only establishes that a
+/// matching target exists; the composition layer builds and validates the exact
+/// candidate before consuming the key.
+#[inline]
+fn classify_free_circumflex(buffer: &str, stem: CircumflexStem) -> Option<KeyAction> {
+    let stem_char = stem.as_char();
+
+    // The overwhelmingly common path is an ASCII onset/nucleus. Check it in one
+    // reverse pass; fall back to Unicode vowel tables only if a composed scalar
+    // appears before a matching ASCII target.
+    let mut ascii = true;
+    for byte in buffer.bytes().rev() {
+        if !byte.is_ascii() {
+            ascii = false;
+            break;
+        }
+        if !byte.is_ascii_alphabetic() {
+            return None;
+        }
+        if byte.eq_ignore_ascii_case(&(stem_char as u8)) {
+            return Some(KeyAction::FreeCircumflex(stem));
+        }
+    }
+    if ascii {
+        return None;
+    }
+
+    buffer
+        .chars()
+        .rev()
+        .take_while(|ch| ch.is_alphabetic())
+        .find(|&vowel| {
+            let shape = shape_on_vowel(vowel);
+            let plain = strip_shape(vowel).unwrap_or(vowel);
+            matches!(shape, None | Some(VowelShape::Circumflex))
+                && vowel_stem(plain).is_some_and(|target| target.eq_ignore_ascii_case(&stem_char))
+        })
+        .map(|_| KeyAction::FreeCircumflex(stem))
 }
 
 fn last_char(buffer: &str) -> Option<char> {
@@ -188,31 +248,6 @@ fn classify_stroke(buffer: &str, key: char) -> Option<KeyAction> {
     None
 }
 
-fn classify_digraph(buffer: &str, key: char) -> Option<KeyAction> {
-    let last = last_char(buffer)?;
-
-    for base in ['a', 'e', 'o'] {
-        if is_plain_vowel(last, base) && key.eq_ignore_ascii_case(&base) {
-            return Some(KeyAction::Shape(VowelShape::Circumflex));
-        }
-    }
-
-    None
-}
-
-fn classify_revert_circumflex(buffer: &str, key: char) -> Option<KeyAction> {
-    let last = last_char(buffer)?;
-    if shape_on_vowel(last) != Some(VowelShape::Circumflex) {
-        return None;
-    }
-    let plain = strip_shape(last)?;
-    if key.eq_ignore_ascii_case(&plain) {
-        Some(KeyAction::Shape(VowelShape::Circumflex))
-    } else {
-        None
-    }
-}
-
 /// Tone keys (`s` `f` `r` `x` `j`) are ordinary Latin letters too, so only treat
 /// one as a tone when there is a vowel to receive it. With no vowel the key stays
 /// a literal character — a leading `f`/`j`, a consonant onset (`tr`), or an
@@ -267,6 +302,33 @@ mod tests {
             classify_key("o", 'o'),
             KeyAction::Shape(VowelShape::Circumflex)
         );
+    }
+
+    #[test]
+    fn classify_free_position_circumflex() {
+        assert_eq!(
+            classify_key("chan", 'a'),
+            KeyAction::FreeCircumflex(CircumflexStem::A)
+        );
+        assert_eq!(
+            classify_key("dèm", 'e'),
+            KeyAction::FreeCircumflex(CircumflexStem::E)
+        );
+        assert_eq!(
+            classify_key("hom", 'O'),
+            KeyAction::FreeCircumflex(CircumflexStem::O)
+        );
+        assert_eq!(
+            classify_key("camer", 'a'),
+            KeyAction::FreeCircumflex(CircumflexStem::A)
+        );
+        assert_eq!(classify_key("chan", 'i'), KeyAction::Normal);
+        assert_eq!(classify_key("cha n", 'a'), KeyAction::Normal);
+    }
+
+    #[test]
+    fn key_action_stays_compact() {
+        assert!(std::mem::size_of::<KeyAction>() <= 2);
     }
 
     #[test]

--- a/crates/funput-core/src/validation/reachability.rs
+++ b/crates/funput-core/src/validation/reachability.rs
@@ -8,7 +8,7 @@ use std::sync::LazyLock;
 
 use crate::unicode::marks::{Tone, vowel_stem};
 use crate::validation::coda::{STOP_CODAS, coda_in, normalized_coda, nucleus_tone};
-use crate::validation::parse::parse_syllable;
+use crate::validation::parse::{SyllableParts, parse_syllable};
 use crate::validation::rhyme;
 
 /// Longer than every deshaped rhyme (max is 4 chars, e.g. `uong`), so a query
@@ -26,6 +26,12 @@ fn plain_base(c: char) -> char {
         'ư' => 'u',
         other => other,
     }
+}
+
+/// Stem with tone removed but vowel shape preserved (`ồ` → `ô`).
+fn shaped_base(c: char) -> char {
+    let stem = vowel_stem(c).unwrap_or(c);
+    char::to_lowercase(stem).next().unwrap_or(stem)
 }
 
 /// The rhyme inventory with tone/shape stripped, deshaped and sorted once.
@@ -68,10 +74,14 @@ fn any_rhyme_with_prefix(prefix: &[char]) -> bool {
 ///    (A stop coda with no tone yet stays alive — the tone follows the coda.)
 pub fn is_definitely_invalid(buffer: &str) -> bool {
     let parts = parse_syllable(buffer);
+    is_definitely_invalid_parts(&parts)
+}
+
+pub(crate) fn is_definitely_invalid_parts(parts: &SyllableParts<'_>) -> bool {
     if parts.nucleus_chars().next().is_none() {
         return false; // still building the onset
     }
-    let Some((coda, coda_len)) = normalized_coda(&parts) else {
+    let Some((coda, coda_len)) = normalized_coda(parts) else {
         return true; // longer than any Vietnamese coda — no rhyme can match
     };
     let coda = &coda[..coda_len];
@@ -97,4 +107,30 @@ pub fn is_definitely_invalid(buffer: &str) -> bool {
         );
     }
     false
+}
+
+/// Whether the candidate's actual shaped rhyme is a prefix of a Vietnamese rhyme.
+/// Unlike eager English restore, this deliberately does not deshape vowels: a new
+/// circumflex must prove that its precise result (`ôe`, not plain `oe`) is reachable.
+pub(crate) fn has_shaped_rhyme_prefix(parts: &SyllableParts<'_>) -> bool {
+    if parts.nucleus_chars().next().is_none() {
+        return false;
+    }
+    let Some((coda, coda_len)) = normalized_coda(parts) else {
+        return false;
+    };
+
+    let mut query = ['\0'; MAX_QUERY];
+    let mut len = 0;
+    for ch in parts
+        .nucleus_chars()
+        .chain(coda[..coda_len].iter().copied())
+    {
+        if len == MAX_QUERY {
+            return false;
+        }
+        query[len] = shaped_base(ch);
+        len += 1;
+    }
+    rhyme::has_prefix(&query[..len])
 }

--- a/crates/funput-core/src/validation/rhyme.rs
+++ b/crates/funput-core/src/validation/rhyme.rs
@@ -49,6 +49,22 @@ pub fn is_valid_rhyme(rhyme: &str) -> bool {
     SORTED_RHYMES.binary_search(&rhyme).is_ok()
 }
 
+/// Whether any valid shaped rhyme starts with `prefix`.
+///
+/// Used by free-position shape candidates, where deshaping would over-accept an
+/// impossible rhyme such as `ôe` merely because plain `oe` exists.
+pub(crate) fn has_prefix(prefix: &[char]) -> bool {
+    let first = SORTED_RHYMES.partition_point(|rhyme| {
+        rhyme.chars().cmp(prefix.iter().copied()) == std::cmp::Ordering::Less
+    });
+    SORTED_RHYMES.get(first).is_some_and(|rhyme| {
+        let mut chars = rhyme.chars();
+        prefix
+            .iter()
+            .all(|&expected| chars.next() == Some(expected))
+    })
+}
+
 /// The full toneless rhyme inventory (for prefix/reachability checks).
 pub fn all() -> &'static [&'static str] {
     VALID_RHYMES
@@ -83,5 +99,12 @@ mod tests {
         for rhyme in all() {
             assert!(is_valid_rhyme(rhyme), "{rhyme} missing from sorted view");
         }
+    }
+
+    #[test]
+    fn shaped_prefix_distinguishes_oe_from_nonexistent_o_circumflex_e() {
+        assert!(has_prefix(&['o', 'e']));
+        assert!(!has_prefix(&['ô', 'e']));
+        assert!(has_prefix(&['â', 't']));
     }
 }

--- a/crates/funput-core/src/validation/syllable.rs
+++ b/crates/funput-core/src/validation/syllable.rs
@@ -10,6 +10,7 @@ use crate::validation::coda::{
     STOP_CODAS, VALID_CODAS, coda_in, normalized_coda, nucleus_tone, toneless_rhyme,
 };
 use crate::validation::parse::{SyllableParts, is_valid_onset, parse_syllable};
+use crate::validation::reachability::{has_shaped_rhyme_prefix, is_definitely_invalid_parts};
 use crate::validation::rhyme::is_valid_rhyme;
 
 /// Result of validating a modifier keystroke against the current buffer.
@@ -47,14 +48,17 @@ fn violates_ckg_spelling(onset: &str, parts: &SyllableParts) -> bool {
 
 fn validate_modifier(buffer: &str) -> ModifierValidation {
     let parts = parse_syllable(buffer);
+    validate_parts(&parts)
+}
 
+fn validate_parts(parts: &SyllableParts<'_>) -> ModifierValidation {
     if parts.invalid_onset || !is_valid_onset(parts.onset) {
         return ModifierValidation::PassThrough;
     }
     if parts.nucleus_chars().next().is_none() {
         return ModifierValidation::Ignored;
     }
-    if violates_ckg_spelling(parts.onset, &parts) {
+    if violates_ckg_spelling(parts.onset, parts) {
         return ModifierValidation::PassThrough;
     }
 
@@ -62,12 +66,21 @@ fn validate_modifier(buffer: &str) -> ModifierValidation {
     // English word, pass the key through. A single trailing consonant is allowed
     // (the user may still be typing, e.g. "mix" → "mĩx").
     if parts.coda_chars().nth(1).is_some() {
-        match normalized_coda(&parts) {
+        match normalized_coda(parts) {
             Some((coda, len)) if coda_in(VALID_CODAS, &coda[..len]) => {}
             _ => return ModifierValidation::PassThrough,
         }
     }
     ModifierValidation::Allow
+}
+
+/// Validate a newly shaped candidate in one parse: orthographic structure, the
+/// exact shaped-rhyme prefix, and tone/coda reachability must all agree.
+pub(crate) fn is_viable_shape_candidate(buffer: &str) -> bool {
+    let parts = parse_syllable(buffer);
+    matches!(validate_parts(&parts), ModifierValidation::Allow)
+        && has_shaped_rhyme_prefix(&parts)
+        && !is_definitely_invalid_parts(&parts)
 }
 
 /// Validate tone key (1–5) against the current buffer.

--- a/crates/funput-core/tests/telex/basic.rs
+++ b/crates/funput-core/tests/telex/basic.rs
@@ -87,6 +87,53 @@ fn telex_free_position_marks() {
 }
 
 #[test]
+fn telex_free_position_circumflex() {
+    for (canonical, free, expected) in [
+        ("chaan", "chana", "chân"),
+        ("deem", "deme", "dêm"),
+        ("hoom", "homo", "hôm"),
+    ] {
+        assert_eq!(type_keys(canonical), expected);
+        assert_eq!(type_keys(free), expected);
+    }
+
+    for (tone_after, tone_before, expected) in [
+        ("chanas", "chasna", "chấn"),
+        ("chanaf", "chafna", "chần"),
+        ("chanar", "charna", "chẩn"),
+        ("chanax", "chaxna", "chẫn"),
+        ("chanaj", "chajna", "chận"),
+    ] {
+        assert_eq!(type_keys(tone_after), expected);
+        assert_eq!(type_keys(tone_before), expected);
+    }
+
+    // A tone may be pending before the first vowel and becomes unambiguous once
+    // the free-position circumflex resolves the syllable.
+    assert_eq!(type_keys("chfana"), "chần");
+
+    // A stop coda without a tone is reachable, not complete: the later sắc key
+    // must still be able to finish the syllable.
+    assert_eq!(type_keys("chatas"), "chất");
+
+    // Open rhymes and two-letter codas use the same resolver as simple codas.
+    assert_eq!(type_keys("asa"), "ấ");
+    assert_eq!(type_keys("efe"), "ề");
+    assert_eq!(type_keys("oso"), "ố");
+    assert_eq!(type_keys("kenhe"), "kênh");
+    assert_eq!(type_keys("congo"), "công");
+
+    assert_eq!(type_keys("Chana"), "Chân");
+    assert_eq!(type_keys("CHANA"), "CHÂN");
+    assert_eq!(type_keys("chanaa"), "chana");
+}
+
+#[test]
+fn telex_free_position_circumflex_keeps_existing_regressions() {
+    assert_eq!(type_keys("booong"), "boong");
+}
+
+#[test]
 fn telex_validation_and_pass_through() {
     // A tone letter with no vowel to land on is kept literally, not dropped.
     assert_eq!(

--- a/crates/funput-engine/benches/process_char.rs
+++ b/crates/funput-engine/benches/process_char.rs
@@ -15,6 +15,8 @@ use funput_engine::Engine;
 const TELEX: &str =
     "Tooi yeeu tieesng Vieejt. Hoom nay troiwf nuwowcs ddepj. Ban cos khoeer khoong?";
 const VNI: &str = "To6i ye6u tie6ng1 Vie6t5. Ho6m nay tro7i2 nu7o7c1 dde9p5. Ban co1 khoe3 kho6ng?";
+const TELEX_CIRCUMFLEX_CANONICAL: &str = "Chaan chaanf deem hoom chaats. Chaan!";
+const TELEX_CIRCUMFLEX_FREE: &str = "Chana chanaf deme homo chatas. Chana!";
 
 fn run(input: &str, method: InputMethod) {
     let mut engine = Engine::new();
@@ -33,6 +35,15 @@ fn bench(c: &mut Criterion) {
         group.throughput(Throughput::Elements(input.chars().count() as u64));
         group.bench_function(BenchmarkId::new("paragraph", name), |b| {
             b.iter(|| run(black_box(input), method))
+        });
+    }
+    for (name, input) in [
+        ("canonical", TELEX_CIRCUMFLEX_CANONICAL),
+        ("free-position", TELEX_CIRCUMFLEX_FREE),
+    ] {
+        group.throughput(Throughput::Elements(input.chars().count() as u64));
+        group.bench_function(BenchmarkId::new("circumflex", name), |b| {
+            b.iter(|| run(black_box(input), InputMethod::Telex))
         });
     }
     group.finish();

--- a/crates/funput-engine/tests/alloc_budget.rs
+++ b/crates/funput-engine/tests/alloc_budget.rs
@@ -59,6 +59,11 @@ static ALLOCATOR: CountingAlloc = CountingAlloc;
 const TELEX_TEXT: &str =
     "Tooi yeeu tieesng Vieejt. Hoom nay troiwf nuwowcs ddepj. Go~ text nhanh! ";
 
+/// Equal-length canonical/free-position pairs isolate the new resolver without
+/// changing the number of processed keys.
+const CANONICAL_CIRCUMFLEX: &str = "chaan chaanf deem hoom chaats Chaan ";
+const FREE_CIRCUMFLEX: &str = "chana chanaf deme homo chatas Chana ";
+
 /// Type `text` through `engine`, returning (allocs, bytes) attributed to it.
 fn measure(engine: &mut Engine, text: &str) -> (usize, usize) {
     let before_allocs = ALLOCS.load(Ordering::Relaxed);
@@ -72,9 +77,8 @@ fn measure(engine: &mut Engine, text: &str) -> (usize, usize) {
     )
 }
 
-fn assert_within_budget(label: &str, engine: &mut Engine) {
-    let keys = TELEX_TEXT.chars().count() as f64;
-    let (allocs, bytes) = measure(engine, TELEX_TEXT);
+fn assert_counts_within_budget(label: &str, text: &str, allocs: usize, bytes: usize) {
+    let keys = text.chars().count() as f64;
     let allocs_per_key = allocs as f64 / keys;
     let bytes_per_key = bytes as f64 / keys;
     println!("{label}: {allocs_per_key:.1} allocs/key, {bytes_per_key:.0} bytes/key");
@@ -88,6 +92,11 @@ fn assert_within_budget(label: &str, engine: &mut Engine) {
         "{label}: {bytes_per_key:.0} bytes/key exceeds the {MAX_BYTES_PER_KEY} budget \
          — a change added heap traffic to the keystroke hot path"
     );
+}
+
+fn assert_within_budget(label: &str, engine: &mut Engine) {
+    let (allocs, bytes) = measure(engine, TELEX_TEXT);
+    assert_counts_within_budget(label, TELEX_TEXT, allocs, bytes);
 }
 
 #[test]
@@ -105,4 +114,16 @@ fn keystroke_alloc_budget() {
 
     engine.set_spell_check(true);
     assert_within_budget("spell-check on", &mut engine);
+
+    engine.set_spell_check(false);
+    engine.clear();
+    let canonical = measure(&mut engine, CANONICAL_CIRCUMFLEX);
+    engine.clear();
+    let free = measure(&mut engine, FREE_CIRCUMFLEX);
+    println!("circumflex pairs: canonical={canonical:?}, free-position={free:?}");
+    assert!(
+        free.0 <= canonical.0,
+        "free-position circumflex added allocation events: canonical={canonical:?}, free={free:?}"
+    );
+    assert_counts_within_budget("free-position circumflex", FREE_CIRCUMFLEX, free.0, free.1);
 }

--- a/crates/funput-engine/tests/diacritics/placement.rs
+++ b/crates/funput-engine/tests/diacritics/placement.rs
@@ -43,6 +43,8 @@ fn modern_tone_style_oa_oe_uy() {
     assert_eq!(run_modern(InputMethod::Telex, "hoanf"), "hoàn");
     assert_eq!(run_modern(InputMethod::Telex, "ngoaif"), "ngoài");
     assert_eq!(run_modern(InputMethod::Vni, "tru7o7n2g"), "trường");
+    // A free-position circumflex preserves an existing tone under both styles.
+    assert_eq!(run_modern(InputMethod::Telex, "chafna"), "chần");
 }
 
 #[test]
@@ -51,6 +53,7 @@ fn traditional_keeps_oa_oe_uy_on_first_vowel() {
     assert_eq!(run(InputMethod::Telex, "hoaf"), "hòa");
     assert_eq!(run(InputMethod::Telex, "thuyr"), "thủy");
     assert_eq!(run(InputMethod::Telex, "khoer"), "khỏe");
+    assert_eq!(run(InputMethod::Telex, "chafna"), "chần");
 }
 
 #[test]

--- a/crates/funput-engine/tests/methods/telex.rs
+++ b/crates/funput-engine/tests/methods/telex.rs
@@ -55,3 +55,45 @@ fn telex_truowng_complex() {
         "trương"
     );
 }
+
+#[test]
+fn telex_free_position_circumflex_sends_minimal_diff() {
+    let (buffer, results) = crate::support::type_keys(InputMethod::Telex, "chana");
+    assert_eq!(buffer, "chân");
+    let result = &results[4];
+    assert_eq!(result.action, Action::Send);
+    assert_eq!(result.backspace, 2);
+    assert_eq!(result.output, "ân");
+}
+
+#[test]
+fn telex_free_position_circumflex_preserves_raw_keys_and_flips() {
+    let mut engine = funput_engine::Engine::new();
+    for key in "homo".chars() {
+        engine.process_char(key);
+    }
+    assert_eq!(engine.buffer(), "hôm");
+    assert_eq!(engine.keys(), "homo");
+
+    let raw = engine.flip_composing();
+    assert_eq!(raw.action, Action::Send);
+    assert_eq!(engine.buffer(), "homo");
+
+    let vietnamese = engine.flip_composing();
+    assert_eq!(vietnamese.action, Action::Send);
+    assert_eq!(engine.buffer(), "hôm");
+
+    engine.flip_composing();
+    let space = engine.process_char(' ');
+    assert_eq!(space.action, Action::None);
+    assert!(engine.buffer().is_empty());
+    assert!(engine.keys().is_empty());
+}
+
+#[test]
+fn telex_free_position_circumflex_restores_non_vietnamese_runs() {
+    assert_eq!(
+        crate::support::app_text(InputMethod::Telex, "camera banana "),
+        "camera banana "
+    );
+}

--- a/crates/funput-ffi/src/lib.rs
+++ b/crates/funput-ffi/src/lib.rs
@@ -23,8 +23,8 @@
 //! panic in the engine is caught at the boundary and turned into a no-op result —
 //! it never unwinds into the host (which would abort the whole IME process).
 
-mod config;
 mod compose;
+mod config;
 mod shortcuts;
 mod support;
 mod types;

--- a/crates/funput-ffi/src/support.rs
+++ b/crates/funput-ffi/src/support.rs
@@ -59,5 +59,8 @@ pub(crate) fn copy_codepoints(dst: &mut [u32], chars: impl Iterator<Item = char>
 
 /// Decode UTF-32 codepoints into a `String`, skipping invalid scalars.
 pub(crate) fn decode_codepoints(codepoints: &[u32]) -> String {
-    codepoints.iter().filter_map(|&c| char::from_u32(c)).collect()
+    codepoints
+        .iter()
+        .filter_map(|&c| char::from_u32(c))
+        .collect()
 }


### PR DESCRIPTION
## What changed

- support free-position Telex circumflex modifiers for `aa`, `ee`, and `oo` after the vowel nucleus, tone, or coda
- preserve the exact target stem, Unicode case, existing tone, and established Traditional/Modern tone placement
- support non-adjacent revert by removing the circumflex and appending the repeated key literally
- validate transformed candidates structurally without a dictionary, while preserving canonical adjacent Telex fast paths
- retain raw session keys so the existing flip action restores ambiguous Latin input such as `homo`
- add core, engine, allocation, corpus, and paired canonical/free-position benchmark coverage

## Why

Telex modifiers can arrive in different orders during natural or rollover typing. Previously, only adjacent `aa`, `ee`, and `oo` reliably applied a circumflex. A repeated vowel typed later in the same word was treated literally even when it unambiguously formed a reachable Vietnamese syllable.

## Impact

Equivalent key orders now converge, including `chaan`/`chana` → `chân`, `chafna` → `chần`, `deme` → `dêm`, and `homo` → `hôm`. Invalid candidates such as `camera` and `banana` remain Latin, and `booong` → `boong` retains the existing loanword escape. The feature is always enabled for Telex on every platform through the existing core API.

No public API, ABI, FFI/JNI signature, setting, or `Engine` state is added.

## Dependency

This is the Telex V1 foundation for the stacked Telex V2 PRs #59, #61, #62, and #60.

## Validation

- `cargo test --workspace`
- property tests and spell-check corpus passed
- Telex/VNI coverage sample: 100%
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `size_of::<Engine>()`: 136 bytes
- allocation budget unchanged: 2 allocations/key and 24 B/key
- core free-position throughput: approximately 18.4 million keys/second
- engine free-position throughput: approximately 10.6 million keys/second
- `git diff --check`
