### PR TITLE
feat(suggestions): add personal suggestion engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,8 @@ dependencies = [
  "criterion",
  "funput-core",
  "funput-engine",
+ "funput-suggestions",
+ "tempfile",
 ]
 
 [[package]]
@@ -493,6 +495,16 @@ dependencies = [
  "funput-core",
  "funput-engine",
  "jni",
+]
+
+[[package]]
+name = "funput-suggestions"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+ "proptest",
+ "tempfile",
+ "unicode-normalization",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/funput-core",
     "crates/funput-engine",
+    "crates/funput-suggestions",
     "crates/funput-cli",
     "crates/funput-ffi",
     "crates/funput-jni",

--- a/benchmarks/results/personal-suggestions-v1.md
+++ b/benchmarks/results/personal-suggestions-v1.md
@@ -1,0 +1,63 @@
+# Personal suggestions V1 benchmark
+
+Measured on 2026-07-18 with Rust 1.96.0 in the workspace Release profile. Criterion
+used a warm 5,000-word personal lexicon; the percentile harness sampled 100,000
+queries. Disk measurements include `sync_data`/`sync_all` and run outside the
+typing hot path.
+
+## Lookup and memory
+
+| Path | Median |
+|---|---:|
+| Exact prefix, 1 scalar | 68 ns |
+| Exact prefix, 5 scalars | 214 ns |
+| Exact prefix, 8 scalars | 326 ns |
+| Accent-folded prefix | 111 ns |
+| Miss | 141 ns |
+| C FFI top-3 query | 267 ns |
+| Learn existing word | 2.39 µs |
+
+The Rust latency harness measured p50 **250 ns**, p95 **250 ns**, p99 **292 ns**
+and 3.87 million queries/second. The C FFI harness measured p50 **250 ns**, p95
+**292 ns**, p99 **292 ns** and 3.54 million queries/second. Warm Rust lookup made
+zero heap allocations across 100,000 queries.
+
+The 5,000-word fixture retained approximately **572,504 bytes**. Tests enforce a
+4 MiB retained-heap budget, a 2 MiB snapshot budget, a hard 5,000-word capacity,
+and non-growing trie node counts during 100,000-operation churn.
+
+## Persistence
+
+| Operation | Median |
+|---|---:|
+| Open 5,000-word snapshot | 2.17 ms |
+| Open snapshot + replay 100 journal tokens | 3.98 ms |
+| Flush 256 mutations | 5.19 ms |
+| Compact 5,000 words | 9.83 ms |
+
+The journal automatically compacts at 64 KiB and rejects oversized input files;
+tests cover truncated frames, corrupted snapshots, newer schemas, abandoned
+temporary files, and bounded journal growth.
+
+An initial eviction implementation rebuilt the trie for every journal token and
+took 143 ms to reopen. Stable slot replacement reduced the same benchmark to
+3.98 ms; a rebuild now happens only when an already-promoted word is evicted.
+
+## Existing typing regression guard
+
+Criterion comparisons against `before-suggestions` report:
+
+| Existing path | Median change | Result |
+|---|---:|---|
+| funput-core Telex compose | -0.38% | No change detected |
+| funput-engine Telex paragraph | +1.39% | Within noise threshold |
+| funput-ffi Telex process + render | +1.04% | No change detected |
+| funput-ffi VNI process + render | +0.62% | Within noise threshold |
+
+The engine allocation guard is unchanged at **1.1 allocations / 4 bytes per
+keypress** for both default and spell-check paths. Suggestion functions are new,
+independent exports and are not called by `funput_process_char` or the composer.
+
+The stripped Release dynamic library grew from 402,592 bytes to 585,216 bytes
+(+182,624 bytes); the static archive grew by 601,400 bytes. Both include the new
+Unicode normalizer, persistence code, trie, and C ABI.

--- a/crates/funput-ffi/Cargo.toml
+++ b/crates/funput-ffi/Cargo.toml
@@ -12,9 +12,11 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [dependencies]
 funput-core = { path = "../funput-core" }
 funput-engine = { path = "../funput-engine" }
+funput-suggestions = { path = "../funput-suggestions" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
+tempfile = "3.27.0"
 
 [[bench]]
 name = "latency"
@@ -22,4 +24,8 @@ harness = false
 
 [[bench]]
 name = "advanced_telex"
+harness = false
+
+[[bench]]
+name = "suggestions"
 harness = false

--- a/crates/funput-ffi/README.en.md
+++ b/crates/funput-ffi/README.en.md
@@ -22,6 +22,10 @@ yields a `None` result) and **panic-safe**: every entry point that touches the e
 `support::safe()` (`catch_unwind`), so a panic in the engine is caught at the boundary and turned into a
 no-op result — it **never** unwinds into the host (which would abort the whole IME process).
 
+Personal suggestions use a separate opaque `FunputSuggestionEngine` handle. Queries return at most
+three UTF-32 candidates as a POD; open/learn/flush/compact/reset failures return null, `false`, or an
+empty result. Platforms drive this handle serially on a worker, never from the composition path.
+
 ```c
 typedef struct FunputEngine FunputEngine;   // opaque handle
 
@@ -94,6 +98,8 @@ src/lib.rs          # module root: opaque FunputEngine + new/free + re-export su
 src/config.rs       # 7 setters: method/tone_style/enabled/smart|eager_restore/spell/autocap
 src/compose.rs      # process_char/backspace/flip_composing/clear/arm/buffer
 src/shortcuts.rs    # add_shortcut/clear_shortcuts (text expansion, "gõ tắt")
+src/suggestions.rs  # fail-silent personal suggestion handle/API
+src/suggestion_types.rs # fixed top-3 candidate/stats PODs
 src/support.rs      # safe(): catch_unwind guard for the C boundary
 src/types.rs        # #[repr(C)] FunputResult + from_ime() + CHARS_CAP/ACTION_*
 cbindgen.toml
@@ -110,7 +116,7 @@ Edition 2024 note: use `#[unsafe(no_mangle)]` and explicit `unsafe { }` around `
 
 ## Dependencies & callers
 
-- `funput-ffi → funput-engine → funput-core`.
+- `funput-ffi → funput-engine → funput-core`, plus independent `funput-ffi → funput-suggestions`.
 - Consumers: `platforms/macos` (Swift, bridging header) and `platforms/linux/fcitx5` (C++,
   `ffi_handle.h`). **Not** used by: `funput-cli`, the Windows shell (both link the engine directly).
 

--- a/crates/funput-ffi/README.md
+++ b/crates/funput-ffi/README.md
@@ -22,6 +22,10 @@ tự map keycode → char). Mọi hàm **null-safe** (handle null / codepoint kh
 (`catch_unwind`), nên panic trong engine bị chặn tại biên và trả kết quả no-op — **không bao giờ**
 unwind sang host (điều sẽ abort cả tiến trình IME).
 
+Personal suggestion dùng một opaque handle riêng (`FunputSuggestionEngine`). Query trả tối đa ba
+candidate UTF-32 bằng POD; open/learn/flush/compact/reset lỗi đều trả null, `false` hoặc kết quả rỗng.
+Handle này chỉ được gọi tuần tự trên worker của platform và không tham gia đường compose.
+
 ```c
 typedef struct FunputEngine FunputEngine;   // opaque handle
 
@@ -93,6 +97,8 @@ src/lib.rs          # module root: opaque FunputEngine + new/free + re-export su
 src/config.rs       # 7 setter: method/tone_style/enabled/smart|eager_restore/spell/autocap
 src/compose.rs      # process_char/backspace/flip_composing/clear/arm/buffer
 src/shortcuts.rs    # add_shortcut/clear_shortcuts (gõ tắt)
+src/suggestions.rs  # personal suggestion handle + API fail-silent
+src/suggestion_types.rs # POD top-3 candidate/stats
 src/support.rs      # safe(): catch_unwind guard cho biên C
 src/types.rs        # #[repr(C)] FunputResult + from_ime() + CHARS_CAP/ACTION_*
 cbindgen.toml
@@ -109,7 +115,7 @@ Lưu ý edition 2024: dùng `#[unsafe(no_mangle)]` và `unsafe { }` tường min
 
 ## Phụ thuộc & ai gọi
 
-- `funput-ffi → funput-engine → funput-core`.
+- `funput-ffi → funput-engine → funput-core`, và `funput-ffi → funput-suggestions` độc lập.
 - Consumer: `platforms/macos` (Swift, bridging header) và `platforms/linux/fcitx5` (C++,
   `ffi_handle.h`). **Không** dùng: `funput-cli`, Windows shell (đều link engine trực tiếp).
 

--- a/crates/funput-ffi/benches/suggestions.rs
+++ b/crates/funput-ffi/benches/suggestions.rs
@@ -1,0 +1,33 @@
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use funput_ffi::{
+    funput_suggestion_engine_free, funput_suggestion_engine_new_in_memory, funput_suggestion_learn,
+    funput_suggestion_query,
+};
+
+fn bench(c: &mut Criterion) {
+    let engine = funput_suggestion_engine_new_in_memory();
+    for index in 0..5_000 {
+        let word: Vec<u32> = format!("word{index:04}").chars().map(u32::from).collect();
+        unsafe {
+            funput_suggestion_learn(engine, word.as_ptr(), word.len());
+            funput_suggestion_learn(engine, word.as_ptr(), word.len());
+        }
+    }
+    let prefix: Vec<u32> = "word1".chars().map(u32::from).collect();
+    let mut group = c.benchmark_group("suggestions_ffi");
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("query_top3", |b| {
+        b.iter(|| {
+            black_box(unsafe {
+                funput_suggestion_query(engine, black_box(prefix.as_ptr()), prefix.len())
+            })
+        })
+    });
+    group.finish();
+    unsafe { funput_suggestion_engine_free(engine) };
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/crates/funput-ffi/cbindgen.toml
+++ b/crates/funput-ffi/cbindgen.toml
@@ -7,7 +7,12 @@ tab_width = 4
 style = "type"
 
 [export]
-include = ["FunputResult"]
+include = [
+    "FunputResult",
+    "FunputSuggestionCandidate",
+    "FunputSuggestionResult",
+    "FunputSuggestionStats",
+]
 
 [parse]
 parse_deps = false

--- a/crates/funput-ffi/examples/suggestion_latency.rs
+++ b/crates/funput-ffi/examples/suggestion_latency.rs
@@ -1,0 +1,41 @@
+use std::time::Instant;
+
+use funput_ffi::{
+    funput_suggestion_engine_free, funput_suggestion_engine_new_in_memory, funput_suggestion_learn,
+    funput_suggestion_query,
+};
+
+const SAMPLES: usize = 100_000;
+
+fn main() {
+    let engine = funput_suggestion_engine_new_in_memory();
+    for index in 0..5_000 {
+        let word: Vec<u32> = format!("word{index:04}").chars().map(u32::from).collect();
+        unsafe {
+            funput_suggestion_learn(engine, word.as_ptr(), word.len());
+            funput_suggestion_learn(engine, word.as_ptr(), word.len());
+        }
+    }
+    let prefix: Vec<u32> = "word1".chars().map(u32::from).collect();
+    let mut samples = Vec::with_capacity(SAMPLES);
+    let started = Instant::now();
+    for _ in 0..SAMPLES {
+        let sample = Instant::now();
+        std::hint::black_box(unsafe {
+            funput_suggestion_query(engine, prefix.as_ptr(), prefix.len())
+        });
+        samples.push(sample.elapsed().as_nanos());
+    }
+    let elapsed = started.elapsed();
+    samples.sort_unstable();
+    let percentile = |value: usize| samples[(SAMPLES * value / 100).min(SAMPLES - 1)];
+    println!("samples={SAMPLES}");
+    println!("p50_ns={}", percentile(50));
+    println!("p95_ns={}", percentile(95));
+    println!("p99_ns={}", percentile(99));
+    println!(
+        "queries_per_second={:.0}",
+        SAMPLES as f64 / elapsed.as_secs_f64()
+    );
+    unsafe { funput_suggestion_engine_free(engine) };
+}

--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -16,6 +16,10 @@
 
 #define METHOD_TELEX_ADVANCED 2
 
+#define SUGGESTION_CAP 3
+
+#define SUGGESTION_CHARS_CAP 32
+
 /**
  * Max output codepoints carried inline. Generous enough for English-restore of
  * long words; longer output is truncated (practically never happens).
@@ -38,6 +42,12 @@
 typedef struct FunputEngine FunputEngine;
 
 /**
+ * Opaque, single-owner personal suggestion handle. It is independent from the
+ * Vietnamese composition engine and must be driven from a serial worker.
+ */
+typedef struct FunputSuggestionEngine FunputSuggestionEngine;
+
+/**
  * Result of one keystroke, returned by value (POD, no allocation, no free).
  *
  * `chars[0..count]` are the output codepoints (UTF-32) to inject after deleting
@@ -49,6 +59,27 @@ typedef struct {
     uint32_t count;
     uint32_t chars[CHARS_CAP];
 } FunputResult;
+
+typedef struct {
+    uint32_t count;
+    uint32_t chars[SUGGESTION_CHARS_CAP];
+} FunputSuggestionCandidate;
+
+typedef struct {
+    uint32_t count;
+    FunputSuggestionCandidate candidates[SUGGESTION_CAP];
+} FunputSuggestionResult;
+
+typedef struct {
+    uint32_t words;
+    uint32_t promoted_words;
+    uint32_t exact_nodes;
+    uint32_t folded_nodes;
+    uint32_t pending_mutations;
+    uint64_t journal_bytes;
+    uint64_t estimated_heap_bytes;
+    uint64_t last_snapshot_bytes;
+} FunputSuggestionStats;
 
 #ifdef __cplusplus
 extern "C" {
@@ -225,6 +256,74 @@ void funput_add_shortcut(FunputEngine *engine,
  * `engine` must be a valid handle or null.
  */
 void funput_clear_shortcuts(FunputEngine *engine);
+
+FunputSuggestionEngine *funput_suggestion_engine_new_in_memory(void);
+
+/**
+ * Open a local store from a UTF-8 path. Failure returns null without logging.
+ *
+ * # Safety
+ * `path` must point to `path_len` readable bytes, or be null.
+ */
+FunputSuggestionEngine *funput_suggestion_engine_open(const uint8_t *path, uintptr_t path_len);
+
+/**
+ * # Safety
+ * `engine` must be a live suggestion handle or null.
+ */
+void funput_suggestion_engine_free(FunputSuggestionEngine *engine);
+
+/**
+ * Record one completed UTF-32 token. Returns false for invalid input or failure.
+ *
+ * # Safety
+ * `token` must point to `token_len` readable codepoints, or be null.
+ */
+bool funput_suggestion_learn(FunputSuggestionEngine *engine,
+                             const uint32_t *token,
+                             uintptr_t token_len);
+
+/**
+ * Return at most three UTF-32 candidates by value. Any failure returns empty.
+ *
+ * # Safety
+ * `prefix` must point to `prefix_len` readable codepoints, or be null.
+ */
+FunputSuggestionResult funput_suggestion_query(const FunputSuggestionEngine *engine,
+                                               const uint32_t *prefix,
+                                               uintptr_t prefix_len);
+
+/**
+ * Flush pending learned tokens to the journal.
+ *
+ * # Safety
+ * `engine` must be a live suggestion handle or null and may not be used concurrently.
+ */
+bool funput_suggestion_flush(FunputSuggestionEngine *engine);
+
+/**
+ * Replace the journal with a compact crash-safe snapshot.
+ *
+ * # Safety
+ * `engine` must be a live suggestion handle or null and may not be used concurrently.
+ */
+bool funput_suggestion_compact(FunputSuggestionEngine *engine);
+
+/**
+ * Remove all learned words from memory and local persistence.
+ *
+ * # Safety
+ * `engine` must be a live suggestion handle or null and may not be used concurrently.
+ */
+bool funput_suggestion_reset(FunputSuggestionEngine *engine);
+
+/**
+ * Return counters and byte estimates without exposing learned text.
+ *
+ * # Safety
+ * `engine` must be a live suggestion handle or null and may not be used concurrently.
+ */
+FunputSuggestionStats funput_suggestion_stats(const FunputSuggestionEngine *engine);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/crates/funput-ffi/src/lib.rs
+++ b/crates/funput-ffi/src/lib.rs
@@ -26,6 +26,10 @@
 mod compose;
 mod config;
 mod shortcuts;
+mod suggestion_query;
+mod suggestion_store;
+mod suggestion_types;
+mod suggestions;
 mod support;
 mod types;
 
@@ -41,6 +45,19 @@ pub use config::{
     funput_set_spell_check, funput_set_tone_style,
 };
 pub use shortcuts::{funput_add_shortcut, funput_clear_shortcuts};
+pub use suggestion_query::{funput_suggestion_learn, funput_suggestion_query};
+pub use suggestion_store::{
+    funput_suggestion_compact, funput_suggestion_flush, funput_suggestion_reset,
+    funput_suggestion_stats,
+};
+pub use suggestion_types::{
+    FunputSuggestionCandidate, FunputSuggestionResult, FunputSuggestionStats, SUGGESTION_CAP,
+    SUGGESTION_CHARS_CAP,
+};
+pub use suggestions::{
+    FunputSuggestionEngine, funput_suggestion_engine_free, funput_suggestion_engine_new_in_memory,
+    funput_suggestion_engine_open,
+};
 pub use types::{ACTION_NONE, ACTION_RESTORE, ACTION_SEND, CHARS_CAP, FunputResult};
 
 /// Opaque IME engine handle for C callers. Create with [`funput_engine_new`],

--- a/crates/funput-ffi/src/suggestion_query.rs
+++ b/crates/funput-ffi/src/suggestion_query.rs
@@ -1,0 +1,57 @@
+use funput_suggestions::LearnOutcome;
+
+use crate::suggestion_types::FunputSuggestionResult;
+use crate::suggestions::{FunputSuggestionEngine, codepoints_from_raw};
+use crate::support::safe;
+
+/// Record one completed UTF-32 token. Returns false for invalid input or failure.
+///
+/// # Safety
+/// `token` must point to `token_len` readable codepoints, or be null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_suggestion_learn(
+    engine: *mut FunputSuggestionEngine,
+    token: *const u32,
+    token_len: usize,
+) -> bool {
+    safe(false, || {
+        let Some(engine) = (unsafe { engine.as_mut() }) else {
+            return false;
+        };
+        let Some(codepoints) = codepoints_from_raw(token, token_len) else {
+            return false;
+        };
+        let Some(text) = decode_valid_codepoints(codepoints) else {
+            return false;
+        };
+        !matches!(engine.inner.learn(&text), LearnOutcome::Ignored)
+    })
+}
+
+/// Return at most three UTF-32 candidates by value. Any failure returns empty.
+///
+/// # Safety
+/// `prefix` must point to `prefix_len` readable codepoints, or be null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_suggestion_query(
+    engine: *const FunputSuggestionEngine,
+    prefix: *const u32,
+    prefix_len: usize,
+) -> FunputSuggestionResult {
+    safe(FunputSuggestionResult::default(), || {
+        let Some(engine) = (unsafe { engine.as_ref() }) else {
+            return FunputSuggestionResult::default();
+        };
+        let Some(codepoints) = codepoints_from_raw(prefix, prefix_len) else {
+            return FunputSuggestionResult::default();
+        };
+        let Some(text) = decode_valid_codepoints(codepoints) else {
+            return FunputSuggestionResult::default();
+        };
+        FunputSuggestionResult::from_set(engine.inner.suggest(&text))
+    })
+}
+
+fn decode_valid_codepoints(codepoints: &[u32]) -> Option<String> {
+    codepoints.iter().copied().map(char::from_u32).collect()
+}

--- a/crates/funput-ffi/src/suggestion_store.rs
+++ b/crates/funput-ffi/src/suggestion_store.rs
@@ -1,0 +1,45 @@
+use crate::suggestion_types::FunputSuggestionStats;
+use crate::suggestions::{FunputSuggestionEngine, with_mut};
+use crate::support::safe;
+
+/// Flush pending learned tokens to the journal.
+///
+/// # Safety
+/// `engine` must be a live suggestion handle or null and may not be used concurrently.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_suggestion_flush(engine: *mut FunputSuggestionEngine) -> bool {
+    with_mut(engine, |engine| engine.flush().is_ok())
+}
+
+/// Replace the journal with a compact crash-safe snapshot.
+///
+/// # Safety
+/// `engine` must be a live suggestion handle or null and may not be used concurrently.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_suggestion_compact(engine: *mut FunputSuggestionEngine) -> bool {
+    with_mut(engine, |engine| engine.compact().is_ok())
+}
+
+/// Remove all learned words from memory and local persistence.
+///
+/// # Safety
+/// `engine` must be a live suggestion handle or null and may not be used concurrently.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_suggestion_reset(engine: *mut FunputSuggestionEngine) -> bool {
+    with_mut(engine, |engine| engine.reset().is_ok())
+}
+
+/// Return counters and byte estimates without exposing learned text.
+///
+/// # Safety
+/// `engine` must be a live suggestion handle or null and may not be used concurrently.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_suggestion_stats(
+    engine: *const FunputSuggestionEngine,
+) -> FunputSuggestionStats {
+    safe(FunputSuggestionStats::default(), || {
+        unsafe { engine.as_ref() }
+            .map(|engine| engine.inner.stats().into())
+            .unwrap_or_default()
+    })
+}

--- a/crates/funput-ffi/src/suggestion_types.rs
+++ b/crates/funput-ffi/src/suggestion_types.rs
@@ -1,0 +1,69 @@
+use funput_suggestions::{SuggestionSet, SuggestionStats};
+
+use crate::support;
+
+pub const SUGGESTION_CAP: usize = 3;
+pub const SUGGESTION_CHARS_CAP: usize = 32;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FunputSuggestionCandidate {
+    pub count: u32,
+    pub chars: [u32; SUGGESTION_CHARS_CAP],
+}
+
+impl Default for FunputSuggestionCandidate {
+    fn default() -> Self {
+        Self {
+            count: 0,
+            chars: [0; SUGGESTION_CHARS_CAP],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct FunputSuggestionResult {
+    pub count: u32,
+    pub candidates: [FunputSuggestionCandidate; SUGGESTION_CAP],
+}
+
+impl FunputSuggestionResult {
+    pub(crate) fn from_set(set: SuggestionSet<'_>) -> Self {
+        let mut result = Self::default();
+        for (index, text) in set.iter().take(SUGGESTION_CAP).enumerate() {
+            let candidate = &mut result.candidates[index];
+            candidate.count = support::copy_codepoints(&mut candidate.chars, text.chars()) as u32;
+            result.count += 1;
+        }
+        result
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct FunputSuggestionStats {
+    pub words: u32,
+    pub promoted_words: u32,
+    pub exact_nodes: u32,
+    pub folded_nodes: u32,
+    pub pending_mutations: u32,
+    pub journal_bytes: u64,
+    pub estimated_heap_bytes: u64,
+    pub last_snapshot_bytes: u64,
+}
+
+impl From<SuggestionStats> for FunputSuggestionStats {
+    fn from(stats: SuggestionStats) -> Self {
+        Self {
+            words: stats.words as u32,
+            promoted_words: stats.promoted_words as u32,
+            exact_nodes: stats.exact_nodes as u32,
+            folded_nodes: stats.folded_nodes as u32,
+            pending_mutations: stats.pending_mutations as u32,
+            journal_bytes: stats.journal_bytes,
+            estimated_heap_bytes: stats.estimated_heap_bytes as u64,
+            last_snapshot_bytes: stats.last_snapshot_bytes,
+        }
+    }
+}

--- a/crates/funput-ffi/src/suggestions.rs
+++ b/crates/funput-ffi/src/suggestions.rs
@@ -1,0 +1,81 @@
+use std::path::Path;
+use std::ptr;
+use std::slice;
+
+use funput_suggestions::{SuggestionConfig, SuggestionEngine};
+
+use crate::support::safe;
+
+/// Opaque, single-owner personal suggestion handle. It is independent from the
+/// Vietnamese composition engine and must be driven from a serial worker.
+pub struct FunputSuggestionEngine {
+    pub(crate) inner: SuggestionEngine,
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn funput_suggestion_engine_new_in_memory() -> *mut FunputSuggestionEngine {
+    safe(ptr::null_mut(), || {
+        Box::into_raw(Box::new(FunputSuggestionEngine {
+            inner: SuggestionEngine::in_memory(SuggestionConfig::default()),
+        }))
+    })
+}
+
+/// Open a local store from a UTF-8 path. Failure returns null without logging.
+///
+/// # Safety
+/// `path` must point to `path_len` readable bytes, or be null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_suggestion_engine_open(
+    path: *const u8,
+    path_len: usize,
+) -> *mut FunputSuggestionEngine {
+    safe(ptr::null_mut(), || {
+        let Some(bytes) = bytes_from_raw(path, path_len) else {
+            return ptr::null_mut();
+        };
+        let Ok(path) = std::str::from_utf8(bytes) else {
+            return ptr::null_mut();
+        };
+        let Ok(inner) = SuggestionEngine::open(Path::new(path), SuggestionConfig::default()) else {
+            return ptr::null_mut();
+        };
+        Box::into_raw(Box::new(FunputSuggestionEngine { inner }))
+    })
+}
+
+/// # Safety
+/// `engine` must be a live suggestion handle or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_suggestion_engine_free(engine: *mut FunputSuggestionEngine) {
+    safe((), || {
+        if !engine.is_null() {
+            drop(unsafe { Box::from_raw(engine) });
+        }
+    });
+}
+
+pub(crate) fn bytes_from_raw<'a>(pointer: *const u8, len: usize) -> Option<&'a [u8]> {
+    if pointer.is_null() {
+        return (len == 0).then_some(&[]);
+    }
+    Some(unsafe { slice::from_raw_parts(pointer, len) })
+}
+
+pub(crate) fn codepoints_from_raw<'a>(pointer: *const u32, len: usize) -> Option<&'a [u32]> {
+    if pointer.is_null() {
+        return (len == 0).then_some(&[]);
+    }
+    Some(unsafe { slice::from_raw_parts(pointer, len) })
+}
+
+pub(crate) fn with_mut(
+    engine: *mut FunputSuggestionEngine,
+    operation: impl FnOnce(&mut SuggestionEngine) -> bool,
+) -> bool {
+    safe(false, || {
+        unsafe { engine.as_mut() }
+            .map(|engine| operation(&mut engine.inner))
+            .unwrap_or(false)
+    })
+}

--- a/crates/funput-ffi/tests/suggestions.rs
+++ b/crates/funput-ffi/tests/suggestions.rs
@@ -1,0 +1,80 @@
+use funput_ffi::{
+    FunputSuggestionResult, funput_suggestion_engine_free, funput_suggestion_engine_new_in_memory,
+    funput_suggestion_engine_open, funput_suggestion_flush, funput_suggestion_learn,
+    funput_suggestion_query, funput_suggestion_reset, funput_suggestion_stats,
+};
+
+fn codepoints(text: &str) -> Vec<u32> {
+    text.chars().map(u32::from).collect()
+}
+
+fn learn(engine: *mut funput_ffi::FunputSuggestionEngine, text: &str) -> bool {
+    let text = codepoints(text);
+    unsafe { funput_suggestion_learn(engine, text.as_ptr(), text.len()) }
+}
+
+fn query(
+    engine: *const funput_ffi::FunputSuggestionEngine,
+    prefix: &str,
+) -> FunputSuggestionResult {
+    let prefix = codepoints(prefix);
+    unsafe { funput_suggestion_query(engine, prefix.as_ptr(), prefix.len()) }
+}
+
+fn candidate(result: &FunputSuggestionResult, index: usize) -> String {
+    let candidate = &result.candidates[index];
+    candidate.chars[..candidate.count as usize]
+        .iter()
+        .filter_map(|value| char::from_u32(*value))
+        .collect()
+}
+
+#[test]
+fn learns_queries_and_resets_through_c_abi() {
+    let engine = funput_suggestion_engine_new_in_memory();
+    assert!(!engine.is_null());
+    assert!(learn(engine, "chào"));
+    assert_eq!(query(engine, "ch").count, 0);
+    assert!(learn(engine, "chào"));
+    let result = query(engine, "ch");
+    assert_eq!(result.count, 1);
+    assert_eq!(candidate(&result, 0), "chào");
+    assert_eq!(unsafe { funput_suggestion_stats(engine) }.words, 1);
+    assert!(unsafe { funput_suggestion_flush(engine) });
+    assert!(unsafe { funput_suggestion_reset(engine) });
+    assert_eq!(query(engine, "ch").count, 0);
+    unsafe { funput_suggestion_engine_free(engine) };
+}
+
+#[test]
+fn null_and_invalid_inputs_fail_silently() {
+    let empty = unsafe { funput_suggestion_query(std::ptr::null(), std::ptr::null(), 0) };
+    assert_eq!(empty.count, 0);
+    assert!(!unsafe { funput_suggestion_learn(std::ptr::null_mut(), std::ptr::null(), 0) });
+    let engine = funput_suggestion_engine_new_in_memory();
+    let invalid = [0x11_0000u32];
+    assert!(!unsafe { funput_suggestion_learn(engine, invalid.as_ptr(), 1) });
+    assert_eq!(
+        unsafe { funput_suggestion_query(engine, invalid.as_ptr(), 1) }.count,
+        0
+    );
+    unsafe { funput_suggestion_engine_free(engine) };
+}
+
+#[test]
+fn persistent_handle_round_trips_without_owned_results() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().to_string_lossy();
+    let engine = unsafe { funput_suggestion_engine_open(path.as_ptr(), path.len()) };
+    assert!(!engine.is_null());
+    assert!(learn(engine, "đường"));
+    assert!(learn(engine, "đường"));
+    assert!(unsafe { funput_ffi::funput_suggestion_compact(engine) });
+    unsafe { funput_suggestion_engine_free(engine) };
+
+    let reopened = unsafe { funput_suggestion_engine_open(path.as_ptr(), path.len()) };
+    let result = query(reopened, "du");
+    assert_eq!(result.count, 1);
+    assert_eq!(candidate(&result, 0), "đường");
+    unsafe { funput_suggestion_engine_free(reopened) };
+}

--- a/crates/funput-suggestions/Cargo.toml
+++ b/crates/funput-suggestions/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "funput-suggestions"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+unicode-normalization = "0.1.25"
+
+[dev-dependencies]
+criterion = { version = "0.8.2", features = ["html_reports"] }
+proptest = "1.11.0"
+tempfile = "3.27.0"
+
+[[bench]]
+name = "suggestions"
+harness = false

--- a/crates/funput-suggestions/README.md
+++ b/crates/funput-suggestions/README.md
@@ -1,0 +1,10 @@
+# funput-suggestions
+
+Local-only personal word suggestions for Funput platform shells. The crate owns a
+bounded mutable top-3 trie and crash-safe snapshot/journal persistence, but it does
+not observe key events, document context, network state, or the Vietnamese composer.
+
+Platform code must give the engine completed tokens and call it from one serial
+worker. Querying is read-only, allocation-free after warm-up, and performs no I/O.
+Persistence is explicit through `flush` and `compact`, allowing keyboard shells to
+schedule disk work outside their input hot path.

--- a/crates/funput-suggestions/benches/suggestions.rs
+++ b/crates/funput-suggestions/benches/suggestions.rs
@@ -1,0 +1,111 @@
+use std::hint::black_box;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use funput_suggestions::{SuggestionConfig, SuggestionEngine};
+use tempfile::TempDir;
+
+fn populated() -> SuggestionEngine {
+    let mut engine = SuggestionEngine::in_memory(SuggestionConfig::default());
+    for index in 0..5_000 {
+        let word = format!("word{index:04}");
+        engine.learn(&word);
+        engine.learn(&word);
+    }
+    for word in ["không", "khỏe", "khoa", "hòa", "hoa"] {
+        engine.learn(word);
+        engine.learn(word);
+    }
+    engine
+}
+
+fn bench_lookup(c: &mut Criterion) {
+    let engine = populated();
+    let mut group = c.benchmark_group("suggestions/lookup");
+    group.throughput(Throughput::Elements(1));
+    for (name, prefix) in [
+        ("exact-short", "w"),
+        ("exact-medium", "word1"),
+        ("exact-long", "word1234"),
+        ("folded", "ho"),
+        ("miss", "zzzz"),
+    ] {
+        group.bench_with_input(BenchmarkId::new("top3", name), prefix, |b, prefix| {
+            b.iter(|| black_box(engine.suggest(black_box(prefix))).len());
+        });
+    }
+    group.finish();
+}
+
+fn bench_learning(c: &mut Criterion) {
+    let mut engine = populated();
+    c.bench_function("suggestions/learn/existing", |b| {
+        b.iter(|| black_box(engine.learn(black_box("word1234"))))
+    });
+}
+
+fn persistent() -> (TempDir, SuggestionEngine) {
+    let directory = tempfile::tempdir().unwrap();
+    let mut engine = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    for index in 0..5_000 {
+        let word = format!("word{index:04}");
+        engine.learn(&word);
+        engine.learn(&word);
+    }
+    engine.compact().unwrap();
+    (directory, engine)
+}
+
+fn bench_persistence(c: &mut Criterion) {
+    let (directory, mut engine) = persistent();
+    c.bench_function("suggestions/persistence/open_snapshot", |b| {
+        b.iter(|| {
+            black_box(
+                SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap(),
+            )
+        })
+    });
+
+    for index in 0..100 {
+        engine.learn(&format!("journal{index:03}"));
+    }
+    engine.flush().unwrap();
+    c.bench_function("suggestions/persistence/open_with_journal", |b| {
+        b.iter(|| {
+            black_box(
+                SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap(),
+            )
+        })
+    });
+
+    let mut group = c.benchmark_group("suggestions/persistence/write");
+    group.sample_size(20);
+    group.bench_function("flush_256", |b| {
+        b.iter_batched(
+            || {
+                let directory = tempfile::tempdir().unwrap();
+                let mut engine =
+                    SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+                for index in 0..256 {
+                    engine.learn(&format!("pending{index:03}"));
+                }
+                (directory, engine)
+            },
+            |(_directory, mut engine)| {
+                engine.flush().unwrap();
+                black_box(())
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.bench_function("compact_5000", |b| {
+        b.iter_batched(
+            persistent,
+            |(_directory, mut engine)| black_box(engine.compact().unwrap()),
+            BatchSize::LargeInput,
+        )
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_lookup, bench_learning, bench_persistence);
+criterion_main!(benches);

--- a/crates/funput-suggestions/examples/latency.rs
+++ b/crates/funput-suggestions/examples/latency.rs
@@ -1,0 +1,38 @@
+use std::time::Instant;
+
+use funput_suggestions::{SuggestionConfig, SuggestionEngine};
+
+const SAMPLES: usize = 100_000;
+
+fn main() {
+    let mut engine = SuggestionEngine::in_memory(SuggestionConfig::default());
+    for index in 0..5_000 {
+        let word = format!("word{index:04}");
+        engine.learn(&word);
+        engine.learn(&word);
+    }
+
+    let mut samples = Vec::with_capacity(SAMPLES);
+    let started = Instant::now();
+    for index in 0..SAMPLES {
+        let prefix = if index % 2 == 0 { "word1" } else { "missing" };
+        let sample = Instant::now();
+        std::hint::black_box(engine.suggest(std::hint::black_box(prefix)));
+        samples.push(sample.elapsed().as_nanos());
+    }
+    let elapsed = started.elapsed();
+    samples.sort_unstable();
+    let percentile = |value: usize| samples[(SAMPLES * value / 100).min(SAMPLES - 1)];
+    println!("samples={SAMPLES}");
+    println!("p50_ns={}", percentile(50));
+    println!("p95_ns={}", percentile(95));
+    println!("p99_ns={}", percentile(99));
+    println!(
+        "queries_per_second={:.0}",
+        SAMPLES as f64 / elapsed.as_secs_f64()
+    );
+    println!(
+        "estimated_heap_bytes={}",
+        engine.stats().estimated_heap_bytes
+    );
+}

--- a/crates/funput-suggestions/src/config.rs
+++ b/crates/funput-suggestions/src/config.rs
@@ -1,0 +1,24 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SuggestionConfig {
+    pub max_words: usize,
+    pub max_token_scalars: usize,
+    pub promotion_uses: u32,
+}
+
+impl Default for SuggestionConfig {
+    fn default() -> Self {
+        Self {
+            max_words: 5_000,
+            max_token_scalars: 32,
+            promotion_uses: 2,
+        }
+    }
+}
+
+pub(crate) fn sanitize(config: SuggestionConfig) -> SuggestionConfig {
+    SuggestionConfig {
+        max_words: config.max_words.max(1),
+        max_token_scalars: config.max_token_scalars.clamp(1, 32),
+        promotion_uses: config.promotion_uses.max(1),
+    }
+}

--- a/crates/funput-suggestions/src/engine.rs
+++ b/crates/funput-suggestions/src/engine.rs
@@ -1,0 +1,80 @@
+use std::io;
+use std::path::Path;
+
+use crate::config::{SuggestionConfig, sanitize};
+use crate::persistence::Store;
+use crate::trie::ArenaTrie;
+use crate::types::WordRecord;
+
+pub(crate) const PENDING_LIMIT: usize = 256;
+pub(crate) const JOURNAL_COMPACT_BYTES: u64 = 64 * 1024;
+
+pub struct SuggestionEngine {
+    pub(crate) config: SuggestionConfig,
+    pub(crate) words: Vec<WordRecord>,
+    pub(crate) exact: ArenaTrie,
+    pub(crate) folded: ArenaTrie,
+    pub(crate) sequence: u64,
+    pub(crate) pending: Vec<String>,
+    pub(crate) pending_overflow: bool,
+    pub(crate) store: Option<Store>,
+    pub(crate) last_snapshot_bytes: u64,
+    pub(crate) journal_bytes: u64,
+}
+
+impl SuggestionEngine {
+    pub fn in_memory(config: SuggestionConfig) -> Self {
+        Self {
+            config: sanitize(config),
+            words: Vec::new(),
+            exact: ArenaTrie::new(),
+            folded: ArenaTrie::new(),
+            sequence: 0,
+            pending: Vec::with_capacity(PENDING_LIMIT),
+            pending_overflow: false,
+            store: None,
+            last_snapshot_bytes: 0,
+            journal_bytes: 0,
+        }
+    }
+
+    pub fn open(path: impl AsRef<Path>, config: SuggestionConfig) -> io::Result<Self> {
+        let config = sanitize(config);
+        let (store, loaded) = Store::open(path.as_ref())?;
+        let mut engine = Self::in_memory(config);
+        engine.store = Some(store);
+        engine.words = loaded.words;
+        engine.sequence = loaded.sequence;
+        engine.journal_bytes = loaded.journal_bytes;
+        engine.enforce_capacity();
+        engine.rebuild_tries();
+        for token in loaded.journal {
+            engine.learn_inner(&token, false);
+        }
+        engine.pending.clear();
+        engine.pending_overflow = false;
+        Ok(engine)
+    }
+
+    pub(crate) fn lowest_ranked_index(&self) -> Option<usize> {
+        self.words
+            .iter()
+            .enumerate()
+            .min_by(|(_, left), (_, right)| {
+                left.uses
+                    .cmp(&right.uses)
+                    .then_with(|| left.last_used.cmp(&right.last_used))
+                    .then_with(|| right.text.cmp(&left.text))
+            })
+            .map(|(index, _)| index)
+    }
+
+    fn enforce_capacity(&mut self) {
+        while self.words.len() > self.config.max_words {
+            let Some(index) = self.lowest_ranked_index() else {
+                break;
+            };
+            self.words.swap_remove(index);
+        }
+    }
+}

--- a/crates/funput-suggestions/src/learning.rs
+++ b/crates/funput-suggestions/src/learning.rs
@@ -1,0 +1,87 @@
+use crate::engine::{PENDING_LIMIT, SuggestionEngine};
+use crate::types::{LearnOutcome, WordRecord};
+
+impl SuggestionEngine {
+    pub fn learn(&mut self, token: &str) -> LearnOutcome {
+        self.learn_inner(token, true)
+    }
+
+    pub(crate) fn learn_inner(&mut self, token: &str, record_pending: bool) -> LearnOutcome {
+        let normalized = crate::normalize::exact(token);
+        let length = normalized.chars().count();
+        if length == 0
+            || length > self.config.max_token_scalars
+            || normalized.chars().any(char::is_whitespace)
+        {
+            return LearnOutcome::Ignored;
+        }
+
+        self.sequence = self.sequence.saturating_add(1);
+        let (word_id, previous_uses, rebuild) = self.upsert_word(normalized.clone());
+        if record_pending {
+            if self.pending.len() < PENDING_LIMIT {
+                self.pending.push(normalized);
+            } else {
+                self.pending_overflow = true;
+            }
+        }
+        if rebuild {
+            self.rebuild_tries();
+        } else if self.words[word_id as usize].uses >= self.config.promotion_uses {
+            self.index_word(word_id);
+        }
+
+        let uses = self.words[word_id as usize].uses;
+        if previous_uses == 0 {
+            LearnOutcome::Recorded
+        } else if previous_uses < self.config.promotion_uses && uses >= self.config.promotion_uses {
+            LearnOutcome::Promoted
+        } else {
+            LearnOutcome::Updated
+        }
+    }
+
+    fn upsert_word(&mut self, normalized: String) -> (u32, u32, bool) {
+        if let Some(index) = self.words.iter().position(|word| word.text == normalized) {
+            let word = &mut self.words[index];
+            let previous = word.uses;
+            word.uses = word.uses.saturating_add(1);
+            word.last_used = self.sequence;
+            return (index as u32, previous, false);
+        }
+        let record = WordRecord {
+            text: normalized,
+            uses: 1,
+            last_used: self.sequence,
+        };
+        if self.words.len() < self.config.max_words {
+            let index = self.words.len() as u32;
+            self.words.push(record);
+            return (index, 0, false);
+        }
+        let index = self.lowest_ranked_index().unwrap_or(0);
+        let rebuild = self.words[index].uses >= self.config.promotion_uses;
+        self.words[index] = record;
+        (index as u32, 0, rebuild)
+    }
+
+    pub(crate) fn index_word(&mut self, word_id: u32) {
+        let word = &self.words[word_id as usize].text;
+        self.exact
+            .insert(crate::normalize::exact_chars(word), word_id, &self.words);
+        let folded = crate::normalize::folded(word);
+        if folded != *word {
+            self.folded.insert(folded.chars(), word_id, &self.words);
+        }
+    }
+
+    pub(crate) fn rebuild_tries(&mut self) {
+        self.exact.clear();
+        self.folded.clear();
+        for index in 0..self.words.len() {
+            if self.words[index].uses >= self.config.promotion_uses {
+                self.index_word(index as u32);
+            }
+        }
+    }
+}

--- a/crates/funput-suggestions/src/lib.rs
+++ b/crates/funput-suggestions/src/lib.rs
@@ -1,0 +1,22 @@
+//! Small, local-only personal suggestion engine.
+//!
+//! This crate is deliberately independent from the Vietnamese composition engine.
+//! Platforms own it on a background worker; lookup never performs I/O.
+
+mod config;
+mod engine;
+mod learning;
+mod normalize;
+mod persistence;
+mod query;
+mod ranking;
+mod storage;
+mod trie;
+mod types;
+
+pub use config::SuggestionConfig;
+pub use engine::SuggestionEngine;
+pub use types::{LearnOutcome, SuggestionSet, SuggestionStats};
+
+#[cfg(test)]
+mod tests;

--- a/crates/funput-suggestions/src/normalize.rs
+++ b/crates/funput-suggestions/src/normalize.rs
@@ -1,0 +1,37 @@
+use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
+
+pub(crate) fn exact_chars(input: &str) -> impl Iterator<Item = char> + '_ {
+    input.nfc().flat_map(char::to_lowercase)
+}
+
+pub(crate) fn folded_chars(input: &str) -> impl Iterator<Item = char> + '_ {
+    input
+        .nfd()
+        .flat_map(char::to_lowercase)
+        .filter(|ch| !is_combining_mark(*ch))
+        .map(|ch| match ch {
+            'đ' => 'd',
+            'Đ' => 'D',
+            _ => ch,
+        })
+}
+
+pub(crate) fn exact(input: &str) -> String {
+    exact_chars(input).collect()
+}
+
+pub(crate) fn folded(input: &str) -> String {
+    folded_chars(input).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_case_nfc_and_vietnamese_marks() {
+        assert_eq!(exact("A\u{0301}NH"), "ánh");
+        assert_eq!(folded("Đường"), "duong");
+        assert_eq!(folded("HOÀ"), "hoa");
+    }
+}

--- a/crates/funput-suggestions/src/persistence/binary.rs
+++ b/crates/funput-suggestions/src/persistence/binary.rs
@@ -1,0 +1,76 @@
+use std::io;
+
+pub(super) struct Cursor<'a> {
+    bytes: &'a [u8],
+    position: usize,
+}
+
+impl<'a> Cursor<'a> {
+    pub(super) fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, position: 0 }
+    }
+
+    pub(super) fn take(&mut self, len: usize) -> io::Result<&'a [u8]> {
+        let end = self.position.checked_add(len).ok_or_else(invalid_data)?;
+        let value = self
+            .bytes
+            .get(self.position..end)
+            .ok_or_else(invalid_data)?;
+        self.position = end;
+        Ok(value)
+    }
+
+    pub(super) fn u16(&mut self) -> io::Result<u16> {
+        Ok(u16::from_le_bytes(
+            self.take(2)?.try_into().map_err(|_| invalid_data())?,
+        ))
+    }
+
+    pub(super) fn u32(&mut self) -> io::Result<u32> {
+        Ok(u32::from_le_bytes(
+            self.take(4)?.try_into().map_err(|_| invalid_data())?,
+        ))
+    }
+
+    pub(super) fn u64(&mut self) -> io::Result<u64> {
+        Ok(u64::from_le_bytes(
+            self.take(8)?.try_into().map_err(|_| invalid_data())?,
+        ))
+    }
+
+    pub(super) fn remaining(&self) -> usize {
+        self.bytes.len() - self.position
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.position == self.bytes.len()
+    }
+}
+
+pub(super) fn put_u16(out: &mut Vec<u8>, value: u16) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+pub(super) fn put_u32(out: &mut Vec<u8>, value: u32) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+pub(super) fn put_u64(out: &mut Vec<u8>, value: u64) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+pub(crate) fn checksum(bytes: &[u8]) -> u32 {
+    let mut crc = u32::MAX;
+    for byte in bytes {
+        crc ^= u32::from(*byte);
+        for _ in 0..8 {
+            let mask = 0u32.wrapping_sub(crc & 1);
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+pub(super) fn invalid_data() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, "invalid personal lexicon data")
+}

--- a/crates/funput-suggestions/src/persistence/journal.rs
+++ b/crates/funput-suggestions/src/persistence/journal.rs
@@ -1,0 +1,61 @@
+use std::fs;
+use std::io;
+
+use super::binary::{Cursor, checksum, invalid_data};
+use super::{JOURNAL_MAGIC, MAX_JOURNAL_BYTES, Store, VERSION};
+
+impl Store {
+    pub(super) fn load_journal(&self) -> io::Result<(Vec<String>, u64)> {
+        let path = self.journal_path();
+        let bytes = match fs::metadata(&path) {
+            Ok(metadata) if metadata.len() > MAX_JOURNAL_BYTES => return Err(invalid_data()),
+            Ok(_) => fs::read(path)?,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok((Vec::new(), 0)),
+            Err(error) => return Err(error),
+        };
+        let journal_bytes = bytes.len() as u64;
+        let mut cursor = Cursor::new(&bytes);
+        let mut tokens = Vec::new();
+        while !cursor.is_empty() {
+            match decode_frame(&mut cursor) {
+                Ok(frame) => tokens.extend(frame),
+                Err(error) if error.kind() == io::ErrorKind::Unsupported => return Err(error),
+                Err(_) => break,
+            }
+        }
+        Ok((tokens, journal_bytes))
+    }
+}
+
+fn decode_frame(cursor: &mut Cursor<'_>) -> io::Result<Vec<String>> {
+    if cursor.take(JOURNAL_MAGIC.len())? != JOURNAL_MAGIC {
+        return Err(invalid_data());
+    }
+    if cursor.u16()? != VERSION {
+        return Err(io::Error::new(io::ErrorKind::Unsupported, "journal schema"));
+    }
+    let payload_len = cursor.u32()? as usize;
+    let expected = cursor.u32()?;
+    let payload = cursor.take(payload_len)?;
+    if checksum(payload) != expected {
+        return Err(invalid_data());
+    }
+    let mut payload = Cursor::new(payload);
+    let count = payload.u32()? as usize;
+    if count > payload.remaining() / 2 {
+        return Err(invalid_data());
+    }
+    let mut tokens = Vec::with_capacity(count);
+    for _ in 0..count {
+        let len = payload.u16()? as usize;
+        tokens.push(
+            std::str::from_utf8(payload.take(len)?)
+                .map_err(|_| invalid_data())?
+                .to_owned(),
+        );
+    }
+    if !payload.is_empty() {
+        return Err(invalid_data());
+    }
+    Ok(tokens)
+}

--- a/crates/funput-suggestions/src/persistence/mod.rs
+++ b/crates/funput-suggestions/src/persistence/mod.rs
@@ -1,0 +1,104 @@
+mod binary;
+mod journal;
+mod snapshot;
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use crate::types::WordRecord;
+use binary::{checksum as crc32, put_u16, put_u32};
+
+const SNAPSHOT_MAGIC: &[u8; 8] = b"FPSNAP01";
+const JOURNAL_MAGIC: &[u8; 4] = b"FPJR";
+const VERSION: u16 = 1;
+const MAX_SNAPSHOT_BYTES: u64 = 2 * 1024 * 1024;
+const MAX_JOURNAL_BYTES: u64 = 1024 * 1024;
+
+pub(crate) struct Store {
+    pub(super) root: PathBuf,
+}
+
+pub(crate) struct Loaded {
+    pub(crate) words: Vec<WordRecord>,
+    pub(crate) sequence: u64,
+    pub(crate) journal: Vec<String>,
+    pub(crate) journal_bytes: u64,
+}
+
+impl Store {
+    pub(crate) fn open(root: &Path) -> io::Result<(Self, Loaded)> {
+        fs::create_dir_all(root)?;
+        let store = Self {
+            root: root.to_owned(),
+        };
+        let snapshot = store.load_snapshot()?;
+        let (words, sequence, snapshot_valid) = match snapshot {
+            Some((words, sequence)) => (words, sequence, true),
+            None => (Vec::new(), 0, false),
+        };
+        let (journal, journal_bytes) = if snapshot_valid {
+            store.load_journal()?
+        } else {
+            (Vec::new(), 0)
+        };
+        Ok((
+            store,
+            Loaded {
+                words,
+                sequence,
+                journal,
+                journal_bytes,
+            },
+        ))
+    }
+
+    pub(crate) fn append_journal(&self, tokens: &[String]) -> io::Result<u64> {
+        if tokens.is_empty() {
+            return Ok(0);
+        }
+        let mut payload = Vec::new();
+        put_u32(&mut payload, tokens.len() as u32);
+        for token in tokens {
+            put_u16(&mut payload, token.len() as u16);
+            payload.extend_from_slice(token.as_bytes());
+        }
+        let mut frame = Vec::with_capacity(14 + payload.len());
+        frame.extend_from_slice(JOURNAL_MAGIC);
+        put_u16(&mut frame, VERSION);
+        put_u32(&mut frame, payload.len() as u32);
+        put_u32(&mut frame, crc32(&payload));
+        frame.extend_from_slice(&payload);
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.journal_path())?;
+        file.write_all(&frame)?;
+        file.sync_data()?;
+        Ok(frame.len() as u64)
+    }
+
+    pub(crate) fn compact(&self, words: &[WordRecord], sequence: u64) -> io::Result<u64> {
+        let bytes = snapshot::encode(words, sequence);
+        let temporary = self.root.join("personal-lexicon.snapshot.tmp");
+        let mut file = File::create(&temporary)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        fs::rename(&temporary, self.snapshot_path())?;
+        let journal = File::create(self.journal_path())?;
+        journal.sync_all()?;
+        Ok(bytes.len() as u64)
+    }
+
+    pub(super) fn snapshot_path(&self) -> PathBuf {
+        self.root.join("personal-lexicon.snapshot")
+    }
+
+    pub(super) fn journal_path(&self) -> PathBuf {
+        self.root.join("personal-lexicon.journal")
+    }
+}
+
+#[cfg(test)]
+pub(crate) use binary::checksum;

--- a/crates/funput-suggestions/src/persistence/snapshot.rs
+++ b/crates/funput-suggestions/src/persistence/snapshot.rs
@@ -1,0 +1,81 @@
+use std::fs::File;
+use std::io::{self, Read};
+
+use crate::types::WordRecord;
+
+use super::binary::{Cursor, checksum, invalid_data, put_u16, put_u32, put_u64};
+use super::{MAX_SNAPSHOT_BYTES, SNAPSHOT_MAGIC, Store, VERSION};
+
+pub(super) fn encode(words: &[WordRecord], sequence: u64) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(SNAPSHOT_MAGIC);
+    put_u16(&mut bytes, VERSION);
+    put_u64(&mut bytes, sequence);
+    put_u32(&mut bytes, words.len() as u32);
+    for word in words {
+        put_u16(&mut bytes, word.text.len() as u16);
+        bytes.extend_from_slice(word.text.as_bytes());
+        put_u32(&mut bytes, word.uses);
+        put_u64(&mut bytes, word.last_used);
+    }
+    let sum = checksum(&bytes);
+    put_u32(&mut bytes, sum);
+    bytes
+}
+
+impl Store {
+    pub(super) fn load_snapshot(&self) -> io::Result<Option<(Vec<WordRecord>, u64)>> {
+        let mut bytes = Vec::new();
+        match File::open(self.snapshot_path()) {
+            Ok(mut file) => {
+                if file.metadata()?.len() > MAX_SNAPSHOT_BYTES {
+                    return Ok(None);
+                }
+                file.read_to_end(&mut bytes)?;
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Ok(Some((Vec::new(), 0)));
+            }
+            Err(error) => return Err(error),
+        }
+        decode(&bytes)
+    }
+}
+
+fn decode(bytes: &[u8]) -> io::Result<Option<(Vec<WordRecord>, u64)>> {
+    if bytes.len() < SNAPSHOT_MAGIC.len() + 2 + 8 + 4 + 4 {
+        return Ok(None);
+    }
+    let (content, checksum_bytes) = bytes.split_at(bytes.len() - 4);
+    if checksum(content) != Cursor::new(checksum_bytes).u32()? {
+        return Ok(None);
+    }
+    let mut cursor = Cursor::new(content);
+    if cursor.take(SNAPSHOT_MAGIC.len())? != SNAPSHOT_MAGIC {
+        return Ok(None);
+    }
+    if cursor.u16()? != VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "personal lexicon schema is newer or unsupported",
+        ));
+    }
+    let sequence = cursor.u64()?;
+    let count = cursor.u32()? as usize;
+    if count > cursor.remaining() / 14 {
+        return Ok(None);
+    }
+    let mut words = Vec::with_capacity(count);
+    for _ in 0..count {
+        let len = cursor.u16()? as usize;
+        let text = std::str::from_utf8(cursor.take(len)?)
+            .map_err(|_| invalid_data())?
+            .to_owned();
+        words.push(WordRecord {
+            text,
+            uses: cursor.u32()?,
+            last_used: cursor.u64()?,
+        });
+    }
+    Ok(cursor.is_empty().then_some((words, sequence)))
+}

--- a/crates/funput-suggestions/src/query.rs
+++ b/crates/funput-suggestions/src/query.rs
@@ -1,0 +1,70 @@
+use std::array;
+
+use crate::engine::SuggestionEngine;
+use crate::trie::{NONE, TOP_K};
+use crate::types::{SuggestionSet, SuggestionStats, WordRecord};
+
+impl SuggestionEngine {
+    pub fn suggest(&self, prefix: &str) -> SuggestionSet<'_> {
+        let scalar_count = crate::normalize::exact_chars(prefix).count();
+        if scalar_count == 0 || scalar_count > self.config.max_token_scalars {
+            return SuggestionSet {
+                items: [None; TOP_K],
+                len: 0,
+            };
+        }
+        let exact = self.exact.find(crate::normalize::exact_chars(prefix));
+        let differs =
+            crate::normalize::folded_chars(prefix).ne(crate::normalize::exact_chars(prefix));
+        let folded = if differs {
+            [NONE; TOP_K]
+        } else {
+            self.folded.find(crate::normalize::folded_chars(prefix))
+        };
+
+        let mut ids = [NONE; TOP_K];
+        let mut len = 0;
+        for id in exact.into_iter().chain(folded) {
+            if id != NONE && !ids[..len].contains(&id) && len < TOP_K {
+                ids[len] = id;
+                len += 1;
+            }
+        }
+        let items = array::from_fn(|index| {
+            ids.get(index)
+                .copied()
+                .filter(|id| *id != NONE)
+                .and_then(|id| self.words.get(id as usize))
+                .map(|word| word.text.as_str())
+        });
+        SuggestionSet { items, len }
+    }
+
+    pub fn stats(&self) -> SuggestionStats {
+        let word_bytes = self.words.capacity() * size_of::<WordRecord>()
+            + self
+                .words
+                .iter()
+                .map(|word| word.text.capacity())
+                .sum::<usize>();
+        let pending_bytes = self.pending.capacity() * size_of::<String>()
+            + self.pending.iter().map(String::capacity).sum::<usize>();
+        SuggestionStats {
+            words: self.words.len(),
+            promoted_words: self
+                .words
+                .iter()
+                .filter(|word| word.uses >= self.config.promotion_uses)
+                .count(),
+            exact_nodes: self.exact.node_count(),
+            folded_nodes: self.folded.node_count(),
+            pending_mutations: self.pending.len(),
+            journal_bytes: self.journal_bytes,
+            estimated_heap_bytes: word_bytes
+                + pending_bytes
+                + self.exact.heap_bytes()
+                + self.folded.heap_bytes(),
+            last_snapshot_bytes: self.last_snapshot_bytes,
+        }
+    }
+}

--- a/crates/funput-suggestions/src/ranking.rs
+++ b/crates/funput-suggestions/src/ranking.rs
@@ -1,0 +1,18 @@
+use crate::trie::NONE;
+use crate::types::WordRecord;
+
+pub(crate) fn ranks_before(left: u32, right: u32, words: &[WordRecord]) -> bool {
+    if left == NONE {
+        return false;
+    }
+    if right == NONE {
+        return true;
+    }
+    let left = &words[left as usize];
+    let right = &words[right as usize];
+    left.uses
+        .cmp(&right.uses)
+        .then_with(|| left.last_used.cmp(&right.last_used))
+        .then_with(|| right.text.cmp(&left.text))
+        .is_gt()
+}

--- a/crates/funput-suggestions/src/storage.rs
+++ b/crates/funput-suggestions/src/storage.rs
@@ -1,0 +1,55 @@
+use std::io;
+
+use crate::engine::{JOURNAL_COMPACT_BYTES, SuggestionEngine};
+
+impl SuggestionEngine {
+    pub fn flush(&mut self) -> io::Result<()> {
+        if self.pending.is_empty() && !self.pending_overflow {
+            return Ok(());
+        }
+        if self.pending_overflow {
+            return self.compact().map(|_| ());
+        }
+        let Some(store) = &self.store else {
+            self.pending.clear();
+            return Ok(());
+        };
+        self.journal_bytes = self
+            .journal_bytes
+            .saturating_add(store.append_journal(&self.pending)?);
+        self.pending.clear();
+        if self.journal_bytes >= JOURNAL_COMPACT_BYTES
+            && let Err(error) = self.compact()
+        {
+            self.pending_overflow = true;
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    pub fn compact(&mut self) -> io::Result<u64> {
+        let Some(store) = &self.store else {
+            self.pending.clear();
+            self.pending_overflow = false;
+            self.last_snapshot_bytes = 0;
+            self.journal_bytes = 0;
+            return Ok(0);
+        };
+        let bytes = store.compact(&self.words, self.sequence)?;
+        self.pending.clear();
+        self.pending_overflow = false;
+        self.last_snapshot_bytes = bytes;
+        self.journal_bytes = 0;
+        Ok(bytes)
+    }
+
+    pub fn reset(&mut self) -> io::Result<()> {
+        self.words.clear();
+        self.exact.clear();
+        self.folded.clear();
+        self.sequence = 0;
+        self.pending.clear();
+        self.pending_overflow = false;
+        self.compact().map(|_| ())
+    }
+}

--- a/crates/funput-suggestions/src/tests/learning.rs
+++ b/crates/funput-suggestions/src/tests/learning.rs
@@ -1,0 +1,67 @@
+use proptest::prelude::*;
+
+use super::*;
+
+#[test]
+fn second_use_promotes_and_ranking_is_deterministic() {
+    let mut engine = SuggestionEngine::in_memory(SuggestionConfig::default());
+    assert_eq!(engine.learn("không"), LearnOutcome::Recorded);
+    assert!(engine.suggest("kh").is_empty());
+    assert_eq!(engine.learn("không"), LearnOutcome::Promoted);
+    learned(&mut engine, "khỏe", 3);
+    learned(&mut engine, "khoa", 2);
+    assert_eq!(texts(&engine, "kh"), ["khỏe", "khoa", "không"]);
+}
+
+#[test]
+fn exact_and_folded_results_merge_without_duplicates() {
+    let mut engine = SuggestionEngine::in_memory(SuggestionConfig::default());
+    learned(&mut engine, "hoa", 4);
+    learned(&mut engine, "hòa", 3);
+    learned(&mut engine, "hóa", 2);
+    assert_eq!(texts(&engine, "ho"), ["hoa", "hòa", "hóa"]);
+    assert_eq!(texts(&engine, "hò"), ["hòa"]);
+}
+
+#[test]
+fn decomposed_uppercase_query_matches_nfc_words() {
+    let mut engine = SuggestionEngine::in_memory(SuggestionConfig::default());
+    learned(&mut engine, "ánh", 2);
+    assert_eq!(texts(&engine, "A\u{0301}"), ["ánh"]);
+}
+
+#[test]
+fn capacity_evicts_one_off_words_and_remains_bounded() {
+    let config = SuggestionConfig {
+        max_words: 3,
+        ..SuggestionConfig::default()
+    };
+    let mut engine = SuggestionEngine::in_memory(config);
+    learned(&mut engine, "alpha", 2);
+    engine.learn("beta");
+    engine.learn("gamma");
+    engine.learn("delta");
+    assert_eq!(engine.stats().words, 3);
+    assert_eq!(texts(&engine, "al"), ["alpha"]);
+}
+
+#[test]
+fn invalid_or_oversized_tokens_are_ignored() {
+    let mut engine = SuggestionEngine::in_memory(SuggestionConfig {
+        max_token_scalars: 4,
+        ..SuggestionConfig::default()
+    });
+    assert_eq!(engine.learn(""), LearnOutcome::Ignored);
+    assert_eq!(engine.learn("hai từ"), LearnOutcome::Ignored);
+    assert_eq!(engine.learn("abcde"), LearnOutcome::Ignored);
+    assert_eq!(engine.stats().words, 0);
+}
+
+proptest! {
+    #[test]
+    fn arbitrary_unicode_never_panics(value in any::<String>()) {
+        let mut engine = SuggestionEngine::in_memory(SuggestionConfig::default());
+        let _ = engine.learn(&value);
+        let _ = engine.suggest(&value);
+    }
+}

--- a/crates/funput-suggestions/src/tests/mod.rs
+++ b/crates/funput-suggestions/src/tests/mod.rs
@@ -1,0 +1,15 @@
+mod learning;
+mod persistence;
+mod stress;
+
+use super::*;
+
+fn learned(engine: &mut SuggestionEngine, word: &str, uses: usize) {
+    for _ in 0..uses {
+        engine.learn(word);
+    }
+}
+
+fn texts(engine: &SuggestionEngine, prefix: &str) -> Vec<String> {
+    engine.suggest(prefix).iter().map(str::to_owned).collect()
+}

--- a/crates/funput-suggestions/src/tests/persistence.rs
+++ b/crates/funput-suggestions/src/tests/persistence.rs
@@ -1,0 +1,97 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+
+use tempfile::tempdir;
+
+use super::*;
+
+#[test]
+fn snapshot_and_journal_round_trip() {
+    let directory = tempdir().unwrap();
+    {
+        let mut engine =
+            SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+        learned(&mut engine, "chào", 2);
+        engine.compact().unwrap();
+        learned(&mut engine, "chào", 1);
+        learned(&mut engine, "chúc", 2);
+        engine.flush().unwrap();
+    }
+    let reopened = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    assert_eq!(texts(&reopened, "ch"), ["chào", "chúc"]);
+    assert_eq!(reopened.stats().words, 2);
+}
+
+#[test]
+fn truncated_journal_keeps_complete_frames() {
+    let directory = tempdir().unwrap();
+    let mut engine = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    learned(&mut engine, "một", 2);
+    engine.compact().unwrap();
+    learned(&mut engine, "mới", 2);
+    engine.flush().unwrap();
+    let journal = directory.path().join("personal-lexicon.journal");
+    OpenOptions::new()
+        .append(true)
+        .open(journal)
+        .unwrap()
+        .write_all(b"FPJ")
+        .unwrap();
+    drop(engine);
+    let reopened = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    assert_eq!(texts(&reopened, "m"), ["mới", "một"]);
+}
+
+#[test]
+fn corrupt_snapshot_fails_closed_to_an_empty_store() {
+    let directory = tempdir().unwrap();
+    fs::write(
+        directory.path().join("personal-lexicon.snapshot"),
+        b"corrupt",
+    )
+    .unwrap();
+    fs::write(
+        directory.path().join("personal-lexicon.journal"),
+        b"ignored",
+    )
+    .unwrap();
+    let engine = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    assert!(engine.suggest("anything").is_empty());
+}
+
+#[test]
+fn newer_schema_is_rejected_without_overwriting_it() {
+    let directory = tempdir().unwrap();
+    let snapshot = directory.path().join("personal-lexicon.snapshot");
+    let mut engine = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    learned(&mut engine, "schema", 2);
+    engine.compact().unwrap();
+    drop(engine);
+    let mut bytes = fs::read(&snapshot).unwrap();
+    bytes[8..10].copy_from_slice(&2u16.to_le_bytes());
+    let content_len = bytes.len() - 4;
+    let sum = crate::persistence::checksum(&bytes[..content_len]);
+    bytes[content_len..].copy_from_slice(&sum.to_le_bytes());
+    fs::write(&snapshot, &bytes).unwrap();
+    let error = SuggestionEngine::open(directory.path(), SuggestionConfig::default())
+        .err()
+        .expect("newer schema must be unavailable");
+    assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
+    assert_eq!(fs::read(snapshot).unwrap(), bytes);
+}
+
+#[test]
+fn abandoned_temporary_snapshot_keeps_last_good_state() {
+    let directory = tempdir().unwrap();
+    let mut engine = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    learned(&mut engine, "antoàn", 2);
+    engine.compact().unwrap();
+    fs::write(
+        directory.path().join("personal-lexicon.snapshot.tmp"),
+        b"partial",
+    )
+    .unwrap();
+    drop(engine);
+    let reopened = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    assert_eq!(texts(&reopened, "an"), ["antoàn"]);
+}

--- a/crates/funput-suggestions/src/tests/stress.rs
+++ b/crates/funput-suggestions/src/tests/stress.rs
@@ -1,0 +1,65 @@
+use tempfile::tempdir;
+
+use super::*;
+
+#[test]
+fn stress_is_bounded_after_one_hundred_thousand_operations() {
+    let mut engine = SuggestionEngine::in_memory(SuggestionConfig::default());
+    for index in 0..100_000 {
+        engine.learn(&format!("word{:04}", index % 6_000));
+        let _ = engine.suggest("word");
+    }
+    let stats = engine.stats();
+    assert_eq!(stats.words, 5_000);
+    assert!(stats.estimated_heap_bytes < 4 * 1024 * 1024, "{stats:?}");
+}
+
+#[test]
+fn five_thousand_word_snapshot_stays_under_budget() {
+    let directory = tempdir().unwrap();
+    let mut engine = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    for index in 0..5_000 {
+        let word = format!("word{index:04}");
+        learned(&mut engine, &word, 2);
+    }
+    let stats = engine.stats();
+    assert!(stats.estimated_heap_bytes < 4 * 1024 * 1024, "{stats:?}");
+    assert!(engine.compact().unwrap() < 2 * 1024 * 1024);
+}
+
+#[test]
+fn capacity_churn_does_not_grow_the_trie() {
+    let mut engine = SuggestionEngine::in_memory(SuggestionConfig {
+        max_words: 100,
+        ..SuggestionConfig::default()
+    });
+    for index in 0..100 {
+        learned(&mut engine, &format!("stable{index:03}"), 2);
+    }
+    let before = engine.stats();
+    for index in 0..10_000 {
+        engine.learn(&format!("transient{index:05}"));
+    }
+    let after = engine.stats();
+    assert_eq!(after.words, 100);
+    assert!(
+        after.exact_nodes <= before.exact_nodes,
+        "{before:?} -> {after:?}"
+    );
+}
+
+#[test]
+fn journal_auto_compacts_before_it_can_grow_unbounded() {
+    let directory = tempdir().unwrap();
+    let mut engine = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    let token = "abcdefghijklmnopqrstuvwxyzabcdef";
+    for _ in 0..24 {
+        for _ in 0..100 {
+            engine.learn(token);
+        }
+        engine.flush().unwrap();
+    }
+    let stats = engine.stats();
+    assert!(stats.journal_bytes < 64 * 1024, "{stats:?}");
+    assert!(stats.last_snapshot_bytes > 0, "{stats:?}");
+}

--- a/crates/funput-suggestions/src/trie.rs
+++ b/crates/funput-suggestions/src/trie.rs
@@ -1,0 +1,139 @@
+use std::cmp::Ordering;
+
+use crate::ranking::ranks_before;
+use crate::types::WordRecord;
+
+pub(crate) const NONE: u32 = u32::MAX;
+pub(crate) const TOP_K: usize = 3;
+
+#[derive(Debug, Clone)]
+struct Node {
+    label: char,
+    first_child: u32,
+    next_sibling: u32,
+    top: [u32; TOP_K],
+}
+
+impl Node {
+    fn new(label: char) -> Self {
+        Self {
+            label,
+            first_child: NONE,
+            next_sibling: NONE,
+            top: [NONE; TOP_K],
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ArenaTrie {
+    nodes: Vec<Node>,
+}
+
+impl ArenaTrie {
+    pub(crate) fn new() -> Self {
+        Self {
+            nodes: vec![Node::new('\0')],
+        }
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.nodes.clear();
+        self.nodes.push(Node::new('\0'));
+    }
+
+    pub(crate) fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub(crate) fn heap_bytes(&self) -> usize {
+        self.nodes.capacity() * size_of::<Node>()
+    }
+
+    pub(crate) fn insert(
+        &mut self,
+        chars: impl Iterator<Item = char>,
+        word_id: u32,
+        words: &[WordRecord],
+    ) {
+        let mut node = 0u32;
+        for ch in chars {
+            node = self.ensure_child(node, ch);
+            Self::update_top(&mut self.nodes[node as usize], word_id, words);
+        }
+    }
+
+    pub(crate) fn find(&self, chars: impl Iterator<Item = char>) -> [u32; TOP_K] {
+        let mut node = 0u32;
+        let mut consumed = false;
+        for ch in chars {
+            consumed = true;
+            let Some(next) = self.child(node, ch) else {
+                return [NONE; TOP_K];
+            };
+            node = next;
+        }
+        if consumed {
+            self.nodes[node as usize].top
+        } else {
+            [NONE; TOP_K]
+        }
+    }
+
+    fn child(&self, parent: u32, label: char) -> Option<u32> {
+        let mut current = self.nodes[parent as usize].first_child;
+        while current != NONE {
+            let node = &self.nodes[current as usize];
+            match node.label.cmp(&label) {
+                Ordering::Equal => return Some(current),
+                Ordering::Greater => return None,
+                Ordering::Less => current = node.next_sibling,
+            }
+        }
+        None
+    }
+
+    fn ensure_child(&mut self, parent: u32, label: char) -> u32 {
+        let mut previous = NONE;
+        let mut current = self.nodes[parent as usize].first_child;
+        while current != NONE {
+            let node = &self.nodes[current as usize];
+            match node.label.cmp(&label) {
+                Ordering::Equal => return current,
+                Ordering::Greater => break,
+                Ordering::Less => {
+                    previous = current;
+                    current = node.next_sibling;
+                }
+            }
+        }
+
+        let index = self.nodes.len() as u32;
+        let mut node = Node::new(label);
+        node.next_sibling = current;
+        self.nodes.push(node);
+        if previous == NONE {
+            self.nodes[parent as usize].first_child = index;
+        } else {
+            self.nodes[previous as usize].next_sibling = index;
+        }
+        index
+    }
+
+    fn update_top(node: &mut Node, word_id: u32, words: &[WordRecord]) {
+        let mut candidates = [NONE; TOP_K + 1];
+        candidates[..TOP_K].copy_from_slice(&node.top);
+        if !node.top.contains(&word_id) {
+            candidates[TOP_K] = word_id;
+        }
+
+        for left in 0..candidates.len() {
+            for right in (left + 1)..candidates.len() {
+                if ranks_before(candidates[right], candidates[left], words) {
+                    candidates.swap(left, right);
+                }
+            }
+        }
+        node.top.copy_from_slice(&candidates[..TOP_K]);
+    }
+}

--- a/crates/funput-suggestions/src/types.rs
+++ b/crates/funput-suggestions/src/types.rs
@@ -1,0 +1,48 @@
+use crate::trie::TOP_K;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LearnOutcome {
+    Ignored,
+    Recorded,
+    Promoted,
+    Updated,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SuggestionStats {
+    pub words: usize,
+    pub promoted_words: usize,
+    pub exact_nodes: usize,
+    pub folded_nodes: usize,
+    pub pending_mutations: usize,
+    pub journal_bytes: u64,
+    pub estimated_heap_bytes: usize,
+    pub last_snapshot_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SuggestionSet<'a> {
+    pub(crate) items: [Option<&'a str>; TOP_K],
+    pub(crate) len: usize,
+}
+
+impl<'a> SuggestionSet<'a> {
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &'a str> + '_ {
+        self.items[..self.len].iter().filter_map(|item| *item)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WordRecord {
+    pub(crate) text: String,
+    pub(crate) uses: u32,
+    pub(crate) last_used: u64,
+}

--- a/crates/funput-suggestions/tests/alloc_budget.rs
+++ b/crates/funput-suggestions/tests/alloc_budget.rs
@@ -1,0 +1,42 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use funput_suggestions::{SuggestionConfig, SuggestionEngine};
+
+struct CountingAllocator;
+
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.realloc(pointer, layout, size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+#[test]
+fn warm_lookup_does_not_allocate() {
+    let mut engine = SuggestionEngine::in_memory(SuggestionConfig::default());
+    for word in ["không", "khỏe", "khoa", "hòa"] {
+        engine.learn(word);
+        engine.learn(word);
+    }
+    let before = ALLOCATIONS.load(Ordering::Relaxed);
+    for _ in 0..100_000 {
+        std::hint::black_box(engine.suggest(std::hint::black_box("kh")));
+    }
+    let allocations = ALLOCATIONS.load(Ordering::Relaxed) - before;
+    assert_eq!(allocations, 0, "warm lookup allocated {allocations} times");
+}


### PR DESCRIPTION
## Summary

- add the independent `funput-suggestions` crate with bounded word storage and compact top-3 tries
- support exact NFC/lowercase lookup and Vietnamese accent-folded lookup without I/O on query
- learn words locally, promote on the second use, rank by frequency/recency/lexical order, and cap storage at 5,000 records
- persist through checksummed snapshots and journals with truncated-frame recovery and atomic compaction
- expose a separate fail-silent C ABI with opaque handles, fixed-size POD results, and panic containment
- add Criterion benchmarks, percentile harnesses, allocation guards, corruption tests, and 100,000-operation stress coverage

## Why

Funput needs a private, low-latency foundation for personal suggestions before the mobile UI is integrated. Keeping this engine separate from the composer ensures unavailable storage, malformed input, I/O failures, or FFI panics cannot change Vietnamese typing behavior.

## Performance and memory

- Rust query p95: 250 ns with a warm 5,000-word lexicon
- C FFI query p95: 292 ns
- warm Rust lookup: zero heap allocations across 100,000 queries
- retained heap: approximately 559 KiB for the 5,000-word fixture, below the 4 MiB budget
- snapshot: below the 2 MiB budget
- existing typing median regression: at most 1.39%, within the 3% budget
- trie nodes and memory remain bounded during 100,000-operation capacity churn

## Failure behavior and privacy

- no network, telemetry, cloud sync, database, async runtime, or composer integration
- invalid input, null pointers, corrupted data, unsupported schemas, I/O errors, and panics return neutral results
- query performs no disk I/O and caller-owned result buffers require no free function
- newer persistence schemas are preserved and never overwritten

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --release`
- warm lookup allocation budget
- Criterion before/after checks for `funput-core`, `funput-engine`, and `funput-ffi`
- static XCFramework Release build for iOS device and simulator
- generated C header check and `git diff --check`

## Follow-up

The iOS worker, token tracking, toolbar, settings, and App Group persistence integration remain in #76 and should merge after this foundation.
