### PR TITLE
feat(engine): add configure() + funput_configure config API (non-breaking)

### DIFF
--- a/crates/funput-engine/src/engine/config.rs
+++ b/crates/funput-engine/src/engine/config.rs
@@ -2,9 +2,27 @@ use std::collections::HashMap;
 
 use funput_core::{InputMethod, ToneStyle};
 
-use crate::Engine;
+use crate::{Engine, EngineConfig};
 
 impl Engine {
+    /// Apply a whole [`EngineConfig`] at once — the batch equivalent of the
+    /// individual `set_*` methods, preserving their side effects (a method change
+    /// clears the in-progress word; turning auto-capitalize off resets its tracking).
+    /// `enabled` and the gõ tắt shortcuts are separate and left untouched.
+    pub fn configure(&mut self, config: EngineConfig) {
+        self.set_method(config.method);
+        self.set_tone_style(config.tone_style);
+        self.set_smart_restore(config.smart_restore);
+        self.set_eager_restore(config.eager_restore);
+        self.set_spell_check(config.spell_check);
+        self.set_auto_capitalize(config.auto_capitalize);
+    }
+
+    /// The current engine configuration (method, tone style, and the feature toggles).
+    pub fn config(&self) -> &EngineConfig {
+        &self.session.config
+    }
+
     pub fn set_enabled(&mut self, enabled: bool) {
         self.session.enabled = enabled;
     }

--- a/crates/funput-engine/src/lib.rs
+++ b/crates/funput-engine/src/lib.rs
@@ -19,5 +19,6 @@ mod engine;
 mod model;
 
 pub use engine::Engine;
+pub use model::EngineConfig;
 pub use model::key_source::KeySource;
 pub use model::result::{Action, ImeResult};

--- a/crates/funput-engine/src/model/config.rs
+++ b/crates/funput-engine/src/model/config.rs
@@ -8,24 +8,24 @@
 use funput_core::{InputMethod, ToneStyle};
 
 /// The engine's user-facing options. Runtime composition state (buffer, raw keys,
-/// capitalization tracking, the flip override) stays in [`super::Session`].
+/// capitalization tracking, the flip override) stays in the internal `Session`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct EngineConfig {
+pub struct EngineConfig {
     /// Input method grammar (Telex / VNI / Telex Advanced).
-    pub(crate) method: InputMethod,
+    pub method: InputMethod,
     /// Tone-mark placement style (traditional `hòa` vs modern `hoà`).
-    pub(crate) tone_style: ToneStyle,
+    pub tone_style: ToneStyle,
     /// Auto-restore non-Vietnamese words to their raw Latin keys.
-    pub(crate) smart_restore: bool,
+    pub smart_restore: bool,
     /// Restore the instant a word dead-ends, without waiting for a word boundary.
     /// Only meaningful while `smart_restore` is on.
-    pub(crate) eager_restore: bool,
+    pub eager_restore: bool,
     /// Spell-check ("Kiểm tra chính tả"): only place a diacritic when the result can
     /// still become a real Vietnamese syllable. Off by default.
-    pub(crate) spell_check: bool,
+    pub spell_check: bool,
     /// Auto-capitalize ("Tự động viết hoa"): uppercase the first letter of a word at
     /// the start of a sentence. Off by default.
-    pub(crate) auto_capitalize: bool,
+    pub auto_capitalize: bool,
 }
 
 impl Default for EngineConfig {

--- a/crates/funput-engine/src/model/mod.rs
+++ b/crates/funput-engine/src/model/mod.rs
@@ -7,13 +7,13 @@
 //! - `result` — the output model: the [`crate::Action`] / [`crate::ImeResult`] a
 //!   platform applies.
 //!
-//! `key_source` and `result` are re-exported as the crate's public types from the
-//! crate root; `Session` and `EngineConfig` stay crate-internal.
+//! `key_source`, `result`, and `config` ([`EngineConfig`]) are re-exported as the
+//! crate's public types from the crate root; `Session` stays crate-internal.
 
 mod config;
 pub(crate) mod key_source;
 pub(crate) mod result;
 mod session;
 
-pub(crate) use config::EngineConfig;
+pub use config::EngineConfig;
 pub(crate) use session::Session;

--- a/crates/funput-engine/tests/engine_api.rs
+++ b/crates/funput-engine/tests/engine_api.rs
@@ -4,8 +4,8 @@
 //! These exercise only the public API, so they live here as integration tests
 //! rather than inline in `src/lib.rs`.
 
-use funput_core::InputMethod;
-use funput_engine::{Action, Engine, ImeResult, KeySource};
+use funput_core::{InputMethod, ToneStyle};
+use funput_engine::{Action, Engine, EngineConfig, ImeResult, KeySource};
 
 #[test]
 fn engine_new_defaults() {
@@ -455,4 +455,41 @@ fn vni_numpad_covers_all_digit_roles() {
         engine.process_key(digit, KeySource::Numpad);
         assert_eq!(engine.buffer(), "", "numpad {digit} should not modify 'a'");
     }
+}
+
+// ---- configure(): the batch config API (mirrors the individual set_* methods) ----
+
+#[test]
+fn configure_applies_all_options() {
+    let mut engine = Engine::new();
+    engine.configure(EngineConfig {
+        method: InputMethod::Vni,
+        tone_style: ToneStyle::Modern,
+        smart_restore: false,
+        eager_restore: false,
+        spell_check: true,
+        auto_capitalize: true,
+    });
+    assert_eq!(engine.method(), InputMethod::Vni);
+    assert_eq!(engine.tone_style(), ToneStyle::Modern);
+    let config = engine.config();
+    assert_eq!(config.method, InputMethod::Vni);
+    assert!(config.spell_check && config.auto_capitalize);
+    assert!(!config.smart_restore && !config.eager_restore);
+}
+
+/// `configure` keeps the `set_*` side effect: switching method mid-word clears the
+/// in-progress composition.
+#[test]
+fn configure_method_change_clears_composition() {
+    let mut engine = Engine::new(); // Telex
+    for key in "chaof".chars() {
+        engine.process_char(key);
+    }
+    assert_eq!(engine.buffer(), "chào");
+    engine.configure(EngineConfig {
+        method: InputMethod::Vni,
+        ..EngineConfig::default()
+    });
+    assert_eq!(engine.buffer(), ""); // method change discarded the old-grammar word
 }

--- a/crates/funput-ffi/cbindgen.toml
+++ b/crates/funput-ffi/cbindgen.toml
@@ -8,6 +8,7 @@ style = "type"
 
 [export]
 include = [
+    "FunputConfig",
     "FunputResult",
     "FunputSuggestionCandidate",
     "FunputSuggestionResult",

--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -70,6 +70,25 @@ typedef struct {
     uint32_t chars[CHARS_CAP];
 } FunputResult;
 
+/**
+ * A whole engine configuration passed by value over the C ABI — the six user
+ * options. `enabled` and the gõ tắt shortcut table have their own functions.
+ */
+typedef struct {
+    /**
+     * `0 = Telex`, `1 = VNI`, `2 = Telex Advanced` (see `METHOD_*`).
+     */
+    uint8_t method;
+    /**
+     * `0 = Traditional`, `1 = Modern`.
+     */
+    uint8_t tone_style;
+    bool smart_restore;
+    bool eager_restore;
+    bool spell_check;
+    bool auto_capitalize;
+} FunputConfig;
+
 typedef struct {
     uint32_t count;
     uint32_t chars[SUGGESTION_CHARS_CAP];
@@ -206,6 +225,17 @@ void funput_set_method(FunputEngine *engine, uint8_t method);
  * `engine` must be a valid handle or null.
  */
 void funput_set_tone_style(FunputEngine *engine, uint8_t style);
+
+/**
+ * Apply a whole [`FunputConfig`] at once — the batch equivalent of the individual
+ * `funput_set_*` functions, with the same side effects (a method change clears the
+ * composition; auto-capitalize off resets its tracking). `funput_set_enabled` and
+ * the shortcut table are separate and left untouched.
+ *
+ * # Safety
+ * `engine` must be a valid handle or null.
+ */
+void funput_configure(FunputEngine *engine, FunputConfig config);
 
 /**
  * Enable or disable Vietnamese composition.

--- a/crates/funput-ffi/src/engine/config.rs
+++ b/crates/funput-ffi/src/engine/config.rs
@@ -5,6 +5,7 @@
 //! boundary rule "every FFI call goes through the guard" holds uniformly.
 
 use funput_core::{InputMethod, ToneStyle};
+use funput_engine::EngineConfig;
 
 use super::FunputEngine;
 use crate::abi;
@@ -14,6 +15,24 @@ pub const METHOD_VNI: u8 = 1;
 pub const METHOD_TELEX_ADVANCED: u8 = 2;
 const TONE_STYLE_MODERN: u8 = 1;
 
+/// Decode the wire method byte; any unknown value falls back to standard Telex.
+fn decode_method(method: u8) -> InputMethod {
+    match method {
+        METHOD_VNI => InputMethod::Vni,
+        METHOD_TELEX_ADVANCED => InputMethod::TelexAdvanced,
+        _ => InputMethod::Telex,
+    }
+}
+
+/// Decode the wire tone-style byte (`1 = Modern`, anything else = Traditional).
+fn decode_tone_style(style: u8) -> ToneStyle {
+    if style == TONE_STYLE_MODERN {
+        ToneStyle::Modern
+    } else {
+        ToneStyle::Traditional
+    }
+}
+
 /// Set the input method: `0 = Telex`, `1 = VNI`, `2 = Telex Advanced`.
 /// Any other value falls back to standard Telex.
 ///
@@ -21,11 +40,7 @@ const TONE_STYLE_MODERN: u8 = 1;
 /// `engine` must be a valid handle or null.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn funput_set_method(engine: *mut FunputEngine, method: u8) {
-    let method = match method {
-        METHOD_VNI => InputMethod::Vni,
-        METHOD_TELEX_ADVANCED => InputMethod::TelexAdvanced,
-        _ => InputMethod::Telex,
-    };
+    let method = decode_method(method);
     unsafe { abi::with_engine_mut(engine, |e| e.set_method(method)) }
 }
 
@@ -36,12 +51,43 @@ pub unsafe extern "C" fn funput_set_method(engine: *mut FunputEngine, method: u8
 /// `engine` must be a valid handle or null.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn funput_set_tone_style(engine: *mut FunputEngine, style: u8) {
-    let style = if style == TONE_STYLE_MODERN {
-        ToneStyle::Modern
-    } else {
-        ToneStyle::Traditional
-    };
+    let style = decode_tone_style(style);
     unsafe { abi::with_engine_mut(engine, |e| e.set_tone_style(style)) }
+}
+
+/// A whole engine configuration passed by value over the C ABI — the six user
+/// options. `enabled` and the gõ tắt shortcut table have their own functions.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FunputConfig {
+    /// `0 = Telex`, `1 = VNI`, `2 = Telex Advanced` (see `METHOD_*`).
+    pub method: u8,
+    /// `0 = Traditional`, `1 = Modern`.
+    pub tone_style: u8,
+    pub smart_restore: bool,
+    pub eager_restore: bool,
+    pub spell_check: bool,
+    pub auto_capitalize: bool,
+}
+
+/// Apply a whole [`FunputConfig`] at once — the batch equivalent of the individual
+/// `funput_set_*` functions, with the same side effects (a method change clears the
+/// composition; auto-capitalize off resets its tracking). `funput_set_enabled` and
+/// the shortcut table are separate and left untouched.
+///
+/// # Safety
+/// `engine` must be a valid handle or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_configure(engine: *mut FunputEngine, config: FunputConfig) {
+    let cfg = EngineConfig {
+        method: decode_method(config.method),
+        tone_style: decode_tone_style(config.tone_style),
+        smart_restore: config.smart_restore,
+        eager_restore: config.eager_restore,
+        spell_check: config.spell_check,
+        auto_capitalize: config.auto_capitalize,
+    };
+    unsafe { abi::with_engine_mut(engine, |e| e.configure(cfg)) }
 }
 
 /// Enable or disable Vietnamese composition.

--- a/crates/funput-ffi/src/engine/mod.rs
+++ b/crates/funput-ffi/src/engine/mod.rs
@@ -22,9 +22,9 @@ pub use compose::{
     funput_clear, funput_flip_composing, funput_process_char, funput_process_key,
 };
 pub use config::{
-    METHOD_TELEX, METHOD_TELEX_ADVANCED, METHOD_VNI, funput_set_auto_capitalize,
-    funput_set_eager_restore, funput_set_enabled, funput_set_method, funput_set_smart_restore,
-    funput_set_spell_check, funput_set_tone_style,
+    FunputConfig, METHOD_TELEX, METHOD_TELEX_ADVANCED, METHOD_VNI, funput_configure,
+    funput_set_auto_capitalize, funput_set_eager_restore, funput_set_enabled, funput_set_method,
+    funput_set_smart_restore, funput_set_spell_check, funput_set_tone_style,
 };
 pub use result::{ACTION_NONE, ACTION_RESTORE, ACTION_SEND, CHARS_CAP, FunputResult};
 pub use shortcuts::{funput_add_shortcut, funput_clear_shortcuts};

--- a/crates/funput-ffi/src/lib.rs
+++ b/crates/funput-ffi/src/lib.rs
@@ -35,13 +35,13 @@ mod engine;
 mod suggestion;
 
 pub use engine::{
-    ACTION_NONE, ACTION_RESTORE, ACTION_SEND, CHARS_CAP, FunputEngine, FunputResult, METHOD_TELEX,
-    METHOD_TELEX_ADVANCED, METHOD_VNI, SOURCE_NUMPAD, SOURCE_STANDARD, funput_add_shortcut,
-    funput_arm_capitalization, funput_backspace, funput_buffer, funput_clear,
-    funput_clear_shortcuts, funput_engine_free, funput_engine_new, funput_flip_composing,
-    funput_process_char, funput_process_key, funput_set_auto_capitalize, funput_set_eager_restore,
-    funput_set_enabled, funput_set_method, funput_set_smart_restore, funput_set_spell_check,
-    funput_set_tone_style,
+    ACTION_NONE, ACTION_RESTORE, ACTION_SEND, CHARS_CAP, FunputConfig, FunputEngine, FunputResult,
+    METHOD_TELEX, METHOD_TELEX_ADVANCED, METHOD_VNI, SOURCE_NUMPAD, SOURCE_STANDARD,
+    funput_add_shortcut, funput_arm_capitalization, funput_backspace, funput_buffer, funput_clear,
+    funput_clear_shortcuts, funput_configure, funput_engine_free, funput_engine_new,
+    funput_flip_composing, funput_process_char, funput_process_key, funput_set_auto_capitalize,
+    funput_set_eager_restore, funput_set_enabled, funput_set_method, funput_set_smart_restore,
+    funput_set_spell_check, funput_set_tone_style,
 };
 pub use suggestion::{
     FunputSuggestionCandidate, FunputSuggestionEngine, FunputSuggestionResult,

--- a/crates/funput-ffi/tests/round_trip.rs
+++ b/crates/funput-ffi/tests/round_trip.rs
@@ -1,9 +1,10 @@
 //! Round-trip tests: drive the `extern "C"` API exactly like a C caller would.
 
 use funput_ffi::{
-    ACTION_NONE, ACTION_SEND, FunputResult, SOURCE_NUMPAD, funput_add_shortcut, funput_backspace,
-    funput_buffer, funput_clear, funput_clear_shortcuts, funput_engine_free, funput_engine_new,
-    funput_process_char, funput_process_key, funput_set_method,
+    ACTION_NONE, ACTION_SEND, FunputConfig, FunputResult, SOURCE_NUMPAD, funput_add_shortcut,
+    funput_backspace, funput_buffer, funput_clear, funput_clear_shortcuts, funput_configure,
+    funput_engine_free, funput_engine_new, funput_process_char, funput_process_key,
+    funput_set_method,
 };
 
 fn output(result: &FunputResult) -> String {
@@ -117,6 +118,29 @@ fn read_buffer(engine: *const funput_ffi::FunputEngine) -> String {
         .iter()
         .filter_map(|&c| char::from_u32(c))
         .collect()
+}
+
+#[test]
+fn configure_applies_config_by_value() {
+    unsafe {
+        let engine = funput_engine_new();
+        // One call sets the whole config; method = VNI (1) so `a1` composes `á`.
+        funput_configure(
+            engine,
+            FunputConfig {
+                method: 1, // VNI
+                tone_style: 0,
+                smart_restore: true,
+                eager_restore: true,
+                spell_check: false,
+                auto_capitalize: false,
+            },
+        );
+        funput_process_char(engine, 'a' as u32);
+        funput_process_char(engine, '1' as u32);
+        assert_eq!(read_buffer(engine), "á");
+        funput_engine_free(engine);
+    }
 }
 
 #[test]

--- a/crates/funput-term/src/config/mod.rs
+++ b/crates/funput-term/src/config/mod.rs
@@ -15,7 +15,7 @@
 use std::path::PathBuf;
 
 use funput_core::{InputMethod, ToneStyle};
-use funput_engine::Engine;
+use funput_engine::{Engine, EngineConfig};
 
 use crate::terminal::DEFAULT_VI_CURSOR_COLOR;
 
@@ -95,12 +95,14 @@ impl TermConfig {
     /// Push the engine-affecting options into a fresh engine. Replaces the whole
     /// shortcut table so repeated calls stay consistent.
     pub fn apply_to(&self, engine: &mut Engine) {
-        engine.set_method(self.method);
-        engine.set_tone_style(self.tone_style);
-        engine.set_smart_restore(self.smart_restore);
-        engine.set_eager_restore(self.eager_restore);
-        engine.set_spell_check(self.spell_check);
-        engine.set_auto_capitalize(self.auto_capitalize);
+        engine.configure(EngineConfig {
+            method: self.method,
+            tone_style: self.tone_style,
+            smart_restore: self.smart_restore,
+            eager_restore: self.eager_restore,
+            spell_check: self.spell_check,
+            auto_capitalize: self.auto_capitalize,
+        });
         engine.clear_shortcuts();
         for (trigger, expansion) in &self.shortcuts {
             engine.add_shortcut(trigger.clone(), expansion.clone());


### PR DESCRIPTION
> **Stacked on #92** (`refactor(engine): extract EngineConfig`). Review/merge #92 first;
> GitHub will retarget this to `main` once #92 lands. The diff here is H2-only.

## Summary

**H2, step 1 of the config-API cleanup — fully non-breaking.**

Expose the `EngineConfig` that #92 grouped internally as a real public API, so a whole
configuration is applied in one call instead of a chain of `set_*` / `funput_set_*`.
This is the seam that lets a future feature toggle be added in one place. **Additive:
the individual setters stay, so no platform is forced to change.**

## What changed

- **funput-engine**: `EngineConfig` is now `pub` (re-exported from the crate root).
  Added `Engine::configure(EngineConfig)` — it delegates to the existing `set_*`
  methods, so the side effects are preserved (a method change clears the in-progress
  word; auto-capitalize off resets its tracking) — and `Engine::config() -> &EngineConfig`.
- **funput-ffi**: added `#[repr(C)] FunputConfig` + `funput_configure(engine, FunputConfig)`,
  and regenerated `funput.h`. Factored out `decode_method` / `decode_tone_style` (reused
  by the setters and `configure`).
- **funput-term**: `TermConfig::apply_to` now calls `engine.configure(...)` — a real
  consumer proving the API and shedding its six setter calls.

## Non-breaking — verified

- `funput.h` diff is **additions only** (`FunputConfig` + `funput_configure`); every
  existing symbol is byte-identical. No `pub fn` / `pub extern` signature changed.
- **macOS** `xcodebuild` **BUILD SUCCEEDED** and **Windows** `cargo check
  --target x86_64-pc-windows-gnu` passes against the updated engine/header — both still
  on the old `set_*`, untouched.
- `cargo test --workspace` green; added `configure` tests in `funput-engine`
  (`engine_api.rs`) and `funput-ffi` (`round_trip.rs`).
- `cargo clippy --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`,
  `cargo fmt --check` all clean.

## Follow-ups (each its own PR, needs the platform's toolchain)

Migrate the remaining consumers to `configure` — macOS & Windows (verifiable here),
then iOS (rebuild the vendored xcframework header), Linux fcitx5/ibus, Android
(JNI + Kotlin). A final PR removes the old `set_*` / `funput_set_*` once all platforms
have migrated (that is the only breaking step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
