### PR TITLE
test(ios): fix the four red KeyboardRendererTests

### DIFF
--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/AlphabeticSurfaceTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/AlphabeticSurfaceTests.swift
@@ -30,23 +30,23 @@ struct AlphabeticSurfaceTests {
         #expect(locked?.isEqual(UIImage(systemName: "capslock.fill")) == true)
     }
 
-    @Test("Character hit testing reaches its interaction control")
-    func characterHitTesting() {
+    /// One overlay receives every touch (so a finger can slide between keys), and the
+    /// key is resolved from geometry; keycap controls only render and carry a11y.
+    @Test("A touch on a keycap is routed to that key through the touch overlay")
+    func characterHitTesting() throws {
         let layout = StandardKeyboardLayouts.letters(.vni)
         let surface = KeyboardSurfaceView(presentation: KeyboardPresentation(layout: layout))
         surface.frame = CGRect(x: 0, y: 0, width: 390, height: 304)
         surface.layoutIfNeeded()
 
-        let key = accessibleControls(in: surface).first {
-            $0.accessibilityLabel == "a"
-        }
-        let point = key.map {
-            $0.convert(CGPoint(x: $0.bounds.midX, y: $0.bounds.midY), to: surface)
-        }
-        let hitView = point.flatMap { surface.hitTest($0, with: nil) }
+        let keys = accessibleControls(in: surface)
+        let key = try #require(keys.first { $0.accessibilityLabel == "a" })
+        let point = key.convert(CGPoint(x: key.bounds.midX, y: key.bounds.midY), to: surface)
 
-        #expect(key != nil)
-        #expect(hitView is UIControl)
+        // The overlay is the topmost interactive view there, and it resolves the point
+        // back to the key the user aimed at.
+        #expect(surface.hitTest(point, with: nil) === surface.touchOverlay)
+        #expect(surface.touchOverlay.resolvedHit(at: point)?.key.id == "character-a")
     }
 
     @Test("Shift preserves Liquid Glass surfaces")

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardInteractionTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardInteractionTests.swift
@@ -29,7 +29,10 @@ struct KeyboardInteractionTests {
         #expect(events.map(\.phase) == [.pressed, .pressed, .released, .released])
         #expect(events.map(\.key.id) == ["key-a", "key-b", "key-a", "key-b"])
         #expect(controller.activeKey == nil)
-        #expect(previews == ["key-a", "key-b", nil])
+        // The preview always follows the newest live touch, so releasing "a" while "b"
+        // is still held re-points it at "b" (hence "key-b" twice) before the last
+        // release clears it.
+        #expect(previews == ["key-a", "key-b", "key-b", nil])
     }
 
     @Test("Sustained rollover never cancels or drops a release")

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/PersonalSuggestionToolbarTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/PersonalSuggestionToolbarTests.swift
@@ -23,7 +23,7 @@ struct PersonalSuggestionToolbarTests {
         #expect(buttons.contains { $0.accessibilityLabel == "Biểu tượng cảm xúc" })
         let suggestion = buttons.first { $0.accessibilityLabel == "Gợi ý, từ0" }
         #expect(suggestion != nil)
-        suggestion?.sendActions(for: .touchUpInside)
+        suggestion.map(tap)
         #expect(selected == [values[0]])
     }
 
@@ -49,6 +49,20 @@ struct PersonalSuggestionToolbarTests {
 
     private func candidates(_ count: Int) -> [KeyboardSuggestionCandidate] {
         (0..<count).map { KeyboardSuggestionCandidate(text: "từ\($0)", generation: 7) }
+    }
+
+    /// Fire a control's registered `touchUpInside` actions.
+    ///
+    /// `UIControl.sendActions(for:)` dispatches through `UIApplication.shared`, which a
+    /// SwiftPM test bundle has no host app for — the actions are silently dropped. So
+    /// invoke the target/action pairs the control actually holds.
+    private func tap(_ control: UIControl) {
+        for target in control.allTargets {
+            let actions = control.actions(forTarget: target, forControlEvent: .touchUpInside)
+            for action in actions ?? [] {
+                _ = (target as AnyObject).perform(Selector(action), with: control)
+            }
+        }
     }
 
     private func visibleButtons(in view: UIView) -> [UIButton] {

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/ThemeRendererColorTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/ThemeRendererColorTests.swift
@@ -41,10 +41,14 @@ struct ThemeRendererColorTests {
         backdrop.apply(theme: theme, traits: traits, image: UIImage(systemName: "photo"))
         backdrop.layoutIfNeeded()
 
-        let image = try #require(backdrop.subviews.compactMap { $0 as? UIImageView }.first)
+        // The image, gradient and overlay sit inside the backdrop's rounded themed
+        // container, which is stacked above the material view — not in the backdrop's
+        // own subviews.
+        let themed = try #require(backdrop.subviews.last)
+        let image = try #require(themed.subviews.compactMap { $0 as? UIImageView }.first)
         #expect(!image.isHidden)
         #expect(backdrop.contentView.isHidden)
-        #expect(backdrop.subviews.last?.backgroundColor?.cgColor.alpha == 0.35)
+        #expect(themed.subviews.last?.backgroundColor?.cgColor.alpha == 0.35)
     }
 
     @Test("Glass key tint uses a bounded independent color layer")


### PR DESCRIPTION
## Summary

The four long-red `KeyboardRendererTests` are green. **FunputKit now runs clean: 59
suites, 0 failures (`** TEST SUCCEEDED **`).**

I diagnosed each one before touching it. **In all four cases the product code is
correct** — the tests were asserting mechanics the renderer no longer uses. So each was
**retargeted at current behaviour rather than deleted**: the thing each test set out to
cover is still worth covering.

## The four, with root cause

| Test | Root cause | Fix |
|---|---|---|
| `AlphabeticSurfaceTests` — hit testing | Touches now go to **one** `KeyboardTouchOverlayView`, not per-key `UIControl`s — that's what lets a finger slide between keys "without depending on button-style `touchUpInside`" (its own doc). So `hitView is UIControl` can never hold. | Assert the overlay **is** the hit view *and* that it resolves the point back to the `a` key — the routing the old test meant to cover. |
| `PersonalSuggestionToolbarTests` — tap | `UIControl.sendActions(for:)` dispatches via `UIApplication.shared`, and a **SwiftPM test bundle has no host app** — the tap was silently dropped. | A `tap` helper that invokes the control's registered target/action pairs, with the reason documented. |
| `KeyboardInteractionTests` — rollover | The preview **follows the newest live touch**, so releasing `a` while `b` is held re-points it at `b`. The expectation assumed no refresh on that release. | Expectation updated to the real sequence, with the semantic spelled out in a comment. |
| `ThemeRendererColorTests` — image background | The image/gradient/overlay live inside the backdrop's **themed container**, stacked above the material view. The test searched the backdrop's *direct* subviews, where `materialView` sits. | Look inside the themed container. |

### How I proved the toolbar one (rather than guessing)

A temporary diagnostic test printed the button's wiring and both dispatch paths:

```
label=Gợi ý, từ0  hidden=false  tag=0  enabled=true  targets=1  actions=["selectCandidate:"]
selectedAfterSend=0            ← sendActions(.touchUpInside)
selectedAfterDirectPerform=1   ← invoking the registered action directly
hasApp=false                   ← UIApplication.shared is absent
```

The production wiring is intact; only the test's dispatch mechanism was wrong. (The
diagnostic file was removed.)

## Nothing was deleted

Worth stating explicitly, since the ask allowed cleanup: **no test was dropped**. Each
still covers real behaviour (touch routing, suggestion selection, rollover previews,
themed image background), and two of them now cover it *better* — the hit-test one
actually verifies which key a touch resolves to, which the old `is UIControl` assertion
never did.

## Verification

- `Scripts/test-funput-kit.sh` → `** TEST SUCCEEDED **`, 59/59 suites, 0 failures.
- `Scripts/check-swift-loc.sh` → passes (I had to tighten `AlphabeticSurfaceTests` to
  land at exactly 150).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
