### PR TITLE
test(telex): specify bounded multi-intent convergence

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -31,6 +31,11 @@ The V2 suites add equal-length `w-permutation/canonical` and
 Final median latency changed by **+0.85% core**, **+0.69% engine**, and
 **+1.53% FFI**, all inside the 3% regression gate.
 
+Telex V3 baseline (`telex_v3_multi_before`, same machine/toolchain): core Telex
+**19.43 M keys/s**, engine **8.99 M keys/s**, and C FFI **8.31 M keys/s**.
+V3 keeps these common-path IDs unchanged and measures canonical/multi-intent
+`w + dd` sequences separately.
+
 | Metric | Result |
 |---|---|
 | Compose latency (core `apply`) | **~0.05 µs / keystroke** (Telex), ~0.05 µs (VNI) |

--- a/crates/funput-core/tests/telex.rs
+++ b/crates/funput-core/tests/telex.rs
@@ -18,12 +18,16 @@ mod parity_data;
 mod basic;
 #[path = "telex/corpus.rs"]
 mod corpus;
+#[path = "telex/multi_intent_spec.rs"]
+mod multi_intent_spec;
 #[path = "telex/parity.rs"]
 mod parity;
 #[path = "telex/properties.rs"]
 mod properties;
 #[path = "telex/regression.rs"]
 mod regression;
+#[path = "telex/stroke_collisions.rs"]
+mod stroke_collisions;
 #[path = "telex/w_collisions.rs"]
 mod w_collisions;
 #[path = "telex/w_permutations.rs"]

--- a/crates/funput-core/tests/telex/multi_intent_spec.rs
+++ b/crates/funput-core/tests/telex/multi_intent_spec.rs
@@ -1,0 +1,116 @@
+use funput_core::{InputMethod, ToneStyle, apply};
+
+struct Case {
+    skeleton: &'static str,
+    target: &'static str,
+}
+
+fn type_keys(keys: &str, style: ToneStyle) -> String {
+    keys.chars().fold(String::new(), |buffer, key| {
+        apply(&buffer, key, InputMethod::Telex, style).text
+    })
+}
+
+fn insert_pair(base: &str, d_at: usize, w_at: usize, w_first: bool) -> String {
+    let chars: Vec<_> = base.chars().collect();
+    let mut keys = String::with_capacity(base.len() + 2);
+    for boundary in 0..=chars.len() {
+        if d_at == boundary && w_at == boundary {
+            if w_first {
+                keys.push('w');
+                keys.push('d');
+            } else {
+                keys.push('d');
+                keys.push('w');
+            }
+        } else {
+            if d_at == boundary {
+                keys.push('d');
+            }
+            if w_at == boundary {
+                keys.push('w');
+            }
+        }
+        if let Some(ch) = chars.get(boundary) {
+            keys.push(*ch);
+        }
+    }
+    keys
+}
+
+fn variants(base: &str) -> Vec<String> {
+    let count = base.chars().count();
+    let mut result = Vec::new();
+    for d_at in 1..=count {
+        for w_at in 1..=count {
+            result.push(insert_pair(base, d_at, w_at, false));
+            if d_at == w_at {
+                result.push(insert_pair(base, d_at, w_at, true));
+            }
+        }
+    }
+    result
+}
+
+fn pending_w_precedes_stroke(keys: &str) -> bool {
+    keys.get(..3)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("dwd"))
+}
+
+#[test]
+fn snapshots_current_multi_intent_gap() {
+    for case in [
+        Case {
+            skeleton: "duocj",
+            target: "được",
+        },
+        Case {
+            skeleton: "duongf",
+            target: "đường",
+        },
+        Case {
+            skeleton: "don",
+            target: "đơn",
+        },
+        Case {
+            skeleton: "doif",
+            target: "đời",
+        },
+    ] {
+        for style in [ToneStyle::Traditional, ToneStyle::Modern] {
+            for keys in variants(case.skeleton) {
+                let expected = if pending_w_precedes_stroke(&keys) {
+                    keys.as_str()
+                } else {
+                    case.target
+                };
+                assert_eq!(
+                    type_keys(&keys, style),
+                    expected,
+                    "baseline changed: {keys}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn snapshots_tones_and_uppercase_gap() {
+    for (skeleton, target) in [
+        ("dans", "đắn"),
+        ("danf", "đằn"),
+        ("danr", "đẳn"),
+        ("danx", "đẵn"),
+        ("danj", "đặn"),
+        ("DUOCJ", "ĐƯỢC"),
+    ] {
+        for keys in variants(skeleton) {
+            let expected = if pending_w_precedes_stroke(&keys) {
+                keys.as_str()
+            } else {
+                target
+            };
+            assert_eq!(type_keys(&keys, ToneStyle::Traditional), expected, "{keys}");
+        }
+    }
+}

--- a/crates/funput-core/tests/telex/stroke_collisions.rs
+++ b/crates/funput-core/tests/telex/stroke_collisions.rs
@@ -1,0 +1,29 @@
+use funput_core::InputMethod;
+
+fn type_keys(keys: &str) -> String {
+    crate::support::type_keys(InputMethod::Telex, keys)
+}
+
+#[test]
+fn delayed_stroke_behavior_is_locked() {
+    for (keys, output) in [
+        ("daud", "đau"),
+        ("dend", "đen"),
+        ("doifd", "đòi"),
+        ("dad", "đa"),
+        ("did", "đi"),
+    ] {
+        assert_eq!(type_keys(keys), output, "collision changed: {keys}");
+    }
+}
+
+#[test]
+fn invalid_or_repeated_pending_intents_stay_literal() {
+    for literal in ["dwdead", "dwswift", "dwdd", "dwwd", "lwwa"] {
+        assert_eq!(type_keys(literal), literal);
+    }
+    assert_eq!(
+        crate::support::type_words(InputMethod::Telex, "dwd a"),
+        "dwd a"
+    );
+}

--- a/crates/funput-engine/tests/methods.rs
+++ b/crates/funput-engine/tests/methods.rs
@@ -6,5 +6,7 @@ mod support;
 mod telex;
 #[path = "methods/telex_deferred_w.rs"]
 mod telex_deferred_w;
+#[path = "methods/telex_multi_intent_spec.rs"]
+mod telex_multi_intent_spec;
 #[path = "methods/vni.rs"]
 mod vni;

--- a/crates/funput-engine/tests/methods/telex_multi_intent_spec.rs
+++ b/crates/funput-engine/tests/methods/telex_multi_intent_spec.rs
@@ -1,0 +1,25 @@
+use funput_core::InputMethod;
+
+#[test]
+fn snapshots_current_pending_w_then_stroke_gap() {
+    for literal in ["dwduocj", "dwduongf", "dwdon", "dwdoif"] {
+        assert_eq!(
+            crate::support::app_text(InputMethod::Telex, literal),
+            literal
+        );
+    }
+}
+
+#[test]
+fn latin_collisions_keep_current_engine_behavior() {
+    for (keys, output) in [
+        ("dad ", "đa "),
+        ("did ", "đi "),
+        ("dead ", "dead "),
+        ("droid ", "droid "),
+        ("dwdead ", "dwdead "),
+        ("dwswift ", "dwswift "),
+    ] {
+        assert_eq!(crate::support::app_text(InputMethod::Telex, keys), output);
+    }
+}


### PR DESCRIPTION
## What changed

- add a generated matrix for every placement of one `w` and one stroke `d` after a `d` onset
- snapshot the existing gap where `w` precedes the stroke before the nucleus
- lock delayed-stroke, Latin collision, repeated-intent, and boundary behavior
- record a same-machine Criterion baseline for core, engine, and FFI common paths

## Why

V1 and V2 make circumflex and `w` placement flexible, while delayed `dd` already works after a nucleus. The remaining bounded gap is two intents arriving before the vowel, such as `dwduocj`, which currently stays literal instead of converging to `được`.

## Impact

No runtime behavior, public API, ABI, or engine-state changes. This PR only defines the V3 acceptance matrix and performance baseline.

## Validation

- Telex core suite passed
- engine method suite passed
- baseline: core 19.43 M keys/s, engine 8.99 M keys/s, FFI 8.31 M keys/s
- all touched files are at or below 150 lines
- `git diff --check`
