### PR TITLE
refactor(macos): extract vietnameseUIBinding, restoring the 150-LOC limit

### DIFF
--- a/platforms/macos/Funput/MenuBar/MenuBarControlCenter.swift
+++ b/platforms/macos/Funput/MenuBar/MenuBarControlCenter.swift
@@ -8,14 +8,7 @@ struct MenuBarControlCenter: View {
         VStack(spacing: Theme.Spacing.md) {
             MenuBarStatusHeader()
             methodSelector(selection: $settings.inputMethod)
-            // Route writes through `setVietnameseFromUI` so the choice binds to the
-            // app the user returns to (not lost to the per-app default on refocus).
-            shortcutSummary(
-                isVietnameseEnabled: Binding(
-                    get: { settings.vietnameseEnabled },
-                    set: { settings.setVietnameseFromUI($0) }
-                )
-            )
+            shortcutSummary(isVietnameseEnabled: settings.vietnameseUIBinding)
             MenuBarActionCluster()
         }
         .padding(Theme.Spacing.md)

--- a/platforms/macos/Funput/Model/AppSettings+VietnameseOverride.swift
+++ b/platforms/macos/Funput/Model/AppSettings+VietnameseOverride.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 /// Per-app VI/EN resolution — the macOS port of the Windows shell's override map
 /// (`platforms/windows/src/shell.rs`). A manual toggle is pinned per app for the
@@ -37,5 +38,12 @@ extension AppSettings {
     func setVietnameseFromUI(_ on: Bool) {
         vietnameseEnabled = on
         pendingVietnameseOverride = on
+    }
+
+    /// Binding for the VI/EN switches in Funput's own UI. Writes route through
+    /// [`setVietnameseFromUI`] rather than assigning `vietnameseEnabled` directly, so
+    /// every switch shares that binding semantic instead of restating it per call site.
+    var vietnameseUIBinding: Binding<Bool> {
+        Binding(get: { self.vietnameseEnabled }, set: { self.setVietnameseFromUI($0) })
     }
 }

--- a/platforms/macos/Funput/Settings/SettingsSidebar.swift
+++ b/platforms/macos/Funput/Settings/SettingsSidebar.swift
@@ -140,14 +140,7 @@ private struct SidebarQuickInputControl: View {
                 // Custom Liquid Glass toggle instead of Picker(.segmented): the native
                 // segmented control only tints its selected segment while the window
                 // is key/active, so `Theme.accent` wouldn't show reliably here.
-                // Route writes through `setVietnameseFromUI` so the choice binds to
-                // the app the user returns to (not lost to the per-app default).
-                GlassLanguageToggle(
-                    isVietnameseEnabled: Binding(
-                        get: { settings.vietnameseEnabled },
-                        set: { settings.setVietnameseFromUI($0) }
-                    )
-                )
+                GlassLanguageToggle(isVietnameseEnabled: settings.vietnameseUIBinding)
             }
         }
     }


### PR DESCRIPTION
## Summary

My per-app VI/EN fix (#96) duplicated the same six-line `Binding` in **both** UI call
sites, which pushed `SettingsSidebar.swift` to **154 LOC** — over the project's
150-line-per-file rule. This fixes the violation by removing the duplication rather
than just shaving lines.

`AppSettings.vietnameseUIBinding` now states that binding semantic once, next to the
override logic it wraps, so each switch is a single line:

```swift
GlassLanguageToggle(isVietnameseEnabled: settings.vietnameseUIBinding)
```

## Changes

| File | LOC |
|---|---|
| `Model/AppSettings+VietnameseOverride.swift` | 41 → 49 (adds the binding; imports SwiftUI, as `Model/KeyCombo.swift` already does) |
| `Settings/SettingsSidebar.swift` | **154 → 147** ✅ |
| `MenuBar/MenuBarControlCenter.swift` | 74 → 67 |

Net −6 lines. **Every macOS Swift file is now ≤ 150 LOC.**

## Verification

- `xcodebuild … test`: **TEST SUCCEEDED** (9/9). The existing `VietnameseOverrideTests`
  already cover this binding's semantic (`setVietnameseFromUI` → pending choice binds to
  the next focused app), so the extraction is guarded by tests rather than by inspection.
- Behavior unchanged — pure extraction of an identical closure.

## Note for a possible follow-up

`SettingsSidebar.swift` sits at 147/150, so headroom is thin: it holds two types
(`SettingsSidebar` ≈107 lines + `private struct SidebarQuickInputControl` ≈40). Splitting
those is the natural next step if the file grows again — I left it out here to keep this
PR a focused rule fix, and because `platforms/macos/Funput/Settings/` already holds 6
files (the ≤5-files-per-directory convention isn't currently applied to the macOS Swift
tree: `Model/` has 9, `IME/`, `DesignSystem/`, `Settings/`, `Settings/Panes/` have 6). Worth
its own pass if you want that convention enforced on Swift too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
