### PR TITLE
refactor!: drop the per-option setters now that every shell uses configure

### DIFF
--- a/crates/funput-cli/src/dev/sim.rs
+++ b/crates/funput-cli/src/dev/sim.rs
@@ -58,9 +58,9 @@ pub fn simulate(method: InputMethod, input: &str) -> Simulation {
 pub fn simulate_with(config: SimConfig, input: &str) -> Simulation {
     let mut engine = Engine::new();
     engine.set_method(config.method);
-    engine.set_tone_style(config.tone_style);
-    engine.set_smart_restore(config.smart_restore);
-    engine.set_spell_check(config.spell_check);
+    engine.update_config(|c| c.tone_style = config.tone_style);
+    engine.update_config(|c| c.smart_restore = config.smart_restore);
+    engine.update_config(|c| c.spell_check = config.spell_check);
 
     let mut app_text = String::new();
     let mut steps = Vec::new();

--- a/crates/funput-engine/src/engine/config.rs
+++ b/crates/funput-engine/src/engine/config.rs
@@ -5,17 +5,32 @@ use funput_core::{InputMethod, ToneStyle};
 use crate::{Engine, EngineConfig};
 
 impl Engine {
-    /// Apply a whole [`EngineConfig`] at once — the batch equivalent of the
-    /// individual `set_*` methods, preserving their side effects (a method change
-    /// clears the in-progress word; turning auto-capitalize off resets its tracking).
+    /// Apply a whole [`EngineConfig`] — the entry point platform shells use to push
+    /// their settings.
+    ///
+    /// Two side effects: switching input method discards a word composed under the
+    /// old grammar, and turning auto-capitalize off drops its pending state.
     /// `enabled` and the gõ tắt shortcuts are separate and left untouched.
     pub fn configure(&mut self, config: EngineConfig) {
-        self.set_method(config.method);
-        self.set_tone_style(config.tone_style);
-        self.set_smart_restore(config.smart_restore);
-        self.set_eager_restore(config.eager_restore);
-        self.set_spell_check(config.spell_check);
-        self.set_auto_capitalize(config.auto_capitalize);
+        let method_changed = self.session.config.method != config.method;
+        let auto_capitalize_off = !config.auto_capitalize;
+        self.session.config = config;
+        if method_changed {
+            self.session.clear();
+        }
+        if auto_capitalize_off {
+            self.session.cap_armed = false;
+            self.session.cap_sentence_ended = false;
+        }
+    }
+
+    /// Change part of the configuration, keeping the rest — for callers that flip one
+    /// option rather than pushing a whole config (a settings field, a dev tool, a
+    /// test). Routes through [`Engine::configure`], so the same side effects apply.
+    pub fn update_config(&mut self, edit: impl FnOnce(&mut EngineConfig)) {
+        let mut config = self.session.config.clone();
+        edit(&mut config);
+        self.configure(config);
     }
 
     /// The current engine configuration (method, tone style, and the feature toggles).
@@ -31,44 +46,19 @@ impl Engine {
         self.session.enabled
     }
 
-    /// Change input method and discard any composition using the old grammar.
+    /// Switch input method on its own, discarding any composition typed under the old
+    /// grammar. Kept as a dedicated call because the iOS and Android keyboards flip the
+    /// method at runtime from their Telex/VNI key, outside any settings change.
     pub fn set_method(&mut self, method: InputMethod) {
-        if self.session.config.method != method {
-            self.session.clear();
-            self.session.config.method = method;
-        }
+        self.update_config(|config| config.method = method);
     }
 
     pub fn method(&self) -> InputMethod {
         self.session.config.method
     }
 
-    pub fn set_tone_style(&mut self, style: ToneStyle) {
-        self.session.config.tone_style = style;
-    }
-
     pub fn tone_style(&self) -> ToneStyle {
         self.session.config.tone_style
-    }
-
-    pub fn set_smart_restore(&mut self, on: bool) {
-        self.session.config.smart_restore = on;
-    }
-
-    pub fn set_eager_restore(&mut self, on: bool) {
-        self.session.config.eager_restore = on;
-    }
-
-    pub fn set_spell_check(&mut self, on: bool) {
-        self.session.config.spell_check = on;
-    }
-
-    pub fn set_auto_capitalize(&mut self, on: bool) {
-        self.session.config.auto_capitalize = on;
-        if !on {
-            self.session.cap_armed = false;
-            self.session.cap_sentence_ended = false;
-        }
     }
 
     pub fn arm_capitalization(&mut self) {

--- a/crates/funput-engine/tests/alloc_budget.rs
+++ b/crates/funput-engine/tests/alloc_budget.rs
@@ -112,9 +112,9 @@ fn keystroke_alloc_budget() {
 
     assert_within_budget("default settings", &mut engine);
 
-    engine.set_spell_check(true);
+    engine.update_config(|c| c.spell_check = true);
     assert_within_budget("spell-check on", &mut engine);
 
-    engine.set_spell_check(false);
+    engine.update_config(|c| c.spell_check = false);
     pairs::assert_paired_allocations(&mut engine);
 }

--- a/crates/funput-engine/tests/diacritics/placement.rs
+++ b/crates/funput-engine/tests/diacritics/placement.rs
@@ -13,7 +13,7 @@ fn run(m: InputMethod, keys: &str) -> String {
 fn run_modern(m: InputMethod, keys: &str) -> String {
     let mut e = Engine::new();
     e.set_method(m);
-    e.set_tone_style(ToneStyle::Modern);
+    e.update_config(|c| c.tone_style = ToneStyle::Modern);
     for k in keys.chars() {
         e.process_char(k);
     }

--- a/crates/funput-engine/tests/engine_api.rs
+++ b/crates/funput-engine/tests/engine_api.rs
@@ -54,7 +54,7 @@ fn type_word(engine: &mut Engine, word: &str) -> String {
 #[test]
 fn spell_check_off_keeps_legacy_diacritic() {
     let mut engine = Engine::new();
-    engine.set_smart_restore(false);
+    engine.update_config(|c| c.smart_restore = false);
     // Default: spell-check off → `tetf` composes `tèt` (huyền) as before, even
     // though a stop coda may only carry sắc / nặng.
     assert_eq!(type_word(&mut engine, "tetf"), "tèt");
@@ -63,8 +63,8 @@ fn spell_check_off_keeps_legacy_diacritic() {
 #[test]
 fn spell_check_on_blocks_invalid_syllable() {
     let mut engine = Engine::new();
-    engine.set_smart_restore(false);
-    engine.set_spell_check(true);
+    engine.update_config(|c| c.smart_restore = false);
+    engine.update_config(|c| c.spell_check = true);
     // `tèt` is not a real syllable → the huyền key stays a literal: `tetf`.
     assert_eq!(type_word(&mut engine, "tetf"), "tetf");
     // Real syllables are unaffected.
@@ -76,7 +76,7 @@ fn spell_check_on_blocks_invalid_syllable() {
 
 fn engine_autocap() -> Engine {
     let mut e = Engine::new();
-    e.set_auto_capitalize(true);
+    e.update_config(|c| c.auto_capitalize = true);
     e
 }
 

--- a/crates/funput-engine/tests/methods/telex_advanced.rs
+++ b/crates/funput-engine/tests/methods/telex_advanced.rs
@@ -99,7 +99,7 @@ fn inherited_pending_intent_restores_at_boundary() {
 #[test]
 fn capitalization_backspace_and_method_switch_stay_synchronized() {
     let mut engine = engine();
-    engine.set_auto_capitalize(true);
+    engine.update_config(|c| c.auto_capitalize = true);
     engine.arm_capitalization();
     engine.process_char('[');
     assert_eq!(engine.buffer(), "Ư");

--- a/crates/funput-engine/tests/restore/toggle.rs
+++ b/crates/funput-engine/tests/restore/toggle.rs
@@ -27,7 +27,7 @@ fn defaults_restore_eagerly() {
 fn smart_off_keeps_composed_word() {
     // No restore at all: the composed Vietnamese form is kept even for English.
     let mut e = telex();
-    e.set_smart_restore(false);
+    e.update_config(|c| c.smart_restore = false);
     typed(&mut e, "text");
     assert_eq!(e.buffer(), "tẽt"); // not restored mid-word
     let space = e.process_char(' ');
@@ -38,7 +38,7 @@ fn smart_off_keeps_composed_word() {
 fn eager_off_restores_only_at_boundary() {
     // Smart on, eager off: keep composing mid-word, restore when the word ends.
     let mut e = telex();
-    e.set_eager_restore(false);
+    e.update_config(|c| c.eager_restore = false);
     typed(&mut e, "text");
     assert_eq!(e.buffer(), "tẽt"); // no instant restore
     let space = e.process_char(' ');
@@ -51,8 +51,8 @@ fn toggles_do_not_disturb_valid_vietnamese() {
     // A real syllable is kept regardless of the toggles.
     for (smart, eager) in [(true, true), (true, false), (false, false)] {
         let mut e = telex();
-        e.set_smart_restore(smart);
-        e.set_eager_restore(eager);
+        e.update_config(|c| c.smart_restore = smart);
+        e.update_config(|c| c.eager_restore = eager);
         typed(&mut e, "vieejt");
         assert_eq!(e.buffer(), "việt");
     }

--- a/crates/funput-ffi/README.en.md
+++ b/crates/funput-ffi/README.en.md
@@ -39,11 +39,15 @@ typedef struct {
 FunputEngine *funput_engine_new(void);
 void          funput_engine_free(FunputEngine *engine);
 
-void          funput_set_method(FunputEngine *engine, uint8_t method);      // 0=Telex, 1=VNI
-void          funput_set_tone_style(FunputEngine *engine, uint8_t style);   // 0=Traditional, 1=Modern
-void          funput_set_enabled(FunputEngine *engine, bool enabled);
-void          funput_set_smart_restore(FunputEngine *engine, bool on);
-void          funput_set_eager_restore(FunputEngine *engine, bool on);
+typedef struct {                 // every option, passed by value
+    uint8_t method;              //   0=Telex, 1=VNI, 2=Telex Advanced
+    uint8_t tone_style;          //   0=Traditional, 1=Modern
+    bool smart_restore, eager_restore, spell_check, auto_capitalize;
+} FunputConfig;
+
+void          funput_configure(FunputEngine *engine, FunputConfig config);   // apply the whole set
+void          funput_set_method(FunputEngine *engine, uint8_t method);       // runtime method switch
+void          funput_set_enabled(FunputEngine *engine, bool enabled);        // runtime VI/EN
 void          funput_clear(FunputEngine *engine);                            // word boundary / focus change
 
 FunputResult  funput_process_char(FunputEngine *engine, uint32_t codepoint);
@@ -98,7 +102,7 @@ src/lib.rs          # crate root: docs + module tree + flat C re-export surface
 src/engine/         # composition IME C API (FunputEngine)
                     #   mod.rs      opaque FunputEngine + new/free + group re-exports
                     #   compose.rs  process_char/key, buffer, backspace, flip, clear, arm
-                    #   config.rs   7 setters: method/tone_style/enabled/smart|eager/spell/autocap
+                    #   config.rs   FunputConfig + configure() + set_method/set_enabled
                     #   shortcuts.rs add_shortcut/clear_shortcuts (text expansion, "gõ tắt")
                     #   result.rs   #[repr(C)] FunputResult + from_ime() + CHARS_CAP/ACTION_*
 src/suggestion/     # personal-suggestion C API (FunputSuggestionEngine)

--- a/crates/funput-ffi/README.md
+++ b/crates/funput-ffi/README.md
@@ -39,11 +39,15 @@ typedef struct {
 FunputEngine *funput_engine_new(void);
 void          funput_engine_free(FunputEngine *engine);
 
-void          funput_set_method(FunputEngine *engine, uint8_t method);      // 0=Telex, 1=VNI
-void          funput_set_tone_style(FunputEngine *engine, uint8_t style);   // 0=Traditional, 1=Modern
-void          funput_set_enabled(FunputEngine *engine, bool enabled);
-void          funput_set_smart_restore(FunputEngine *engine, bool on);
-void          funput_set_eager_restore(FunputEngine *engine, bool on);
+typedef struct {                 // toàn bộ tuỳ chọn, truyền theo giá trị
+    uint8_t method;              //   0=Telex, 1=VNI, 2=Telex Advanced
+    uint8_t tone_style;          //   0=Traditional, 1=Modern
+    bool smart_restore, eager_restore, spell_check, auto_capitalize;
+} FunputConfig;
+
+void          funput_configure(FunputEngine *engine, FunputConfig config);   // áp cả cụm
+void          funput_set_method(FunputEngine *engine, uint8_t method);       // đổi kiểu gõ lúc chạy
+void          funput_set_enabled(FunputEngine *engine, bool enabled);        // VI/EN lúc chạy
 void          funput_clear(FunputEngine *engine);                            // ranh giới từ / đổi focus
 
 FunputResult  funput_process_char(FunputEngine *engine, uint32_t codepoint);
@@ -97,7 +101,7 @@ src/lib.rs          # crate root: docs + module tree + re-export surface phẳng
 src/engine/         # C API composition (FunputEngine)
                     #   mod.rs      opaque FunputEngine + new/free + re-export nhóm
                     #   compose.rs  process_char/key, buffer, backspace, flip, clear, arm
-                    #   config.rs   7 setter: method/tone_style/enabled/smart|eager/spell/autocap
+                    #   config.rs   FunputConfig + configure() + set_method/set_enabled
                     #   shortcuts.rs add_shortcut/clear_shortcuts (gõ tắt)
                     #   result.rs   #[repr(C)] FunputResult + from_ime() + CHARS_CAP/ACTION_*
 src/suggestion/     # C API personal suggestions (FunputSuggestionEngine)

--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -218,15 +218,6 @@ FunputResult funput_flip_composing(FunputEngine *engine);
 void funput_set_method(FunputEngine *engine, uint8_t method);
 
 /**
- * Set the tone-mark placement style: `0 = Traditional` (`hòa`), `1 = Modern`
- * (`hoà`) — any other value = Traditional.
- *
- * # Safety
- * `engine` must be a valid handle or null.
- */
-void funput_set_tone_style(FunputEngine *engine, uint8_t style);
-
-/**
  * Apply a whole [`FunputConfig`] at once — the batch equivalent of the individual
  * `funput_set_*` functions, with the same side effects (a method change clears the
  * composition; auto-capitalize off resets its tracking). `funput_set_enabled` and
@@ -244,43 +235,6 @@ void funput_configure(FunputEngine *engine, FunputConfig config);
  * `engine` must be a valid handle or null.
  */
 void funput_set_enabled(FunputEngine *engine, bool enabled);
-
-/**
- * Toggle auto-restore of non-Vietnamese words to their raw Latin keystrokes
- * (`card` stays `card`). When off, the composed buffer is always kept.
- *
- * # Safety
- * `engine` must be a valid handle or null.
- */
-void funput_set_smart_restore(FunputEngine *engine, bool on);
-
-/**
- * Toggle eager restore — flip to raw keys the instant a word dead-ends instead of
- * waiting for a word boundary. Only applies while smart restore is on.
- *
- * # Safety
- * `engine` must be a valid handle or null.
- */
-void funput_set_eager_restore(FunputEngine *engine, bool on);
-
-/**
- * Toggle spell-check ("Kiểm tra chính tả") — only place a diacritic when the result
- * can still become a real Vietnamese syllable, otherwise keep the modifier key as a
- * literal. Off by default.
- *
- * # Safety
- * `engine` must be a valid handle or null.
- */
-void funput_set_spell_check(FunputEngine *engine, bool on);
-
-/**
- * Toggle auto-capitalize ("Tự động viết hoa") — uppercase the first letter of a word
- * that starts a sentence. Off by default; a no-op while off.
- *
- * # Safety
- * `engine` must be a valid handle or null.
- */
-void funput_set_auto_capitalize(FunputEngine *engine, bool on);
 
 /**
  * Define a text-expansion shortcut (gõ tắt): typing `trigger` then a word boundary

--- a/crates/funput-ffi/src/engine/config.rs
+++ b/crates/funput-ffi/src/engine/config.rs
@@ -44,17 +44,6 @@ pub unsafe extern "C" fn funput_set_method(engine: *mut FunputEngine, method: u8
     unsafe { abi::with_engine_mut(engine, |e| e.set_method(method)) }
 }
 
-/// Set the tone-mark placement style: `0 = Traditional` (`hòa`), `1 = Modern`
-/// (`hoà`) — any other value = Traditional.
-///
-/// # Safety
-/// `engine` must be a valid handle or null.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn funput_set_tone_style(engine: *mut FunputEngine, style: u8) {
-    let style = decode_tone_style(style);
-    unsafe { abi::with_engine_mut(engine, |e| e.set_tone_style(style)) }
-}
-
 /// A whole engine configuration passed by value over the C ABI — the six user
 /// options. `enabled` and the gõ tắt shortcut table have their own functions.
 #[repr(C)]
@@ -97,45 +86,4 @@ pub unsafe extern "C" fn funput_configure(engine: *mut FunputEngine, config: Fun
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn funput_set_enabled(engine: *mut FunputEngine, enabled: bool) {
     unsafe { abi::with_engine_mut(engine, |e| e.set_enabled(enabled)) }
-}
-
-/// Toggle auto-restore of non-Vietnamese words to their raw Latin keystrokes
-/// (`card` stays `card`). When off, the composed buffer is always kept.
-///
-/// # Safety
-/// `engine` must be a valid handle or null.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn funput_set_smart_restore(engine: *mut FunputEngine, on: bool) {
-    unsafe { abi::with_engine_mut(engine, |e| e.set_smart_restore(on)) }
-}
-
-/// Toggle eager restore — flip to raw keys the instant a word dead-ends instead of
-/// waiting for a word boundary. Only applies while smart restore is on.
-///
-/// # Safety
-/// `engine` must be a valid handle or null.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn funput_set_eager_restore(engine: *mut FunputEngine, on: bool) {
-    unsafe { abi::with_engine_mut(engine, |e| e.set_eager_restore(on)) }
-}
-
-/// Toggle spell-check ("Kiểm tra chính tả") — only place a diacritic when the result
-/// can still become a real Vietnamese syllable, otherwise keep the modifier key as a
-/// literal. Off by default.
-///
-/// # Safety
-/// `engine` must be a valid handle or null.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn funput_set_spell_check(engine: *mut FunputEngine, on: bool) {
-    unsafe { abi::with_engine_mut(engine, |e| e.set_spell_check(on)) }
-}
-
-/// Toggle auto-capitalize ("Tự động viết hoa") — uppercase the first letter of a word
-/// that starts a sentence. Off by default; a no-op while off.
-///
-/// # Safety
-/// `engine` must be a valid handle or null.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn funput_set_auto_capitalize(engine: *mut FunputEngine, on: bool) {
-    unsafe { abi::with_engine_mut(engine, |e| e.set_auto_capitalize(on)) }
 }

--- a/crates/funput-ffi/src/engine/mod.rs
+++ b/crates/funput-ffi/src/engine/mod.rs
@@ -23,8 +23,7 @@ pub use compose::{
 };
 pub use config::{
     FunputConfig, METHOD_TELEX, METHOD_TELEX_ADVANCED, METHOD_VNI, funput_configure,
-    funput_set_auto_capitalize, funput_set_eager_restore, funput_set_enabled, funput_set_method,
-    funput_set_smart_restore, funput_set_spell_check, funput_set_tone_style,
+    funput_set_enabled, funput_set_method,
 };
 pub use result::{ACTION_NONE, ACTION_RESTORE, ACTION_SEND, CHARS_CAP, FunputResult};
 pub use shortcuts::{funput_add_shortcut, funput_clear_shortcuts};

--- a/crates/funput-ffi/src/lib.rs
+++ b/crates/funput-ffi/src/lib.rs
@@ -39,9 +39,8 @@ pub use engine::{
     METHOD_TELEX, METHOD_TELEX_ADVANCED, METHOD_VNI, SOURCE_NUMPAD, SOURCE_STANDARD,
     funput_add_shortcut, funput_arm_capitalization, funput_backspace, funput_buffer, funput_clear,
     funput_clear_shortcuts, funput_configure, funput_engine_free, funput_engine_new,
-    funput_flip_composing, funput_process_char, funput_process_key, funput_set_auto_capitalize,
-    funput_set_eager_restore, funput_set_enabled, funput_set_method, funput_set_smart_restore,
-    funput_set_spell_check, funput_set_tone_style,
+    funput_flip_composing, funput_process_char, funput_process_key, funput_set_enabled,
+    funput_set_method,
 };
 pub use suggestion::{
     FunputSuggestionCandidate, FunputSuggestionEngine, FunputSuggestionResult,

--- a/crates/funput-jni/src/engine/mod.rs
+++ b/crates/funput-jni/src/engine/mod.rs
@@ -6,7 +6,8 @@
 //!   safe no-op.
 //! - [`lifecycle`] — `nativeCreate` / `nativeDestroy` / `nativeClear`.
 //! - [`composition`] — `nativeProcess` / `nativeBoundary` / `nativeBackspace`.
-//! - [`settings`] — `nativeSetMethod` / `nativeSetToneStyle` / the boolean toggles.
+//! - [`settings`] — `nativeConfigure` (the durable options in one call) and
+//!   `nativeSetEnabled` (runtime VI/EN).
 //!
 //! Exports link by `#[no_mangle]` symbol name, so their module location is
 //! invisible to the Android runtime.

--- a/platforms/macos/Funput/Model/InputMethod.swift
+++ b/platforms/macos/Funput/Model/InputMethod.swift
@@ -49,7 +49,7 @@ enum InputMethod: String, CaseIterable, Identifiable, Codable {
 }
 
 /// Tone-mark placement style. Raw value matches `funput_core`
-/// (`Traditional = 0`, `Modern = 1`), so it passes straight to `funput_set_tone_style`.
+/// (`Traditional = 0`, `Modern = 1`), so it passes straight into `FunputConfig`.
 enum ToneStyle: Int, CaseIterable, Identifiable, Codable {
     case traditional = 0
     case modern = 1

--- a/platforms/windows/src/compose.rs
+++ b/platforms/windows/src/compose.rs
@@ -20,7 +20,7 @@ impl FieldComposer {
     pub fn new() -> Self {
         let mut engine = Engine::new();
         // A config field keeps what the user composes (no English auto-restore).
-        engine.set_smart_restore(false);
+        engine.update_config(|c| c.smart_restore = false);
         Self {
             engine,
             method: InputMethod::Telex,
@@ -37,7 +37,7 @@ impl FieldComposer {
     pub fn reset(&mut self, text: &str, method: InputMethod, tone: ToneStyle) {
         self.method = method;
         self.engine.set_method(method);
-        self.engine.set_tone_style(tone);
+        self.engine.update_config(|c| c.tone_style = tone);
         self.engine.clear();
         self.committed = text.to_string();
     }


### PR DESCRIPTION
## Summary

Final step of the config-API work (#92 → #93 → #94/#97/#99/#100/#101). Every shell now
pushes its settings as one batch, so the five per-option entry points have **no platform
callers left**.

Rather than leaving five near-identical setters, they collapse into **one generic
editor** — which keeps partial updates ergonomic for the in-tree callers that legitimately
flip a single option (a dev tool, a settings field, tests):

```rust
engine.configure(config);                              // whole config — platform shells
engine.update_config(|c| c.spell_check = true);        // one option  — tools & tests
let current = engine.config();                         // read
```

## ⚠️ BREAKING (C ABI)

Removed: `funput_set_tone_style`, `funput_set_smart_restore`, `funput_set_eager_restore`,
`funput_set_spell_check`, `funput_set_auto_capitalize` → use **`funput_configure`**.

**Kept on purpose:** `funput_set_method` and `funput_set_enabled` — iOS and Android switch
the input method and VI/EN **at runtime** (keyboard keys, per-field state), outside any
settings change. Trimming those too would have forced a full `configure` for a single
runtime toggle.

The regenerated `funput.h` is **deletions only: −46, +0**.

## Changes

- **funput-engine**: `update_config(|c| …)` replaces the five setters. `configure` no
  longer delegates through them, so both side effects — a method change clears the
  composition, auto-capitalize off drops its pending state — now live in **one** place
  instead of being spread across two methods. `set_method` becomes a thin wrapper over
  `update_config`, so there's a single implementation of those semantics.
- **funput-ffi**: five exports removed; header regenerated.
- **Migrated the remaining callers** to `update_config`: `funput-cli`'s `dev/sim`, the
  Windows settings-field composer (`compose.rs`), and the engine integration tests.
- **Docs**: both `funput-ffi` READMEs (C API listing + layout), the `funput-jni` module
  doc (still described `nativeSetToneStyle`), and a stale macOS comment.

## Verification

Rust: `cargo test --workspace` (29 suites), `clippy --workspace --all-targets -D warnings`,
`cargo fmt --check` — all clean.

**All five project LOC checkers pass**: `scripts/check-loc.sh` (134 crate src files),
`platforms/linux/check-loc.sh`, both `check-swift-loc.sh`, `check-kotlin-loc.sh`.

Every consumer rebuilt against the trimmed ABI:

| Platform | Result |
|---|---|
| macOS | `xcodebuild` **BUILD SUCCEEDED** |
| Windows | `cargo check --target x86_64-pc-windows-gnu` ✅ |
| Linux | shared headers compile `-Wall -Wextra -Werror` ✅ |
| iOS | xcframework rebuilt; FunputKit **69 tests**, only the 4 pre-existing `KeyboardRendererTests` failures (unchanged from `main`) |
| Android | `:ime:testDebugUnitTest` + `:ime:assembleDebug` (Rust `.so` per ABI) **BUILD SUCCESSFUL** |

## End state of the config API

```
configure(EngineConfig)          batch — what every shell calls
update_config(|c| …)             partial edit — tools, settings fields, tests
config() -> &EngineConfig        read
set_method / set_enabled         runtime switches (iOS/Android keyboard keys)
```

Adding an engine option is now: a field on `EngineConfig`, its mapping in
`funput_configure` / `nativeConfigure`, and the platform's own settings plumbing —
no new FFI export, no new setter, no ripple through five shells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
