### PR TITLE
refactor(telex): target delayed stroke intents

### DIFF
--- a/crates/funput-core/src/composition/intent/mod.rs
+++ b/crates/funput-core/src/composition/intent/mod.rs
@@ -3,6 +3,7 @@
 
 mod candidate;
 mod circumflex;
+mod stroke;
 mod target;
 mod w;
 
@@ -12,6 +13,7 @@ use crate::{ToneStyle, TransformKind, TransformResult};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ModifierIntent {
     Circumflex { stem: CircumflexStem, key: char },
+    Stroke { key: char },
     DeferredW { key: char },
 }
 
@@ -28,6 +30,7 @@ pub(crate) fn resolve(buffer: &str, intent: ModifierIntent, style: ToneStyle) ->
         ModifierIntent::Circumflex { stem, key } => {
             circumflex::resolve(buffer, char::from(stem), key, style)
         }
+        ModifierIntent::Stroke { key } => stroke::resolve(buffer, key),
         ModifierIntent::DeferredW { key } => w::resolve(buffer, key),
     }
 }

--- a/crates/funput-core/src/composition/intent/stroke.rs
+++ b/crates/funput-core/src/composition/intent/stroke.rs
@@ -1,0 +1,42 @@
+use crate::TransformKind;
+use crate::composition::apply::apply_stroke;
+use crate::composition::revert::try_revert_stroke;
+
+use super::IntentResolution;
+
+pub(super) fn resolve(buffer: &str, key: char) -> IntentResolution {
+    if let Some(mut text) = try_revert_stroke(buffer) {
+        text.push(key);
+        return IntentResolution::Reverted(text);
+    }
+
+    let result = apply_stroke(buffer);
+    if result.kind == TransformKind::Applied {
+        IntentResolution::Applied(result.text)
+    } else {
+        let mut text = result.text;
+        text.push(key);
+        IntentResolution::Literal(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn applies_and_reverts_the_existing_target() {
+        assert_eq!(
+            resolve("duoc", 'd'),
+            IntentResolution::Applied("đuoc".into())
+        );
+        assert_eq!(
+            resolve("được", 'd'),
+            IntentResolution::Reverted("dượcd".into())
+        );
+        assert_eq!(
+            resolve("DUOC", 'D'),
+            IntentResolution::Applied("ĐUOC".into())
+        );
+    }
+}

--- a/crates/funput-core/src/composition/transform/action.rs
+++ b/crates/funput-core/src/composition/transform/action.rs
@@ -18,7 +18,7 @@ pub(crate) fn apply_action(
     spell_check: bool,
 ) -> TransformResult {
     match action {
-        KeyAction::Stroke => stroke(buffer, key, spell_check),
+        KeyAction::Stroke => stroke(buffer, key, style, spell_check),
         KeyAction::Tone(value) => tone(buffer, key, value, style, spell_check),
         KeyAction::Shape(value) => shape(buffer, key, value, spell_check),
         KeyAction::FreeCircumflex(stem) => {
@@ -34,13 +34,24 @@ pub(crate) fn apply_action(
     }
 }
 
-fn stroke(buffer: &str, key: char, checked: bool) -> TransformResult {
+fn stroke(buffer: &str, key: char, style: ToneStyle, checked: bool) -> TransformResult {
+    if !ends_with_stroke_target(buffer) {
+        let result = resolve(buffer, ModifierIntent::Stroke { key }, style).into_result();
+        return gates::spell_check(buffer, key, checked, result);
+    }
     if let Some(text) = try_revert_stroke(buffer) {
         return reverted(append(&text, key));
     }
     let result = gates::validation(buffer, key, validate_stroke(buffer))
         .unwrap_or_else(|| apply_stroke(buffer));
     gates::spell_check(buffer, key, checked, result)
+}
+
+fn ends_with_stroke_target(buffer: &str) -> bool {
+    buffer
+        .chars()
+        .last()
+        .is_some_and(|ch| matches!(ch, 'd' | 'D' | 'đ' | 'Đ'))
 }
 
 fn tone(


### PR DESCRIPTION
## What changed

- introduce a private targeted stroke intent for delayed Telex `dd`
- keep adjacent `dd` on the existing fast path
- centralize delayed stroke apply/revert while preserving the current rightmost target used by abbreviations
- keep `KeyAction`, public APIs, ABI, and `Engine` unchanged

## Why

Pending `w` needs to compose with the already-supported delayed stroke without duplicating Unicode mapping or stroke/revert logic. Moving the delayed path behind the private intent abstraction provides that shared primitive before behavior changes.

## Impact

No intended behavior change. Existing `daud → đau`, `GDD → GĐ`, revert, Flip, diffs, spell-check, and VNI behavior remain unchanged.

## Dependency

Stacked on the V3 specification PR and intended to merge after it.

## Validation

- core, Telex, VNI, engine method, and diacritic suites passed
- common-path median delta: core -2.04%, engine +1.26%, FFI +2.47%
- `Engine` and public `KeyAction` layout unchanged
- all touched files are at or below 150 lines
- `git diff --check`
