### PR TITLE
refactor(macos): apply engine settings via funput_configure

### DIFF
--- a/platforms/macos/Funput/IME/ComposerConfiguration.swift
+++ b/platforms/macos/Funput/IME/ComposerConfiguration.swift
@@ -42,12 +42,17 @@ struct ComposerConfiguration: Equatable {
 
 extension FunputComposer {
     func apply(_ configuration: ComposerConfiguration) {
-        setMethod(configuration.inputMethod)
-        setToneStyle(configuration.toneStyle)
+        configure(
+            FunputConfig(
+                method: configuration.inputMethod.ffiValue,
+                tone_style: UInt8(configuration.toneStyle.rawValue),
+                smart_restore: configuration.smartEnglishRestore,
+                eager_restore: configuration.eagerRestore,
+                spell_check: configuration.spellCheckEnabled,
+                auto_capitalize: configuration.autoCapitalizeEnabled
+            )
+        )
+        // `enabled` is a runtime toggle, not part of the batch config.
         setEnabled(configuration.enabled)
-        setSmartRestore(configuration.smartEnglishRestore)
-        setEagerRestore(configuration.eagerRestore)
-        setSpellCheck(configuration.spellCheckEnabled)
-        setAutoCapitalize(configuration.autoCapitalizeEnabled)
     }
 }

--- a/platforms/macos/Funput/IME/FunputComposer.swift
+++ b/platforms/macos/Funput/IME/FunputComposer.swift
@@ -16,39 +16,15 @@ final class FunputComposer {
         funput_engine_free(handle)
     }
 
-    func setMethod(_ method: InputMethod) {
-        funput_set_method(handle, method.ffiValue)
-    }
-
-    /// Tone-mark placement style (traditional `hòa` vs modern `hoà`).
-    func setToneStyle(_ style: ToneStyle) {
-        funput_set_tone_style(handle, UInt8(style.rawValue))
-    }
-
     func setEnabled(_ enabled: Bool) {
         funput_set_enabled(handle, enabled)
     }
 
-    /// Auto-restore non-Vietnamese words to their raw Latin keystrokes.
-    func setSmartRestore(_ on: Bool) {
-        funput_set_smart_restore(handle, on)
-    }
-
-    /// Restore the instant a word dead-ends, without waiting for a word boundary.
-    func setEagerRestore(_ on: Bool) {
-        funput_set_eager_restore(handle, on)
-    }
-
-    /// Spell-check ("Kiểm tra chính tả"): only place a diacritic when it forms a
-    /// valid Vietnamese syllable, otherwise keep the modifier key literal.
-    func setSpellCheck(_ on: Bool) {
-        funput_set_spell_check(handle, on)
-    }
-
-    /// Auto-capitalize ("Tự động viết hoa"): uppercase the first letter at the start
-    /// of a sentence.
-    func setAutoCapitalize(_ on: Bool) {
-        funput_set_auto_capitalize(handle, on)
+    /// Apply the whole engine configuration (method, tone style, and the feature
+    /// toggles) in one FFI call — the batch equivalent of the former per-option
+    /// setters. `enabled` is a separate runtime toggle (see `setEnabled`).
+    func configure(_ config: FunputConfig) {
+        funput_configure(handle, config)
     }
 
     /// Arm capitalization for the next word (call on focus so the first letter typed


### PR DESCRIPTION
> **Stacked on #93** (`funput_configure` API). Merge order: #92 → #93 → this. GitHub
> retargets to `main` as the bases land; the diff here is macOS-only (2 files).

## Summary

Migrate the macOS shell to the batch config API added in #93. `ComposerConfiguration.apply`
now builds a single `FunputConfig` and calls `funput_configure`, replacing the chain of six
`funput_set_*` wrapper calls.

## What changed

- **`FunputComposer.swift`**: replace `setMethod` / `setToneStyle` / `setSmartRestore` /
  `setEagerRestore` / `setSpellCheck` / `setAutoCapitalize` with one
  `configure(_ config: FunputConfig)` → `funput_configure(handle, config)`. `setEnabled`
  stays (the VI/EN toggle uses it; `enabled` is a runtime toggle, not batch config).
- **`ComposerConfiguration.swift`**: `apply` maps the settings snapshot to `FunputConfig`
  in one call (`inputMethod.ffiValue`, `UInt8(toneStyle.rawValue)`, and the four bools),
  then `setEnabled`.

Net **−19 lines**; the six per-option wrappers collapse to one call site.

## Verification

- **`xcodebuild` … BUILD SUCCEEDED** (Debug, arm64).
- No remaining references to the removed setters anywhere in `platforms/macos`.
- The `ComposerConfigurationTests` target only exercises the (unchanged) value type.

## Behavior

Unchanged. `funput_configure` applies the same six options with the same side effects the
individual setters had (a method change clears the composition; auto-capitalize off resets
its tracking), and `enabled` is still applied via `setEnabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
