### PR TITLE
refactor(engine): extract EngineConfig from Session (non-breaking)

### DIFF
--- a/crates/funput-engine/src/compose/boundary/mod.rs
+++ b/crates/funput-engine/src/compose/boundary/mod.rs
@@ -15,7 +15,7 @@ pub(crate) fn should_restore(session: &Session) -> bool {
     if session.restore_override == Some(RestoreOverride::ForceVietnamese) {
         return false;
     }
-    session.smart_restore
+    session.config.smart_restore
         && !session.buffer.is_empty()
         && session.keys != session.buffer
         && !is_complete_syllable(&session.buffer)
@@ -23,7 +23,8 @@ pub(crate) fn should_restore(session: &Session) -> bool {
 }
 
 fn keystrokes_intend_vietnamese(session: &Session) -> bool {
-    let unresolved_w = session.method.is_telex_family() && session.buffer.contains(['w', 'W']);
+    let unresolved_w =
+        session.config.method.is_telex_family() && session.buffer.contains(['w', 'W']);
     (session.buffer.contains(['đ', 'Đ']) && !unresolved_w)
         || session.keys.contains(|c: char| c.is_ascii_digit())
 }
@@ -44,7 +45,7 @@ fn shortcut_expansion(session: &Session, boundary_key: char) -> Option<ImeResult
 }
 
 fn update_caps_on_boundary(session: &mut Session, key: char) {
-    if !session.auto_capitalize {
+    if !session.config.auto_capitalize {
         return;
     }
     match key {

--- a/crates/funput-engine/src/compose/boundary/tests/mod.rs
+++ b/crates/funput-engine/src/compose/boundary/tests/mod.rs
@@ -2,19 +2,21 @@ use std::collections::HashMap;
 
 use funput_core::{InputMethod, ToneStyle};
 
-use crate::model::Session;
+use crate::model::{EngineConfig, Session};
 
 fn session(method: InputMethod, buffer: &str, keys: &str) -> Session {
     Session {
         enabled: true,
-        method,
-        tone_style: ToneStyle::Traditional,
+        config: EngineConfig {
+            method,
+            tone_style: ToneStyle::Traditional,
+            smart_restore: true,
+            eager_restore: true,
+            spell_check: false,
+            auto_capitalize: false,
+        },
         buffer: buffer.into(),
         keys: keys.into(),
-        smart_restore: true,
-        eager_restore: true,
-        spell_check: false,
-        auto_capitalize: false,
         cap_sentence_ended: false,
         cap_armed: false,
         shortcuts: HashMap::new(),

--- a/crates/funput-engine/src/compose/pipeline.rs
+++ b/crates/funput-engine/src/compose/pipeline.rs
@@ -18,9 +18,9 @@ pub(crate) fn process(session: &mut Session, key: char, capitalize_shortcut: boo
     let mut result = apply_checked(
         &session.buffer,
         key,
-        session.method,
-        session.tone_style,
-        session.spell_check,
+        session.config.method,
+        session.config.tone_style,
+        session.config.spell_check,
     );
     if capitalize_shortcut && result.kind == TransformKind::Applied {
         uppercase_direct_vowel(&mut result.text);
@@ -47,8 +47,8 @@ pub(crate) fn process(session: &mut Session, key: char, capitalize_shortcut: boo
         // smart + eager toggles. Skip on Reverted (a deliberate user restore) and when
         // nothing was transformed (`keys == composed`, e.g. a literal digit `ng1`).
         None => {
-            if session.smart_restore
-                && session.eager_restore
+            if session.config.smart_restore
+                && session.config.eager_restore
                 && result.kind != TransformKind::Reverted
                 && session.keys != composed
                 && is_definitely_invalid(&composed)

--- a/crates/funput-engine/src/compose/pipeline/tests.rs
+++ b/crates/funput-engine/src/compose/pipeline/tests.rs
@@ -24,7 +24,7 @@ fn applied_tone_telex() {
 #[test]
 fn ignored_appends_literal_vni() {
     let mut session = Session::new();
-    session.method = InputMethod::Vni;
+    session.config.method = InputMethod::Vni;
     session.buffer.push_str("ng");
     session.keys.push_str("ng1");
     let result = process(&mut session, '1', false);

--- a/crates/funput-engine/src/engine/config.rs
+++ b/crates/funput-engine/src/engine/config.rs
@@ -15,38 +15,38 @@ impl Engine {
 
     /// Change input method and discard any composition using the old grammar.
     pub fn set_method(&mut self, method: InputMethod) {
-        if self.session.method != method {
+        if self.session.config.method != method {
             self.session.clear();
-            self.session.method = method;
+            self.session.config.method = method;
         }
     }
 
     pub fn method(&self) -> InputMethod {
-        self.session.method
+        self.session.config.method
     }
 
     pub fn set_tone_style(&mut self, style: ToneStyle) {
-        self.session.tone_style = style;
+        self.session.config.tone_style = style;
     }
 
     pub fn tone_style(&self) -> ToneStyle {
-        self.session.tone_style
+        self.session.config.tone_style
     }
 
     pub fn set_smart_restore(&mut self, on: bool) {
-        self.session.smart_restore = on;
+        self.session.config.smart_restore = on;
     }
 
     pub fn set_eager_restore(&mut self, on: bool) {
-        self.session.eager_restore = on;
+        self.session.config.eager_restore = on;
     }
 
     pub fn set_spell_check(&mut self, on: bool) {
-        self.session.spell_check = on;
+        self.session.config.spell_check = on;
     }
 
     pub fn set_auto_capitalize(&mut self, on: bool) {
-        self.session.auto_capitalize = on;
+        self.session.config.auto_capitalize = on;
         if !on {
             self.session.cap_armed = false;
             self.session.cap_sentence_ended = false;
@@ -54,7 +54,7 @@ impl Engine {
     }
 
     pub fn arm_capitalization(&mut self) {
-        if self.session.auto_capitalize {
+        if self.session.config.auto_capitalize {
             self.session.cap_armed = true;
         }
     }

--- a/crates/funput-engine/src/engine/process.rs
+++ b/crates/funput-engine/src/engine/process.rs
@@ -18,7 +18,8 @@ impl Engine {
         if !self.session.enabled {
             return ImeResult::none();
         }
-        if source.forces_literal_digit(key) || boundary::is_word_boundary(self.session.method, key)
+        if source.forces_literal_digit(key)
+            || boundary::is_word_boundary(self.session.config.method, key)
         {
             return boundary::on_word_boundary(&mut self.session, key);
         }
@@ -36,7 +37,7 @@ impl Engine {
     }
 
     fn prepare_key(&mut self, key: char) -> (char, bool) {
-        if !self.session.auto_capitalize || !self.session.buffer.is_empty() {
+        if !self.session.config.auto_capitalize || !self.session.buffer.is_empty() {
             return (key, false);
         }
         let armed = self.session.cap_armed;
@@ -48,7 +49,7 @@ impl Engine {
         if key.is_alphabetic() {
             return (key.to_ascii_uppercase(), false);
         }
-        let shortcut = self.session.method.is_advanced_telex() && matches!(key, '[' | ']');
+        let shortcut = self.session.config.method.is_advanced_telex() && matches!(key, '[' | ']');
         (key, shortcut)
     }
 }

--- a/crates/funput-engine/src/model/config.rs
+++ b/crates/funput-engine/src/model/config.rs
@@ -1,0 +1,42 @@
+//! User-configurable engine options, grouped out of the per-word [`super::Session`]
+//! state so adding a feature toggle touches one struct instead of the god-object.
+//!
+//! These six options map 1:1 to the public `Engine::set_*` methods (and, over the
+//! FFI, to `funput_set_*`). Keeping them together is also the seam for a future
+//! `Engine::configure(EngineConfig)` API — this type would simply become `pub`.
+
+use funput_core::{InputMethod, ToneStyle};
+
+/// The engine's user-facing options. Runtime composition state (buffer, raw keys,
+/// capitalization tracking, the flip override) stays in [`super::Session`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EngineConfig {
+    /// Input method grammar (Telex / VNI / Telex Advanced).
+    pub(crate) method: InputMethod,
+    /// Tone-mark placement style (traditional `hòa` vs modern `hoà`).
+    pub(crate) tone_style: ToneStyle,
+    /// Auto-restore non-Vietnamese words to their raw Latin keys.
+    pub(crate) smart_restore: bool,
+    /// Restore the instant a word dead-ends, without waiting for a word boundary.
+    /// Only meaningful while `smart_restore` is on.
+    pub(crate) eager_restore: bool,
+    /// Spell-check ("Kiểm tra chính tả"): only place a diacritic when the result can
+    /// still become a real Vietnamese syllable. Off by default.
+    pub(crate) spell_check: bool,
+    /// Auto-capitalize ("Tự động viết hoa"): uppercase the first letter of a word at
+    /// the start of a sentence. Off by default.
+    pub(crate) auto_capitalize: bool,
+}
+
+impl Default for EngineConfig {
+    fn default() -> Self {
+        Self {
+            method: InputMethod::Telex,
+            tone_style: ToneStyle::Traditional,
+            smart_restore: true,
+            eager_restore: true,
+            spell_check: false,
+            auto_capitalize: false,
+        }
+    }
+}

--- a/crates/funput-engine/src/model/mod.rs
+++ b/crates/funput-engine/src/model/mod.rs
@@ -1,15 +1,19 @@
 //! Data types that flow through the engine.
 //!
 //! - `session` — the internal, mutable per-session state (crate-private).
+//! - `config` — the user-configurable options ([`EngineConfig`]) grouped out of
+//!   `session`; the seam for a future public `Engine::configure` API.
 //! - `key_source` — the input model: where a keystroke physically came from.
 //! - `result` — the output model: the [`crate::Action`] / [`crate::ImeResult`] a
 //!   platform applies.
 //!
 //! `key_source` and `result` are re-exported as the crate's public types from the
-//! crate root; `Session` stays crate-internal.
+//! crate root; `Session` and `EngineConfig` stay crate-internal.
 
+mod config;
 pub(crate) mod key_source;
 pub(crate) mod result;
 mod session;
 
+pub(crate) use config::EngineConfig;
 pub(crate) use session::Session;

--- a/crates/funput-engine/src/model/session.rs
+++ b/crates/funput-engine/src/model/session.rs
@@ -2,36 +2,21 @@
 
 use std::collections::HashMap;
 
-use funput_core::{InputMethod, ToneStyle};
-
 use crate::compose::RestoreOverride;
+use crate::model::EngineConfig;
 
 /// Mutable session held by [`crate::Engine`]. Internal — not part of the public API.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Session {
     pub(crate) enabled: bool,
-    pub(crate) method: InputMethod,
-    /// Tone-mark placement style (traditional `hòa` vs modern `hoà`).
-    pub(crate) tone_style: ToneStyle,
+    /// User-configurable options (method, tone style, restore/spell/cap toggles).
+    pub(crate) config: EngineConfig,
     /// Composed text currently shown in the app (the composition span).
     pub(crate) buffer: String,
     /// Raw keystrokes since the last word boundary. Lets English restore
     /// (phase E3) rebuild the original Latin text when the composed buffer is
     /// not a complete Vietnamese syllable (`keys != buffer && !is_complete_syllable(buffer)`).
     pub(crate) keys: String,
-    /// Auto-restore words that aren't valid Vietnamese to their raw Latin keys.
-    /// When `false`, the composed buffer is always kept (no English restore).
-    pub(crate) smart_restore: bool,
-    /// Restore the instant a word becomes a dead end, without waiting for a word
-    /// boundary. Only meaningful while `smart_restore` is on.
-    pub(crate) eager_restore: bool,
-    /// Spell-check ("Kiểm tra chính tả"): only place a diacritic when the result can
-    /// still become a real Vietnamese syllable, otherwise keep the modifier key as a
-    /// literal (UniKey-style strict diacritics). Off by default.
-    pub(crate) spell_check: bool,
-    /// Auto-capitalize ("Tự động viết hoa"): uppercase the first letter of a word at
-    /// the start of a sentence. Off by default.
-    pub(crate) auto_capitalize: bool,
     /// A sentence-ending mark (`.`/`!`/`?`) was just seen; waiting for whitespace to
     /// confirm the next word starts a new sentence. Survives `clear()` — capitalize
     /// state spans word commits.
@@ -58,14 +43,9 @@ impl Session {
     pub(crate) fn new() -> Self {
         Self {
             enabled: true,
-            method: InputMethod::Telex,
-            tone_style: ToneStyle::Traditional,
+            config: EngineConfig::default(),
             buffer: String::new(),
             keys: String::new(),
-            smart_restore: true,
-            eager_restore: true,
-            spell_check: false,
-            auto_capitalize: false,
             cap_sentence_ended: false,
             cap_armed: false,
             shortcuts: HashMap::new(),
@@ -90,13 +70,15 @@ impl Default for Session {
 
 #[cfg(test)]
 mod tests {
+    use funput_core::InputMethod;
+
     use super::*;
 
     #[test]
     fn new_defaults() {
         let session = Session::new();
         assert!(session.enabled);
-        assert_eq!(session.method, InputMethod::Telex);
+        assert_eq!(session.config.method, InputMethod::Telex);
         assert!(session.buffer.is_empty());
         assert!(session.keys.is_empty());
         assert!(session.shortcuts.is_empty());


### PR DESCRIPTION
## Summary

**Step 1 of 2** for the feature-model cleanup — a **non-breaking** internal change.

`Session` (crate-internal state) had grown into a 14-field god-object. Six of those
fields are *user-facing options* — `method`, `tone_style`, `smart_restore`,
`eager_restore`, `spell_check`, `auto_capitalize` — that map 1:1 to the public
`Engine::set_*` methods and the `funput_set_*` FFI. This PR groups them into a new
`pub(crate) model::EngineConfig`, so `Session` drops to 9 fields (`config` + runtime
state) and adding a feature toggle touches one struct instead of the whole object.

## What changed

- **`model/config.rs`** (new): `EngineConfig { the six options }` + `Default`.
- **`model/session.rs`**: replace the six fields with `config: EngineConfig`;
  `new()` uses `EngineConfig::default()`; `clear()` unchanged.
- **~22 access sites** `session.<opt>` → `session.config.<opt>` across
  `engine/config.rs`, `engine/process.rs`, `compose/pipeline.rs`,
  `compose/boundary/mod.rs`, and two test files.
- The runtime state (`enabled`, `buffer`, `keys`, cap-tracking, `vn_form`,
  `restore_override`, `shortcuts`) stays flat — it isn't config.

## Non-breaking

The public setters/getters keep their **exact signatures** (they just write to
`config`), so:
- **No public API change** — verified: no `pub fn`/`pub extern` signature in
  `funput-engine`/`funput-ffi` changed.
- **`funput.h` byte-identical** — verified with `git diff`.
- **All five platform shells** (macOS, Windows, Linux fcitx5/ibus, JNI) are
  untouched. `cargo test --workspace` is green.

`Session` and `EngineConfig` are both `pub(crate)`.

## Why this sets up step 2

The later (breaking) change can now be a thin, mechanical surface change: make
`EngineConfig` `pub`, add `Engine::configure(EngineConfig)` / `config()` and a single
`funput_configure` FFI, regenerate `funput.h`, and update the platforms — the
grouping and internal wiring already exist, so step 2 no longer has to untangle the
god-object at the same time.

## Testing

- `cargo test -p funput-engine` green; `cargo test --workspace` green.
- `cargo clippy -p funput-engine --all-targets -- -D warnings`,
  `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo fmt --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
