### PR TITLE
fix(ios): make fast typing robust

### DIFF
--- a/platforms/ios/Funput.xcodeproj/project.pbxproj
+++ b/platforms/ios/Funput.xcodeproj/project.pbxproj
@@ -22,6 +22,11 @@
 		FA260000000000000000020B /* KeyboardConfiguration in Frameworks */ = {isa = PBXBuildFile; productRef = FA2600000000000000000118 /* KeyboardConfiguration */; };
 		FA260000000000000000020C /* FunputShared in Frameworks */ = {isa = PBXBuildFile; productRef = FA2600000000000000000104 /* FunputShared */; };
 		FA260000000000000000020D /* KeyboardConfiguration in Frameworks */ = {isa = PBXBuildFile; productRef = FA2600000000000000000105 /* KeyboardConfiguration */; };
+		FA260000000000000000020E /* KeyboardLayout in Frameworks */ = {isa = PBXBuildFile; productRef = FA2600000000000000000122 /* KeyboardLayout */; };
+		FA260000000000000000020F /* KeyboardRenderer in Frameworks */ = {isa = PBXBuildFile; productRef = FA2600000000000000000123 /* KeyboardRenderer */; };
+		FA2600000000000000000210 /* FunputShared in Frameworks */ = {isa = PBXBuildFile; productRef = FA2600000000000000000124 /* FunputShared */; };
+		FA2600000000000000000211 /* ThemeRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = FA2600000000000000000125 /* ThemeRuntime */; };
+		FA2600000000000000000212 /* ThemeSchema in Frameworks */ = {isa = PBXBuildFile; productRef = FA2600000000000000000126 /* ThemeSchema */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -123,6 +128,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				5FEF3E313009341000B5155D /* KeyboardInput in Frameworks */,
+				FA260000000000000000020E /* KeyboardLayout in Frameworks */,
+				FA260000000000000000020F /* KeyboardRenderer in Frameworks */,
+				FA2600000000000000000210 /* FunputShared in Frameworks */,
+				FA2600000000000000000211 /* ThemeRuntime in Frameworks */,
+				FA2600000000000000000212 /* ThemeSchema in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -224,6 +234,11 @@
 			name = FunputTests;
 			packageProductDependencies = (
 				FA2600000000000000000121 /* KeyboardInput */,
+				FA2600000000000000000122 /* KeyboardLayout */,
+				FA2600000000000000000123 /* KeyboardRenderer */,
+				FA2600000000000000000124 /* FunputShared */,
+				FA2600000000000000000125 /* ThemeRuntime */,
+				FA2600000000000000000126 /* ThemeSchema */,
 			);
 			productName = FunputTests;
 			productReference = 5FB3C7C43001F78400CE4906 /* FunputTests.xctest */;
@@ -517,6 +532,7 @@
 				DEVELOPMENT_TEAM = RSARFZ5CD3;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -544,7 +560,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Funput/Funput.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = RSARFZ5CD3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -560,7 +576,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2026.6;
+				MARKETING_VERSION = 1.2026.7;
 				PRODUCT_BUNDLE_IDENTIFIER = app.funput.funput;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -580,9 +596,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Funput/Funput.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = RSARFZ5CD3;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_TESTABILITY = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
@@ -596,7 +613,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2026.6;
+				MARKETING_VERSION = 1.2026.7;
 				PRODUCT_BUNDLE_IDENTIFIER = app.funput.funput;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -625,7 +642,7 @@
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Funput.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Funput";
 			};
@@ -647,7 +664,7 @@
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Funput.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Funput";
 			};
@@ -700,7 +717,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Keyboard/Keyboard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = RSARFZ5CD3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Keyboard/Info.plist;
@@ -713,7 +730,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2026.6;
+				MARKETING_VERSION = 1.2026.7;
 				PRODUCT_BUNDLE_IDENTIFIER = app.funput.funput.Keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -731,7 +748,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Keyboard/Keyboard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 12;
 				DEVELOPMENT_TEAM = RSARFZ5CD3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Keyboard/Info.plist;
@@ -744,7 +761,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2026.6;
+				MARKETING_VERSION = 1.2026.7;
 				PRODUCT_BUNDLE_IDENTIFIER = app.funput.funput.Keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -884,6 +901,31 @@
 			isa = XCSwiftPackageProductDependency;
 			package = FA2600000000000000000001 /* XCLocalSwiftPackageReference "Packages/FunputKit" */;
 			productName = KeyboardInput;
+		};
+		FA2600000000000000000122 /* KeyboardLayout */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FA2600000000000000000001 /* XCLocalSwiftPackageReference "Packages/FunputKit" */;
+			productName = KeyboardLayout;
+		};
+		FA2600000000000000000123 /* KeyboardRenderer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FA2600000000000000000001 /* XCLocalSwiftPackageReference "Packages/FunputKit" */;
+			productName = KeyboardRenderer;
+		};
+		FA2600000000000000000124 /* FunputShared */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FA2600000000000000000001 /* XCLocalSwiftPackageReference "Packages/FunputKit" */;
+			productName = FunputShared;
+		};
+		FA2600000000000000000125 /* ThemeRuntime */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FA2600000000000000000001 /* XCLocalSwiftPackageReference "Packages/FunputKit" */;
+			productName = ThemeRuntime;
+		};
+		FA2600000000000000000126 /* ThemeSchema */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FA2600000000000000000001 /* XCLocalSwiftPackageReference "Packages/FunputKit" */;
+			productName = ThemeSchema;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/platforms/ios/FunputTests/KeyboardDocumentSynchronizerRobustnessTests.swift
+++ b/platforms/ios/FunputTests/KeyboardDocumentSynchronizerRobustnessTests.swift
@@ -1,0 +1,62 @@
+@_spi(Testing) import KeyboardInput
+import Testing
+
+@MainActor
+struct KeyboardDocumentSynchronizerRobustnessTests {
+    @Test("Authored echoes are exact after context normalization")
+    func exactEchoMatching() {
+        var driver = KeyboardDocumentSynchronizerTestDriver(context: "prefix-foobar")
+        driver.insert("x")
+
+        let before = driver.consumeEcho("prefix-foobar")
+        let current = driver.consumeEcho("prefix-foobarx")
+        let looseSuffix = driver.consumeEcho("foobar")
+        #expect(before)
+        #expect(current)
+        #expect(!looseSuffix)
+    }
+
+    @Test("Only the current and immediately previous word epochs survive")
+    func boundedWordEpochs() {
+        var driver = KeyboardDocumentSynchronizerTestDriver()
+        driver.insert("mot")
+        driver.insert(" ", closesEpoch: true)
+        driver.insert("hai")
+        let firstEpochRetained = driver.consumeEcho("mot")
+        #expect(firstEpochRetained)
+
+        driver.insert(" ", closesEpoch: true)
+        driver.insert("ba")
+        let firstEpochExpired = driver.consumeEcho("mot")
+        #expect(!firstEpochExpired)
+        #expect(driver.pendingContextCount <= 64)
+    }
+
+    @Test("External correction replaces the shadow and resets active composition")
+    func externalCorrection() {
+        var driver = KeyboardDocumentSynchronizerTestDriver(context: "helo")
+        driver.insert("x")
+        driver.acceptExternal("hello")
+
+        #expect(driver.snapshotContext == "hello")
+        let delayedEcho = driver.consumeEcho("helox")
+        #expect(delayedEcho)
+        #expect(driver.snapshotContext == "hello")
+        #expect(driver.requiresReset(context: "hello!", buffer: "hello"))
+    }
+
+    @Test("Selection forces active composition to reset")
+    func selectionReset() {
+        let driver = KeyboardDocumentSynchronizerTestDriver(context: "xin")
+        #expect(driver.requiresReset(context: "xin", buffer: "xin", hasSelection: true))
+    }
+
+    @Test("Ten thousand mutations keep the ledger bounded")
+    func ledgerRemainsBounded() {
+        var driver = KeyboardDocumentSynchronizerTestDriver()
+        for _ in 0..<10_000 { driver.insert("a") }
+
+        #expect(driver.pendingContextCount <= 64)
+        #expect(driver.snapshotContext?.count == 128)
+    }
+}

--- a/platforms/ios/FunputTests/KeyboardPresentationHotPathTests.swift
+++ b/platforms/ios/FunputTests/KeyboardPresentationHotPathTests.swift
@@ -1,0 +1,59 @@
+import KeyboardLayout
+import KeyboardRenderer
+import Testing
+import UIKit
+
+@MainActor
+struct KeyboardPresentationHotPathTests {
+    @Test("Shift, language, and Enter updates preserve key control identity")
+    func stateOnlyUpdatesDoNotRebuildControls() {
+        let layout = StandardKeyboardLayouts.letters(.vni)
+        let surface = KeyboardSurfaceView(presentation: KeyboardPresentation(layout: layout))
+        surface.frame = CGRect(x: 0, y: 0, width: 390, height: 304)
+        surface.layoutIfNeeded()
+        let before = Set(keyControls(in: surface).map(ObjectIdentifier.init))
+
+        var presentation = surface.presentation
+        presentation.shiftState = .uppercase
+        presentation.language = .english
+        presentation.enterAction = .search
+        surface.presentation = presentation
+        surface.layoutIfNeeded()
+
+        let after = Set(keyControls(in: surface).map(ObjectIdentifier.init))
+        #expect(!before.isEmpty)
+        #expect(before == after)
+    }
+
+    @Test("State-only updates preserve Liquid Glass effect instances")
+    func stateOnlyUpdatesPreserveGlass() {
+        guard #available(iOS 26, *) else { return }
+        let surface = KeyboardSurfaceView()
+        surface.frame = CGRect(x: 0, y: 0, width: 390, height: 304)
+        surface.layoutIfNeeded()
+        let before = Set(effectViews(in: surface).map(ObjectIdentifier.init))
+
+        var presentation = surface.presentation
+        presentation.shiftState = .uppercase
+        surface.presentation = presentation
+        surface.layoutIfNeeded()
+
+        let after = Set(effectViews(in: surface).map(ObjectIdentifier.init))
+        #expect(!before.isEmpty)
+        #expect(before == after)
+    }
+
+    private func keyControls(in view: UIView) -> [UIControl] {
+        view.subviews.flatMap { child in
+            let own = (child as? UIControl).map { $0.isAccessibilityElement ? [$0] : [] } ?? []
+            return own + keyControls(in: child)
+        }
+    }
+
+    private func effectViews(in view: UIView) -> [UIVisualEffectView] {
+        view.subviews.flatMap { child in
+            let own = (child as? UIVisualEffectView).map { [$0] } ?? []
+            return own + effectViews(in: child)
+        }
+    }
+}

--- a/platforms/ios/FunputTests/KeyboardSpaceInteractionTests.swift
+++ b/platforms/ios/FunputTests/KeyboardSpaceInteractionTests.swift
@@ -1,0 +1,60 @@
+@_spi(Testing) import KeyboardRenderer
+import KeyboardLayout
+import Testing
+import UIKit
+
+@MainActor
+struct KeyboardSpaceInteractionTests {
+    @Test("A Space swipe emits one language action and no Space release")
+    func spaceSwipeSuppressesRelease() {
+        let driver = KeyboardTouchTestDriver()
+        driver.begin(token: 1, key: space)
+        driver.move(token: 1, key: space, point: CGPoint(x: 40, y: 0))
+        driver.end(token: 1)
+
+        #expect(driver.events.filter { $0.phase == .swiped(.toggleLanguage) }.count == 1)
+        #expect(!driver.events.contains { $0.phase == .released })
+        #expect(driver.queueDepth == 0)
+    }
+
+    @Test("Accessibility Space swipe emits exactly one semantic action")
+    func accessibilitySpaceSwipe() {
+        let driver = KeyboardTouchTestDriver()
+        driver.performAccessibilitySwipe(key: space, action: .toggleLanguage)
+
+        #expect(driver.events.map(\.phase) == [.swiped(.toggleLanguage)])
+        #expect(driver.queueDepth == 0)
+    }
+
+    @Test("Holding Space repeats and does not add an extra Space on release")
+    func spaceHoldRepeats() {
+        let driver = KeyboardTouchTestDriver()
+        driver.begin(token: 1, key: space)
+        driver.runNextRepeat()
+        driver.runNextRepeat()
+        driver.end(token: 1)
+
+        #expect(driver.events.map(\.phase) == [.pressed, .repeated, .repeated])
+        #expect(driver.queueDepth == 0)
+    }
+
+    @Test("A repeated Space cannot also toggle language")
+    func repeatedSpaceSuppressesLateSwipe() {
+        let driver = KeyboardTouchTestDriver()
+        driver.begin(token: 1, key: space)
+        driver.runNextRepeat()
+        driver.move(token: 1, key: space, point: CGPoint(x: 40, y: 0))
+
+        #expect(driver.events.map(\.phase) == [.pressed, .repeated])
+        #expect(driver.queueDepth == 0)
+    }
+
+    private var space: KeySpec {
+        KeySpec(
+            id: "space",
+            label: "Tiếng Việt",
+            role: .space,
+            horizontalSwipeAction: .toggleLanguage
+        )
+    }
+}

--- a/platforms/ios/FunputTests/KeyboardTouchPipelineTests.swift
+++ b/platforms/ios/FunputTests/KeyboardTouchPipelineTests.swift
@@ -1,0 +1,90 @@
+@_spi(Testing) import KeyboardRenderer
+import KeyboardLayout
+import Testing
+import UIKit
+
+@MainActor
+struct KeyboardTouchPipelineTests {
+    @Test("A touch commits the key under the finger at release")
+    func movesBetweenKeys() {
+        let driver = KeyboardTouchTestDriver()
+        let a = key("a"), b = key("b")
+
+        driver.begin(token: 1, key: a)
+        driver.move(token: 1, key: b, point: CGPoint(x: 20, y: 0))
+        driver.end(token: 1)
+
+        #expect(driver.events.last?.phase == .released)
+        #expect(driver.events.last?.key.id == b.id)
+    }
+
+    @Test("Ending outside the tracking region cancels instead of committing")
+    func outsideReleaseCancels() {
+        let driver = KeyboardTouchTestDriver()
+        let a = key("a")
+
+        driver.begin(token: 1, key: a)
+        driver.move(token: 1, key: nil, point: CGPoint(x: -100, y: -100))
+        driver.end(token: 1)
+
+        #expect(driver.events.last?.phase == .cancelled)
+        #expect(!driver.events.contains { $0.phase == .released })
+    }
+
+    @Test("Missing terminal event is reconciled without blocking successors")
+    func orphanedTouchDoesNotBlock() {
+        let driver = KeyboardTouchTestDriver()
+        let a = key("a"), b = key("b")
+
+        driver.begin(token: 1, key: a)
+        driver.begin(token: 2, key: b)
+        driver.reconcile(activeTokens: [2])
+        driver.end(token: 2)
+
+        #expect(driver.events.suffix(2).map(\.phase) == [.cancelled, .released])
+        #expect(driver.events.suffix(2).map(\.key.id) == [a.id, b.id])
+        #expect(driver.queueDepth == 0)
+    }
+
+    @Test("One hundred thousand overlapping transitions preserve ordering")
+    func hundredThousandTransitions() {
+        let driver = KeyboardTouchTestDriver()
+        let a = key("a"), b = key("b")
+        let cycles = 25_000
+
+        for cycle in 0..<cycles {
+            let first = UInt64(cycle * 2 + 1)
+            let second = first + 1
+            driver.begin(token: first, key: a)
+            driver.begin(token: second, key: b)
+            driver.end(token: second)
+            driver.end(token: first)
+        }
+
+        let releases = driver.events.lazy.filter { $0.phase == .released }.map(\.key.id)
+        #expect(releases.count == cycles * 2)
+        #expect(Array(releases.prefix(4)) == [a.id, b.id, a.id, b.id])
+        #expect(driver.queueDepth == 0)
+    }
+
+    @Test("Geometry assigns horizontal and vertical gaps to the nearest key")
+    func gapHitTesting() {
+        let a = key("a"), b = key("b")
+        let geometry = ResolvedKeyboard(
+            size: CGSize(width: 100, height: 50),
+            toolbarFrame: nil,
+            rows: [[
+                ResolvedKey(spec: a, frame: CGRect(x: 0, y: 0, width: 40, height: 40)),
+                ResolvedKey(spec: b, frame: CGRect(x: 50, y: 0, width: 40, height: 40)),
+            ]]
+        )
+        #expect(KeyboardTouchTestDriver.hitKey(in: geometry, at: CGPoint(x: 44, y: 20))?.id == a.id)
+        #expect(KeyboardTouchTestDriver.hitKey(in: geometry, at: CGPoint(x: 46, y: 20))?.id == b.id)
+        #expect(KeyboardTouchTestDriver.hitKey(in: geometry, at: CGPoint(x: -10, y: 20))?.id == a.id)
+        #expect(KeyboardTouchTestDriver.hitKey(in: geometry, at: CGPoint(x: -13, y: 20)) == nil)
+    }
+
+    private func key(_ label: String) -> KeySpec {
+        KeySpec(id: "key-\(label)", label: label, role: .character)
+    }
+}

--- a/platforms/ios/Keyboard/Configuration/KeyboardViewController+Configuration.swift
+++ b/platforms/ios/Keyboard/Configuration/KeyboardViewController+Configuration.swift
@@ -19,6 +19,8 @@ extension KeyboardViewController {
         configuration = configurationStore.load()
 #endif
         themeCatalog = ThemeCatalog(customThemes: customThemeStore.load())
+        cachedPresentationConfiguration = nil
+        cachedThemedPresentation = nil
         let theme = themeCatalog.theme(id: configuration.selectedThemeID)
         let assetID = theme?.backgroundEffects.image?.assetID
         let data = assetID.flatMap(themeAssetStore.renderedData)

--- a/platforms/ios/Keyboard/KeyboardViewController+Input.swift
+++ b/platforms/ios/Keyboard/KeyboardViewController+Input.swift
@@ -3,6 +3,7 @@ import KeyboardConfiguration
 import KeyboardInput
 import KeyboardLayout
 import KeyboardRenderer
+import os
 import UIKit
 
 extension KeyboardViewController {
@@ -24,6 +25,21 @@ extension KeyboardViewController {
             return
         }
 
+        let signpostID = OSSignpostID(log: KeyboardControllerSignpost.log)
+        os_signpost(
+            .begin,
+            log: KeyboardControllerSignpost.log,
+            name: "KeyHandler",
+            signpostID: signpostID
+        )
+        defer {
+            os_signpost(
+                .end,
+                log: KeyboardControllerSignpost.log,
+                name: "KeyHandler",
+                signpostID: signpostID
+            )
+        }
         let previousState = inputCoordinator.state
         let document = TextDocumentProxyAdapter(proxy: textDocumentProxy)
         inputCoordinator.handle(event.key, document: document)
@@ -34,6 +50,21 @@ extension KeyboardViewController {
     }
 
     func updateInputPresentation() {
+        let signpostID = OSSignpostID(log: KeyboardControllerSignpost.log)
+        os_signpost(
+            .begin,
+            log: KeyboardControllerSignpost.log,
+            name: "PresentationUpdate",
+            signpostID: signpostID
+        )
+        defer {
+            os_signpost(
+                .end,
+                log: KeyboardControllerSignpost.log,
+                name: "PresentationUpdate",
+                signpostID: signpostID
+            )
+        }
         let state = inputCoordinator.state
         var presentation = keyboardView.presentation
         presentation.layout = KeyboardLayoutResolver.resolve(
@@ -43,11 +74,7 @@ extension KeyboardViewController {
             showsSystemInputModeKey: configuration.showsGlobeKey,
             showsNumberRow: configuration.showsNumberRow
         )
-        let themed = KeyboardPresentationFactory.make(
-            from: configuration,
-            layout: presentation.layout,
-            catalog: themeCatalog
-        )
+        let themed = configuredThemedPresentation()
         presentation.sizing = themed.sizing
         presentation.shiftState = state.shiftState
         presentation.language = state.language
@@ -64,4 +91,22 @@ extension KeyboardViewController {
         }
         updatePreferredHeight()
     }
+
+    private func configuredThemedPresentation() -> KeyboardPresentation {
+        if cachedPresentationConfiguration == configuration,
+           let cachedThemedPresentation {
+            return cachedThemedPresentation
+        }
+        let value = KeyboardPresentationFactory.make(
+            from: configuration,
+            catalog: themeCatalog
+        )
+        cachedPresentationConfiguration = configuration
+        cachedThemedPresentation = value
+        return value
+    }
+}
+
+private enum KeyboardControllerSignpost {
+    static let log = OSLog(subsystem: "app.funput.keyboard", category: "Controller")
 }

--- a/platforms/ios/Keyboard/KeyboardViewController.swift
+++ b/platforms/ios/Keyboard/KeyboardViewController.swift
@@ -23,6 +23,8 @@ final class KeyboardViewController: UIInputViewController {
     var displayedSurface = KeyboardSurface.funput
     var configuration = FunputConfiguration.default
     var themeCatalog = ThemeCatalog()
+    var cachedPresentationConfiguration: FunputConfiguration?
+    var cachedThemedPresentation: KeyboardPresentation?
     let configurationStore = FunputConfigurationStore()
     var resolvedTextInputTraits = ResolvedTextInputTraits(
         editorMode: .text,

--- a/platforms/ios/Packages/FunputKit/Package.swift
+++ b/platforms/ios/Packages/FunputKit/Package.swift
@@ -28,31 +28,41 @@ let package = Package(
         ),
         .target(
             name: "KeyboardInput",
-            dependencies: ["FunputEngine", "KeyboardLayout", "FunputShared"]
+            dependencies: [
+                .target(name: "FunputEngine"),
+                .target(name: "KeyboardLayout"),
+                .target(name: "FunputShared"),
+            ]
         ),
         .target(name: "KeyboardLayout"),
         .target(
             name: "FunputShared",
-            dependencies: ["KeyboardLayout"]
+            dependencies: [.target(name: "KeyboardLayout")]
         ),
         .target(name: "ThemeSchema"),
         .target(
             name: "ThemeRuntime",
-            dependencies: ["ThemeSchema", "FunputShared"]
+            dependencies: [
+                .target(name: "ThemeSchema"),
+                .target(name: "FunputShared"),
+            ]
         ),
         .target(
             name: "KeyboardRenderer",
-            dependencies: ["KeyboardLayout", "ThemeSchema"],
+            dependencies: [
+                .target(name: "KeyboardLayout"),
+                .target(name: "ThemeSchema"),
+            ],
             resources: [.process("Resources")]
         ),
         .target(
             name: "KeyboardConfiguration",
             dependencies: [
-                "FunputShared",
-                "ThemeRuntime",
-                "ThemeSchema",
-                "KeyboardRenderer",
-                "KeyboardLayout",
+                .target(name: "FunputShared"),
+                .target(name: "ThemeRuntime"),
+                .target(name: "ThemeSchema"),
+                .target(name: "KeyboardRenderer"),
+                .target(name: "KeyboardLayout"),
             ]
         ),
         .testTarget(

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardDocumentSynchronizer+Ledger.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardDocumentSynchronizer+Ledger.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+@MainActor
+extension KeyboardDocumentSynchronizer {
+    func contextContainsBuffer(_ context: String?, _ buffer: String) -> Bool {
+        guard !buffer.isEmpty else { return true }
+        return normalize(context).hasSuffix(buffer)
+    }
+
+    mutating func updateAuthoredSnapshot(
+        from current: KeyboardDocumentSnapshot,
+        contextBeforeInput: String
+    ) {
+        snapshot = KeyboardDocumentSnapshot(
+            documentIdentifier: current.documentIdentifier,
+            contextBeforeInput: contextBeforeInput,
+            hasSelection: false
+        )
+        appendAuthoredContext(contextBeforeInput)
+    }
+
+    mutating func appendAuthoredContext(_ context: String?) {
+        let context = normalize(context)
+        if currentEpoch.contexts.last == context { return }
+        currentEpoch.contexts.append(context)
+        if currentEpoch.contexts.count > Self.epochContextLimit {
+            currentEpoch.contexts.removeFirst(16)
+        }
+        trimPreviousEpoch()
+    }
+
+    mutating func closeCurrentEpoch() {
+        let retained = Array(currentEpoch.contexts.suffix(Self.retainedPreviousContextLimit))
+        previousEpoch = EchoEpoch(generation: currentEpoch.generation, contexts: retained)
+        currentEpoch = EchoEpoch(generation: nextGeneration)
+        nextGeneration &+= 1
+    }
+
+    mutating func trimPreviousEpoch() {
+        let available = max(0, Self.epochContextLimit - currentEpoch.contexts.count)
+        let keep = min(Self.retainedPreviousContextLimit, available)
+        guard var previous = previousEpoch, previous.contexts.count > keep else { return }
+        previous.contexts = Array(previous.contexts.suffix(keep))
+        previousEpoch = previous
+    }
+
+    mutating func resetEchoLedger() {
+        previousEpoch = nil
+        currentEpoch = EchoEpoch(generation: nextGeneration)
+        nextGeneration &+= 1
+    }
+
+    func normalized(_ snapshot: KeyboardDocumentSnapshot) -> KeyboardDocumentSnapshot {
+        KeyboardDocumentSnapshot(
+            documentIdentifier: snapshot.documentIdentifier,
+            contextBeforeInput: normalize(snapshot.contextBeforeInput),
+            hasSelection: snapshot.hasSelection
+        )
+    }
+
+    func normalize(_ context: String?) -> String {
+        String((context ?? "").suffix(Self.shadowContextLimit))
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardDocumentSynchronizer.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardDocumentSynchronizer.swift
@@ -7,27 +7,36 @@ public enum KeyboardDocumentEvent: Equatable, Sendable {
     case selectionChanged
 }
 
+/// Maintains a bounded local shadow and a generation-scoped ledger of contexts
+/// authored by Funput. Exact normalized matching acknowledges delayed UIKit
+/// echoes without allowing arbitrary old suffixes to keep composition alive.
 @MainActor
 struct KeyboardDocumentSynchronizer {
-    private static let shadowContextLimit = 128
-    private static let authoredContextLimit = 256
+    static let shadowContextLimit = 128
+    static let epochContextLimit = 64
+    static let retainedPreviousContextLimit = 32
 
-    private(set) var snapshot: KeyboardDocumentSnapshot?
+    struct EchoEpoch {
+        let generation: UInt64
+        var contexts: [String] = []
+    }
+
+    var snapshot: KeyboardDocumentSnapshot?
     private(set) var isApplyingMutation = false
-    private var snapshotBeforeMutation: KeyboardDocumentSnapshot?
-    private var authoredContexts: [String?] = []
-    private var nextAuthoredContextIndex = 0
+    var snapshotBeforeMutation: KeyboardDocumentSnapshot?
+    var currentEpoch = EchoEpoch(generation: 0)
+    var previousEpoch: EchoEpoch?
+    var nextGeneration: UInt64 = 1
+    var closesEpochAfterMutation = false
 
-    var pendingAuthoredContextCount: Int { authoredContexts.count }
+    var pendingAuthoredContextCount: Int {
+        currentEpoch.contexts.count + (previousEpoch?.contexts.count ?? 0)
+    }
 
-    mutating func beginMutation() {
+    mutating func beginMutation(closesEpoch: Bool = false) {
         snapshotBeforeMutation = snapshot
-        // textDidChange lags fast typing, so the host may echo the state from
-        // BEFORE this mutation. Keep it acknowledgeable: an unmatched echo
-        // reads as an external edit and resets composition mid-word.
+        closesEpochAfterMutation = closesEpoch
         if let snapshot {
-            // Preserve nil too: UIKit uses it for an empty document, and the
-            // first delayed callback can echo that pre-insertion state.
             appendAuthoredContext(snapshot.contextBeforeInput)
         }
         isApplyingMutation = true
@@ -35,116 +44,72 @@ struct KeyboardDocumentSynchronizer {
 
     mutating func finishMutation() -> (snapshot: KeyboardDocumentSnapshot, changed: Bool)? {
         isApplyingMutation = false
-        defer { snapshotBeforeMutation = nil }
+        defer {
+            snapshotBeforeMutation = nil
+            if closesEpochAfterMutation { closeCurrentEpoch() }
+            closesEpochAfterMutation = false
+        }
         guard let snapshot else { return nil }
         return (snapshot, snapshotBeforeMutation != snapshot)
     }
 
     mutating func recordInsertion(_ text: String) {
         guard !text.isEmpty, let current = snapshot else { return }
-        // nil base context = empty document; the shadow must stay matchable.
-        let context = String(
-            ((current.contextBeforeInput ?? "") + text).suffix(Self.shadowContextLimit)
-        )
+        let context = normalize((current.contextBeforeInput ?? "") + text)
         updateAuthoredSnapshot(from: current, contextBeforeInput: context)
     }
 
     mutating func recordDeletion() {
         guard let current = snapshot else { return }
-        var context = current.contextBeforeInput
-        if !current.hasSelection, context?.isEmpty == false {
-            context?.removeLast()
-        }
+        var context = normalize(current.contextBeforeInput)
+        if !current.hasSelection, !context.isEmpty { context.removeLast() }
         updateAuthoredSnapshot(from: current, contextBeforeInput: context)
     }
 
-    /// Returns true for callbacks produced by mutations already reflected in the
-    /// local shadow document. Intermediate delete/insert callbacks are ignored
-    /// until the host reaches the final shadow context.
     mutating func consumeAuthoredTextChange(
         documentIdentifier: UUID,
         contextBeforeInput: String?
     ) -> Bool {
         guard let snapshot,
               snapshot.documentIdentifier == documentIdentifier else { return false }
-        if contextsMatch(snapshot.contextBeforeInput, contextBeforeInput) {
-            return true
-        }
-        return authoredContexts.contains {
-            contextsMatch($0, contextBeforeInput)
-        }
+        let context = normalize(contextBeforeInput)
+        if normalize(snapshot.contextBeforeInput) == context { return true }
+        return currentEpoch.contexts.contains(context)
+            || previousEpoch?.contexts.contains(context) == true
     }
 
-    mutating func accept(_ snapshot: KeyboardDocumentSnapshot) {
-        self.snapshot = snapshot
-        clearAuthoredContexts()
+    mutating func accept(
+        _ snapshot: KeyboardDocumentSnapshot,
+        preservingAuthoredEchoes: Bool = false
+    ) {
+        self.snapshot = normalized(snapshot)
+        guard !preservingAuthoredEchoes else { return }
+        resetEchoLedger()
     }
 
     mutating func invalidate() {
         snapshot = nil
         isApplyingMutation = false
         snapshotBeforeMutation = nil
-        clearAuthoredContexts()
+        closesEpochAfterMutation = false
+        resetEchoLedger()
     }
 
     func requiresCompositionReset(
         for current: KeyboardDocumentSnapshot,
         composerBuffer: String
     ) -> Bool {
+        let current = normalized(current)
         guard let previous = snapshot else {
             return !contextContainsBuffer(current.contextBeforeInput, composerBuffer)
         }
-        if previous.documentIdentifier != current.documentIdentifier {
-            return true
-        }
-        if current.hasSelection, !composerBuffer.isEmpty {
-            return true
-        }
+        if previous.documentIdentifier != current.documentIdentifier { return true }
+        if current.hasSelection, !composerBuffer.isEmpty { return true }
         guard !composerBuffer.isEmpty else { return false }
-        if let oldContext = previous.contextBeforeInput,
-           let newContext = current.contextBeforeInput,
-           oldContext != newContext {
+        if normalize(previous.contextBeforeInput) != normalize(current.contextBeforeInput) {
             return true
         }
         return !contextContainsBuffer(current.contextBeforeInput, composerBuffer)
     }
 
-    private func contextContainsBuffer(_ context: String?, _ buffer: String) -> Bool {
-        guard !buffer.isEmpty, let context else { return true }
-        return context.hasSuffix(buffer)
-    }
-
-    private mutating func updateAuthoredSnapshot(
-        from current: KeyboardDocumentSnapshot,
-        contextBeforeInput: String?
-    ) {
-        snapshot = KeyboardDocumentSnapshot(
-            documentIdentifier: current.documentIdentifier,
-            contextBeforeInput: contextBeforeInput,
-            hasSelection: false
-        )
-        appendAuthoredContext(contextBeforeInput)
-    }
-
-    private mutating func appendAuthoredContext(_ context: String?) {
-        if authoredContexts.count < Self.authoredContextLimit {
-            authoredContexts.append(context)
-            return
-        }
-        authoredContexts[nextAuthoredContextIndex] = context
-        nextAuthoredContextIndex = (nextAuthoredContextIndex + 1)
-            % Self.authoredContextLimit
-    }
-
-    private mutating func clearAuthoredContexts() {
-        authoredContexts.removeAll(keepingCapacity: true)
-        nextAuthoredContextIndex = 0
-    }
-
-    // Hosts report an empty document as either nil or "" — same state.
-    private func contextsMatch(_ expected: String?, _ actual: String?) -> Bool {
-        let expected = expected ?? "", actual = actual ?? ""
-        return expected == actual
-            || (!expected.isEmpty && actual.hasSuffix(expected))
-    }
 }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardDocumentSynchronizerTestDriver.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardDocumentSynchronizerTestDriver.swift
@@ -1,0 +1,58 @@
+#if os(iOS) && canImport(FunputCore)
+import Foundation
+
+/// Release-build unit-test seam for the document echo state machine.
+@_spi(Testing)
+@MainActor
+public struct KeyboardDocumentSynchronizerTestDriver {
+    public let documentIdentifier: UUID
+    private var synchronizer = KeyboardDocumentSynchronizer()
+
+    public init(context: String? = "") {
+        documentIdentifier = UUID()
+        synchronizer.accept(KeyboardDocumentSnapshot(
+            documentIdentifier: documentIdentifier,
+            contextBeforeInput: context,
+            hasSelection: false
+        ))
+    }
+
+    public var snapshotContext: String? { synchronizer.snapshot?.contextBeforeInput }
+    public var pendingContextCount: Int { synchronizer.pendingAuthoredContextCount }
+
+    public mutating func insert(_ text: String, closesEpoch: Bool = false) {
+        synchronizer.beginMutation(closesEpoch: closesEpoch)
+        synchronizer.recordInsertion(text)
+        _ = synchronizer.finishMutation()
+    }
+
+    public mutating func acceptExternal(_ context: String?, hasSelection: Bool = false) {
+        synchronizer.accept(
+            KeyboardDocumentSnapshot(
+                documentIdentifier: documentIdentifier,
+                contextBeforeInput: context,
+                hasSelection: hasSelection
+            ),
+            preservingAuthoredEchoes: true
+        )
+    }
+
+    public mutating func consumeEcho(_ context: String?) -> Bool {
+        synchronizer.consumeAuthoredTextChange(
+            documentIdentifier: documentIdentifier,
+            contextBeforeInput: context
+        )
+    }
+
+    public func requiresReset(context: String?, buffer: String, hasSelection: Bool = false) -> Bool {
+        synchronizer.requiresCompositionReset(
+            for: KeyboardDocumentSnapshot(
+                documentIdentifier: documentIdentifier,
+                contextBeforeInput: context,
+                hasSelection: hasSelection
+            ),
+            composerBuffer: buffer
+        )
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardInputCoordinator+Document.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardInputCoordinator+Document.swift
@@ -46,12 +46,16 @@ extension KeyboardInputCoordinator {
     }
 
     func insertDocumentText(_ text: String, document: any KeyboardDocument) {
+        let signpostID = KeyboardInputSignposts.begin("ProxyInsert")
         document.insertText(text)
+        KeyboardInputSignposts.end("ProxyInsert", signpostID)
         documentSynchronizer.recordInsertion(text)
     }
 
     func deleteDocumentBackward(_ document: any KeyboardDocument) {
+        let signpostID = KeyboardInputSignposts.begin("ProxyDelete")
         document.deleteBackward()
+        KeyboardInputSignposts.end("ProxyDelete", signpostID)
         documentSynchronizer.recordDeletion()
     }
 
@@ -69,7 +73,10 @@ extension KeyboardInputCoordinator {
         if mustReset {
             resetCompositionState()
         }
-        documentSynchronizer.accept(snapshot)
+        documentSynchronizer.accept(
+            snapshot,
+            preservingAuthoredEchoes: event != .activated
+        )
         if event == .activated || snapshotChanged {
             synchronizeCapitalization(
                 with: snapshot,

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardInputCoordinator+Literal.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardInputCoordinator+Literal.swift
@@ -11,7 +11,7 @@ extension KeyboardInputCoordinator {
     public func insertLiteral(_ text: String, document: any KeyboardDocument) {
         guard !text.isEmpty else { return }
         synchronizeBeforeInput(document)
-        documentSynchronizer.beginMutation()
+        documentSynchronizer.beginMutation(closesEpoch: true)
         composer.clear()
         insertDocumentText(text, document: document)
         finishDocumentMutation(preserveOneShotShift: true)

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardInputCoordinator+Text.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardInputCoordinator+Text.swift
@@ -10,7 +10,9 @@ extension KeyboardInputCoordinator {
         }
 
         for scalar in text.unicodeScalars {
+            let signpostID = KeyboardInputSignposts.begin("ComposerFFI")
             let result = composer.process(scalar)
+            KeyboardInputSignposts.end("ComposerFFI", signpostID)
             if result.action == .none {
                 insertDocumentText(String(scalar), document: document)
             } else {

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardInputCoordinator.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardInputCoordinator.swift
@@ -32,10 +32,12 @@ public final class KeyboardInputCoordinator {
     }
 
     public func handle(_ key: KeySpec, document: any KeyboardDocument) {
+        let signpostID = KeyboardInputSignposts.begin("CoordinatorHandle")
+        defer { KeyboardInputSignposts.end("CoordinatorHandle", signpostID) }
         synchronizeBeforeInput(document)
         let mutatesDocument = key.role.mutatesDocument
         if mutatesDocument {
-            documentSynchronizer.beginMutation()
+            documentSynchronizer.beginMutation(closesEpoch: key.role.closesCompositionEpoch)
         }
         defer {
             if mutatesDocument {
@@ -80,6 +82,13 @@ private extension KeyRole {
             true
         default:
             false
+        }
+    }
+
+    var closesCompositionEpoch: Bool {
+        switch self {
+        case .space, .punctuation, .enter: true
+        default: false
         }
     }
 }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardInputSignposts.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardInputSignposts.swift
@@ -1,0 +1,19 @@
+#if os(iOS) && canImport(FunputCore)
+import os
+
+enum KeyboardInputSignposts {
+    static let log = OSLog(subsystem: "app.funput.keyboard", category: "Input")
+
+    @inline(__always)
+    static func begin(_ name: StaticString) -> OSSignpostID {
+        let identifier = OSSignpostID(log: log)
+        os_signpost(.begin, log: log, name: name, signpostID: identifier)
+        return identifier
+    }
+
+    @inline(__always)
+    static func end(_ name: StaticString, _ identifier: OSSignpostID) {
+        os_signpost(.end, log: log, name: name, signpostID: identifier)
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardPressCommitQueue.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardPressCommitQueue.swift
@@ -6,6 +6,8 @@ import KeyboardLayout
 /// Overlapping fingers may lift in either order. Keeping completion separate
 /// from emission prevents an older key from appearing after a newer key.
 struct KeyboardPressCommitQueue {
+    typealias TouchToken = UInt64
+
     enum Completion {
         case released
         case cancelled
@@ -19,43 +21,61 @@ struct KeyboardPressCommitQueue {
     }
 
     private struct Entry {
-        let key: KeySpec
+        let token: TouchToken
+        var key: KeySpec
         var completion: Completion?
         var bufferedRepeatCount = 0
     }
 
     private var entries: [Entry] = []
+    private var head = 0
+
+    init() {
+        entries.reserveCapacity(10)
+    }
 
     var activeKey: KeySpec? {
-        entries.last { $0.completion == nil }?.key
+        entries[head...].last { $0.completion == nil }?.key
     }
 
-    var isEmpty: Bool { entries.isEmpty }
+    var isEmpty: Bool { head == entries.count }
+    var pendingTokens: Set<TouchToken> {
+        Set(entries[head...].lazy.filter { $0.completion == nil }.map(\.token))
+    }
+    var depth: Int { entries.count - head }
 
-    mutating func append(_ key: KeySpec) {
-        entries.append(Entry(key: key))
+    mutating func append(token: TouchToken, key: KeySpec) {
+        precondition(index(for: token) == nil, "A touch token may only be queued once")
+        entries.append(Entry(token: token, key: key))
     }
 
-    func hasPendingKey(id: String) -> Bool {
-        pendingIndex(for: id) != nil
+    func hasPendingTouch(_ token: TouchToken) -> Bool {
+        pendingIndex(for: token) != nil
     }
 
     @discardableResult
-    mutating func complete(id: String, as completion: Completion) -> Bool {
-        guard let index = pendingIndex(for: id) else { return false }
+    mutating func update(token: TouchToken, key: KeySpec) -> Bool {
+        guard let index = pendingIndex(for: token) else { return false }
+        entries[index].key = key
+        return true
+    }
+
+    @discardableResult
+    mutating func complete(token: TouchToken, as completion: Completion) -> Bool {
+        guard let index = pendingIndex(for: token) else { return false }
         entries[index].completion = completion
         return true
     }
 
     mutating func cancelAll() {
-        for index in entries.indices where entries[index].completion == nil {
+        for index in head..<entries.count where entries[index].completion == nil {
             entries[index].completion = .cancelled
         }
     }
 
     @discardableResult
-    mutating func bufferRepeat(for id: String) -> Bool {
-        guard let index = pendingIndex(for: id) else { return false }
+    mutating func bufferRepeat(for token: TouchToken) -> Bool {
+        guard let index = pendingIndex(for: token) else { return false }
         entries[index].bufferedRepeatCount += 1
         return true
     }
@@ -63,13 +83,15 @@ struct KeyboardPressCommitQueue {
     /// Removes one ready action from the head. A nil result means the queue is
     /// empty or its oldest touch has not finished yet.
     mutating func popReadyAction() -> ReadyAction? {
-        guard let first = entries.first else { return nil }
+        guard head < entries.count else { return nil }
+        let first = entries[head]
         if first.bufferedRepeatCount > 0 {
-            entries[0].bufferedRepeatCount -= 1
+            entries[head].bufferedRepeatCount -= 1
             return .event(KeyboardKeyEvent(key: first.key, phase: .repeated))
         }
         guard let completion = first.completion else { return nil }
-        entries.removeFirst()
+        head += 1
+        compactIfNeeded()
         switch completion {
         case .released:
             return .event(KeyboardKeyEvent(key: first.key, phase: .released))
@@ -82,8 +104,23 @@ struct KeyboardPressCommitQueue {
         }
     }
 
-    private func pendingIndex(for id: String) -> Int? {
-        entries.firstIndex { $0.key.id == id && $0.completion == nil }
+    private func index(for token: TouchToken) -> Int? {
+        entries[head...].firstIndex { $0.token == token }
+    }
+
+    private func pendingIndex(for token: TouchToken) -> Int? {
+        entries[head...].firstIndex { $0.token == token && $0.completion == nil }
+    }
+
+    private mutating func compactIfNeeded() {
+        if head == entries.count {
+            entries.removeAll(keepingCapacity: true)
+            head = 0
+            return
+        }
+        guard head >= 64 else { return }
+        entries.removeFirst(head)
+        head = 0
     }
 }
 #endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController+Actions.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController+Actions.swift
@@ -1,0 +1,95 @@
+#if canImport(UIKit)
+import KeyboardLayout
+import os
+
+extension KeyboardSurfaceInteractionController {
+    func finishSwipe(token: TouchToken, state: TouchState, action: KeySwipeAction) {
+        touches.removeValue(forKey: token)
+        if let key = state.currentKey { setHighlighted(key, false) }
+        if repeatTouch == token { clearKeyRepeat() }
+        commitQueue.complete(token: token, as: .swiped(action))
+        endSignpost(state, token: token, phase: 3)
+        if hapticsEnabled { haptics.perform(.control) }
+        refreshPreview()
+        flushCompletedKeys()
+    }
+
+    func repeatActiveKey() {
+        guard let token = repeatTouch,
+              let state = touches[token],
+              state.initialKey.role == .backspace || state.initialKey.role == .space,
+              commitQueue.bufferRepeat(for: token) else { return }
+        if hapticsEnabled { haptics.perform(.deleteRepeat) }
+        flushCompletedKeys()
+    }
+
+    func finishRepeatedTouch(token: TouchToken, state: TouchState) {
+        touches.removeValue(forKey: token)
+        if let key = state.currentKey { setHighlighted(key, false) }
+        commitQueue.complete(token: token, as: .suppressed)
+        endSignpost(state, token: token, phase: 1)
+        refreshPreview()
+        flushCompletedKeys()
+    }
+
+    func flushCompletedKeys() {
+        while let action = commitQueue.popReadyAction() {
+            switch action {
+            case let .event(event): onEvent(event)
+            case .suppressed: continue
+            }
+        }
+    }
+
+    func setHighlighted(_ key: KeySpec, _ highlighted: Bool) {
+        let oldCount = highlightCounts[key.id, default: 0]
+        let newCount = max(0, oldCount + (highlighted ? 1 : -1))
+        if newCount == 0 {
+            highlightCounts.removeValue(forKey: key.id)
+        } else {
+            highlightCounts[key.id] = newCount
+        }
+        if oldCount == 0, newCount == 1 { onHighlight(key, true) }
+        if oldCount == 1, newCount == 0 { onHighlight(key, false) }
+    }
+
+    func refreshPreview() {
+        guard let token = touches.keys.max(),
+              let state = touches[token],
+              let key = state.currentKey else {
+            onPreview(nil, nil)
+            return
+        }
+        onPreview(key, state.currentFrame)
+    }
+
+    func clearKeyRepeat() {
+        repeatController.cancel()
+        repeatTouch = nil
+    }
+
+    func takeLegacyToken(for keyID: String) -> TouchToken? {
+        guard var tokens = legacyTokensByKeyID[keyID], !tokens.isEmpty else { return nil }
+        let token = tokens.removeFirst()
+        if tokens.isEmpty {
+            legacyTokensByKeyID.removeValue(forKey: keyID)
+        } else {
+            legacyTokensByKeyID[keyID] = tokens
+        }
+        return token
+    }
+
+    func endSignpost(_ state: TouchState, token: TouchToken, phase: Int) {
+        os_signpost(
+            .end,
+            log: KeyboardTouchSignpost.log,
+            name: "TouchSemantic",
+            signpostID: state.signpostID,
+            "token=%{public}llu phase=%{public}d depth=%{public}d",
+            token,
+            phase,
+            commitQueue.depth
+        )
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController+Lifecycle.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController+Lifecycle.swift
@@ -1,0 +1,82 @@
+#if canImport(UIKit)
+import UIKit
+
+extension KeyboardSurfaceInteractionController {
+    func endTouch(token: TouchToken) {
+        guard let state = touches.removeValue(forKey: token) else { return }
+        if let key = state.currentKey { setHighlighted(key, false) }
+        let wasRepeating = repeatTouch == token && repeatController.finish()
+        if repeatTouch == token { repeatTouch = nil }
+        commitQueue.complete(
+            token: token,
+            as: state.currentKey == nil ? .cancelled : (wasRepeating ? .suppressed : .released)
+        )
+        endSignpost(state, token: token, phase: state.currentKey == nil ? 2 : 1)
+        refreshPreview()
+        flushCompletedKeys()
+    }
+
+    func cancelTouch(token: TouchToken) {
+        guard let state = touches.removeValue(forKey: token) else { return }
+        if let key = state.currentKey { setHighlighted(key, false) }
+        if repeatTouch == token { clearKeyRepeat() }
+        commitQueue.complete(token: token, as: .cancelled)
+        endSignpost(state, token: token, phase: 2)
+        refreshPreview()
+        flushCompletedKeys()
+    }
+
+    func reconcileActiveTouches(_ activeTokens: Set<TouchToken>) {
+        let orphaned = Set(touches.keys).subtracting(activeTokens)
+        for token in orphaned { cancelTouch(token: token) }
+    }
+
+    func cancelAll() {
+        for (token, state) in touches {
+            if let key = state.currentKey { setHighlighted(key, false) }
+            endSignpost(state, token: token, phase: 2)
+        }
+        touches.removeAll(keepingCapacity: true)
+        commitQueue.cancelAll()
+        clearKeyRepeat()
+        refreshPreview()
+        flushCompletedKeys()
+        legacyTokensByKeyID.removeAll(keepingCapacity: true)
+    }
+
+    func handle(
+        _ event: KeyboardKeyEvent,
+        sourceFrame: CGRect?,
+        presentation: KeyboardPresentation
+    ) {
+        switch event.phase {
+        case .pressed:
+            let token = nextLegacyToken
+            nextLegacyToken &+= 1
+            legacyTokensByKeyID[event.key.id, default: []].append(token)
+            beginTouch(
+                token: token,
+                key: event.key,
+                point: sourceFrame.map { CGPoint(x: $0.midX, y: $0.midY) } ?? .zero,
+                sourceFrame: sourceFrame,
+                presentation: presentation
+            )
+        case .released:
+            if let token = takeLegacyToken(for: event.key.id) { endTouch(token: token) }
+        case .cancelled:
+            if let token = takeLegacyToken(for: event.key.id) { cancelTouch(token: token) }
+        case let .swiped(action):
+            if let token = legacyTokensByKeyID[event.key.id]?.first,
+               let state = touches[token] {
+                finishSwipe(token: token, state: state, action: action)
+                _ = takeLegacyToken(for: event.key.id)
+            } else if commitQueue.isEmpty {
+                if presentation.isHapticFeedbackEnabled { haptics.perform(.space) }
+                onEvent(event)
+            }
+        case .repeated:
+            break
+        }
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController+Tracking.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController+Tracking.swift
@@ -1,0 +1,91 @@
+#if canImport(UIKit)
+import KeyboardLayout
+import os
+import UIKit
+
+extension KeyboardSurfaceInteractionController {
+    func beginTouch(
+        token: TouchToken,
+        key: KeySpec,
+        point: CGPoint,
+        sourceFrame: CGRect?,
+        presentation: KeyboardPresentation
+    ) {
+        guard touches[token] == nil else { return }
+        hapticsEnabled = presentation.isHapticFeedbackEnabled
+        let signpostID = OSSignpostID(log: KeyboardTouchSignpost.log)
+        touches[token] = TouchState(
+            initialKey: key,
+            startPoint: point,
+            currentKey: key,
+            currentFrame: sourceFrame,
+            signpostID: signpostID
+        )
+        commitQueue.append(token: token, key: key)
+        os_signpost(
+            .begin,
+            log: KeyboardTouchSignpost.log,
+            name: "TouchSemantic",
+            signpostID: signpostID,
+            "token=%{public}llu depth=%{public}d",
+            token,
+            commitQueue.depth
+        )
+        setHighlighted(key, true)
+        if hapticsEnabled, let type = KeyHapticTypeMapper.map(key.role) {
+            haptics.perform(type)
+        }
+        if presentation.isKeySoundEnabled { UIDevice.current.playInputClick() }
+        if repeatTouch == nil, key.role == .backspace || key.role == .space {
+            repeatTouch = token
+            repeatController.start()
+        }
+        if presentation.showsKeyPreviews { refreshPreview() }
+        onEvent(KeyboardKeyEvent(key: key, phase: .pressed))
+    }
+
+    func moveTouch(
+        token: TouchToken,
+        key hitKey: KeySpec?,
+        point: CGPoint,
+        sourceFrame: CGRect?,
+        presentation: KeyboardPresentation
+    ) {
+        guard var state = touches[token] else { return }
+        hapticsEnabled = presentation.isHapticFeedbackEnabled
+        if let action = state.swipeTracker.update(
+            translation: CGPoint(x: point.x - state.startPoint.x, y: point.y - state.startPoint.y),
+            action: state.initialKey.horizontalSwipeAction
+        ) {
+            touches[token] = state
+            let hadRepeated = repeatTouch == token && repeatController.finish()
+            if repeatTouch == token { repeatTouch = nil }
+            if hadRepeated {
+                finishRepeatedTouch(token: token, state: state)
+            } else {
+                finishSwipe(token: token, state: state, action: action)
+            }
+            return
+        }
+
+        let target = state.initialKey.horizontalSwipeAction == nil
+            ? hitKey
+            : (hitKey == nil ? nil : state.initialKey)
+        guard target?.id != state.currentKey?.id else {
+            state.currentFrame = sourceFrame
+            touches[token] = state
+            return
+        }
+        if let old = state.currentKey { setHighlighted(old, false) }
+        state.currentKey = target
+        state.currentFrame = sourceFrame
+        if let target {
+            setHighlighted(target, true)
+            commitQueue.update(token: token, key: target)
+        }
+        if repeatTouch == token, target?.role != state.initialKey.role { clearKeyRepeat() }
+        touches[token] = state
+        if presentation.showsKeyPreviews { refreshPreview() }
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController.swift
@@ -1,150 +1,67 @@
 #if canImport(UIKit)
 import KeyboardLayout
+import os
 import UIKit
 
-/// Turns raw key touch phases into input events. Supports rollover: several keys
-/// can be held at once while typing fast, each committing on its own release.
+/// Converts tracked touches into semantic keyboard events while preserving
+/// touch-down ordering. Raw touches are identified independently from keys so a
+/// finger can move between keycaps before it commits.
 @MainActor
 final class KeyboardSurfaceInteractionController {
+    typealias TouchToken = KeyboardPressCommitQueue.TouchToken
     typealias PreviewHandler = (_ key: KeySpec?, _ sourceFrame: CGRect?) -> Void
+    typealias HighlightHandler = (_ key: KeySpec, _ highlighted: Bool) -> Void
 
-    private let haptics: KeyboardHaptics
-    private let onEvent: (KeyboardKeyEvent) -> Void
-    private let onPreview: PreviewHandler
-    private let repeatScheduler: BackspaceRepeatController.Scheduler
-    private lazy var repeatController = BackspaceRepeatController(
+    struct TouchState {
+        let initialKey: KeySpec
+        let startPoint: CGPoint
+        var currentKey: KeySpec?
+        var currentFrame: CGRect?
+        var swipeTracker = KeySwipeGestureTracker()
+        let signpostID: OSSignpostID
+    }
+
+    let haptics: KeyboardHaptics
+    let onEvent: (KeyboardKeyEvent) -> Void
+    let onPreview: PreviewHandler
+    let onHighlight: HighlightHandler
+    let repeatScheduler: BackspaceRepeatController.Scheduler
+    lazy var repeatController = BackspaceRepeatController(
         schedule: repeatScheduler
     ) { [weak self] in
-        self?.repeatBackspace()
+        self?.repeatActiveKey()
     }
-    private var commitQueue = KeyboardPressCommitQueue()
-    private var backspaceKeyID: String?
-    private var previewKeyID: String?
-    private var hapticsEnabled = true
+    var commitQueue = KeyboardPressCommitQueue()
+    var touches: [TouchToken: TouchState] = [:]
+    var highlightCounts: [String: Int] = [:]
+    var repeatTouch: TouchToken?
+    var hapticsEnabled = true
+    var legacyTokensByKeyID: [String: [TouchToken]] = [:]
+    var nextLegacyToken: TouchToken = 1 << 63
+
     var activeKey: KeySpec? { commitQueue.activeKey }
+    var queueDepth: Int { commitQueue.depth }
 
     init(
         feedbackView: UIView = UIView(),
         onEvent: @escaping (KeyboardKeyEvent) -> Void,
         onPreview: @escaping PreviewHandler,
+        onHighlight: @escaping HighlightHandler = { _, _ in },
         repeatScheduler: @escaping BackspaceRepeatController.Scheduler =
             BackspaceRepeatController.schedule
     ) {
         haptics = KeyboardHaptics(view: feedbackView)
         self.onEvent = onEvent
         self.onPreview = onPreview
+        self.onHighlight = onHighlight
         self.repeatScheduler = repeatScheduler
+        touches.reserveCapacity(10)
         haptics.prepare()
     }
 
-    func handle(
-        _ event: KeyboardKeyEvent,
-        sourceFrame: CGRect?,
-        presentation: KeyboardPresentation
-    ) {
-        hapticsEnabled = presentation.isHapticFeedbackEnabled
-        switch event.phase {
-        case .pressed:
-            begin(event.key, sourceFrame: sourceFrame, presentation: presentation)
-        case .released:
-            finish(event.key)
-        case .cancelled:
-            cancel(event.key)
-        case .repeated:
-            break
-        case .swiped:
-            handleSwipe(event)
-        }
-    }
+}
 
-    func cancelAll() {
-        commitQueue.cancelAll()
-        clearBackspaceRepeat()
-        clearPreview()
-        flushCompletedKeys()
-    }
-
-    private func begin(
-        _ key: KeySpec,
-        sourceFrame: CGRect?,
-        presentation: KeyboardPresentation
-    ) {
-        commitQueue.append(key)
-        if hapticsEnabled, let type = KeyHapticTypeMapper.map(key.role) {
-            haptics.perform(type)
-        }
-        if presentation.isKeySoundEnabled { UIDevice.current.playInputClick() }
-        if presentation.showsKeyPreviews {
-            previewKeyID = key.id
-            onPreview(key, sourceFrame)
-        }
-        if key.role == .backspace {
-            backspaceKeyID = key.id
-            repeatController.start()
-        }
-        onEvent(KeyboardKeyEvent(key: key, phase: .pressed))
-    }
-
-    private func finish(_ key: KeySpec) {
-        guard commitQueue.hasPendingKey(id: key.id) else { return }
-        let wasRepeating = key.role == .backspace && repeatController.finish()
-        if key.role == .backspace { backspaceKeyID = nil }
-        commitQueue.complete(id: key.id, as: wasRepeating ? .suppressed : .released)
-        if key.id == previewKeyID { clearPreview() }
-        flushCompletedKeys()
-    }
-
-    private func cancel(_ key: KeySpec) {
-        guard commitQueue.complete(id: key.id, as: .cancelled) else { return }
-        if key.role == .backspace { clearBackspaceRepeat() }
-        if key.id == previewKeyID { clearPreview() }
-        flushCompletedKeys()
-    }
-
-    private func handleSwipe(_ event: KeyboardKeyEvent) {
-        if commitQueue.hasPendingKey(id: event.key.id) {
-            guard case let .swiped(action) = event.phase else { return }
-            commitQueue.complete(id: event.key.id, as: .swiped(action))
-            if event.key.id == backspaceKeyID { clearBackspaceRepeat() }
-            if event.key.id == previewKeyID { clearPreview() }
-        } else if !commitQueue.isEmpty {
-            return
-        } else {
-            // Accessibility can invoke the action without a preceding touch.
-            if hapticsEnabled { haptics.perform(.control) }
-            onEvent(event)
-            return
-        }
-        if hapticsEnabled { haptics.perform(.control) }
-        flushCompletedKeys()
-    }
-
-    private func repeatBackspace() {
-        guard let id = backspaceKeyID,
-              commitQueue.bufferRepeat(for: id) else { return }
-        if hapticsEnabled { haptics.perform(.deleteRepeat) }
-        flushCompletedKeys()
-    }
-
-    private func flushCompletedKeys() {
-        while let action = commitQueue.popReadyAction() {
-            switch action {
-            case let .event(event):
-                onEvent(event)
-            case .suppressed:
-                continue
-            }
-        }
-    }
-
-    private func clearBackspaceRepeat() {
-        repeatController.cancel()
-        backspaceKeyID = nil
-    }
-
-    private func clearPreview() {
-        previewKeyID = nil
-        onPreview(nil, nil)
-    }
+enum KeyboardTouchSignpost {
+    static let log = OSLog(subsystem: "app.funput.keyboard", category: "Touch")
 }
 #endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardTouchOverlayView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardTouchOverlayView.swift
@@ -1,0 +1,134 @@
+#if canImport(UIKit)
+import KeyboardLayout
+import UIKit
+
+/// One multi-touch surface for all keycaps. Central tracking lets a finger move
+/// across keys without depending on button-style `touchUpInside` delivery.
+@MainActor
+final class KeyboardTouchOverlayView: UIView {
+    typealias TouchToken = KeyboardPressCommitQueue.TouchToken
+    typealias Hit = (key: KeySpec, frame: CGRect)
+
+    var onBegin: ((TouchToken, Hit, CGPoint) -> Void)?
+    var onMove: ((TouchToken, Hit?, CGPoint) -> Void)?
+    var onEnd: ((TouchToken) -> Void)?
+    var onCancel: ((TouchToken) -> Void)?
+    var onReconcile: ((Set<TouchToken>) -> Void)?
+
+    private static let outerTolerance: CGFloat = 12
+    private var keys: [ResolvedKey] = []
+    private var trackingBounds = CGRect.null
+    private var tokens: [ObjectIdentifier: TouchToken] = [:]
+    private var nextToken: TouchToken = 1
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isMultipleTouchEnabled = true
+        isOpaque = false
+        backgroundColor = .clear
+        isAccessibilityElement = false
+        tokens.reserveCapacity(10)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func updateGeometry(_ geometry: ResolvedKeyboard) {
+        keys = geometry.keys
+        let union = keys.reduce(CGRect.null) { $0.union($1.frame) }
+        trackingBounds = union.insetBy(
+            dx: -Self.outerTolerance,
+            dy: -Self.outerTolerance
+        )
+    }
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        trackingBounds.contains(point)
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        for touch in touches {
+            let point = touch.location(in: self)
+            guard let hit = hit(at: point) else { continue }
+            let identifier = ObjectIdentifier(touch)
+            guard tokens[identifier] == nil else { continue }
+            let token = nextToken
+            nextToken &+= 1
+            tokens[identifier] = token
+            onBegin?(token, hit, point)
+        }
+        reconcile(event)
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        for touch in touches {
+            guard let token = tokens[ObjectIdentifier(touch)] else { continue }
+            let point = touch.location(in: self)
+            onMove?(token, trackingBounds.contains(point) ? hit(at: point) : nil, point)
+        }
+        reconcile(event)
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        for touch in touches {
+            let identifier = ObjectIdentifier(touch)
+            guard let token = tokens.removeValue(forKey: identifier) else { continue }
+            let point = touch.location(in: self)
+            onMove?(token, trackingBounds.contains(point) ? hit(at: point) : nil, point)
+            onEnd?(token)
+        }
+        reconcile(event)
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        for touch in touches {
+            guard let token = tokens.removeValue(forKey: ObjectIdentifier(touch)) else { continue }
+            onCancel?(token)
+        }
+        reconcile(event)
+    }
+
+    func cancelAllTrackedTouches() {
+        let active = Array(tokens.values)
+        tokens.removeAll(keepingCapacity: true)
+        active.forEach { onCancel?($0) }
+        onReconcile?([])
+    }
+
+    func resolvedHit(at point: CGPoint) -> Hit? {
+        hit(at: point)
+    }
+
+    private func hit(at point: CGPoint) -> Hit? {
+        guard trackingBounds.contains(point), !keys.isEmpty else { return nil }
+        var best: ResolvedKey?
+        var bestDistance = CGFloat.greatestFiniteMagnitude
+        for key in keys where key.spec.role != .placeholder {
+            let dx = max(max(key.frame.minX - point.x, 0), point.x - key.frame.maxX)
+            let dy = max(max(key.frame.minY - point.y, 0), point.y - key.frame.maxY)
+            let distance = dx * dx + dy * dy
+            if distance < bestDistance {
+                bestDistance = distance
+                best = key
+            }
+        }
+        return best.map { ($0.spec, $0.frame) }
+    }
+
+    private func reconcile(_ event: UIEvent?) {
+        guard let allTouches = event?.allTouches else {
+            onReconcile?(Set(tokens.values))
+            return
+        }
+        let activeIdentifiers = Set(allTouches.lazy.filter {
+            $0.phase == .began || $0.phase == .moved || $0.phase == .stationary
+        }.map { ObjectIdentifier($0) })
+        let activeTokens = Set(tokens.compactMap { identifier, token in
+            activeIdentifiers.contains(identifier) ? token : nil
+        })
+        onReconcile?(activeTokens)
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardTouchTestDriver.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardTouchTestDriver.swift
@@ -1,0 +1,117 @@
+#if canImport(UIKit)
+import KeyboardLayout
+import UIKit
+
+/// Release-build unit-test seam. SPI keeps touch internals out of the normal
+/// KeyboardRenderer API while allowing the app's native test target to drive
+/// the exact production controller.
+@_spi(Testing)
+@MainActor
+public final class KeyboardTouchTestDriver {
+    private final class EventBox {
+        var values: [KeyboardKeyEvent] = []
+    }
+
+    @MainActor
+    private final class CancellationBox {
+        var isCancelled = false
+    }
+
+    @MainActor
+    private final class ManualRepeatScheduler {
+        private var pending: [(CancellationBox, @MainActor @Sendable () -> Void)] = []
+
+        func schedule(
+            _ delay: TimeInterval,
+            _ action: @escaping @MainActor @Sendable () -> Void
+        ) -> KeyboardScheduledAction {
+            _ = delay
+            let cancellation = CancellationBox()
+            pending.append((cancellation, action))
+            return KeyboardScheduledAction { cancellation.isCancelled = true }
+        }
+
+        func runNext() {
+            guard !pending.isEmpty else { return }
+            let (cancellation, action) = pending.removeFirst()
+            if !cancellation.isCancelled { action() }
+        }
+    }
+
+    private let box: EventBox
+    private let repeatScheduler: ManualRepeatScheduler
+    private let controller: KeyboardSurfaceInteractionController
+    private let presentation: KeyboardPresentation
+
+    public var events: [KeyboardKeyEvent] { box.values }
+    public var queueDepth: Int { controller.queueDepth }
+
+    public init() {
+        let box = EventBox()
+        let repeatScheduler = ManualRepeatScheduler()
+        var presentation = KeyboardPresentation()
+        presentation.isHapticFeedbackEnabled = false
+        presentation.isKeySoundEnabled = false
+        presentation.showsKeyPreviews = false
+        self.box = box
+        self.repeatScheduler = repeatScheduler
+        self.presentation = presentation
+        controller = KeyboardSurfaceInteractionController(
+            onEvent: { box.values.append($0) },
+            onPreview: { _, _ in },
+            repeatScheduler: { delay, action in
+                repeatScheduler.schedule(delay, action)
+            }
+        )
+    }
+
+    public func begin(token: UInt64, key: KeySpec, point: CGPoint = .zero) {
+        controller.beginTouch(
+            token: token,
+            key: key,
+            point: point,
+            sourceFrame: nil,
+            presentation: presentation
+        )
+    }
+
+    public func move(token: UInt64, key: KeySpec?, point: CGPoint) {
+        controller.moveTouch(
+            token: token,
+            key: key,
+            point: point,
+            sourceFrame: nil,
+            presentation: presentation
+        )
+    }
+
+    public func end(token: UInt64) {
+        controller.endTouch(token: token)
+    }
+
+    public func runNextRepeat() {
+        repeatScheduler.runNext()
+    }
+
+    public func reconcile(activeTokens: Set<UInt64>) {
+        controller.reconcileActiveTouches(activeTokens)
+    }
+
+    public func performAccessibilitySwipe(key: KeySpec, action: KeySwipeAction) {
+        controller.handle(
+            .init(key: key, phase: .swiped(action)),
+            sourceFrame: nil,
+            presentation: presentation
+        )
+    }
+
+    public static func hitKey(
+        in geometry: ResolvedKeyboard,
+        at point: CGPoint
+    ) -> KeySpec? {
+        let overlay = KeyboardTouchOverlayView()
+        overlay.updateGeometry(geometry)
+        return overlay.resolvedHit(at: point)?.key
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/KeyboardKeyControl.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/KeyboardKeyControl.swift
@@ -16,6 +16,7 @@ final class KeyboardKeyControl: UIControl {
     private var appliedInterfaceStyle: UIUserInterfaceStyle?
     private var appliedReduceTransparency: Bool?
     private var swipeTracker = KeySwipeGestureTracker()
+    var role: KeyRole { spec.role }
 
     init(spec: KeySpec) {
         self.spec = spec
@@ -57,6 +58,11 @@ final class KeyboardKeyControl: UIControl {
         emit(.pressed)
         emit(.released)
         return true
+    }
+
+    func setPressed(_ pressed: Bool, presentation: KeyboardPresentation?) {
+        guard let presentation else { return }
+        surface.setPressed(pressed, theme: presentation.theme, animated: true)
     }
 
     private func configureAccessibility() {

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/KeyboardSurfaceView+Presentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/KeyboardSurfaceView+Presentation.swift
@@ -1,0 +1,118 @@
+#if canImport(UIKit)
+import KeyboardLayout
+import UIKit
+
+extension KeyboardSurfaceView {
+    func presentationDidChange(from oldValue: KeyboardPresentation) {
+        let layoutChanged = oldValue.layout != presentation.layout
+        let sizingChanged = oldValue.sizing != presentation.sizing
+        let themeChanged = oldValue.theme != presentation.theme
+        if layoutChanged {
+            touchOverlay.cancelAllTrackedTouches()
+            interactionController.cancelAll()
+            rebuildKeys()
+        }
+        if layoutChanged || sizingChanged { geometryCache = nil }
+        if layoutChanged || themeChanged {
+            applyPresentation()
+        } else {
+            var roles = Set<KeyRole>()
+            if oldValue.shiftState != presentation.shiftState {
+                roles.formUnion([.character, .shift, .vniModifier])
+            }
+            if oldValue.language != presentation.language { roles.insert(.space) }
+            if oldValue.enterAction != presentation.enterAction { roles.insert(.enter) }
+            applyPresentation(to: roles)
+            if oldValue.showsKeyPreviews, !presentation.showsKeyPreviews {
+                updatePreview(nil, sourceFrame: nil)
+            }
+        }
+        if layoutChanged || sizingChanged {
+            invalidateIntrinsicContentSize()
+            setNeedsLayout()
+        }
+    }
+
+    func rebuildKeys() {
+        keyControls.values.forEach { $0.removeFromSuperview() }
+        let specs = presentation.layout.rows.flatMap(\.keys)
+        keyControls = Dictionary(uniqueKeysWithValues: specs.map { spec in
+            let control = KeyboardKeyControl(spec: spec)
+            control.onEvent = { [weak self, weak control] event in
+                self?.route(event, from: control)
+            }
+            return (spec.id, control)
+        })
+        keysHost.install(Array(keyControls.values))
+    }
+
+    func applyPresentation() {
+        backdropView.apply(theme: presentation.theme, traits: traitCollection, image: backgroundImage)
+        previewView.apply(theme: presentation.theme, traits: traitCollection)
+        keysHost.apply(presentation: presentation)
+        toolbarView.apply(
+            spec: presentation.layout.toolbar,
+            theme: presentation.theme,
+            traits: traitCollection
+        )
+        keyControls.values.forEach {
+            $0.apply(presentation: presentation, traits: traitCollection)
+        }
+    }
+
+    func applyPresentation(to roles: Set<KeyRole>) {
+        guard !roles.isEmpty else { return }
+        keyControls.values.lazy.filter { roles.contains($0.role) }.forEach {
+            $0.apply(presentation: presentation, traits: traitCollection)
+        }
+    }
+
+    func configureTouchOverlay() {
+        touchOverlay.onBegin = { [weak self] token, hit, point in
+            guard let self else { return }
+            interactionController.beginTouch(
+                token: token,
+                key: hit.key,
+                point: point,
+                sourceFrame: hit.frame,
+                presentation: presentation
+            )
+        }
+        touchOverlay.onMove = { [weak self] token, hit, point in
+            guard let self else { return }
+            interactionController.moveTouch(
+                token: token,
+                key: hit?.key,
+                point: point,
+                sourceFrame: hit?.frame,
+                presentation: presentation
+            )
+        }
+        touchOverlay.onEnd = { [weak self] token in
+            self?.interactionController.endTouch(token: token)
+        }
+        touchOverlay.onCancel = { [weak self] token in
+            self?.interactionController.cancelTouch(token: token)
+        }
+        touchOverlay.onReconcile = { [weak self] active in
+            self?.interactionController.reconcileActiveTouches(active)
+        }
+    }
+
+    func resolvedGeometry() -> ResolvedKeyboard {
+        if let cache = geometryCache,
+           cache.size == bounds.size,
+           cache.layout == presentation.layout,
+           cache.sizing == presentation.sizing {
+            return cache.value
+        }
+        let value = KeyboardGeometry.resolve(
+            layout: presentation.layout,
+            size: bounds.size,
+            sizing: presentation.sizing
+        )
+        geometryCache = (bounds.size, presentation.layout, presentation.sizing, value)
+        return value
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/KeyboardSurfaceView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/KeyboardSurfaceView.swift
@@ -14,17 +14,27 @@ public final class KeyboardSurfaceView: UIView {
     public var onKeyEvent: ((KeyboardKeyEvent) -> Void)?
     public var onSystemInputModeEvent: ((UIView, UIEvent) -> Void)?
 
-    private let backdropView = KeyboardBackdropView()
-    private let toolbarView = KeyboardToolbarView()
-    private let contentHost = UIView()
-    private let keysHost = KeyboardKeysHostView()
+    let backdropView = KeyboardBackdropView()
+    let toolbarView = KeyboardToolbarView()
+    let contentHost = UIView()
+    let keysHost = KeyboardKeysHostView()
+    let touchOverlay = KeyboardTouchOverlayView()
     let previewView = KeyboardKeyPreviewView()
     lazy var interactionController = KeyboardSurfaceInteractionController(
         feedbackView: self,
         onEvent: { [weak self] event in self?.onKeyEvent?(event) },
-        onPreview: { [weak self] key, frame in self?.updatePreview(key, sourceFrame: frame) }
+        onPreview: { [weak self] key, frame in self?.updatePreview(key, sourceFrame: frame) },
+        onHighlight: { [weak self] key, highlighted in
+            self?.keyControls[key.id]?.setPressed(highlighted, presentation: self?.presentation)
+        }
     )
-    private var keyControls: [String: KeyboardKeyControl] = [:]
+    var keyControls: [String: KeyboardKeyControl] = [:]
+    var geometryCache: (
+        size: CGSize,
+        layout: KeyboardLayout,
+        sizing: KeyboardSizingProfile,
+        value: ResolvedKeyboard
+    )?
 
     public init(presentation: KeyboardPresentation = KeyboardPresentation()) {
         self.presentation = presentation
@@ -53,17 +63,15 @@ public final class KeyboardSurfaceView: UIView {
         backdropView.frame = bounds
         contentHost.frame = bounds
         keysHost.frame = bounds
+        touchOverlay.frame = bounds
 
         guard bounds.width > 0, bounds.height > 0 else { return }
-        let geometry = KeyboardGeometry.resolve(
-            layout: presentation.layout,
-            size: bounds.size,
-            sizing: presentation.sizing
-        )
+        let geometry = resolvedGeometry()
         toolbarView.frame = geometry.toolbarFrame ?? .zero
         geometry.keys.forEach { key in
             keyControls[key.spec.id]?.frame = key.frame
         }
+        touchOverlay.updateGeometry(geometry)
     }
 
     public override func traitCollectionDidChange(_ previousTraits: UITraitCollection?) {
@@ -75,12 +83,14 @@ public final class KeyboardSurfaceView: UIView {
     public override func didMoveToWindow() {
         super.didMoveToWindow()
         if window == nil {
+            touchOverlay.cancelAllTrackedTouches()
             interactionController.cancelAll()
         }
     }
 
     private func configureView() {
         isMultipleTouchEnabled = true
+        contentHost.isMultipleTouchEnabled = true
         clipsToBounds = true
         isOpaque = false
         backgroundColor = .clear
@@ -89,7 +99,9 @@ public final class KeyboardSurfaceView: UIView {
         addSubview(contentHost)
         contentHost.addSubview(keysHost)
         contentHost.addSubview(toolbarView)
+        contentHost.addSubview(touchOverlay)
         addSubview(previewView)
+        configureTouchOverlay()
         toolbarView.onEvent = { [weak self] event in self?.route(event, from: nil) }
         toolbarView.onSystemInputModeEvent = { [weak self] source, event in
             self?.onSystemInputModeEvent?(source, event)
@@ -110,41 +122,5 @@ public final class KeyboardSurfaceView: UIView {
         setNeedsLayout()
     }
 
-    private func presentationDidChange(from oldValue: KeyboardPresentation) {
-        if oldValue.layout != presentation.layout {
-            interactionController.cancelAll()
-            rebuildKeys()
-        }
-        applyPresentation()
-        invalidateIntrinsicContentSize()
-        setNeedsLayout()
-    }
-
-    private func rebuildKeys() {
-        keyControls.values.forEach { $0.removeFromSuperview() }
-        let specs = presentation.layout.rows.flatMap(\.keys)
-        keyControls = Dictionary(uniqueKeysWithValues: specs.map { spec in
-            let control = KeyboardKeyControl(spec: spec)
-            control.onEvent = { [weak self, weak control] event in
-                self?.route(event, from: control)
-            }
-            return (spec.id, control)
-        })
-        keysHost.install(Array(keyControls.values))
-    }
-
-    private func applyPresentation() {
-        backdropView.apply(theme: presentation.theme, traits: traitCollection, image: backgroundImage)
-        previewView.apply(theme: presentation.theme, traits: traitCollection)
-        keysHost.apply(presentation: presentation)
-        toolbarView.apply(
-            spec: presentation.layout.toolbar,
-            theme: presentation.theme,
-            traits: traitCollection
-        )
-        keyControls.values.forEach {
-            $0.apply(presentation: presentation, traits: traitCollection)
-        }
-    }
 }
 #endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/KeyboardDocumentSynchronizerEpochTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/KeyboardDocumentSynchronizerEpochTests.swift
@@ -1,0 +1,77 @@
+@testable import KeyboardInput
+import Foundation
+import Testing
+
+@MainActor
+struct KeyboardDocumentSynchronizerEpochTests {
+    @Test("A word boundary retains only the immediately previous echo epoch")
+    func wordBoundaryRotatesEchoEpochs() {
+        let identifier = UUID()
+        var synchronizer = KeyboardDocumentSynchronizer()
+        synchronizer.accept(KeyboardDocumentSnapshot(
+            documentIdentifier: identifier,
+            contextBeforeInput: "",
+            hasSelection: false
+        ))
+
+        synchronizer.beginMutation()
+        synchronizer.recordInsertion("mot")
+        _ = synchronizer.finishMutation()
+        synchronizer.beginMutation(closesEpoch: true)
+        synchronizer.recordInsertion(" ")
+        _ = synchronizer.finishMutation()
+        synchronizer.beginMutation()
+        synchronizer.recordInsertion("hai")
+        _ = synchronizer.finishMutation()
+
+        let consumedPreviousEpoch = synchronizer.consumeAuthoredTextChange(
+            documentIdentifier: identifier,
+            contextBeforeInput: "mot"
+        )
+        #expect(consumedPreviousEpoch)
+
+        synchronizer.beginMutation(closesEpoch: true)
+        synchronizer.recordInsertion(" ")
+        _ = synchronizer.finishMutation()
+        synchronizer.beginMutation()
+        synchronizer.recordInsertion("ba")
+        _ = synchronizer.finishMutation()
+
+        let consumedExpiredEpoch = synchronizer.consumeAuthoredTextChange(
+            documentIdentifier: identifier,
+            contextBeforeInput: "mot"
+        )
+        #expect(!consumedExpiredEpoch)
+    }
+
+    @Test("External correction preserves delayed authored echo recognition")
+    func externalCorrectionPreservesPendingEchoRecognition() {
+        let identifier = UUID()
+        var synchronizer = KeyboardDocumentSynchronizer()
+        synchronizer.accept(KeyboardDocumentSnapshot(
+            documentIdentifier: identifier,
+            contextBeforeInput: "helo",
+            hasSelection: false
+        ))
+        synchronizer.beginMutation()
+        synchronizer.recordInsertion("x")
+        _ = synchronizer.finishMutation()
+
+        synchronizer.accept(
+            KeyboardDocumentSnapshot(
+                documentIdentifier: identifier,
+                contextBeforeInput: "hello",
+                hasSelection: false
+            ),
+            preservingAuthoredEchoes: true
+        )
+
+        #expect(synchronizer.snapshot?.contextBeforeInput == "hello")
+        let consumed = synchronizer.consumeAuthoredTextChange(
+            documentIdentifier: identifier,
+            contextBeforeInput: "helox"
+        )
+        #expect(consumed)
+        #expect(synchronizer.snapshot?.contextBeforeInput == "hello")
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/KeyboardDocumentSynchronizerTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/KeyboardDocumentSynchronizerTests.swift
@@ -131,7 +131,8 @@ struct KeyboardDocumentSynchronizerTests {
             _ = synchronizer.finishMutation()
         }
 
-        #expect(synchronizer.pendingAuthoredContextCount == 256)
+        #expect(synchronizer.pendingAuthoredContextCount > 0)
+        #expect(synchronizer.pendingAuthoredContextCount <= 64)
         #expect(synchronizer.snapshot?.contextBeforeInput?.count == 128)
 
         let consumed = synchronizer.consumeAuthoredTextChange(
@@ -141,6 +142,8 @@ struct KeyboardDocumentSynchronizerTests {
         #expect(consumed)
         // A current callback is not a monotonic watermark: UIKit can still
         // deliver an older callback that was already queued behind it.
-        #expect(synchronizer.pendingAuthoredContextCount == 256)
+        #expect(synchronizer.pendingAuthoredContextCount > 0)
+        #expect(synchronizer.pendingAuthoredContextCount <= 64)
     }
+
 }

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/AlphabeticSurfaceTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/AlphabeticSurfaceTests.swift
@@ -68,6 +68,23 @@ struct AlphabeticSurfaceTests {
         #expect(updatedEffects == originalEffects)
     }
 
+    @Test("Shift updates content without rebuilding key controls")
+    func shiftPreservesKeyControls() {
+        let layout = StandardKeyboardLayouts.letters(.vni)
+        let surface = KeyboardSurfaceView(presentation: KeyboardPresentation(layout: layout))
+        surface.frame = CGRect(x: 0, y: 0, width: 390, height: 304)
+        surface.layoutIfNeeded()
+        let before = Set(accessibleControls(in: surface).map(ObjectIdentifier.init))
+
+        var presentation = surface.presentation
+        presentation.shiftState = .uppercase
+        surface.presentation = presentation
+        surface.layoutIfNeeded()
+        let after = Set(accessibleControls(in: surface).map(ObjectIdentifier.init))
+
+        #expect(before == after)
+    }
+
     @Test("Liquid Glass keys use native adaptive styling")
     func nativeGlassStyling() {
         guard #available(iOS 26.0, *) else { return }

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardInteractionTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardInteractionTests.swift
@@ -89,35 +89,6 @@ struct KeyboardInteractionTests {
         #expect(controller.activeKey == nil)
     }
 
-    @Test("Backspace repeat emits ticks and suppresses release")
-    func backspaceRepeatIntegration() {
-        let scheduler = TestRepeatScheduler()
-        var events: [KeyboardKeyEvent] = []
-        let controller = KeyboardSurfaceInteractionController(
-            onEvent: { events.append($0) },
-            onPreview: { _, _ in },
-            repeatScheduler: scheduler.schedule
-        )
-        var presentation = KeyboardPresentation()
-        presentation.isHapticFeedbackEnabled = false
-        let backspace = KeySpec(id: "backspace", label: "", role: .backspace)
-
-        controller.handle(
-            event(backspace, .pressed),
-            sourceFrame: nil,
-            presentation: presentation
-        )
-        scheduler.runNext()
-        controller.handle(
-            event(backspace, .released),
-            sourceFrame: nil,
-            presentation: presentation
-        )
-
-        #expect(events.map(\.phase) == [.pressed, .repeated])
-        #expect(controller.activeKey == nil)
-    }
-
     private func key(_ label: String) -> KeySpec {
         KeySpec(
             id: "key-\(label)",

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardRepeatInteractionTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardRepeatInteractionTests.swift
@@ -1,0 +1,60 @@
+#if canImport(UIKit)
+@testable import KeyboardRenderer
+import KeyboardLayout
+import Testing
+
+@MainActor
+struct KeyboardRepeatInteractionTests {
+    @Test("Backspace repeat emits ticks and suppresses release")
+    func backspaceRepeatIntegration() {
+        let backspace = KeySpec(id: "backspace", label: "", role: .backspace)
+        let (controller, scheduler, events, presentation) = makeSubject()
+
+        controller.handle(event(backspace, .pressed), sourceFrame: nil, presentation: presentation)
+        scheduler.runNext()
+        controller.handle(event(backspace, .released), sourceFrame: nil, presentation: presentation)
+
+        #expect(events.value.map(\.phase) == [.pressed, .repeated])
+        #expect(controller.activeKey == nil)
+    }
+
+    @Test("Space hold emits repeated spaces and suppresses the release")
+    func spaceRepeatIntegration() {
+        let space = KeySpec(id: "space", label: "space", role: .space)
+        let (controller, scheduler, events, presentation) = makeSubject()
+
+        controller.handle(event(space, .pressed), sourceFrame: nil, presentation: presentation)
+        scheduler.runNext()
+        scheduler.runNext()
+        controller.handle(event(space, .released), sourceFrame: nil, presentation: presentation)
+
+        #expect(events.value.map(\.phase) == [.pressed, .repeated, .repeated])
+        #expect(events.value.filter { $0.key.role == .space && $0.phase == .repeated }.count == 2)
+        #expect(controller.activeKey == nil)
+    }
+
+    private final class EventBox { var value: [KeyboardKeyEvent] = [] }
+
+    private func makeSubject() -> (
+        KeyboardSurfaceInteractionController,
+        TestRepeatScheduler,
+        EventBox,
+        KeyboardPresentation
+    ) {
+        let scheduler = TestRepeatScheduler()
+        let events = EventBox()
+        let controller = KeyboardSurfaceInteractionController(
+            onEvent: { events.value.append($0) },
+            onPreview: { _, _ in },
+            repeatScheduler: scheduler.schedule
+        )
+        var presentation = KeyboardPresentation()
+        presentation.isHapticFeedbackEnabled = false
+        return (controller, scheduler, events, presentation)
+    }
+
+    private func event(_ key: KeySpec, _ phase: KeyboardKeyEvent.Phase) -> KeyboardKeyEvent {
+        KeyboardKeyEvent(key: key, phase: phase)
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeycapGeometryTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeycapGeometryTests.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 @testable import KeyboardRenderer
 import KeyboardLayout
 import Testing
@@ -28,3 +29,4 @@ struct KeycapGeometryTests {
         #expect(hitArea.frame == control.bounds)
     }
 }
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/ThemeImageCropTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/ThemeImageCropTests.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 @testable import KeyboardRenderer
 import Testing
 import UIKit
@@ -30,3 +31,4 @@ struct ThemeImageCropTests {
         }
     }
 }
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/ThemeRendererColorTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/ThemeRendererColorTests.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 @testable import KeyboardRenderer
 import KeyboardLayout
 import Testing
@@ -124,3 +125,4 @@ private extension UIColor {
         return zip(a, b).allSatisfy { abs($0 - $1) < 0.01 }
     }
 }
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/ThemeRendererSurfaceTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/ThemeRendererSurfaceTests.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 @testable import KeyboardRenderer
 import KeyboardLayout
 import Testing
@@ -132,3 +133,4 @@ struct ThemeRendererSurfaceTests {
         )
     }
 }
+#endif


### PR DESCRIPTION
## What changed

- replace per-key `touchUpInside` handling with a centralized multi-touch overlay that tracks each `UITouch`, commits the key under the finger at release, fills key gaps, and preserves touch-down ordering
- bind Space swipe and Space/Backspace repeat to the originating touch, reconcile missing terminal events, and cancel safely across keyboard lifecycle changes
- replace loose document-context matching with a bounded generation/epoch ledger so stale UIKit echoes and host autocorrection cannot leak an old composition into a new word
- cache keyboard geometry/theme presentation and update only affected keys while keeping privacy-safe signposts for touch, composer/FFI, proxy mutation, presentation, and total handler latency
- repair the Release unit-test target, add rollover/repeat/document/presentation stress coverage, and split Swift files to satisfy the project 150-LOC rule

## Why

Fast overlapping touches could finish in a different order than they began, while the old control pipeline identified pending work by key ID and depended on individual control delivery. At the same time, loose suffix matching could accept stale `UITextDocumentProxy` callbacks as current state. Those races could drop or reorder key events, duplicate characters, or introduce text the user did not type.

## Impact

Fast two-thumb typing now has deterministic ordering and bounded recovery. Space and Backspace hold repeat consistently, Space swipe cannot also emit a Space, and external document changes reset composition without stale echoes contaminating the next word. The Rust core and Telex/VNI rules are unchanged.

## Validation

- Funput iOS Release: 63 tests passed
- FunputKit Release: 86 tests passed
- 100,000 synthetic touch transitions passed with stable ordering and bounded queue depth
- Release simulator build succeeded
- Swift LOC check passed (maximum 150 lines per file)
- `git diff --check` passed

Final latency and host-app behavior will be validated on physical devices using the included local signposts.
