### PR TITLE
refactor(ios): apply engine settings via funput_configure

### DIFF
--- a/platforms/ios/Packages/FunputKit/Sources/FunputEngine/FunputComposer.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputEngine/FunputComposer.swift
@@ -27,32 +27,31 @@ public final class FunputComposer {
         releaseHandle(handle)
     }
 
+    /// Applies every durable option in one FFI call. Same side effects the per-option
+    /// setters had: a method change clears the composition, and turning
+    /// auto-capitalize off resets its tracking.
+    public func configure(_ options: FunputCompositionOptions) {
+        funput_configure(
+            handle,
+            FunputConfig(
+                method: options.inputMethod.rawValue,
+                tone_style: options.toneStyle.rawValue,
+                smart_restore: options.smartRestore,
+                eager_restore: options.eagerRestore,
+                spell_check: options.spellCheck,
+                auto_capitalize: options.autoCapitalize
+            )
+        )
+    }
+
+    /// Switches the input method on its own, for the keyboard's Telex/VNI key — the
+    /// rest of the configuration is untouched.
     public func setInputMethod(_ method: FunputInputMethod) {
         funput_set_method(handle, method.rawValue)
     }
 
-    public func setToneStyle(_ style: FunputToneStyle) {
-        funput_set_tone_style(handle, style.rawValue)
-    }
-
     public func setEnabled(_ enabled: Bool) {
         funput_set_enabled(handle, enabled)
-    }
-
-    public func setSmartRestore(_ enabled: Bool) {
-        funput_set_smart_restore(handle, enabled)
-    }
-
-    public func setEagerRestore(_ enabled: Bool) {
-        funput_set_eager_restore(handle, enabled)
-    }
-
-    public func setSpellCheck(_ enabled: Bool) {
-        funput_set_spell_check(handle, enabled)
-    }
-
-    public func setAutoCapitalize(_ enabled: Bool) {
-        funput_set_auto_capitalize(handle, enabled)
     }
 
     public func armCapitalization() {

--- a/platforms/ios/Packages/FunputKit/Sources/FunputEngine/FunputCompositionTypes.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputEngine/FunputCompositionTypes.swift
@@ -8,6 +8,38 @@ public enum FunputToneStyle: UInt8, CaseIterable, Sendable {
     case modern = 1
 }
 
+/// The engine's durable user options, applied in one call by
+/// ``FunputComposer/configure(_:)``.
+///
+/// Typed counterpart of the C ABI's `FunputConfig`, so callers outside `FunputEngine`
+/// never touch the C layer. The runtime state — whether Vietnamese composition is
+/// currently on (``FunputComposer/setEnabled(_:)``) and a mid-session method switch
+/// (``FunputComposer/setInputMethod(_:)``) — is deliberately not part of this type.
+public struct FunputCompositionOptions: Equatable, Sendable {
+    public var inputMethod: FunputInputMethod
+    public var toneStyle: FunputToneStyle
+    public var smartRestore: Bool
+    public var eagerRestore: Bool
+    public var spellCheck: Bool
+    public var autoCapitalize: Bool
+
+    public init(
+        inputMethod: FunputInputMethod,
+        toneStyle: FunputToneStyle,
+        smartRestore: Bool,
+        eagerRestore: Bool,
+        spellCheck: Bool,
+        autoCapitalize: Bool
+    ) {
+        self.inputMethod = inputMethod
+        self.toneStyle = toneStyle
+        self.smartRestore = smartRestore
+        self.eagerRestore = eagerRestore
+        self.spellCheck = spellCheck
+        self.autoCapitalize = autoCapitalize
+    }
+}
+
 public enum FunputCompositionAction: UInt8, Sendable {
     case none = 0
     case send = 1

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Configuration/KeyboardInputCoordinator+Configuration.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Configuration/KeyboardInputCoordinator+Configuration.swift
@@ -12,12 +12,16 @@ public extension KeyboardInputCoordinator {
     /// language chosen here can still be toggled at runtime afterward.
     func apply(_ configuration: FunputConfiguration) {
         composer.clear()
-        composer.setInputMethod(configuration.inputMethod.engineMethod)
-        composer.setToneStyle(configuration.toneStyle.engineToneStyle)
-        composer.setSpellCheck(configuration.spellCheck)
-        composer.setSmartRestore(configuration.smartRestore)
-        composer.setEagerRestore(configuration.eagerRestore)
-        composer.setAutoCapitalize(configuration.autoCapitalize)
+        composer.configure(
+            FunputCompositionOptions(
+                inputMethod: configuration.inputMethod.engineMethod,
+                toneStyle: configuration.toneStyle.engineToneStyle,
+                smartRestore: configuration.smartRestore,
+                eagerRestore: configuration.eagerRestore,
+                spellCheck: configuration.spellCheck,
+                autoCapitalize: configuration.autoCapitalize
+            )
+        )
         shiftController.resetTapSequence()
         documentSynchronizer.invalidate()
         personalSuggestionsEnabled = configuration.personalSuggestionsEnabled

--- a/platforms/ios/Packages/FunputKit/Tests/FunputEngineTests/FunputConfigureTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputEngineTests/FunputConfigureTests.swift
@@ -1,0 +1,106 @@
+#if os(iOS) && canImport(FunputCore)
+import FunputEngine
+import Testing
+
+/// `FunputComposer.configure` marshals ``FunputCompositionOptions`` into the C ABI's
+/// `FunputConfig` field by field. A swapped field would still compile, so each option
+/// is asserted through observable composition behavior rather than by inspection.
+@MainActor
+struct FunputConfigureTests {
+    private func options(
+        inputMethod: FunputInputMethod = .telex,
+        toneStyle: FunputToneStyle = .traditional,
+        smartRestore: Bool = true,
+        eagerRestore: Bool = true,
+        spellCheck: Bool = false,
+        autoCapitalize: Bool = false
+    ) -> FunputCompositionOptions {
+        FunputCompositionOptions(
+            inputMethod: inputMethod,
+            toneStyle: toneStyle,
+            smartRestore: smartRestore,
+            eagerRestore: eagerRestore,
+            spellCheck: spellCheck,
+            autoCapitalize: autoCapitalize
+        )
+    }
+
+    @Test("Configure applies the input method")
+    func inputMethod() {
+        let composer = FunputComposer()
+        composer.configure(options(inputMethod: .vni))
+        composer.process("a")
+        composer.process("1") // VNI: digit is the tone key
+        #expect(composer.buffer() == "á")
+    }
+
+    @Test("Configure applies the tone style")
+    func toneStyle() {
+        // `hoaf` places the tone traditionally on `o`, modern on `a`.
+        let traditional = FunputComposer()
+        traditional.configure(options(toneStyle: .traditional))
+        let modern = FunputComposer()
+        modern.configure(options(toneStyle: .modern))
+
+        for scalar in "hoaf".unicodeScalars {
+            traditional.process(scalar)
+            modern.process(scalar)
+        }
+        #expect(traditional.buffer() == "hòa")
+        #expect(modern.buffer() == "hoà")
+    }
+
+    @Test("Configure applies spell-check independently of the other toggles")
+    func spellCheck() {
+        // `tetf` is not a real syllable: with spell-check the huyền key stays literal.
+        let checked = FunputComposer()
+        checked.configure(options(smartRestore: false, spellCheck: true))
+        let unchecked = FunputComposer()
+        unchecked.configure(options(smartRestore: false, spellCheck: false))
+
+        for scalar in "tetf".unicodeScalars {
+            checked.process(scalar)
+            unchecked.process(scalar)
+        }
+        #expect(checked.buffer() == "tetf")
+        #expect(unchecked.buffer() == "tèt")
+    }
+
+    @Test("Configure applies auto-capitalize")
+    func autoCapitalize() {
+        let composer = FunputComposer()
+        composer.configure(options(autoCapitalize: true))
+        composer.armCapitalization()
+        for scalar in "viet".unicodeScalars {
+            composer.process(scalar)
+        }
+        #expect(composer.buffer() == "Viet")
+
+        // Off (the default) leaves the first letter alone.
+        let plain = FunputComposer()
+        plain.configure(options())
+        plain.armCapitalization()
+        for scalar in "viet".unicodeScalars {
+            plain.process(scalar)
+        }
+        #expect(plain.buffer() == "viet")
+    }
+
+    @Test("Configure applies eager restore")
+    func eagerRestore() {
+        // `text` dead-ends as Vietnamese: eager restore flips it back immediately,
+        // while without it the composed form is kept until a word boundary.
+        let eager = FunputComposer()
+        eager.configure(options(eagerRestore: true))
+        let lazy = FunputComposer()
+        lazy.configure(options(eagerRestore: false))
+
+        for scalar in "text".unicodeScalars {
+            eager.process(scalar)
+            lazy.process(scalar)
+        }
+        #expect(eager.buffer() == "text")
+        #expect(lazy.buffer() == "tẽt")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Migrate the iOS keyboard to the batch config API. The C type stays **inside** the
`FunputEngine` module — callers pass a typed `FunputCompositionOptions`, mirroring how
the composer already hides the C ABI behind `FunputInputMethod` / `FunputToneStyle`
(`KeyboardInput` depends on `FunputEngine`, not on `FunputCore`, so the C struct isn't
even visible there).

## Changes

- **`FunputCompositionTypes.swift`**: add `FunputCompositionOptions` — the six durable
  options, `Equatable & Sendable`, matching the module's existing
  `FunputComposition*` vocabulary. (Named "Options" rather than "Config" so it can't be
  confused with `FunputConfiguration`, the app-level preferences type it maps from.)
- **`FunputComposer.swift`**: add `configure(_:)` → `funput_configure`; drop
  `setToneStyle`, `setSmartRestore`, `setEagerRestore`, `setSpellCheck`,
  `setAutoCapitalize` — `apply(_:)` was their only caller.
- **`KeyboardInputCoordinator+Configuration.swift`**: `apply(_:)` builds the options once.

### Why `setInputMethod` stays

Unlike macOS/Windows/Linux, iOS switches method **at runtime** — the keyboard's
Telex/VNI key (`toggleInputMethod()`) and the coordinator's `init`. It is a standalone
operation, not merely part of applying durable config, so it keeps its own entry point
(as does `setEnabled`). This also means the existing engine tests needed no changes.

## Testing

**`FunputConfigureTests` (new, 5 tests — all green).** Each option is asserted through
*observable composition*, so a swapped field in the `FunputConfig` marshalling fails the
suite instead of compiling silently:

| Option | Assertion |
|---|---|
| `inputMethod` | VNI: `a` + `1` → `á` |
| `toneStyle` | `hoaf` → `hòa` (traditional) vs `hoà` (modern) |
| `spellCheck` | `tetf` → `tetf` (on) vs `tèt` (off) |
| `autoCapitalize` | `viet` → `Viet` (on) vs `viet` (off) |
| `eagerRestore` | `text` → `text` (on) vs `tẽt` (off) |

Verified on the dev Mac:
- `Scripts/build-ffi.sh` — rebuilt the xcframework for device + both simulator arches.
- `Scripts/check-swift-loc.sh` — **passes** (≤150 lines per file, incl. the new test).
- `Scripts/test-funput-kit.sh` — runs on the iOS Simulator; `FunputEngineTests` is
  **26 tests / 5 suites passed**.

### About the 4 `KeyboardRendererTests` failures in that run

**Pre-existing, proven — not caused by this change.** I re-ran the suite from a clean
`origin/main` worktree and got an *identical* failure set (hit testing, theme image
background, suggestion toolbar, touch rollover — all UIKit rendering/touch, none of
which touch composition config):

```
Character hit testing reaches its interaction control
Image background replaces gradient and applies adaptive overlay
Keeps logo utilities and emits one candidate
Overlapping presses are tracked for rollover instead of cancelled
```

(The rollover one matches the known simulator limitation — overlap playback needs a real
device.) Worth fixing, but out of scope here.

## Correction to my earlier estimate

I had flagged iOS as "can't verify locally — needs the vendored header re-committed."
Both were wrong: the xcframework is **gitignored** (a build artifact regenerated from
`crates/funput-ffi/include/funput.h`), so this PR carries **no binary or header churn**,
and the full simulator suite does run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
