### PR TITLE
feat(windows): expose Advanced Telex

### DIFF
--- a/docs/features/advanced-telex.md
+++ b/docs/features/advanced-telex.md
@@ -2,11 +2,11 @@
 
 ## Trạng thái
 
-V5 đã hiện thực core/engine và C FFI/JNI. macOS là platform đầu tiên expose UI,
-persistence và selection; Windows/Linux sẽ tích hợp sau. Đây là tính năng desktop:
-iOS/Android không expose hoặc persist mode này, còn wire ID `2` trong FFI/JNI vẫn
-được giữ dormant. Tên hiển thị là **Telex nâng cao**; tên kỹ thuật là
-`TelexAdvanced` và giá trị cấu hình ổn định là `telex_advanced`.
+V5 đã hiện thực core/engine và C FFI/JNI. macOS và Windows expose UI, persistence
+và selection; Linux sẽ tích hợp sau. Đây là tính năng desktop: iOS/Android không
+expose hoặc persist mode này, còn wire ID `2` trong FFI/JNI vẫn được giữ dormant.
+Tên hiển thị là **Telex nâng cao**; tên kỹ thuật là `TelexAdvanced` và giá trị cấu
+hình ổn định là `telex_advanced`.
 
 ## Mục tiêu
 
@@ -104,9 +104,9 @@ chứng lại `size_of::<Engine>()` và ABI tests.
 
 ### Platform
 
-Platform không tự hiện thực quy tắc gõ. macOS hiển thị **Telex**, **Telex nâng
-cao**, **VNI** theo thứ tự đó, persist `telex_advanced`, migrate cấu hình integer cũ
-và truyền mode qua C FFI. Windows/Linux sẽ làm tương tự trong plan riêng.
+Platform không tự hiện thực quy tắc gõ. macOS và Windows hiển thị **Telex**,
+**Telex nâng cao**, **VNI** theo thứ tự đó và persist `telex_advanced`. macOS truyền
+mode qua C FFI; Windows dùng trực tiếp Rust engine. Linux sẽ tích hợp sau.
 
 iOS/Android không thêm UI, persistence hoặc wiring cho mode này. Khi một consumer
 không hỗ trợ đọc `telex_advanced`, nó phải giữ input method hiện tại thay vì ép về
@@ -127,8 +127,8 @@ Config interchange mở rộng `preferences.inputMethod` thành:
 - Core, engine và FFI common-path không chậm quá 3% so với baseline trước V5.
 - Viet74K đạt 100% với cả Telex canonical và Full Telex shortcut encoding.
 - Không nới allocation budget hiện tại; kiểm tra lại kích thước Engine và ABI.
-- Core, engine, C FFI và JNI dùng cùng behavior và wire mapping; macOS đã tích hợp
-  selection qua C FFI, Windows/Linux làm sau và mobile giữ mapping dormant.
+- Core, engine, C FFI và JNI dùng cùng behavior và wire mapping; macOS và Windows
+  đã tích hợp selection, Linux làm sau và mobile giữ mapping dormant.
 
 ## Ngoài phạm vi V5
 

--- a/platforms/CONFIG_FORMAT.md
+++ b/platforms/CONFIG_FORMAT.md
@@ -64,7 +64,7 @@ one machine imports on another. macOS is the first implementation
 | `version` | — | Format version (currently `1`). Required. |
 | `exportedAt` | — | ISO-8601 timestamp. Metadata only. |
 | `source` | — | `platform` + `appVersion` that produced the file. Metadata only. |
-| `preferences.inputMethod` | ✅ | `telex`, `telex_advanced`, or `vni`. Advanced Telex is currently desktop-only and exposed on macOS; unsupported consumers keep their current selection. |
+| `preferences.inputMethod` | ✅ | `telex`, `telex_advanced`, or `vni`. Advanced Telex is desktop-only and exposed on macOS/Windows; unsupported consumers keep their current selection. |
 | `preferences.*` | ✅ | Other typing options; each is optional and applied only if present. |
 | `shortcuts[]` | ✅ | `{ trigger, expansion }`. Local UUIDs are dropped; recreated on import. |
 | `platform.macos.toggleShortcut` | ❌ | `KeyCombo` (`keyCode` is AppKit-specific). Applied only on macOS, only if present. |

--- a/platforms/windows/src/compose.rs
+++ b/platforms/windows/src/compose.rs
@@ -12,6 +12,7 @@ use funput_engine::Engine;
 /// reset folds the buffer into `committed`.
 pub struct FieldComposer {
     engine: Engine,
+    method: InputMethod,
     committed: String,
 }
 
@@ -22,6 +23,7 @@ impl FieldComposer {
         engine.set_smart_restore(false);
         Self {
             engine,
+            method: InputMethod::Telex,
             committed: String::new(),
         }
     }
@@ -33,6 +35,7 @@ impl FieldComposer {
     /// Start a fresh composition with `text` already in the field (focus-in), applying
     /// the user's current method/tone so it matches global typing.
     pub fn reset(&mut self, text: &str, method: InputMethod, tone: ToneStyle) {
+        self.method = method;
         self.engine.set_method(method);
         self.engine.set_tone_style(tone);
         self.engine.clear();
@@ -47,7 +50,7 @@ impl FieldComposer {
         if !is_text(c) {
             return self.current();
         }
-        if c.is_whitespace() || c.is_ascii_punctuation() {
+        if c.is_whitespace() || (c.is_ascii_punctuation() && !self.is_advanced_shortcut(c)) {
             // Word boundary: fold the composed word + this separator into committed.
             self.committed.push_str(self.engine.buffer());
             self.committed.push(c);
@@ -72,6 +75,10 @@ impl FieldComposer {
             self.engine.on_backspace();
         }
         self.current()
+    }
+
+    fn is_advanced_shortcut(&self, c: char) -> bool {
+        self.method == InputMethod::TelexAdvanced && matches!(c, '[' | ']')
     }
 }
 

--- a/platforms/windows/src/settings/method.rs
+++ b/platforms/windows/src/settings/method.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "lowercase")]
 pub enum Method {
     Telex,
+    #[serde(rename = "telex_advanced")]
+    TelexAdvanced,
     Vni,
 }
 
@@ -12,14 +14,15 @@ impl Method {
     pub fn core(self) -> InputMethod {
         match self {
             Self::Telex => InputMethod::Telex,
+            Self::TelexAdvanced => InputMethod::TelexAdvanced,
             Self::Vni => InputMethod::Vni,
         }
     }
 
-    /// Compile-only compatibility until Windows exposes Telex Advanced.
     pub fn from_core(method: InputMethod) -> Self {
         match method {
-            InputMethod::Telex | InputMethod::TelexAdvanced => Self::Telex,
+            InputMethod::Telex => Self::Telex,
+            InputMethod::TelexAdvanced => Self::TelexAdvanced,
             InputMethod::Vni => Self::Vni,
             _ => unreachable!("Windows must integrate a newly added input method"),
         }
@@ -28,6 +31,7 @@ impl Method {
     pub fn id(self) -> &'static str {
         match self {
             Self::Telex => "telex",
+            Self::TelexAdvanced => "telex_advanced",
             Self::Vni => "vni",
         }
     }
@@ -35,6 +39,7 @@ impl Method {
     pub fn from_id(id: &str) -> Option<Self> {
         match id {
             "telex" => Some(Self::Telex),
+            "telex_advanced" => Some(Self::TelexAdvanced),
             "vni" => Some(Self::Vni),
             _ => None,
         }

--- a/platforms/windows/src/tray.rs
+++ b/platforms/windows/src/tray.rs
@@ -1,51 +1,42 @@
-//! Tray icon + menu, built on the standalone `tray-icon` crate (no WebView2).
-//! Left-click toggles Tiếng Việt (VI/EN) like Unikey; the icon reflects the state
-//! (color = VI, monochrome white = EN). Right-click opens the menu: pick Telex/VNI,
-//! settings, guide, quit.
-//!
-//! This lives on the keyboard-hook thread (the one running a Win32 message loop):
-//! `install()` creates the tray there, and `drain_events()` — called after each
-//! message dispatch — reacts to clicks/menu picks. Settings and Onboarding are
-//! launched as short-lived child processes so the tray process stays lightweight.
+//! Native tray menu hosted on the keyboard-hook thread's Win32 message loop.
 
 use std::cell::RefCell;
 
 use funput_core::InputMethod;
-use tray_icon::menu::{CheckMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem};
+use tray_icon::menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem};
 use tray_icon::{Icon, MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
 
 use crate::{hook, shell, windows_ui};
+
+mod method_menu;
+use method_menu::MethodMenu;
 
 const TRAY_PNG: &[u8] = include_bytes!("../icons/tray.png"); // VI: original color icon
 const TRAY_MONO_PNG: &[u8] = include_bytes!("../icons/tray-mono.png"); // EN: monochrome white
 
 struct TrayState {
     tray: TrayIcon,
-    vni: CheckMenuItem,
-    telex: CheckMenuItem,
+    methods: MethodMenu,
 }
 
 thread_local! {
     static TRAY: RefCell<Option<TrayState>> = const { RefCell::new(None) };
 }
 
-/// Build the tray icon + menu on the current thread. Must run on a thread with a
-/// Win32 message loop (the hook thread) so menu/click messages are delivered.
+/// Build the tray on the current keyboard-hook thread.
 pub fn install() {
     let on = shell::enabled();
     let method = shell::method();
 
-    let vni = CheckMenuItem::with_id("vni", "VNI", true, method == InputMethod::Vni, None);
-    let telex = CheckMenuItem::with_id("telex", "Telex", true, method == InputMethod::Telex, None);
+    let methods = MethodMenu::new(method);
     let settings = MenuItem::with_id("settings", "Cài đặt…", true, None);
     let guide = MenuItem::with_id("guide", "Hướng dẫn", true, None);
     let update = MenuItem::with_id("check-update", "Kiểm tra cập nhật…", true, None);
     let quit = MenuItem::with_id("quit", "Thoát", true, None);
 
     let menu = Menu::new();
+    methods.append_to(&menu);
     menu.append_items(&[
-        &vni,
-        &telex,
         &PredefinedMenuItem::separator(),
         &settings,
         &guide,
@@ -64,7 +55,7 @@ pub fn install() {
         .build()
         .expect("build tray icon");
 
-    TRAY.with(|c| *c.borrow_mut() = Some(TrayState { tray, vni, telex }));
+    TRAY.with(|c| *c.borrow_mut() = Some(TrayState { tray, methods }));
 
     // Keep the tray icon/tooltip in sync when VI/EN flips from the keyboard hotkey
     // or per-app auto-switch — both fire on this (hook) thread.
@@ -87,15 +78,13 @@ pub fn drain_events() {
     }
 
     while let Ok(ev) = MenuEvent::receiver().try_recv() {
-        match ev.id.0.as_str() {
-            "vni" => {
-                shell::set_method(InputMethod::Vni);
-                set_checks(true, false);
-            }
-            "telex" => {
-                shell::set_method(InputMethod::Telex);
-                set_checks(false, true);
-            }
+        let id = ev.id.0.as_str();
+        if let Some(method) = method_menu::method_for_id(id) {
+            shell::set_method(method);
+            sync_method(method);
+            continue;
+        }
+        match id {
             "settings" => {
                 windows_ui::launch_settings(false);
             }
@@ -118,7 +107,7 @@ pub fn drain_events() {
 /// changed the config file and the background engine reloaded it.
 pub fn sync_from_shell() {
     let method = shell::method();
-    set_checks(method == InputMethod::Vni, method == InputMethod::Telex);
+    sync_method(method);
     refresh(shell::enabled());
 }
 
@@ -133,11 +122,10 @@ fn refresh(on: bool) {
     });
 }
 
-fn set_checks(vni: bool, telex: bool) {
+fn sync_method(method: InputMethod) {
     TRAY.with(|c| {
         if let Some(s) = c.borrow().as_ref() {
-            s.vni.set_checked(vni);
-            s.telex.set_checked(telex);
+            s.methods.sync(method);
         }
     });
 }
@@ -153,6 +141,6 @@ fn tooltip(enabled: bool) -> String {
     if enabled {
         "Funput — Tiếng Việt (VI)".to_string()
     } else {
-        "Funput — Tắt (EN)".to_string()
+        "Funput — Tiếng Anh (EN)".to_string()
     }
 }

--- a/platforms/windows/src/tray/method_menu.rs
+++ b/platforms/windows/src/tray/method_menu.rs
@@ -1,0 +1,54 @@
+use funput_core::InputMethod;
+use tray_icon::menu::{CheckMenuItem, Menu};
+
+const TELEX_ID: &str = "telex";
+const ADVANCED_ID: &str = "telex_advanced";
+const VNI_ID: &str = "vni";
+
+pub struct MethodMenu {
+    telex: CheckMenuItem,
+    advanced: CheckMenuItem,
+    vni: CheckMenuItem,
+}
+
+impl MethodMenu {
+    pub fn new(method: InputMethod) -> Self {
+        let menu = Self {
+            telex: item(TELEX_ID, "Telex"),
+            advanced: item(ADVANCED_ID, "Telex nâng cao"),
+            vni: item(VNI_ID, "VNI"),
+        };
+        menu.sync(method);
+        menu
+    }
+
+    pub fn append_to(&self, menu: &Menu) {
+        menu.append_items(&[&self.telex, &self.advanced, &self.vni])
+            .expect("append input methods");
+    }
+
+    pub fn sync(&self, method: InputMethod) {
+        let (telex, advanced, vni) = match method {
+            InputMethod::Telex => (true, false, false),
+            InputMethod::TelexAdvanced => (false, true, false),
+            InputMethod::Vni => (false, false, true),
+            _ => (true, false, false),
+        };
+        self.telex.set_checked(telex);
+        self.advanced.set_checked(advanced);
+        self.vni.set_checked(vni);
+    }
+}
+
+pub fn method_for_id(id: &str) -> Option<InputMethod> {
+    match id {
+        TELEX_ID => Some(InputMethod::Telex),
+        ADVANCED_ID => Some(InputMethod::TelexAdvanced),
+        VNI_ID => Some(InputMethod::Vni),
+        _ => None,
+    }
+}
+
+fn item(id: &str, label: &str) -> CheckMenuItem {
+    CheckMenuItem::with_id(id, label, true, false, None)
+}

--- a/platforms/windows/src/windows_ui/onboarding.rs
+++ b/platforms/windows/src/windows_ui/onboarding.rs
@@ -25,9 +25,10 @@ pub(super) fn open() {
 
     let weak = window.as_weak();
     window.on_pick_method(move |value| {
-        if let Some(method) = Method::from_id(&value) {
-            commands::set_method(method);
-        }
+        let Some(method) = Method::from_id(&value) else {
+            return;
+        };
+        commands::set_method(method);
         if let Some(window) = weak.upgrade() {
             window.set_method(value);
         }

--- a/platforms/windows/src/windows_ui/settings_callbacks.rs
+++ b/platforms/windows/src/windows_ui/settings_callbacks.rs
@@ -1,26 +1,22 @@
 //! Settings callbacks and live model synchronization.
 
-use std::cell::RefCell;
+use slint::ComponentHandle;
 
-use slint::{ComponentHandle, Model};
-
-use super::{models, settings_window};
-use crate::compose::FieldComposer;
-use crate::config_transfer::{self, ImportSummary};
 use crate::settings::{FlipHotkey, Hotkey, Method, ToneStyle};
-use crate::{commands, recorder, shell, Compose, SettingsWindow};
+use crate::{commands, recorder, SettingsWindow};
 
-thread_local! {
-    /// Vietnamese composer for the gõ tắt expansion field (UI thread only).
-    static COMPOSER: RefCell<FieldComposer> = RefCell::new(FieldComposer::new());
-}
+use super::models;
+
+mod config;
+mod content;
 
 pub(super) fn wire(window: &SettingsWindow) {
     let weak = window.as_weak();
     window.on_pick_method(move |value| {
-        if let Some(method) = Method::from_id(&value) {
-            commands::set_method(method);
-        }
+        let Some(method) = Method::from_id(&value) else {
+            return;
+        };
+        commands::set_method(method);
         if let Some(window) = weak.upgrade() {
             window.set_method(value);
         }
@@ -92,165 +88,12 @@ pub(super) fn wire(window: &SettingsWindow) {
     window.on_set_auto_cap(commands::set_auto_capitalize);
     window.on_set_launch(commands::set_launch_at_login);
 
-    wire_apps(window);
-    wire_shortcuts(window);
-    wire_composer(window);
+    content::wire(window);
 
     window.on_open_link(|url| commands::open_url(url.as_str()));
     window.on_check_update(commands::check_for_updates);
     window.on_install_update(commands::install_update);
     window.on_relaunch_now(commands::relaunch_after_update);
 
-    wire_config_transfer(window);
-}
-
-/// Export/Import cấu hình. Native file dialogs (rfd) run modally on the UI thread;
-/// after a successful import the whole window is re-populated from the new state.
-fn wire_config_transfer(window: &SettingsWindow) {
-    window.on_export_config(|| {
-        let Some(path) = rfd::FileDialog::new()
-            .set_file_name(format!(
-                "Funput-config-{}.json",
-                config_transfer::today_stamp()
-            ))
-            .add_filter("JSON", &["json"])
-            .save_file()
-        else {
-            return;
-        };
-        if let Err(err) = commands::export_config(&path) {
-            message(&format!("Không xuất được cấu hình: {err}"));
-        }
-    });
-
-    let weak = window.as_weak();
-    window.on_import_config(move || {
-        let Some(path) = rfd::FileDialog::new()
-            .add_filter("JSON", &["json"])
-            .pick_file()
-        else {
-            return;
-        };
-        match commands::import_config(&path) {
-            Ok(summary) => {
-                if let Some(window) = weak.upgrade() {
-                    settings_window::populate(&window);
-                }
-                message(&import_message(&summary));
-            }
-            Err(err) => message(&err.to_string()),
-        }
-    });
-}
-
-fn message(text: &str) {
-    rfd::MessageDialog::new()
-        .set_title("Cấu hình")
-        .set_description(text)
-        .show();
-}
-
-fn import_message(summary: &ImportSummary) -> String {
-    let mut lines = vec!["Đã áp các tuỳ chọn gõ.".to_string()];
-    if summary.shortcuts_added > 0 || summary.shortcuts_updated > 0 {
-        lines.push(format!(
-            "Gõ tắt: thêm {}, cập nhật {}.",
-            summary.shortcuts_added, summary.shortcuts_updated
-        ));
-    } else {
-        lines.push("Không có gõ tắt mới.".to_string());
-    }
-    if summary.applied_platform {
-        lines.push("Đã áp phím tắt và danh sách app bỏ qua.".to_string());
-    }
-    if summary.newer_version {
-        lines.push("Lưu ý: tệp từ phiên bản mới hơn — một số mục có thể bị bỏ qua.".to_string());
-    }
-    lines.join("\n")
-}
-
-fn wire_apps(window: &SettingsWindow) {
-    let weak = window.as_weak();
-    window.on_add_app(move |id| {
-        if let Some(app) = shell::recent_apps()
-            .into_iter()
-            .find(|app| app.id == id.as_str())
-        {
-            commands::add_excluded_app(app);
-        }
-        if let Some(window) = weak.upgrade() {
-            settings_window::refresh_apps(&window);
-        }
-    });
-
-    let weak = window.as_weak();
-    window.on_remove_app(move |id| {
-        commands::remove_excluded_app(&id);
-        if let Some(window) = weak.upgrade() {
-            settings_window::refresh_apps(&window);
-        }
-    });
-}
-
-fn wire_shortcuts(window: &SettingsWindow) {
-    let weak = window.as_weak();
-    window.on_add_shortcut(move || {
-        commands::add_shortcut();
-        if let Some(window) = weak.upgrade() {
-            window.set_shortcuts(models::shortcuts(&shell::shortcuts()));
-        }
-    });
-
-    let weak = window.as_weak();
-    window.on_remove_shortcut(move |index| {
-        commands::remove_shortcut(index.max(0) as usize);
-        if let Some(window) = weak.upgrade() {
-            window.set_shortcuts(models::shortcuts(&shell::shortcuts()));
-        }
-    });
-
-    let weak = window.as_weak();
-    window.on_edit_trigger(move |index, text| {
-        let index = index.max(0) as usize;
-        commands::set_shortcut_trigger(index, text.to_string());
-        if let Some(window) = weak.upgrade() {
-            let model = window.get_shortcuts();
-            if let Some(mut entry) = model.row_data(index) {
-                entry.trigger = text;
-                model.set_row_data(index, entry);
-            }
-        }
-    });
-
-    let weak = window.as_weak();
-    window.on_edit_expansion(move |index, text| {
-        let index = index.max(0) as usize;
-        commands::set_shortcut_expansion(index, text.to_string());
-        if let Some(window) = weak.upgrade() {
-            let model = window.get_shortcuts();
-            if let Some(mut entry) = model.row_data(index) {
-                entry.expansion = text;
-                model.set_row_data(index, entry);
-            }
-        }
-    });
-}
-
-fn wire_composer(window: &SettingsWindow) {
-    let compose = window.global::<Compose>();
-    compose.on_reset(|text| {
-        let (method, tone) = shell::method_and_tone();
-        COMPOSER.with(|composer| composer.borrow_mut().reset(text.as_str(), method, tone));
-    });
-    compose.on_key(|text| {
-        let character = text.chars().next().unwrap_or('\0');
-        COMPOSER
-            .with(|composer| composer.borrow_mut().key(character))
-            .into()
-    });
-    compose.on_backspace(|| {
-        COMPOSER
-            .with(|composer| composer.borrow_mut().backspace())
-            .into()
-    });
+    config::wire(window);
 }

--- a/platforms/windows/src/windows_ui/settings_callbacks/config.rs
+++ b/platforms/windows/src/windows_ui/settings_callbacks/config.rs
@@ -1,0 +1,69 @@
+use slint::ComponentHandle;
+
+use crate::config_transfer::{self, ImportSummary};
+use crate::{commands, SettingsWindow};
+
+use super::super::settings_window;
+
+pub(super) fn wire(window: &SettingsWindow) {
+    window.on_export_config(|| {
+        let Some(path) = rfd::FileDialog::new()
+            .set_file_name(format!(
+                "Funput-config-{}.json",
+                config_transfer::today_stamp()
+            ))
+            .add_filter("JSON", &["json"])
+            .save_file()
+        else {
+            return;
+        };
+        if let Err(err) = commands::export_config(&path) {
+            message(&format!("Không xuất được cấu hình: {err}"));
+        }
+    });
+
+    let weak = window.as_weak();
+    window.on_import_config(move || {
+        let Some(path) = rfd::FileDialog::new()
+            .add_filter("JSON", &["json"])
+            .pick_file()
+        else {
+            return;
+        };
+        match commands::import_config(&path) {
+            Ok(summary) => {
+                if let Some(window) = weak.upgrade() {
+                    settings_window::populate(&window);
+                }
+                message(&import_message(&summary));
+            }
+            Err(err) => message(&err.to_string()),
+        }
+    });
+}
+
+fn message(text: &str) {
+    rfd::MessageDialog::new()
+        .set_title("Cấu hình")
+        .set_description(text)
+        .show();
+}
+
+fn import_message(summary: &ImportSummary) -> String {
+    let mut lines = vec!["Đã áp các tuỳ chọn gõ.".to_string()];
+    if summary.shortcuts_added > 0 || summary.shortcuts_updated > 0 {
+        lines.push(format!(
+            "Gõ tắt: thêm {}, cập nhật {}.",
+            summary.shortcuts_added, summary.shortcuts_updated
+        ));
+    } else {
+        lines.push("Không có gõ tắt mới.".to_string());
+    }
+    if summary.applied_platform {
+        lines.push("Đã áp phím tắt và danh sách app bỏ qua.".to_string());
+    }
+    if summary.newer_version {
+        lines.push("Lưu ý: tệp từ phiên bản mới hơn — một số mục có thể bị bỏ qua.".to_string());
+    }
+    lines.join("\n")
+}

--- a/platforms/windows/src/windows_ui/settings_callbacks/content.rs
+++ b/platforms/windows/src/windows_ui/settings_callbacks/content.rs
@@ -1,0 +1,112 @@
+use std::cell::RefCell;
+
+use slint::{ComponentHandle, Model};
+
+use crate::compose::FieldComposer;
+use crate::{commands, shell, Compose, SettingsWindow};
+
+use super::super::{models, settings_window};
+
+thread_local! {
+    static COMPOSER: RefCell<FieldComposer> = RefCell::new(FieldComposer::new());
+}
+
+pub(super) fn wire(window: &SettingsWindow) {
+    wire_apps(window);
+    wire_shortcuts(window);
+    wire_composer(window);
+}
+
+fn wire_apps(window: &SettingsWindow) {
+    let weak = window.as_weak();
+    window.on_add_app(move |id| {
+        if let Some(app) = shell::recent_apps()
+            .into_iter()
+            .find(|app| app.id == id.as_str())
+        {
+            commands::add_excluded_app(app);
+        }
+        if let Some(window) = weak.upgrade() {
+            settings_window::refresh_apps(&window);
+        }
+    });
+
+    let weak = window.as_weak();
+    window.on_remove_app(move |id| {
+        commands::remove_excluded_app(&id);
+        if let Some(window) = weak.upgrade() {
+            settings_window::refresh_apps(&window);
+        }
+    });
+}
+
+fn wire_shortcuts(window: &SettingsWindow) {
+    let weak = window.as_weak();
+    window.on_add_shortcut(move || {
+        commands::add_shortcut();
+        if let Some(window) = weak.upgrade() {
+            window.set_shortcuts(models::shortcuts(&shell::shortcuts()));
+        }
+    });
+
+    let weak = window.as_weak();
+    window.on_remove_shortcut(move |index| {
+        commands::remove_shortcut(index.max(0) as usize);
+        if let Some(window) = weak.upgrade() {
+            window.set_shortcuts(models::shortcuts(&shell::shortcuts()));
+        }
+    });
+
+    let weak = window.as_weak();
+    window.on_edit_trigger(move |index, text| {
+        update_shortcut(&weak, index, text, true);
+    });
+
+    let weak = window.as_weak();
+    window.on_edit_expansion(move |index, text| {
+        update_shortcut(&weak, index, text, false);
+    });
+}
+
+fn update_shortcut(
+    weak: &slint::Weak<SettingsWindow>,
+    index: i32,
+    text: slint::SharedString,
+    trigger: bool,
+) {
+    let index = index.max(0) as usize;
+    if trigger {
+        commands::set_shortcut_trigger(index, text.to_string());
+    } else {
+        commands::set_shortcut_expansion(index, text.to_string());
+    }
+    let Some(window) = weak.upgrade() else { return };
+    let model = window.get_shortcuts();
+    if let Some(mut entry) = model.row_data(index) {
+        if trigger {
+            entry.trigger = text
+        } else {
+            entry.expansion = text
+        }
+        model.set_row_data(index, entry);
+    }
+}
+
+fn wire_composer(window: &SettingsWindow) {
+    let compose = window.global::<Compose>();
+    compose.on_reset(|text| {
+        let (method, tone) = shell::method_and_tone();
+        COMPOSER.with(|composer| composer.borrow_mut().reset(text.as_str(), method, tone));
+    });
+    compose.on_key(|text| {
+        let character = text.chars().next().unwrap_or('\0');
+        COMPOSER
+            .with(|composer| composer.borrow_mut().key(character))
+            .into()
+    });
+    compose.on_backspace(|| {
+        COMPOSER
+            .with(|composer| composer.borrow_mut().backspace())
+            .into()
+    });
+}

--- a/platforms/windows/ui/method_selector.slint
+++ b/platforms/windows/ui/method_selector.slint
@@ -1,0 +1,16 @@
+// Shared input-method selector. Display order is independent from persisted IDs.
+
+import { Segmented } from "theme.slint";
+
+export component MethodSelector inherits Segmented {
+    in property <string> method;
+    callback picked(string);
+
+    options: [
+        { id: "telex", label: "Telex" },
+        { id: "telex_advanced", label: "Telex nâng cao" },
+        { id: "vni", label: "VNI" },
+    ];
+    current: root.method;
+    changed(value) => { root.picked(value); }
+}

--- a/platforms/windows/ui/onboarding.slint
+++ b/platforms/windows/ui/onboarding.slint
@@ -2,8 +2,9 @@
 // Rust (`windows_ui.rs`) sets the properties and handles the callbacks.
 
 import { Palette, Button, Switch } from "std-widgets.slint";
-import { Theme, Card, Segmented, KeyCap, Dot } from "theme.slint";
+import { Theme, Card, KeyCap, Dot } from "theme.slint";
 import { Backdrop } from "backdrop.slint";
+import { OnboardingMethodStep } from "onboarding_method.slint";
 
 export component OnboardingWindow inherits Window {
     title: "Chào mừng đến Funput";
@@ -52,23 +53,9 @@ export component OnboardingWindow inherits Window {
                         }
                     }
 
-                    if root.step == 1: VerticalLayout {
-                        alignment: center;
-                        spacing: Theme.sp-sm;
-                        HorizontalLayout {
-                            alignment: center;
-                            Image { source: @image-url("icons/keyboard.svg"); colorize: Theme.accent; width: 42px; height: 42px; }
-                        }
-                        Text { text: "Chọn kiểu gõ"; font-size: 20px; font-weight: 700; horizontal-alignment: center; color: Palette.foreground; }
-                        Text { text: "Có thể đổi bất cứ lúc nào trong Cài đặt."; font-size: 14px; horizontal-alignment: center; color: Theme.subtle; }
-                        HorizontalLayout {
-                            alignment: center;
-                            Segmented {
-                                options: [{ id: "telex", label: "Telex" }, { id: "vni", label: "VNI" }];
-                                current: root.method;
-                                changed(v) => { root.pick-method(v); }
-                            }
-                        }
+                    if root.step == 1: OnboardingMethodStep {
+                        method: root.method;
+                        pick-method(value) => { root.pick-method(value); }
                     }
 
                     if root.step == 2: VerticalLayout {

--- a/platforms/windows/ui/onboarding_method.slint
+++ b/platforms/windows/ui/onboarding_method.slint
@@ -1,0 +1,52 @@
+// Input-method step extracted from the onboarding wizard.
+
+import { Palette } from "std-widgets.slint";
+import { Theme } from "theme.slint";
+import { MethodSelector } from "method_selector.slint";
+
+export component OnboardingMethodStep inherits VerticalLayout {
+    in property <string> method;
+    callback pick-method(string);
+
+    alignment: center;
+    spacing: Theme.sp-sm;
+
+    HorizontalLayout {
+        alignment: center;
+        Image {
+            source: @image-url("icons/keyboard.svg");
+            colorize: Theme.accent;
+            width: 42px;
+            height: 42px;
+        }
+    }
+    Text {
+        text: "Chọn kiểu gõ";
+        font-size: 20px;
+        font-weight: 700;
+        horizontal-alignment: center;
+        color: Palette.foreground;
+    }
+    Text {
+        text: "Có thể đổi bất cứ lúc nào trong Cài đặt.";
+        font-size: 14px;
+        horizontal-alignment: center;
+        color: Theme.subtle;
+    }
+    HorizontalLayout {
+        alignment: center;
+        MethodSelector {
+            method: root.method;
+            picked(value) => { root.pick-method(value); }
+        }
+    }
+    Text {
+        text: root.method == "telex_advanced"
+            ? "Full Telex — [→ư, ]→ơ, w đầu từ→ư"
+            : "";
+        visible: self.text != "";
+        font-size: 12px;
+        horizontal-alignment: center;
+        color: Theme.subtle;
+    }
+}

--- a/platforms/windows/ui/page_input.slint
+++ b/platforms/windows/ui/page_input.slint
@@ -1,7 +1,8 @@
-// Settings → "Kiểu gõ": input method (Telex/VNI) + tone-mark placement style.
+// Settings → "Kiểu gõ": input method + tone-mark placement style.
 
 import { Palette } from "std-widgets.slint";
 import { Theme, Card, Row, Segmented } from "theme.slint";
+import { MethodSelector } from "method_selector.slint";
 
 export component InputPage inherits VerticalLayout {
     in property <string> method;
@@ -14,13 +15,14 @@ export component InputPage inherits VerticalLayout {
     Card {
         Row {
             title: "Phương thức";
-            subtitle: root.method == "telex"
-                ? "Dấu bằng chữ cái — aa→â, ow→ơ, as→á, dd→đ"
-                : "Dấu bằng chữ số — a6→â, o7→ơ, a1→á, d9→đ";
-            Segmented {
-                options: [{ id: "telex", label: "Telex" }, { id: "vni", label: "VNI" }];
-                current: root.method;
-                changed(v) => { root.pick-method(v); }
+            subtitle: root.method == "telex_advanced"
+                ? "Full Telex — [→ư, ]→ơ, w đầu từ→ư"
+                : (root.method == "telex"
+                    ? "Dấu bằng chữ cái — aa→â, ow→ơ, as→á, dd→đ"
+                    : "Dấu bằng chữ số — a6→â, o7→ơ, a1→á, d9→đ");
+            MethodSelector {
+                method: root.method;
+                picked(value) => { root.pick-method(value); }
             }
         }
     }


### PR DESCRIPTION
## Summary

- add the stable `telex_advanced` Windows setting and map it to `InputMethod::TelexAdvanced`
- expose Telex / Telex nâng cao / VNI consistently in Settings, Onboarding, and the tray
- share the Slint method selector and keep display order independent from internal IDs
- route `[` and `]` through the settings-field composer only in Advanced Telex
- keep the existing VNI default and config schema compatibility

## Dependency

Stacked on the core/macOS Advanced Telex PR. Merge that PR first.

## Validation

- MinGW Windows target check, Clippy, and test compilation
- root workspace tests, fmt, Clippy, diff and LOC checks
- Slint Settings/Onboarding layout review in light and dark modes
- no iOS/Android production changes
