### PR TITLE
fix(linux): restore GTK Settings build

### DIFF
--- a/platforms/linux/settings-gtk/src/framework.rs
+++ b/platforms/linux/settings-gtk/src/framework.rs
@@ -11,7 +11,6 @@
 use gtk::gio;
 use gtk::gio::prelude::*;
 use gtk::glib;
-use gtk::glib::prelude::*; // ToVariant / FromVariant
 
 /// True when per-app auto-switch is available, i.e. Fcitx5 is the active IME.
 pub fn per_app_supported() -> bool {

--- a/platforms/linux/settings-gtk/src/settings_window/shortcuts/row.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/shortcuts/row.rs
@@ -60,10 +60,10 @@ fn bind_edit(index: usize, entry: &EntryRow, expander: ExpanderRow, trigger: boo
 }
 
 fn bind_focus(index: usize, entry: &EntryRow, trigger: bool) {
-    let entry = entry.clone();
+    let entry_for_leave = entry.clone();
     let focus = gtk::EventControllerFocus::new();
     focus.connect_leave(move |_| {
-        let text = entry.text().to_string();
+        let text = entry_for_leave.text().to_string();
         Settings::update(move |settings| {
             if let Some(item) = settings.shortcuts.get_mut(index) {
                 if trigger {


### PR DESCRIPTION
## Summary

- keep the original GTK `EntryRow` available when attaching its focus controller
- give the focus-leave closure a dedicated cloned row
- remove the unused GLib prelude import that failed warning-clean builds

## Root cause

The shortcut-row refactor shadowed the borrowed `EntryRow` with an owned clone. The `move` closure then consumed that clone before `add_controller` tried to use it, causing `E0382` in every Linux release job.

## Impact

This restores compilation of the GTK Settings application for the Debian and RPM release matrix without changing runtime behavior.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo fmt --manifest-path platforms/linux/settings-gtk/Cargo.toml -- --check`
- `platforms/linux/check-loc.sh main`
- `git diff --check`

The Linux-native release workflow remains the final validation for GTK system dependencies.
