### PR TITLE
feat(telex): converge deferred w with stroke intents

### DIFF
--- a/crates/funput-core/src/composition/intent/w.rs
+++ b/crates/funput-core/src/composition/intent/w.rs
@@ -34,18 +34,31 @@ pub(super) fn resolve(buffer: &str, key: char) -> IntentResolution {
     let Some(w_offset) = pending_offset(buffer) else {
         return IntentResolution::Literal(appended(buffer, key));
     };
+    if matches!(key, 'd' | 'D') && has_only_stroke_target(buffer, w_offset) {
+        return super::stroke::resolve(buffer, key);
+    }
     let mut candidate = String::with_capacity(buffer.len() + key.len_utf8() + 2);
     candidate.push_str(&buffer[..w_offset]);
     candidate.push_str(&buffer[w_offset + 1..]);
     candidate.push(key);
 
     let Some(KeyAction::Shape(shape)) = classify_w(&candidate) else {
-        return raw(buffer, key, candidate);
+        return raw(buffer, key, w_offset, candidate);
     };
     if apply_in_place(&mut candidate, shape) && is_viable_shape_candidate(&candidate) {
         return IntentResolution::Applied(candidate);
     }
-    raw(buffer, key, candidate)
+    raw(buffer, key, w_offset, candidate)
+}
+
+fn has_only_stroke_target(buffer: &str, w_offset: usize) -> bool {
+    let mut chars = buffer[..w_offset]
+        .chars()
+        .chain(buffer[w_offset + 1..].chars());
+    chars
+        .next()
+        .is_some_and(|ch| matches!(ch, 'd' | 'D' | 'đ' | 'Đ'))
+        && chars.next().is_none()
 }
 
 fn apply_in_place(text: &mut String, shape: crate::unicode::shapes::VowelShape) -> bool {
@@ -81,8 +94,20 @@ fn pending_offset(buffer: &str) -> Option<usize> {
         .map(|(offset, _)| offset)
 }
 
-fn raw(buffer: &str, key: char, mut reusable: String) -> IntentResolution {
+fn raw(buffer: &str, key: char, w_offset: usize, mut reusable: String) -> IntentResolution {
     reusable.clear();
+    if has_only_stroke_target(buffer, w_offset) && buffer.contains(['đ', 'Đ']) {
+        for ch in buffer.chars() {
+            reusable.push(match ch {
+                'đ' => 'd',
+                'Đ' => 'D',
+                _ => ch,
+            });
+        }
+        reusable.push(if buffer.contains('Đ') { 'D' } else { 'd' });
+        reusable.push(key);
+        return IntentResolution::Deferred(reusable);
+    }
     reusable.push_str(buffer);
     reusable.push(key);
     IntentResolution::Deferred(reusable)
@@ -106,5 +131,20 @@ mod tests {
         assert!(!has_pending("w"));
         assert!(!has_pending("lww"));
         assert!(!has_pending("law"));
+    }
+
+    #[test]
+    fn pending_marker_allows_one_stroke_intent() {
+        assert_eq!(resolve("dw", 'd'), IntentResolution::Applied("đw".into()));
+        assert_eq!(resolve("dW", 'D'), IntentResolution::Applied("đW".into()));
+        assert_eq!(resolve("đw", 'd'), IntentResolution::Reverted("dwd".into()));
+        assert_eq!(
+            resolve("gdw", 'd'),
+            IntentResolution::Deferred("gdwd".into())
+        );
+        assert_eq!(
+            resolve("đw", 'e'),
+            IntentResolution::Deferred("dwde".into())
+        );
     }
 }

--- a/crates/funput-core/tests/telex/multi_intent_spec.rs
+++ b/crates/funput-core/tests/telex/multi_intent_spec.rs
@@ -52,13 +52,8 @@ fn variants(base: &str) -> Vec<String> {
     result
 }
 
-fn pending_w_precedes_stroke(keys: &str) -> bool {
-    keys.get(..3)
-        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("dwd"))
-}
-
 #[test]
-fn snapshots_current_multi_intent_gap() {
+fn all_bounded_multi_intent_orders_converge() {
     for case in [
         Case {
             skeleton: "duocj",
@@ -79,15 +74,10 @@ fn snapshots_current_multi_intent_gap() {
     ] {
         for style in [ToneStyle::Traditional, ToneStyle::Modern] {
             for keys in variants(case.skeleton) {
-                let expected = if pending_w_precedes_stroke(&keys) {
-                    keys.as_str()
-                } else {
-                    case.target
-                };
                 assert_eq!(
                     type_keys(&keys, style),
-                    expected,
-                    "baseline changed: {keys}"
+                    case.target,
+                    "did not converge: {keys}"
                 );
             }
         }
@@ -95,7 +85,7 @@ fn snapshots_current_multi_intent_gap() {
 }
 
 #[test]
-fn snapshots_tones_and_uppercase_gap() {
+fn tones_and_uppercase_converge() {
     for (skeleton, target) in [
         ("dans", "đắn"),
         ("danf", "đằn"),
@@ -105,12 +95,7 @@ fn snapshots_tones_and_uppercase_gap() {
         ("DUOCJ", "ĐƯỢC"),
     ] {
         for keys in variants(skeleton) {
-            let expected = if pending_w_precedes_stroke(&keys) {
-                keys.as_str()
-            } else {
-                target
-            };
-            assert_eq!(type_keys(&keys, ToneStyle::Traditional), expected, "{keys}");
+            assert_eq!(type_keys(&keys, ToneStyle::Traditional), target, "{keys}");
         }
     }
 }

--- a/crates/funput-core/tests/telex/stroke_collisions.rs
+++ b/crates/funput-core/tests/telex/stroke_collisions.rs
@@ -19,11 +19,8 @@ fn delayed_stroke_behavior_is_locked() {
 
 #[test]
 fn invalid_or_repeated_pending_intents_stay_literal() {
-    for literal in ["dwdead", "dwswift", "dwdd", "dwwd", "lwwa"] {
+    for literal in ["dwdead", "dwswift", "dwwd", "lwwa"] {
         assert_eq!(type_keys(literal), literal);
     }
-    assert_eq!(
-        crate::support::type_words(InputMethod::Telex, "dwd a"),
-        "dwd a"
-    );
+    assert_eq!(type_keys("dwdd"), "dwd");
 }

--- a/crates/funput-engine/tests/methods/telex_multi_intent_spec.rs
+++ b/crates/funput-engine/tests/methods/telex_multi_intent_spec.rs
@@ -1,12 +1,14 @@
 use funput_core::InputMethod;
 
 #[test]
-fn snapshots_current_pending_w_then_stroke_gap() {
-    for literal in ["dwduocj", "dwduongf", "dwdon", "dwdoif"] {
-        assert_eq!(
-            crate::support::app_text(InputMethod::Telex, literal),
-            literal
-        );
+fn pending_w_then_stroke_converges() {
+    for (keys, output) in [
+        ("dwduocj", "được"),
+        ("dwduongf", "đường"),
+        ("dwdon", "đơn"),
+        ("dwdoif", "đời"),
+    ] {
+        assert_eq!(crate::support::app_text(InputMethod::Telex, keys), output);
     }
 }
 


### PR DESCRIPTION
## What changed

- allow one deferred `w` to compose with one stroke `d` before the vowel nucleus
- resolve `dw + d → đw`, then consume the same marker when the vowel arrives
- restore the literal raw order if the pending `w` later becomes invalid
- preserve repeated-stroke revert, uppercase, tone styles, collision, and boundary semantics

## Why

The pending-`w` dispatcher previously owned every following key, so a stroke key typed before the vowel was appended instead of being resolved. This left fast rollover sequences such as `dwduocj` literal even though neighboring permutations already produced `được`.

## Impact

Every bounded insertion order now converges for representative words including `được`, `đường`, `đơn`, `đời`, and all five tones of `đắn`. Invalid runs such as `dwdead` remain literal, and raw session keys remain available to Flip.

## Dependency

Stacked on the targeted stroke-intent refactor and intended to merge after it.

## Validation

- generated core permutation matrix passed under Traditional and Modern styles
- engine convergence and collision tests passed
- common-path median delta: core -1.99%, engine +1.67%, FFI +0.27%
- resolver file remains exactly 150 lines; every touched file meets the LOC gate
- `git diff --check`
