### PR TITLE
fix(ios): align key hints and blend themed keyboard edges

### DIFF
--- a/platforms/ios/Keyboard/KeyboardViewController+Emoji.swift
+++ b/platforms/ios/Keyboard/KeyboardViewController+Emoji.swift
@@ -39,6 +39,7 @@ extension KeyboardViewController {
     func refreshEmojiPresentation() {
         emojiView.apply(
             theme: keyboardView.presentation.theme,
+            blendsSystemEdge: keyboardView.presentation.blendsSystemEdge,
             recent: emojiRecentsStore.load().compactMap(emojiItem)
         )
     }

--- a/platforms/ios/Keyboard/KeyboardViewController+Input.swift
+++ b/platforms/ios/Keyboard/KeyboardViewController+Input.swift
@@ -82,6 +82,7 @@ extension KeyboardViewController {
         presentation.language = state.language
         presentation.enterAction = state.enterAction
         presentation.theme = themed.theme
+        presentation.blendsSystemEdge = themed.blendsSystemEdge
         presentation.isHapticFeedbackEnabled = configuration.isHapticFeedbackEnabled
         presentation.isKeySoundEnabled = configuration.isKeySoundEnabled
         presentation.showsKeyPreviews = !state.editorMode.isPassword && configuration.showsKeyPreviews

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardConfiguration/Presentation/KeyboardPresentationFactory.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardConfiguration/Presentation/KeyboardPresentationFactory.swift
@@ -31,6 +31,8 @@ public enum KeyboardPresentationFactory {
             layout: layout,
             sizing: sizing,
             theme: theme,
+            blendsSystemEdge: selectedTheme(for: configuration, catalog: catalog).id
+                != BundledThemes.default.id,
             language: configuration.language,
             isHapticFeedbackEnabled: configuration.isHapticFeedbackEnabled,
             isKeySoundEnabled: configuration.isKeySoundEnabled,
@@ -44,11 +46,18 @@ public enum KeyboardPresentationFactory {
         for configuration: FunputConfiguration,
         catalog: ThemeCatalog = ThemeCatalog()
     ) -> ResolvedTheme {
-        let authored = catalog.theme(id: configuration.selectedThemeID) ?? BundledThemes.default
+        let authored = selectedTheme(for: configuration, catalog: catalog)
         let context = ThemeResolveContext(
             reduceTransparency: UIAccessibility.isReduceTransparencyEnabled
         )
         return ThemeRuntime.resolve(authored, context: context)
+    }
+
+    private static func selectedTheme(
+        for configuration: FunputConfiguration,
+        catalog: ThemeCatalog
+    ) -> KeyboardTheme {
+        catalog.theme(id: configuration.selectedThemeID) ?? BundledThemes.default
     }
 }
 #endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Emoji/EmojiKeyboardView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Emoji/EmojiKeyboardView.swift
@@ -14,6 +14,7 @@ public final class EmojiKeyboardView: UIView {
     var sections: [(category: EmojiCategory, items: [EmojiItem])] = []
     var selectedCategory = EmojiCategory.smileysPeople
     var theme = ResolvedTheme.funputGlass
+    var blendsSystemEdge = false
     public var backgroundImage: UIImage? { didSet { applyTheme() } }
     private let catalog: EmojiCatalog
 
@@ -44,8 +45,13 @@ public final class EmojiKeyboardView: UIView {
         applyTheme()
     }
 
-    public func apply(theme: ResolvedTheme, recent: [EmojiItem]) {
+    public func apply(
+        theme: ResolvedTheme,
+        blendsSystemEdge: Bool = false,
+        recent: [EmojiItem]
+    ) {
         self.theme = theme
+        self.blendsSystemEdge = blendsSystemEdge
         reload(recent: recent)
         applyTheme()
     }
@@ -104,7 +110,12 @@ public final class EmojiKeyboardView: UIView {
 
     private func applyTheme() {
         let label = theme.label.uiColor(for: traitCollection)
-        backdropView.apply(theme: theme, traits: traitCollection, image: backgroundImage)
+        backdropView.apply(
+            theme: theme,
+            traits: traitCollection,
+            image: backgroundImage,
+            blendsSystemEdge: blendsSystemEdge
+        )
         bottomBar.apply(color: label, selected: selectedCategory)
         collectionView.reloadData()
     }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/Content/KeyboardKeyContentGeometry.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/Content/KeyboardKeyContentGeometry.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct KeyboardKeyContentFrames {
+    let primaryLabel: CGRect
+    let hint: CGRect
+    let icon: CGRect
+}
+
+enum KeyboardKeyContentGeometry {
+    static func frames(in bounds: CGRect, hintLineHeight: CGFloat) -> KeyboardKeyContentFrames {
+        let inset = max(6, bounds.height * 0.2)
+        let hintHeight = min(bounds.height * 0.3, hintLineHeight + 2)
+        return KeyboardKeyContentFrames(
+            primaryLabel: bounds.insetBy(dx: 5, dy: inset * 0.5),
+            hint: CGRect(x: 4, y: 3, width: bounds.width - 8, height: hintHeight),
+            icon: bounds.insetBy(dx: inset, dy: inset)
+        )
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/Content/KeyboardKeyContentView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/Content/KeyboardKeyContentView.swift
@@ -13,6 +13,7 @@ final class KeyboardKeyContentView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         [label, secondaryLabel].forEach(configureLabel)
+        secondaryLabel.textAlignment = .right
         configureIcon()
         spacebarView.isUserInteractionEnabled = false
         addSubview(spacebarView)
@@ -25,21 +26,14 @@ final class KeyboardKeyContentView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        let inset = max(6, bounds.height * 0.2)
-        label.frame = bounds.insetBy(dx: 5, dy: inset * 0.5)
-        iconView.frame = bounds.insetBy(dx: inset, dy: inset)
+        let frames = KeyboardKeyContentGeometry.frames(
+            in: bounds,
+            hintLineHeight: secondaryLabel.font.lineHeight
+        )
+        label.frame = frames.primaryLabel
+        iconView.frame = frames.icon
+        secondaryLabel.frame = frames.hint
         spacebarView.frame = bounds
-
-        let hintHeight = bounds.height * 0.32
-        secondaryLabel.frame = CGRect(x: 2, y: 2, width: bounds.width - 4, height: hintHeight)
-        if !secondaryLabel.isHidden {
-            label.frame = CGRect(
-                x: 4,
-                y: hintHeight * 0.7,
-                width: bounds.width - 8,
-                height: bounds.height - hintHeight * 0.7 - 2
-            )
-        }
     }
 
     func apply(

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Presentation/KeyboardPresentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Presentation/KeyboardPresentation.swift
@@ -7,6 +7,7 @@ public struct KeyboardPresentation: Hashable, Sendable {
     public var layout: KeyboardLayout
     public var sizing: KeyboardSizingProfile
     public var theme: ResolvedTheme
+    public var blendsSystemEdge: Bool
     public var shiftState: ShiftState
     public var language: KeyboardLanguage
     public var enterAction: KeyboardEnterAction
@@ -18,6 +19,7 @@ public struct KeyboardPresentation: Hashable, Sendable {
         layout: KeyboardLayout = .funputQWERTY,
         sizing: KeyboardSizingProfile = .default,
         theme: ResolvedTheme = .funputGlass,
+        blendsSystemEdge: Bool = false,
         shiftState: ShiftState = .lowercase,
         language: KeyboardLanguage = .vietnamese,
         enterAction: KeyboardEnterAction = .newLine,
@@ -28,6 +30,7 @@ public struct KeyboardPresentation: Hashable, Sendable {
         self.layout = layout
         self.sizing = sizing
         self.theme = theme
+        self.blendsSystemEdge = blendsSystemEdge
         self.shiftState = shiftState
         self.language = language
         self.enterAction = enterAction

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/KeyboardBackdropView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/KeyboardBackdropView.swift
@@ -5,11 +5,14 @@ import UIKit
 @MainActor
 final class KeyboardBackdropView: UIView {
     private let materialView = UIVisualEffectView()
+    private let themedView = UIView()
     private let imageView = UIImageView()
     private let gradientView = UIView()
     private let overlayView = UIView()
     private let gradientLayer = CAGradientLayer()
+    private let edgeMaskLayer = CAGradientLayer()
     private var theme = ResolvedTheme.funputGlass
+    private var blendsSystemEdge = false
     private(set) var usesHostMaterial = false
     var contentView: UIView { gradientView }
     var effect: UIVisualEffect? { materialView.effect }
@@ -18,7 +21,13 @@ final class KeyboardBackdropView: UIView {
         super.init(frame: frame)
         isOpaque = false
         isUserInteractionEnabled = false
-        [materialView, imageView, gradientView, overlayView].forEach(addSubview)
+        addSubview(materialView)
+        addSubview(themedView)
+        [imageView, gradientView, overlayView].forEach(themedView.addSubview)
+        themedView.layer.cornerRadius = 18
+        themedView.layer.cornerCurve = .continuous
+        themedView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        themedView.layer.masksToBounds = true
         gradientView.layer.addSublayer(gradientLayer)
         imageView.clipsToBounds = true
         imageView.contentMode = .scaleToFill
@@ -31,13 +40,21 @@ final class KeyboardBackdropView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        [materialView, imageView, gradientView, overlayView].forEach { $0.frame = bounds }
+        [materialView, themedView].forEach { $0.frame = bounds }
+        [imageView, gradientView, overlayView].forEach { $0.frame = themedView.bounds }
         gradientLayer.frame = bounds
+        updateEdgeMask()
         updateImageCrop()
     }
 
-    func apply(theme: ResolvedTheme, traits: UITraitCollection, image: UIImage? = nil) {
+    func apply(
+        theme: ResolvedTheme,
+        traits: UITraitCollection,
+        image: UIImage? = nil,
+        blendsSystemEdge: Bool = false
+    ) {
         self.theme = theme
+        self.blendsSystemEdge = blendsSystemEdge
         imageView.image = image
         let usesImage = theme.backgroundEffects.mode == .image && image != nil
         imageView.isHidden = !usesImage
@@ -51,6 +68,8 @@ final class KeyboardBackdropView: UIView {
         } else {
             applyGradient(theme: theme, traits: traits)
         }
+        themedView.layer.mask = blendsSystemEdge ? edgeMaskLayer : nil
+        updateEdgeMask()
     }
 
     private func configureMaterial(theme: ResolvedTheme, usesImage: Bool) {
@@ -94,6 +113,19 @@ final class KeyboardBackdropView: UIView {
 
     private func resolved(_ color: UIColor, opaque: Bool) -> UIColor {
         opaque ? color.withAlphaComponent(1) : color
+    }
+
+    private func updateEdgeMask() {
+        guard blendsSystemEdge, bounds.height > 0 else { return }
+        edgeMaskLayer.frame = themedView.bounds
+        edgeMaskLayer.colors = [
+            UIColor.white.cgColor,
+            UIColor.white.cgColor,
+            UIColor.clear.cgColor,
+        ]
+        edgeMaskLayer.locations = KeyboardSystemEdgeBlend.locations(for: bounds.height)
+        edgeMaskLayer.startPoint = CGPoint(x: 0.5, y: 0)
+        edgeMaskLayer.endPoint = CGPoint(x: 0.5, y: 1)
     }
 }
 #endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/KeyboardSurfaceView+Presentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/KeyboardSurfaceView+Presentation.swift
@@ -7,6 +7,7 @@ extension KeyboardSurfaceView {
         let layoutChanged = oldValue.layout != presentation.layout
         let sizingChanged = oldValue.sizing != presentation.sizing
         let themeChanged = oldValue.theme != presentation.theme
+        let edgeBlendChanged = oldValue.blendsSystemEdge != presentation.blendsSystemEdge
         if layoutChanged {
             touchOverlay.cancelAllTrackedTouches()
             interactionController.cancelAll()
@@ -16,6 +17,7 @@ extension KeyboardSurfaceView {
         if layoutChanged || themeChanged {
             applyPresentation()
         } else {
+            if edgeBlendChanged { applyBackdropPresentation() }
             var roles = Set<KeyRole>()
             if oldValue.shiftState != presentation.shiftState {
                 roles.formUnion([.character, .shift, .vniModifier])
@@ -47,7 +49,7 @@ extension KeyboardSurfaceView {
     }
 
     func applyPresentation() {
-        backdropView.apply(theme: presentation.theme, traits: traitCollection, image: backgroundImage)
+        applyBackdropPresentation()
         previewView.apply(theme: presentation.theme, traits: traitCollection)
         keysHost.apply(presentation: presentation)
         toolbarView.apply(
@@ -58,6 +60,15 @@ extension KeyboardSurfaceView {
         keyControls.values.forEach {
             $0.apply(presentation: presentation, traits: traitCollection)
         }
+    }
+
+    func applyBackdropPresentation() {
+        backdropView.apply(
+            theme: presentation.theme,
+            traits: traitCollection,
+            image: backgroundImage,
+            blendsSystemEdge: presentation.blendsSystemEdge
+        )
     }
 
     func applyPresentation(to roles: Set<KeyRole>) {

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/KeyboardSystemEdgeBlend.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/KeyboardSystemEdgeBlend.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+enum KeyboardSystemEdgeBlend {
+    static func depth(for height: CGFloat) -> CGFloat {
+        min(32, max(24, height * 0.09))
+    }
+
+    static func locations(for height: CGFloat) -> [NSNumber] {
+        guard height > 0 else { return [0, 1, 1] }
+        let bottomDepth = min(depth(for: height), height * 0.5)
+        let bottom = max(0.5, min(1, 1 - bottomDepth / height))
+        return [0, NSNumber(value: bottom), 1]
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardConfigurationTests/KeyboardPresentationFactoryTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardConfigurationTests/KeyboardPresentationFactoryTests.swift
@@ -13,14 +13,18 @@ struct KeyboardPresentationFactoryTests {
     func selectedThemeResolves() {
         var config = FunputConfiguration.default
         config.selectedThemeID = "app.funput.theme.midnight"
-        #expect(KeyboardPresentationFactory.make(from: config).theme == resolved(.midnight))
+        let presentation = KeyboardPresentationFactory.make(from: config)
+        #expect(presentation.theme == resolved(.midnight))
+        #expect(presentation.blendsSystemEdge)
     }
 
     @Test("Unknown theme id falls back to the bundled default")
     func unknownThemeFallsBack() {
         var config = FunputConfiguration.default
         config.selectedThemeID = "does.not.exist"
-        #expect(KeyboardPresentationFactory.resolvedTheme(for: config) == resolved(BundledThemes.default))
+        let presentation = KeyboardPresentationFactory.make(from: config)
+        #expect(presentation.theme == resolved(BundledThemes.default))
+        #expect(!presentation.blendsSystemEdge)
     }
 
     @Test("Configuration flags map onto the presentation")
@@ -45,6 +49,7 @@ struct KeyboardPresentationFactoryTests {
     @Test("Default configuration id matches the default bundled theme")
     func defaultThemeIdMatchesBundled() {
         #expect(FunputConfiguration.defaultThemeID == BundledThemes.default.id)
+        #expect(!KeyboardPresentationFactory.make(from: .default).blendsSystemEdge)
     }
 
     @Test("Custom geometry maps into presentation sizing")

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardKeyContentLayoutTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardKeyContentLayoutTests.swift
@@ -1,0 +1,23 @@
+@testable import KeyboardRenderer
+import Foundation
+import Testing
+
+struct KeyboardKeyContentLayoutTests {
+    @Test(
+        "Hints stay above the unchanged primary-label frame",
+        arguments: [CGSize(width: 34, height: 42), CGSize(width: 52, height: 60)]
+    )
+    func hintDoesNotMovePrimaryLabel(size: CGSize) {
+        let bounds = CGRect(origin: .zero, size: size)
+        let frames = KeyboardKeyContentGeometry.frames(in: bounds, hintLineHeight: 11)
+        let expectedPrimary = bounds.insetBy(
+            dx: 5,
+            dy: max(6, bounds.height * 0.2) * 0.5
+        )
+
+        #expect(frames.primaryLabel == expectedPrimary)
+        #expect(frames.hint.midY < frames.primaryLabel.midY)
+        #expect(frames.hint.minY == 3)
+        #expect(frames.hint.maxX == bounds.maxX - 4)
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardSystemEdgeBlendTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardSystemEdgeBlendTests.swift
@@ -1,0 +1,20 @@
+@testable import KeyboardRenderer
+import Foundation
+import Testing
+
+struct KeyboardSystemEdgeBlendTests {
+    @Test("Edge bridge stays within its visual depth budget")
+    func depthBounds() {
+        #expect(KeyboardSystemEdgeBlend.depth(for: 200) == 24)
+        #expect(KeyboardSystemEdgeBlend.depth(for: 304) == 27.36)
+        #expect(KeyboardSystemEdgeBlend.depth(for: 500) == 32)
+    }
+
+    @Test("Mask remains opaque until the system-facing bottom transition")
+    func maskLocations() {
+        let locations = KeyboardSystemEdgeBlend.locations(for: 300).map(\.doubleValue)
+        #expect(locations[0] == 0)
+        #expect(abs(locations[1] - 0.91) < 0.0001)
+        #expect(locations[2] == 1)
+    }
+}


### PR DESCRIPTION
## Summary

- keep Telex and VNI hint glyphs in a dedicated upper-right frame without moving the primary key label
- preserve identical primary-label geometry across lowercase, Shift, and Caps Lock presentations
- add a theme-aware system-edge bridge for Classic, Midnight, and custom keyboard backgrounds while leaving Funput Glass unchanged
- fade only the final 24–32 pt of themed backgrounds into host material and retain continuous 18 pt top corners
- apply the same backdrop behavior to the alphabetic and emoji keyboard surfaces

## Why

Secondary hint labels previously changed the primary label frame, so hinted keys sat lower than neighboring keys and shifted again with uppercase presentation. Opaque and strongly tinted themes also ended at a hard boundary above the system-owned globe and microphone strip, making the keyboard look like two unrelated surfaces.

## User impact

- character labels now stay visually aligned across every key and shift state
- hint glyphs remain readable in the upper-right corner without being clipped at the top edge
- non-default themes transition naturally into iOS system chrome instead of leaving a contrasting bottom band
- Funput Glass retains its existing host-material appearance
- key geometry, hit testing, touch ordering, composition, and typing performance are unchanged

## Implementation notes

- the edge mask affects only gradient, image, and overlay background layers; keys, toolbar content, previews, and touch surfaces are not masked
- the mask is recomputed only when theme presentation or bounds change, never in the keypress hot path
- invalid theme IDs fall back to Funput Glass without enabling the additional edge blend

## Validation

- FunputKit Release: 92 tests passed
- iOS Funput Release: 78 tests passed
- iOS Release device build succeeded
- Swift LOC limit passed (maximum 150 lines per file)
- `git diff --check`

## Device validation

Final visual confirmation should cover Classic, Midnight, a custom gradient, and a custom image theme in portrait and landscape on a physical device.
