### PR TITLE
fix(macos): pin manual VI/EN choices per app instead of reverting on refocus

### DIFF
--- a/platforms/macos/Funput/IME/FunputInputController+Composition.swift
+++ b/platforms/macos/Funput/IME/FunputInputController+Composition.swift
@@ -4,10 +4,10 @@ import InputMethodKit
 extension FunputInputController {
     func applyPerAppDefault() {
         let settings = AppSettings.shared
-        guard !settings.excludedApps.isEmpty else { return }
         let front = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
-        let vietnamese = !settings.isExcluded(front)
-        guard settings.vietnameseEnabled != vietnamese else { return }
+        guard let vietnamese = settings.resolveVietnamese(for: front),
+            settings.vietnameseEnabled != vietnamese
+        else { return }
         settings.vietnameseEnabled = vietnamese
         composer.setEnabled(vietnamese)
     }
@@ -51,7 +51,12 @@ extension FunputInputController {
 
     func toggleEnabled() {
         let settings = AppSettings.shared
-        settings.vietnameseEnabled.toggle()
+        // The hotkey fires while the target app is focused, so the choice pins to
+        // that app — the per-app default won't revert it on the next focus change.
+        settings.pinVietnamese(
+            !settings.vietnameseEnabled,
+            to: NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        )
         composer.setEnabled(settings.vietnameseEnabled)
     }
 

--- a/platforms/macos/Funput/IME/FunputInputController.swift
+++ b/platforms/macos/Funput/IME/FunputInputController.swift
@@ -106,10 +106,11 @@ final class FunputInputController: IMKInputController {
         if let client = sender as? IMKTextInput { commit(into: client) }
     }
 
-    /// Focus moved into this client. Apply the per-app default: apps on the exclusion
-    /// list switch to English, every other app switches to Vietnamese. This updates
-    /// `vietnameseEnabled` (so the menu bar reflects it immediately) and the user can
-    /// still toggle manually afterwards until focus changes again.
+    /// Focus moved into this client. Apply the per-app resolution: a manual VI/EN
+    /// choice pinned for this app wins; otherwise apps on the exclusion list switch
+    /// to English and every other app to Vietnamese. This updates `vietnameseEnabled`
+    /// (so the menu bar reflects it immediately); a manual toggle stays pinned for
+    /// the app it was made in (see `AppSettings.resolveVietnamese`).
     override func activateServer(_ sender: Any!) {
         super.activateServer(sender)
         applyPerAppDefault()

--- a/platforms/macos/Funput/MenuBar/MenuBarControlCenter.swift
+++ b/platforms/macos/Funput/MenuBar/MenuBarControlCenter.swift
@@ -8,7 +8,14 @@ struct MenuBarControlCenter: View {
         VStack(spacing: Theme.Spacing.md) {
             MenuBarStatusHeader()
             methodSelector(selection: $settings.inputMethod)
-            shortcutSummary(isVietnameseEnabled: $settings.vietnameseEnabled)
+            // Route writes through `setVietnameseFromUI` so the choice binds to the
+            // app the user returns to (not lost to the per-app default on refocus).
+            shortcutSummary(
+                isVietnameseEnabled: Binding(
+                    get: { settings.vietnameseEnabled },
+                    set: { settings.setVietnameseFromUI($0) }
+                )
+            )
             MenuBarActionCluster()
         }
         .padding(Theme.Spacing.md)

--- a/platforms/macos/Funput/Model/AppSettings+VietnameseOverride.swift
+++ b/platforms/macos/Funput/Model/AppSettings+VietnameseOverride.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Per-app VI/EN resolution — the macOS port of the Windows shell's override map
+/// (`platforms/windows/src/shell.rs`). A manual toggle is pinned per app for the
+/// session and wins over the exclusion-list default on later focus changes, so
+/// choosing EN no longer snaps back to VI the moment focus moves.
+extension AppSettings {
+    /// Decide the VI/EN target when focus lands on the app `front`, consuming a
+    /// pending UI choice into the per-app map. Priority: pending UI choice →
+    /// per-app pin → exclusion-list default. Returns `nil` when nothing applies
+    /// (no pin and no exclusion list configured) — leave the current state as-is.
+    func resolveVietnamese(for front: String?) -> Bool? {
+        if let pending = pendingVietnameseOverride {
+            pendingVietnameseOverride = nil
+            if let front { vietnameseOverrides[front] = pending }
+            return pending
+        }
+        if let front, let pinned = vietnameseOverrides[front] {
+            return pinned
+        }
+        guard !excludedApps.isEmpty else { return nil }
+        return !isExcluded(front)
+    }
+
+    /// Record a VI/EN choice made by the toggle hotkey. The hotkey fires while the
+    /// target app is focused, so the choice pins to that app immediately; any stale
+    /// pending UI choice is dropped.
+    func pinVietnamese(_ on: Bool, to bundleId: String?) {
+        vietnameseEnabled = on
+        if let bundleId { vietnameseOverrides[bundleId] = on }
+        pendingVietnameseOverride = nil
+    }
+
+    /// Record a VI/EN choice made from Funput's own UI (menu bar / Settings). Our
+    /// window holds focus at that moment, so the choice binds to the next app the
+    /// user returns to — otherwise the per-app default would revert it on refocus.
+    func setVietnameseFromUI(_ on: Bool) {
+        vietnameseEnabled = on
+        pendingVietnameseOverride = on
+    }
+}

--- a/platforms/macos/Funput/Model/AppSettings.swift
+++ b/platforms/macos/Funput/Model/AppSettings.swift
@@ -81,6 +81,14 @@ final class AppSettings {
     /// the table to the engine (instead of doing it on every keystroke). Not persisted.
     @ObservationIgnored private(set) var shortcutsRevision = 0
 
+    /// Manual VI/EN choices per app id. A toggle (hotkey or Funput's own UI) pins the
+    /// choice for that app, winning over the exclusion-list default on later focus
+    /// changes — parity with the Windows shell's override map. Session-only.
+    @ObservationIgnored var vietnameseOverrides: [String: Bool] = [:]
+    /// A VI/EN choice made from Funput's own UI while our window held focus — bound
+    /// to the next app the user returns to (see `resolveVietnamese`). Session-only.
+    @ObservationIgnored var pendingVietnameseOverride: Bool?
+
     /// Bumped when an external `funput://settings` request arrives (the /Applications
     /// launcher, opened from Spotlight). Observed by the menu bar label, which opens
     /// the Settings window. Not persisted.

--- a/platforms/macos/Funput/Settings/SettingsSidebar.swift
+++ b/platforms/macos/Funput/Settings/SettingsSidebar.swift
@@ -140,7 +140,14 @@ private struct SidebarQuickInputControl: View {
                 // Custom Liquid Glass toggle instead of Picker(.segmented): the native
                 // segmented control only tints its selected segment while the window
                 // is key/active, so `Theme.accent` wouldn't show reliably here.
-                GlassLanguageToggle(isVietnameseEnabled: $settings.vietnameseEnabled)
+                // Route writes through `setVietnameseFromUI` so the choice binds to
+                // the app the user returns to (not lost to the per-app default).
+                GlassLanguageToggle(
+                    isVietnameseEnabled: Binding(
+                        get: { settings.vietnameseEnabled },
+                        set: { settings.setVietnameseFromUI($0) }
+                    )
+                )
             }
         }
     }

--- a/platforms/macos/FunputTests/VietnameseOverrideTests.swift
+++ b/platforms/macos/FunputTests/VietnameseOverrideTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+
+@testable import Funput
+
+/// Per-app VI/EN resolution (`AppSettings.resolveVietnamese`) — the macOS port of
+/// the Windows shell's override map. A manual toggle must survive focus changes
+/// instead of being reverted by the exclusion-list default.
+@MainActor
+final class VietnameseOverrideTests: XCTestCase {
+    private func makeSettings() -> (AppSettings, () -> Void) {
+        let suiteName = "app.funput.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let settings = AppSettings(defaults: defaults)
+        return (settings, { defaults.removePersistentDomain(forName: suiteName) })
+    }
+
+    func testExclusionDefaultAppliesWhenNothingIsPinned() {
+        let (settings, cleanup) = makeSettings()
+        defer { cleanup() }
+        settings.excludedApps = [ExcludedApp(id: "dev.warp.Warp-Stable", name: "Warp")]
+
+        XCTAssertEqual(settings.resolveVietnamese(for: "dev.warp.Warp-Stable"), false)
+        XCTAssertEqual(settings.resolveVietnamese(for: "com.apple.TextEdit"), true)
+    }
+
+    func testNoExclusionListAndNoPinLeavesStateUntouched() {
+        let (settings, cleanup) = makeSettings()
+        defer { cleanup() }
+        XCTAssertNil(settings.resolveVietnamese(for: "com.apple.TextEdit"))
+    }
+
+    func testHotkeyPinSurvivesRefocus() {
+        let (settings, cleanup) = makeSettings()
+        defer { cleanup() }
+        settings.excludedApps = [ExcludedApp(id: "dev.warp.Warp-Stable", name: "Warp")]
+
+        // User toggles EN via the hotkey while TextEdit (non-excluded) is focused.
+        settings.pinVietnamese(false, to: "com.apple.TextEdit")
+        XCTAssertFalse(settings.vietnameseEnabled)
+
+        // Refocusing TextEdit must keep EN — this was the "always snaps back to VI" bug.
+        XCTAssertEqual(settings.resolveVietnamese(for: "com.apple.TextEdit"), false)
+        // Other apps still get the exclusion-list default.
+        XCTAssertEqual(settings.resolveVietnamese(for: "com.apple.Safari"), true)
+    }
+
+    func testUIChoiceBindsToTheNextFocusedApp() {
+        let (settings, cleanup) = makeSettings()
+        defer { cleanup() }
+        settings.excludedApps = [ExcludedApp(id: "dev.warp.Warp-Stable", name: "Warp")]
+
+        // User picks EN in the menu bar while Funput's own window holds focus.
+        settings.setVietnameseFromUI(false)
+
+        // The next focused app consumes the pending choice and pins it…
+        XCTAssertEqual(settings.resolveVietnamese(for: "com.apple.TextEdit"), false)
+        // …so it sticks on later refocus, while other apps keep the default.
+        XCTAssertEqual(settings.resolveVietnamese(for: "com.apple.TextEdit"), false)
+        XCTAssertEqual(settings.resolveVietnamese(for: "com.apple.Safari"), true)
+    }
+
+    func testHotkeyPinDropsStalePendingUIChoice() {
+        let (settings, cleanup) = makeSettings()
+        defer { cleanup() }
+        settings.setVietnameseFromUI(false)
+
+        // A later hotkey toggle (VI) in Safari wins; the stale pending EN is dropped.
+        settings.pinVietnamese(true, to: "com.apple.Safari")
+        XCTAssertEqual(settings.resolveVietnamese(for: "com.apple.Safari"), true)
+        XCTAssertNil(settings.pendingVietnameseOverride)
+    }
+}


### PR DESCRIPTION
## Bug

With a **non-empty exclusion list**, `applyPerAppDefault` re-applied the exclusion
default on **every** `activateServer` (every app *and field* focus change). Any manual
VI/EN toggle — hotkey or the menu-bar/Settings switch — was silently reverted to VI the
moment focus moved, so the menu bar appeared **stuck on "VI"**.

The Windows shell already solves this with a per-app override map
(`platforms/windows/src/shell.rs`: `overrides` + `pending_override`); macOS lacked the
equivalent. This PR ports that model — behavior is now consistent across platforms.

## How it works now

Resolution priority on focus change (`AppSettings.resolveVietnamese(for:)`):

1. **Pending UI choice** — a toggle made in Funput's own UI (menu bar / Settings) while
   our window held focus binds to the **next app** the user returns to, then pins there.
2. **Per-app pin** — a hotkey toggle fires while the target app is focused, so it pins
   to that app **immediately** (and drops any stale pending choice).
3. **Exclusion default** — excluded apps → EN, others → VI (unchanged).
4. Empty list and no pin → leave the current state untouched (unchanged).

Pins are **session-only** (in-memory), same as Windows.

## Changes

- `AppSettings`: session-only `vietnameseOverrides` + `pendingVietnameseOverride`.
- `AppSettings+VietnameseOverride.swift` (new): `resolveVietnamese(for:)`,
  `pinVietnamese(_:to:)`, `setVietnameseFromUI(_:)`.
- `FunputInputController+Composition`: `toggleEnabled` pins to the frontmost app;
  `applyPerAppDefault` consults the resolver.
- `MenuBarControlCenter` / `SettingsSidebar`: the `GlassLanguageToggle` writes route
  through `setVietnameseFromUI`.

## Testing

- New `VietnameseOverrideTests` (5 cases): exclusion defaults, hotkey pin survives
  refocus (the reported bug), UI choice binds to the next focused app, stale pending
  dropped, empty-list no-op.
- `xcodebuild test`: **TEST SUCCEEDED** (9/9, including the existing suites).

## Notes

- Pre-existing bug, independent of the config-API stack (#92–#94) — based off `main`.
- Found while investigating a "VI/EN always shows VI" report; the same machine also had
  a recorded ⌘P toggle shortcut (⌘-combos never reach an IMKInputController, so such a
  toggle silently does nothing). ShortcutRecorder validation for that is tracked
  separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
