### PR TITLE
feat(android): retone a committed word after Backspace

### DIFF
--- a/crates/funput-engine/src/engine/editing.rs
+++ b/crates/funput-engine/src/engine/editing.rs
@@ -1,7 +1,35 @@
+use funput_core::is_complete_syllable;
+
 use crate::compose::{diff, flip};
 use crate::{Engine, ImeResult};
 
 impl Engine {
+    /// Re-open an already-committed word as the live composition, so the next
+    /// keystroke edits it — the host uses this when the caret lands back on a word
+    /// (Android: Backspace over the space after `chào`, then `s` gives `cháo`).
+    ///
+    /// Returns whether `text` was taken. Only a complete Vietnamese syllable is,
+    /// which keeps English words and URLs from silently becoming editable; the host
+    /// should leave the document untouched when this is `false`.
+    ///
+    /// The raw keystrokes that produced `text` are gone, so they are seeded from the
+    /// text itself — the same state `on_backspace` leaves behind. Composition only
+    /// ever reads the buffer, so tone and shape edits work from here; there is no raw
+    /// form to flip back to, which makes the flip hotkey a no-op on an adopted word.
+    pub fn adopt(&mut self, text: &str) -> bool {
+        if !self.session.enabled || text.is_empty() || !is_complete_syllable(text) {
+            return false;
+        }
+        // clear() + push_str refills the session strings in place, so seeding them
+        // costs nothing; the syllable check above is the only allocation here (it
+        // builds a rhyme string), the same one every word boundary already pays.
+        self.session.clear();
+        self.session.buffer.push_str(text);
+        self.session.keys.push_str(text);
+        self.session.vn_form.push_str(text);
+        true
+    }
+
     /// Synchronize engine state after a Backspace passed through to the host app.
     pub fn on_backspace(&mut self) -> ImeResult {
         if !self.session.enabled {

--- a/crates/funput-engine/tests/adopt.rs
+++ b/crates/funput-engine/tests/adopt.rs
@@ -1,0 +1,109 @@
+//! Re-opening a committed word for editing (`Engine::adopt`).
+//!
+//! Android calls this when Backspace puts the caret back on a finished word, so the
+//! next keystroke retones it instead of typing a literal letter.
+
+use funput_core::InputMethod;
+use funput_engine::Engine;
+
+fn engine(method: InputMethod) -> Engine {
+    let mut engine = Engine::new();
+    engine.set_method(method);
+    engine
+}
+
+fn type_into(engine: &mut Engine, keys: &str) -> String {
+    for key in keys.chars() {
+        engine.process_char(key);
+    }
+    engine.buffer().to_owned()
+}
+
+/// The reason this exists: type `chào`, commit it with Space, delete the space, adopt
+/// the word again, then a tone key edits it in place.
+#[test]
+fn adopted_word_accepts_a_new_tone() {
+    let mut engine = engine(InputMethod::Telex);
+    assert_eq!(type_into(&mut engine, "chaof"), "chào");
+    engine.process_char(' '); // word boundary commits and clears the session
+    assert_eq!(engine.buffer(), "");
+
+    assert!(engine.adopt("chào"));
+    assert_eq!(engine.buffer(), "chào");
+    engine.process_char('s'); // sắc replaces huyền
+    assert_eq!(engine.buffer(), "cháo");
+}
+
+#[test]
+fn adopted_word_matches_typing_it_from_scratch() {
+    let mut adopted = engine(InputMethod::Telex);
+    assert!(adopted.adopt("chào"));
+    adopted.process_char('s');
+
+    let mut typed = engine(InputMethod::Telex);
+    assert_eq!(type_into(&mut typed, "chaofs"), adopted.buffer());
+}
+
+#[test]
+fn adopts_a_capitalized_syllable() {
+    // Sentence-initial words must be re-editable too.
+    let mut engine = engine(InputMethod::Telex);
+    assert!(engine.adopt("Chào"));
+    engine.process_char('s');
+    assert_eq!(engine.buffer(), "Cháo");
+}
+
+#[test]
+fn adopts_a_toneless_syllable_and_adds_a_tone() {
+    let mut engine = engine(InputMethod::Vni);
+    assert!(engine.adopt("chao"));
+    engine.process_char('2'); // VNI huyền
+    assert_eq!(engine.buffer(), "chào");
+}
+
+/// Anything that is not a Vietnamese syllable is refused, so English words and URLs
+/// never silently become editable.
+#[test]
+fn refuses_text_that_is_not_a_syllable() {
+    let mut engine = engine(InputMethod::Telex);
+    for text in ["", "text", "tẽt", "hello", "funput.app", "chào bạn"] {
+        assert!(!engine.adopt(text), "should not adopt {text:?}");
+        assert_eq!(engine.buffer(), "", "buffer must stay empty after refusing");
+    }
+}
+
+#[test]
+fn refuses_while_disabled() {
+    let mut engine = engine(InputMethod::Telex);
+    engine.set_enabled(false);
+    assert!(!engine.adopt("chào"));
+    assert_eq!(engine.buffer(), "");
+}
+
+/// Adopting replaces whatever was composing, and leaves no raw form to flip back to
+/// (the keystrokes that produced the word are gone).
+#[test]
+fn adopting_replaces_composition_and_leaves_nothing_to_flip() {
+    let mut engine = engine(InputMethod::Telex);
+    type_into(&mut engine, "meo");
+    assert!(engine.adopt("chào"));
+    assert_eq!(engine.buffer(), "chào");
+    assert_eq!(engine.keys(), "chào");
+    assert_eq!(engine.flip_composing().action, funput_engine::Action::None);
+}
+
+/// A word boundary after editing an adopted word commits the edited form, not the
+/// original raw keys (English restore must not fire on valid Vietnamese).
+#[test]
+fn boundary_after_editing_keeps_the_vietnamese_form() {
+    let mut engine = engine(InputMethod::Telex);
+    assert!(engine.adopt("chào"));
+    engine.process_char('s');
+    let result = engine.process_char(' ');
+    let committed = if result.action == funput_engine::Action::None {
+        "cháo ".to_owned()
+    } else {
+        result.output
+    };
+    assert_eq!(committed, "cháo ");
+}

--- a/crates/funput-engine/tests/alloc_budget.rs
+++ b/crates/funput-engine/tests/alloc_budget.rs
@@ -99,6 +99,39 @@ fn assert_within_budget(label: &str, engine: &mut Engine) {
     assert_counts_within_budget(label, TELEX_TEXT, allocs, bytes);
 }
 
+/// Re-opening a committed word (Android's Backspace path) costs one small allocation
+/// per call, and only that one.
+///
+/// Measured: 1 alloc / 8 B, entirely from the `is_complete_syllable` gate — its
+/// `toneless_rhyme` builds the rhyme string, the one allocation `funput-core`'s
+/// validation makes. The engine already pays it once per word boundary, and `adopt`
+/// runs once per Backspace-onto-a-word, so it is proportionate. The point of the
+/// budget is the *rest*: seeding buffer/keys/vn_form must stay in-place refills, so
+/// swapping them for `to_string()` (three more allocations) trips this.
+const MAX_ADOPT_ALLOCS_PER_CALL: usize = 1;
+
+fn assert_adopt_within_budget(engine: &mut Engine) {
+    engine.clear();
+    assert!(engine.adopt("chào")); // first call may still grow a string's capacity
+    engine.clear();
+
+    let calls = 64;
+    let before_allocs = ALLOCS.load(Ordering::Relaxed);
+    let before_bytes = BYTES.load(Ordering::Relaxed);
+    for _ in 0..calls {
+        std::hint::black_box(engine.adopt("chào"));
+    }
+    let allocs = ALLOCS.load(Ordering::Relaxed) - before_allocs;
+    let bytes = BYTES.load(Ordering::Relaxed) - before_bytes;
+    println!("adopt: {allocs} allocs, {bytes} bytes over {calls} calls");
+    assert!(
+        allocs <= calls * MAX_ADOPT_ALLOCS_PER_CALL,
+        "adopt allocated {allocs} times over {calls} calls (budget \
+         {MAX_ADOPT_ALLOCS_PER_CALL}/call) — it must refill the session strings in \
+         place instead of building new ones"
+    );
+}
+
 #[test]
 fn keystroke_alloc_budget() {
     let mut engine = Engine::new();
@@ -116,5 +149,6 @@ fn keystroke_alloc_budget() {
     assert_within_budget("spell-check on", &mut engine);
 
     engine.update_config(|c| c.spell_check = false);
+    assert_adopt_within_budget(&mut engine);
     pairs::assert_paired_allocations(&mut engine);
 }

--- a/crates/funput-jni/src/engine/composition.rs
+++ b/crates/funput-jni/src/engine/composition.rs
@@ -3,10 +3,28 @@
 use funput_engine::Action;
 use jni::EnvUnowned;
 use jni::objects::JString;
-use jni::sys::{jint, jlong};
+use jni::sys::{jboolean, jint, jlong};
 
 use super::registry;
-use crate::abi::{JavaObject, string_result};
+use crate::abi::{JavaObject, neutral, safe, string_result};
+
+/// Re-open an already-committed word as the live composition, so the next keystroke
+/// edits it (Backspace back onto `chào`, then `s` gives `cháo`).
+///
+/// Returns whether the word was taken — only a complete Vietnamese syllable is, so the
+/// caller must leave the document untouched when this is `false`.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_app_funput_funput_ime_nativebridge_FunputNative_nativeAdopt(
+    mut env: EnvUnowned<'_>,
+    _this: JavaObject<'_>,
+    handle: jlong,
+    word: JString<'_>,
+) -> jboolean {
+    safe(false, || {
+        let text = neutral(env.with_env(|env| word.try_to_string(env)).into_outcome());
+        registry::with_mut(handle, |engine| engine.adopt(&text)).unwrap_or(false)
+    })
+}
 
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_app_funput_funput_ime_nativebridge_FunputNative_nativeProcess<

--- a/platforms/android/.agents/skills/adaptive/SKILL.md
+++ b/platforms/android/.agents/skills/adaptive/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: adaptive
+description: Instructions to make or update an app's UI so that it adapts to different
+  Android devices including phones, tablets, foldables, laptops, desktop, TV, Auto
+  and XR. It includes how to handle different window sizes, pointing devices (such
+  as mouse) and text entry devices (such as keyboard) using the Compose MediaQuery
+  API. It also covers multi-pane layouts using Navigation3 Scenes, adaptive UI components
+  (such as buttons) with varying target sizes, and adaptive layouts (including navigation
+  areas - nav rails and nav bars) using the Compose Grid and FlexBox APIs.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-07-02'
+  keywords:
+  - android
+  - ui
+  - adaptive
+  - Grid
+  - FlexBox
+  - MediaQuery
+  - navigation
+---
+
+## Prerequisites
+
+The app must:
+
+- Use Compose for all screens. If it's still using Fragments or Views, suggest using the XML to Compose skill to migrate those screens.
+- Use Jetpack Navigation 3. If it doesn't, suggest the Navigation 3 skill to migrate the app.
+
+## Workflow to make an app adaptive
+
+To make an app adaptive, follow these steps or a subset of them adapting to the
+task.
+
+- Step 1: Verify current UI
+- Step 2: Make the navigation bar adaptive
+- Step 3: Add multi-pane layouts
+- Step 4: Make vertical lists adaptive by changing the number of columns
+- Step 5: Hide app bars when scrolling
+
+## Step 1. Verify current UI
+
+Ensure that screenshot tests exist to verify the current UI on different form
+factors. If they don't exist, add the [Compose Preview Screenshot Testing
+tool](references/android/develop/ui/compose/tooling/debug.md). Use the following annotation to create previews for all the major form
+factors. For example:
+
+
+```kotlin
+@Preview(name = "Phone", device = Devices.PHONE, showBackground = true)
+@Preview(name = "Foldable", device = Devices.FOLDABLE, showBackground = true)
+@Preview(name = "Tablet", device = Devices.TABLET, showBackground = true)
+@Preview(name = "Desktop", device = Devices.DESKTOP, showBackground = true)
+annotation class FormFactorPreviews
+
+@PreviewTest
+@FormFactorPreviews
+@Composable
+fun FeedScreenPreview() {
+    SnippetsTheme {
+        Box {
+            Text("My Screen")
+        }
+    }
+}
+```
+
+<br />
+
+## Step 2. Make the navigation bar adaptive
+
+Bottom navigation bars are optimized for touch input when the user is holding a
+phone in portrait mode. On larger screen hand-held devices, like tablets and
+unfolded foldables, the navigation area must be accessible from the edge of the
+screen (navigation rail).
+
+If you need to provide more screen space for the content, hide the
+navigation area. Examples of this include:
+
+- Hiding the navigation bar when the user scrolls down and showing it again when the user scrolls up. The assumption is that when the user is scrolling down, they are consuming content but when scrolling up they are trying to navigate away from that content.
+- Hiding the navigation area when its content is distracting. For example, in camera previews or when displaying a full-screen photo.
+
+When the detail screen is displayed full-screen on mobile, full-screen mode must
+be deactivated on larger screens.
+
+Steps to migrate:
+
+- Locate the existing navigation bar.
+- Convert each item to a `NavigationSuiteItem`.
+- Identify whether the navigation bar's visibility changes. For example, if it is wrapped with an `AnimatedContent` or `AnimatedVisibility` composable. If so, follow the guidance in the "Control navigation area visibility".
+- Replace the container that held the navigation bar (often a `Scaffold`) with `NavigationSuiteScaffold` from the Material 3 adaptive layouts library.
+- Supply the navigation items using the `navigationItems` parameter of `NavigationSuiteScaffold`.
+
+### Step 2.1. Control navigation area visibility
+
+If the navigation bar's visibility changes - it is hidden under certain
+scenarios or on certain screens - this behavior must be maintained with the
+adaptive navigation area. This is done using `NavigationSuiteScaffold`'s `state`
+parameter.
+
+Steps to migrate:
+
+- Identify the scenarios under which the navigation bar is hidden. This is usually done with a boolean variable for the visibility. Use `isNavBarVisible` or `shouldShowNavBar` as the variable name.
+- Create an instance of `NavigationSuiteScaffoldState` using `rememberNavigationSuiteScaffoldState()` and pass it to `NavigationSuiteScaffold`.
+- When the navigation area visibility changes, use a `LaunchedEffect` to call `show` or `hide` on the `NavigationSuiteScaffoldState`.
+
+For example:
+
+
+```kotlin
+// Pass this variable to any composable that needs to control the navigation area visibility
+var isNavBarVisible by remember { mutableStateOf(true) }
+val scaffoldVisibilityState = rememberNavigationSuiteScaffoldState()
+
+NavigationSuiteScaffold(
+    navigationSuiteItems = navItems,
+    state = scaffoldVisibilityState
+) {
+    // Main content
+}
+
+LaunchedEffect(isNavBarVisible){
+    if (isNavBarVisible) {
+        scaffoldVisibilityState.show()
+    } else {
+        scaffoldVisibilityState.hide()
+    }
+}
+```
+
+<br />
+
+## Step 3. Add multi-pane layouts using Navigation 3 Scenes
+
+Analyze the codebase looking for related screens - tapping on something in one
+screen opens another screen that shows information related to the first. There
+are two canonical screen relationships: list-detail and supporting pane.
+
+IMPORTANT: You must use the Navigation 3 `SceneStrategy` approach to implement
+multi-pane layouts. Do not use `ListDetailPaneScaffold` or
+`SupportingPaneScaffold`.
+
+### Step 3.1. List-detail
+
+#### Identify the list and detail screens
+
+List-detail layouts display a list of items (this is the list screen) and
+clicking on an item opens a new screen that shows more details about that item
+(the detail screen).
+
+Typical usage includes productivity apps like email, notes, and messaging.
+
+Unless requested explicitly, avoid this pattern when the detail content requires
+substantial screen space (e.g., images or media that benefits from a full-screen
+presentation).
+
+#### Add a Material list-detail SceneStrategy
+
+- Add the `androidx.compose.material3.adaptive:adaptive-navigation3` library
+- Create an `androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy` using `rememberListDetailSceneStrategy`
+- Pass the `ListDetailSceneStrategy` to `NavDisplay` using its `sceneStrategies` parameter
+
+#### Use metadata to identify the list and detail screens
+
+- Add metadata using `entry(metadata = ...)` or `NavEntry(metadata = ...)` to the list entry using `ListDetailSceneStrategy.listPane(detailPlaceholder = {
+  <placeholder composable> })`.
+- Use the `detailPlaceholder` parameter to add a placeholder on the detail screen when no list items are selected.
+- Add metadata to the detail entry using `ListDetailSceneStrategy.detailPane()`.
+
+#### Important considerations
+
+- When a detail screen displays its content full-screen on mobile (content fills the entire screen, bars or rails are hidden), full-screen mode must be deactivated if it's part of a list-detail layout.
+- Detail screens must not show a back arrow when on a list-detail layout.
+
+For a reference implementation, check the [Nav3 **Material** List Detail
+recipe](references/android/guide/navigation/navigation-3/recipes/material-listdetail.md).
+
+### Step 3.2. Supporting pane
+
+Identify supporting pane screens where a main screen displays a single item, and
+selecting it opens a "supporting screen" with more details. The supporting
+screen complements the main screen and is shown in a supporting pane.
+
+#### Add a Material supporting pane `SceneStrategy`
+
+- If you haven't already, add the `androidx.compose.material3.adaptive:adaptive-navigation3` library
+- Create an `androidx.compose.material3.adaptive.navigation3.SupportingPaneSceneStrategy` using `rememberSupportingPaneSceneStrategy`
+- Pass the `SupportingPaneSceneStrategy` to `NavDisplay` using its `sceneStrategies` parameter
+
+#### Use metadata to identify the main and supporting screens
+
+- Add metadata using `entry(metadata = ...)` or `NavEntry(metadata = ...)` to the main entry using `SupportingPaneSceneStrategy.mainPane()`
+- Add metadata to the supporting entry using `SupportingPaneSceneStrategy.supportingPane()`
+
+### Step 3.3. Run screenshot tests
+
+If you have made changes, record new reference files. Ask the user to visually
+verify that the new layouts are correct.
+
+## Step 4. Make vertical lists adaptive by changing the number of columns
+
+### Step 4.1. Make lazy lists adaptive
+
+Look for the following vertical list composables: `LazyColumn`,
+`LazyVerticalGrid`, `LazyVerticalStaggeredGrid`.
+
+Steps to migrate:
+
+- Choose a suitable minimum width in dp for the column. The item must be clearly visible to the user at this width.
+- For `LazyColumn`: change to a `LazyVerticalGrid` and follow the instruction later
+- For `LazyVerticalGrid`: change the `columns` parameter to use `GridCells.Adaptive(<width>.dp)`
+- For `LazyVerticalStaggeredGrid`: change the `columns` parameter to use `StaggeredGridCells.Adaptive(<width>.dp)`
+
+### Step 4.2. Migrate non-lazy lists to Grid
+
+WARNING: Grid is an experimental API available from Compose 1.11.0-beta01.
+Confirm with the user that they are happy to use an experimental API in their
+codebase.
+
+Look for any `Column` that contains multiple items of the same type and replace
+it with `Grid`. Do not replace it with `LazyVerticalGrid` or any other lazy
+layout. Do not place `Grid` inside the existing `Column`. Completely replace it.
+
+`Grid` is configured by supplying a lambda (an extension function on
+`GridConfigurationScope`) to its `config` parameter. Inside the lambda,
+`constraints` provides the minimum and maximum dimensions of the grid container
+and can be used to change the number of rows and columns based on the available
+size. For example, the following code configures `Grid` such that when the
+available width is:
+
+- less than 800dp, a 2x4 grid is used
+- 800dp or more, a 4x2 grid is used
+
+
+```kotlin
+Grid(
+    config = {
+        val maxWidthDp = constraints.maxWidth.toDp()
+        val (cols, rows) = if (maxWidthDp < 800.dp){
+            2 to 4
+        } else{
+            4 to 2
+        }
+
+        val gapSizeDp = 8.dp
+        val cellSize = ((maxWidthDp - (gapSizeDp * (cols - 1))) / cols).coerceAtLeast(0.dp)
+        repeat(cols) { column(cellSize) }
+        repeat(rows) { row(cellSize) }
+        gap(gapSizeDp)
+    }
+) { /** items **/ }
+```
+
+<br />
+
+`Grid` is an experimental API so add the `@OptIn(ExperimentalGridApi::class)`
+annotation to any function that uses it.
+
+## Step 5: Hide App Bars when scrolling
+
+In an app with multiple top-level destinations, each screen must manage its own
+app bar state independently. There are two main scroll behaviors:
+
+- `exitUntilCollapsedScrollBehavior`: Hides on scroll down, stays hidden while you scroll up until you reach the very top (0 offset).
+- `enterAlwaysScrollBehavior`: Hides on scroll down, shows immediately on scroll up.
+
+## Final step: Build and test
+
+Build the app and run the local tests. If the project has screenshot tests, run
+them but DO NOT update the reference images. Prompt the user to do this after
+they have viewed the screenshot diffs.
+
+## Additional documentation for experimental adaptive APIs
+
+The following APIs are available from Compose 1.11.0-beta01.
+
+### FlexBox
+
+Check the FlexBox documentation:
+
+- [Overview](references/android/develop/ui/compose/layouts/adaptive/flexbox/index.md)
+- [Get started - setup](references/android/develop/ui/compose/layouts/adaptive/flexbox/get-started.md)
+- [Set container behavior](references/android/develop/ui/compose/layouts/adaptive/flexbox/container-behavior.md)
+- [Set item behavior](references/android/develop/ui/compose/layouts/adaptive/flexbox/item-behavior.md)
+
+## MediaQuery
+
+Check the [MediaQuery documentation](references/android/develop/ui/compose/layouts/adaptive/mediaquery/index.md) when you need to query the device's
+screen size, pointer precision, keyboard type, whether it has cameras or
+microphones, and other device capabilities.
+
+## Grid
+
+Check the Grid documentation when you need to display a fixed number of items in
+a grid layout:
+
+- [Overview](references/android/develop/ui/compose/layouts/adaptive/grid/index.md)
+- [Get started - setup](references/android/develop/ui/compose/layouts/adaptive/grid/get-started.md)
+- [Set container properties](references/android/develop/ui/compose/layouts/adaptive/grid/container-properties.md)
+- [Set item properties](references/android/develop/ui/compose/layouts/adaptive/grid/item-properties.md)

--- a/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/flexbox/container-behavior.md
+++ b/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/flexbox/container-behavior.md
@@ -1,0 +1,112 @@
+To configure the behavior of the `FlexBox` container, create a `FlexBoxConfig`
+block and supply it using the `config` parameter.
+
+
+```kotlin
+FlexBox(
+    config = {
+        direction(FlexDirection.Column)
+        wrap(FlexWrap.Wrap)
+        alignItems(FlexAlignItems.Center)
+        alignContent(FlexAlignContent.SpaceAround)
+        justifyContent(FlexJustifyContent.Center)
+        gap(16.dp)
+    }
+) { // child items
+}
+```
+
+<br />
+
+Use `FlexBoxConfig` to define the layout direction, wrapping behavior,
+alignment, and gaps between items.
+
+## Layout direction
+
+The `direction` function sets the main axis, which dictates the direction
+items are laid out in. It accepts the following values:
+
+- `Row` (default): Sets the main axis to be horizontal. In left-to-right locales this will be left-to-right, with the opposite in right-to-left.
+- `RowReverse`: Reverses the direction of `Row`.
+- `Column`: Sets the main axis to be vertical, top-to-bottom.
+- `ColumnReverse`: Reverses the direction of `Column`.
+
+## Align items and distribute extra space
+
+The following sections describe how to align items and distribute extra space
+along the main and cross axes.
+
+### Along the main axis
+
+Use `justifyContent` to distribute items along the main axis. The following
+table shows the behavior when the direction is `Row`.
+
+|---|---|
+|   | ![Illustration of a horizontal main axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/main-axis.png) |
+| `Start` | ![Items aligned to the start of the main axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/mainaxis-start.png) |
+| `Center` | ![Items aligned to the center of the main axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/mainaxis-center.png) |
+| `End` | ![Items aligned to the end of the main axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/mainaxis-end.png) |
+| `SpaceBetween` | ![Items distributed along the main axis with space between them.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/mainaxis-spacebetween.png) |
+| `SpaceAround` | ![Items distributed along the main axis with space around them.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/mainaxis-spacearound.png) |
+| `SpaceEvenly` | ![Items distributed along the main axis with space evenly around them.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/mainaxis-spaceevenly.png) |
+
+### Along the cross axis
+
+Use `alignItems` to align items along the cross axis within a single line. This
+behavior can be overridden by individual items using the
+[`alignSelf` modifier](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/item-behavior#item-alignment).
+
+The following images show the behavior when the direction is `Row`:
+
+|---|---|---|---|---|---|
+| ![Illustration of a vertical cross axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/crossaxis.png) | ![Items aligned to the start of the cross axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/crossaxis-start.png) | ![Items aligned to the end of the cross axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/crossaxis-end.png) | ![Items aligned to the center of the cross axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/crossaxis-center.png) | ![Items stretched to fill the cross axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/crossaxis-stretch.png) | ![Items aligned to their baseline along the cross axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/crossaxis-baseline.png) |
+|   | `Start` | `End` | `Center` | `Stretch` | `Baseline` |
+
+Use `alignContent` to align lines to the cross axis and to distribute extra
+space between lines. This property only applies when there are multiple lines
+(wrapping is enabled). The following images show the behavior when the direction
+is `Row`:
+
+|---|---|---|---|---|---|---|
+| ![Illustration of a vertical cross axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/crossaxis.png) | ![Multiple lines of items aligned to the start of the cross axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/aligncontent-start.png) | ![Multiple lines of items aligned to the end of the cross axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/aligncontent-end.png) | ![Multiple lines of items aligned to the center of the cross axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/aligncontent-center.png) | ![Multiple lines of items stretched to fill the cross axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/aligncontent-stretch.png) | ![Multiple lines of items distributed along the cross axis with space between them.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/aligncontent-spacebetween.png) | ![Multiple lines of items distributed along the cross axis with space around them.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/aligncontent-spacearound.png) |
+|   | `Start` | `End` | `Center` | `Stretch` | `SpaceBetween` | `SpaceAround` |
+
+## Wrap items
+
+Wrapping lets a `FlexBox` container become multi-line, moving items that don't
+fit onto a new row or column along the cross-axis. Configure wrapping behavior
+using `wrap`.
+
+|---|---|
+| **`FlexWrap` value** | **Example using direction `Row`** |
+| `NoWrap` (default): Prevents items from wrapping. Items overflow if the main size is insufficient. | ![Items in a single line overflowing the container because wrapping is disabled.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/wrapitems-1.png) |
+| `Wrap`: When there is insufficient space for an item (plus any [gap](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/container-behavior#add-gaps)), a new line is created in the direction of the cross axis. For example, if the direction is `Row`, a new line is added **below**. | ![Items wrapping onto a new line below because wrapping is enabled.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/wrapitems-2.png) |
+| `WrapReverse`: The same as `Wrap`, except the new line is added in the opposite direction to the cross axis. For example, if the direction is `Row`, a new line is added **above**. | ![Items wrapping onto a new line above because reverse wrapping is enabled.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/wrapitems-3.png) |
+
+The following example shows how the `FlexBox` wrapping algorithm works. The
+`FlexBox` container has a main size of `100dp`, with `wrap` set to
+`FlexWrap.Wrap` and a gap of `8dp`. It contains three items with `basis` `20dp`,
+`40dp`, and `50dp`, respectively.
+
+There is `100dp` available space in the line. Child 1 is `20dp`.
+There is space, so Child 1 is placed into the line.
+![First item placed in the FlexBox container.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/algorithm-1.png) **Figure 1.** First item placed in the `FlexBox` container.
+
+There is `80dp` available space in the line. The gap is `8dp`. Child 2 is
+`40dp`. The required space is `48dp`. There is space, so the gap and Child 2
+are placed into the line.
+![Second item placed in the FlexBox container after the first item.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/algorithm-2.png) **Figure 2.** Second item placed in the `FlexBox` container after the first item.
+
+There is `32dp` available space in the line. The gap is `8dp`. Child 3 is
+`50dp`. The required space is `58dp`. There is not enough space in the current
+line, so Child 3 is placed in a new line.
+![Third item placed on a new line because it doesn't fit on the first line.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/algorithm-3.png) **Figure 3.** Third item placed on a new line because it doesn't fit on the first line.
+
+## Add gaps between items
+
+Add gaps between rows and columns using `rowGap` and `columnGap`. This is useful
+to avoid adding spacing modifiers to children.
+
+|---|---|---|
+| ![Row gap adds vertical space between items.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/gap-1.png) | ![Column gap adds horizontal space between items.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/gap-2.png) | ![Gap adds both horizontal and vertical space between items.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/gap-3.png) |
+| `rowGap` adds vertical space between items and lines. | `columnGap` adds horizontal space between items and lines. | `gap` is a convenience function that adds both `columnGap` and `rowGap`. |

--- a/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/flexbox/get-started.md
+++ b/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/flexbox/get-started.md
@@ -1,0 +1,69 @@
+This page describes how to implement basic `FlexBox` layouts.
+
+## Set up project
+
+1. Add the [`androidx.compose.foundation.layout`](https://developer.android.com/jetpack/androidx/versions) library to your project's
+   `lib.versions.toml`.
+
+       [versions]
+       compose = "1.12.0-beta02"
+
+       [libraries]
+       androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout", version.ref = "compose" }
+
+2. Add the library dependency to your app's `build.gradle.kts`.
+
+       dependencies {
+           implementation(libs.androidx.compose.foundation.layout)
+       }
+
+## Create basic FlexBox layouts
+
+**Example 1** : `FlexBox` lays out two `Text` elements that are centrally
+aligned.
+
+
+```kotlin
+FlexBox(
+    config = {
+        direction(FlexDirection.Column)
+        alignItems(FlexAlignItems.Center)
+    }
+) {
+    Text(text = "Hello", fontSize = 48.sp)
+    Text(text = "World!", fontSize = 48.sp)
+}
+```
+
+<br />
+
+![Hello World text composables stacked on top of each other in a basic FlexBox implementation.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/basic-flexbox.png)
+
+**Example 2** : `FlexBox` wraps five items onto two rows and grows them unequally
+to fill the available space on each row. There is an `8.dp`
+gap, both vertically and horizontally, between the items.
+
+
+```kotlin
+FlexBox(
+    config = {
+        wrap(FlexWrap.Wrap)
+        gap(8.dp)
+    }
+) {
+    // All boxes have an intrinsic width of 100.dp
+    // Some grow to fill any remaining space on the row.
+    RedRoundedBox()
+    BlueRoundedBox()
+    GreenRoundedBox(modifier = Modifier.flex { grow(1.0f) })
+    OrangeRoundedBox(modifier = Modifier.flex { grow(1.0f) })
+    PinkRoundedBox(modifier = Modifier.flex { grow(1.0f) })
+}
+```
+
+<br />
+
+![Two rows of colored items, with three unequally sized items distributed across the top row and two unequally sized items across the bottom row.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/basic-flexbox-2.png)
+
+To learn more about `FlexBox` behavior, see [Set container behavior](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/container-behavior) and [Set
+item behavior](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/item-behavior).

--- a/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/flexbox/index.md
+++ b/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/flexbox/index.md
@@ -1,0 +1,81 @@
+> [!NOTE]
+> **Note:** FlexBox is an experimental API and is likely to change in the future. To use it, annotate your code with `@ExperimentalFlexBoxApi`. Please file any issues or feedback on the [issue tracker](https://issuetracker.google.com/issues/new?component=1876021&title=%5BFlexBox%5D).
+
+[`FlexBox`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/FlexBox.composable#FlexBox(androidx.compose.ui.Modifier,androidx.compose.foundation.layout.FlexBoxConfig,kotlin.Function1)) is a container that lays out items in a single direction. It can
+resize, wrap, align, and distribute space among items to optimally fill the
+available space. It's a useful layout for different sized items and for resizing
+items when the available space changes.
+
+With `FlexBox`, you can:
+
+- Control how items grow and shrink to fill the available space
+- Wrap items onto new rows or columns when there isn't enough space for them
+- Distribute extra space between items using convenient presets
+
+## When to use FlexBox
+
+`FlexBox` is usually used to display a small number of items *within* an
+overall screen layout. For an overall screen layout,
+`Grid` is usually a better choice. `FlexBox` does not support lazy-loading of
+items. To display large numbers of items, use [lazy lists and grids](https://developer.android.com/develop/ui/compose/lists). If you
+need to wrap items, use `FlexBox` instead of `FlowRow` and `FlowColumn`.
+
+## Terminology and concepts
+
+> [!IMPORTANT]
+> **Key Point:** `FlexBox` is heavily influenced by the [CSS Flexible Box Layout specification](https://www.w3.org/TR/css-flexbox-1/) and has almost identical concepts, terminology, and behavior. If you're familiar with `display: flex`, you'll find `FlexBox`'s properties and behavior almost identical.
+
+`FlexBox` lays out its items in either horizontal or vertical *lines* . This
+direction of these lines establishes the *main axis* . 90 degrees to the main
+axis is the *cross axis* . The length of the `FlexBox` along the main axis is
+known as the *main size* . The corresponding cross axis length is known as the
+*cross size* . These sizes and axes form the basis of `FlexBox`'s behavior.
+
+
+![FlexBox with horizontal main axis and vertical cross axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/intro-row-2.png) **Figure 1.** Axes and sizes when the `FlexBox` direction is `Row`. ![FlexBox with vertical main axis and horizontal cross axis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/intro-column.png) **Figure 2.** Axes and sizes when the `FlexBox` direction is `Column`.
+
+<br />
+
+### Apply properties
+
+You can apply `FlexBox` properties in two ways:
+
+- To the `FlexBox` container using `FlexBox(config)`
+- To an item inside the `FlexBox` using `Modifier.flex`
+
+| **Container properties (`config`**) | **Item properties (`Modifier.flex`**) |
+|---|---|
+| - `direction` - the item layout direction - `wrap` - whether to wrap items if the **main size** is insufficient - `justifyContent` - how to **distribute** items along the **main axis** - `alignItems` - how to **align** items along the **cross axis** - `alignContent` - how to distribute extra space from the **cross size** when there are multiple lines - `rowGap` / `columnGap` - adds space between items and lines See [Set container behavior](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/container-behavior) for more information about these properties. | - `basis` - the size of the item before any extra space from the **main size** is distributed - `grow` - the share of extra space from the **main size** that this item should receive - `shrink` - the share of space deficit from the **main size** that this item should receive - `alignSelf` - how to distribute extra space from the **cross size** to this item, overrides `alignItems` - `order` - controls the layout order See [Set item behavior](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/item-behavior) for more information about these properties. |
+
+### Understand the `FlexBox` layout algorithm
+
+One of `FlexBox`'s most powerful features is its ability to resize its children
+to best fit the space available to it. Understanding how `FlexBox` does this can
+help you set `FlexBox` properties to optimize your UI for all possible sizes.
+
+`FlexBox`'s layout algorithm works in the following way:
+
+1. **Calculate child base size** : Use the child's [`basis` value](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/item-behavior#set-initial-size)
+   to calculate its initial size along the main axis before any extra space is
+   distributed.
+
+2. **Sort the children** : Sort the children by their [`order`](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/item-behavior#item-order) values, if
+   present.
+
+3. **Build lines** : For each child, check if its initial size plus
+   [`gap`](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/container-behavior#add-gaps) will fit into the remaining space on the current line.
+   If so, place this child into the line. If not, place it onto a new line if
+   [wrapping is enabled](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/container-behavior#wrap-items), or place the item into the current line
+   where it will overflow (it will be partially obscured by the edge of the
+   container).
+
+4. **Align or resize items in the main axis** : For each line, distribute extra
+   space *to* or between items by [resizing](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/item-behavior#item-size) or
+   [aligning](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/container-behavior#main-axis) them.
+
+5. **Align or resize items in the cross axis** : For each line, distribute extra
+   space to or between items and lines by [stretching or aligning
+   them](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/container-behavior#cross-axis).
+
+Now that you're familiar with `FlexBox` concepts, see [Get started](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/get-started) to
+create a basic `FlexBox`.

--- a/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/flexbox/item-behavior.md
+++ b/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/flexbox/item-behavior.md
@@ -1,0 +1,170 @@
+Use `Modifier.flex` to control how an item changes size, order, and is aligned
+inside a `FlexBox`.
+
+## Item size
+
+Use the `basis`, `grow`, and `shrink` functions to control an item's size.
+
+
+```kotlin
+FlexBox {
+    RedRoundedBox(
+        modifier = Modifier.flex {
+            basis(FlexBasis.Auto)
+            grow(1.0f)
+            shrink(0.5f)
+        }
+    )
+}
+```
+
+<br />
+
+### Set initial size
+
+Use `basis` to specify the item's initial size before any extra space is
+distributed. You can think of this as the item's *preferred* size.
+
+|---|---|---|---|
+| **Value type** | **Behavior** | **Code snippet** Note: The boxes have a maximum intrinsic size of `100dp` | **Example using container width `600dp`** |
+| `Auto` (default) | Use the item's maximum intrinsic size. For example, a `Text` composable's maximum intrinsic width is the width of all its text on a single line - no wrapping. | ```kotlin FlexBox { RedRoundedBox( Modifier.flex { basis(FlexBasis.Auto) } ) BlueRoundedBox( Modifier.flex { basis(FlexBasis.Auto) } ) } ``` | ![Items sized based on their intrinsic size using basis Auto.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/initialsize-1.png) |
+| Fixed `dp` | A fixed size in Dp. | ```kotlin FlexBox { RedRoundedBox( Modifier.flex { basis(200.dp) } ) BlueRoundedBox( Modifier.flex { basis(100.dp) } ) } ``` | ![Items sized to a fixed dp value using basis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/initialsize-2.png) |
+| Percentage | A percentage of the container size. | ```kotlin FlexBox { RedRoundedBox( Modifier.flex { basis(0.7f) } ) BlueRoundedBox( Modifier.flex { basis(0.3f) } ) } ``` | ![Items sized as a percentage of container size using basis.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/initialsize-3.png) |
+
+If the basis value is less than the item's intrinsic minimum size, the intrinsic
+minimum size is used instead. For example, if a `Text` item that contains a word
+requires `50dp` to display, but also has `basis = 10.dp`, a
+value of `50dp` is used.
+
+### Grow items when there's space
+
+Use `grow` to specify how much an item grows when there is extra space. This is
+space remaining in the `FlexBox` container after all the items' `basis` values
+have been added up. The `grow` value indicates *how much* of the extra space a
+given child will receive, relative to its siblings. By default, items won't
+grow.
+
+The following example shows a `FlexBox` with three child items. Each has a basis
+value of `100dp`. The first child has a positive `grow` value. Since there is
+only one child with a `grow` value, the actual value is irrelevant - as long as
+it's positive, the child receives all the extra space.
+
+The images show the `FlexBox` behavior when its container size is `600dp`.
+
+|---|---|
+| ```kotlin FlexBox { RedRoundedBox( title = "400dp", modifier = Modifier.flex { grow(1f) } ) BlueRoundedBox(title = "100dp") GreenRoundedBox(title = "100dp") } ``` | Each child has a basis value of `100dp`. There is `300dp` of extra space. ![Three items with 100dp basis each, in a 600dp container, before growth.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/growitems-1.png) Child 1 grows by `300dp` to fill the extra space. ![First item grows to fill 300dp of extra space.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/growitems-2.png) |
+
+In the following example, the container size and `basis` size are the same. The
+difference is that each child has a different `grow` value.
+
+|---|---|
+| ```kotlin FlexBox { RedRoundedBox( title = "150dp", modifier = Modifier.flex { grow(1f) } ) BlueRoundedBox( title = "200dp", modifier = Modifier.flex { grow(2f) } ) GreenRoundedBox( title = "250dp", modifier = Modifier.flex { grow(3f) } ) } ``` | Each child has a basis value of `100dp`. There is `300dp` of extra space. ![Three items with 100dp basis each, in a 600dp container, before growth, with different grow values.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/growitems-3.png) The total grow value is 6. Child 1 grows by (1 / 6) \* 300 = `50dp` Child 2 grows by (2 / 6) \* 300 = `100dp` Child 3 grows by (3 / 6) \* 300 = `150dp` ![Items grow to fill 300dp of extra space based on relative grow values.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/growitems-4.png) |
+
+### Shrink items when there's insufficient space
+
+Use `shrink` to specify how much an item shrinks when the `FlexBox` container
+has insufficient space for all the items. `shrink` works the same way as `grow`
+except that, instead of distributing *extra space* to items, the *space deficit*
+is distributed to items. The `shrink` value specifies how much of the space
+deficit the item receives, or rather, how much the item will shrink by. By
+default, items have a `shrink` value of `1f`, meaning they shrink equally.
+
+The following example shows two `Text` composables with the same text. The first
+child has a shrink value of `1f`, meaning it shrinks to absorb all the space
+deficit.
+
+
+```kotlin
+FlexBox {
+    Text(
+        "The quick brown fox",
+        fontSize = 36.sp,
+        modifier = Modifier
+            .background(PastelRed)
+            .flex { shrink(1f) }
+    )
+    Text(
+        "The quick brown fox",
+        fontSize = 36.sp,
+        modifier = Modifier
+            .background(PastelBlue)
+            .flex { shrink(0f) }
+    )
+}
+```
+
+<br />
+
+As the container size shrinks, Child 1 shrinks.
+
+|---|---|
+| **Container size** | **FlexBox UI** |
+| `700dp` | ![Two items in a 700dp container.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/containersize-1.png) |
+| `500dp` | ![First item shrinks as container size reduces to 500dp.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/containersize-2.png) |
+| `450dp` | ![First item shrinks further as container size reduces to 450dp.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/containersize-3.png) |
+
+## Item alignment
+
+Use `alignSelf` to control how an item is aligned to the cross axis. This
+overrides the [`alignItems` property](https://developer.android.com/develop/ui/compose/layouts/adaptive/flexbox/container-behavior#align-distribute) of the container for this item. It
+has all the same possible values, with the addition of `Auto` which inherits the
+behavior of the `FlexBox` container.
+
+For example, this `FlexBox` has `alignItems` set to `Start` and five children
+which override the cross axis alignment.
+
+
+```kotlin
+FlexBox(
+    config = {
+        alignItems(FlexAlignItems.Start)
+    }
+) {
+    RedRoundedBox()
+    BlueRoundedBox(modifier = Modifier.flex { alignSelf(FlexAlignSelf.Center) })
+    GreenRoundedBox(modifier = Modifier.flex { alignSelf(FlexAlignSelf.End) })
+    PinkRoundedBox(modifier = Modifier.flex { alignSelf(FlexAlignSelf.Stretch) })
+    OrangeRoundedBox(modifier = Modifier.flex { alignSelf(FlexAlignSelf.Baseline) })
+}
+```
+
+<br />
+
+![Five children of varying sizes overriding the alignItems property.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/item-alignment.png)
+
+## Item order
+
+By default, `FlexBox` lays out items in the order that they are declared in
+code. Override this behavior using `order`.
+
+The default value for `order` is zero, and `FlexBox` sorts items based on this
+value in ascending order. Any items that have the same `order` value are
+laid out in the same order they are declared in. Use negative and positive
+`order` values to move items to the start or end of a layout without changing
+where they are declared.
+
+The following example shows two child items. The first has the default `order`
+of zero, and the second has an order of `-1`. After sorting, Child 1 appears
+after Child 2.
+
+
+```kotlin
+FlexBox {
+    // Declared first, but will be placed after visually
+    RedRoundedBox(
+        title = "World"
+    )
+
+    // Declared second, but will be placed first visually
+    BlueRoundedBox(
+        title = "Hello",
+        modifier = Modifier.flex {
+            order(-1)
+        }
+    )
+}
+```
+
+<br />
+
+![Two rounded boxes, with the first containing the text Hello and the second containing the text World.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/flexbox/itemorder.png)

--- a/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/grid/container-properties.md
+++ b/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/grid/container-properties.md
@@ -1,0 +1,320 @@
+You can define a Grid container configuration to create flexible layouts
+that respond to different screen sizes and content types.
+This page describes how to do the following:
+
+- [Define a grid](https://developer.android.com/develop/ui/compose/layouts/adaptive/grid/container-properties#grid-definition): Set up the basic structure of rows and columns.
+- [Place items in a grid](https://developer.android.com/develop/ui/compose/layouts/adaptive/grid/container-properties#item-placement): Understand how items are placed into grid cells and how to change flow direction.
+- [Manage track sizing](https://developer.android.com/develop/ui/compose/layouts/adaptive/grid/container-properties#grid-track-size): Use fixed, percentage, flexible, and intrinsic sizing to set track sizes.
+- [Set gaps](https://developer.android.com/develop/ui/compose/layouts/adaptive/grid/container-properties#grid-gap): Manage the "gutters" between rows and columns.
+
+## Define a grid
+
+A grid consists of columns and rows.
+The [`Grid`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/Grid.composable#Grid(kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1)) composable has a `config` parameter
+that accepts a lambda to define the columns and rows
+within [`GridConfigurationScope`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/GridConfigurationScope).
+The following example defines a grid that has three rows and two columns,
+each with a fixed size specified in [`Dp`](https://developer.android.com/reference/kotlin/androidx/compose/ui/unit/Dp):
+
+
+```kotlin
+Grid(
+    config = {
+        repeat(2) {
+            column(160.dp)
+        }
+        repeat(3) {
+            row(90.dp)
+        }
+    }
+) {
+}
+```
+
+<br />
+
+## Place items in a grid
+
+`Grid` takes the UI elements
+in the `content` lambda and places them into grid cells.
+The grid lays out items regardless of
+whether you have explicitly defined the rows and columns.
+By default,
+`Grid` tries to place a UI element in the available grid cell in the row;
+if it can't, it places it in an available grid cell in the next row.
+If there are no empty cells, `Grid` creates a new row.
+
+In the following example, the grid has six grid cells
+and places a card into each one (Figure 1).
+Each grid cell is `160dp` x `90dp`,
+making the total grid size `320dp` x `270dp`.
+
+
+```kotlin
+Grid(
+    config = {
+        repeat(2) {
+            column(160.dp)
+        }
+        repeat(3) {
+            row(90.dp)
+        }
+    }
+) {
+    Card1()
+    Card2()
+    Card3()
+    Card4()
+    Card5()
+    Card6()
+}
+```
+
+<br />
+
+![Six cards are placed in a grid that has three rows and two columns.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/placement.png) **Figure 1**. Six cards are placed in a grid that has three rows and two columns.
+
+To change this default behavior to filling by column,
+set the [`flow`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/GridConfigurationScope#flow()) property to [`GridFlow.Column`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/GridFlow#Column()).
+
+
+```kotlin
+Grid(
+    config = {
+        repeat(2) {
+            column(160.dp)
+        }
+        repeat(3) {
+            row(90.dp)
+        }
+        gap(8.dp)
+        flow = GridFlow.Column // Grid tries to place items to fill the column
+    },
+) {
+    Card1()
+    Card2()
+    Card3()
+    Card4()
+    Card5()
+    Card6()
+}
+```
+
+<br />
+
+![The flow function changes the direction to place items.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/grid-flow.png) **Figure 2** . `GridFlow.Row` (left) and `GridFlow.Column` (right).
+
+## Manage track sizing
+
+Rows and columns are collectively referred to as a [grid track](https://developer.android.com/develop/ui/compose/layouts/adaptive/grid#grid-track).
+You can specify the size of a grid track using one of the following methods:
+
+- **Fixed** (`Dp`): Allocates a specific size (e.g., `column(180.dp)`).
+- **Percentage** (`Float`): Allocates a percentage of the total available space from `0.0f` to `1.0f` (e.g., `row(0.5f)` for 50%).
+- **Flexible** ([`Fr`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/Fr)): Distributes remaining space proportionally after fixed and percentage tracks are calculated. For example, if two rows are set to `1.fr` and `3.fr`, the latter receives 75% of the remaining height.
+- **Intrinsic** : Sizes the track based on the content inside it. For more information, see [Determine grid track size intrinsically](https://developer.android.com/develop/ui/compose/layouts/adaptive/grid/container-properties#intrinsic-grid-track-size).
+
+The following example uses the different track sizing options
+to define the row heights:
+
+
+```kotlin
+Grid(
+    config = {
+        column(1f)
+
+        row(100.dp)
+        row(0.2f)
+        row(1.fr)
+        row(GridTrackSize.Auto)
+    },
+    modifier = Modifier.height(480.dp)
+) {
+    PastelRedCard("Fixed(100.dp)")
+        PastelGreenCard("Percentage(0.2f)")
+    PastelBlueCard("Flex(1.fr)")
+        PastelYellowCard("Auto")
+
+}
+```
+
+<br />
+
+![Row heights defined using the four primary track sizing options.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/track-sizes.png) **Figure 3** . Row heights defined using the four primary track sizing options in `Grid`.
+
+### Set the minimum size for flexible grid tracks
+
+When a grid container has no remaining space,
+a standard flexible track can shrink to `0.dp`.
+To prevent this and ensure content isn't crushed,
+use [`GridTrackSize.MinMax`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/GridTrackSize#MinMax(androidx.compose.ui.unit.Dp,androidx.compose.foundation.layout.Fr))
+to enforce an explicit minimum size while keeping the track flexible.
+
+The following example allocates at least `100.dp` to the first row:
+
+
+```kotlin
+Grid(
+    config = {
+        column(1f)
+        // The first row has a minimum height of 100.dp and can expand to 
+        // the half of the remaining space.
+        row(GridTrackSize.MinMax(100.dp, 1.fr))
+        // The second row takes the half of the remaining space.
+        row(1.fr)
+        // The third row has a fixed height of 200.dp.
+        row(200.dp)
+    },
+    modifier = Modifier.size(360.dp) // Total grid height is 360.dp
+) {
+    PastelRedCard("MinMax(100.dp, 1.fr)")
+        PastelGreenCard("Flex(1.fr)")
+    PastelBlueCard("Fixed(200.dp)")
+}
+```
+
+<br />
+
+![Row heights defined using the four primary track sizing options.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/track-size-minmax.png) **Figure 4** . The first row has at least `100.dp` height.
+
+### Set the minimum grid track size to place lazy lists
+
+Standard flexible tracks automatically query the intrinsic sizes of
+their children to establish a base size.
+However, Jetpack Compose prohibits querying the intrinsic sizes of
+[`SubcomposeLayout`](https://developer.android.com/reference/kotlin/androidx/compose/ui/layout/SubcomposeLayout.composable#SubcomposeLayout(androidx.compose.ui.Modifier,kotlin.Function2)), which backs components,
+such as [`LazyColumn`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/lazy/LazyColumn.composable) and [`LazyRow`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/lazy/LazyRow.composable).
+
+Placing a lazy list inside a standard flexible track causes
+an [`IllegalStateException`](https://developer.android.com/reference/java/lang/IllegalStateException) crash.
+To safely place lazy lists inside a flexible grid track,
+use `MinMax` with an explicit minimum size (such as `0.dp`)
+to bypass the intrinsic measurement pass.
+
+
+```kotlin
+Grid(
+    config = {
+        column(1f)
+        // The first row's height is determined by the height of the Text composable.
+        row(GridTrackSize.Auto)
+        // The second row occupies the remaining space, allowing the LazyColumn to scroll.
+        row(GridTrackSize.MinMax(0.dp, 1.fr))
+
+        gap(8.dp)
+    },
+    modifier = Modifier.size(width = 170.dp, height = 240.dp)
+) {
+    Text("Lazy column in a Grid")
+    // The LazyColumn is placed in the second row, filling the remaining space.
+    LazyColumn(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        items(100) { number ->
+            PastelGreenCard("Card $number")
+        }
+    }
+}
+```
+
+<br />
+
+![Row heights defined using the four primary track sizing options.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/lazy-column-in-grid.png) **Figure 5** . `LazyColumn` in a grid cell.
+
+### Determine grid track size intrinsically
+
+You can use [intrinsic sizing](https://developer.android.com/develop/ui/compose/layouts/intrinsic-measurements) for a `Grid`
+when you want the layout to adapt to the content,
+rather than forcing it into a fixed container.
+The grid track size is determined with the following values:
+
+- [`GridTrackSize.MaxContent`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/GridTrackSize#MaxContent()): Use the content's maximum intrinsic size (e.g., the width is determined by the full length of the text in a text block with no wrapping).
+- [`GridTrackSize.MinContent`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/GridTrackSize#MinContent()): Use the content's minimum intrinsic size (e.g., the width is determined by the longest single word in a text block).
+- [`GridTrackSize.Auto`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/GridTrackSize#Auto()): Use a flexible size for a track that adapts based on available space. It behaves like `MaxContent` by default, but shrinks and wraps its content to fit within the parent container.
+
+The following example places two texts side by side.
+The column size for the first text is determined
+by the required minimum width to display the text,
+and the second column width depends on the required maximum width of the text.
+
+
+```kotlin
+Grid(
+    config = {
+        column(GridTrackSize.MinContent)
+        column(GridTrackSize.MaxContent)
+        row(1.0f)
+    },
+    modifier = Modifier.width(480.dp)
+) {
+    Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras imperdiet.")
+    Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras imperdiet.")
+}
+```
+
+<br />
+
+![Intrinsic sizes specified in the columns.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/intrinsic-size.png) **Figure 5**. Intrinsic sizes specified in the columns.
+
+## Set gaps between rows and columns
+
+Once your grid tracks are sized,
+you can modify the [grid gap](https://developer.android.com/develop/ui/compose/layouts/adaptive/grid#grid-gap) to refine the spacing between the tracks.
+You can specify the column gap with the [`columnGap`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/GridConfigurationScope#columnGap(androidx.compose.ui.unit.Dp)) function,
+and the row gap with [`rowGap`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/GridConfigurationScope#rowGap(androidx.compose.ui.unit.Dp)). In the following example,
+there is a `16dp` gap between each row,
+and an `8dp` gap between each column (Figure 5).
+
+
+```kotlin
+Grid(
+    config = {
+        repeat(2) {
+            column(160.dp)
+        }
+        repeat(3) {
+            row(90.dp)
+        }
+        rowGap(16.dp)
+        columnGap(8.dp)
+    }
+) {
+    Card1()
+    Card2()
+    Card3()
+    Card4()
+    Card5()
+    Card6()
+}
+```
+
+<br />
+
+![Gaps between rows and columns.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/gaps.png) **Figure 6**. Gaps between rows and columns.
+
+You can also use the convenience function [`gap`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/GridConfigurationScope#gap(androidx.compose.ui.unit.Dp))
+to define gaps of the same column and row size,
+and to define column and gap sizes separately using a single function.
+The following code adds `8dp` gaps to the grid:
+
+
+```kotlin
+Grid(
+    config = {
+        repeat(2) {
+            column(160.dp)
+        }
+        repeat(3) {
+            row(90.dp)
+        }
+        gap(8.dp) // Equivalent to columnGap(8.dp) and rowGap(8.dp)
+    }
+) {
+    Card1()
+    Card2()
+    Card3()
+    Card4()
+    Card5()
+    Card6()
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/grid/get-started.md
+++ b/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/grid/get-started.md
@@ -1,0 +1,51 @@
+This page describes how to implement basic [`Grid`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/Grid.composable#Grid(kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1)) layouts.
+
+## Set up project
+
+1. Add the [`androidx.compose.foundation.layout`](https://developer.android.com/jetpack/androidx/versions) library to your project's
+   `lib.versions.toml`.
+
+       [versions]
+       compose = "1.12.0-beta02"
+
+       [libraries]
+       androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout", version.ref = "compose" }
+
+2. Add the library dependency to your app's `build.gradle.kts`.
+
+       dependencies {
+           implementation(libs.androidx.compose.foundation.layout)
+       }
+
+## Create a basic grid
+
+The following example creates a basic 2x3 grid,
+with the columns and rows having a fixed size of `100.dp`.
+
+
+```kotlin
+Grid(
+    config = {
+        repeat(2) {
+            column(100.dp)
+        }
+        repeat(3) {
+            row(100.dp)
+        }
+    }
+) {
+    Card1(containerColor = PastelRed)
+    Card2(containerColor = PastelGreen)
+    Card3(containerColor = PastelBlue)
+    Card4(containerColor = PastelPink)
+    Card5(containerColor = PastelOrange)
+    Card6(containerColor = PastelYellow)
+}
+```
+
+<br />
+
+![A basic grid consists of rows and columns with fixed size.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/six-cards-in-grid.png) **Figure 1**. A basic grid consists of rows and columns with fixed size.
+
+To learn how to implement more advanced grids,
+see [Set container properties](https://developer.android.com/develop/ui/compose/layouts/adaptive/grid/container-properties) and [Set item properties](https://developer.android.com/develop/ui/compose/layouts/adaptive/grid/item-properties).

--- a/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/grid/index.md
+++ b/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/grid/index.md
@@ -1,0 +1,73 @@
+> [!NOTE]
+> **Note:** `Grid` is an experimental API and is subject to change. File any issues on the [issue tracker](https://issuetracker.google.com/issues/new?component=1876021&template=1424126).
+
+[`Grid`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/Grid.composable#Grid(kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1)) is a Jetpack Compose API
+that lets you flexibly implement a two-dimensional layout.
+With this API, you can display items in multi-column
+or multi-row layouts that adapt to the available container size.
+![A flexible and adaptive two-dimensional layout with Grid](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/example.png) **Figure 1.** A flexible and adaptive two-dimensional layout with `Grid`.
+
+## How is Grid different from similar composables?
+
+Compose already offers similar components, such as [`LazyVerticalGrid`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/lazy/grid/LazyVerticalGrid.composable#LazyVerticalGrid(androidx.compose.foundation.lazy.grid.GridCells,androidx.compose.ui.Modifier,androidx.compose.foundation.lazy.grid.LazyGridState,androidx.compose.foundation.layout.PaddingValues,kotlin.Boolean,androidx.compose.foundation.layout.Arrangement.Vertical,androidx.compose.foundation.layout.Arrangement.Horizontal,androidx.compose.foundation.gestures.FlingBehavior,kotlin.Boolean,androidx.compose.foundation.OverscrollEffect,kotlin.Function1)).
+These components are mainly for visualization of large, homogeneous data sets---
+for example, displaying a content catalog in a video streaming app.
+These components are NOT designed
+for the structural layout of a screen or complex component.
+
+You can also implement a two-dimensional layout
+by combining multiple `Row` and `Column` composables.
+However, this approach has some downsides,
+such as deep hierarchies and difficulties in adaptability.
+
+The following table provides an overview
+of which layouts are suitable for each API:
+
+| Component | Purpose |
+|---|---|
+| `LazyVerticalGrid`, `LazyStaggeredGrid`, `LazyHorizontalGrid` | Visualization of large, homogeneous data sets that require lazy loading. |
+| `Row`, `Column`, `FlexBox` | One-dimensional layout |
+| `Grid` | Two-dimensional layout |
+
+> [!NOTE]
+> **Note:** `Grid` doesn't support lazy loading.
+
+## Terminology
+
+Familiarize yourself with the following terminology
+to understand how `Grid` works.
+
+### Grid line
+
+A grid is made up of lines, which run horizontally and vertically.
+If your grid has three rows, it has four horizontal lines,
+including the one after the last row.
+In the following image, each dotted line represents a grid line:
+![The grid consists of four horizontal lines and three vertical lines.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/grid-line.png) **Figure 2**. The grid consists of four horizontal lines and three vertical lines.
+
+### Grid track
+
+A grid track is the space between two grid lines.
+A row track is between two horizontal lines,
+and a column track is between two vertical lines.
+To define the size of these tracks,
+assign a size to them when you create the grid.
+![A grid track for the first row.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/grid-track.png) **Figure 3**. A grid track for the first row.
+
+### Grid cell
+
+A grid cell is the intersection of a row and column track.
+![A grid cell that is an intersection of the second row and the second column.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/grid-cell.png) **Figure 4**. A grid cell that is an intersection of the second row and the second column.
+
+### Grid area
+
+A grid area consists of several grid cells.
+You can define a grid area by making an item span multiple tracks.
+![A grid area that consists of four grid cells.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/grid-area.png) **Figure 5**. A grid area that consists of four grid cells.
+
+### Grid gap
+
+A grid gap is the gutter between grid tracks.
+You can't place a UI element into a gap,
+but you can span a UI element across it.
+![A grid gap between the first column and the second column.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/grid-gap.png) **Figure 6**. A grid gap between the first column and the second column.

--- a/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/grid/item-properties.md
+++ b/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/grid/item-properties.md
@@ -1,0 +1,168 @@
+While the `Grid` config defines the overall structure,
+you use the [`gridItem`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/GridScope#(androidx.compose.ui.Modifier).gridItem(kotlin.Int,kotlin.Int,kotlin.Int,kotlin.Int,androidx.compose.ui.Alignment)) modifier to control the position, spanning,
+and alignment of items within that structure.
+
+## Set the item position
+
+Place an item into a specific track or cell
+with the `row` and `column` parameters.
+
+The `row` and `column` parameters specify the row and column track indexes
+that the item is placed in.
+Track indexes are 1-based---they start at one.
+Specifying only `row` or `column` (not both) places the item
+in the next available space in that track.
+Specifying both places the item into that cell.
+
+Use a positive integer to specify the track index from the start.
+For example, to place an item in the first row and column,
+use `gridItem(row = 1, column = 1)`.
+
+Use a negative integer to specify the track relative to the end.
+For example, to place an item in the second-to-last row and column, use
+`gridItem(row = -2, column = -2)`.
+
+In the following example, Card **#2** is placed
+in the second row and the second column.
+Card **#3** is assigned to the last row (indexed by -1),
+where it automatically occupies
+the first available column in that track (Figure 1).
+
+
+```kotlin
+Grid(
+    config = {
+        repeat(2) {
+            column(160.dp)
+        }
+        repeat(3) {
+            row(90.dp)
+        }
+        gap(8.dp)
+    }
+) {
+    Card1()
+    Card2(modifier = Modifier.gridItem(row = 2, column = 2))
+    Card3(modifier = Modifier.gridItem(row = -1, column = -2))
+}
+```
+
+<br />
+
+![Card #2 is placed in the grid cell
+in the second row and the second column,
+and Card #3 is placed in the first column in the third row.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/position.png) **Figure 1** . Card **#2** is placed in the grid cell in the second row and the second column, and Card **#3** is placed in the first column in the third row.
+
+## Span rows and columns
+
+Use the `rowSpan` and `columnSpan` parameters
+to span an item over multiple cells.
+You can place a UI element into a [grid area](https://developer.android.com/develop/ui/compose/layouts/adaptive/grid#grid-area),
+which is the area consisting of several [grid cells](https://developer.android.com/develop/ui/compose/layouts/adaptive/grid#grid-cell).
+The `gridItem` modifier lets you specify the grid area
+with the `rowSpan` and `columnSpan` parameters.
+In the following example,
+Card **#1** is placed in the area consisting of two rows and two columns
+(Figure 2).
+
+
+```kotlin
+Grid(
+    config = {
+        repeat(3) {
+            column(160.dp)
+        }
+        repeat(3) {
+            row(90.dp)
+        }
+        rowGap(8.dp)
+        columnGap(8.dp)
+    }
+) {
+    Card1(modifier = Modifier.gridItem(rowSpan = 2, columnSpan = 2))
+    Card2()
+    Card3()
+    Card4(modifier = Modifier.gridItem(columnSpan = 3))
+}
+```
+
+<br />
+
+![Card #4 spans three columns](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/spanning.png) **Figure 2** . Card **#4** spans three columns.
+
+## Set the alignment in a grid area
+
+You can set the alignment of the UI element in a grid area
+by specifying it in the `alignment` parameter of the [`gridItem`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/GridScope#(androidx.compose.ui.Modifier).gridItem(kotlin.Int,kotlin.Int,kotlin.Int,kotlin.Int,androidx.compose.ui.Alignment)) modifier.
+In the following example, **#1** is placed in the center of the grid area
+consisting of two columns and two rows.
+
+
+```kotlin
+Grid(
+    config = {
+        repeat(3) {
+            column(160.dp)
+        }
+        repeat(3) {
+            row(90.dp)
+        }
+        rowGap(8.dp)
+        columnGap(8.dp)
+    },
+) {
+    Text(
+        text = "#1",
+        modifier = Modifier
+            .gridItem(
+                rowSpan = 2,
+                columnSpan = 2,
+                alignment = Alignment.Center
+            ),
+    )
+    Card2()
+    Card3()
+    Card4(modifier = Modifier.gridItem(columnSpan = 3))
+}
+```
+
+<br />
+
+![The Text with #1 is placed in the center of the grid area
+consisting of two rows and two columns.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/alignment.png) **Figure 3** . The Text with **#1** is placed in the center of the grid area consisting of two rows and two columns.
+
+## Auto-placement mixed with placed items
+
+A UI element in `Grid`
+that has no position specification undergoes auto-placement.
+This example shows how you can mix auto-placed elements
+and the UI elements with specified grid cells.
+Card **#2** and Card **#4** are placed in specified grid cells,
+and the other items are auto-placed.
+
+
+```kotlin
+Grid(
+    config = {
+        repeat(2) {
+            column(160.dp)
+        }
+        repeat(3) {
+            row(90.dp)
+        }
+        rowGap(16.dp)
+        columnGap(8.dp)
+    }
+) {
+    Card1()
+    Card2(modifier = Modifier.gridItem(row = 2, column = 2))
+    Card3()
+    Card4(modifier = Modifier.gridItem(row = 3, column = 1))
+    Card5()
+    Card6()
+}
+```
+
+<br />
+
+![Card #3 is placed next to Card <b>#1</b>, as it is an auto-placement.](https://developer.android.com/static/develop/ui/compose/images/layouts/adaptive/grid/autoplacement-mixed-with-placement.png) **Figure 4** . Card **#3** is placed next to Card **#1**, as it is an auto-placement.

--- a/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/mediaquery/index.md
+++ b/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/layouts/adaptive/mediaquery/index.md
@@ -1,0 +1,329 @@
+> [!NOTE]
+> **Note:** The `mediaQuery` function and the related data types are experimental and subject to change. File any issues on the [issue tracker](https://issuetracker.google.com/issues?q=componentid:1876021).
+
+You need various types of information, such as device capability
+and app status, to update your app layout.
+Window width and height are the most commonly used information.
+In addition to that, you can refer to the following information:
+
+- Window posture
+- Pointing devices precision
+- Keyboard type
+- Whether the camera and microphone are supported by the device
+- The distance between a user and the device display
+
+Because the information is updated dynamically,
+you need to monitor it and trigger recomposition when any update happens.
+The [`mediaQuery`](https://developer.android.com/reference/kotlin/androidx/compose/ui/mediaQuery.composable#mediaQuery(kotlin.Function1)) function abstracts the details of the information retrieval
+and lets you focus on defining the condition to trigger the layout updates.
+The following example switches the layout to `TabletopLayout`
+when the foldable posture is tabletop:
+
+
+```kotlin
+@Composable
+fun VideoPlayer(
+    // ...
+) {
+    // ...
+            if (mediaQuery { windowPosture == UiMediaScope.Posture.Tabletop }) {
+                TabletopLayout()
+            } else {
+                FlatLayout()
+            }
+    // ...
+}
+```
+
+<br />
+
+## Enable the `mediaQuery` function
+
+To enable the `mediaQuery` function,
+set the `isMediaQueryIntegrationEnabled` attribute of
+the [`ComposeUiFlags`](https://developer.android.com/reference/kotlin/androidx/compose/ui/ComposeUiFlags) object to `true`:
+
+
+```kotlin
+class MyApplication : Application() {
+    override fun onCreate() {
+        ComposeUiFlags.isMediaQueryIntegrationEnabled = true
+        super.onCreate()
+    }
+}
+```
+
+<br />
+
+## Define a condition with parameters
+
+You can define a condition as a lambda
+that is evaluated within [`UiMediaScope`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope).
+The `mediaQuery` function evaluates the condition according to
+the current status and the device capabilities.
+The function returns a boolean value,
+so you can determine the layout with conditional branches
+like an `if` expression.
+Table 1 describes the parameters available in `UiMediaScope`.
+
+| Parameter | Value type | Description |
+|---|---|---|
+| `windowWidth` | [`Dp`](https://developer.android.com/reference/kotlin/androidx/compose/ui/unit/Dp) | The current window width in dp. |
+| `windowHeight` | `Dp` | The current window height in dp. |
+| `windowPosture` | [`UiMediaScope.Posture`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.Posture) | The current posture of the application window. |
+| `pointerPrecision` | [`UiMediaScope.PointerPrecision`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.PointerPrecision) | The highest precision of the available pointing devices. |
+| `keyboardKind` | [`UiMediaScope.KeyboardKind`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.KeyboardKind) | The type of keyboard available or connected. |
+| `hasCamera` | `Boolean` | Whether the camera is supported on the device. |
+| `hasMicrophone` | `Boolean` | Whether the microphone is supported on the device. |
+| `viewingDistance` | [`UiMediaScope.ViewingDistance`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.ViewingDistance) | The typical distance between the user and the device screen. |
+
+A `UiMediaScope` object resolves the values of the parameters.
+The `mediaQuery` function uses [`LocalUiMediaScope.current`](https://developer.android.com/reference/kotlin/androidx/compose/ui/package-summary#LocalUiMediaScope())
+to access the `UiMediaScope` object,
+which represents the current device capabilities and context.
+This object is dynamically updated when any changes are made,
+such as when the user changes the device posture.
+The `mediaQuery` function then evaluates the `query` lambda
+with the updated `UiMediaScope` object and returns a boolean value.
+For example, the following snippet chooses between `TabletopLayout`
+and `FlatLayout` based on the `windowPosture` parameter value.
+
+
+```kotlin
+@Composable
+fun VideoPlayer(
+    // ...
+) {
+    // ...
+            if (mediaQuery { windowPosture == UiMediaScope.Posture.Tabletop }) {
+                TabletopLayout()
+            } else {
+                FlatLayout()
+            }
+    // ...
+}
+```
+
+<br />
+
+### Make a decision based on the window size
+
+[Window size classes](https://developer.android.com/develop/ui/compose/layouts/adaptive/use-window-size-classes) are a set of opinionated viewport breakpoints
+that help you design, develop, and test adaptive layouts.
+You can compare the two parameters representing the current window size
+with the threshold defined in the window size classes.
+The following example changes the number of panes according to the window width.
+[`WindowSizeClass`](https://developer.android.com/reference/androidx/window/core/layout/WindowSizeClass) class has constants for the thresholds
+of window size classes (Figure 1).
+
+The [`derivedMediaQuery`](https://developer.android.com/reference/kotlin/androidx/compose/ui/derivedMediaQuery.composable#derivedMediaQuery(kotlin.Function1)) function evaluates the `query` lambda
+and wraps the result in a [`derivedStateOf`](https://developer.android.com/develop/ui/compose/side-effects#derivedstateof).
+Because `windowWidth` and `windowHeight` can update frequently,
+call the `derivedMediaQuery` function instead of the `mediaQuery` function
+when you refer to those parameters in the `query` lambda.
+
+
+```kotlin
+val narrowerThanMedium by derivedMediaQuery {
+    windowWidth < WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND.dp
+}
+val narrowerThanExpanded by derivedMediaQuery {
+    windowWidth < WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND.dp
+}
+when {
+    narrowerThanMedium -> SinglePaneLayout()
+    narrowerThanExpanded -> TwoPaneLayout()
+    else -> ThreePaneLayout()
+}
+```
+
+<br />
+
+**Figure 1**. Layout is updated according to the window width.
+
+### Update layout according to the window posture
+
+The `windowPosture` parameter describes the current window posture
+as a `UiMediaScope.Posture` object.
+You can check the current [posture](https://developer.android.com/develop/ui/compose/layouts/adaptive/foldables/learn-about-foldables) by comparing the parameter
+with the values defined in the `UiMediaScope.Posture` class.
+The following example switches layout according to the window posture:
+
+
+```kotlin
+when {
+    mediaQuery { windowPosture == UiMediaScope.Posture.Tabletop } -> TabletopLayout()
+    mediaQuery { windowPosture == UiMediaScope.Posture.Book } -> BookLayout()
+    mediaQuery { windowPosture == UiMediaScope.Posture.Flat } -> FlatLayout()
+}
+```
+
+<br />
+
+### Check the precision of the available pointing device
+
+A high precision pointing device helps users to point a UI element precisely.
+The precision of a pointing device depends on the device type.
+
+The `pointerPrecision` parameter describes the precision
+of the available pointing devices, such as a mouse and touchscreen.
+There are four values defined in the `UiMediaScope.PointerPrecision` class:
+[`Fine`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.PointerPrecision#Fine()), [`Coarse`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.PointerPrecision#Coarse()), [`Blunt`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.PointerPrecision#Blunt()), and [`None`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.PointerPrecision#None()).
+`None` means that no pointing device is available.
+The precision ranges from highest to lowest in this order:
+`Fine`, `Coarse`, and `Blunt`.
+
+If multiple pointing devices are available and their precisions are different,
+the parameter is resolved with the highest one.
+For example, if there are two pointing devices --- a `Fine` precision device and
+a `Blunt` precision device ---
+`Fine` is the value of the `pointerPrecision` parameter.
+
+The following example shows a larger button
+when the user is using a pointing device with low precision:
+
+
+```kotlin
+if (mediaQuery { pointerPrecision == UiMediaScope.PointerPrecision.Blunt }) {
+    LargeSizeButton()
+} else {
+    NormalSizeButton()
+}
+```
+
+<br />
+
+### Check the available keyboard type
+
+The `keyboardKind` parameter represents the type of the available keyboards:
+[`Physical`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.KeyboardKind#Physical()), [`Virtual`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.KeyboardKind#Virtual()), and [`None`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.KeyboardKind#None()).
+If an on-screen keyboard is displayed and
+a hardware keyboard is available at the same time,
+the parameter is resolved as `Physical`.
+If neither is detected, `None` is the value of the parameter.
+The following example shows a message suggesting that users connect a keyboard
+when no keyboard is detected:
+
+
+```kotlin
+if (mediaQuery { keyboardKind == UiMediaScope.KeyboardKind.None }) {
+    SuggestKeyboardConnect()
+}
+```
+
+<br />
+
+### Check if the device supports camera and microphone
+
+Some devices don't support cameras or microphones.
+You can check if the device supports a camera and a microphone
+with the `hasCamera` parameter and the `hasMicrophone` parameter.
+The following example shows buttons to use with camera and microphone
+when the device supports them:
+
+
+```kotlin
+Row {
+    OutlinedTextField(state = rememberTextFieldState())
+    // Show the MicButton when the device supports a microphone.
+    if (mediaQuery { hasMicrophone }) {
+        MicButton()
+    }
+    // Show the CameraButton when the device supports a camera.
+    if (mediaQuery { hasCamera }) {
+        CameraButton()
+    }
+}
+```
+
+<br />
+
+### Adjust UI with the estimated viewing distance
+
+Viewing distance is a factor that helps determine layout.
+If the user is using the app from a distance,
+they would expect the text and UI elements to be bigger.
+The `viewingDistance` parameter provides an estimate of the viewing distance
+based on the device type and its typical usage context.
+
+There are three values defined in the `UiMediaScope.ViewingDistance` class:
+[`Near`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.ViewingDistance#Near()), [`Medium`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.ViewingDistance#Medium()), and [`Far`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.ViewingDistance#Far()).
+`Near` means that the screen is in close range,
+and `Far` means that the device is viewed from a distance.
+The following example increases the font size when the viewing distance is
+`Far` or `Medium`:
+
+
+```kotlin
+val fontSize = when {
+    mediaQuery { viewingDistance == UiMediaScope.ViewingDistance.Far } -> 20.sp
+    mediaQuery { viewingDistance == UiMediaScope.ViewingDistance.Medium } -> 18.sp
+    else -> 16.sp
+}
+```
+
+<br />
+
+## Preview a UI component
+
+You can call the `mediaQuery` and `derivedMediaQuery` functions in the
+composable functions to preview UI components.
+The following snippet chooses between `TabletopLayout`
+and `FlatLayout` based on the `windowPosture` parameter value.
+To preview the `TabletopLayout`, the `windowPosture` parameter should be
+[`UiMediaScope.Posture.Tabletop`](https://developer.android.com/reference/kotlin/androidx/compose/ui/UiMediaScope.Posture#Tabletop()).
+
+
+```kotlin
+when {
+    mediaQuery { windowPosture == UiMediaScope.Posture.Tabletop } -> TabletopLayout()
+    mediaQuery { windowPosture == UiMediaScope.Posture.Book } -> BookLayout()
+    mediaQuery { windowPosture == UiMediaScope.Posture.Flat } -> FlatLayout()
+}
+```
+
+<br />
+
+The `mediaQuery` and `derivedMediaQuery` functions evaluate
+the given `query` lambda within a `UiMediaScope` object,
+which is provided as `LocalUiMediaScope.current`.
+You can override it with the following steps:
+
+1. Enable the `mediaQuery` function.
+2. Define a custom object that implements the `UiMediaScope` interface.
+3. Set the custom object to the `LocalUiMediaScope` with the [`CompositionLocalProvider`](https://developer.android.com/reference/kotlin/androidx/compose/runtime/CompositionLocalProvider.composable#CompositionLocalProvider(androidx.compose.runtime.CompositionLocalContext,kotlin.Function0)) function.
+4. Call the composable to preview in the content lambda of the `CompositionLocalProvider` function.
+
+You can preview the `TabletopLayout` with the following example:
+
+
+```kotlin
+@Preview
+@Composable
+fun PreviewLayoutForTabletop() {
+    // Step 1: Enable the mediaQuery function
+    ComposeUiFlags.isMediaQueryIntegrationEnabled = true
+
+    val currentUiMediaScope = LocalUiMediaScope.current
+    // Step 2: Define a custom object implementing the UiMediaScope interface.
+    // The object overrides the windowPosture parameter.
+    // The resolution of the remaining parameters is deferred to the currentUiMediaScope object.
+    val uiMediaScope = remember(currentUiMediaScope) {
+        object : UiMediaScope by currentUiMediaScope {
+            override val windowPosture: UiMediaScope.Posture = UiMediaScope.Posture.Tabletop
+        }
+    }
+
+    // Step 3: Set the object to the LocalUiMediaScope.
+    CompositionLocalProvider(LocalUiMediaScope provides uiMediaScope) {
+        // Step 4: Call the composable to preview.
+        when {
+            mediaQuery { windowPosture == UiMediaScope.Posture.Tabletop } -> TabletopLayout()
+            mediaQuery { windowPosture == UiMediaScope.Posture.Book } -> BookLayout()
+            mediaQuery { windowPosture == UiMediaScope.Posture.Flat } -> FlatLayout()
+        }
+    }
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/tooling/debug.md
+++ b/platforms/android/.agents/skills/adaptive/references/android/develop/ui/compose/tooling/debug.md
@@ -1,0 +1,114 @@
+Tools for debugging your Compose UI are available in Android Studio.
+
+## Layout Inspector
+
+Layout Inspector lets you inspect a Compose layout inside a running app in an
+emulator or physical device. You can use the Layout Inspector to check how often
+a composable is recomposed or skipped, which can help identify issues with your
+app. For example, some coding errors might force your UI to recompose
+excessively, which can cause [poor performance](https://developer.android.com/develop/ui/compose/performance).
+Some coding errors can prevent your UI from recomposing and, therefore,
+prevent your UI changes from showing up on the screen. If you're new to
+Layout inspector, check the [guidance](https://developer.android.com/studio/debug/layout-inspector) on how to
+run it.
+
+> [!NOTE]
+> **Note:** If you're not seeing Compose components in layout inspector, make sure you are not removing `META-INF/androidx.compose.*.version` files from the APK. These are required for layout inspector to work.
+
+### Get recomposition counts
+
+When debugging your Compose layouts, knowing when composables
+[recompose](https://developer.android.com/develop/ui/compose/mental-model#recomposition) is important in
+understanding whether your UI is implemented properly. For example, if it's
+recomposing too many times, your app might be doing more work than is necessary.
+On the other hand, components that don't recompose when you anticipate them to
+can lead to unexpected behaviors.
+
+The Layout Inspector shows you when discrete composables in your layout
+hierarchy have either recomposed or skipped, as you interact with your app. In
+Android Studio, your recompositions are highlighted to help you determine
+where in the UI your composables are recomposing.
+
+**Figure 1.** Recompositions are highlighted in Layout Inspector.
+
+The highlighted portion shows a gradient overlay of the composable in the image
+section of the Layout Inspector, and gradually disappears so that you can get an
+idea of where in the UI the composable with the highest recompositions can be
+found. If one composable is recomposing at a higher rate than another
+composable, then the first composable receives a stronger gradient overlay
+color. If you double-click a composable in the layout inspector, you're taken to
+the corresponding code for analysis.
+
+> [!NOTE]
+> **Note:** To view recomposition counts, make sure your app is using an API level of 29 or higher, and `Compose 1.2.0` or higher. Then, deploy your app as you normally would.
+
+![](https://developer.android.com/static/develop/ui/compose/images/li-recomposition-counts.png) **Figure 2.**The composition and skip counter in Layout Inspector.
+
+Open the **Layout Inspector** window and connect to your app process. In the
+**Component Tree** , there are two columns that appear next to the layout
+hierarchy. The first column shows the number of compositions for each node and
+the second column displays the number of skips for each node. Selecting a
+composable node shows the dimensions and parameters of the composable, unless
+it's an inline function, in which case the parameters can't be shown. You can
+also see similar information in the **Attributes** pane when you select a
+composable from the **Component Tree** or the **Layout Display**.
+
+Resetting the count can help you understand recompositions or skips during a
+specific interaction with your app. If you want to reset the count, click
+**Reset** near the top of the **Component Tree** pane.
+
+> [!NOTE]
+> **Note:** If you don't see the new columns in the **Component Tree** pane, you can view them by selecting **Show Recomposition Counts** from the **View Options** menu ![Layout Inspector View Options
+> icon](https://developer.android.com/static/studio/images/buttons/live-layout-inspector-view-options-icon.png) near the top of the **Component Tree** pane, as shown in the following image.
+
+![Enable the composition and skip counter in Layout
+Inspector](https://developer.android.com/static/develop/ui/compose/images/li-show-recomposition-counts.png)
+
+**Figure 3**. Enable the composition and skip counter in Layout Inspector.
+
+### Compose semantics
+
+In Compose, [Semantics](https://developer.android.com/develop/ui/compose/accessibility/semantics) describe your UI in an
+alternative manner that is understandable for
+[Accessibility](https://developer.android.com/develop/ui/compose/accessibility) services and for the
+[Testing](https://developer.android.com/develop/ui/compose/testing) framework. You can use the Layout Inspector
+to inspect semantic information in your Compose layouts.
+![Semantic information displayed using the Layout Inspector.](https://developer.android.com/static/develop/ui/compose/images/layout_inspector_semantics_new.png) **Figure 4.** Semantic information displayed using the Layout Inspector.
+
+When selecting a Compose node, use the **Attributes** pane to check whether it
+declares semantic information directly, merges semantics from its children, or
+both. To quickly identify which nodes include semantics, either declared or
+merged, use select the **View options** drop-down in the **Component Tree** pane
+and select **Highlight Semantics Layers**. This highlights only the nodes in the
+tree that include semantics, and you can use your keyboard to quickly navigate
+between them.
+
+## Compose UI Check
+
+To help you build more adaptive and accessible UIs in Jetpack Compose, Android
+Studio provides a UI Check mode in Compose Preview. This feature is similar
+to [Accessibility Scanner](https://developer.android.com/guide/topics/ui/accessibility/testing#accessibility-scanner)
+for views.
+
+When you activate Compose UI check mode on a Compose Preview, Android Studio
+automatically audits your Compose UI and suggests improvements to make your UI
+more accessible and adaptive. Android Studio checks that your UI works across
+different screen sizes. In the **Problems** panel, the tool shows the issues
+that it detects, such as text stretched on large screens or low color contrast.
+
+To access this feature, click the UI Check icon on Compose Preview:
+![](https://developer.android.com/static/studio/images/design/compose-ui-check-entry.png) **Figure 5.** Entry point to UI check mode.
+
+UI check automatically previews your UI in different configurations and
+highlights issues found in different configurations. In the **Problems** panel,
+when you click an issue, you can see the details of the issue, suggested fixes,
+and the renderings that highlight the area of the issue.
+![](https://developer.android.com/static/studio/images/design/compose-ui-check.png) **Figure 6.** UI check mode in action.
+
+### Fix with AI
+
+For issues detected in UI Check mode, you can use the AI agent to propose and
+apply code fixes. Click the **Fix with AI** button on an issue in the
+**Problems** panel. The agent analyzes the problem and your code to suggest
+changes that resolve the accessibility or adaptive issue.
+![](https://developer.android.com/static/studio/preview/features/images/ui-check-mode-single-fix.png) **Figure 7.** The agent fixes UI issues in UI Check mode.

--- a/platforms/android/.agents/skills/adaptive/references/android/guide/navigation/navigation-3/recipes/material-listdetail.md
+++ b/platforms/android/.agents/skills/adaptive/references/android/guide/navigation/navigation-3/recipes/material-listdetail.md
@@ -1,0 +1,141 @@
+# Material List-Detail Recipe
+
+This recipe demonstrates how to create an adaptive list-detail layout using the `ListDetailSceneStrategy` from the Material 3 Adaptive library. This layout automatically adjusts to show one, two, or three panes depending on the available screen width.
+
+## How it works
+
+This example has three destinations: `ConversationList`, `ConversationDetail`, and `Profile`.
+
+### `ListDetailSceneStrategy`
+
+The key to this recipe is the `rememberListDetailSceneStrategy`, which provides the logic for the adaptive layout.
+
+- **Pane Roles**: Each destination is assigned a role using metadata:
+
+  - `ListDetailSceneStrategy.listPane()`: For the primary (list) content. This pane is always visible. A placeholder can be provided to be shown in the detail pane area when no detail content is selected.
+  - `ListDetailSceneStrategy.detailPane()`: For the secondary (detail) content.
+  - `ListDetailSceneStrategy.extraPane()`: For tertiary content.
+- **Adaptive Layout** : The `ListDetailSceneStrategy` automatically handles the layout. On smaller screens, only one pane is shown at a time. On wider screens, it will show the list and detail panes side-by-side. On very wide screens, it can show all three panes: list, detail, and extra.
+
+- **Navigation** : Navigation between the panes is handled by adding and removing destinations from the back stack as usual. The `ListDetailSceneStrategy` observes the back stack and adjusts the layout accordingly.
+
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/material/listdetail)
+
+```
+package com.example.nav3recipes.material.listdetail
+
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
+import androidx.compose.material3.adaptive.layout.calculatePaneScaffoldDirective
+import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
+import androidx.compose.material3.adaptive.navigation3.rememberListDetailSceneStrategy
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.content.ContentRed
+import com.example.nav3recipes.content.ContentYellow
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import kotlinx.serialization.Serializable
+
+@Serializable
+private object ConversationList : NavKey
+
+@Serializable
+private data class ConversationDetail(val id: String) : NavKey
+
+@Serializable
+private data object Profile : NavKey
+
+class MaterialListDetailActivity : ComponentActivity() {
+
+    @OptIn(ExperimentalMaterial3AdaptiveApi::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+
+        setContent {
+
+            val backStack = rememberNavBackStack(ConversationList)
+
+            // Override the defaults so that there isn't a horizontal space between the panes.
+            // See b/418201867
+            val windowAdaptiveInfo = currentWindowAdaptiveInfoV2()
+            val directive = remember(windowAdaptiveInfo) {
+                calculatePaneScaffoldDirective(windowAdaptiveInfo)
+                    .copy(horizontalPartitionSpacerSize = 0.dp)
+            }
+            val listDetailStrategy = rememberListDetailSceneStrategy<NavKey>(directive = directive)
+
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+                sceneStrategies = listOf(listDetailStrategy),
+                entryProvider = entryProvider {
+                    entry<ConversationList>(
+                        metadata = ListDetailSceneStrategy.listPane(
+                            detailPlaceholder = {
+                                ContentYellow("Choose a conversation from the list")
+                            }
+                        )
+                    ) {
+                        ContentRed("Welcome to Nav3") {
+                            Button(onClick = dropUnlessResumed {
+                                backStack.add(ConversationDetail("ABC"))
+                            }) {
+                                Text("View conversation")
+                            }
+                        }
+                    }
+                    entry<ConversationDetail>(
+                        metadata = ListDetailSceneStrategy.detailPane()
+                    ) { conversation ->
+                        ContentBlue("Conversation ${conversation.id} ") {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Button(onClick = dropUnlessResumed {
+                                    backStack.add(Profile)
+                                }) {
+                                    Text("View profile")
+                                }
+                            }
+                        }
+                    }
+                    entry<Profile>(
+                        metadata = ListDetailSceneStrategy.extraPane()
+                    ) {
+                        ContentGreen("Profile")
+                    }
+                }
+            )
+        }
+    }
+}
+```

--- a/platforms/android/.agents/skills/agp-9-upgrade/SKILL.md
+++ b/platforms/android/.agents/skills/agp-9-upgrade/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: agp-9-upgrade
+description: Upgrades, or migrates, an Android project to use Android Gradle Plugin
+  (AGP) version 9. Do not use this skill for migrating Kotlin Multiplatform (KMP)
+  projects.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-06-25'
+  keywords:
+  - Android Gradle Plugin 9
+  - AGP 9
+  - AGP Upgrade
+  - AGP Migration
+  - New AGP DSL
+  - Migrate to built-in Kotlin
+---
+
+## Migration guide
+
+See the [AGP 9 migration guide](references/android/build/releases/agp-9-0-0-release-notes.md) for the major changes, many
+breaking, in AGP 9 compared to AGP 8.
+
+## Requirements
+
+If the user requests to update or migrate to AGP 9, first check the AGP version
+used in the project. If it is lower than 9, stop and ask the user to run the AGP
+Upgrade Assistant in Android Studio to update to the latest stable version of
+AGP, and confirm when done. The user may also request that this requirement be
+skipped; if this is the case, you should update the version of AGP to the latest
+stable version as part of the AGP 9 migration. See the
+[AGP 9 migration guide](references/android/build/releases/agp-9-0-0-release-notes.md) for how to do this.
+
+Each version of AGP has its own set of compatibilities with other tools, such as
+Gradle, JDK, and Kotlin. The release notes for each of these versions will
+include a **Compatibility** table indicating the minimum versions for these
+tools.
+
+Do not use this skill for KMP projects, as they are unsupported.
+
+## Steps
+
+If AGP is already at 9 or higher, then do the following:
+
+### Step 1: Update dependencies
+
+If KSP (`com.google.devtools.ksp`) is used in the project, ensure it is on
+version 2.3.6 or higher.
+
+If Hilt is used in the project, ensure it is on version 2.59.2 or higher.
+
+### Step 2: Migrate to built-in Kotlin
+
+See [the guide](references/android/build/migrate-to-built-in-kotlin.md) for detailed information.
+
+### Step 3. Migrate to the new AGP DSL
+
+See [the guide](references/android/build/releases/agp-9-0-0-release-notes.md) for detailed information.
+
+See also [gradle-recipes](references/recipes.md) for examples on how to migrate old code to code
+that is compatible with AGP 9 and the new DSL.
+
+### Step 4. Migrate kapt to KSP or legacy-kapt
+
+If KSP (`com.google.devtools.ksp`) or kapt (`org.jetbrains.kotlin.kapt`) are
+used in the project, see [KSP, kapt, and legacy-kapt](references/ksp-kapt.md) for detailed migration
+steps.
+
+### Step 5. BuildConfig
+
+If any Android module contains custom BuildConfig fields, see [BuildConfig](references/buildconfig.md)
+for detailed information.
+
+### Step 6. Update gradle.properties
+
+After the migration, check gradle.properties. Remove the following flags:
+
+1. android.builtInKotlin
+2. android.newDsl
+3. android.uniquePackageNames
+4. android.enableAppCompileTimeRClass
+
+Additionally, delete all temporary files you've created.
+
+## Guidelines
+
+- Never write or run python scripts.
+- Only search the Gradle dependency cache when inspecting external dependencies, and only as a last resort.
+- Never add `android.disallowKotlinSourceSets=false` to `gradle.properties`.
+- When verifying changes, don't run the `clean` task. This is a waste of time.
+
+## Verification
+
+After migration, verify the following:
+
+1. Gradle IDE sync succeeds.
+2. `./gradlew help` succeeds.
+3. `./gradlew build --dry-run` succeeds.
+
+## Troubleshooting
+
+Paparazzi v2.0.0-alpha04 and lower versions have issues with AGP 9. See
+[references/paparazzi-gradle-9.md](references/paparazzi-gradle-9.md) for details.

--- a/platforms/android/.agents/skills/agp-9-upgrade/references/android/build/migrate-to-built-in-kotlin.md
+++ b/platforms/android/.agents/skills/agp-9-upgrade/references/android/build/migrate-to-built-in-kotlin.md
@@ -1,0 +1,416 @@
+Android Gradle plugin 9.0 introduces built-in Kotlin support and enables it
+by default. That means you no longer have to apply the
+`org.jetbrains.kotlin.android` (or `kotlin-android`) plugin in your build files
+to compile Kotlin source files.
+With built-in Kotlin, your build files are simpler and you can avoid
+compatibility issues between AGP and the `kotlin-android` plugin.
+
+> [!NOTE]
+> **Note:** Built-in Kotlin replaces the `kotlin-android` plugin only. If you are writing a Kotlin Multiplatform (KMP) library module, you still need to apply the `org.jetbrains.kotlin.multiplatform` plugin and the [`com.android.kotlin.multiplatform.library`](https://developer.android.com/kotlin/multiplatform/plugin) plugin. Also, using the `org.jetbrains.kotlin.multiplatform` plugin together with the `com.android.library` or `com.android.application` plugin is no longer allowed when built-in Kotlin is enabled.
+
+## Enable built-in Kotlin
+
+You need AGP 9.0 or higher to have built-in Kotlin support.
+AGP 9.0 already enables built-in Kotlin for all your modules where you apply
+AGP, so you don't need to do anything to enable it. However, if you previously
+[opted out of built-in Kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin#opt-out-of-built-in-kotlin) by setting `android.builtInKotlin=false`
+in the `gradle.properties` file, you need to remove that setting or set it to
+`true`.
+
+> [!NOTE]
+> **Note:** You can also enable built-in Kotlin for [one module at a time](https://developer.android.com/build/migrate-to-built-in-kotlin#module-by-module-migration).
+
+Built-in Kotlin requires some changes to your project, so after you
+have built-in Kotlin enabled, follow the next steps to migrate your project.
+
+## Migration steps
+
+After you upgrade your project from an older AGP version to AGP 9.0 or after
+you manually [enable built-in Kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin#enable-built-in-kotlin), you might see the following error
+message:
+
+    Failed to apply plugin 'org.jetbrains.kotlin.android'.
+    > Cannot add extension with name 'kotlin', as there is an extension already registered with that name.
+
+...or
+
+    Failed to apply plugin 'com.jetbrains.kotlin.android'
+    > The 'org.jetbrains.kotlin.android' plugin is no longer required for Kotlin support since AGP 9.0.
+
+This error occurs because built-in Kotlin requires some changes to your project.
+To resolve this error, follow these steps:
+
+> [!NOTE]
+> **Note:** If you're not yet ready to migrate your project, you can also [opt out of built-in Kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin#opt-out-of-built-in-kotlin).
+
+1. [Remove the `kotlin-android` plugin](https://developer.android.com/build/migrate-to-built-in-kotlin#migration-steps-remove-kotlin-android-plugin)
+2. [Migrate the `kotlin-kapt` plugin if necessary](https://developer.android.com/build/migrate-to-built-in-kotlin#migration-steps-migrate-kotlin-kapt-plugin)
+3. [Migrate the `android.kotlinOptions{}` DSL if necessary](https://developer.android.com/build/migrate-to-built-in-kotlin#migration-steps-migrate-kotlin-options)
+4. [Migrate the `kotlin.sourceSets{}` DSL if necessary](https://developer.android.com/build/migrate-to-built-in-kotlin#migration-steps-migrate-kotlin-source-sets)
+
+### 1. Remove the `kotlin-android` plugin
+
+Remove the `org.jetbrains.kotlin.android` (or `kotlin-android`) plugin from
+the module-level build files where you apply it.
+The exact code to remove depends on
+whether you use [version catalogs](https://docs.gradle.org/current/userguide/version_catalogs.html) to declare plugins.
+
+### With version catalogs
+
+### Kotlin
+
+```kotlin
+// Module-level build file
+plugins {
+    alias(libs.plugins.kotlin.android)
+}
+```
+
+### Groovy
+
+```groovy
+// Module-level build file
+plugins {
+    alias(libs.plugins.kotlin.android)
+}
+```
+
+### No version catalogs
+
+### Kotlin
+
+```kotlin
+// Module-level build file
+plugins {
+    id("org.jetbrains.kotlin.android")
+}
+```
+
+### Groovy
+
+```groovy
+// Module-level build file
+plugins {
+    id 'org.jetbrains.kotlin.android'
+}
+```
+
+Then, remove the plugin from your top-level build file:
+
+### With version catalogs
+
+### Kotlin
+
+```kotlin
+// Top-level build file
+plugins {
+    alias(libs.plugins.kotlin.android) apply false
+}
+```
+
+### Groovy
+
+```groovy
+// Top-level build file
+plugins {
+    alias(libs.plugins.kotlin.android) apply false
+}
+```
+
+### No version catalogs
+
+### Kotlin
+
+```kotlin
+// Top-level build file
+plugins {
+    id("org.jetbrains.kotlin.android") version "KOTLIN_VERSION" apply false
+}
+```
+
+### Groovy
+
+```groovy
+// Top-level build file
+plugins {
+    id 'org.jetbrains.kotlin.android' version 'KOTLIN_VERSION' apply false
+}
+```
+
+If you use version catalogs, also remove the plugin definition from the
+version catalog TOML file (usually `gradle/libs.versions.toml`):
+
+```toml
+[plugins]
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "KOTLIN_VERSION" }
+```
+
+### 2. Migrate the `kotlin-kapt` plugin if necessary
+
+The `org.jetbrains.kotlin.kapt` (or `kotlin-kapt`) plugin is incompatible with
+built-in Kotlin. If you use `kapt`, we recommend that you
+[migrate your project to KSP](https://developer.android.com/build/migrate-to-ksp).
+
+If you can't migrate to KSP yet, replace the `kotlin-kapt` plugin with the
+`com.android.legacy-kapt` plugin, using the same version as your Android Gradle
+plugin.
+
+For example, with version catalogs, update your version catalog TOML
+file as follows:
+
+```toml
+[plugins]
+android-application = { id = "com.android.application", version.ref = "AGP_VERSION" }
+
+# Add the following plugin definition
+legacy-kapt = { id = "com.android.legacy-kapt", version.ref = "AGP_VERSION" }
+
+# Remove the following plugin definition
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "KOTLIN_VERSION" }
+```
+
+Then, update your build files:
+
+### Kotlin
+
+```kotlin
+// Top-level build file
+plugins {
+    alias(libs.plugins.legacy.kapt) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
+}
+```
+
+### Groovy
+
+```groovy
+// Top-level build file
+plugins {
+    alias(libs.plugins.legacy.kapt) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
+}
+```
+
+### Kotlin
+
+```kotlin
+// Module-level build file
+plugins {
+    alias(libs.plugins.legacy.kapt)
+    alias(libs.plugins.kotlin.kapt)
+}
+```
+
+### Groovy
+
+```groovy
+// Module-level build file
+plugins {
+    alias(libs.plugins.legacy.kapt)
+    alias(libs.plugins.kotlin.kapt)
+}
+```
+
+> [!NOTE]
+> **Note:** If you declare the `kotlin-kapt` plugin in the `plugins{}` block as `kotlin("kapt") version "<KOTLIN_VERSION>"`, then remove that line instead.
+
+### 3. Migrate the `android.kotlinOptions{}` DSL if necessary
+
+If you use the `android.kotlinOptions{}` DSL, you need to
+migrate it to the [`kotlin.compilerOptions{}`](https://kotlinlang.org/docs/gradle-compiler-options.html#migrate-from-kotlinoptions-to-compileroptions) DSL.
+
+For example, update this code:
+
+### Kotlin
+
+```kotlin
+android {
+    kotlinOptions {
+        languageVersion = "2.0"
+        jvmTarget = "11"
+    }
+}
+```
+
+### Groovy
+
+```groovy
+android {
+    kotlinOptions {
+        languageVersion = "2.0"
+        jvmTarget = "11"
+    }
+}
+```
+
+...to the new DSL:
+
+### Kotlin
+
+```kotlin
+kotlin {
+    compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+        // Optional: Set jvmTarget
+        // jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
+```
+
+### Groovy
+
+```groovy
+kotlin {
+    compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+        // Optional: Set jvmTarget
+        // jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
+```
+
+> [!NOTE]
+> **Note:** With built-in Kotlin, you don't need to set `kotlin.compilerOptions.jvmTarget` because its value defaults to `android.compileOptions.targetCompatibility`.
+
+### 4. Migrate the `kotlin.sourceSets{}` DSL if necessary
+
+When you use the `kotlin-android` plugin, AGP lets you add additional Kotlin
+source directories using either the [`android.sourceSets{}`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/AndroidSourceSet) DSL or the
+[`kotlin.sourceSets{}`](https://kotlinlang.org/api/kotlin-gradle-plugin/kotlin-gradle-plugin-api/org.jetbrains.kotlin.gradle.plugin/-kotlin-source-set/) DSL.
+With the `android.sourceSets{}` DSL, you can add the directories to either the
+`AndroidSourceSet.kotlin` set or the `AndroidSourceSet.java` set.
+
+With built-in Kotlin, the only supported option is to add the directories to the
+`AndroidSourceSet.kotlin` set using the `android.sourceSets{}` DSL.
+If you use unsupported options, migrate them as follows:
+
+### Kotlin
+
+```kotlin
+# Adding Kotlin source directories to kotlin.sourceSets is not supported
+kotlin.sourceSets.named("main") {
+    kotlin.srcDir("additionalSourceDirectory/kotlin")
+}
+
+# Adding Kotlin source directories to AndroidSourceSet.java is also not supported
+android.sourceSets.named("main") {
+    java.directories += "additionalSourceDirectory/kotlin"
+}
+
+# Add Kotlin source directories to AndroidSourceSet.kotlin
+android.sourceSets.named("main") {
+    kotlin.directories += "additionalSourceDirectory/kotlin"
+}
+```
+
+### Groovy
+
+```groovy
+# Adding Kotlin source directories to kotlin.sourceSets is not supported
+kotlin.sourceSets.named("main") {
+    kotlin.srcDir("additionalSourceDirectory/kotlin")
+}
+
+# Adding Kotlin source directories to AndroidSourceSet.java is also not supported
+android.sourceSets.named("main") {
+    java.directories.add("additionalSourceDirectory/kotlin")
+}
+
+# Add Kotlin source directories to AndroidSourceSet.kotlin
+android.sourceSets.named("main") {
+    kotlin.directories.add("additionalSourceDirectory/kotlin")
+}
+```
+
+If you want to add a Kotlin source directory to a specific variant or if the
+directory is generated by a task, you can use the
+[`addStaticSourceDirectory`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/SourceDirectories#addStaticSourceDirectory(kotlin.String)) or [`addGeneratedSourceDirectory`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/SourceDirectories#addGeneratedSourceDirectory(org.gradle.api.tasks.TaskProvider,kotlin.Function1)) methods
+in the [variant API](https://developer.android.com/build/extend-agp#variant-api-artifacts-tasks):
+
+### Kotlin
+
+```kotlin
+androidComponents.onVariants { variant ->
+    variant.sources.kotlin!!.addStaticSourceDirectory("additionalSourceDirectory/kotlin")
+    variant.sources.kotlin!!.addGeneratedSourceDirectory(TASK_PROVIDER, TASK_OUTPUT)
+}
+```
+
+### Groovy
+
+```groovy
+androidComponents.onVariants { variant ->
+    variant.sources.kotlin!!.addStaticSourceDirectory("additionalSourceDirectory/kotlin")
+    variant.sources.kotlin!!.addGeneratedSourceDirectory(TASK_PROVIDER, TASK_OUTPUT)
+}
+```
+
+## Report issues
+
+If you encounter issues after completing the previous steps,
+review the known issues in [issue #438678642](https://issuetracker.google.com/438678642) and give us
+feedback if needed.
+
+## Opt out of built-in Kotlin
+
+If you are unable to migrate your project to use built-in Kotlin, set
+`android.builtInKotlin=false` in the `gradle.properties` file to temporarily
+disable it.
+When you do that, the build shows a warning reminding you to migrate to built-in
+Kotlin as you won't be able to disable built-in Kotlin in AGP 10.0.
+
+> [!NOTE]
+> **Note:** You also need to set `android.newDsl=false` to opt out of the [new DSL](https://developer.android.com/r/tools/new-dsl) because the `kotlin-android` plugin is not compatible with it.
+
+Once you're ready to migrate your project, [enable built-in Kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin#enable-built-in-kotlin)
+and follow the [migration steps](https://developer.android.com/build/migrate-to-built-in-kotlin#migration-steps).
+
+## Module-by-module migration
+
+The `android.builtInKotlin` Gradle property lets you enable or disable built-in
+Kotlin for all your modules where you apply AGP.
+
+If migrating all your modules at once is challenging, you can migrate one module
+at a time:
+
+1. Set `android.builtInKotlin=false` in the `gradle.properties` file to
+   disable built-in Kotlin for all modules.
+
+2. Apply the `com.android.built-in-kotlin` plugin to the module
+   you want to enable built-in Kotlin, using the same version as your
+   Android Gradle plugin.
+
+3. Follow the previous [migration steps](https://developer.android.com/build/migrate-to-built-in-kotlin#migration-steps) to migrate this module to
+   built-in Kotlin.
+
+4. Once you've migrated all your modules, remove the
+   `android.builtInKotlin=false` setting in `gradle.properties`
+   and the `com.android.built-in-kotlin` plugin in your build files.
+
+## Option to selectively disable built-in Kotlin
+
+Android Gradle plugin 9.0 enables built-in Kotlin for all modules where it is
+applied.
+We recommend disabling built-in Kotlin selectively for modules that don't have
+Kotlin sources in large projects.
+This removes both the Kotlin compilation task, which has a small build
+performance cost, and the automatic dependency on the Kotlin standard library.
+
+To disable built-in Kotlin for a module,
+set `enableKotlin = false` in that module's build file:
+
+### Kotlin
+
+```kotlin
+android {
+    enableKotlin = false
+}
+```
+
+### Groovy
+
+```groovy
+android {
+    enableKotlin = false
+}
+```

--- a/platforms/android/.agents/skills/agp-9-upgrade/references/android/build/releases/agp-9-0-0-release-notes.md
+++ b/platforms/android/.agents/skills/agp-9-upgrade/references/android/build/releases/agp-9-0-0-release-notes.md
@@ -1,0 +1,556 @@
+<br />
+
+Android Gradle plugin 9.0 is a major release that brings API and behavior
+changes.
+
+To update to Android Gradle plugin 9.0.1, use the
+[Android Gradle plugin Upgrade Assistant](https://developer.android.com/build/agp-upgrade-assistant). The AGP upgrade assistant helps
+preserve existing behaviors when upgrading your project whenever appropriate, so
+you can upgrade your project to use AGP 9.0 even if you're not ready to
+adopt all the new defaults in AGP 9.0.
+
+There are also two agent skills available to make the upgrade process easier.
+For a non-KMP app, try the [AGP 9 upgrade skill](https://github.com/android/skills/tree/main/build/agp/agp-9-upgrade) from the
+Android skills repository. For a KMP app, try the [AGP 9 upgrade
+skill](https://github.com/Kotlin/kotlin-agent-skills/tree/main/skills/kotlin-tooling-agp9-migration) from JetBrains. For more information about using skills
+in Android Studio, see [Extend Agent Mode with skills](https://developer.android.com/studio/gemini/skills).
+
+## Compatibility
+
+The maximum API level that Android Gradle plugin 9.0 supports is API level 36.1.
+Here is other compatibility info:
+
+
+|   | Minimum version | Default version | Notes |
+|---:|:---:|:---:|:---:|
+| Gradle | 9.1.0 | 9.1.0 | To learn more, see [updating Gradle](https://developer.android.com/build/releases/gradle-plugin?buildsystem=ndk-build#updating-gradle). |
+| SDK Build Tools | 36.0.0 | 36.0.0 | [Install](https://developer.android.com/studio/intro/update#sdk-manager) or [configure](https://developer.android.com/tools/releases/build-tools) SDK Build Tools. |
+| NDK | N/A | 28.2.13676358 | [Install](https://developer.android.com/studio/projects/install-ndk#specific-version) or [configure](https://developer.android.com/studio/projects/install-ndk#apply-specific-version) a different version of the NDK. |
+| JDK | 17 | 17 | To learn more, see [setting the JDK version](https://developer.android.com/studio/intro/studio-config#jdk). |
+
+<br />
+
+## The `android` DSL classes now only implement the new public interfaces
+
+Over the last several years, we have introduced
+[new interfaces](https://developer.android.com/reference/tools/gradle-api) for our DSL and API in order to
+better control which APIs are public. AGP versions
+7.x and 8.x still used the old DSL types (for example `BaseExtension`) which
+also implemented the new public interfaces, in order to maintain compatibility
+as work progressed on the interfaces.
+
+AGP 9.0 uses our new DSL interfaces exclusively,
+and the implementations have changed to new types that are fully hidden. This
+also removes access to the old, deprecated variant API.
+
+To update to AGP 9.0, you might need to do the following:
+
+- **Ensure your project is compatible with [built-in
+  Kotlin](https://developer.android.com/build/releases/agp-9-0-0-release-notes#android-gradle-plugin-built-in-kotlin):** The `org.jetbrains.kotlin.android` plugin is not compatible with the new DSL.
+- **Switch KMP projects to the
+  [Android Gradle Library Plugin for KMP](https://developer.android.com/kotlin/multiplatform/plugin):**
+  Using the `org.jetbrains.kotlin.multiplatform` plugin in the same Gradle
+  subproject as the `com.android.library` and `com.android.application` plugins
+  is not compatible with the new DSL.
+
+  > [!NOTE]
+  > **Note:** The new KMP integration does not support using KMP and the Android Application plugin in the same Gradle subproject. To migrate, extract your Android app to a separate subproject.
+
+- **Update your build files:**
+  While the change of interfaces is meant to keep
+  the DSL as similar as possible, there might be
+  [some small changes](https://developer.android.com/build/releases/agp-9-0-0-release-notes#android-gradle-plugin-changed-dsl).
+
+- **Update your custom build logic to reference the new DSL and API:**
+  Replace any references to the internal DSL with the public DSL interfaces.
+  In most cases this will be a one-to-one replacement.
+  Replace any use of the `applicationVariants` and similar APIs with the new
+  [`androidComponents` API](https://developer.android.com/build/extend-agp#variant-api-artifacts-tasks).
+  This might be more complex, as the `androidComponents` API
+  is designed to be more stable to keep plugins compatible longer. Check our
+  [Gradle Recipes](https://github.com/android/gradle-recipes/tree/agp-9.0)
+  for examples.
+
+- **Update third-party plugins:**
+  Some third-party plugins might still depend on interfaces or APIs that are
+  no longer exposed. Migrate to versions of those plugins which are compatible
+  with AGP 9.0.
+
+The switch to the new DSL interfaces prevents plugins and Gradle build scripts
+using various deprecated APIs, including:
+
+| Deprecated API in the `android` block | Function | Replacement |
+|---|---|---|
+| `applicationVariants`, `libraryVariants`, `testVariants`, and `unitTestVariants` | Extension points for plugins to add new functionality to AGP. | Replace this with the [`androidComponents.onVariants`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/AndroidComponentsExtension#onVariants(com.android.build.api.variant.VariantSelector,kotlin.Function1)) API, for example: ```kotlin androidComponents { onVariants() { variant -> variant.signingConfig .enableV1Signing.set(false) } } ``` There might not be a direct replacement for all previous APIs. [File an issue](https://developer.android.com/studio/report-bugs) if there is a use case that is not covered by the new variant APIs. |
+| `variantFilter` | Allows selected variants to be disabled. | Replace this with the [`androidComponents.beforeVariants`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/AndroidComponentsExtension#beforeVariants(com.android.build.api.variant.VariantSelector,kotlin.Function1))) API, for example: ```kotlin androidComponents { beforeVariants( selector() .withBuildType("debug") .withFlavor("color", "blue") ) { variantBuilder -> variantBuilder.enable = false } } ``` |
+| `deviceProvider` and `testServer` | Registration of custom test environments for running tests against Android devices and emulators. | Switch to [Gradle-managed devices](https://developer.android.com/studio/test/gradle-managed-devices). |
+| `sdkDirectory`, `ndkDirectory`, `bootClasspath`, `adbExecutable`, and `adbExe` | Using various components of the Android SDK for custom tasks. | Switch to [`androidComponents.sdkComponents`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/SdkComponents). |
+| `registerArtifactType`, `registerBuildTypeSourceProvider`, `registerProductFlavorSourceProvider`, `registerJavaArtifact`, `registerMultiFlavorSourceProvider`, and `wrapJavaSourceSet` | Obsolete functionality mostly related to the handling of generated sources in Android Studio, which stopped working in AGP 7.2.0. | There is no direct replacement for these APIs. |
+| `dexOptions` | Obsolete settings related to the `dx` tool, which has been replaced by [`d8`](https://developer.android.com/tools/d8). None of the settings have had any effect since Android Gradle plugin 7.0. | There is no direct replacement. |
+| `generatePureSplits` | Generate configuration splits for instant apps. | The ability to ship configuration splits is now built in to Android app bundles. |
+| `aidlPackagedList` | AIDL files to package in the AAR to expose it as API for libraries and apps that depend on this library. | This is still exposed on [`LibraryExtension`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/LibraryExtension) but not on the other extension types. |
+
+If you update to AGP 9.0 and see the following error message, it means that
+your project is still referencing some of the old types:
+
+    java.lang.ClassCastException: class com.android.build.gradle.internal.dsl.ApplicationExtensionImpl$AgpDecorated_Decorated
+    cannot be cast to class com.android.build.gradle.BaseExtension
+
+If you are blocked by incompatible third-party plugins, you can opt out and
+get back the old implementations for the DSL, as well as the old variant API.
+While doing this, the new interfaces are also available, and you can still
+update your own build logic to the new API. To opt out, include this line in
+your `gradle.properties` file:
+
+    android.newDsl=false
+
+The previous classes are marked as deprecated in AGP 9.0. This means projects
+that opt out of the `newDsl` flag will see deprecation warnings, including on
+the `android` block itself.
+
+> [!CAUTION]
+> **Caution:** The ability to opt-out will be removed in AGP 10.0 (mid-2026).
+
+You can also start upgrading to the new APIs before upgrading to AGP 9.0. The
+new interfaces have been present for many AGP versions and so you can have a mix
+of new and old. The [AGP API reference docs](https://developer.android.com/reference/tools/gradle-api) show the API
+surface for each AGP version, and when each class, method and field was
+added.
+
+We're reaching out to the authors of commonly used plugins to help them adapt
+and release plugins that are fully compatible with the new modes, and will
+continue to enhance the AGP Upgrade Assistant in Android Studio to guide you
+through the migration.
+
+If you find that the new DSL or Variant API are missing capabilities or
+features, please file an [issue](https://issuetracker.google.com/issues/new?component=192708&template=840533) as soon as possible.
+
+## Built-in Kotlin
+
+Android Gradle plugin 9.0 introduces built-in Kotlin support and enables it
+by default. That means you no longer have to apply the
+`org.jetbrains.kotlin.android` (or `kotlin-android`) plugin in your build files
+to compile Kotlin source files.
+This simplifies the Kotlin integration with AGP, avoids the use of
+deprecated APIs, and improves performance in some cases.
+
+Therefore, when you upgrade your project to AGP 9.0, you need to also
+[migrate to built-in Kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin) or [opt out](https://developer.android.com/build/migrate-to-built-in-kotlin#opt-out-of-built-in-kotlin).
+
+You can also [selectively disable built-in Kotlin support](https://developer.android.com/build/migrate-to-built-in-kotlin#selectively-disable) for Gradle
+subprojects that don't have Kotlin sources.
+
+## Runtime dependency on Kotlin Gradle plugin
+
+To provide [built-in Kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin) support, Android Gradle plugin 9.0 now has a
+runtime dependency on Kotlin Gradle plugin (KGP) 2.2.10.
+That means you no longer have to declare a KGP version, and if you use a KGP
+version lower than 2.2.10, Gradle will automatically upgrade your KGP version to
+2.2.10.
+Likewise, if you use a KSP version lower than 2.2.10-2.0.2, AGP will upgrade it
+to 2.2.10-2.0.2 to match the KGP version.
+
+### Upgrade to a higher KGP version
+
+To use a higher version of KGP or KSP, add the following to your top-level build
+file:
+
+    buildscript {
+        dependencies {
+            // For KGP
+            classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:KGP_VERSION")
+
+            // For KSP
+            classpath("com.google.devtools.ksp:symbol-processing-gradle-plugin:KSP_VERSION")
+        }
+    }
+
+### Downgrade to a lower KGP version
+
+You can only downgrade the KGP version if you've
+[opted out of built-in Kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin#opt-out-of-built-in-kotlin).
+This is because AGP 9.0 enables built-in Kotlin by default, and built-in Kotlin
+requires KGP 2.2.10 or higher.
+
+To use a lower version of KGP or KSP, declare that version in your top-level
+build file using a [strict version](https://docs.gradle.org/current/userguide/dependency_versions.html#sec:strict-version) declaration:
+
+    buildscript {
+        dependencies {
+            // For KGP
+            classpath("org.jetbrains.kotlin:kotlin-gradle-plugin") {
+                version { strictly("KGP_VERSION") }
+            }
+
+            // For KSP
+            classpath("com.google.devtools.ksp:symbol-processing-gradle-plugin") {
+                version { strictly("KSP_VERSION") }
+            }
+        }
+    }
+
+Note that the minimum KGP version you can downgrade to is 2.0.0.
+
+> [!CAUTION]
+> **Caution:** When you downgrade the KGP version, your project might not be compatible with future minor releases of AGP 9, and it might not work with test fixtures.
+
+## IDE support for test fixtures
+
+AGP 9.0 brings full Android Studio IDE support for
+[test fixtures](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/TestFixtures).
+
+## Fused Library Plugin
+
+The Fused Library Plugin (Preview) lets you publish multiple
+libraries as a single Android Library AAR. This can make it easier for your
+users to depend on your published artifacts.
+
+For information about getting started, see
+[Publish multiple Android libraries as one with Fused Library](https://developer.android.com/build/publish-library/fused-library).
+
+## Behavior changes
+
+Android Gradle plugin 9.0 has the following new behaviors:
+
+| Behavior | Recommendation |
+|---|---|
+| Android Gradle plugin 9.0 uses NDK version `r28c` by default. | Consider specifying the NDK version you want to use explicitly. |
+| Android Gradle plugin 9.0 by default requires consumers of a library to use the same or higher compile SDK version. | Use the same or higher compile SDK when consuming a library. If this is not possible, or you want to give consumers of a library you publish more time to switch, set [`AarMetadata.minCompileSdk`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/AarMetadata#minCompileSdk()) explicitly. |
+
+AGP 9.0 includes updates to the following Gradle properties' defaults.
+This gives you the choice to preserve the AGP 8.13 behavior when upgrading:
+
+| Property | Function | Change from AGP 8.13 to AGP 9.0 | Recommendation |
+|---|---|---|---|
+| `android.newDsl` | Use the new DSL interfaces, without exposing the legacy implementations of the `android` block. This also means the legacy variant API, such as `android.applicationVariants` is no longer accessible. | `false` → `true` | You can opt out by setting `android.newDsl=false`. Once all plugins and build logic your project uses are compatible, remove the opt out. |
+| `android.builtInKotlin` | Enables [built-in Kotlin](https://developer.android.com/build/releases/agp-9-0-0-release-notes#android-gradle-plugin-built-in-kotlin) | `false` → `true` | [Migrate to built-in Kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin) if you can or [opt out](https://developer.android.com/build/migrate-to-built-in-kotlin#opt-out-of-built-in-kotlin). |
+| `android.uniquePackageNames` | Enforces that each library has a distinct package name. | `false` → `true` | Specify unique package names for all libraries within your project. If that is not possible, you can disable this flag while you migrate. |
+| `android.useAndroidx` | Use [`androidx`](https://developer.android.com/jetpack/androidx) dependencies by default. | `false` → `true` | Adopt [`androidx`](https://developer.android.com/jetpack/androidx/migrate) dependencies. |
+| `android.default.androidx.test.runner` | Run on-device tests with the [`androidx.test.runner.AndroidJUnitRunner`](https://developer.android.com/training/testing/instrumented-tests/androidx-test-libraries/runner) class by default, replacing the default of the deprecated [`InstrumentationTestRunner`](https://developer.android.com/reference/android/test/InstrumentationTestRunner) for ``` android { defaultConfig { testInstrumentationRunner = "..." } } ``` | `false` → `true` | Adopt [`AndroidJUnitRunner`](https://developer.android.com/training/testing/instrumented-tests/androidx-test-libraries/runner), or specify your custom `testInstrumentationRunner` explicitly. |
+| `android.dependency.useConstraints` | Controls the use of dependency constraints between configurations. The default in AGP 9.0 is `false` which only uses constraints in application device tests (AndroidTest). Setting this to `true` will revert back to the 8.13 behavior. | `true` → `false` | Don't use dependency constraints everywhere unless you need them. Accepting the new default of this flag also enables optimizations in the project import process which should reduce the import time for builds with many Android library subprojects. |
+| `android.enableAppCompileTimeRClass` | Compile code in applications against a non-final R class, bringing application compilation in line with library compilation. This improves incrementality and paves the way for future performance optimizations to the resource processing flow. | `false` → `true` | Many projects can just adopt the new behavior with no source changes. If the R class fields are used anywhere that requires a constant, such as switch cases, refactor to use chained if statements. |
+| `android.sdk.defaultTargetSdkToCompileSdkIfUnset` | Uses the compile SDK version as the default value for the target SDK version in apps and tests. Before this change, the target SDK version would default to the min SDK version. | `false` → `true` | Specify the target SDK version explicitly for apps and tests. |
+| `android.onlyEnableUnitTestForTheTestedBuildType` | Only creates unit test components for the tested build type. In the default project this results in a single unit test for debug, where the previous behavor was to have unit tests run for debug or release. | `false` → `true` | If your project doesn't require tests to run for both debug and release, no change is required. |
+| `android.proguard.failOnMissingFiles` | Fails the build with an error if any of the keep files specified in the AGP DSL don't exist on disk. Before this change typos in filenames would result in files being silently ignored. | `false` → `true` | Remove any invalid proguard files declarations |
+| `android.r8.optimizedResourceShrinking` | Allows R8 to keep fewer Android resources by considering classes and Android resources together. | `false` → `true` | If your project's keep rules are already complete, no change is required. |
+| `android.r8.strictFullModeForKeepRules` | Allows R8 to keep less by not implicitly keeping the default constructor when a class is kept. That is, `-keep class A` no longer implies `-keep class A { <init>(); }` | `false` → `true` | If your project's keep rules are already complete, no change is required. <br /> Replace `-keep class A` with `-keep class A { <init>(); }` in your project's keep rules for any cases where you need the default constructor to be kept. |
+| `android.defaults.buildfeatures.resvalues` | Enables [`resValues`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/HasAndroidResources#resValues()) in all subprojects | `true` → `false` | Enable `resValues` in only the subprojects that need it by setting the following in those projects' Gradle build files: ``` android { buildFeatures { resValues = true } } ``` |
+| `android.defaults.buildfeatures.shaders` | Enables [shader compilation](https://developer.android.com/ndk/guides/graphics/shader-compilers) in all subprojects | `true` → `false` | Enable shader compilation in only the subprojects that contain shaders to be compiled by setting the following in those projects' Gradle build files: ``` android { buildFeatures { shaders = true } } ``` |
+| `android.r8.proguardAndroidTxt.disallowed` | In AGP 9.0, `getDefaultProguardFile()` will only support `proguard-android-optimize.txt` rather than `proguard-android.txt`. This is to prevent accidental usage of the `­dontoptimize` flag, which is included in `proguard-android.txt`. | `false` → `true` | You can explicitly specify `­dontoptimize` in a custom proguardFile if you want to avoid optimization, alongside using `proguard-android-optimize.txt`. Make sure to remove the `­dontoptimize` flag from this file if possible, as it reduces R8 optimization benefits. If not, opt out by setting `android.r8.globalOptionsInConsumerRules.disallowed=false`. |
+| `android.r8.globalOptionsInConsumerRules.disallowed` | From AGP 9.0, Android library and feature module publishing will fail if consumer keep files contain problematic Proguard configurations. Consumer keep files that include global options like `­dontoptimize` or `­dontobfuscate` should only be used in application modules, and can reduce optimization benefits for library users. Android App module compilation will silently ignore any such global options if embedded in a pre-compiled dependency (JAR or AAR). You can see when this occurs by checking configuration.txt (typically in a path like `<app_module>/build/outputs/mapping/<build_variant>/configuration.txt`) for comments like: `# REMOVED CONSUMER RULE: ­dontoptimize` | `false` → `true` | Published libraries should remove any incompatible rules. Internal libraries should move any incompatible but required rules to a proguardFile in an app module instead. Opt out by setting `android.r8.globalOptionsInConsumerRules.disallowed=false`. Once all your consumer keep files are compatible, remove the opt out. |
+| `android.sourceset.disallowProvider` | Disallow passing providers for generated sources using the [`AndroidSourceSet`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/AndroidSourceSet) DSL. | `false` → `true` | Use the [`Sources`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/Sources) API on `androidComponents` to register generated sources. |
+| `android.custom.shader.path.required` | Requires the shader compiler path to be explicitly set in `local.properties` if shader compilation is enabled. | `false` → `true` | Add `glslc.dir=/path/to/shader-tools` to your project's `local.properties`. |
+
+## Removed features
+
+Android Gradle plugin 9.0 removes the following functionality:
+
+- **Embedded Wear OS app support**  
+  AGP 9.0 removes support for embedding Wear OS apps, which is no longer supported in Play. This includes removing the `wearApp` configurations and the [`AndroidSourceSet.wearAppConfigurationName`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/dsl/AndroidSourceSet#wearAppConfigurationName()) DSL. See [Distribute to Wear OS](https://developer.android.com/distribute/best-practices/launch/distribute-wear) for how to publish your app to Wear OS.
+- **`androidDependencies` and `sourceSets` report task**
+- **Density split APK support**   
+  AGP 9.0 removes support for creating split APKs based on screen density. The functionality and the related APIs have been removed. To split APKs based on screen density using AGP 9.0 or higher, use [app bundles](https://developer.android.com/guide/app-bundle).
+
+## Changed DSL
+
+Android Gradle plugin 9.0 has the following breaking DSL changes:
+
+- The parameterization of [`CommonExtension`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/CommonExtension) has been removed.
+
+  In itself, this is only a source-level breaking change to help
+  avoid future source-level breaking changes, but it also means that
+  the block methods need to move from [`CommonExtension`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/CommonExtension) to
+  [`ApplicationExtension`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/ApplicationExtension), [`LibraryExtension`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/LibraryExtension),
+  [`DynamicFeatureExtension`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/DynamicFeatureExtension) and [`TestExtension`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/TestExtension).
+
+  When upgrading your project to AGP 9.0, refactor Gradle plugin code
+  which uses those parameters or the block methods. For example the following
+  plugin is updated to remove the type parameter and not rely on the
+  removed block methods:
+
+  **AGP 8.13**
+
+      val commonExtension: CommonExtension<*, *, *, *, *, *> =
+              extensions.getByType(CommonExtension::class)
+      commonExtension.apply {
+          defaultConfig {
+              minSdk {
+                  version = release(28)
+              }
+          }
+      }
+
+  **AGP 9.0**
+
+      val commonExtension: CommonExtension =
+              extensions.getByType(CommonExtension::class)
+      commonExtension.apply {
+          defaultConfig.apply {
+              minSdk {
+                  version = release(28)
+              }
+          }
+      }
+
+  For plugins which target a range of AGP versions, using the getter directly
+  is binary compatible with AGP versions lower than 9.0.
+
+## Removed DSL
+
+Android Gradle plugin 9.0 removes:
+
+- [`AndroidSourceSet.jni`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/dsl/AndroidSourceSet#jni(kotlin.Function1)), because it was not functional.
+
+- [`AndroidSourceSet.wearAppConfigurationName`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/dsl/AndroidSourceSet#wearAppConfigurationName()), as it relates to the
+  removed embedded Wear OS app support.
+
+- [`BuildType.isRenderscriptDebuggable`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/dsl/BuildType#isRenderscriptDebuggable()), because it was not functional.
+
+- [`DependencyVariantSelection`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/dsl/DependencyVariantSelection). It is replaced By
+  [`DependencySelection`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/DependencySelection), which is exposed as
+  [`kotlin.android.localDependencySelection`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/KotlinMultiplatformAndroidLibraryExtension#localDependencySelection(kotlin.Function1))
+
+- [`Installation.installOptions(String)`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/dsl/Installation#installOptions(kotlin.String)). It is replaced by the
+  mutable property of [`Installation.installOptions`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/Installation#installOptions()).
+
+- The experimental, but never stabilized [`PostProcessing`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/dsl/PostProcessing) block.
+
+- [`ProductFlavor.setDimension`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/dsl/ProductFlavor#setDimension(kotlin.String)), which is replaced by the
+  [`dimension`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/dsl/ProductFlavor#dimension()) property
+
+- `LanguageSplitOptions`, which was only useful for
+  [Google Play Instant](https://developer.android.com/topic/google-play-instant), which is deprecated.
+
+- [`DensitySplit`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/dsl/DensitySplit), because the feature is no longer supported.
+  Replacement is to use [App Bundles](https://developer.android.com/guide/app-bundle).
+
+## Removed APIs
+
+Android Gradle plugin 9.0 removes:
+
+- [`AndroidComponentsExtension.finalizeDSl`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/AndroidComponentsExtension#finalizeDSl(org.gradle.api.Action)). It is replaced by
+  [`finalizeDsl`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/DslLifecycle#finalizeDsl(kotlin.Function1))
+
+- [`Component.transformClassesWith`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/Component#transformClassesWith(java.lang.Class,com.android.build.api.instrumentation.InstrumentationScope,kotlin.Function1)). It is replaced by
+  [`Instrumentation.transformClassesWith`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/Instrumentation#transformClassesWith(java.lang.Class,com.android.build.api.instrumentation.InstrumentationScope,kotlin.Function1))
+
+- [`Component.setAsmFramesComputationMode`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/Component#setAsmFramesComputationMode(com.android.build.api.instrumentation.FramesComputationMode)). It is replaced by
+  [`Instrumentation.setAsmFramesComputationMode`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/Instrumentation#setAsmFramesComputationMode(com.android.build.api.instrumentation.FramesComputationMode))
+
+- [`ComponentBuilder.enabled`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/ComponentBuilder#enabled()). It is replaced by
+  [`ComponentBuilder.enable`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/ComponentBuilder#enable()).
+
+- [`DependenciesInfoBuilder.includedInApk`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/DependenciesInfoBuilder#includedInApk()). Is is replaced by
+  [`includeInApk`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/DependenciesInfoBuilder#includeInApk())
+
+- [`DependenciesInfoBuilder.includedInBundle`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/DependenciesInfoBuilder#includedInBundle()). Is is replaced by
+  [`includeInBundle`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/DependenciesInfoBuilder#includeInBundle())
+
+- [`GeneratesApk.targetSdkVersion`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/GeneratesApk#targetSdkVersion()). Is is replaced by [`targetSdk`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/GeneratesApk#targetSdk())
+
+- [`Variant.minSdkVersion`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/Variant#minSdkVersion()). Is is replaced by [`minSdk`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/Variant#minSdk())
+
+- [`Variant.maxSdkVersion`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/Variant#maxSdkVersion()). Is is replaced by [`maxSdk`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/Variant#maxSdk())
+
+- [`Variant.targetSdkVersion`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/Variant#targetSdkVersion()). Is is replaced by [`targetSdk`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/Variant#targetSdk())
+
+- [`Variant.unitTest`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/Variant#unitTest()), as it was not applicable to the
+  [`com.android.test`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/gradle/TestPlugin) plugin.
+  `unitTest` is available on [`VariantBuilder`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/VariantBuilder) subtypes extending
+  [`HasUnitTest`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/HasUnitTest).
+
+- [`VariantBuilder.targetSdk`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/VariantBuilder#targetSdk()) and [`targetSdkPreview`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/VariantBuilder#targetSdkPreview()),
+  as they were not meaningful in libraries. Use
+  [`GeneratesApkBuilder.targetSdk`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/GeneratesApkBuilder#targetSdk()) or
+  [`GeneratesApkBuilder.targetSdkPreview`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/GeneratesApkBuilder#targetSdkPreview())
+  instead.
+
+- [`VariantBuilder.enableUnitTest`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/VariantBuilder#enableUnitTest()), as it was not applicable to the
+  [`com.android.test`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/gradle/TestPlugin) plugin.
+  `enableUnitTest` is available on [`VariantBuilder`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/VariantBuilder) subtypes extending
+  [`HasUnitTestBuilder`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/HasUnitTestBuilder).
+
+- [`VariantBuilder.unitTestEnabled`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/VariantBuilder#unitTestEnabled()) is removed in favor of the more
+  consistently
+  named [`enableUnitTest`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/HasUnitTestBuilder#enableUnitTest()) on the [`VariantBuilder`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/VariantBuilder) subtypes
+  extending [`HasUnitTestBuilder`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/HasUnitTestBuilder).
+
+- [`VariantOutput.enable`](https://developer.android.com/reference/tools/gradle-api/8.13/com/android/build/api/variant/VariantOutput#enable()). Is is replaced by [`enabled`](https://developer.android.com/reference/tools/gradle-api/9.0/com/android/build/api/variant/VariantOutput#enabled())
+
+- The deprecated and disabled `FeaturePlugin` and `FeatureExtension`.
+
+- The deprecated and disabled `BaseExtension.registerTransform` APIs, which
+  only remained to allow compiling against the latest AGP version while
+  targeting running on AGP 4.2 or lower.
+
+## Removed Gradle properties
+
+The following Gradle properties were initially added as ways to globally
+disable features that were enabled by default.
+
+These features have been disabled by default since AGP 8.0 or lower. Enable
+these features in only the sub-projects that use them for a more efficient
+build.
+
+| Property | Function | Replacement |
+|---|---|---|
+| `android.defaults.buildfeatures.aidl` | Enables [AIDL compilation](https://source.android.com/docs/core/architecture/aidl) in all subprojects | Enable AIDL compilation in only the subprojects where there are AIDL sources by setting the following property in those projects' Gradle build files: ``` android { buildFeatures { aidl = true } } ``` in the Gradle build file of each subproject containing AIDL sources |
+| `android.defaults.buildfeatures.renderscript` | Enables [RenderScript compilation](https://source.android.com/docs/core/architecture/vndk/renderscript) in all subprojects | Enable renderscript compilation in only the subprojects where there are renderscript sources by setting the following property in those projects' Gradle build files: ``` android { buildFeatures { renderScript = true } } ``` |
+
+## Enforced Gradle properties
+
+AGP 9.0 throws an error if you set the following Gradle properties.
+
+The [Android Gradle plugin Upgrade Assistant](https://developer.android.com/build/agp-upgrade-assistant) won't upgrade projects to
+AGP 9.0 that use these properties.
+
+| Property | Function |
+|---|---|
+| `android.r8.integratedResourceShrinking` | Resource shrinking is now always run as part of R8, the previous implementation has been removed. |
+| `android.enableNewResourceShrinker.preciseShrinking` | Resource shrinking now always uses precise resource shrinking, which enables more to be removed. |
+
+## R8 changes
+
+The following R8 changes are included in AGP 9.0.0.
+
+### New configuration option `-processkotlinnullchecks`
+
+We've added the new R8 option `-processkotlinnullchecks` to configure R8 for
+processing Kotlin null checks. The option takes a mandatory argument that must
+be one of the following three values: `keep`, `remove_message` and `remove`.
+The option processes the following null checks added by the Kotlin
+compiler:
+
+    class kotlin.jvm.internal.Intrinsics {
+      void checkNotNull(java.lang.Object);
+      void checkNotNull(java.lang.Object, java.lang.String);
+      void checkExpressionValueIsNotNull(
+          java.lang.Object, java.lang.String);
+      void checkNotNullExpressionValue(
+          java.lang.Object, java.lang.String);
+      void checkReturnedValueIsNotNull(
+          java.lang.Object, java.lang.String);
+      void checkReturnedValueIsNotNull(
+          java.lang.Object, java.lang.String, java.lang.String);
+      void checkFieldIsNotNull(java.lang.Object, java.lang.String);
+      void checkFieldIsNotNull(
+          java.lang.Object, java.lang.String, java.lang.String);
+      void checkParameterIsNotNull(java.lang.Object, java.lang.String);
+      void checkNotNullParameter(java.lang.Object, java.lang.String);
+    }
+
+The option values, ordered from the weakest to the strongest, have the
+following effect:
+
+- `keep` doesn't change the checks.
+- `remove_message` rewrites each check method call to a call to `getClass()` on the first argument of the call (effectively keeping the null check, but without any message).
+- `remove` completely removes the checks.
+
+By default R8
+uses `remove_message`. Any specification of `-processkotlinnullchecks`
+will override that. If specified multiple times the strongest value is
+used.
+
+### Stop propagating keep info to companion methods
+
+When keep rules match interface methods that are subject to desugaring,
+R8 previously internally transferred the *disallow optimization* and *disallow
+shrinking* bits to the synthesized companion methods.
+
+Starting with AGP 9.0, keep rules no longer apply to
+companion methods. This is consistent with the fact that keep rules are
+not applicable to other compiler synthesized fields/methods/classes.
+
+By transferring the *disallow optimization* and *disallow shrinking* bits to
+the companion methods, the following use case was previously supported:
+
+1. Compile a library with `default`/`static`/`private` interface methods to DEX with `minSdk` \< 24 and rules that keep the interface methods.
+2. Compile an app with the library on classpath and `-applymapping`.
+3. Merge the app and the library.
+
+Note that this only works with `-applymapping` since the `disallow
+obfuscation` bit is not transferred to the companion methods---that is, the
+companion classes generated from step 1 would have obfuscated method
+names.
+
+Going forward this use case is no longer supported for `minSdk` \<
+24. The workaround is to do the following:
+
+1. Desugar the library with `default`/`static`/`private` interface methods to class files with `minSdk` \< 24.
+2. Compile the desugared artifact using R8 and rules that keep the interface methods on the companion classes.
+3. Compile the app with the library on classpath.
+4. Merge the app and the desugared artifact.
+
+Another side effect of this is that it is no longer possible to keep the
+inner class and enclosing method attributes for anonymous and local classes
+inside interface companion methods.
+
+### Change the default emitted source file to `r8-map-id-<MAP_ID>`
+
+This change is in AGP starting from 8.12.0.
+
+The default emitted source file attribute for a class changes from
+`SourceFile` to `r8-map-id-<MAP_ID>` when retracing is required (that is,
+when either obfuscation or optimization is enabled).
+
+Given an obfuscated stack trace, the new source file attribute makes it
+possible to extract the ID of the mapping file that is required for
+retracing, which can be used to support
+[automated retracing of stack traces in Logcat](https://developer.android.com/studio/preview/features#logcat-retrace).
+
+If a custom source file attribute is used (`-renamesourcefileattribute`)
+this custom source file attribute continues to take precedence.
+
+In ProGuard compatibility mode (when `gradle.properties` contains
+`android.enableR8.fullMode=false`), emitting a source file attribute of
+`r8-map-id-<MAP_ID>` only takes effect if the `SourceFile`
+attribute is *not* kept. Apps that use ProGuard compatibility mode and want
+to include the mapping file ID in their stack traces should remove
+`-keepattributes SourceFile` (or migrate to R8 full mode).
+
+The map ID used in `r8-map-id-<MAP_ID>` is the full map hash, and not a 7
+character prefix of the map hash which was previously used.
+
+### Enable use of minimized synthetic names in L8 desugaring
+
+The name of synthetic classes generated by D8 normally contains the substring
+`$$ExternalSynthetic` that tells you that this is a synthetic generated by D8.
+Moreover, the name of the synthetic also encodes the synthetic kind (for
+example, `Backport`, `Lambda`). This has a negative impact on the resulting DEX
+size, since the class names take up more space in the string pool.
+
+AGP 9.0 configures L8 (core library desugaring) so that the DEX
+file containing all `j$` classes uses a new shortened class name format
+for synthetic classes. The new class name uses a numeric ID (for example, `$1`).
+
+### Remove support for `-addconfigurationdebugging`
+
+AGP 9.0 removes support for `-addconfigurationdebugging`. The compiler now
+reports a warning if the flag is used.
+
+### Remove support for generating L8 rules from D8/R8
+
+This change is only relevant for developers using the D8/R8 command line or
+APIs directly.
+
+R8 9.0 removes support for generating keep rules for L8 from D8 and R8.
+You should instead use `TraceReferences` for this purpose.
+
+More specifically, the methods
+`D8Command.builder.setDesugaredLibraryKeepRuleConsumer` and
+`R8Command.Builder.setDesugaredLibraryKeepRuleConsumer` are removed, and the
+support for `--desugared-lib-pg-conf-output` is removed from the command line
+options of D8 and R8.
+
+## Fixed issues
+
+### Android Gradle plugin 9.0.0
+
+| Fixed Issues ||
+|---|---|
+| **Android Gradle Plugin** | |---| | [Issue #171293712](https://issuetracker.google.com/issues/171293712) Feature Request: Inject ideal AGP version as a property | | [Issue #443976533](https://issuetracker.google.com/issues/443976533) Stabilize SingleArtifact.VERSION_CONTROL_INFO_FILE | | [Issue #223643506](https://issuetracker.google.com/issues/223643506) androidTest connectedCheck logcat output is broken | | [Issue #386221070](https://issuetracker.google.com/issues/386221070) Built-in Kotlin support in AGP should not synchronize with the Kotlin sourcesets | | [Issue #460094802](https://issuetracker.google.com/issues/460094802) missingDimensionStrategy prefers a flavor maching its own name even from an unrelated dimension | | [Issue #386221070](https://issuetracker.google.com/issues/386221070) Built-in Kotlin support in AGP should not synchronize with the Kotlin sourcesets | | [Issue #471410336](https://issuetracker.google.com/issues/471410336) AGP 9.0.0-rc01 doesn't resolve Kotlin libraries via kotlin() function | | [Issue #450851465](https://issuetracker.google.com/issues/450851465) Built-in-kotlin does not publish kotlin-stdlib dependency constraint in maven pom | | [Issue #420592288](https://issuetracker.google.com/issues/420592288) Add a test case for divergence between compileSdk and targetSdk | | [Issue #449153004](https://issuetracker.google.com/issues/449153004) empty resConfigs value leads to obscure aapt error | | [Issue #447375921](https://issuetracker.google.com/issues/447375921) Pure Java project have dependency on kotlin stdlib. | | [Issue #368600704](https://issuetracker.google.com/issues/368600704) Remove deprecated KotlinMultiplatformAndroidCompilationBuilder properties in AGP 9.0 | | [Issue #445209309](https://issuetracker.google.com/issues/445209309) \`com.android.tools.build:gradle:9.0.0-alpha05\` should have an api dependency on KGP and gradle-api | | [Issue #452645779](https://issuetracker.google.com/issues/452645779) Rename com.android.experimental.built-in-kotlin Gradle plugin | | [Issue #446220448](https://issuetracker.google.com/issues/446220448) AGP9: \`variant.sources.kotlin!!.addGeneratedSourceDirectory()\` is not working | | [Issue #448450771](https://issuetracker.google.com/issues/448450771) Aar metadata checks on compile Sdk uses the old DSL | | [Issue #441523448](https://issuetracker.google.com/issues/441523448) Remove deprecated \`com.android.build.api.dsl.ManagedDevices.devices\` property | | [Issue #386221070](https://issuetracker.google.com/issues/386221070) Built-in Kotlin support in AGP should not synchronize with the Kotlin sourcesets | | [Issue #433758231](https://issuetracker.google.com/issues/433758231) Fail android library publishing if consumer keep file contains -dontobfuscate | | [Issue #241955408](https://issuetracker.google.com/issues/241955408) No Options to Print Mapping for Optimized Resources | | [Issue #436595826](https://issuetracker.google.com/issues/436595826) Make it an error to call finalizeDsl after this phase has been passed | | [Issue #457089670](https://issuetracker.google.com/issues/457089670) AGP initializes jetifier config even when jetifier is disabled | | [Issue #452246814](https://issuetracker.google.com/issues/452246814) built in kotlin does not add kotlinStdlib as a compile time dependency when \`kotlin.stdlib.default.dependency\` is true to module and pom files | | [Issue #442250902](https://issuetracker.google.com/issues/442250902) New optimizaation DSL does not create configuration.txt by default | | [Issue #443587266](https://issuetracker.google.com/issues/443587266) AGP 8.13.0 fails to verify nav graph in a module | | [Issue #444260628](https://issuetracker.google.com/issues/444260628) AGP uses deprecated Gradle API: multi-string notation | | [Issue #347732357](https://issuetracker.google.com/issues/347732357) Warn users trying to use legacy multidex library with minSdkVersion \>=21 | | [Issue #333831734](https://issuetracker.google.com/issues/333831734) A build fails if there are code generation tasks | | [Issue #446123111](https://issuetracker.google.com/issues/446123111) With \`android.builtInKotlin=false\` and \`android.newDsl=false\` and \`android.enableLegacyVariantApi=false\`, using \`kotlin-android\` plugin will fail with "API 'applicationVariants' is obsolete" | | [Issue #443037365](https://issuetracker.google.com/issues/443037365) Built-in Kotlin fails to resolve unversioned kotlin-stdlib when kotlin.stdlib.default.dependency=false | | [Issue #445967244](https://issuetracker.google.com/issues/445967244) DexData opens a file without closing, preventing cleanup | | [Issue #368609737](https://issuetracker.google.com/issues/368609737) AndroidSourceDirectorySet should stop extending PatternFilterable in AGP 9.0 | | [Issue #389707041](https://issuetracker.google.com/issues/389707041) Test Fixture Error in test only modules | | [Issue #353249347](https://issuetracker.google.com/issues/353249347) Incorrect error when using context receivers in test fixtures | | [Issue #351046197](https://issuetracker.google.com/issues/351046197) Incorrect IDE errors for Kotlin code in testFixtures | | [Issue #446889652](https://issuetracker.google.com/issues/446889652) \`legacy-kapt\` plugin skips annotation processing unlike \`kotlin-kapt\` | | [Issue #446492061](https://issuetracker.google.com/issues/446492061) compileSdkSpec.minorApiLevel is not working with SettingsExtension | | [Issue #429253579](https://issuetracker.google.com/issues/429253579) \[fused lib - public\] Generated fused library does not include sources | | [Issue #149770867](https://issuetracker.google.com/issues/149770867) extractNativeLibs and useEmbeddedDex should not be coming from the manifest | | [Issue #449114518](https://issuetracker.google.com/issues/449114518) Warnings from R8 in AGP 9.0.0-alpha09 | | [Issue #368426598](https://issuetracker.google.com/issues/368426598) Remove deprecated AndroidSourceSet.jni in AGP 9.0 | | [Issue #368484483](https://issuetracker.google.com/issues/368484483) Remove Installation.installOptions() in AGP 9.0 | | [Issue #368482484](https://issuetracker.google.com/issues/368482484) Remove BuildType.isRenderscriptDebuggable in AGP 9.0. | | [Issue #428646179](https://issuetracker.google.com/issues/428646179) Remove android.defaults.buildfeatures.renderscript | | [Issue #436887358](https://issuetracker.google.com/issues/436887358) \`com.android.kotlin.multiplatform.library\` crashes with Gradle Managed Devices | | [Issue #428645763](https://issuetracker.google.com/issues/428645763) Remove \`android.defaults.buildfeatures.aidl\` defaults gradle.properties flags | | [Issue #294183018](https://issuetracker.google.com/issues/294183018) Fail build when proguard file does not exist | | [Issue #254305041](https://issuetracker.google.com/issues/254305041) remove buildconfig defaults gradle.properties flags | | [Issue #280674230](https://issuetracker.google.com/issues/280674230) Change the app's targetSdk default value to be based on compileSdk instead of minSdk | | [Issue #436878535](https://issuetracker.google.com/issues/436878535) When \`isIncludeAndroidResources\` is enabled, \`process{Variant}UnitTestManifest\` fails to merge tools:overrideLibrary usages in AGP 8.12.0 | | [Issue #411739086](https://issuetracker.google.com/issues/411739086) AGP causing deprecation warnings in Gradle for JVM test tasks | | [Issue #235457021](https://issuetracker.google.com/issues/235457021) DependencyReportTask is incompatible with the configuration cache | | [Issue #369246556](https://issuetracker.google.com/issues/369246556) Switch default source/target Java version from Java 8 to Java 11 in AGP 9.0 | | [Issue #258855275](https://issuetracker.google.com/issues/258855275) Flip android.useAndroidX default to true | | [Issue #442763200](https://issuetracker.google.com/issues/442763200) Better exception when applying kapt plugin with built-in Kotlin. | | [Issue #441679226](https://issuetracker.google.com/issues/441679226) android.proguard.failOnMissingFiles is not working for consumerProguardFiles | | [Issue #443051391](https://issuetracker.google.com/issues/443051391) Update Kotlin Gradle plugin dependency to 2.2.10 | | [Issue #429981132](https://issuetracker.google.com/issues/429981132) Create KotlinJvmAndroidCompilation using KGP API | | [Issue #442869731](https://issuetracker.google.com/issues/442869731) Kotlin explicit API mode applied to test sources | |
+| **Lint** | |---| | [Issue #430991549](https://issuetracker.google.com/issues/430991549) AGP 8.11.0: lintAnalyzeRelease task crashes when applying .gradle.kts files with apply(from = "...") | | [Issue #441536820](https://issuetracker.google.com/issues/441536820) Lint ChecksSdkIntAtLeast Check does not check if the annotated value is correct | | [Issue #446696613](https://issuetracker.google.com/issues/446696613) Built-in Kotlin does not add .kotlin_module to META-INF | | [Issue #449031505](https://issuetracker.google.com/issues/449031505) Lint classpath contains duplicate classes at different versions | | [Issue #448148350](https://issuetracker.google.com/issues/448148350) Overriding private resources workaround not working (tools:override = "true") | | [Issue #405676712](https://issuetracker.google.com/issues/405676712) Bug: removal of unused resources doesn't also remove the translations of them, and doesn't ask about it either | | [Issue #440415636](https://issuetracker.google.com/issues/440415636) Lint throwing warning "Could not clean up K2 caches" | | [Issue #440415636](https://issuetracker.google.com/issues/440415636) Lint throwing warning "Could not clean up K2 caches" | |
+| **Lint Integration** | |---| | [Issue #460068798](https://issuetracker.google.com/issues/460068798) AndroidLintAnalysisTask cache misses across different JDK vendors or minor versions due to systemPropertyInputs.javaVersion differences | | [Issue #444447002](https://issuetracker.google.com/issues/444447002) Lint automatically uses latest installed SDK despite compileSdk, doesn't register as task input and breaks caching | |
+| **Shrinker (R8)** | |---| | [Issue #454927488](https://issuetracker.google.com/issues/454927488) R8 optimized resource shrinking silently fails if using final resource IDs | |
+
+<br />

--- a/platforms/android/.agents/skills/agp-9-upgrade/references/buildconfig.md
+++ b/platforms/android/.agents/skills/agp-9-upgrade/references/buildconfig.md
@@ -1,0 +1,54 @@
+When an Android module contains custom BuildConfig fields, the following steps
+are necessary to ensure a correct build.
+
+### Step 1: Enable the buildConfig build feature
+
+In a build script:
+
+    android {
+      buildFeatures {
+        buildConfig = true
+      }
+    }
+
+In custom build-logic for an app module:
+
+    extensions.configure<com.android.build.api.dsl.ApplicationExtension> {
+      buildFeatures {
+        buildConfig = true
+      }
+    }
+
+In custom build-logic for a library module:
+
+    extensions.configure<com.android.build.api.dsl.LibraryExtension> {
+      buildFeatures {
+        buildConfig = true
+      }
+    }
+
+In custom build-logic using `CommonExtension`:
+
+    extensions.configure<com.android.build.api.dsl.CommonExtension> {
+      buildFeatures {
+        buildConfig = true
+      }
+    }
+
+### Step 2: Migrate to the new API
+
+Use the **addCustomBuildConfigFields** recipe from the [gradle-recipes](https://developer.android.com/agents/skills/build/agp/agp-9-upgrade/references/recipes)
+repository.
+
+**IMPORTANT:** For `BuildConfigField`s with a type of `String`, the `value` field
+*must* include quotation marks as part of the String. For example:
+
+    BuildConfigField(
+      type = "String",
+      value = "\"Some value\"",
+      comment = "Optional comment",
+    )
+
+It is an **error** if the `value` field doesn't include quotation marks as
+part of the String. For example, `value = "Some value"` **is an error** . This is
+because the `value` is written out literally.

--- a/platforms/android/.agents/skills/agp-9-upgrade/references/ksp-kapt.md
+++ b/platforms/android/.agents/skills/agp-9-upgrade/references/ksp-kapt.md
@@ -1,0 +1,39 @@
+When migrating to built-in Kotlin, it is important to consider usage of `kapt`
+and the `org.jetbrains.kotlin.kapt` (also known as the `kotlin("kapt")`) plugin.
+The goal is to migrate as many `kapt` usages to `ksp` as possible.
+
+Follow these steps when migrating `kapt`:
+
+## 1. Remove all references to the `org.jetbrains.kotlin.kapt` plugin
+
+The `org.jetbrains.kotlin.kapt` (also known as `kotlin("kapt")`) plugin is
+incompatible with built-in Kotlin. Remove it when migrating to built-in Kotlin.
+
+## 2. Check each usage of `kapt`
+
+Check each usage of `kapt` to see if it is compatible with `ksp`. To check if a
+dependency is compatible with `ksp`, inspect the dependency's jar. For it to be
+compatible with `ksp`, the jar must have a file,
+`services/com.google.devtools.ksp.processing.SymbolProcessorProvider`. If it
+does not, it is **incompatible** with `ksp`.
+
+For example, the `androidx.room:room-compiler` library is compatible with KSP
+since version 2.3.0-beta02. We can verify this by finding the jar file in the
+Gradle caches directory, which is typically located at
+`~/.gradle/caches/modules-2/files-2.1/` on Linux and Mac. In this specific case,
+the `androidx.room:room-compiler` dependency is located at
+`~/.gradle/caches/modules-2/files-2.1/androidx.room/room-compiler/`.
+
+More generally, you can find a dependency by looking in
+`~/.gradle/caches/modules-2/files-2.1/group-name/artifact-name/`.
+
+## 3. Migrate to KSP where possible
+
+For each usage of `kapt` that is compatible with `ksp`, use `ksp`. The prior
+step explains how to check compatibility.
+
+## 4. Apply legacy-kapt
+
+If a Gradle module has `kapt` dependencies that cannot be migrated to `ksp`
+because they are incompatible (see step 2), then leave that dependency alone and
+apply the `com.android.legacy-kapt` plugin.

--- a/platforms/android/.agents/skills/agp-9-upgrade/references/paparazzi-gradle-9.md
+++ b/platforms/android/.agents/skills/agp-9-upgrade/references/paparazzi-gradle-9.md
@@ -1,0 +1,30 @@
+If Paparazzi is used in the project, update it to version 2.0.0-alpha04 or
+higher.
+
+Paparazzi version 2.0.0-alpha04 and lower is not fully compatible with Gradle
+9, and Gradle 9 is required by AGP 9. This means that, without workarounds,
+projects that use Paparazzi v2.0.0-alpha04 and lower cannot migrate to AGP 9.
+
+At time of writing, there are no higher versions of Paparazzi. That is,
+v2.0.0-alpha04 is the latest release.
+
+The issue is due to Paparazzi using internal classes from Gradle that tend to
+move in breaking ways without warning. This specific issue is related to HTML
+test reports. To work around it, disable those HTML test reports. Here
+are two examples of how to do this, one for Kotlin DSL and the other for Groovy
+DSL. Any module that has the paparazzi plugin (`app.cash.paparazzi`) applied
+must apply one of these two workarounds.
+
+Kotlin DSL:
+
+    tasks.withType<Test>().configureEach {
+      // https://github.com/cashapp/paparazzi/issues/2111
+      reports.html.required = false
+    }
+
+Groovy DSL:
+
+    tasks.withType(Test).configureEach {
+      // https://github.com/cashapp/paparazzi/issues/2111
+      reports.html.required = false
+    }

--- a/platforms/android/.agents/skills/agp-9-upgrade/references/recipes.md
+++ b/platforms/android/.agents/skills/agp-9-upgrade/references/recipes.md
@@ -1,0 +1,62 @@
+When migrating to AGP's new DSL, any Gradle code (plugins or logic in build
+scripts) that relied on the old DSL will stop working. Such code must be
+migrated.
+
+## Guidelines
+
+- **DO NOT** search the web for examples of how to do this. Use the **gradle-recipes** repository examples **only**.
+- **DO NOT** use AGP internals in migrated code.
+- **DO** use only public APIs in migrated code.
+
+In some cases, there is a one-to-one replacement for the old code. Some examples
+are in [the AGP 9.0.0 release notes](https://developer.android.com/build/releases/agp-9-0-0-release-notes).
+
+In other cases, there is no direct one-to-one replacement. For these situations,
+the [gradle-recipes repo](https://github.com/android/gradle-recipes) is a great resource. You can checkout one of its
+AGP 9.x branches, such as `agp-9.0`, `agp-9.1`, or `agp-9.2`. These branches
+contain recipes for common situations in Android projects. The following table
+lists the compatibility for recipes for each version of AGP.
+
+## Compatibility table
+
+| AGP version | gradle-recipes branch |
+|---|---|
+| 9.0.x | agp-9.0 |
+| 9.1.x | agp-9.1 |
+| 9.2.x | agp-9.2 |
+
+## Recipes and use-cases
+
+The following table links use-cases to recipes.
+
+| Recipe | Use-case |
+|---|---|
+| addCustomBuildConfigFields | Add custom BuildConfig fields |
+| listenToArtifacts | Rename APK |
+
+Additional details for each use-case follow.
+
+### Add custom BuildConfig fields
+
+See the detailed guide at [BuildConfig](https://developer.android.com/agents/skills/build/agp/agp-9-upgrade/references/buildconfig).
+
+### Renaming an APK
+
+In the old DSL, an APK could be renamed very simply. Here's an example:
+
+    android {
+      applicationVariants.all {
+        outputs.all {
+          val output = this as com.android.build.gradle.api.ApkVariantOutput
+          val fileName = output.outputFileName
+          if (fileName.contains("release")) {
+            output.outputFileName = "my-cool-new-name.apk"
+          }
+        }
+      }
+    }
+
+However, with AGP 9 and the new DSL, `applicationVariants` is no longer
+available. You must instead react to artifact creation using the
+`androidComponents.onVariants` API. A complete example of this is available in
+the **gradle-recipes** repository in the `listenToArtifacts` recipe.

--- a/platforms/android/.agents/skills/android-cli/SKILL.md
+++ b/platforms/android/.agents/skills/android-cli/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: android-cli
+description: Provides instructions for installing and using the `android` CLI. The `android` command-line tool is a critical tool for Android development and helps you create new Android projects, run Android apps on devices, manage and interact with Android virtual devices (including screenshots and UI inspection), manage Android SDK components, look up official Android documentation, and discover and install official Android skills.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  keywords:
+  - sdk
+  - emulator
+  - skills
+  - docs
+  - knowledge base
+  - project creation
+  - screenshots
+---
+# Android CLI Specialist
+
+This skill provides instructions for using the `android` CLI tool. The tool includes various commands for creating projects, running applications, interacting with devices, and managing the CLI environment.
+
+## Installation
+
+If the android tool is not in the path, install it. To install run the following command:
+Linux: curl -fsSL https://dl.google.com/android/cli/latest/linux_x86_64/install.sh | bash
+Mac Arm: curl -fsSL https://dl.google.com/android/cli/latest/darwin_arm64/install.sh | bash
+Mac Intel: curl -fsSL https://dl.google.com/android/cli/latest/darwin_x86_64/install.sh | bash
+Windows: curl -fsSL https://dl.google.com/android/cli/latest/windows_x86_64/install.cmd -o "%TEMP%\i.cmd" && "%TEMP%\i.cmd"
+
+## SDK management
+To manage the installation of Android SDKs and tools, use the `sdk` command. For example:
+
+- `android sdk install <package>[@<version>]...`: Install specific packages. Multiple packages can be specified, separated by spaces. `<version>` defaults to latest. For example: `android sdk install platforms/android-30@2 platforms/android-34`
+- `android sdk update [<pkg-name>]`: Update a specific package or all packages to the latest version.
+- `android sdk remove <pkg-name>`: Remove a package from the local SDK.
+- `android sdk list --all`: List installed and available SDK packages.
+
+## Project creation
+Create projects from templates using the `create` command.
+
+For example: `android create empty-activity --name="My App" --output=./my-app`
+
+## Interacting with devices
+For more information on interacting with running devices, see [here](references/interact.md)
+
+## Running journey tests
+For more information on running journeys, see [here](references/journeys.md)
+
+## Doc searching
+The `docs` command searches authoritative, high-quality Android developer documentation in the Android Knowledge Base.
+By providing a few keywords, this tool will return high quality articles that contain examples or guidance on how to use Android APIs or libraries.
+Use this tool to obtain additional information on how to achieve Android-specific tasks or to know more about Android APIs, surfaces, libraries, or devices.
+
+Always use this tool to get the most up-to-date information about Android concepts. Typical good use cases are:
+  - Finding migration guides for APIs.
+  - Finding examples for APIs.
+  - Finding up-to-date information about Android APIs.
+  - Finding best practices for Android concepts.
+
+## Running APKs
+Use the `run` command to run Android apps.
+
+## Managing emulators
+
+Manage Android Virtual Devices (AVDs) using the `android emulator` command
+
+## Capturing screenshots
+
+Capture an image of the current screen of a connected Android device and output it to a file using the `android screenshot` command.
+
+## Managing skills
+
+Manage antigravity agent skills for Android using the `android skills` command.
+
+## Inspecting UI Layouts
+
+Use the `android layout` command to inspect the UI layout of an Android application. It returns the layout tree of an Android application in JSON format. When debugging UI errors, this is often a much faster approach than taking a screenshot.
+
+## Updating the CLI
+
+Update the Android CLI using the `android update` command.
+
+# `android help` output
+
+Usage: android [-hV] [--sdk=PARAM] [COMMAND]
+  -h, --help        Show this help message and exit.
+      --sdk=PARAM   Path to the Android SDK
+  -V, --version     Print version information and exit.
+Commands:
+  create    Create a new Android project
+  describe  Analyzes an Android project to generate descriptive metadata.
+  docs      Android documentation commands
+  emulator  Emulator commands
+  help      Shows the help of all commands
+  info      Print environment information (SDK Location, etc.)
+  init      Initializes the environment (eg. skills) for Android CLI.
+  layout    Returns the layout tree of an application
+  run       Deploy an Android Application
+  screen    Commands to view the device
+  sdk       Download and list SDK packages
+  skills    Manage skills
+  studio    Android Studio commands
+  update    Update the Android CLI
+
+create
+          Usage: android create [-h] [--verbose] [--list] [--minSdk=api]
+                                --name=applicationName [-o=dest-path] [template-name]
+          Create a new Android project
+                [template-name]      The template name
+            -h, --help               Show this help message and exit.
+                --minSdk=api         The 'minSdk' supported by the application (default
+                                       is defined in the template)
+                --name=applicationName
+                                     The name of the application (e.g. 'My Application')
+            -o, --output=dest-path   The destination project directory path (default is
+                                       '.')
+                --verbose            Enables verbose output
+                --list               List all available templates
+
+describe
+          Usage: android describe [-hV] [--project_dir=PARAM]
+          Analyzes an Android project to generate descriptive metadata.
+          This command identifies and outputs the paths to JSON files that detail the
+          project's structure, including build targets and their corresponding output
+          artifact locations (e.g., APKs). This information enables other tools and
+          commands to locate build artifacts efficiently.
+            -h, --help                Show this help message and exit.
+                --project_dir=PARAM   The project directory to describe
+            -V, --version             Print version information and exit.
+
+docs
+          Usage: android docs [-h] [COMMAND]
+          Android documentation commands
+            -h, --help   Show this help message and exit.
+          Commands:
+            search  Search Android documentation
+            fetch   Fetch Android documentation
+
+emulator
+          Usage: android emulator [-h] [COMMAND]
+          Emulator commands
+            -h, --help   Show this help message and exit.
+          Commands:
+            create  Creates a virtual device
+            start   Launches the specified virtual device. This command will return when
+                      the emulator is fully started and ready to use.
+            stop    Stops the specified virtual device
+            list    Lists available virtual devices
+            remove  Delete a virtual device
+
+help
+          Usage: android help [COMMAND]
+          Shows the help of all commands
+                [COMMAND]   The command to show help for
+
+info
+          Usage: android info <field>
+          Print environment information (SDK Location, etc.)
+                <field>   The specific field to print the value of. If omitted print all.
+
+init
+          Usage: android init
+          Initializes the environment (eg. skills) for Android CLI.
+
+layout
+          Usage: android layout [-dhp] [--device=PARAM] [-o=PARAM]
+          Returns the layout tree of an application
+            -d, --diff           Returns a flat list of the layout elements that have
+                                   changed since the last invocation of ui-dump
+                --device=PARAM   The device serial number
+            -h, --help           Show this help message and exit.
+            -o, --output=PARAM   Writes the layout tree to the specified file or
+                                   directory. If omitted, prints the tree to standard
+                                   output
+            -p, --pretty         Pretty-prints the returned JSON
+
+run
+          Usage: android run [-h] [--debug] [--activity=PARAM] [--device=PARAM]
+                             [--type=PARAM] [--apks=PARAM[,PARAM...]]...
+          Deploy an Android Application
+                --activity=PARAM   The activity name
+                --apks=PARAM[,PARAM...]
+                                   The paths to the APKs
+                --debug            Run in debug mode
+                --device=PARAM     The device serial number
+            -h, --help             Show this help message and exit.
+                --type=PARAM       The component type (ACTIVITY, SERVICE, etc.)
+
+screen
+          Usage: android screen [-h] [COMMAND]
+          Commands to view the device
+            -h, --help   Show this help message and exit.
+          Commands:
+            capture  Outputs the device screen to a PNG
+            resolve  Target UI elements visually
+
+sdk
+          Usage: android sdk [COMMAND]
+          Download and list SDK packages
+          Commands:
+            install  Install SDK packages
+            update   Update one or all packages to the latest version
+            remove   Remove a package from the SDK
+            list     List installed and available SDK packages
+
+skills
+          Usage: android skills [COMMAND]
+          Manage skills
+          Commands:
+            add     Install a skill
+            remove  Remove a skill
+            list    List available skills
+            find    Find skills by keyword
+
+studio
+          Usage: android studio [-h] [COMMAND]
+          Android Studio commands
+            -h, --help   Show this help message and exit.
+          Commands:
+            find-declaration        Find declaration of a symbol
+            find-usages             Find usages of a symbol
+            open-file               Open a file in Android Studio
+            check                   Check the status of running Studio instances
+            analyze-file            Analyze a file in Android Studio
+            render-compose-preview  Render a Compose preview in Android Studio
+            version-lookup          Looks up the latest available versions on the
+                                      internet of maven artifacts, Android versions, and
+                                      more.
+
+update
+          Usage: android update [--url=PARAM]
+          Update the Android CLI
+                --url=PARAM   The URL to download the update from

--- a/platforms/android/.agents/skills/android-cli/references/interact.md
+++ b/platforms/android/.agents/skills/android-cli/references/interact.md
@@ -1,0 +1,83 @@
+# Tools
+Run `android layout --help` and `android screen --help`.
+
+## UI Dump
+`android layout`  returns a flat JSON list of the UI elements on screen.
+`android layout --diff` returns a flat JSON list of the UI elements that have changed since the last call to `layout` or `layout --diff`
+
+Each JSON object represents a UI element in the Android app. The following properties may be present:
+- `text` - any literal text the element contains
+- `resourceId` - the Android resource id used to refer to the element
+- `contentDesc` - a description of a UI element for use by accessibility tools
+- `interactions` - the set of user interactions the element supports. May contain one or more of: `checkable`, `clickable`, `focusable`, `scrollable`, `long-clickable`, `password`
+- `state` - the set of states the element is in. May contain one or more of `checked`, `focused`, `selected`
+- `bounds` - the screen coordinates of the bounding rectangle of the element, in the format `[min X,min Y][max X, max Y]`
+- `center` - the screen coordinates of the center of the element, in the format `[x,y]`
+- `off-screen` - if true, the element is in the UI hierarchy but not visible; it may require scrolling to view.
+
+Use `layout` as a primary means of examining an Android app. Use `layout --diff` to focus on changes and to keep your context small.
+Example: When entering digits into a calculator, use `layout --diff` to output only the digit readout element.
+
+`layout` may fail due to the app displaying a WebView or animation; in these cases, use `android screen --annotate` to inspect the app.
+This failure will likely resolve after navigating away from the current screen.
+
+## Screenshot
+`android screen capture -o <file path>` saves a PNG of the current device screen to `<file path>`
+
+Use `screen capture` as a secondary means of examining an Android app
+Examples:
+- Understanding the content of an on-screen image
+- Looking at a `WebView` (web content does not always appear in the ui dump)
+- Trying to find a UI element by its visual appearance
+
+**IMPORTANT**: Always *VISUALLY* examine the PNG image returned from `android screen` BEFORE doing anything else.
+
+## Annotated Screenshot
+`android screen capture --annotate -o <file path>`
+`android screen resolve --screen <path> --string <string>`
+
+The `--annotate` command adds numerical labels and bounding boxes around UI elements. Use this command to locate UI elements that cannot
+be located in the `layout` output.
+
+**IMPORTANT**: When using `android screen --annotate`, always *VISUALLY* examine the resulting PNG file.
+
+To refer to these labels in input commands, use `screen resolve` to convert labels into coordinates:
+
+`android screen resolve --screen <file path> --string "#3"` returns `<x coord of region 3> <y coord of region 3>`
+
+To save turns, you can combine shell commands:
+
+`adb shell input $(android screen resolve --screen screen.png --string "tap #34")`
+
+This command taps on region #34 from `screen.png`
+
+## Input
+Use `adb shell input` for interacting with Android devices.
+Refer to the `"interactions"` property of an element for what interactions can be performed on a particular element.
+
+Interact with UI elements with their `center` coordinate or their `bounds` coordinates:
+```json
+{
+  "key": -248568265,
+  "class": "android.widget.Button",
+  "bounds": "[138,9][167,38]",
+  "center": "[152,23]"
+}
+```
+To tap on this button, you would execute `adb shell input tap 152 23`. This taps the center.
+
+```json
+{
+  "key": 12487234,
+  "class": "com.example.ui.ScrollableList",
+  "bounds": "[100,200][400,600]",
+  "center": "[250,400]"
+}
+```
+To scroll down on this list, you would execute `adb shell input swipe 250 400 600 500`. This swipes from the center to the bottom over 500ms.
+
+# Android Interaction Rules
+1. Always ensure text input fields have `"focused"` in their `"state"` list before entering text
+2. If an element has `"scrollable"` in its `"interactions"` list, try scrolling it when looking for missing UI elements
+2. Always scroll slowly when executing scroll inputs. The 5th argument to `adb shell input swipe` controls scroll duration.
+3. Content may take time to load; if a `layout` is missing information after you take an action, wait a few seconds, then perform `layout --diff` to see if anything changes.

--- a/platforms/android/.agents/skills/android-cli/references/journeys.md
+++ b/platforms/android/.agents/skills/android-cli/references/journeys.md
@@ -1,0 +1,97 @@
+A journey is an XML-specified test of an Android app's behavior. It consists of a list of `<action>` elements. For example:
+```xml
+<journey name="My Journey">
+   <description>
+      A sample journey to illustrate the format
+   </description>
+   <actions>
+     <action>
+       Tap the "Home" icon
+     </action>
+     <action>
+       Verify that the app is on its Home screen
+     </action>
+   </actions>
+</journey>
+```
+
+Evaluate a journey by proceeding through the `<actions>` list in sequential order. Evaluate each `<action>` block individually.
+A journey succeeds if all elements in the `<actions>` list succeed.
+
+A journey is a test case for an app. The journey XML is the source of truth; if the app disagrees with the journey, the app has failed.
+Additionally, if the app exits, crashes, or freezes, journey evaluation stops and the journey fails.
+
+**IMPORTANT** - Execute each step EXACTLY as written, and independently of other steps! If an action says to `"tap the first search result"`,
+you MUST find the search results and tap the first one. Do this even if you believe you know the intent behind the action.
+
+## Taking Actions
+Some `<action>` elements specify UI interactions to perform on the running Android app. Perform the interaction and verify that the app does 
+not crash or behave in an unexpected manner. This is the *only* verification you should perform for an `<action>`.
+
+If the interaction cannot be performed as specified, the journey fails. 
+Example: 
+```<action>Click the red button</action>```
+If you determine a red button is not present in the UI, the journey fails. 
+
+If the text of an `<action>` specifies a list of actions, break it into sub-actions and evaluate them individually: 
+Example:
+```<action>Search for soda and add the first result to the cart</action>```
+This should be evaluated as:
+```
+<action>Search for soda</action>
+<action>Add the first result to the cart</action>
+```
+
+If an `<action>` contains something that is not a specification for a UI interaction, alert the user that the journey is malformed and exit
+early, specifying the error in question.
+
+## Verifying Expectations
+`<action>` elements that begin with "check" or "verify" specify expectations for the current state of the Android app. Determine the current
+state of the app and check if the expectations are met.
+
+Determine the current state of the app by inspecting the current screen of the device without interacting with it.
+Example:
+```<action>Check if "Switch 2" is visible on the screen</action>```
+This requires only inspecting the current screen, not scrolling or interacting. If "Switch 2" is not currently visible, the action fails.
+
+If the expectations are not met, mark the `<action>` as a failure and the journey evaluation ends. A single `<action>` may contain
+multiple expectations.
+Example:
+```<action>Verify that the app is on the Home screen, the Home icon is blue, and the temperature is displayed</action>```
+This `<action>` fails if ANY of the following are false:
+- The app is on the Home screen
+- There is a Home icon, and it is blue
+- A temperature is displayed
+
+## Handling failure 
+When running a journey, evaluate it as a test. Failure is acceptable, and often expected. Proper reporting of failures is the priority.
+
+Keep debugging and troubleshooting to a minimum; assume that tools are showing you the correct output every time. The goal is to determine 
+if the *current* Android app can correctly handle the *current* steps outlined in the journey. Suggestions for bug fixes, clarification, or 
+other improvements should be kept to journey evaluation summary at the end.
+
+## Summarizing
+For each `<action>` you evaluated, output JSON describing the results.
+
+```
+{
+  "journey:", The name of the journey
+  "results:" [
+    {
+      // A string containing the full text of the <action> 
+      "action": "Click the blue button,
+      // "PASSED" if the instruction was evaluated, "FAILED" if the instruction could not be evaluated, or "SKIPPED" if journey evaluation ended early because an instruction failed 
+      "status": "PASSED", 
+      // A list of the ADB commands executed while evaluating the instruction,
+      "commands": [ "adb input swipe 490 200 500 500 500", "adb input tap 45 920" ],  
+      // Failure reasons, feedback, or other useful information 
+      "comment": "The journey step doesn't specify that the button requires scrolling to see", 
+    },
+    {
+      "action": "The home screen is shown", 
+      "status": "FAILED", 
+      "comment": "The settings page was shown",   
+    },
+  ]
+}
+```

--- a/platforms/android/.agents/skills/android-intent-security/SKILL.md
+++ b/platforms/android/.agents/skills/android-intent-security/SKILL.md
@@ -1,0 +1,547 @@
+---
+name: android-intent-security
+description: Best practices for Android Intent security. Use this skill when auditing
+  component configurations in AndroidManifest.xml activities, services, receivers)
+  or source code handling incoming Intents (getIntent, getParcelableExtra) to prevent
+  Intent Redirection and unauthorized access.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-06-25'
+  keywords:
+  - recipe
+  - Android
+  - Security
+  - Intent
+  - Redirection
+  - PendingIntent
+  - ContentProvider
+  - Service
+  - Signature
+  - Verification
+  - sanitizer
+  - Vulnerability
+  - Best Practices
+---
+
+This skill provides guidelines and patterns to secure Android components
+(Activities, Services, Broadcast Receivers, Content Providers) and handle
+Intents safely, preventing privilege escalation and unauthorized access.
+
+## Glossary
+
+- **Intent:** An asynchronous messaging object used to request an action from another app component.
+- **Exported component:** A component (`android:exported="true"`) that can be launched by other apps on the device.
+- **Sticky intent:** A broadcast intent that remains in the system cache after it's sent, allowing any app to retrieve its contents.
+- **Signature permission:** A permission whose protection level is set to `signature`, granted only to apps signed with the same developer key.
+- **onNewIntent:** An activity lifecycle callback invoked when an activity is launched with `FLAG_ACTIVITY_SINGLE_TOP` and is already running at the top of the history stack.
+- **PendingIntent:** A token granted to a foreign application (for example, system services) allowing it to execute a predefined Intent with the creator's permissions.
+- **Mutable PendingIntent:** A PendingIntent whose underlying Intent parameters can be modified by the receiving application.
+- **ContentProvider:** A component that encapsulates data and provides it to other applications via standard query/insert interfaces.
+- **IntentSanitizer:** A utility class in AndroidX Core used to build a safe, sanitized copy of an incoming Intent by filtering out unauthorized components, actions, or extras.
+- **Intent redirection (forwarding):** A vulnerability where an application receives an intent from an untrusted source and uses it to launch a private, non-exported component.
+
+## Prerequisites
+
+- The agent **MUST** be able to describe the function and security implications of `onCreate`, `onNewIntent`, and the `singleTop` launch mode.
+- The agent **MUST** be able to declare `<activity>`, `<service>`, `<receiver>`, and `<provider>` tags in `AndroidManifest.xml` and define their `android:exported` and `android:permission` attributes.
+- The agent **MUST** be able to implement signature verification checks using `PackageManager`.
+
+## Limitations
+
+- This skill focuses on local inter-component and inter-app communication security on the Android platform.
+- This skill **doesn't** cover network security, web integration, or host-to-server security.
+
+## Setup and dependencies
+
+- **Android SDK:** Minimum API Level 23 (Android 6.0) is required for standard hardware-backed keystore operations and component validation.
+- **AndroidX Core Library:** `androidx.core:core:1.9.0` or higher is **mandatory** to leverage `IntentSanitizer`.
+- **Standard API access:** Standard Android `PackageManager` APIs are required for runtime component verification.
+
+*** ** * ** ***
+
+## Intent security logic and decisions
+
+### 1. Intent routing comparison
+
+Evaluate the security features of different intent delivery methods:
+
+| Intent Delivery Method | Scope | Recommended Use Case |
+|---|---|---|
+| Explicit Intent (Internal) | App Private | Launching internal activities/services |
+| Implicit Intent | System Wide | Launching system camera, dialer, or sharing |
+| Local Broadcasts (LocalBroadcastManager) (DEPRECATED) | App Private | Internal asynchronous event routing. **Deprecated**: Use in-app observers like Kotlin Flows/SharedFlow, LiveData, or reactive patterns instead. |
+| System Broadcasts | System Wide | Receiving system events (NFC, Bluetooth) |
+
+### 2. PendingIntent mutability flag options
+
+Evaluate the security implications of PendingIntent mutability flags:
+
+| Flag Name | Mutability | Recommended Use Case |
+|---|---|---|
+| `PendingIntent.FLAG_IMMUTABLE` | Immutable | Default for almost all PendingIntents, such as alarms and notifications |
+| `PendingIntent.FLAG_MUTABLE` | Mutable | Inline notifications replies, slice actions (requires explicit target intent) |
+
+### 3. Intent handling and redirection logic
+
+IF (the component receives a nested Intent as an extra) {
+IF (AndroidX Core 1.9.0+ and higher is available) {
+MUST construct an `IntentSanitizer` to explicitly allowlist components, actions, data, and extras.
+MUST call `sanitizeByThrowing()` or `sanitizeByFiltering()` before launching.
+} ELSE {
+MUST verify that the nested Intent's target package matches the current application package.
+MUST verify that the target component of the nested Intent is publicly exported.
+}
+NEVER launch the nested Intent directly without validation.
+} ELSE IF (the component handles broadcasts) {
+MUST rely on the system's Protected Broadcast mechanism for system events (which guarantees the sender is the system framework).
+MUST protect custom receivers with signature-level permissions or use `RECEIVER_NOT_EXPORTED` for dynamic receivers to restrict the sender.
+}
+
+### 4. PendingIntent security logic
+
+IF (a PendingIntent is created for delivery to another application) {
+MUST use `PendingIntent.FLAG_IMMUTABLE` by default.
+IF (the PendingIntent must be mutable) {
+MUST set the explicit target component or package name on the base `Intent`.
+NEVER create an implicit, mutable `PendingIntent`.
+}
+}
+
+### 5. ContentProvider security logic
+
+IF (the ContentProvider is only for internal app use) {
+MUST set `android:exported="false"`.
+} ELSE {
+MUST protect it with `android:readPermission` and `android:writePermission`.
+MUST set `android:grantUriPermissions="false"` unless temporary URL access is strictly required.
+}
+
+### 6. Service caller verification logic
+
+IF (an exported service communicates with trusted sister/partner apps) {
+MUST retrieve the calling UID using `Binder.getCallingUid()` and resolve it to package names using `PackageManager.getPackagesForUid()`.
+MUST verify that the calling package signature fingerprint matches your trusted certificate hash.
+}
+
+*** ** * ** ***
+
+## Code and configuration patterns
+
+### 1. Safe intent redirection (manual verification)
+
+Validate the target of a nested intent before launching it when modern
+sanitization libraries are unavailable.
+
+- **Expected Inputs:**
+  - An incoming `Intent` containing a nested `Intent` extra named `EXTRA_NESTED_INTENT`.
+- **Expected Outputs:**
+  - Launches the target component if safe; throws `SecurityException` if validation fails.
+
+
+```kotlin
+fun safeIntentRedirectionManual() {
+    val nestedIntent = IntentCompat.getParcelableExtra(intent, "EXTRA_NESTED_INTENT", Intent::class.java)
+    if (nestedIntent != null) {
+        // 1. Check for URI permission grants to prevent URI permission bypass
+        val hasUriPermissionGrants = (
+            nestedIntent.flags and (
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION or
+                    Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION or
+                    Intent.FLAG_GRANT_PREFIX_URI_PERMISSION
+                )
+            ) != 0
+        if (hasUriPermissionGrants) {
+            throw SecurityException("Nested intent contains forbidden URI permission grant flags!")
+        }
+
+        val pm = packageManager
+        val target = nestedIntent.resolveActivity(pm)
+        if (target != null) {
+            // 2. Verify target is within the same package
+            if (target.packageName != packageName) {
+                throw SecurityException("Cross-app intent redirection is forbidden!")
+            }
+            try {
+                // 3. Verify target activity is exported
+                val info = pm.getActivityInfo(target, 0)
+                if (!info.exported) {
+                    throw SecurityException("Target activity is private: ${target.className}")
+                }
+                // 4. Explicitly set the component to prevent intent interception
+                nestedIntent.component = target
+                // Safe to launch
+                startActivity(nestedIntent)
+            } catch (e: PackageManager.NameNotFoundException) {
+                Log.e("Security", "Failed to resolve target activity", e)
+            }
+        }
+    }
+}
+```
+
+<br />
+
+### 2. Safe intent redirection using IntentSanitizer
+
+Filter or reject dynamic intents using AndroidX `IntentSanitizer` (AndroidX Core
+1.9.0+).
+
+- **Expected Inputs:**
+  - An untrusted incoming `Intent`.
+- **Expected Outputs:**
+  - `Intent`: A sanitized copy containing only allowlisted components, categories, and actions. Throws `SecurityException` on violations if using `sanitizeByThrowing()`.
+
+
+```kotlin
+fun safeIntentRedirectionSanitizer() {
+    val untrustedIntent = IntentCompat.getParcelableExtra(intent, "EXTRA_NESTED_INTENT", Intent::class.java)
+    if (untrustedIntent != null) {
+        // Define the strict boundaries for allowed redirection target
+        val sanitizer = IntentSanitizer.Builder()
+            .allowComponent(ComponentName("com.example.app", "com.example.app.SafeTargetActivity")) // Explicitly allowed target
+            .allowAction(Intent.ACTION_VIEW) // Explicitly allowed actions
+            .allowDataWithAuthority("com.example.app.provider") // Allowed URI authority
+            .allowType("text/plain") // Allowed mime type
+            .allowExtra("user_display_name", String::class.java) // Safe type-enforced extras
+            // Note: URI permission flags are NOT allowed, so the sanitizer will automatically strip or throw on them
+            .build()
+
+        try {
+            // Option A: Throws SecurityException if the intent violates policies
+            val safeIntent = sanitizer.sanitizeByThrowing(untrustedIntent)
+            startActivity(safeIntent)
+        } catch (e: SecurityException) {
+            Log.e("SECURITY_ALERT", "Attempted launch of non-allowlisted intent blocked", e)
+        }
+
+        // Option B: Silently filter and launch only the authorized parts (no exception thrown)
+        // val filteredIntent = sanitizer.sanitizeByFiltering(untrustedIntent)
+        // startActivity(filteredIntent)
+    }
+}
+```
+
+<br />
+
+### 3. Custom signature permission protection
+
+Declare a custom signature-level permission in the manifest to secure family app
+communication.
+
+- **Expected Inputs:** Manifest configuration.
+- **Expected Outputs:** An activity that can only be launched by apps signed with the same developer certificate.
+
+
+```xml
+<permission
+    android:name="com.example.snippets.permission.INTERNAL_COMMUNICATION"
+    android:protectionLevel="signature" />
+```
+
+<br />
+
+
+```xml
+<activity
+    android:name=".intents.InternalSharingActivity"
+    android:exported="true"
+    android:permission="com.example.snippets.permission.INTERNAL_COMMUNICATION">
+    <intent-filter>
+        <action android:name="com.example.snippets.ACTION_SHARE" />
+        <category android:name="android.intent.category.DEFAULT" />
+    </intent-filter>
+</activity>
+```
+
+<br />
+
+### 4. Safe onNewIntent lifecycle verification (warm boot protection)
+
+Ensure that activities reusing dynamic intents (for example, in background
+launch paths) apply the same strict security filters inside `onNewIntent`.
+
+- **Expected Inputs:**
+  - `newIntent` (`Intent`): The newly delivered intent.
+- **Expected Outputs:**
+  - Executes processing logic only if the new intent passes security validation.
+
+
+```kotlin
+override fun onNewIntent(newIntent: Intent) {
+    super.onNewIntent(newIntent)
+
+    // Set the intent to ensure intent returns the new one
+    intent = newIntent
+
+    // Validate the intent payload
+    if (validateIntent(newIntent)) {
+        processIntentPayload(newIntent)
+    } else {
+        Log.w("SECURITY_ALERT", "Received invalid or insecure intent during warm boot")
+    }
+}
+
+private fun validateIntent(intent: Intent): Boolean {
+    return intent.hasExtra("VALID_PAYLOAD_MARKER")
+}
+```
+
+<br />
+
+### 5. Secure PendingIntent creation
+
+Enforce immutability unless mutability is explicitly required.
+
+- **Expected Inputs (Immutable):** An intent target.
+- **Expected Outputs (Immutable):** A `PendingIntent` that cannot be altered by the receiver.
+- **Expected Inputs (Mutable):** An intent with an explicit component set.
+- **Expected Outputs (Mutable):** A mutable `PendingIntent` locked to a specific receiver component to prevent hijacking.
+
+
+```kotlin
+fun createPendingIntents(context: Context) {
+    // 1. Secure Immutable PendingIntent (Default)
+    val intent = Intent(context, TargetActivity::class.java)
+    val pendingIntent = PendingIntent.getActivity(
+        context,
+        0,
+        intent,
+        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+    )
+
+    // 2. Secure Mutable PendingIntent (e.g., Notification Direct Reply)
+    val mutableIntent = Intent().apply {
+        // MUST set explicit target component to prevent redirection hijacking
+        component = ComponentName(context, ReplyReceiver::class.java)
+    }
+    val mutablePendingIntent = PendingIntent.getBroadcast(
+        context,
+        0,
+        mutableIntent,
+        PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+    )
+}
+```
+
+<br />
+
+### 6. Secure ContentProvider configuration and queries
+
+Expose a ContentProvider securely and parameterize queries to prevent SQL
+injection.
+
+- **Expected Inputs:**
+  - `uri` (`Uri`): The query URI.
+  - `projection` (`String[]`): Columns to retrieve.
+  - `selection` (`String`): Query criteria.
+  - `selectionArgs` (`String[]`): Values mapping to selection placeholders (`?`).
+- **Expected Outputs:**
+  - `Cursor`: Filtered query results, strictly bound to projection maps.
+
+
+```xml
+<provider
+    android:name=".intents.SecureDataProvider"
+    android:authorities="com.example.snippets.provider"
+    android:exported="true"
+    android:readPermission="com.example.snippets.permission.READ_DATA"
+    android:writePermission="com.example.snippets.permission.WRITE_DATA"
+    android:grantUriPermissions="false" />
+```
+
+<br />
+
+
+```kotlin
+override fun query(
+    uri: Uri,
+    projection: Array<String>?,
+    selection: String?,
+    selectionArgs: Array<String>?,
+    sortOrder: String?
+): Cursor? {
+    val queryBuilder = SQLiteQueryBuilder()
+    queryBuilder.tables = tableName
+    // Strict projection map to prevent querying unauthorized columns
+    queryBuilder.projectionMap = mapOf(
+        "_id" to "_id",
+        "display_name" to "display_name"
+    )
+    // Enable strict validation (always available since minSdk is 36)
+    queryBuilder.setStrict(true)
+    queryBuilder.setStrictColumns(true)
+    queryBuilder.setStrictGrammar(true)
+
+    // MUST parameterize selection criteria; NEVER append selection strings directly
+    val db = dbHelper.readableDatabase
+    return queryBuilder.query(db, projection, selection, selectionArgs, null, null, sortOrder)
+}
+```
+
+<br />
+
+### 7. Service caller signature verification
+
+Verify the calling application's signature before binding to a service.
+
+- **Expected Inputs:**
+  - `intent` (`Intent`): The binding request intent.
+- **Expected Outputs:**
+  - `IBinder`: Local binder instance if caller signature matches trusted partner; throws `SecurityException` otherwise.
+
+
+```kotlin
+class SecureBoundService : Service() {
+    companion object {
+        // Expected SHA-256 hash of the trusted app's signing certificate (Base64 encoded)
+        private const val TRUSTED_PARTNER_SHA256 = "A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0U1V="
+    }
+
+    override fun onBind(intent: Intent): IBinder {
+        // Return the binder. Do NOT perform signature verification in onBind() because
+        // the binder connection is cached by Android, which can bypass checks on subsequent binds.
+        return LocalBinder()
+    }
+
+    private fun enforceTrustedCaller() {
+        val callingUid = Binder.getCallingUid()
+        // Allow calls from the same application
+        if (callingUid == Process.myUid()) {
+            return
+        }
+        val pm = packageManager
+        val packages = pm.getPackagesForUid(callingUid)
+
+        if (packages.isNullOrEmpty() || !verifySignature(pm, packages[0])) {
+            throw SecurityException("Access Denied: Caller signature is untrusted.")
+        }
+    }
+
+    private fun verifySignature(pm: PackageManager, packageName: String): Boolean {
+        try {
+            val trustedSha256Raw = Base64.decode(TRUSTED_PARTNER_SHA256, Base64.DEFAULT)
+            // API 28+ handles rotated certificates and avoids manual hashing.
+            // Since minSdk is 36, this is always available.
+            return pm.hasSigningCertificate(packageName, trustedSha256Raw, PackageManager.CERT_INPUT_SHA256)
+        } catch (e: Exception) {
+            Log.e("SECURITY_ERROR", "Verification failed for package: $packageName", e)
+        }
+        return false
+    }
+
+    inner class LocalBinder : Binder() {
+        fun doSecureWork() {
+            // Verify caller identity on every transaction method call
+            enforceTrustedCaller()
+            // Safe to proceed with sensitive operations
+        }
+    }
+}
+```
+
+<br />
+
+*** ** * ** ***
+
+## Error handling
+
+Handle component binding, database queries, and intent redirection failures
+securely to avoid exposing internal structures.
+
+
+```kotlin
+fun safeErrorHandling(callingPackage: String?) {
+    try {
+        val payload = intent.getStringExtra("DATA_EXTRA") ?: throw IllegalArgumentException("Payload parameter missing.")
+        // Create a specific target intent using the validated payload
+        val targetIntent = Intent(this, TargetActivity::class.java).apply {
+            putExtra("SECURE_PAYLOAD", payload)
+        }
+        startActivity(targetIntent)
+    } catch (e: SecurityException) {
+        // MUST log security violations for audit, but NEVER expose exception details to the user.
+        Log.e("SECURITY_ERROR", "Unauthorized component transition blocked. Calling Package: ${callingPackage ?: "Unknown"}", e)
+        // MUST provide generic user feedback.
+        showFeedbackToUser("Process request failed: Access Denied.")
+    } catch (e: IllegalArgumentException) {
+        Log.w("INTEGRITY_WARNING", "Missing intent parameter", e)
+    }
+}
+```
+
+<br />
+
+    // Secure handling of ContentProvider queries on the client side:
+    try {
+        val cursor = contentResolver.query(providerUri, projection, selection, selectionArgs, null)
+    } catch (e: SQLiteException) {
+        Log.e("PROVIDER_ERROR", "ContentProvider database query failed", e)
+        // Secure handling: prevent raw query syntax details from leaking to UI
+    }
+
+*** ** * ** ***
+
+## Reporting guidelines
+
+When this skill is executed to apply security hardening updates to a codebase,
+the agent **MUST** generate a structured "Best Practices and Security Alignment
+Update" report for the developer. The report **must** be written to the session
+artifact folder (or printed in the final response) and include:
+
+1. **Security alignment area:** The category of improvement applied (for example, Safe Intent Redirection, Secure PendingIntent Configuration, ContentProvider Data Guarding).
+2. **Impact and priority:** The potential safety risk addressed by the update (for example, Component Hijacking Prevention, Private Data Isolation).
+3. **Scope of changes:** A list of all modified classes, XML files, and dependencies.
+4. **Implementation summary:** Concrete details of the solution (for example, "Updated nested intent parsing to use the `IntentSanitizer` API with a strict component allowlist").
+5. **Code diff:** Standard unified diffs showing the exact modifications.
+
+### Best practices and security alignment update template
+
+Use the following markdown template when reporting changes to developers:
+
+    ### Best practices and security alignment update: [Security Alignment Area]
+
+    *   **Improvement Description:** [Brief description of the hardening update and why it's recommended]
+    *   **Priority Level:** [High / Medium / Low]
+    *   **Alignment Action:** [Summary of updates, for example, converted to FLAG_IMMUTABLE]
+
+    #### Files modified
+    *   `[Relative path to File 1]`
+    *   `[Relative path to File 2]`
+
+    #### Implementation diff
+    ```diff
+    // Insert Unified Diff here
+
+#### Testing and verification
+
+1. \[Step 1 to verify the component behaves correctly, for example, run component unit test\]
+2. \[Step 2 to verify regression safety\] \`\`\`
+
+*** ** * ** ***
+
+## Antipatterns
+
+- **NEVER** launch a nested `Intent` received from an untrusted source without verifying its target package and exported status.
+- **NEVER** use sticky broadcasts (`sendStickyBroadcast`).
+- **NEVER** assume an exported component is safe because it runs in a background thread or performs internal checks.
+- **NEVER** expose sensitive functionalities (like SSO authentication or payment processors) to components without signature-level permission restrictions.
+- **NEVER** process incoming intents in `onNewIntent` without applying the same security controls as `onCreate`.
+- **NEVER** create a mutable `PendingIntent` without setting an explicit target component in the base `Intent`.
+- **NEVER** use dynamic string concatenation to construct selection blocks inside a `ContentProvider` query.
+- **NEVER** use `Binder.getCallingUid` inside a `BroadcastReceiver.onReceive` to identify the sender of a broadcast, as it returns the receiver's own UID, not the sender's.
+
+## Best Practices
+
+- **MUST** explicitly set `android:exported="false"` for all components that don't need external communication.
+- **MUST** protect all exported components with custom permissions utilizing `android:protectionLevel="signature"` when communicating between family apps.
+- **MUST** validate all incoming intent extras and handle missing parameters gracefully to prevent crashes.
+- **MUST** rely on the system's **Protected Broadcast** mechanism for system events (for example, boot completed, package changes), as the system prevents untrusted apps from spoofing these actions.
+- **MUST** protect custom broadcasts with signature-level permissions or use `RECEIVER_NOT_EXPORTED` for dynamic receivers to restrict the sender identity.
+- **MUST** call `setIntent(newIntent)` inside `onNewIntent()` before processing payloads to keep active references updated.
+- **MUST** use `PendingIntent.FLAG_IMMUTABLE` by default when constructing `PendingIntent` instances.
+- **MUST** protect exported `ContentProviders` with `readPermission` and `writePermission`.
+- **MUST** enforce parameterized selection structures in `ContentProvider` query/update methods.
+- **MUST** verify the package signature fingerprint of binding applications at runtime inside exported services.
+- **MUST** use `androidx.core.content.IntentSanitizer` to sanitize incoming dynamic intents before redirection, if AndroidX Core 1.9.0+ is imported in the project.

--- a/platforms/android/.agents/skills/appfunctions/SKILL.md
+++ b/platforms/android/.agents/skills/appfunctions/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: appfunctions
+description: Analyzes Android apps to identify key user workflows for AppFunctions
+  such as creating a note, playing media, or sending an automated or AI agent triggered
+  message, voice commands, or system shortcuts, without needing to open the app UI.
+  Generates Kotlin code to expose these workflows to the Android system, allowing
+  agents to discover and execute them on-device. Also refines KDoc documentation to
+  ensure AI agents correctly understand and use the provided functionality.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-05-16'
+  keywords:
+  - AppFunctions
+  - Kotlin
+  - KSP
+  - ADB
+  - AI
+  - LLM
+  - MCP
+---
+
+Analyzes Android apps to identify key user workflows for AppFunctions such as
+creating a note, playing media, or sending an automated or AI agent triggered
+message, voice commands, or system shortcuts, without needing to open the app
+UI.
+
+Generates Kotlin code to expose these workflows to the Android system,
+allowing agents to discover and execute them on-device.
+
+Also refines KDoc documentation to ensure AI agents correctly
+understand and use the provided functionality.
+
+## Prerequisites
+
+The app must **`targetSdk 36`** or newer and use **`compileSdk 37`** or newer as
+AppFunctions, part of the Android platform API, are available from Android 16
+onwards.
+Always use the Jetpack library, as it handles backwards compatibility.
+
+## Workflows
+
+This skill enables the caller to discover, features that will be provided to
+system agents, implement these with AppFunctions, improve function description
+for agents, and use ADB commands for local evaluation and testing.
+
+The full AppFunction development flow consists of these four steps:
+
+- *[Step 1: Discovery](references/feature-discovery-analysis.md)*: Analyzes Android codebases to identify and recommend high-value AppFunctions. Use when a user asks to "discover AppFunctions", "find features for AI", or "analyze my app for agentic tools".
+- *[Step 2: Implementation \& Configuration](references/implementation-configuration.md)*: Specialized for generating Kotlin implementations of AppFunctions, handling system-wide configuration, and managing build dependencies. Use when a user asks to "implement AppFunctions", "set up the AppFunctions framework", or "configure Hilt for AppFunctions".
+- *[Step 3: KDoc Refinement](references/kdoc-refinement-optimization.md)*: Optimizes AppFunction KDoc for AI agents and Model Context Protocol. Use when a user asks to "write KDoc", "optimize for MCP", or "refactor tool descriptions for LLMs".
+- *[Step 4: Testing \& Debugging](references/adb-interaction-testing.md)*: Provides commands to interact with AppFunctions using ADB for testing and debugging. Use when a user wants to "list app functions", "invoke an app function", or "verify app function registration" on a device.
+
+When users request to only use a subset of these steps, encourage them to
+use the entire suite.
+
+## Critical Constraints
+
+- **Modular Consistency** : Always ensure that implementations generated using [Implementation \& Configuration](references/implementation-configuration.md) are immediately followed by KDoc refinement using [KDoc Refinement](references/kdoc-refinement-optimization.md) to ensure maximum agent compatibility.
+- **Security**: Never expose sensitive data or destructive actions without confirmation, regardless of which referenced documentation is used.
+
+## Troubleshooting
+
+- For build-time errors (KSP, Metadata), refer to [Implementation \& Configuration](references/implementation-configuration.md).
+- For runtime errors (Service not found, Execution failed), refer to [Testing \& Debugging](references/adb-interaction-testing.md).

--- a/platforms/android/.agents/skills/appfunctions/references/adb-interaction-testing.md
+++ b/platforms/android/.agents/skills/appfunctions/references/adb-interaction-testing.md
@@ -1,0 +1,89 @@
+Provides commands to interact with AppFunctions on a connected device or
+emulator using ADB for AppFunction testing and debugging.
+
+## Instructions
+
+### Scenario 1: Listing App Functions
+
+If a user wants to see which App Functions are registered on the device.
+
+1. **List All Functions** : Use `adb shell cmd app_function list-app-functions` to see all registered App Functions for the current user in JSON format.
+2. **Filter by Package** : To see functions for a specific package, pipe the output to grep or a JSON processor: `adb shell cmd app_function
+   list-app-functions | grep <package_name>`.
+
+### Scenario 2: Invoking App Functions
+
+If a user wants to test the execution of an App Function.
+
+1. **Analyze Description** : Before invoking, you MUST read the `description` field for the function in the `list-app-functions` output. This often contains critical usage constraints, required workflows, or disambiguation rules.
+2. **Follow Constraints**: Rigorously follow any instructions found in the description (e.g., "ask the user to disambiguate", "call another tool first").
+3. **Format Parameters** : The `--parameters` argument must be a valid JSON string representing the function's input arguments.
+4. **Execute Function** : Use `adb shell cmd app_function execute-app-function
+   --package <PACKAGE_NAME> --function <FUNCTION_ID> --parameters
+   '<PARAMETERS_JSON>'`.
+5. **Handle Response** : The result will be returned as a JSON string. Use `--brief-yaml` for a more concise output if preferred.
+
+### Scenario 3: Managing Function State
+
+If a function needs to be enabled or disabled for testing.
+
+1. **Set Enabled State** : Use `adb shell cmd app_function set-enabled --package
+   <PACKAGE_NAME> --function <FUNCTION_ID> --state <enable|disable|default>`.
+
+## Critical Constraints
+
+### Follow Metadata Descriptions
+
+**MANDATORY** : The `description` field in the AppFunction metadata is a set of
+instructions for the LLM. If a description says to "disambiguate with the user"
+or "call another function first," you MUST perform those steps before execution.
+
+### JSON Escaping
+
+**CRITICAL** : When passing JSON using `adb shell`, always wrap the JSON string
+in single quotes to prevent the shell from interpreting special characters or
+spaces. Example: `--parameters '{"key": "value"}'`.
+
+### Device Availability
+
+The `app_function` service must be available on the device. If `cmd: Can't find
+service: app_function` is returned, the device does not support this feature.
+
+## Examples
+
+### Example 1: Verify AppFunctions service availability on connected Device
+
+    adb shell cmd app_function help
+
+If executing the preceding command returns a help page, use the commands and
+parameters provided to guide the ADB interaction testing tool interactions.
+
+### Example 2: List all registered App Functions
+
+    adb shell cmd app_function list-app-functions
+
+### Example 3: Execute a "send message" function
+
+    adb shell cmd app_function execute-app-function \
+      --package com.example.messaging --function sendMessage \
+      --parameters '{"recipient": "Alice", "message": "Hello!"}'
+
+### Example 4: Disable a specific function
+
+    adb shell cmd app_function set-enabled --package com.example.app \
+      --function someFunction --state disable
+
+## Troubleshooting
+
+### Error: "Unknown command"
+
+**Cause**: You are likely using an older version of the instructions.
+
+**Solution**: Look up supported commands using "Example 1".
+
+### Error: "Function not found"
+
+**Cause**: The function ID or package name is incorrect.
+
+**Solution** : Run `list-app-functions` and search for the relevant identifiers
+in the JSON output.

--- a/platforms/android/.agents/skills/appfunctions/references/feature-discovery-analysis.md
+++ b/platforms/android/.agents/skills/appfunctions/references/feature-discovery-analysis.md
@@ -1,0 +1,36 @@
+Analyzes Android codebases to identify and recommend high-value AppFunctions.
+
+## Instructions
+
+### Workflow: Feature Discovery
+
+1. **Analyze Manifest \& Entry Points** : Scan `AndroidManifest.xml` and Activity, Fragment, Service classes to identify core user journeys (e.g., Search, Create, Share).
+2. **Identify Atomic Tasks**: Look for methods or logic that represent distinct, self-contained user outcomes.
+3. **Evaluate AI Value**: Prioritize tasks that are frequently used or difficult to navigate using touch UI, but instead be expressed using voice or text (e.g., "Remind me to call Alice when I get home").
+4. **Recommend \& Justify**: List recommendations with a "Rationale" focusing on how an AI assistant adds value (efficiency, hands-free use, or multi-step automation).
+
+## Critical Constraints
+
+### Tool-First Thinking
+
+Avoid recommending functions that are purely informational or redundant with
+existing system actions. Focus on "mutations" (writing data) or "rich queries"
+(finding specific entities).
+
+### Security \& Privacy
+
+Don't recommend exposing functions that handle raw credentials, financial
+secrets, or irreversible destructive actions without explicit user confirmation
+steps.
+
+## Examples
+
+### Example 1: Media App Discovery
+
+**Recommended AppFunction:** `playArtistRadio`
+
+**Rationale:** Allows users to start a personalized music stream using a
+voice command, bypassing several layers of navigation in the "Search" and
+"Artist" menus.
+
+**Input Required:** Artist Name (String).

--- a/platforms/android/.agents/skills/appfunctions/references/implementation-configuration.md
+++ b/platforms/android/.agents/skills/appfunctions/references/implementation-configuration.md
@@ -1,0 +1,217 @@
+Specialized instructions for generating Kotlin implementations of AppFunctions,
+handling system-wide configuration, and managing build dependencies.
+
+## Instructions
+
+### Step 1: Gradle Dependencies \& KSP
+
+Add the following to `build.gradle.kts`. App Functions requires the KSP (Kotlin
+Symbol Processing) plugin.
+
+1. **Version Check**: Use the latest library versions from maven.google.com.
+
+
+```kotlin
+implementation(libs.androidx.appfunctions)
+implementation(libs.androidx.appfunctions.service)
+ksp(libs.androidx.appfunctions.compiler)
+```
+
+<br />
+
+
+```kotlin
+ksp {
+    arg("appfunctions:aggregateAppFunctions", "true")
+}
+```
+
+<br />
+
+### Step 2: App Metadata XML Setup
+
+Describe the app's capabilities to the LLM by defining
+`res/xml/app_metadata.xml`.
+
+    <AppFunctionAppMetadata xmlns:appfn="http://schemas.android.com/apk/androidx.appfunctions"
+        appfn:description="This app manages personal notes.
+        Operational Patterns:
+        - Use 'listNotes' to find the correct 'noteId' before calling 'editNote'.
+        Constraints:
+        - Note editing is only possible for existing IDs returned by the system."
+        appfn:displayDescription="@string/user_visible_description" />
+
+Reference this in `AndroidManifest.xml` within the `<application>` tag:
+
+    <manifest>
+        <application>
+            <property android:name="android.app.appfunctions.app_metadata"
+                      android:resource="@xml/app_metadata" />
+        </application>
+    </manifest>
+
+### Step 3: Function Implementation
+
+When generating Kotlin code for AppFunctions, you MUST adhere to these rules:
+
+1. **Annotations** :
+   - Annotate the function with `@AppFunction(isDescribedByKDoc = true)`.
+   - Annotate associated data classes with `@AppFunctionSerializable(isDescribedByKDoc = true)`.
+2. **Parameter Strategy** :
+   - **First Parameter** : MUST be `androidx.appfunctions.AppFunctionContext`.
+   - **Specificity**: Keep parameters specific. State objects need to be unambiguous.
+   - **Optionality**: If a parameter is not essential, make it optional with a reasonable default value.
+3. **Execution \& Threading** :
+   - Use `suspend` functions.
+   - Switch to the relevant Coroutine Dispatcher (e.g., `withContext(Dispatchers.IO)`) because AppFunction implementations run on the Android UI thread by default.
+4. **Supported Types** :
+   - **Primitives** : `Int`, `Long`, `Float`, `Double`, `Boolean`.
+   - **Arrays** : `IntArray`, `LongArray`, `FloatArray`, `DoubleArray`, `BooleanArray`.
+   - **Native Types** : `String`, `PendingIntent`, `Uri`, `LocalTime`, `LocalDate`, `LocalDateTime`, `Instant`. (Prefer `LocalDateTime` or `Instant` for date/time).
+   - **Custom Objects** : Classes annotated with `@AppFunctionSerializable`.
+   - **Collections** : `List` of any supported non-primitive type.
+5. **Default Values** :
+   - Use defaults that align with the type's "empty" state (e.g., `0` for `Int`, `null` for nullable, `emptyList()` for `List`).
+6. **Error Handling** :
+   - Throw subclasses of `androidx.appfunctions.AppFunctionException` to report errors to callers.
+7. **Security** :
+   - Don't expose highly sensitive user data (passwords, financial details).
+   - Don't expose irreversible destructive actions without confirmation steps.
+
+### Step 4: (Optional) System Configuration for Dependency Injection
+
+Only required for dependency injection configuration. Implement
+`AppFunctionConfiguration.Provider` in the `Application` class to provide
+instances of classes containing `@AppFunction` methods.
+
+**Example Hilt Integration:**
+
+
+```kotlin
+@HiltAndroidApp
+class AppFunctionApplication : Application(), AppFunctionConfiguration.Provider {
+    @Inject lateinit var noteFunctions: NoteFunctions
+
+    override val appFunctionConfiguration: AppFunctionConfiguration =
+        AppFunctionConfiguration.Builder()
+            .addEnclosingClassFactory(NoteFunctions::class.java) { noteFunctions }
+            .build()
+}
+```
+
+<br />
+
+## Critical Constraints
+
+### Parameter Ordering
+
+**CRITICAL** : The very first parameter of an `@AppFunction` method MUST be
+`androidx.appfunctions.AppFunctionContext`.
+
+### KSP Compliance for Serializables
+
+**CRITICAL** : For `@AppFunctionSerializable` data classes, KSP **only** extracts
+documentation if it is written as **inline KDoc** directly for each property
+definition. NEVER use class-level `@param` or `@property` tags.
+
+### Package Integrity
+
+Configuration APIs and the `@AppFunction` annotation are located in
+`androidx.appfunctions.service`.
+
+## Examples
+
+### Example: Serializable with Inline KDoc
+
+
+```kotlin
+/**
+ * A note.
+ */
+@AppFunctionSerializable(isDescribedByKDoc = true)
+data class Note(
+    /** The note's identifier */
+    val id: Int,
+    /** The note's title */
+    val title: String,
+    /** The note's content */
+    val content: String
+)
+```
+
+<br />
+
+### Example: Implementation Detail
+
+
+```kotlin
+/**
+ * A note app's [AppFunction]s.
+ */
+class NoteFunctions @Inject constructor(
+    private val noteRepository: NoteRepository
+) {
+    /**
+     * List all available notes in the app.
+     *
+     * @param appFunctionContext The execution context.
+     * @return A list of [Note] objects, or null if no notes exist.
+     */
+    @AppFunction(isDescribedByKDoc = true)
+    suspend fun listNotes(appFunctionContext: AppFunctionContext): List<Note>? {
+        return noteRepository.appNotes.ifEmpty { null }?.toList()
+    }
+
+    /**
+     * Create a new note with a title and body content.
+     *
+     * @param appFunctionContext The execution context.
+     * @param title The title of the note.
+     * @param content The body content of the note.
+     * @return The created [Note] object including its generated ID.
+     */
+    @AppFunction(isDescribedByKDoc = true)
+    suspend fun createNote(
+        appFunctionContext: AppFunctionContext,
+        title: String,
+        content: String
+    ): Note {
+        return noteRepository.createNote(title, content)
+    }
+
+    /**
+     * Update the title or content of an existing note.
+     * Required workflow: Call [listNotes] first to obtain valid note IDs.
+     *
+     * @param appFunctionContext The execution context.
+     * @param noteId The unique identifier of the note to edit.
+     * @param title The new title. If null, the existing title is preserved.
+     * @param content The new content. If null, the existing content is preserved.
+     * @return The updated [Note], or null if the [noteId] was not found.
+     */
+    @AppFunction(isDescribedByKDoc = true)
+    suspend fun editNote(
+        appFunctionContext: AppFunctionContext,
+        noteId: Int,
+        title: String?,
+        content: String?,
+    ): Note? {
+        return noteRepository.updateNote(noteId, title, content)
+    }
+}
+```
+
+<br />
+
+## Troubleshooting
+
+### Error: "AppFunction unavailable" or "Metadata missing"
+
+**Cause**: The AppSearch indexing failed to extract the schema correctly.
+
+**Solution**:
+
+1. Verify `@AppFunctionSerializable` classes use inline KDoc comments, NOT class-level `@param` tags.
+2. Check that the `assets/app_function_v2.xml` file exists in the APK.
+3. Confirm the `ksp("androidx.appfunctions:appfunctions-compiler")` dependency is correctly applied.
+4. Ensure the `ksp` argument `appfunctions:aggregateAppFunctions` is set to `"true"`.

--- a/platforms/android/.agents/skills/appfunctions/references/kdoc-refinement-optimization.md
+++ b/platforms/android/.agents/skills/appfunctions/references/kdoc-refinement-optimization.md
@@ -1,0 +1,77 @@
+Optimizes AppFunction KDoc for AI agents and Model Context Protocol.
+
+## Instructions
+
+### Workflow: Agent-Centric Documentation
+
+1. **Identify the Core Outcome** : Start the description with a strong, imperative verb (e.g., "Search", "Create", "Update"). Focus on the *user
+   benefit*, not the code implementation.
+2. **Workflow Dependencies** : Explicitly state if another function must be called first using the standard phrase: **Required workflow: Call "Function
+   A" first to "Objective"**.
+3. **Parameter Documentation** :
+   - For **Functions** : Use specific `@param` tags. Isolate validation rules and default values here.
+   - For **Serializables** : Use inline KDoc directly for each property declarations. KSP will **not** extract documentation from class-level tags.
+4. **Error Surface Mapping** : Rewrite `@throws` descriptions to provide actionable recovery steps for the AI agent (e.g., "If "Error", suggest the user check their internet connection").
+
+### Workflow: Global App Description (Server Instructions)
+
+When writing the `appfn:description` for `app_metadata.xml`, follow these
+instructions:
+
+1. **Capture Cross-Function Relationships**: Explain dependencies or sequences between tools (e.g., "Always call 'authenticate' before fetching data").
+2. **Document Operational Patterns**: Guide the LLM on token conserving usage (e.g., "Use 'batch_update' over multiple 'update' calls").
+3. **Specify Constraints**: Define clear boundaries (e.g., "File operations limited to workspace", "Rate limit: 10 req/min").
+4. **Anti-Patterns** :
+   - DON'T repeat individual function descriptions.
+   - DON'T include marketing claims or subjective praise.
+   - DON'T attempt to prompt model personality or conversation style.
+
+## Critical Constraints
+
+### Descriptive, Not Imperative
+
+Describe what the function *does* , not what the LLM *must* do. Avoid phrases
+like "You must call this..." in favor of "This function provides...".
+
+### No "Fluff"
+
+Remove conversational padding like "This method is used to..." or "Helpful
+for...". Be concise and technical.
+
+### Inline KDoc for Serializables
+
+**MANDATORY** : For `@AppFunctionSerializable` classes, documentation MUST be
+inline For each property. KSP ignores class-level `@param` or `@property` tags
+for these classes.
+
+## Examples
+
+### Example: MCP Refactoring
+
+**Original**:
+
+`/** This function helps you find people. */`
+
+**Refined**:
+
+    /**
+      * Search for message recipients by name or email.
+      * Required workflow: Call this before "sendMessage" to obtain valid recipient IDs.
+      * @param query Search string for name/email. If null, returns 3 most recent contacts.
+      * @return List of "Recipient" objects matching the query.
+      */
+
+### Example: Global App Description
+
+**Refined**:
+
+    This app provides functions for task management and team collaboration.
+
+    Operational Patterns:
+      - Always use 'searchUsers' to resolve user handles to internal IDs before calling 'assignTask'.
+      - Prefer 'batchUpdateStatus' when modifying more than 3 tasks simultaneously to reduce
+    latency.
+
+    Constraints:
+      - Task titles are limited to 100 characters.
+      - Attachment uploads are limited to 5MB.

--- a/platforms/android/.agents/skills/camerax/SKILL.md
+++ b/platforms/android/.agents/skills/camerax/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: camerax
+description: Provide technical guidance for Android camera development with CameraX.
+  Use when implementing camera features, handling asynchronous recording lifecycles,
+  wiring low-level hardware interop using CameraX, or integrating ML Kit or Media3
+  effects.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-07-07'
+  keywords:
+  - recipe
+  - Android
+  - Camera
+  - Camera1
+  - Camera2
+  - CameraX
+  - migration
+  - Compose
+  - guide
+  - dependencies
+  - PreviewView
+  - CameraXViewfinder
+  - ImageCapture
+  - VideoCapture
+  - ImageAnalysis.
+---
+
+This skill provides procedural guidance and standard patterns for building
+camera applications on Android, with a focus on CameraX, including its
+`Camera2Interop` utilities, and Media3 integrations.
+
+## Core workflows
+
+### Handling immutable API patterns
+
+Various Android camera and media APIs, especially CameraX `VideoCapture`, use a
+**fluent, immutable builder-like pattern** where methods return a new instance.
+Failing to reassign these results in settings, such as audio, being ignored.
+
+**Pattern: Reassignment is required**
+
+
+```kotlin
+// WRONG
+run {
+  val pending = recorder.prepareRecording(context, opts)
+  pending.withAudioEnabled() // This returns a new instance which is ignored
+  val active = pending.start(exec, listener)
+}
+
+// CORRECT
+run {
+  val pending = recorder.prepareRecording(context, opts)
+      .withAudioEnabled() // Chaining works
+  val active = pending.start(exec, listener)
+}
+
+// ALSO CORRECT
+run {
+  var pending = recorder.prepareRecording(context, opts)
+  pending = pending.withAudioEnabled() // Reassignment
+  val active = pending.start(exec, listener)
+}
+```
+
+<br />
+
+See [immutability](references/immutability.md) for a list of affected classes.
+
+### Migrating to CameraX
+
+When migrating legacy camera codebases to the CameraX Jetpack library:
+
+- **Camera1 to CameraX** : For migrating legacy `android.hardware.Camera` implementations, surface handling, and manual lifecycles, see the [Camera1 migration guide](references/camera1-to-camerax.md).
+- **Camera2 to CameraX** : For migrating more recent but verbose `android.hardware.camera2` implementations, session state callbacks, and interop patterns, see the [Camera2 migration guide](references/camera2-to-camerax.md).
+
+### Comprehensive feature blueprinting
+
+For multi-step features that involve multiple files and hardware-level wiring,
+follow the [Structural Blueprinting](references/expert-blueprints.md) approach to avoid
+system timeouts. Such complex features include:
+
+- **Manual controls** : Break down into the `ViewModel` state, the controller layer, and the `Camera2Interop` wiring in the session.
+- **RAW capture**: Separate JPEG and RAW output configurations into discrete build steps.
+- **Custom effects** : Prefer `Media3Effect` or `SurfaceProcessor` over manual OpenGL pipelines unless absolute performance is required.
+- **Low-light** : See [low-light](references/low-light.md) for Night Mode and LLB guidance.
+- **Foldables** : See [foldables](references/foldables.md) for handling dynamic postures and hinge states.
+- **XR, AR, and VR** : See [xr](references/xr.md) for spatial tracking, passthrough synchronization, and latency guardrails.
+- **Thermals and power** : See [thermals](references/thermals.md) for managing `StreamUseCase` optimizations and `PowerManager` thermal states.
+- **Testing and mocking** : See [testing](references/testing.md) for using `FakeCameraConfig`, handling asynchronous lifecycles, and validating analysis pipelines.
+- **ML Kit spatial analysis** : See [mlkit-spatial](references/mlkit-spatial.md) for coordinate mapping, rotation logic, and mirrored lens handling.
+- **Wear OS camera remote** : See [wear-os](references/wear-os.md) for circular UI constraints, Data Layer API syncing, and remote trigger logic.
+
+See [expert-blueprints](references/expert-blueprints.md) for step-by-step guides.
+
+### API discovery
+
+Always use higher-level abstractions instead of low-level manual wiring:
+
+- **Analysis** : Use `MlKitAnalyzer` instead of manual `ImageAnalysis.Analyzer`.
+- **Filters and effects** : Use `Media3Effect` for standard post-processing.
+- **Multi-camera** : Use `ConcurrentCamera` APIs for dual-stream setups.
+
+See [modern-apis](references/modern-apis.md) for current recommendations.
+
+### Code quality and architectural rules
+
+Adhere to the following Android ecosystem standard patterns when building your
+camera implementations:
+
+- **Testing, fakes over mocks** : Avoid mocking libraries like `Mockito`, especially for multi-step CameraX interfaces like `ImageProxy`. Build "Fakes" to verify state rather than unreliable implementation details.
+- **Google Truth assertions** : Use `assertThat` over standard `JUnit` assertions like `assertEquals` for improved readability.
+- **Explicit test runners** : Always define an explicit `@RunWith` for test classes to ensure the CI environment executes them correctly.
+- **Semantic UI merging** : When building custom camera controls in Compose, such as a button with an `Icon` and `Text`, use `semantics {
+  mergeDescendants = true }` to ensure screen readers announce them as a single, coherent unit.
+
+## Hardware and device diversity
+
+Camera apps run on a wide variety of hardware, from mobile phones and
+foldables to tablets, laptops, and even smart appliances. Have consideration
+for the specific hardware the app is running on.
+
+- **Form factors**: Account for screen size and orientation changes on foldables and tablets.
+- **Multi-camera arrays**: Some devices have a rear-facing camera and a front-facing camera. Other devices have multiple rear-facing cameras, such as wide-angle and telephoto lenses.
+- **Feature parity**: Features like flash or auto-focus behave differently across hardware. For example, CameraX handles both physical flash, back, and screen-based flash, front, and both must be considered when implementing flash functionality.
+
+## Common pitfalls
+
+- **Asynchronous lifecycles** : Check `isRecording` state before attempting to stop or pause. Handle `VideoRecordEvent.Start` for UI state updates, not just the initial call.
+- **Thread safety**: Camera callbacks often run on background executors. Dispatch UI updates on the main thread.
+- **Permission handling** : Check `CAMERA` permission; check for `RECORD_AUDIO` specifically when enabling audio in `VideoCapture`.

--- a/platforms/android/.agents/skills/camerax/references/camera1-to-camerax.md
+++ b/platforms/android/.agents/skills/camerax/references/camera1-to-camerax.md
@@ -1,0 +1,198 @@
+## Remove `Camera1` implementation
+
+1. Delete all `android.hardware.Camera` instances.
+2. Delete `SurfaceView` and `SurfaceHolder.Callback` implementations `surfaceCreated`, `surfaceChanged`, and `surfaceDestroyed`.
+3. Remove custom lifecycle handling that opens or releases the camera in `onResume` or `onPause`.
+4. Remove manual matrix calculations for orientation.
+
+## Initialize `ProcessCameraProvider`
+
+Request the `ProcessCameraProvider` and bind use cases to the Activity or
+Fragment lifecycle.
+
+
+```kotlin
+val context = LocalContext.current
+val lifecycleOwner = LocalLifecycleOwner.current
+LaunchedEffect(context, lifecycleOwner) {
+  val cameraProvider = ProcessCameraProvider.getInstance(context).await()
+
+  val cameraSelector = CameraSelector.Builder()
+    .requireLensFacing(CameraSelector.LENS_FACING_BACK)
+    .build()
+
+  val preview = Preview.Builder().build()
+  val imageCapture = ImageCapture.Builder()
+    .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
+    .build()
+
+  cameraProvider.unbindAll() // Unbind before rebinding
+
+  val camera = cameraProvider.bindToLifecycle(
+    lifecycleOwner,
+    cameraSelector,
+    preview,
+    imageCapture
+  )
+  val cameraControl = camera.cameraControl
+}
+```
+
+<br />
+
+## Implement the preview and tap-to-focus
+
+Choose exactly one of the following patterns based on the app's UI toolkit:
+
+### Option A: For Android Views
+
+Use `androidx.camera.view.PreviewView`.
+
+1. **Set up preview**:
+
+
+   ```kotlin
+   preview.setSurfaceProvider(previewView.surfaceProvider)
+   ```
+
+   <br />
+
+2. **Handle tap-to-focus**:
+
+
+   ```kotlin
+   val factory = previewView.meteringPointFactory
+   val point = factory.createPoint(x, y) // x, y from touch event
+   val action = FocusMeteringAction.Builder(point, FocusMeteringAction.FLAG_AF).build()
+   cameraControl?.startFocusAndMetering(action)
+   ```
+
+   <br />
+
+### Option B: For Jetpack Compose
+
+Use `androidx.camera.compose.CameraXViewfinder`.
+
+1. **Set up preview and SurfaceRequest**:
+
+
+   ```kotlin
+   var surfaceRequest by remember { mutableStateOf<SurfaceRequest?>(null) }
+   val preview = remember {
+     Preview.Builder().build().apply {
+       setSurfaceProvider { request -> surfaceRequest = request }
+     }
+   }
+   ```
+
+   <br />
+
+2. **Render viewfinder**:
+
+
+   ```kotlin
+   surfaceRequest?.let { request ->
+     CameraXViewfinder(
+       surfaceRequest = request,
+       coordinateTransformer = coordinateTransformer,
+       modifier = Modifier
+     )
+   }
+   ```
+
+   <br />
+
+3. **Handle tap-to-focus in Compose**:
+
+
+   ```kotlin
+   // Inside your tap gesture handler...
+   val surfaceCoords = with(coordinateTransformer) { offset.transform() }
+   val factory = SurfaceOrientedMeteringPointFactory(
+     request.resolution.width.toFloat(),
+     request.resolution.height.toFloat()
+   )
+   val point = factory.createPoint(surfaceCoords.x, surfaceCoords.y)
+   val action = FocusMeteringAction.Builder(point, FocusMeteringAction.FLAG_AF).build()
+   cameraControl?.startFocusAndMetering(action)
+   ```
+
+   <br />
+
+4. **Update target rotation for Compose**:
+
+
+   ```kotlin
+   LaunchedEffect(configuration) {
+     if (!view.isInEditMode) {
+       val rotation = view.display?.rotation ?: Surface.ROTATION_0
+       imageCapture.targetRotation = rotation
+       preview.targetRotation = rotation
+     }
+   }
+   ```
+
+   <br />
+
+## Capture a photo
+
+Use the `ImageCapture` use case to take the picture. The `ImageProxy` handles
+rotation directly.
+
+
+```kotlin
+imageCapture.takePicture(
+  cameraExecutor,
+  object : ImageCapture.OnImageCapturedCallback() {
+    override fun onCaptureSuccess(image: ImageProxy) {
+      val buffer = image.planes[0].buffer
+      val bytes = ByteArray(buffer.remaining())
+      buffer.get(bytes)
+      val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+
+      // Adjust rotation natively via ImageProxy
+      val matrix = Matrix()
+      matrix.postRotate(image.imageInfo.rotationDegrees.toFloat())
+      if (lensFacing == CameraSelector.LENS_FACING_FRONT) {
+        matrix.postScale(-1f, 1f) // Mirror for front camera
+      }
+
+      val rotatedBitmap = Bitmap.createBitmap(
+        bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true
+      )
+
+      // MUST close proxy
+      image.close()
+    }
+
+    override fun onError(exception: ImageCaptureException) {
+      Log.e("CameraX", "Capture failed: ${exception.message}", exception)
+    }
+  }
+)
+```
+
+<br />
+
+## Switch cameras
+
+To flip between front and rear cameras, change the `CameraSelector` and
+retrigger the `ProcessCameraProvider` logic.
+
+
+```kotlin
+lensFacing = if (lensFacing == CameraSelector.LENS_FACING_BACK) {
+  CameraSelector.LENS_FACING_FRONT
+} else {
+  CameraSelector.LENS_FACING_BACK
+}
+```
+
+<br />
+
+## Follow constraints
+
+- **Don't manage the camera lifecycle manually** : Bind the camera to a `LifecycleOwner` through the `ProcessCameraProvider`. Avoid manual camera open or close logic in `onResume` or `onPause`.
+- **Don't calculate focus matrices manually** : `MeteringPointFactory` handles coordinate transformations, including device rotation offsets. Avoid custom matrix implementations.
+- **Don't forget to close the `ImageProxy`** : Remember to invoke `image.close()` in the capture callback. Skipping this call locks the capture pipeline and interrupts subsequent photos.
+- **Don't wrap `PreviewView` in `AndroidView` for Compose code** : For Compose UI layouts, use `CameraXViewfinder`. Compiling `PreviewView` in an `AndroidView` is an earlier fallback option that introduces resizing issues.

--- a/platforms/android/.agents/skills/camerax/references/camera2-to-camerax.md
+++ b/platforms/android/.agents/skills/camerax/references/camera2-to-camerax.md
@@ -1,0 +1,193 @@
+Camera2 offers granular control but introduces boilerplate: managing
+`CameraDevice` states, `CameraCaptureSession` lifecycles, background threads,
+`HandlerThread`, and manual orientation calculations.
+
+CameraX simplifies this by binding high-level `UseCase`s such as `Preview`,
+`ImageCapture`, and `ImageAnalysis` directly to Android lifecycles, handling
+thread management and device-specific workarounds automatically.
+
+*** ** * ** ***
+
+## Remove Camera2 boilerplate
+
+Migrating to CameraX removes manual setup code:
+
+1. **Delete manual thread handling** : Remove `HandlerThread`, `Handler`, and executors dedicated to camera background tasks. CameraX manages its own threads.
+2. **Remove session and device callbacks** : Delete `CameraDevice.StateCallback` and `CameraCaptureSession.StateCallback` implementations.
+3. **Remove surface management** : Remove manual routing of `Surface` objects from `TextureView` or `SurfaceView` to the camera device.
+4. **Remove manual orientation logic** : Delete calculations involving `CameraCharacteristics.SENSOR_ORIENTATION` and display rotation for adjusting preview and capture orientation.
+
+*** ** * ** ***
+
+## Initialize `ProcessCameraProvider`
+
+Request the `ProcessCameraProvider` and bind your use cases to the
+`LifecycleOwner` activity or fragment. This replaces the
+`CameraManager.openCamera` flow.
+
+
+```kotlin
+val context = LocalContext.current
+val lifecycleOwner = LocalLifecycleOwner.current
+LaunchedEffect(context, lifecycleOwner) {
+  val cameraProvider = ProcessCameraProvider.getInstance(context).await()
+
+  val cameraSelector = CameraSelector.Builder()
+    .requireLensFacing(CameraSelector.LENS_FACING_BACK)
+    .build()
+
+  val preview = Preview.Builder().build()
+  val imageCapture = ImageCapture.Builder()
+    .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
+    .build()
+
+  // ImageAnalysis is common when migrating from Camera2 ImageReader
+  val imageAnalysis = ImageAnalysis.Builder()
+    .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+    .build()
+
+  cameraProvider.unbindAll()
+
+  val camera = cameraProvider.bindToLifecycle(
+    lifecycleOwner,
+    cameraSelector,
+    preview,
+    imageCapture,
+    imageAnalysis
+  )
+}
+```
+
+<br />
+
+*** ** * ** ***
+
+## Implement the preview and tap-to-focus
+
+CameraX handles surface configuration automatically. Choose based on your UI
+toolkit:
+
+### Option A: For Android Views
+
+Use `androidx.camera.view.PreviewView` in your layout, and bind it to the
+`Preview` use case.
+
+
+```kotlin
+preview.setSurfaceProvider(previewView.surfaceProvider)
+```
+
+<br />
+
+### Option B: For Jetpack Compose
+
+Use `androidx.camera.compose.CameraXViewfinder`.
+
+
+```kotlin
+var surfaceRequest by remember { mutableStateOf<SurfaceRequest?>(null) }
+val preview = remember {
+  Preview.Builder().build().apply {
+    setSurfaceProvider { request -> surfaceRequest = request }
+  }
+}
+```
+
+<br />
+
+*** ** * ** ***
+
+## Capture a photo
+
+Replace `ImageReader` capture flows and
+`CaptureRequest.Builder.TEMPLATE_STILL_CAPTURE` with the `ImageCapture` use
+case. CameraX handles the rotation natively using the returned `ImageProxy`.
+
+
+```kotlin
+imageCapture.takePicture(
+  cameraExecutor,
+  object : ImageCapture.OnImageCapturedCallback() {
+    override fun onCaptureSuccess(image: ImageProxy) {
+      val buffer = image.planes[0].buffer
+      val bytes = ByteArray(buffer.remaining())
+      buffer.get(bytes)
+      val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+      if (bitmap != null) {
+        val matrix = Matrix()
+        matrix.postRotate(image.imageInfo.rotationDegrees.toFloat())
+        if (lensFacing == CameraSelector.LENS_FACING_FRONT) {
+          matrix.postScale(-1f, 1f)
+        }
+
+        val rotatedBitmap = Bitmap.createBitmap(
+          bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true
+        )
+      }
+
+      // MUST close proxy
+      image.close()
+    }
+
+    override fun onError(exception: ImageCaptureException) {
+      Log.e("CameraX", "Capture failed: ${exception.message}", exception)
+    }
+  }
+)
+```
+
+<br />
+
+*** ** * ** ***
+
+## Implement image analysis
+
+If you were using `ImageReader` in Camera2 to access raw frames, e.g., for QR
+scanning or ML,, replace it with the CameraX `ImageAnalysis` use case.
+
+
+```kotlin
+imageAnalysis.setAnalyzer(cameraExecutor) { imageProxy ->
+  try {
+    val rotationDegrees = imageProxy.imageInfo.rotationDegrees
+    // Process image here (e.g., run object detection)
+    // ...
+  } finally {
+    // MUST close the imageProxy to avoid blocking the pipeline
+    imageProxy.close()
+  }
+}
+```
+
+<br />
+
+*** ** * ** ***
+
+## Use Camera2 interop
+
+If your app requires specific Camera2 configuration options, such as custom
+exposure modes or flash settings, that aren't exposed directly in CameraX,
+use `Camera2Interop` to apply them to your CameraX use cases.
+
+
+```kotlin
+// Use Camera2Interop to set Camera2-specific capture options
+val extender = Camera2Interop.Extender(imageCaptureBuilder)
+extender.setCaptureRequestOption(
+  CaptureRequest.CONTROL_AE_MODE,
+  CaptureRequest.CONTROL_AE_MODE_OFF
+).setCaptureRequestOption(
+  CaptureRequest.FLASH_MODE,
+  CaptureRequest.FLASH_MODE_TORCH
+)
+```
+
+<br />
+
+*** ** * ** ***
+
+## Follow constraints
+
+- **Don't open the CameraDevice manually** : Let CameraX manage device opening and closing using `bindToLifecycle`.
+- **Don't forget to close `ImageProxy`** : In both `ImageCapture` and `ImageAnalysis` callbacks, you **must** call `image.close()`. Failure to do so will block the camera pipeline.
+- **Don't block the ImageAnalysis thread** : The analyzer runs frame-by-frame. If you need to perform heavy computations, offload them to a background worker and close the `ImageProxy` as soon as possible.

--- a/platforms/android/.agents/skills/camerax/references/expert-blueprints.md
+++ b/platforms/android/.agents/skills/camerax/references/expert-blueprints.md
@@ -1,0 +1,58 @@
+Complex camera features often fail due to "Agent Stall" or timeouts when
+attempted in a single turn. Use these blueprints to break tasks into manageable
+phases.
+
+## Manual controls
+
+### Phase one: ViewModel and state
+
+1. Define a `ManualSettings` data class.
+2. Add a `MutableStateFlow<ManualSettings>` to your `CameraViewModel`.
+3. Implement the Jetpack Compose UI with sliders and switches to update this flow.
+
+### Phase two: Controller wiring
+
+1. In `CameraController.kt`, create a new function `updateManualSettings(settings: ManualSettings)`.
+2. Map these settings into the `CameraSystem` layer.
+
+### Phase three: CameraX `Camera2Interop` wiring
+
+1. In `CameraSession.kt`, use the `Camera2Interop.Extender` utility to access Camera2 capture request keys.
+2. Apply the hardware keys:
+   - `CaptureRequest.SENSOR_SENSITIVITY` to set ISO sensitivity.
+   - `CaptureRequest.SENSOR_EXPOSURE_TIME` to set exposure time.
+   - `CaptureRequest.LENS_FOCUS_DISTANCE` to set focus distance.
+3. **Critical** : If manual exposure is active, set `CaptureRequest.CONTROL_AE_MODE` to `CameraMetadata.CONTROL_AE_MODE_OFF`. ---
+
+## RAW and JPEG capture
+
+### Phase one: Output configuration
+
+1. Verify device support for RAW capture using `CameraInfo`.
+2. Configure `ImageCapture.Builder` with `OUTPUT_FORMAT_RAW_JPEG` or `OUTPUT_FORMAT_RAW`.
+
+### Phase two: Implementation
+
+1. Provide `ImageCapture.OutputFileOptions` for the target storage locations.
+2. Invoke `takePicture`. CameraX internally manages `DngCreator` to wrap RAW data with the required `CameraCharacteristics` and `CaptureResult` metadata.
+
+*** ** * ** ***
+
+## Apply image effects
+
+### Phase one: Effects selection
+
+1. Use the `androidx.media3:media3-effect` dependency.
+2. Use `RgbFilter` or `HslAdjustment` for standard color grading.
+
+### Phase two: Application
+
+1. Configure `Composition.Builder` or `MediaItem.Builder` with the list of effects.
+2. Inject the list of effects into the CameraX `Recorder` or `Preview` using the `setEffects` method.
+
+*** ** * ** ***
+
+## Low-light capture
+
+For guidance on Night Mode Extensions and Low Light Boost,
+[low-light.md](https://developer.android.com/agents/skills/camera/camerax/references/low-light).

--- a/platforms/android/.agents/skills/camerax/references/foldables.md
+++ b/platforms/android/.agents/skills/camerax/references/foldables.md
@@ -1,0 +1,83 @@
+Foldable devices introduce unique challenges for camera applications, including
+dynamic layout changes, multiple display orientations, and physical device
+postures, such as tabletop and book modes.
+
+## Manage fold states and postures
+
+| State | Posture | User interaction | Implementation goal |
+|---|---|---|---|
+| `FLAT` | Standard | Full screen preview | Conventional mobile phone layout. |
+| `HALF_OPENED` | Tabletop | Lower half for controls | Split-screen layout, viewfinder on top, controls on bottom. |
+| `HALF_OPENED` | Book | Side-by-side | Viewfinder on one panel, gallery and controls on the other. |
+
+*** ** * ** ***
+
+## Follow the implementation guide
+
+### Detect posture changes
+
+Use the Jetpack WindowManager library to observe the device's hinge state and
+fold layout.
+
+
+```kotlin
+lifecycleScope.launch {
+    lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        windowInfoTracker.windowLayoutInfo(activity)
+            .collect { layoutInfo ->
+                val displayFeature = layoutInfo.displayFeatures
+                    .filterIsInstance<FoldingFeature>()
+                    .firstOrNull()
+
+                updateCameraLayout(displayFeature)
+            }
+    }
+}
+```
+
+<br />
+
+### Handle tabletop mode
+
+In Tabletop mode, horizontal fold, you should move the viewfinder to the top
+half of the screen and the controls to the bottom half to prevent the user from
+seeing a "bent" image.
+
+- **Identify orientation:** Check `FoldingFeature.orientation`.
+- **Calculate geometry:** Use `FoldingFeature.bounds` to identify the hinge's physical location on the screen.
+- **Update UI:** Apply padding or constraints to move the `PreviewView` above the hinge.
+
+### Coordinate mapping and `Viewport`
+
+When the UI layout changes due to a fold, you **must** update the `Viewport` to
+ensure that tap-to-focus and image capture coordinates remain accurate.
+
+
+```kotlin
+val viewport = ViewPort.Builder(Rational(viewfinder.width, viewfinder.height), display.rotation)
+    .setScaleType(ViewPort.FILL_CENTER)
+    .build()
+
+val useCaseGroup = UseCaseGroup.Builder()
+    .addUseCase(preview)
+    .setViewPort(viewport)
+    .build()
+```
+
+<br />
+
+### Rear display mode
+
+Some foldables allow using the rear camera with the cover display while the
+device is unfolded.
+
+- **Verification:** If available through OEM SDKs or Android 14 (API level 34) or higher, check `DeviceState.REAR_DISPLAY_STATE`.
+- **Logic:** Handle preview detachment and reattachment on different display surfaces with varying aspect ratios.
+
+*** ** * ** ***
+
+## Foldable pitfalls
+
+- **Hinge distortion:** Don't span the camera preview across a hinge in `HALF_OPENED` state.
+- **Physical orientation:** The camera sensor's physical orientation relative to the screen often changes when you fold or unfold the device. Always rely on `CameraInfo.getSensorRotationDegrees`.
+- **Latency:** Rebinding `UseCase` objects during a fold event is expensive. Use the internal scaling of `PreviewView` before performing a full `bindToLifecycle` reconfiguration.

--- a/platforms/android/.agents/skills/camerax/references/immutability.md
+++ b/platforms/android/.agents/skills/camerax/references/immutability.md
@@ -1,0 +1,60 @@
+Many Android APIs are designed with immutability in mind to prevent race
+conditions in async environments. However, this often trips up developers used
+to mutable builder patterns.
+
+## Common immutable classes
+
+The following classes use fluent APIs that **return a new instance**. You must
+reassign the variable.
+
+| Class | Methods that return a new instance | Result if not reassigned |
+|---|---|---|
+| `PendingRecording` | `withAudioEnabled`, `asPersistentRecording` | Audio isn't recorded. |
+| `ImageCapture.Builder` | `setTargetRotation`, `setTargetResolution` | The output has the wrong orientation. |
+| `Recorder.Builder` | `setQualitySelector`, `setExecutor` | The recording uses the default quality. |
+| `Viewport.Builder` | `setScaleType`, `setLayoutDirection` | The viewfinder is stretched. |
+
+## Use standard patterns
+
+### CameraX video recording
+
+To set up video recording, use the following code:
+
+
+```kotlin
+// WRONG
+run {
+  val pending = recorder.prepareRecording(context, opts)
+  pending.withAudioEnabled() // This returns a new instance which is ignored
+  val active = pending.start(exec, listener)
+}
+
+// CORRECT
+run {
+  val pending = recorder.prepareRecording(context, opts)
+      .withAudioEnabled() // Chaining works
+  val active = pending.start(exec, listener)
+}
+
+// ALSO CORRECT
+run {
+  var pending = recorder.prepareRecording(context, opts)
+  pending = pending.withAudioEnabled() // Reassignment
+  val active = pending.start(exec, listener)
+}
+```
+
+<br />
+
+### Viewport construction
+
+To set up the viewport, use the following code:
+
+
+```kotlin
+val viewport = ViewPort.Builder(Rational(width, height), displayRotation)
+    .setScaleType(ViewPort.FILL_CENTER)
+    .build()
+```
+
+<br />

--- a/platforms/android/.agents/skills/camerax/references/low-light.md
+++ b/platforms/android/.agents/skills/camerax/references/low-light.md
@@ -1,0 +1,124 @@
+This guide covers implementing low-light features using **Night mode
+extensions** and **Low Light Boost (LLB)**.
+
+## Choosing the right tool
+
+| Feature | Used for | Implementation | UX impact |
+|---|---|---|---|
+| **Night mode** | High-quality stills | `ExtensionsManager` | Possibly requires user to hold still for several seconds. |
+| **LLB, AE mode** | Real-time preview or video | `Camera2Interop`, CameraX utility | Hardware drops the frame rate to increase brightness. |
+| **LLB, Play services** | Real-time preview and video | `SurfaceProcessor` | Software-based brightening; maintains a higher frame rate. |
+
+*** ** * ** ***
+
+## Night mode extension
+
+CameraX Extensions provide access to the device's built-in computational
+photography pipeline.
+
+### Basic setup
+
+To set up the extension, initialize the extension manager:
+
+
+```kotlin
+// Use ListenableFuture.await() extension function for coroutine support
+val extensionsManager = ExtensionsManager.getInstanceAsync(context, cameraProvider).await()
+if (extensionsManager.isExtensionAvailable(cameraSelector, ExtensionMode.NIGHT)) {
+    val nightSelector = extensionsManager.getExtensionEnabledCameraSelector(
+        cameraSelector, ExtensionMode.NIGHT
+    )
+    cameraProvider.bindToLifecycle(lifecycleOwner, nightSelector, imageCapture, preview)
+}
+```
+
+<br />
+
+### Comprehensive features
+
+- **Image postview** : Display a low-resolution image immediately while the multi-frame processing occurs.
+
+  ```kotlin
+  val imageCapture = ImageCapture.Builder()
+      .setPostviewEnabled(true)
+      .build()
+  ```
+- **Extension strength** : Let users control the intensity of the night effect.
+
+  ```kotlin
+  // Set the strength of the active extension (e.g. NIGHT mode intensity)
+  val extensionsManager = ExtensionsManager.getInstanceAsync(context, cameraProvider).await()
+  val extensionsControl = extensionsManager.getCameraExtensionsControl(camera.cameraControl)
+  extensionsControl?.setExtensionStrength(strength)
+  ```
+- **Capture progress** : Show a UI progress bar for long exposures.
+
+  ```kotlin
+  // Use the suspend extension function for takePicture to avoid callback boilerplate
+  try {
+      val result = imageCapture.takePicture(outputOptions)
+      // Use result.savedUri or other fields
+  } catch (e: ImageCaptureException) {
+      // Handle capture failure
+  }
+  ```
+
+*** ** * ** ***
+
+## Low-light boost
+
+LLB is designed for preview and video streams where you prefer high frame rates.
+
+### AE mode
+
+The built-in CameraX way to prioritize brightness. It modifies the hardware's
+auto-exposure algorithm.
+
+- **Activation** : Use `CameraControl.enableLowLightBoostAsync`.
+- **Implementation** :
+
+  ```kotlin
+  // Enable Low Light Boost (LLB) natively in CameraX 1.4+
+  camera.cameraControl.enableLowLightBoostAsync(true)
+  ```
+- **Monitoring** : Observe `CameraInfo.lowLightBoostState` to track when the hardware actively applies the enhancement.
+
+### Google Play services LLB
+
+It's a multi-step implementation that uses a session-based `SurfaceProcessor`.
+
+**Dependency** : `com.google.android.gms:play-services-camera-low-light-boost`
+
+To implement Google Play services LLB, follow these core steps:
+
+1. **Initialize client** : `val client = LowLightBoost.getClient`.
+2. **Implement `SurfaceProcessor`** :
+   - **Manage session** : Call `client.createSession`.
+   - **Forward required metadata** : Observe the camera's `TotalCaptureResult` stream and forward every result to the session: `session.processCaptureResult`.
+   - **Provide surface** : Get the input surface from the session, `session.getCameraSurface`, and provide it to the camera's `SurfaceRequest`.
+   - **Lifecycle** : Release the session, `session.release`, when the processor is closed or the `SurfaceRequest` completes.
+3. **Wire using `CameraEffect`** :
+
+   ```kotlin
+   val effect = SimpleCameraEffect(
+       CameraEffect.PREVIEW or CameraEffect.VIDEO_CAPTURE,
+       executor,
+       llbSurfaceProcessor
+   ) { throw it }
+
+   // Add to UseCaseGroup
+   val useCaseGroup = UseCaseGroup.Builder()
+       .addUseCase(preview)
+       .addUseCase(videoCapture)
+       .addEffect(effect)
+       .build()
+   ```
+4. **Scene detection** : Use `session.setSceneDetectorCallback` to receive `boostStrength` updates for real-time UI indicators.
+
+*** ** * ** ***
+
+## Implementation notes
+
+- **Thread safety** : Always handle `ExtensionsManager` and `LowLightBoostClient` initialization asynchronously.
+- **FPS trade-offs**: AE mode LLB often drops the frame rate significantly to increase brightness.
+- **Compatibility** : Extensions, Night Mode, possibly conflict with `ConcurrentCamera`. Always verify support before binding.

--- a/platforms/android/.agents/skills/camerax/references/mlkit-spatial.md
+++ b/platforms/android/.agents/skills/camerax/references/mlkit-spatial.md
@@ -1,0 +1,75 @@
+When you use ML Kit for features such as face mesh, object detection, or pose
+detection, the most common failure point is the coordinate disparity between the
+analysis image and the viewfinder UI.
+
+## The mapping mindset
+
+| Dimension | Analysis frame | Viewfinder UI on the screen |
+|---|---|---|
+| Resolution | Fixed, such as 640x480 | Dynamic, such as 1080x2400 |
+| Rotation | 0° for the raw buffer | 90° or 270° in portrait or landscape mode |
+| Origin | Top-left of buffer at (0,0) | Top-left of screen at (0,0) |
+
+*** ** * ** ***
+
+## Follow the implementation guide
+
+### Coordinate transformation matrix
+
+Android provides the `Viewport` and `UseCaseGroup` APIs to calculate the
+transformation matrix automatically. **Don't** calculate aspect ratio scaling
+manually.
+
+
+```kotlin
+val transform = previewView.viewPort?.let { viewPort ->
+    // Use CameraX's built-in coordinate mapper
+    viewPort.getTransformationMatrix(imageProxy.imageInfo.rotationDegrees)
+}
+```
+
+<br />
+
+### Handling the "double rotation" bug
+
+ML Kit results, bounding boxes, are relative to the **rotated buffer**. If the
+device is in portrait, the buffer is often 480x640, landscape, but the screen
+is 1080x1920.
+
+To map the coordinates, use the following workflow:
+
+1. Query `imageProxy.imageInfo.rotationDegrees`.
+2. Pass this rotation to the ML Kit `InputImage`.
+3. Use the `MappingUtils.transformRect` method to map the result `Rect` to the screen.
+
+### Face mesh and pose normalization
+
+For high-precision spatial analysis, for example, "Is the user's hand at a
+specific screen button?", use **normalized coordinates from 0.0 to 1.0**.
+
+
+```kotlin
+// Example: Converting a Pose landmark to a Screen Coordinate
+val screenX = landmark.position.x / analysisWidth * screenWidth
+val screenY = landmark.position.y / analysisHeight * screenHeight
+```
+
+<br />
+
+**Warning** : Always account for **mirrored lenses** . If the `LENS_FACING_FRONT`
+is used, you must flip the X-coordinate: `actualX = screenWidth - screenX`.
+
+### Overlays and canvas clipping
+
+Use a custom `GraphicOverlay` view on top of the `PreviewView`.
+
+- **Buffer lock** : Ensure your `GraphicOverlay` clears its canvas every time a new `ImageAnalysis` frame is processed to prevent "ghosting" of bounding boxes.
+
+*** ** * ** ***
+
+## Spatial pitfalls
+
+- **The "stretched box" bug** : Caused by assuming the Analysis Frame aspect ratio, 4:3, matches the screen aspect ratio, 21:9. Use `PreviewView.SCALE_TYPE_FILL_CENTER` and map coordinates accordingly.
+- **Latency** : If ML processing exceeds 50 ms, the bounding box trails behind the user's face.
+  - **Fix** : Use `ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST` to avoid queuing stale frames.
+- **Sensor vs. display rotation** : On some tablets, the sensor is mounted horizontally. Always query `display.rotation` and `cameraInfo.sensorRotationDegrees`.

--- a/platforms/android/.agents/skills/camerax/references/modern-apis.md
+++ b/platforms/android/.agents/skills/camerax/references/modern-apis.md
@@ -1,0 +1,42 @@
+Always prefer these various abstractions over legacy Camera2 or early CameraX
+implementations.
+
+## Compare APIs
+
+| Use case | Legacy or verbose way | Recommendation |
+|---|---|---|
+| QR or face scanning | `ImageAnalysis.Analyzer` and manual ByteBuffer math | **`MlKitAnalyzer`**, which automates coordinate mapping and multi-format support |
+| Post-processing | Custom OpenGL shaders or `SurfaceTexture` | **`Media3Effect`** for composable, declarative effects |
+| Dual camera | Manual binding of two UseCases | **`ConcurrentCamera`**, which provides built-in support in CameraX 1.3 and higher |
+| High dynamic range | Manual bit-depth and profile config | **`DynamicRange`** , which uses `DYNAMIC_RANGE_HLG10` or `SDR` |
+| Zoom and focus | `Camera2Interop` for CameraX-to-Camera2 mapping | **`CameraControl.setZoomRatio`** or **`setLinearZoom`** |
+
+## Hardware awareness
+
+Modern APIs abstract away the complexity of hardware diversity.
+
+- **`CameraSelector`** : Use `DEFAULT_BACK_CAMERA` or `DEFAULT_FRONT_CAMERA` instead of hardcoding camera IDs. Use `filter` if you need specific lens capabilities.
+- **Extensions** : Before enabling advanced modes, such as night, bokeh, and face retouch, use `ExtensionsManager` to query whether the device supports them.
+- **Foldables** : Observe `Lifecycle` and `Viewport` updates to handle posture changes, like a half-opened posture, on foldable devices.
+
+## Required dependencies
+
+Add the following dependencies to your `libs.versions.toml` file:
+
+    # CameraX ML Kit
+
+    androidx-camera-mlkit-vision = { group = "androidx.camera", name =
+    "camera-mlkit-vision", version.ref = "camerax" }
+
+    # Media3 effects
+
+    androidx-media3-effect = { group = "androidx.media3", name = "media3-effect",
+    version.ref = "media3" }
+
+    # Camera extensions
+
+    androidx-camera-extensions = { group = "androidx.camera", name =
+    "camera-extensions", version.ref = "camerax" }
+
+Refer to the official [CameraX Release Notes](https://developer.android.com/jetpack/androidx/releases/camera) for the
+stable versions.

--- a/platforms/android/.agents/skills/camerax/references/testing.md
+++ b/platforms/android/.agents/skills/camerax/references/testing.md
@@ -1,0 +1,69 @@
+Automated testing for camera features is notoriously difficult because you
+can't easily mock physical hardware, lighting, or motion. This guide provides
+patterns for reliable, hermetic camera tests.
+
+## Develop a testing mindset
+
+| Challenge | Conventional approach | Camera technical approach |
+|---|---|---|
+| **Frameworks** | `Mockito` or `MockK` | **Fakes over mocks** |
+| **Assertions** | `assertEquals`, `assertTrue` | **Google Truth, `assertThat`** |
+| **Environment** | Implied environments | **Explicit `@RunWith` annotations** |
+| **Async operations** | `Thread.sleep` | **Explicit `timeoutMillis` or `IdlingResource`** |
+
+*** ** * ** ***
+
+## Follow the implementation guide
+
+### Fakes over mocks
+
+**Don't use Mockito.** Relying on mocks for complex, rapidly changing interfaces
+like `ImageProxy` or `CameraInfo` makes tests brittle. Instead, build "Fake"
+implementations that verify state rather than behavior.
+
+
+```kotlin
+// Create a Fake ImageProxy for ML Testing (Fakes over Mocks)
+val fakeImage = FakeImageProxy(w = 640, h = 480)
+
+// Feed the fake buffer into your analyzer
+```
+
+<br />
+
+### Mock camera capabilities
+
+Use `FakeAppConfig` from `androidx.camera:camera-testing` to simulate specific
+hardware constraints in tests, such as a device without a flash.
+
+
+```kotlin
+// Use awaitInstance() extension function for coroutine-based provider retrieval
+val cameraProvider = ProcessCameraProvider.awaitInstance(context)
+```
+
+<br />
+
+### Use Truth assertions
+
+Use Google Truth, `assertThat`, instead of standard JUnit assertions. It
+provides more readable assertion chains and useful failure messages.
+
+### Test asynchronous lifecycles
+
+Camera initialization is asynchronous. Use `IdlingResource` to ensure
+your test waits for the `UseCase` to be bound before asserting.
+
+To test asynchronous lifecycles, use the following pattern:
+
+1. Wrap the `ProcessCameraProvider` initialization in a `CountDownLatch` or `IdlingResource`.
+2. Assert only after the `cameraControl` instance is non-null.
+
+*** ** * ** ***
+
+## Testing pitfalls
+
+- **Resource leaks** : To prevent "Camera in Use" errors, in your `@After` block, call `cameraProvider.unbindAll`.
+- **The "flaky initializer"**: Camera tests often fail on CI because the "Virtual Camera" takes too long to warm up. Use a sufficient explicit timeout for the first initialization.
+- **Permission blockers** : To bypass the system permission dialogs, in your Espresso tests, use `GrantPermissionRule`.
+- **Resolution mismatch** : Tests on emulators often default to 640x480. Ensure your `ResolutionSelector` handles this low-res fallback correctly.

--- a/platforms/android/.agents/skills/camerax/references/thermals.md
+++ b/platforms/android/.agents/skills/camerax/references/thermals.md
@@ -1,0 +1,85 @@
+Camera operations are among the most power-intensive tasks on mobile devices.
+Without proactive management, the system throttle hardware, drop frames, or
+force-close the camera app.
+
+## The thermal management strategy
+
+| Priority | Strategy | Implementation |
+|---|---|---|
+| **1. Inform** | Use case hints | Provide `StreamUseCase` to allow the OS to optimize hardware. |
+| **2. Monitor** | Thermal state listener | Observe `PowerManager.addThermalStatusListener`. |
+| **3. Act** | Graceful degradation | Dynamically reduce FPS, resolution, or disable demanding effects such as HDR. |
+
+*** ** * ** ***
+
+## Follow the implementation guide
+
+### Stream use case optimization
+
+Android 13 (API level 33) introduced `StreamUseCase`. This is the **single most
+effective** way to tell the hardware how to balance quality versus power.
+
+
+```kotlin
+// In CameraX: Set the hint on your Use Case
+val preview = Preview.Builder()
+    .setTargetName("Preview")
+    .apply {
+        Camera2Interop.Extender(this).setStreamUseCase(
+            CameraMetadata.SCALER_AVAILABLE_STREAM_USE_CASES_VIDEO_CALL.toLong()
+        )
+    }
+    .build()
+```
+
+<br />
+
+Review the following key use cases for stream optimization:
+
+- `PREVIEW`: This option is the default and provides a balanced configuration.
+- `STILL_CAPTURE`: This option provides high-quality capture for short bursts.
+- `VIDEO_RECORD`: This option maintains sustained power and is optimized for encoding.
+- `VIDEO_CALL`: This option minimizes power consumption for long-duration sessions.
+
+### Monitor thermal status
+
+Don't wait for a crash. Monitor the `PowerManager` status and react before
+`THERMAL_STATUS_CRITICAL`.
+
+
+```kotlin
+val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+powerManager.addThermalStatusListener { status ->
+    when (status) {
+        PowerManager.THERMAL_STATUS_MODERATE -> {
+            // Signal to UI: "Device is warming up"
+        }
+        PowerManager.THERMAL_STATUS_SEVERE -> {
+            // ACTION: Reduce Frame Rate from 60fps to 30fps
+            // ACTION: Disable HDR or High-Quality Post-processing
+        }
+        PowerManager.THERMAL_STATUS_CRITICAL -> {
+            // ACTION: Close the camera session to prevent hardware damage
+        }
+    }
+}
+```
+
+<br />
+
+### Graceful degradation tiers
+
+| Tier | Action | User impact |
+|---|---|---|
+| **Mild** | Stop background analysis using ML Kit | Minimal |
+| **Moderate** | Cap frame rate to 30 FPS | Noticeable but smooth |
+| **Severe** | Drop resolution from 1080p to 720p | Significant visual change |
+| **Critical** | Shut down the session | App unusable in safe mode |
+
+*** ** * ** ***
+
+## Thermal pitfalls
+
+- **The "double work" bug**: Don't run two high-resolution streams---such as a preview and a video capture stream---at different aspect ratios unless necessary. This forces the image signal processor (ISP) to perform double the scaling work, which generates excessive heat.
+- **Surface overload** : Don't use multi-step `SurfaceProcessor` or `Media3Effect` chains during `THERMAL_STATUS_SEVERE`.
+- **Flash heat** : Flash or torch usage generates high thermal load. Proactively disable the flash if thermal status is `SEVERE`.

--- a/platforms/android/.agents/skills/camerax/references/wear-os.md
+++ b/platforms/android/.agents/skills/camerax/references/wear-os.md
@@ -1,0 +1,76 @@
+Developing camera features for Wear OS is rarely about the watch's own lens, if
+it even has one. It's almost always about creating a **Remote Viewfinder** to
+control the phone's camera.
+
+## The Wear OS remote mindset
+
+| Feature | Phone camera app | Wear OS remote app |
+|---|---|---|
+| **Screen** | Rectangular (Large) | **Circular and less than 2 inches in size** |
+| **Connectivity** | Local Hardware | **Bluetooth or Wi-Fi data layer API** |
+| **Latency** | Direct and less than 20 ms | **Networked, 100 ms to 500 ms** |
+| **Interaction** | Multi-touch gestures | **Rotary input or single taps** |
+
+*** ** * ** ***
+
+## Follow the implementation guide
+
+### The circular UI challenge
+
+Wear OS devices are often round. Standard rectangular layouts clip corner
+buttons.
+
+Follow these blueprint recommendations:
+
+- Use `Horologist` or `Wear Compose` libraries.
+- Use `ScalingLazyColumn` for lists so that items stay within the "safe zone" of the circular display.
+- **Preview scaling**: Crop the center of the rectangular phone viewfinder to fit the circular watch screen.
+
+### Stream the viewfinder
+
+You can't send a raw 60 fps stream over Bluetooth. compress and throttle.
+
+
+```kotlin
+// Example: Sending a viewfinder frame to the watch
+val bitmap = previewView.bitmap // Capture current frame
+if (bitmap != null) {
+    val compressed = compressToJpeg(bitmap, quality = 50)
+    val request = PutDataMapRequest.create("/camera/preview").apply {
+        dataMap.putAsset("image", Asset.createFromBytes(compressed))
+    }
+    Wearable.getDataClient(context).putDataItem(request.asPutDataRequest())
+}
+```
+
+<br />
+
+**Optimization** : Cap the watch preview at **10-15 fps** to preserve battery and
+bandwidth.
+
+### Remote triggers and syncing
+
+Use the `MessageClient` for low-latency commands like "Take Photo" or "Switch
+Camera."
+
+
+```kotlin
+// Watch sends a trigger to the phone
+Wearable.getMessageClient(context).sendMessage(nodeId, "/camera/capture", null)
+```
+
+<br />
+
+### Rotary input support
+
+On devices that support it, use the physical crown, Rotary Input, to control
+**Zoom** or **Exposure**.
+
+*** ** * ** ***
+
+## Wear OS pitfalls
+
+- **Corner clipping** : Placing a **Close** button in the top-right corner of a square layout makes it impossible to tap the button on a round watch display.
+- **Battery drain**: Sustained Bluetooth data transfer, viewfinder sync, drains watch battery. Proactively close the remote app if the phone screen is turned off.
+- **Node discovery** : The phone is possibly connected to multiple "Nodes" (watches, earbuds, or tablets). Ensure your `CapabilityClient` filters for the specific `camera_remote_host` capability.
+- **Disconnect handling**: If the watch disconnects, the phone camera must stop its high-power preview to save energy.

--- a/platforms/android/.agents/skills/camerax/references/xr.md
+++ b/platforms/android/.agents/skills/camerax/references/xr.md
@@ -1,0 +1,54 @@
+Developing camera features for XR devices, headsets, and AR glasses requires a
+shift from 2D pixel-pushing to 3D spatial awareness.
+
+## Understand the XR development mindset
+
+| Concept | Mobile focus | **XR focus** |
+|---|---|---|
+| **Input** | Raw camera stream | **Spatial tracking (visual-inertial odometry (VIO) or simultaneous localization and mapping (SLAM))** |
+| **Output** | Screen viewfinder | **Stereo passthrough and occlusion** |
+| **Constraint** | Battery life | **Motion-to-photon latency (less than 20 ms)** |
+
+*** ** * ** ***
+
+## Follow the implementation guide
+
+### API selection
+
+On XR devices, standard `CameraX` implementations are often restricted or
+insufficient. Always use spatial software development kits (SDKs):
+
+- **ARCore**: Use ARCore for plane detection, depth sensing, and motion tracking.
+- **OpenXR**: Use OpenXR as the cross-platform standard for VR and AR rendering and input.
+- **OEM SDKs**: Use manufacturer-specific libraries for hardware-accelerated passthrough.
+
+### Handle spatial passthrough
+
+Unlike a 2D viewport, XR passthrough is often system-managed.
+
+**\[Key requirement\] Frame synchronization**: Synchronize your application's
+frame clock with the headset's head-mounted display (HMD) pose.
+
+```kotlin
+// Example: Querying the spatial pose for the current camera frame
+val headPose = xrSession.getHeadPose(frameTime)
+val projectionMatrix = headPose.getProjectionMatrix(eyeIndex)
+```
+
+<br />
+
+### Manage depth and occlusion
+
+Digital content must respect real-world depth to ensure accurate occlusion.
+
+- **Depth map** : Access raw depth data using `ARCore` or `SurfaceProcessor` to create an occlusion mask.
+- **Hardware buffers** : Use `HardwareBuffer` to share camera frames directly with the GPU without CPU-side copies to minimize latency.
+
+*** ** * ** ***
+
+## XR pitfalls
+
+- **The nausea limit**: Any processing that delays the viewfinder by more than 20 ms causes user sickness. Don't perform image processing on the main thread.
+- **Privacy restrictions** : Some XR devices return a black frame if you attempt to record the "Passthrough" layer. Check `Session.isRecordingSupported`.
+- **Field of view (FOV)**: The camera FOV possibly doesn't match the display FOV. Use the SDK's projection matrixes instead of calculating aspect ratios manually.
+- **Front buffer rendering** : If the device supports it, use `FrontBufferRenderer` for real-time overlays to bypass standard double-buffering latency.

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/SKILL.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/SKILL.md
@@ -1,0 +1,337 @@
+---
+name: display-glasses-with-jetpack-compose-glimmer
+description: Provides guidelines for developing projected Android XR apps for display
+  glasses using the Jetpack Compose Glimmer UI toolkit. This skill covers foundational
+  Glimmer design principles, workflows for implementing Jetpack Compose Glimmer, and
+  interaction models for the glasses form factor. Use this skill to build an Android
+  XR Augmented Experience app with Jetpack Compose Glimmer that adheres to the Glimmer
+  design system for optimized glasses styling.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-07-09'
+  keywords:
+  - Jetpack Compose Glimmer
+  - audio glasses
+  - display glasses
+  - Projected Activity
+  - GlimmerTheme
+  - Additive Display
+  - Android XR - Augmented Experiences
+---
+
+## Glossary
+
+| Term | Definition |
+|---|---|
+| **Intelligent Eyewear** | All-day wear, hands-free devices that provide access to information. Equipped with speakers, a camera, and a microphone. Some are audio-only (audio glasses), and some also have a display (display glasses). |
+| **Display Glasses** | Audio glasses with the addition of a small, private display for glanceable visuals that harmonize with audio output. |
+| **Jetpack Compose Glimmer** | A Compose UI toolkit for building augmented Android XR experiences, optimized for display glasses. It provides components, theming, and behaviors for transparent displays. |
+| **Projected Activity (Glasses Activity)** | An Android `Activity` that runs on a host device (phone) but its UI and interactions are projected to a connected, intelligent eyewear device (audio or display glasses). |
+| **Projected Device** | An XR device connected to an Android-powered device (host). Host projects the application content to the Projected device and let users interact with it. |
+| **GlimmerTheme** | The root provider for styling tokens, including GlimmerColors, GlimmerTypography, and GlimmerShapes. |
+| **Additive Display** | A display technology where black (#000000) is rendered as 100% transparent. UI is built by adding light to the environment. Display glasses have an additive display. |
+| **Augmented Experiences** | Android XR experiences that enhance a user's focus and presence in the real world. They are lightweight and additive, helping users while they are on-the-go |
+| **Visual Angle** | A unit of measurement for perceived size in XR. The minimum readable text size is 0.6 degrees (approx. 18sp at 1 m). |
+
+## Prerequisites
+
+- Mobile project must target `compileSdk` 37 or higher. If the `compileSdk` is lower than 37, increase the `compileSdk` to 37.
+- Ensure you are using the latest library dependencies from [Create your first
+  activity for intelligent eyewear](https://developer.android.com/develop/xr/jetpack-xr-sdk/ai-glasses/first-activity).
+
+## Core Constraints
+
+- **Don't:** Use `MaterialTheme` or Material Components.
+- **Do:** Use `GlimmerTheme` and Jetpack Compose Glimmer Components.
+- **Do:** Use `createGoogleSansFlexTypography()` from `androidx.xr.glimmer:glimmer-google-fonts` as the `Typography` value for `GlimmerTheme` to ensure that consistent typography is applied throughout the components.
+
+## Limitations
+
+- Specific hardware device models or their unique capabilities are not detailed.
+- **Elevation:** Standard Material 3 shadow or elevation modifiers are not supported. You must use `ShadowScope` or `Depth` tokens from Jetpack Compose Glimmer.
+- **Minimum Size:** The absolute minimum size for readable text is 18sp (0.6°). Anything smaller will fail legibility checks.
+- **Text Weight:** Avoid "Thin" or "Hairline" weights; they cause shimmering and aliasing on additive AR lenses.
+
+## 1. Set up dependencies
+
+- **Setup Projected Activity:** First, you need to create a new projected activity for your app. If the project doesn't already have one, see [Create
+  your first activity for intelligent eyewear](https://developer.android.com/develop/xr/jetpack-xr-sdk/ai-glasses/first-activity). Use [references/projectedcontext-source.md](references/projectedcontext-source.md) to launch the Glasses Projected activity on the Projected Device. Ensure that you specify `xr_projected` for the `android:requiredDisplayCategory` attribute in app manifest to tell the system that this activity will use a projected context to access hardware from a connected device.
+- **Mobile App Integration:** If the project contains an existing mobile app, you must create a new Glasses Activity dedicated to rendering Glimmer UI. For detailed configuration, heavily reference [Create your first activity
+  for intelligent eyewear](https://developer.android.com/develop/xr/jetpack-xr-sdk/ai-glasses/first-activity). If there isn't already a method to launch the Glasses Activity, add a button to the existing mobile app UI labeled "Launch on Glasses" that uses `ProjectedContext` to launch the Glasses Activity on the glasses. Always keep this button in a highly visible location, such as an overlay Floating Action Button (FAB) or the top navigation bar, to ensure users discover the projection capability. If the glasses aren't connected, disable the button. Don't launch the Glasses Activity on the phone, only on the display glasses. If it makes sense to automatically launch the Glasses Activity without an explicit launch button, then do so.
+- **UI Library:** Identify if the project has the `androidx.xr.glimmer:glimmer` library, if not it must be added to the project. See [Declaring Jetpack Compose Glimmer Dependencies](https://developer.android.com/jetpack/androidx/releases/xr-glimmer#declaring_dependencies) to fetch the latest dependency version.
+- **Theming:** All Glimmer components must be wrapped within the `GlimmerTheme` composable to ensure correct token resolution.
+- **Mandatory black background:** Display glasses use additive displays. Any non-black color in the background blocks the real world. **You must always** set a pure black background (`Modifier.background(Color.Black)`) on the root container of your Projected Activity.
+- **Font:** The default font is Google Sans Flex. Use `androidx.xr.glimmer.googlefonts` library with the default type styles unless otherwise specified. Use `createGoogleSansFlexTypography` to create a `Typography` instance with the Google Sans Flex configuration. Provide this `Typography` instance as normal through `GlimmerTheme`. Use [references/glimmersansflextypography-source.md](references/glimmersansflextypography-source.md) for configuration.
+- **Hardware Capabilities:** Different types of intelligent eyewear devices have different capabilities. To check for these at runtime, see the [Check
+  device capabilities at runtime for intelligent eyewear](https://developer.android.com/develop/xr/jetpack-xr-sdk/ai-glasses/check-capabilities).
+- **Hardware Permissions:** To request hardware permissions like the microphone and camera, see the [Request hardware permissions for
+  intelligent eyewear](references/android/develop/xr/jetpack-xr-sdk/request-hardware-permissions.md).
+- **Hardware Access:** To use the glasses camera, sensors, or access the phone's hardware, see the [Use a projected context to access hardware on
+  intelligent eyewear](references/android/develop/xr/jetpack-xr-sdk/access-hardware-projected-context.md).
+
+## 2. Minimize and translate the UI
+
+- For display glasses, build UI using components from the Jetpack Compose Glimmer framework.
+- Use depth to communicate element priority and hierarchy.
+- Design from the bottom up, trying to minimize how much of the real world you cover. Always bottom align UI to the glasses display.
+- **One Thing at a Time:** Prioritize the user's awareness of the real world. Show only one primary piece of information at a time (for example, using a `Stack`) to minimize obstruction of the user's field of view. Avoid multiple simultaneous cards.
+- **Color Contrast:** Ensure at least a 70% tone difference between foreground and background using the HCT color space. For calculation metrics, use [references/material-hct-source.md](references/material-hct-source.md).
+
+## 3. Map input controls
+
+- Map app interactions, such as tap and swipe, to the available hardware controls on the glasses, such as the touchpad.
+- Inputs are more 1-dimensional; users typically make one control input at a time.
+- Avoid nesting scrolling controls.
+- Jetpack Compose Glimmer components are designed to work with standard input methods, such as a tap or swipe on the glasses' touchpad.
+- Use System Back to dismiss temporary states or detailed views.
+- To add input, focus, tap, swipe to your Glasses UI, follow [Focus in Jetpack
+  Compose Glimmer](references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/focus.md).
+  - For a detailed breakdown of hardware inputs, see [Hardware Controls for
+    display glasses](references/android/design/ui/ai-glasses/guides/interaction/inputs.md)
+
+## 4. Build with Jetpack Compose Glimmer
+
+Jetpack Compose Glimmer is the UI toolkit for building augmented experiences on
+display glasses.
+
+### Key Features
+
+- **Glimmer Theming:** A simplified glasses-specific theme for optimal visibility.
+- **Pre-compatible Input:** Supports tap and swipe by default.
+- **Pre-built Components:** Provides optimized composables like `Card`, `ListItem`, `Button`, etc.
+
+### Focus Management in Glimmer
+
+- Jetpack Compose Glimmer uses a one-dimensional focus search.
+- Focus movement is continuous for scrollable containers and discrete for elements like a row of buttons.
+- To enable the system to automatically set initial focus, you must set the `isInitialFocusOnFocusableAvailable` flag to `true` in your activity's `onCreate` method. For more information on how to implement, see [Focus in
+  Jetpack Compose Glimmer](references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/focus.md).
+
+### Implementing Glimmer Styles
+
+Glimmer styles are accessed through the `GlimmerTheme` object. Use
+[references/glimmertheme-source.md](references/glimmertheme-source.md) for reference.
+
+| Category | Token | Value / Role |
+|---|---|---|
+| **Color** | primary | #9BBFFF (Focal color) |
+| **Color** | secondary | #4C88E9 (Focal color) |
+| **Color** | surface | #262626 (Transparent base - renders as transparent) |
+| **Color** | outline | #606460 (3.dp border color) |
+| **Shape** | Standard | `RoundedCornerShape(36.dp)` |
+| **Shape** | Small | `RoundedCornerShape(12.dp)` |
+
+#### Typography Scale (Google Sans Flex)
+
+**Strict default:** When creating Glimmer UI you must use Google Sans Flex
+unless a custom brand typeface is explicitly specified.
+**Variable Font Settings:** As Google Sans Flex is a variable font, you must
+configure the following axes:
+
+- **Roundness (`ROND`):** Always set to `100f` for the signature rounded appearance.
+- **Width (`wdth`):** Set to `100f`.
+- **Optical Size (`opsz`):** Set to `9f`.
+- **Weight (`wght`):** Use specific values for different roles (Title: `725f`, Body: `520f`, Caption: `650f`).
+
+| Style Name | Size / Line-Height | Weight Axis | Width | Roundness | Optical size |
+|---|---|---|---|---|---|
+| **Title Large** | 30.sp / 36.sp | 725 | 100 | 100 | 9 |
+| **Title Medium** | 24.sp / 32.sp | 725 | 100 | 100 | 9 |
+| **Title Small** | 20.sp / 28.sp | 725 | 100 | 100 | 9 |
+| **Body Large** | 30.sp / 36.sp | 520 | 100 | 100 | 9 |
+| **Body Medium** | 24.sp / 32.sp | 520 | 100 | 100 | 9 |
+| **Body Small** | 20.sp / 28.sp | 520 | 100 | 100 | 9 |
+| **Caption** | 18.sp / 28.sp | 650 | 100 | 100 | 9 |
+
+#### Depth Levels
+
+Simulate depth on display glasses using shadows to establish a sense of
+hierarchy through varying levels of emphasis. The Jetpack Compose Glimmer
+controls use `DepthEffect` with 5 preset `DepthEffectLevels`. Use
+[references/deptheffect-source.md](references/deptheffect-source.md) and
+[references/deptheffectlevels-source.md](references/deptheffectlevels-source.md) for reference.
+
+Some examples:
+
+| Level | Usage |
+|---|---|
+| **level1** | Standard rest state for cards and persistent background UI. |
+| **level2** | Standard focus/pressed state for buttons and interactive cards. |
+| **ExtraSmall** | 4.dp |
+
+### Implementing Jetpack Compose Glimmer Components
+
+#### Cards
+
+Cards are a fundamental surface-based container in Glimmer used to group related
+content, such as text, images, icons and actions into a single focal point. They
+establish a clear depth plane (Z-axis) in the Glasses environment, providing a
+stable background for text, images, and icons. Never embed a card within a List
+Item.
+
+##### Core Implementation Logic
+
+- **Surface Hierarchy:** Cards are designed to sit on a base surface or within a list. They provide an automatic visual feedback when focused if an `onClick` lambda is provided.
+- **Interactivity:**
+  - **IF** the entire Card serves as a single trigger (e.g., a media item or a setting): **THEN** provide an `onClick` lambda to enable focus effects.
+  - **ELSE:** Leave `onClick` as `null` if the Card contains multiple internal interactive elements (like separate buttons or switches) to avoid focus contention.
+
+##### Technical Documentation Links
+
+If you are creating a Glimmer Card component, read the:
+
+- **Developer Guidance:** [Jetpack Compose Glimmer: Cards](references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/cards.md)
+- **API Source Code:** Use [references/card-source.md](references/card-source.md).
+- **Implementation Samples:** Use [references/card-samples-source.md](references/card-samples-source.md). (Basic and Interactive Card usage)
+
+#### Buttons
+
+Buttons are the primary triggers for discrete actions in Glimmer. They are
+specifically optimized for the display glasses focus model, where a focus
+highlight is added when focus is moved to the button using the touchpad or other
+methods.
+
+##### Core Implementation Logic
+
+- There are two types of buttons to choose from in Glimmer:
+  - **Standard buttons** (Required text label with optional leading or trailing icons). Use this when there is more space in the UI, or when the meaning of the button isn't clear without text.
+  - **Icon buttons** (icon only). Only use icon buttons when the icon is clearly understandable.
+- Both icon and standard buttons have default and toggle variants:
+  - Default (use for single actions like "buy" or "navigate")
+  - Toggle (use for things with selected states like mute buttons)
+
+##### Technical Documentation Links
+
+If you are creating a Glimmer Button component, read the:
+
+- **Developer Guidance:** [Jetpack Compose Glimmer: Buttons](references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/buttons.md)
+- **API Source Code:** Use [references/button-source.md](references/button-source.md).
+- **Implementation Samples:** Use [references/button-samples-source.md](references/button-samples-source.md).
+
+#### Title Chips
+
+Chips are a pill-shaped, specialized labeling component designed to sit above a
+`Card` or a group of content to provide a title. Use title chips to display
+concise information like a short title, a name, or a status.
+
+##### Guidelines and usage
+
+- **Spatial Spacing:** When using a standalone `TitleChip` above content, you must use `TitleChipDefaults.AssociatedContentSpacing` (8.dp) to maintain the visual hierarchy.
+- **Interactivity:** Title chips are purely for informational purposes, they cannot be targeted or activated for navigation.
+- **Layout** Always center text in a title chip. Never let the title chip go to two lines, and truncate extra words. Keep the label to three words or less.
+
+##### Technical Documentation Links
+
+If you are creating a Glimmer Title Chip component, read the:
+
+- **Developer Guidance:** [Jetpack Compose Glimmer: Title Chips](references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/title-chips.md)
+- **API Source Code:** Use [references/titlechip-source.md](references/titlechip-source.md).
+- **Implementation Samples:** Use [references/titlechip-samples-source.md](references/titlechip-samples-source.md). (Title Chips above group content)
+
+#### Icons
+
+Icons are visual symbols used to represent concepts, actions, or status in a
+concise way. In Glimmer, icons and icon buttons are optimized for the XR
+environment, providing clear visibility on additive displays and gaze-responsive
+feedback for interactive elements.
+
+##### Guidelines and usage
+
+- **Sizing:** Use predefined `IconSizes` (e.g., Standard, Large) to ensure icons remain legible and meet the minimum touch target requirements for the XR environment.
+- **Interactivity:**
+  - **If** an icon serves as a trigger: **Then** you must use an `IconButton` to provide the automatic visual feedback and required tap-target padding.
+  - **ELSE:** Use a standalone `Icon` for non-interactive indicators or status symbols.
+- **Contrast:** **NEVER** use pure black (#000000) for icon tints; always use themed colors or standard Glimmer content colors to ensure the icon is visible against dark or real-world backgrounds.
+- **Icon Library** The default icon library is [Material Symbols](https://fonts.google.com/icons?icon.style=Rounded) with 600 weight, Rounded, Unfilled, unless otherwise specified.
+
+##### Technical Documentation Links
+
+If you are creating a Glimmer Icon component, read the:
+
+- **Developer Guidance:** [Jetpack Compose Glimmer: Icons](references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/icons.md)
+- **API Source Code (Icon):** Use [references/icon-source.md](references/icon-source.md).
+- **API Source Code (IconButton):** Use [references/iconbutton-source.md](references/iconbutton-source.md).
+- **API Source Code (IconSizes):** Use [references/iconsizes-source.md](references/iconsizes-source.md).
+
+#### Lists
+
+Lists are containers that allow you to navigate between and see multiple items
+on glasses. If your use case works with only seeing one item in the list at a
+time, use a Glimmer Stack. Use lists with a Title Chip when the list
+items are similar in type. Also use a Glimmer Stack if the items are of
+different types.
+
+##### Guidelines and usage
+
+- **ListItem Slots:** Use the `ListItem` composable for rows. It provides predefined slots. Use [references/listitem-source.md](references/listitem-source.md) for reference.
+- **Visual Consistency:** When building lists of similar items, always use a consistent background color (typically `GlimmerTheme.colors.surface`) and corner radius (standard 36.dp) for every item. Don't vary these unless you are visually grouping different *types* of content.
+- **Integrated Title Chips:** Glimmer Lists support integrated title chips. **IF** you need a section header within a list: **THEN** enable the integrated title chip rather than adding a standalone `TitleChip` to maintain spatial consistency.
+- **Vertical Arrangement:** ALWAYS use `verticalArrangement =
+  Arrangement.spacedBy(20.dp)` for `VerticalList` to ensure visual separation between items on the glasses display.
+- Be sure to use the default 20 dp spacing between list items unless otherwise specified.
+
+##### Technical Documentation Links
+
+If you are creating a Glimmer List component, read the:
+
+- **API Source Code (List):** Use [references/list-source.md](references/list-source.md).
+- **API Source Code (ListItem):** Use [references/listitem-source.md](references/listitem-source.md).
+- **API Source Code (ListState):** Use [references/liststate-source.md](references/liststate-source.md).
+
+#### Stacks
+
+A stack is a collapsed list that only displays one piece of content at a time,
+in a stacked visual, such as a card. If it is useful to show more than one item
+at a time, use the Glimmer List control. Don't use a title chip with a stack.
+If the items are of different types use a stack to show them. If the items are
+of the same type, use a list.
+
+##### Guidelines and usage
+
+**Layout tips**
+
+- Stacks accept variable height items.
+- Align your stack control with the bottom of the display.
+- The stack control must be 66 dp taller than the tallest item in the stack, allowing room for the scrim and minimizing movement when navigating between items.
+- **Clipping and Layering:** To ensure that items behind the top item are correctly clipped and hidden, you **must** apply the `.itemDecoration(CardDefaults.shape)` modifier to the `Card` (or relevant container) inside every `item` block.
+- **Depth Shadows:** To maintain spatial separation and element priority, utilize Glimmer's `ShadowScope`, `DepthEffect`, or prescribed `DepthEffectLevels` for depth plane scaling.
+
+##### Technical Documentation Links
+
+If you are creating a Glimmer Stack component, read the:
+
+- **API Source Code (Stack):** Use [references/stack-source.md](references/stack-source.md).
+- **API Source Code (StackState):** Use [references/stackstate-source.md](references/stackstate-source.md).
+- **API Source Code (StackItemScope):** Use [references/stackitemscope-source.md](references/stackitemscope-source.md).
+
+#### Text
+
+In Jetpack Compose Glimmer, the [`Text`](references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/text.md) component builds off the Compose
+text component, and lets you set various text properties. Be sure to choose a
+style from the `GlimmerTheme` for your text. Modify the theme for your
+application if you want custom typography.
+
+##### Essential Constraint: Glimmer Text versus Material Text
+
+On transparent Display Glasses (additive displays), standard Material `Text`
+resolves to dark foreground tokens which render as transparent and invisible.
+Glimmer `Text` intelligently manages theme color matching. When no manual color
+override is specified, Glimmer `Text` automatically defaults to the content
+color provided by the nearest Glimmer surface.
+
+- **Don't:** Use Material Text
+- **Do:** Use Glimmer Text
+
+#### Surface
+
+`Surface` is a fundamental building block in Glimmer. Use
+[references/surface-source.md](references/surface-source.md) for reference.
+
+A surface represents a distinct visual area or 'physical' boundary for
+components such as buttons and cards. Use it if you need to build a custom
+component.
+
+## 5. Integrate with system UI
+
+- For a detailed breakdown of notifications on intelligent eyewear, see [Understand notification behavior for intelligent eyewear](https://developer.android.com/develop/xr/jetpack-xr-sdk/ai-glasses/notifications/behavior) and learn how to [Start a glasses activity on display glasses from a notification](https://developer.android.com/develop/xr/jetpack-xr-sdk/ai-glasses/notifications/start-activity).

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/design/ui/ai-glasses/guides/interaction/inputs.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/design/ui/ai-glasses/guides/interaction/inputs.md
@@ -1,0 +1,67 @@
+Glasses have multiple sources and types of interaction inputs, including
+hardware and touch, physical gesture, and voice.
+
+## Hardware controls
+
+Glasses controls can vary depending on device model, but most will include a
+camera button, touchpad, display button, and power switch or button. Hardware
+controls have default interactions, and some can be remapped for your app.
+Consider that inputs for glasses are more 1-dimensional, where users can make
+one control input at a time, compared to touchscreen inputs. The glasses
+hardware controls have default interaction mapping, some of which are handled by
+the app, and others that are handled by the system.
+
+**The system will handle the following inputs:**
+
+- Camera button single press to take photos and camera button hold to take videos
+- Swiping with two fingers on the touchpad for volume
+- Touch \& hold on the touchpad and the wake word on the microphone will launch Gemini
+- System interprets swipe down on display glasses as system back.
+
+**Your app has access to the glasses:**
+
+- Microphone
+- Point-of-View (POV) camera
+- Inertial Measurement Unit (IMU)
+- Camera button double-press
+
+![Design elements should be anchored to the bottom of the
+frame.](https://developer.android.com/static/images/design/ui/glasses/guides/glasses_ixd_inputs_hardware.png)
+
+### AI Glasses
+
+
+| Input | Gesture | Interaction affect |
+|---|---|---|
+| Touchpad (1) | Tap | Play / Pause / Confirm |
+|   | Swipe | Next/Previous/Dismiss |
+|   | Swipe down | N/A |
+|   | Touch \& hold | Invoke AI |
+|   | 2-finger swipe | Volume |
+| Display button (2) | Press | N/A |
+| Camera button (3) | Press | Photo / Video end |
+|   | Touch \& hold | Video start |
+|   | Double press | Camera |
+
+<br />
+
+### AI Glasses with Display
+
+
+| Input | Gesture | Interaction affect |
+|---|---|---|
+| Touchpad (1) | Tap | Play / Pause / Confirm |
+|   | Swipe | UI Navigation |
+|   | Swipe down | Back |
+|   | Touch \& hold | Invoke AI |
+|   | 2-finger swipe | Volume |
+| Display button (2) | Press | Wake/Sleep |
+| Camera button (3) | Press | Photo / Video end |
+|   | Touch \& hold | Video start |
+|   | Double press | Camera |
+
+<br />
+
+![Design elements should be anchored to the bottom of the
+frame.](https://developer.android.com/static/images/design/ui/glasses/guides/glasses_ixd_inputs_focus.png) On
+display focus states have a visual affordances.

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/access-hardware-projected-context.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/access-hardware-projected-context.md
@@ -1,0 +1,360 @@
+Applicable XR devices This guidance helps you build experiences for these types of XR devices. [Learn about XR device types →](https://developer.android.com/develop/xr/devices) ![](https://developer.android.com/static/images/develop/xr/ai-glasses-icon.svg) Audio \&  
+Display Glasses [](https://developer.android.com/develop/xr/devices#audio-display) [Learn about XR device types →](https://developer.android.com/develop/xr/devices)
+
+<br />
+
+After you've [requested and been granted the necessary permissions](https://developer.android.com/develop/xr/jetpack-xr-sdk/request-hardware-permissions), your app
+can access the hardware on the audio glasses or display glasses. The key to
+accessing the glasses' hardware (instead of the phone's hardware), is to use a
+[projected context](https://developer.android.com/develop/xr/jetpack-xr-sdk/glasses/support-different-types#projected-context).
+
+There are two primary ways to get a projected context, depending on where your
+code is executing:
+
+## Get a projected context if your code is running in an projected activity
+
+If your app's code is running from within your [projected activity](https://developer.android.com/develop/xr/jetpack-xr-sdk/glasses/support-different-types#activity-lifecycle), its own
+activity context is already a [projected context](https://developer.android.com/develop/xr/jetpack-xr-sdk/glasses/support-different-types#projected-context). In this scenario, calls
+made within that activity can already access the glasses' hardware.
+
+## Get a projected context for code running in a phone app component
+
+If a part of your app outside of your projected activity (such as a phone
+activity or a service) needs to access the glasses' hardware, it must explicitly
+obtain a projected context. To do this, use the
+[`createProjectedDeviceContext`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#createProjectedDeviceContext(android.content.Context)) method:
+
+
+```kotlin
+@OptIn(ExperimentalProjectedApi::class)
+private fun getGlassesContext(context: Context): Context? {
+    return try {
+        // From a phone Activity or Service, get a context for the AI glasses.
+        ProjectedContext.createProjectedDeviceContext(context)
+    } catch (e: IllegalStateException) {
+        Log.e(TAG, "Failed to create projected device context", e)
+        null
+    }
+}
+```
+
+<br />
+
+### Check for validity
+
+Wrap the [`createProjectedDeviceContext`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#createProjectedDeviceContext(android.content.Context)) call within the
+[`ProjectedContext.isProjectedDeviceConnected`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#isProjectedDeviceConnected(android.content.Context,kotlin.coroutines.CoroutineContext)). While this method returns
+`true`, the projected context remains valid to the connected device, and your
+phone app activity or service (such as a `CameraManager`) can access the AI
+glasses hardware.
+
+### Clean up on disconnect
+
+The projected context is tied to the lifecycle of the connected device, so it is
+destroyed when the device disconnects. When the device disconnects,
+[`ProjectedContext.isProjectedDeviceConnected`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#isProjectedDeviceConnected(android.content.Context,kotlin.coroutines.CoroutineContext)) returns `false`. Your app
+should listen for this change and clean up any system services (such as a
+`CameraManager`) or resources that your app created using that projected
+context.
+
+### Re-initialize on reconnect
+
+When the glasses reconnect, your app can obtain another projected
+context instance using [`createProjectedDeviceContext`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#createProjectedDeviceContext(android.content.Context)), and then
+re-initialize any system services or resources using the new projected context.
+
+## Record audio with the glasses' microphone
+
+You can record audio from the glasses using two distinct methods:
+
+- Use a [projected context](https://developer.android.com/develop/xr/jetpack-xr-sdk/glasses/support-different-types#projected-context).
+- Use Bluetooth Hands-Free Profile (HFP).
+
+### Choose a recording methods
+
+The method you choose depends on whether you need high-fidelity, XR-specific
+audio processing, or standard Bluetooth audio input.
+
+| Recording method | Microphone access | Common use case |
+|---|---|---|
+| Projected Context | Multiple microphones | Recording using a projected context lets your app access multiple microphones from the glasses and its specialized hardware features, such as: - XR-specific spatialization. - Advanced denoising. - Voice separation that distinguishes between wearer's and bystander's voices. - Maintain recording access in multidevice environments even when the glasses are not the active Bluetooth device. |
+| Bluetooth HFP | Single microphone | Relies on the Bluetooth Hands-Free Profile (HFP) for immediate, out-of-the-box compatibility. In this mode, the glasses connect to the phone using standard Headset and Advanced Audio Distribution Profile (A2DP) [profiles](https://developer.android.com/develop/connectivity/bluetooth/profiles), functioning like a typical Bluetooth peripheral. If your app is already designed for standard Bluetooth recording, you can use this method to record audio from the glasses without integrating any XR-specific capabilities. |
+
+### Record audio using a projected context
+
+To record audio using a projected context, first request the required runtime
+permissions, and then record the audio using the [`AudioRecord`](https://developer.android.com/reference/kotlin/android/media/AudioRecord) API, as
+described in the following sections.
+
+#### Request runtime permissions
+
+To access multiple microphones on the glasses, you must request audio
+permissions specifically for the projected device. The standard, phone-scoped
+`RECORD_AUDIO` permission that a user has granted for your app on their mobile
+device is insufficient.
+
+Follow these steps to request the permissions:
+
+1. [Declare the `RECORD_AUDIO` permission](https://developer.android.com/develop/xr/jetpack-xr-sdk/request-hardware-permissions#declare-permissions) in your app's manifest file.
+2. Request the projected-device-scoped permissions in one of the following
+   ways, depending on where your code is executing:
+
+   - **Code executing from a projected activity** : Use the [`ActivityResultLauncher`](https://developer.android.com/reference/kotlin/androidx/activity/result/ActivityResultLauncher) with the [`ProjectedPermissionsResultContract`](https://developer.android.com/reference/kotlin/androidx/xr/projected/permissions/ProjectedPermissionsResultContract#ProjectedPermissionsResultContract()). For more information on using this method, see the [register the permissions launcher](https://developer.android.com/develop/xr/jetpack-xr-sdk/request-hardware-permissions#register) section and subsequent sections in the guide for requesting hardware permissions.
+   - **Code executing from a host phone activity** : Use [`Activity#requestPermissions(permissions, requestCode, deviceId)`](https://developer.android.com/reference/kotlin/android/app/Activity#requestpermissions_1) and provide the device ID obtained from your `projectedDeviceContext`, as described in the [understand the permission request user flow](https://developer.android.com/develop/xr/jetpack-xr-sdk/request-hardware-permissions#permissions-user-flow) section of the guide for requesting hardware permissions.
+
+#### Initialize AudioRecord with a projected context
+
+To ensure that audio is recorded from the glasses rather than the host phone,
+you must associate the `AudioRecord` object with the projected device context.
+
+The following code uses the [`AudioRecord.Builder`](https://developer.android.com/reference/kotlin/android/media/AudioRecord.Builder) and passes the
+`projectedDeviceContext` to the [`setContext`](https://developer.android.com/reference/kotlin/android/media/AudioRecord.Builder#setcontext) method:
+
+
+```kotlin
+// Initialize AudioRecord with projected device context
+val audioRecord = AudioRecord.Builder()
+    .setAudioSource(MediaRecorder.AudioSource.CAMCORDER)
+    .setAudioFormat(audioFormat)
+    .setBufferSizeInBytes(bufferSize)
+    // pass in the projected device context
+    .setContext(projectedDeviceContext)
+    .build()
+
+audioRecord.startRecording()
+```
+
+<br />
+
+##### Key points about the code
+
+- You can set the audio source to [`CAMCORDER`](https://developer.android.com/reference/kotlin/android/media/MediaRecorder.AudioSource#camcorder),
+  [`VOICE_RECOGNITION`](https://developer.android.com/reference/kotlin/android/media/MediaRecorder.AudioSource#voice_recognition), [`VOICE_COMMUNICATION`](https://developer.android.com/reference/kotlin/android/media/MediaRecorder.AudioSource#voice_communication), or
+  [`UNPROCESSED`](https://developer.android.com/reference/kotlin/android/media/MediaRecorder.AudioSource#unprocessed) to tailor the audio processing to your specific use
+  case.
+
+  For example, use `VOICE_COMMUNICATION` if your use case needs automatic
+  noise reduction. `VOICE_RECOGNITION` is processed with acoustic echo
+  cancellation (AEC). And if you need raw, unaltered audio, select
+  `UNPROCESSED` or `CAMCORDER`.
+- To ensure compatibility with the glasses, the `audioFormat` object must
+  define a sample rate of 16kHz and a channel configuration of either mono or
+  stereo (using [`CHANNEL_IN_MONO`](https://developer.android.com/reference/kotlin/android/media/AudioFormat#channel_in_mono) or [`CHANNEL_IN_STEREO`](https://developer.android.com/reference/kotlin/android/media/AudioFormat#channel_in_stereo)).
+
+- Use [`AudioRecord.getMinBufferSize()`](https://developer.android.com/reference/kotlin/android/media/AudioRecord#getminbuffersize) to determine the minimum buffer
+  size to create the `AudioRecord` object. However, to prevent audio drops
+  from the glasses, you should read from this buffer in short, frequent chunks
+  (ideally 20ms slices) rather than waiting for the entire buffer to fill.
+
+> [!WARNING]
+> **Preview:** Support for using the [`MediaRecorder`](https://developer.android.com/reference/kotlin/android/media/MediaRecorder) API with a projected context will be available in an upcoming Android Beta release.
+
+##### Clean up after use
+
+When your app no longer needs the microphone, or when the activity is stopped,
+call [`stop`](https://developer.android.com/reference/kotlin/android/media/AudioRecord#stop) and [`release`](https://developer.android.com/reference/kotlin/android/media/AudioRecord#release) on the `AudioRecord` object.
+
+##### Check for runtime permissions before recording
+
+Before calling [`startRecording`](https://developer.android.com/reference/kotlin/android/media/AudioRecord#startrecording), [verify that the user has granted the
+microphone permission for the glasses](https://developer.android.com/develop/xr/jetpack-xr-sdk/request-hardware-permissions#check-function) using the projected context.
+
+### Record audio using Bluetooth HFP
+
+To record audio using Bluetooth HFP, first request the required runtime
+permissions, and then record the audio using the [`AudioManager`](https://developer.android.com/reference/kotlin/android/media/AudioManager) API, as
+described in the following sections.
+
+#### Request permissions
+
+As with any standard Bluetooth audio device, the [`RECORD_AUDIO`](https://developer.android.com/reference/kotlin/android/Manifest.permission#record_audio),
+[`BLUETOOTH_CONNECT`](https://developer.android.com/reference/kotlin/android/Manifest.permission#bluetooth_connect), and other related permissions are controlled by the
+phone and not the connected device (such as audio glasses or display glasses).
+
+Follow these steps to request the permissions:
+
+1. [Declare following permissions](https://developer.android.com/develop/xr/jetpack-xr-sdk/request-hardware-permissions#declare-permissions) in your app's manifest file:
+
+   - [`RECORD_AUDIO`](https://developer.android.com/reference/kotlin/android/Manifest.permission#record_audio)
+   - [`BLUETOOTH_CONNECT`](https://developer.android.com/reference/kotlin/android/Manifest.permission#bluetooth_connect)
+   - [`MODIFY_AUDIO_SETTINGS`](https://developer.android.com/reference/kotlin/android/Manifest.permission#modify_audio_settings)
+2. Request both the `RECORD_AUDIO` and `BLUETOOTH_CONNECT` permissions at
+   runtime using the [standard Android permission flow](https://developer.android.com/training/permissions/requesting).
+
+#### Use AudioManager to route audio
+
+After the user has granted your app the necessary runtime permissions, use the
+[`AudioManager`](https://developer.android.com/reference/kotlin/android/media/AudioManager) API to set the communication device to
+[`TYPE_BLUETOOTH_SCO`](https://developer.android.com/reference/kotlin/android/media/AudioDeviceInfo#type_bluetooth_sco) to route the audio through Bluetooth HFP. This
+directs the system to retrieve audio from the Bluetooth peripheral.
+
+
+```kotlin
+val audioManager = context.getSystemService(AudioManager::class.java) ?: return
+val devices = audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)
+val hfpDevice = devices.find { it.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO }
+
+hfpDevice?.let { device ->
+    val audioRecord = AudioRecord.Builder()
+        .setAudioSource(MediaRecorder.AudioSource.VOICE_COMMUNICATION)
+        .setAudioFormat(audioFormat)
+        .setBufferSizeInBytes(bufferSize)
+        .build()
+
+    // Route recording to the Bluetooth device
+    audioRecord.setPreferredDevice(device)
+    audioManager.setCommunicationDevice(device)
+
+    audioRecord.startRecording()
+```
+
+<br />
+
+> [!NOTE]
+> **Note:** To learn more about Bluetooth connectivity, refer to our [documentation](https://developer.android.com/develop/connectivity/bluetooth).
+
+## Capture an image with the glasses' camera
+
+To capture an image with the glasses' camera, set up and bind the CameraX's
+[`ImageCapture`](https://developer.android.com/reference/kotlin/androidx/camera/core/ImageCapture) [use case](https://developer.android.com/media/camera/camerax#ease-of-use) to the glasses' camera using the correct
+context for your app:
+
+
+```kotlin
+private fun startCameraOnGlasses(activity: ComponentActivity) {
+    // 1. Get the CameraProvider using the projected context.
+    // When using the projected context, DEFAULT_BACK_CAMERA maps to the AI glasses' camera.
+    val projectedContext = try {
+        ProjectedContext.createProjectedDeviceContext(activity)
+    } catch (e: IllegalStateException) {
+        Log.e(TAG, "AI Glasses context could not be created", e)
+        return
+    }
+
+    val cameraProviderFuture = ProcessCameraProvider.getInstance(projectedContext)
+
+    cameraProviderFuture.addListener({
+        val cameraProvider: ProcessCameraProvider = cameraProviderFuture.get()
+        val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+
+        // 2. Check for the presence of a camera.
+        if (!cameraProvider.hasCamera(cameraSelector)) {
+            Log.w(TAG, "The selected camera is not available.")
+            return@addListener
+        }
+
+        // 3. Query supported streaming resolutions using Camera2 Interop.
+        val cameraInfo = cameraProvider.getCameraInfo(cameraSelector)
+        val camera2CameraInfo = Camera2CameraInfo.from(cameraInfo)
+        val cameraCharacteristics = camera2CameraInfo.getCameraCharacteristic(
+            CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP
+        )
+
+        // 4. Define the resolution strategy.
+        val targetResolution = Size(1920, 1080)
+        val resolutionStrategy = ResolutionStrategy(
+            targetResolution,
+            ResolutionStrategy.FALLBACK_RULE_CLOSEST_LOWER
+        )
+        val resolutionSelector = ResolutionSelector.Builder()
+            .setResolutionStrategy(resolutionStrategy)
+            .build()
+
+        // 5. If you have other continuous use cases bound, such as Preview or ImageAnalysis,
+        // you can use  Camera2 Interop's CaptureRequestOptions to set the FPS
+        val fpsRange = Range(30, 60)
+        val captureRequestOptions = CaptureRequestOptions.Builder()
+            .setCaptureRequestOption(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, fpsRange)
+            .build()
+
+        // 6. Initialize the ImageCapture use case with options.
+        val imageCapture = ImageCapture.Builder()
+            // Optional: Configure resolution, format, etc.
+            .setResolutionSelector(resolutionSelector)
+            .build()
+
+        try {
+            // Unbind use cases before rebinding.
+            cameraProvider.unbindAll()
+
+            // Bind use cases to camera using the Activity as the LifecycleOwner.
+            cameraProvider.bindToLifecycle(
+                activity,
+                cameraSelector,
+                imageCapture
+            )
+        } catch (exc: Exception) {
+            Log.e(TAG, "Use case binding failed", exc)
+        }
+    }, ContextCompat.getMainExecutor(activity))
+}
+```
+
+<br />
+
+### Key points about the code
+
+- Obtains an instance of the [`ProcessCameraProvider`](https://developer.android.com/reference/kotlin/androidx/camera/lifecycle/ProcessCameraProvider) using the [**projected device context**](https://developer.android.com/develop/xr/jetpack-xr-sdk/access-hardware-projected-context#phone-activity-service).
+- Within the projected context's scope, the glasses' primary, outward-pointing camera maps to the `DEFAULT_BACK_CAMERA` when selecting a camera.
+- A pre-binding check uses [`cameraProvider.hasCamera(cameraSelector)`](https://developer.android.com/reference/kotlin/androidx/camera/lifecycle/ProcessCameraProvider#hasCamera(androidx.camera.core.CameraSelector)) to verify that the selected camera is available on the device before proceeding.
+- Uses **Camera2 Interop** with [`Camera2CameraInfo`](https://developer.android.com/reference/kotlin/androidx/camera/camera2/interop/Camera2CameraInfo) to read the underlying [`CameraCharacteristics#SCALER_STREAM_CONFIGURATION_MAP`](https://developer.android.com/reference/kotlin/android/hardware/camera2/CameraCharacteristics#scaler_stream_configuration_map), which can be useful for advanced checks on supported resolutions.
+- A custom [`ResolutionSelector`](https://developer.android.com/reference/kotlin/androidx/camera/core/resolutionselector/ResolutionSelector) is built to precisely control the output image resolution for [`ImageCapture`](https://developer.android.com/reference/kotlin/androidx/camera/core/ImageCapture).
+- Creates an `ImageCapture` use case that is configured with a custom `ResolutionSelector`.
+- Binds the `ImageCapture` use case to the activity's lifecycle. This automatically manages the opening and closing of the camera based on the activity's state (for example, stopping the camera when the activity is paused).
+
+After the glasses' camera is set up, you can capture an image with the
+CameraX's `ImageCapture` class. Refer to the CameraX's documentation to learn
+about using [`takePicture`](https://developer.android.com/media/camera/camerax/take-photo#take_a_picture) to [capture an image](https://developer.android.com/media/camera/camerax/take-photo#take_a_picture).
+
+### Capture a video with the glasses' camera
+
+To capture a video instead of an image with the glasses' camera, replace the
+`ImageCapture` components with the corresponding [`VideoCapture`](https://developer.android.com/reference/kotlin/androidx/camera/video/VideoCapture) components
+and modify the capture execution logic.
+
+The main changes involve using a different use case, creating a different output
+file, and initiating the capture using the appropriate video recording method.
+For more information about the `VideoCapture` API and how to use it, see the
+[CameraX's video capture documentation](https://developer.android.com/media/camera/camerax/video-capture#using-videocapture-api).
+
+> [!IMPORTANT]
+> **Important:** Battery power and thermal dissipation on glasses devices is often limited. When developing for glasses, pay close attention to the requested **output format** and **resolution**, as these can severely impact system power and temperature.
+
+The following table shows the recommended resolution and frame rate depending on
+your app's use case:
+
+| Use case | Resolution | Frame rate |
+|---|---|---|
+| Video Communication | 1280 x 720 | 15 FPS |
+| Computer Vision | 640 x 480 | 10 FPS |
+| AI Video Streaming | 640 x 480 | 1 FPS |
+
+## Access a phone's hardware from a projected activity
+
+An [projected activity](https://developer.android.com/develop/xr/jetpack-xr-sdk/glasses/support-different-types#activity-lifecycle) can also access the phone's hardware (such as the
+camera or microphone) by using [`createHostDeviceContext(context)`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#createHostDeviceContext(android.content.Context)) to get
+the host device's (phone) context:
+
+
+```kotlin
+@OptIn(ExperimentalProjectedApi::class)
+private fun getPhoneContext(activity: ComponentActivity): Context? {
+    return try {
+        // From an AI glasses Activity, get a context for the phone.
+        ProjectedContext.createHostDeviceContext(activity)
+    } catch (e: IllegalStateException) {
+        Log.e(TAG, "Failed to create host device context", e)
+        null
+    }
+}
+```
+
+<br />
+
+When accessing hardware or resources that are specific to the host device
+(phone) in a hybrid app (an app containing both mobile and glasses
+experiences), you must explicitly select the correct context to make sure your
+app can access the correct hardware:
+
+- Use the [`Activity`](https://developer.android.com/reference/kotlin/android/app/Activity) context from the phone `Activity` or the [`ProjectedContext.createHostDeviceContext`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#createHostDeviceContext(android.content.Context)) to get the phone's context.
+- Don't use [`getApplicationContext`](https://developer.android.com/reference/kotlin/android/content/Context#getapplicationcontext) because the application context can incorrectly return the glasses' context if a projected activity was the most-recently-launched component.

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/buttons.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/buttons.md
@@ -1,0 +1,100 @@
+<br />
+
+
+Applicable XR devices This guidance helps you build experiences for these types of XR devices. [Learn about XR device types →](https://developer.android.com/develop/xr/devices) ![](https://developer.android.com/static/images/develop/xr/ai-glasses-icon.svg) Display Glasses [](https://developer.android.com/develop/xr/devices#audio-display) [Learn about XR device types →](https://developer.android.com/develop/xr/devices)
+
+<br />
+
+In Jetpack Compose Glimmer, a [`Button`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Button.composable) is an interactive component that's
+optimized for display glasses input, offering clear visual feedback through its
+states to guide user actions.
+
+Buttons are built on the Jetpack Compose Glimmer [surface system](https://developer.android.com/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/surface), which
+automatically handles physical properties like borders and depth.
+
+The standard button contains a text label and optional icons. You can use it for
+primary or secondary actions. There are also specialized buttons, such as [icon
+buttons](https://developer.android.com/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/icon-buttons) and [toggle buttons](https://developer.android.com/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/toggle-buttons), which are defined as separate components in
+Jetpack Compose Glimmer.
+
+### Default
+
+![](https://developer.android.com/static/images/design/ui/glasses/guides/glasses_components_buttons_anatomy_default.png) An example of some different styles of buttons in Jetpack Compose Glimmer. These examples show default, medium-sized buttons with three button states: Enabled (1), Focused (2), and Pressed (3).
+
+### Large
+
+![](https://developer.android.com/static/images/design/ui/glasses/guides/glasses_components_buttons_large.png) An example of some different styles of buttons in Jetpack Compose Glimmer. These examples show large-sized buttons with three button states: Enabled (1), Focused (2), and Pressed (3).
+
+## Anatomy
+
+A button consists of a container and a label, with optional leading and trailing
+icons.
+
+| Part | Description |
+|---|---|
+| Container | The background surface of the button. |
+| Label | The text describing the action. |
+| Icon (optional) | Leading or trailing visual indicators. |
+
+## Sizes
+
+Jetpack Compose Glimmer buttons support two size variants. These affect the
+minimum height and internal padding.
+
+| Size | Minimum height | Default usage |
+|---|---|---|
+| Medium | 48.dp | Standard actions and lists (default). |
+| Large | 72.dp | High-emphasis actions or primary screen entry points. |
+
+## States
+
+Buttons in Jetpack Compose Glimmer change their appearance to communicate their
+state.
+
+- **Enabled**: The default state for an interactive button.
+- **Focused** : When focused, the button applies a [`GlimmerTheme.depthEffectLevels.level1`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/DepthEffectLevels#level1()) and a focused border highlight.
+- **Pressed**: When activated, a semi-transparent white overlay is applied to the surface.
+- **Disabled**: The button doesn't respond to input and its visual appearance is adjusted.
+
+## Button defaults
+
+The following defaults apply to standard buttons:
+
+- By default, buttons use [`GlimmerTheme.typography.bodySmall`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Typography#bodySmall()). Make sure that text within buttons is concise and clearly describes the action.
+- The default shape for a button is [`GlimmerTheme.shapes.large`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Shapes#large()). This consistent rounding helps users identify buttons across the display glasses interface.
+
+> [!NOTE]
+> **Note:** Any modifier passed to the `Button` composable is applied to the outer layout. While [`ButtonSize`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/ButtonSize) sets the default minimum height, you can also apply custom size modifiers to control the button's final layout, such as [`Modifier.fillMaxWidth`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/fillMaxWidth.modifier).
+
+## Example: Button with text
+
+The following code creates a standard button with text:
+
+
+```kotlin
+@Composable
+fun ButtonSample() {
+    Button(onClick = {}) { Text("Send") }
+}
+```
+
+<br />
+
+## Example: Buttons with leading and trailing icons
+
+You can also add icons to the start (using `leadingIcon`) or end (using
+`trailingIcon`) of the text to provide additional context.
+
+The following code creates a button with a leading icon:
+
+
+```kotlin
+@Composable
+fun ButtonWithLeadingIconSample() {
+    Button(onClick = {}, leadingIcon = { Icon(FavoriteIcon, "Localized description") }) {
+        Text("Send")
+    }
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/cards.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/cards.md
@@ -1,0 +1,97 @@
+<br />
+
+
+Applicable XR devices This guidance helps you build experiences for these types of XR devices. [Learn about XR device types →](https://developer.android.com/develop/xr/devices) ![](https://developer.android.com/static/images/develop/xr/ai-glasses-icon.svg) Display Glasses [](https://developer.android.com/develop/xr/devices#audio-display) [Learn about XR device types →](https://developer.android.com/develop/xr/devices)
+
+<br />
+
+In Jetpack Compose Glimmer, the [`Card`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Card.composable) component serves as the primary
+container for related content, creating a clear visual boundary for digestible
+units of information. Cards are highly adaptable, supporting combinations of
+main content, optional titles, subtitles, and leading or trailing icons. Cards
+fill the maximum available width by default, are focusable, and you can also
+make them clickable. Cards support a vertical arrangement where the header image
+is top-most, followed by the title, subtitle, and body content.
+
+Cards are built on the Jetpack Compose Glimmer [surface system](https://developer.android.com/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/surface), so they
+inherit physical properties like depth effects, clipping, and consistent border
+highlights.
+![](https://developer.android.com/static/images/design/ui/glasses/guides/glasses_components_cards.png) **Figure 1.** An example of some different styles of cards in Jetpack Compose Glimmer.
+
+## Anatomy and slots
+
+A Jetpack Compose Glimmer Card is built from several specialized elements that
+let you customize its content and layout.
+
+| Slot | Description |
+|---|---|
+| Header | The top section of the card, designed to hold an image. |
+| Title and subtitle | These text fields provide the main and secondary labels for the card. The title is placed above the subtitle. |
+| Leading icon | An optional icon (typically an [`Icon`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Icon.composable)) that appears at the beginning of the card's content area. |
+| Trailing icon | An optional icon that appears at the end of the card's content area. |
+| Action | A slot for a primary interactive element, such as a [`Button`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Button.composable). |
+| Main content | The core body of the card for primary [`Text`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Text.composable) or content. |
+
+## Card defaults
+
+The following defaults apply to cards:
+
+- **Width**: Cards fill the maximum available width of the display to optimize legibility on display glasses.
+- **Minimum height** : `80.dp`
+- **Text vertical spacing** : `3.dp`
+- **Header shape** : Uses [`RoundedCornerShape`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/shape/package-summary#RoundedCornerShape(androidx.compose.ui.unit.Dp)) with `24.dp` corners
+- **Content padding** : Defaults to [`GlimmerTheme.componentSpacingValues.medium`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/ComponentSpacingValues#medium()). This affects the outermost padding around header images and the content container.
+- **Shape** : Defaults to [`GlimmerTheme.shapes.medium`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Shapes#medium()).
+- **Text rendering** : Uses the default values from
+  [`GlimmerTheme.typography`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/GlimmerTheme#typography()) for the following slots:
+
+  - Title: [`bodyMedium`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Typography#bodyMedium())
+  - Subtitle: [`caption`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Typography#caption())
+  - Main content: [`bodySmall`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Typography#bodySmall())
+
+## Example: Basic card
+
+The following code creates a basic card:
+
+
+```kotlin
+@Composable
+fun CardSample() {
+    Card { Text("This is a card") }
+}
+```
+
+<br />
+
+## Example: Complex card with multiple slots
+
+The following code shows how to use multiple slots together to build a card.
+
+
+```kotlin
+@Composable
+fun CardWithTitleAndLeadingIconAndHeaderAndAction() {
+    Card(
+        action = {
+            Button(onClick = {}, trailingIcon = { Icon(FavoriteIcon, "Localized description") }) {
+                Text("Send")
+            }
+        },
+        title = { Text("Title") },
+        leadingIcon = { Icon(FavoriteIcon, "Localized description") },
+        header = {
+            Image(MyHeaderImage, "Localized description", contentScale = ContentScale.FillWidth)
+        },
+    ) {
+        Text("This is a card with a title, leading icon, header image, and action")
+    }
+}
+```
+
+<br />
+
+### Key points about the code
+
+- Shows how to utilize various card elements, such as [`header`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Card.composable), [`title`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Card.composable), [`leadingIcon`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Card.composable), and [`action`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Card.composable), to customize the card's content and structure.
+- Uses the standard [`Card`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Card.composable#Card(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.Function0,kotlin.Function0,kotlin.Function0,kotlin.Function0,androidx.compose.ui.graphics.Shape,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,kotlin.Function0)) overload with an action because only the card (or its internal action) needs to be focusable. If you need to make the entire card surface interactive, use the [`Card`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Card.composable#Card(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.Function0,kotlin.Function0,kotlin.Function0,kotlin.Function0,androidx.compose.ui.graphics.Shape,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function0)) overload with `onClick` instead.
+- This card uses an action slot, so the card surface isn't focusable, and focus is directed to the action button instead.

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/focus.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/focus.md
@@ -1,0 +1,107 @@
+<br />
+
+
+Applicable XR devices This guidance helps you build experiences for these types of XR devices. [Learn about XR device types →](https://developer.android.com/develop/xr/devices) ![](https://developer.android.com/static/images/develop/xr/ai-glasses-icon.svg) Display Glasses [](https://developer.android.com/develop/xr/devices#audio-display) [Learn about XR device types →](https://developer.android.com/develop/xr/devices)
+
+<br />
+
+All Jetpack Compose Glimmer components are designed to work with standard input
+methods, such as a tap or swipe on the glasses' touchpad, while also being
+receptive to lower-level input commands that are specific to the hardware on
+display glasses. Jetpack Compose Glimmer components automatically handle the
+necessary input events.
+
+For standard actions like scroll and drag, use the Jetpack Compose Glimmer
+components to promote a consistent experience. However, for custom components or
+bespoke interaction behaviors, you can use existing Compose APIs like
+[`Modifier.draggable`](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier#(androidx.compose.ui.Modifier).draggable(androidx.compose.foundation.gestures.DraggableState,androidx.compose.foundation.gestures.Orientation,kotlin.Boolean,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Boolean,kotlin.coroutines.SuspendFunction2,kotlin.coroutines.SuspendFunction2,kotlin.Boolean)) or [`Modifier.scrollable`](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier#(androidx.compose.ui.Modifier).scrollable(androidx.compose.foundation.gestures.ScrollableState,androidx.compose.foundation.gestures.Orientation,kotlin.Boolean,kotlin.Boolean,androidx.compose.foundation.gestures.FlingBehavior,androidx.compose.foundation.interaction.MutableInteractionSource)).
+
+## Pointer input and focus
+
+On display glasses, pointer input can affect focus:
+
+- **Tap**: Direct interaction for activating element. Focus moves to an element when a user interacts with it.
+- **Swipe**: Used for navigation and scrolling. Unhandled swipe gestures automatically translate into focus movements, enabling seamless UI navigation without direct pointer input.
+
+<br />
+
+> [!WARNING]
+> **(Temporary requirement) Enable required input flag** :
+>
+> <br />
+>
+> Using a feature of Jetpack Compose, the system can automatically set the initial
+> focus to the very-first focusable element when the screen loads, which is often
+> the top-left item on the screen.
+>
+> This feature is still in development and isn't enabled by default. To activate
+> this feature, set the `isInitialFocusOnFocusableAvailable` flag to `true` in
+> your activity's [`onCreate()`](https://developer.android.com/reference/kotlin/android/app/Activity#onCreate(android.os.Bundle)) method.
+>
+>     import androidx.compose.ui.ExperimentalComposeUiApi
+>     import androidx.compose.ui.ComposeUiFlags
+>
+>     class GlassesActivityExample : ComponentActivity() {
+>         override fun onCreate(savedInstanceState: Bundle?) {
+>             @OptIn(ExperimentalComposeUiApi::class)
+>             ComposeUiFlags.isInitialFocusOnFocusableAvailable = true
+>             super.onCreate(savedInstanceState)
+>         }
+>     }
+>
+> <br />
+>
+<br />
+
+## Navigation behavior and order
+
+Focus movement and order change as a user navigates your app.
+
+### Focus movement
+
+On a scrollable container, focus moves continuously with a swipe on the
+touchpad. For discrete elements like a row of buttons, each swipe moves the
+focus one element at a time.
+
+### Focus order
+
+Just like in Jetpack Compose, Jetpack Compose Glimmer uses one-dimensional focus
+search. To learn more about the order of focus traversal, see [Change focus
+traversal order](https://developer.android.com/develop/ui/compose/touch-input/focus/change-focus-traversal-order#override-one-dimensional).
+
+To change the initially-focused item, you can add a top-level
+[`Modifier.focusGroup()`](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier#(androidx.compose.ui.Modifier).focusGroup()) and specify a custom `onEnter`
+[`focusProperty`](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier#(androidx.compose.ui.Modifier).focusProperties(kotlin.Function1)):
+
+    Modifier.focusProperties {
+        onEnter = {
+            initialFocus.requestFocus()
+            // Prevent focus from exiting the group
+            cancelFocusChange()
+        }
+    }
+    .focusGroup()
+
+### Scrolling containers
+
+For an optimal user experience, scrolling containers like lists should be the
+only major component on a screen. Avoid placing a scrollable list directly above
+or below other interactive elements, such as buttons, to prevent navigation
+confusion and promote smooth, predictable focus movement.
+
+## Default focus states
+
+Jetpack Compose Glimmer implements default focus states across its interactable
+components, including surfaces, cards, and list items, promoting consistent and
+clear visual feedback during user interaction.
+![](https://developer.android.com/static/images/design/ui/glasses/guides/glasses_ixd_inputs_focus.png) **Figure 1.** Three focus states in Jetpack Compose Glimmer, which are differentiated using outline-based visual feedback.
+
+- **Default** : The button's background color is derived from
+  [`GlimmerTheme.colors.surface`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Colors#surface()), its main content calculates the content
+  color of that surface.
+
+- **Focused**: The border width is increased to communicate focus.
+
+- **Focused + Pressed** : The background is set to
+  `GlimmerTheme.colors.surface` at increased opacity to communicate its
+  selected state.

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/icons.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/icons.md
@@ -1,0 +1,95 @@
+<br />
+
+
+Applicable XR devices This guidance helps you build experiences for these types of XR devices. [Learn about XR device types →](https://developer.android.com/develop/xr/devices) ![](https://developer.android.com/static/images/develop/xr/ai-glasses-icon.svg) Display Glasses [](https://developer.android.com/develop/xr/devices#audio-display) [Learn about XR device types →](https://developer.android.com/develop/xr/devices)
+
+<br />
+
+In Jetpack Compose Glimmer, the [`Icon`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Icon.composable) component is a UI element for
+rendering single-color icons. Icons intelligently handle tinting and scaling so
+that they remain legible and visually consistent with the [`GlimmerTheme`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/GlimmerTheme.composable).
+
+## Sizes
+
+While icons default to the size provided by [`LocalIconSize`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/package-summary#LocalIconSize()), you can also
+use the three icon sizes provided to set an specific size. These sizes are also
+used by default for the following contexts:
+
+| Size token | Default usage |
+|---|---|
+| `small` | For standard list items or small chips. |
+| `medium` | For standalone icons and title chips. |
+| `large` | For high-emphasis components like cards. |
+
+## Icon sources
+
+Icons can accept [`ImageVector`](https://developer.android.com/reference/kotlin/androidx/compose/ui/graphics/vector/ImageVector), [`ImageBitmap`](https://developer.android.com/reference/kotlin/androidx/compose/ui/graphics/ImageBitmap), or [`Painter`](https://developer.android.com/reference/kotlin/androidx/compose/ui/graphics/painter/Painter) as
+their source. When defining your own icons, use `ImageVector` where possible to
+promote sharp rendering at any scale on display glasses.
+
+## Color and Tinting
+
+- **Automatic tint** : The icon resolves its color based on the `LocalContentColor` provided by the parent surface `LocalContentColor` provided by the parent surface, such as a [`surface`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/surface.composable) or [`Button`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Button.composable).
+- **Manual Tinting** : Use the `tint` parameter to apply a specific color.
+- **Multicolored Assets** : For icons that should not be tinted (like multicolored brand logos), set `tint = Color.Unspecified`.
+- **Generic Images** : For photographs or generic images that don't follow icon sizing and tinting rules, use the standard [`androidx.compose.foundation.Image`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/Image.composable) instead.
+
+## Example: Basic icon within a surface
+
+The following code creates an icon placed inside a circular surface, utilizing
+the theme's primary color:
+
+
+```kotlin
+@Composable
+fun IconSampleUsage() {
+    GlimmerLazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        item { IconSizesSample() }
+        item {
+            Icon(
+                FavoriteIcon,
+                "Localized description",
+                Modifier.surface(
+                        shape = CircleShape,
+                        color = GlimmerTheme.colors.primary,
+                        border = null,
+                    )
+                    .padding(12.dp),
+            )
+        }
+    }
+}
+```
+
+<br />
+
+## Example: Icons with different sizes
+
+The following code demonstrates the different icon sizes:
+
+
+```kotlin
+@Composable
+fun IconSizesSample() {
+    val iconSizes = GlimmerTheme.iconSizes
+    Column(
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(FavoriteIcon, "Localized description", Modifier.size(iconSizes.small))
+        // medium is also the default size, defining explicitly for clarity
+        Icon(FavoriteIcon, "Localized description", Modifier.size(iconSizes.medium))
+        Icon(FavoriteIcon, "Localized description", Modifier.size(iconSizes.large))
+    }
+}
+```
+
+<br />
+
+### Key points about the code
+
+- Each icon's size is customized using [`GlimmerTheme.iconSizes`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/IconSizes) with a modifier. For icons, the default value is [`GlimmerTheme.iconSizes.medium`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/IconSizes#medium()). Use these sizes instead of hard-coding values to maintain consistency across your UI.
+- Provides a localized `contentDescription` for each icon. Always provide these descriptions unless the icon is purely decorative.

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/text.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/text.md
@@ -1,0 +1,68 @@
+<br />
+
+
+Applicable XR devices This guidance helps you build experiences for these types of XR devices. [Learn about XR device types →](https://developer.android.com/develop/xr/devices) ![](https://developer.android.com/static/images/develop/xr/ai-glasses-icon.svg) Display Glasses [](https://developer.android.com/develop/xr/devices#audio-display) [Learn about XR device types →](https://developer.android.com/develop/xr/devices)
+
+<br />
+
+In Jetpack Compose Glimmer, the [`Text`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Text.composable) component lets you set various text
+properties like color, font size, font style, font weight, font family, letter
+spacing, and text alignment.
+
+Jetpack Compose Glimmer Text is unique because it intelligently manages color
+matching. For example, if no color override is specified, the text defaults to
+the content color provided by the nearest surface that it's sitting on.
+
+## Example: Create a text heading in a box
+
+    @Composable
+    fun TextSample() {
+          Text(
+          text = "This is a sample heading",
+          style = GlimmerTheme.typography.titleLarge )
+    }
+
+### Key points about the code
+
+- Because no color is specified, this text looks at the nearest surface to pick the best readable color (usually white).
+
+## Sizing
+
+Typography scale in Jetpack Compose Glimmer is significantly larger than
+standard mobile Material Design. Styles like `TitleLarge` and `BodyLarge` are
+both `30.sp`, and the Caption is `18.sp`:
+
+| Style | Size (sp) | Weight | Line Height |
+|---|---|---|---|
+| titleLarge | 30 | 750 | 36.sp |
+| titleMedium | 24 | 750 | 28.sp |
+| titleSmall | 20 | 750 | 28.sp |
+| bodyLarge | 30 | 520 | 36.sp |
+| bodyMedium | 24 | 520 | 36.sp |
+| bodySmall | 20 | 520 | 28.sp |
+| caption | 18 | 650 | 24.sp |
+
+## Use Google Sans Flex
+
+[Google Sans Flex](https://fonts.google.com/specimen/Google+Sans+Flex?query=google+sans&preview.script=Latn) is a variable font specifically chosen for AI
+glasses that is provided as part of the Jetpack Compose Glimmer. The font's
+rounded corners and adjustable axes allow for ideal optical sizing, ensuring
+that text remains glanceable and legible. If possible, to improve consistency
+for users between your app and the system, use Google Sans Flex for all text
+displayed on display glasses.
+
+To use Google Sans Flex, [add the `glimmer-google-fonts` library to your app's
+dependencies](https://developer.android.com/develop/xr/jetpack-xr-sdk/set-up-sdk#augmented), then apply the font globally to the `GlimmerTheme`:
+
+
+```kotlin
+@Composable
+fun GoogleSansFlexTypographySample() {
+    val typography = createGoogleSansFlexTypography()
+    GlimmerTheme(typography = typography) {
+        Text("Hello World", style = GlimmerTheme.typography.titleLarge)
+    }
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/title-chips.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/title-chips.md
@@ -1,0 +1,63 @@
+<br />
+
+
+Applicable XR devices This guidance helps you build experiences for these types of XR devices. [Learn about XR device types →](https://developer.android.com/develop/xr/devices) ![](https://developer.android.com/static/images/develop/xr/ai-glasses-icon.svg) Display Glasses [](https://developer.android.com/develop/xr/devices#audio-display) [Learn about XR device types →](https://developer.android.com/develop/xr/devices)
+
+<br />
+
+In Jetpack Compose Glimmer, the [`TitleChip`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/TitleChip.composable) component is a non-interactive
+component that provides brief context or labeling for associated content, such
+as a [`Card`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Card.composable) or a [`VerticalList`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/list/VerticalList.composable).
+
+Use title chips for concise information like a short title, a category name, or
+a status indicator. Normally, you should place title chips above the content
+they describe to establish a clear structural relationship.
+![](https://developer.android.com/static/images/design/ui/glasses/guides/glasses_components_titlechip_anatomy.png) **Figure 1.** An example of a default style title chip and sticky title chip in Jetpack Compose Glimmer. Each title chip has a label (1) and an optional leading icon or entity (2).
+
+## Basic example: Create a short title chip
+
+The following code creates a basic title chip:
+
+
+```kotlin
+@Composable
+fun TitleChipSample() {
+    TitleChip { Text("Messages") }
+}
+```
+
+<br />
+
+## Example: Create a title chip with a card
+
+To use a title chip with another component, place the title chip
+[`TitleChipDefaults.associatedContentSpacing`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/TitleChipDefaults#associatedContentSpacing()) above the other component in
+the composable. The following code creates a title chip with a card:
+
+
+```kotlin
+@Composable
+fun TitleChipWithCardSample() {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        TitleChip { Text("Title Chip") }
+        Spacer(Modifier.height(TitleChipDefaults.associatedContentSpacing))
+        Card(
+            title = { Text("Title") },
+            subtitle = { Text("Subtitle") },
+            leadingIcon = { Icon(FavoriteIcon, "Localized description") },
+        ) {
+            Text("Card Content")
+        }
+    }
+}
+```
+
+<br />
+
+### Key points about the code
+
+- The title chip is centered horizontally, which is the usual alignment for a title chip placed above a card.
+- The [`Spacer`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/Spacer.composable#Spacer(androidx.compose.ui.Modifier)) has a fixed height to provide the right amount of vertical spacing between the two components. This is defined using [`TitleChipDefaults.associatedContentSpacing`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/TitleChipDefaults#associatedContentSpacing()).
+- Uses an optional `leadingIcon` to add additional visual context before the text content.
+- The title chip automatically uses the [`caption`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Typography#caption()) style for its text.
+- The title chip isn't interactive. If you need a clickable label, use a [`Button`](https://developer.android.com/reference/kotlin/androidx/xr/glimmer/Button.composable) or another interactive component.

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/request-hardware-permissions.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/android/develop/xr/jetpack-xr-sdk/request-hardware-permissions.md
@@ -1,0 +1,178 @@
+<br />
+
+
+Applicable XR devices This guidance helps you build experiences for these types of XR devices. [Learn about XR device types →](https://developer.android.com/develop/xr/devices) ![](https://developer.android.com/static/images/develop/xr/ai-glasses-icon.svg) Audio \&  
+Display Glasses [](https://developer.android.com/develop/xr/devices#audio-display) [Learn about XR device types →](https://developer.android.com/develop/xr/devices)
+
+<br />
+
+Just like on a phone, accessing sensitive hardware like the camera and
+microphone on audio glasses and display glasses requires explicit user consent.
+These are considered
+**glasses-specific permissions**, and your app must request them at runtime,
+even if it already has the corresponding permissions on the phone.
+
+## Declare the permissions in your app's manifest
+
+Before requesting permissions, you must [declare them in your app's manifest](https://developer.android.com/training/permissions/declaring)
+file using the [`<uses-permission>`](https://developer.android.com/guide/topics/manifest/uses-permission-element) element. This declaration remains the
+same whether the permission is for a phone or a glasses-specific feature, but
+you must still explicitly request it for glasses-specific hardware or
+functionality.
+
+    <manifest ...>
+        <!-- Only declare permissions that your app actually needs. In this example,
+        we declare permissions for the camera. -->
+        <uses-permission android:name="android.permission.CAMERA"/>
+        <application ...>
+            ...
+        </application>
+    </manifest>
+
+## Register the permissions launcher
+
+To request permissions for audio glasses and display glasses, first you use the
+[`ActivityResultLauncher`](https://developer.android.com/reference/kotlin/androidx/activity/result/ActivityResultLauncher) with the [`ProjectedPermissionsResultContract`](https://developer.android.com/reference/kotlin/androidx/xr/projected/permissions/ProjectedPermissionsResultContract#ProjectedPermissionsResultContract())
+method to register the permissions launcher.
+
+
+```kotlin
+// Register the permissions launcher using the ProjectedPermissionsResultContract.
+private val requestPermissionLauncher: ActivityResultLauncher<List<ProjectedPermissionsRequestParams>> =
+    registerForActivityResult(ProjectedPermissionsResultContract()) { results ->
+        if (results[Manifest.permission.CAMERA] == true) {
+            isPermissionDenied = false
+            initializeGlassesFeatures()
+        } else {
+            // Handle permission denial.
+            isPermissionDenied = true
+        }
+    }
+```
+
+<br />
+
+### Key points about the code
+
+- The code creates an [`ActivityResultLauncher`](https://developer.android.com/reference/kotlin/androidx/activity/result/ActivityResultLauncher) using the [`ProjectedPermissionsResultContract`](https://developer.android.com/reference/kotlin/androidx/xr/projected/permissions/ProjectedPermissionsResultContract#ProjectedPermissionsResultContract()) method. The callback receives a map of permission names to their granted status.
+- You need to specify which permissions your app requires, such as [`Manifest.permission.CAMERA`](https://developer.android.com/reference/kotlin/android/Manifest.permission#camera) or [`Manifest.permission.RECORD_AUDIO`](https://developer.android.com/reference/kotlin/android/Manifest.permission#record_audio).
+
+## Create the request function
+
+Next, you'll create a function that uses your app's permissions launcher to
+request the permissions from the user at runtime.
+
+
+```kotlin
+private fun requestHardwarePermissions() {
+    val params = ProjectedPermissionsRequestParams(
+        permissions = listOf(Manifest.permission.CAMERA),
+        rationale = "Camera access is required to overlay digital content on your physical environment."
+    )
+    requestPermissionLauncher.launch(listOf(params))
+}
+```
+
+<br />
+
+### Key points about the code
+
+- The `requestHardwarePermissions` function builds a [`ProjectedPermissionsRequestParams`](https://developer.android.com/reference/kotlin/androidx/xr/projected/permissions/ProjectedPermissionsRequestParams) object. This object bundles the list of permissions your app needs and the user-facing rationale. Make the rationale clear and concise to explain why your app needs these permissions.
+- Calling `launch` on the launcher triggers the [permission request user
+  flow](https://developer.android.com/develop/xr/jetpack-xr-sdk/request-hardware-permissions#permissions-user-flow).
+- Your app should handle both granted and denied results gracefully in the launcher's callback.
+
+## Create the permissions check function
+
+Next, you'll create a function that can check whether the user has granted
+permissions to your app.
+
+
+```kotlin
+private fun hasCameraPermission(): Boolean {
+    return ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) ==
+            PackageManager.PERMISSION_GRANTED
+}
+```
+
+<br />
+
+## Add the permission request logic
+
+And lastly, create the logic that uses these functions to check for and request
+the permissions at runtime.
+
+
+```kotlin
+if (hasCameraPermission()) {
+    initializeGlassesFeatures()
+} else {
+    requestHardwarePermissions()
+}
+```
+
+<br />
+
+### Key points about the code
+
+- If the user has already granted your app the required permissions, the `initializeGlassesFeatures` function is called to initialize your app's experience. This function is defined as [part of your app's activity for AI
+  glasses](https://developer.android.com/develop/xr/jetpack-xr-sdk/glasses/first-activity#create-activity).
+
+## Understand the permission request user flow
+
+When you launch a permission request using the
+[`ProjectedPermissionsResultContract`](https://developer.android.com/reference/kotlin/androidx/xr/projected/permissions/ProjectedPermissionsResultContract#ProjectedPermissionsResultContract()) method, the system initiates a
+coordinated user flow across both the glasses and the phone.
+
+<br />
+
+> [!IMPORTANT]
+> **Important:** You should call the `ProjectedPermissionsResultContract` method from an [`Activity`](https://developer.android.com/reference/kotlin/android/app/Activity) displayed on the glasses. Don't use the standard Android permission APIs (such as [`requestPermissions`](https://developer.android.com/reference/kotlin/androidx/core/app/ActivityCompat#requestPermissions(android.app.Activity,%20java.lang.String%5B%5D,%20int)) with [`ActivityResultLauncher<String>`](https://developer.android.com/reference/kotlin/androidx/activity/result/ActivityResultLauncher)) in code running on the glasses. Doing so attempts to launch a non-interactable permission dialog on the glasses, breaking the user flow.
+>
+> <br />
+>
+> If your app already has an `Activity` displayed on the phone, you should use
+> [`Activity#requestPermissions(permissions, requestCode, deviceId)`](https://developer.android.com/reference/kotlin/android/app/Activity#requestpermissions_1), where
+> the `deviceId` comes from calling the [`getDeviceId`](https://developer.android.com/reference/kotlin/android/content/Context#getdeviceid) method on the
+> [`Context`](https://developer.android.com/reference/kotlin/android/content/Context) returned by calling
+> [`ProjectedContext.createProjectedDeviceContext`](https://developer.android.com/reference/kotlin/androidx/xr/projected/ProjectedContext#createProjectedDeviceContext(android.content.Context)).
+>
+> <br />
+>
+<br />
+
+During the permissions user flow, here is what your app and the user can expect:
+
+1. **On the glasses** : An activity appears on the **projected device
+   (glasses)**, instructing the user to look at their phone to continue.
+
+   <br />
+
+   > [!WARNING]
+   > **Preview:** Currently, the instructions and rationale provided by the system are not audible to the user. To provide an audible rationale to the user, we recommend using [Text to Speech
+   > (TTS)](https://developer.android.com/develop/xr/jetpack-xr-sdk/tts). For example:
+   >
+   > <br />
+   >
+   >     tts?.speak("Please review the permission request on your host device",
+   >     TextToSpeech.QUEUE_ADD,
+   >     null,
+   >     "permission_request")
+   >
+   > <br />
+   >
+   <br />
+
+2. **On the phone** : Concurrently, an activity launches on the **host device
+   (phone)**. This screen displays the rationale string you provided and gives
+   the user the option to proceed or cancel.
+
+3. **On the phone** : If the user accepts the rationale, a modified Android
+   system permission dialog appears on the phone telling the user that they are
+   granting the permission **for the glasses** (not the phone), and the user
+   can formally grant or deny the permission.
+
+4. **Receiving the result** : After the user makes their final choice, the
+   activities on both the phone and glasses are dismissed. Your
+   [`ActivityResultLauncher`](https://developer.android.com/reference/kotlin/androidx/activity/result/ActivityResultLauncher) callback is then invoked with a map containing
+   the granted status for each requested permission.

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/button-samples-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/button-samples-source.md
@@ -1,0 +1,176 @@
+When creating a Glimmer Button component, refer to the following implementation
+samples in `ButtonSamples.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer.samples
+
+import androidx.annotation.Sampled
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.xr.glimmer.Button
+import androidx.xr.glimmer.ButtonSize
+import androidx.xr.glimmer.GlimmerTheme
+import androidx.xr.glimmer.Icon
+import androidx.xr.glimmer.Text
+import androidx.xr.glimmer.list.GlimmerLazyColumn
+
+@Composable
+fun ButtonSampleUsage() {
+    GlimmerLazyColumn(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxSize().wrapContentSize(Alignment.Center),
+    ) {
+        item { ButtonSample() }
+        item { ButtonWithLeadingIconSample() }
+        item { ButtonWithTrailingIconSample() }
+        item { ButtonWithLeadingAndTrailingIconSample() }
+        item { LargeButtonSample() }
+        item { LargeButtonWithLeadingIconSample() }
+        item { LargeButtonWithTrailingIconSample() }
+        item { LargeButtonWithLeadingAndTrailingIconSample() }
+    }
+}
+
+@Sampled
+@Composable
+fun ButtonSample() {
+    Button(onClick = {}) { Text("Send") }
+}
+
+@Sampled
+@Composable
+fun ButtonWithLeadingIconSample() {
+    Button(onClick = {}, leadingIcon = { Icon(FavoriteIcon, "Localized description") }) {
+        Text("Send")
+    }
+}
+
+@Composable
+private fun ButtonWithTrailingIconSample() {
+    Button(onClick = {}, trailingIcon = { Icon(FavoriteIcon, "Localized description") }) {
+        Text("Send")
+    }
+}
+
+@Composable
+private fun ButtonWithLeadingAndTrailingIconSample() {
+    Button(
+        onClick = {},
+        leadingIcon = { Icon(FavoriteIcon, "Localized description") },
+        trailingIcon = { Icon(FavoriteIcon, "Localized description") },
+    ) {
+        Text("Send")
+    }
+}
+
+@Sampled
+@Composable
+fun LargeButtonSample() {
+    Button(onClick = {}, buttonSize = ButtonSize.Large) { Text("Send") }
+}
+
+@Composable
+private fun LargeButtonWithLeadingIconSample() {
+    Button(
+        onClick = {},
+        buttonSize = ButtonSize.Large,
+        leadingIcon = { Icon(FavoriteIcon, "Localized description") },
+    ) {
+        Text("Send")
+    }
+}
+
+@Composable
+private fun LargeButtonWithTrailingIconSample() {
+    Button(
+        onClick = {},
+        buttonSize = ButtonSize.Large,
+        trailingIcon = { Icon(FavoriteIcon, "Localized description") },
+    ) {
+        Text("Send")
+    }
+}
+
+@Composable
+private fun LargeButtonWithLeadingAndTrailingIconSample() {
+    Button(
+        onClick = {},
+        buttonSize = ButtonSize.Large,
+        leadingIcon = { Icon(FavoriteIcon, "Localized description") },
+        trailingIcon = { Icon(FavoriteIcon, "Localized description") },
+    ) {
+        Text("Send")
+    }
+}
+
+@Preview
+@Composable
+private fun ButtonPreview() {
+    GlimmerTheme { ButtonSample() }
+}
+
+@Preview
+@Composable
+private fun ButtonWithLeadingIconPreview() {
+    GlimmerTheme { ButtonWithLeadingIconSample() }
+}
+
+@Preview
+@Composable
+private fun ButtonWithTrailingIconPreview() {
+    GlimmerTheme { ButtonWithTrailingIconSample() }
+}
+
+@Preview
+@Composable
+private fun ButtonWithLeadingAndTrailingIconPreview() {
+    GlimmerTheme { ButtonWithLeadingAndTrailingIconSample() }
+}
+
+@Preview
+@Composable
+private fun LargeButtonPreview() {
+    GlimmerTheme { LargeButtonSample() }
+}
+
+@Preview
+@Composable
+private fun LargeButtonWithLeadingIconPreview() {
+    GlimmerTheme { LargeButtonWithLeadingIconSample() }
+}
+
+@Preview
+@Composable
+private fun LargeButtonWithTrailingIconPreview() {
+    GlimmerTheme { LargeButtonWithTrailingIconSample() }
+}
+
+@Preview
+@Composable
+private fun LargeButtonWithLeadingAndTrailingIconPreview() {
+    GlimmerTheme { LargeButtonWithLeadingAndTrailingIconSample() }
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/button-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/button-source.md
@@ -1,0 +1,213 @@
+When creating a Glimmer Button component, refer to the following source code in
+`Button.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Button is a component used for exposing actions to a user.
+ *
+ * @sample androidx.xr.glimmer.samples.ButtonSample
+ *
+ * Buttons can use icons to provide more context about the action:
+ *
+ * @sample androidx.xr.glimmer.samples.ButtonWithLeadingIconSample
+ *
+ * There are multiple button size variants - providing a different [ButtonSize] will affect default
+ * values used inside this button, such as the minimum height. Note that you can still provide a
+ * size modifier such as [androidx.compose.foundation.layout.size] to change the layout size of this
+ * button, [buttonSize] affects default values and values internal to the button.
+ *
+ * @sample androidx.xr.glimmer.samples.LargeButtonSample
+ * @param onClick called when this button is clicked
+ * @param modifier the [Modifier] to be applied to this button
+ * @param enabled controls the enabled state of this button. When `false`, this button will not
+ *   respond to user input
+ * @param buttonSize the size variant of this button, represented as a [ButtonSize]. Changing
+ *   [buttonSize] will affect some default values used by this button - but the final resulting size
+ *   of the button will still be calculated based on the content of the button, and any provided
+ *   size modifiers such as [androidx.compose.foundation.layout.size]. For example, setting a 100.dp
+ *   size using a size modifier will result in the same layout size regardless of [buttonSize], but
+ *   the provided [buttonSize] will affect other properties such as padding values and the size of
+ *   icons.
+ * @param leadingIcon optional leading icon to be placed before the [content]. This is typically an
+ *   [Icon] tinted with [contentColor] by default.
+ * @param trailingIcon optional trailing icon to be placed after the [content]. This is typically an
+ *   [Icon] tinted with [contentColor] by default.
+ * @param shape the [Shape] used to clip this button, and also used to draw the background and
+ *   border
+ * @param color background color of this button
+ * @param contentColor content color used by components inside [content], [leadingIcon], and
+ *   [trailingIcon].
+ * @param border the border to draw around this button
+ * @param contentPadding the spacing values to apply internally between the container and the
+ *   content
+ * @param interactionSource an optional hoisted [MutableInteractionSource] for observing and
+ *   emitting Interactions for this button. You can use this to change the button's appearance or
+ *   preview the button in different states. Note that if `null` is provided, interactions will
+ *   still happen internally.
+ * @param content the main content, typically [Text], to display inside this button
+ */
+@Composable
+public fun Button(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    buttonSize: ButtonSize = ButtonSize.Medium,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    shape: Shape = GlimmerTheme.shapes.large,
+    color: Color = GlimmerTheme.colors.surface,
+    contentColor: Color = calculateContentColor(color),
+    border: BorderStroke? = SurfaceDefaults.border(),
+    contentPadding: PaddingValues = ButtonDefaults.contentPadding(buttonSize),
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable RowScope.() -> Unit,
+) {
+    val iconSize = ButtonDefaults.iconSize
+    val iconSpacing = ButtonDefaults.iconSpacing
+    val minHeight = ButtonDefaults.minimumHeight(buttonSize)
+
+    val depth =
+        SurfaceDepthEffect(
+            depthEffect = null,
+            focusedDepthEffect = GlimmerTheme.depthEffectLevels.level1,
+        )
+
+    val internalInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+
+    CompositionLocalProvider(LocalTextStyle provides GlimmerTheme.typography.bodySmall) {
+        Row(
+            modifier
+                .semantics { role = Role.Button }
+                .surface(
+                    enabled = enabled,
+                    shape = shape,
+                    color = color,
+                    contentColor = contentColor,
+                    depthEffect = depth,
+                    border = border,
+                    interactionSource = internalInteractionSource,
+                )
+                .clickable(
+                    enabled = enabled,
+                    interactionSource = internalInteractionSource,
+                    onClick = onClick,
+                )
+                .defaultMinSize(minHeight = minHeight)
+                .padding(contentPadding),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (leadingIcon != null) {
+                Box(Modifier.padding(end = iconSpacing)) {
+                    CompositionLocalProvider(LocalIconSize provides iconSize, content = leadingIcon)
+                }
+            }
+            content()
+            if (trailingIcon != null) {
+                Box(Modifier.padding(start = iconSpacing)) {
+                    CompositionLocalProvider(
+                        LocalIconSize provides iconSize,
+                        content = trailingIcon,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * ButtonSize represents the different size variants of a [Button]. ButtonSize will affect default
+ * values used inside a [Button], such as the minimum height and the size of icons.
+ */
+@Immutable
+@JvmInline
+public value class ButtonSize internal constructor(private val value: Int) {
+    public companion object {
+        /** ButtonSize representing a medium [Button]. This is the default size. */
+        public val Medium: ButtonSize = ButtonSize(1)
+        /** ButtonSize representing a large [Button]. */
+        public val Large: ButtonSize = ButtonSize(2)
+    }
+}
+
+/** Default values used for [Button]. */
+public object ButtonDefaults {
+    /** Default content padding used for a [Button] with the specified [buttonSize]. */
+    @Composable
+    public fun contentPadding(buttonSize: ButtonSize): PaddingValues {
+        val componentSpacingValues = GlimmerTheme.componentSpacingValues
+        return if (buttonSize == ButtonSize.Medium) {
+            PaddingValues(
+                horizontal = componentSpacingValues.large,
+                vertical = componentSpacingValues.small,
+            )
+        } else {
+            PaddingValues(componentSpacingValues.large)
+        }
+    }
+
+    /** Default minimum height for [Button] and [ToggleButton] with the specified [buttonSize]. */
+    internal fun minimumHeight(buttonSize: ButtonSize): Dp {
+        return when (buttonSize) {
+            ButtonSize.Medium -> 48.dp
+            ButtonSize.Large -> 72.dp
+            else -> throw IllegalArgumentException("Unknown size $buttonSize.")
+        }
+    }
+
+    /** Default icon size for buttons with non-icon content: [Button], [ToggleButton]. */
+    @get:Composable
+    internal val iconSize: Dp
+        get() = GlimmerTheme.iconSizes.small
+
+    /** Default spacing between icon and content for [Button] and [ToggleButton]. */
+    @get:Composable
+    internal val iconSpacing: Dp
+        get() = GlimmerTheme.componentSpacingValues.extraSmall
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/card-samples-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/card-samples-source.md
@@ -1,0 +1,296 @@
+When creating a Glimmer Card component, refer to the following implementation
+samples in `CardSamples.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer.samples
+
+import androidx.annotation.Sampled
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.BrushPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.xr.glimmer.ActionCard
+import androidx.xr.glimmer.Button
+import androidx.xr.glimmer.Card
+import androidx.xr.glimmer.GlimmerTheme
+import androidx.xr.glimmer.Icon
+import androidx.xr.glimmer.Text
+import androidx.xr.glimmer.list.GlimmerLazyColumn
+
+@Composable
+fun CardSampleUsage() {
+    GlimmerLazyColumn {
+        item { CardSample() }
+        item { CardWithTrailingIconSample() }
+        item { CardWithTitleAndSubtitleAndLeadingIconSample() }
+        item { CardWithTitleAndHeaderSample() }
+        item { ActionCardWithTitleSample() }
+        item { CardWithTitleAndLeadingIconAndHeader() }
+        item { ActionCardWithTitleAndLeadingIconAndHeader() }
+        item { CardWithLongText() }
+        item { CardWithTitleAndSubtitleAndLeadingIconLongText() }
+        item { CardWithTitleAndSubtitleAndLeadingIconAndTrailingIconLongText() }
+    }
+}
+
+@Sampled
+@Composable
+fun CardSample() {
+    Card { Text("This is a card") }
+}
+
+@Sampled
+@Composable
+fun CardWithTrailingIconSample() {
+    Card(trailingIcon = { Icon(FavoriteIcon, "Localized description") }) {
+        Text("This is a card with a trailing icon")
+    }
+}
+
+@Sampled
+@Composable
+fun CardWithTitleAndSubtitleAndLeadingIconSample() {
+    Card(
+        title = { Text("Title") },
+        subtitle = { Text("Subtitle") },
+        leadingIcon = { Icon(FavoriteIcon, "Localized description") },
+    ) {
+        Text("This is a card with a title, subtitle, and leading icon")
+    }
+}
+
+@Sampled
+@Composable
+fun CardWithTitleAndHeaderSample() {
+    Card(
+        title = { Text("Title") },
+        header = {
+            Image(MyHeaderImage, "Localized description", contentScale = ContentScale.FillWidth)
+        },
+    ) {
+        Text("This is a card with a title and header image")
+    }
+}
+
+@Sampled
+@Composable
+fun ActionCardWithTitleSample() {
+    ActionCard(action = { Button(onClick = {}) { Text("Send") } }, title = { Text("Title") }) {
+        Text("This is a card with a title and action")
+    }
+}
+
+@Sampled
+@Composable
+fun ClickableCardSample() {
+    Card(onClick = {}) { Text("This is a card") }
+}
+
+@Sampled
+@Composable
+fun ClickableCardWithTrailingIconSample() {
+    Card(onClick = {}, trailingIcon = { Icon(FavoriteIcon, "Localized description") }) {
+        Text("This is a card with a trailing icon")
+    }
+}
+
+@Sampled
+@Composable
+fun ClickableCardWithTitleAndSubtitleAndLeadingIconSample() {
+    Card(
+        onClick = {},
+        title = { Text("Title") },
+        subtitle = { Text("Subtitle") },
+        leadingIcon = { Icon(FavoriteIcon, "Localized description") },
+    ) {
+        Text("This is a card with a title, subtitle, and leading icon")
+    }
+}
+
+@Sampled
+@Composable
+fun ClickableCardWithTitleAndHeaderSample() {
+    Card(
+        onClick = {},
+        title = { Text("Title") },
+        header = {
+            Image(MyHeaderImage, "Localized description", contentScale = ContentScale.FillWidth)
+        },
+    ) {
+        Text("This is a card with a title and header image")
+    }
+}
+
+@Composable
+fun CardWithTitleAndLeadingIconAndHeader() {
+    Card(
+        title = { Text("Title") },
+        leadingIcon = { Icon(FavoriteIcon, "Localized description") },
+        header = {
+            Image(MyHeaderImage, "Localized description", contentScale = ContentScale.FillWidth)
+        },
+    ) {
+        Text("This is a card with a title, leading icon, and header image")
+    }
+}
+
+@Composable
+fun ActionCardWithTitleAndLeadingIconAndHeader() {
+    ActionCard(
+        action = {
+            Button(onClick = {}, trailingIcon = { Icon(FavoriteIcon, "Localized description") }) {
+                Text("Send")
+            }
+        },
+        title = { Text("Title") },
+        leadingIcon = { Icon(FavoriteIcon, "Localized description") },
+        header = {
+            Image(MyHeaderImage, "Localized description", contentScale = ContentScale.FillWidth)
+        },
+    ) {
+        Text("This is a card with a title, leading icon, header image, and action")
+    }
+}
+
+@Composable
+fun CardWithLongText() {
+    Card {
+        Text(
+            "This is a card with a lot of text that will wrap to multiple lines. The maximum recommend number of lines of text for a card is 10.",
+            maxLines = 10,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+fun CardWithTitleAndSubtitleAndLeadingIconLongText() {
+    Card(
+        title = { Text("Title") },
+        subtitle = { Text("Subtitle") },
+        leadingIcon = { Icon(FavoriteIcon, "Localized description") },
+    ) {
+        Text(
+            "This is a card with a lot of text that will wrap to multiple lines. The maximum recommend number of lines of text for a card is 10."
+        )
+    }
+}
+
+@Composable
+fun CardWithTitleAndSubtitleAndLeadingIconAndTrailingIconLongText() {
+    Card(
+        title = { Text("Title") },
+        subtitle = { Text("Subtitle") },
+        leadingIcon = { Icon(FavoriteIcon, "Localized description") },
+        trailingIcon = { Icon(FavoriteIcon, "Localized description") },
+    ) {
+        Text(
+            "This is a card with a lot of text that will wrap to multiple lines. The maximum recommend number of lines of text for a card is 10."
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CardPreview() {
+    GlimmerTheme { CardSample() }
+}
+
+@Preview
+@Composable
+private fun CardWithTrailingIconPreview() {
+    GlimmerTheme { CardWithTrailingIconSample() }
+}
+
+@Preview
+@Composable
+private fun CardWithTitleAndSubtitleAndLeadingIconPreview() {
+    GlimmerTheme { CardWithTitleAndSubtitleAndLeadingIconSample() }
+}
+
+@Preview
+@Composable
+private fun CardWithTitleAndHeaderPreview() {
+    GlimmerTheme { CardWithTitleAndHeaderSample() }
+}
+
+@Preview
+@Composable
+private fun ActionCardWithTitlePreview() {
+    GlimmerTheme { ActionCardWithTitleSample() }
+}
+
+@Preview
+@Composable
+private fun CardWithTitleAndLeadingIconAndHeaderPreview() {
+    GlimmerTheme { CardWithTitleAndLeadingIconAndHeader() }
+}
+
+@Preview
+@Composable
+private fun ActionCardWithTitleAndLeadingIconAndHeaderPreview() {
+    GlimmerTheme { ActionCardWithTitleAndLeadingIconAndHeader() }
+}
+
+@Preview
+@Composable
+private fun CardWithLongTextPreview() {
+    GlimmerTheme { CardWithLongText() }
+}
+
+@Preview
+@Composable
+private fun CardWithTitleAndSubtitleAndLeadingIconLongTextPreview() {
+    GlimmerTheme { CardWithTitleAndSubtitleAndLeadingIconLongText() }
+}
+
+@Preview
+@Composable
+private fun CardWithTitleAndSubtitleAndLeadingIconAndTrailingIconLongTextPreview() {
+    GlimmerTheme { CardWithTitleAndSubtitleAndLeadingIconAndTrailingIconLongText() }
+}
+
+fun placeholderImagePainter(intrinsicSize: Size): Painter =
+    BrushPainter(
+        Brush.linearGradient(
+            0.0f to Color(0xFF3C8CDE),
+            0.4f to Color(0xFFED73A8),
+            0.6f to Color(0xFFED73A8),
+            1.0f to Color(0xFFE763F9),
+            start = Offset.Zero,
+            end = Offset(intrinsicSize.width, intrinsicSize.height),
+        )
+    )
+
+/**
+ * Placeholder image with a large intrinsic size, to simulate a real life use case of loading a
+ * bitmap
+ */
+private val MyHeaderImage = placeholderImagePainter(Size(1000f, 1000f))
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/card-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/card-source.md
@@ -1,0 +1,566 @@
+When creating a Glimmer Card component, refer to the following source code in
+`Card.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastMap
+import kotlin.math.max
+
+/**
+ * Card is a component used to group related information into a single digestible unit. A card can
+ * adapt to display a wide range of content, from simple text blurbs to more complex summaries with
+ * multiple elements. A card contains text [content], and may also have any combination of [title],
+ * [subtitle], [leadingIcon], and [trailingIcon]. If specified, [title] is placed on top of the
+ * [subtitle], which is placed on top of the [content]. A card fills the maximum width available by
+ * default.
+ *
+ * This Card is focusable - see the other [Card] overload for a clickable Card.
+ *
+ * Cards can also be combined with a [TitleChip]. See the documentation for [TitleChip] for more
+ * information / sample code.
+ *
+ * A simple Card with just text:
+ *
+ * @sample androidx.xr.glimmer.samples.CardSample
+ *
+ * A Card with a trailing icon:
+ *
+ * @sample androidx.xr.glimmer.samples.CardWithTrailingIconSample
+ *
+ * A Card with a title, subtitle, and a leading icon:
+ *
+ * @sample androidx.xr.glimmer.samples.CardWithTitleAndSubtitleAndLeadingIconSample
+ *
+ * A card with a title and a header image:
+ *
+ * @sample androidx.xr.glimmer.samples.CardWithTitleAndHeaderSample
+ * @param modifier the [Modifier] to be applied to this card
+ * @param title optional title to be placed above [subtitle] and [content], below [header]
+ * @param subtitle optional subtitle to be placed above [content], below [title]
+ * @param header optional header image to be placed at the top of the card. This image should
+ *   typically fill the max width available, for example using
+ *   [androidx.compose.ui.layout.ContentScale.FillWidth]. Headers are constrained to a maximum
+ *   aspect ratio (1.6) to avoid taking up too much vertical space, so using a modifier such as
+ *   [androidx.compose.foundation.layout.fillMaxSize] will result in an image that fills the maximum
+ *   aspect ratio.
+ * @param leadingIcon optional leading icon to be placed before [content]. This is typically an
+ *   [Icon] tinted with [contentColor] by default.
+ * @param trailingIcon optional trailing icon to be placed after [content]. This is typically an
+ *   [Icon] tinted with [contentColor] by default.
+ * @param shape the [Shape] used to clip this card, and also used to draw the background and border
+ * @param color background color of this card
+ * @param contentColor content color used by components inside [content], [title], [subtitle],
+ *   [leadingIcon], and [trailingIcon].
+ * @param border the border to draw around this card
+ * @param contentPadding the spacing values to apply internally between the container and the
+ *   content. Note that there is additional padding applied around the content / text / icons inside
+ *   a card, this only affects the outermost content padding.
+ * @param interactionSource an optional hoisted [MutableInteractionSource] for observing and
+ *   emitting Interactions for this card. You can use this to change the card's appearance or
+ *   preview the card in different states. Note that if `null` is provided, interactions will still
+ *   happen internally.
+ * @param content the main content / body text to display inside this card. This is recommended to
+ *   be limited to 10 lines of text.
+ */
+@Composable
+public fun Card(
+    modifier: Modifier = Modifier,
+    title: @Composable (() -> Unit)? = null,
+    subtitle: @Composable (() -> Unit)? = null,
+    header: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    shape: Shape = CardDefaults.shape,
+    color: Color = GlimmerTheme.colors.surface,
+    contentColor: Color = calculateContentColor(color),
+    border: BorderStroke? = SurfaceDefaults.border(),
+    contentPadding: PaddingValues = CardDefaults.contentPadding,
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable () -> Unit,
+) {
+    val internalInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+    CardImpl(
+        modifier =
+            modifier
+                .surface(
+                    shape = shape,
+                    color = color,
+                    contentColor = contentColor,
+                    border = border,
+                    interactionSource = internalInteractionSource,
+                )
+                .focusable(interactionSource = internalInteractionSource),
+        title = title,
+        subtitle = subtitle,
+        header = header,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        contentPadding = contentPadding,
+        content = content,
+    )
+}
+
+/**
+ * Card is a component used to group related information into a single digestible unit. A card can
+ * adapt to display a wide range of content, from simple text blurbs to more complex summaries with
+ * multiple elements. A card contains text [content], and may also have any combination of [title],
+ * [subtitle], [leadingIcon], and [trailingIcon]. If specified, [title] is placed on top of the
+ * [subtitle], which is placed on top of the [content]. A card fills the maximum width available by
+ * default.
+ *
+ * This Card is focusable and clickable - see the other [Card] overload for a Card that is only
+ * focusable.
+ *
+ * Cards can also be combined with a [TitleChip]. See the documentation for [TitleChip] for more
+ * information / sample code.
+ *
+ * A simple clickable Card with just text:
+ *
+ * @sample androidx.xr.glimmer.samples.ClickableCardSample
+ *
+ * A clickable Card with a trailing icon:
+ *
+ * @sample androidx.xr.glimmer.samples.ClickableCardWithTrailingIconSample
+ *
+ * A clickable Card with a title, subtitle, and a leading icon:
+ *
+ * @sample androidx.xr.glimmer.samples.ClickableCardWithTitleAndSubtitleAndLeadingIconSample
+ *
+ * A clickable Card with a title and a header image:
+ *
+ * @sample androidx.xr.glimmer.samples.ClickableCardWithTitleAndHeaderSample
+ * @param onClick called when this card item is clicked
+ * @param modifier the [Modifier] to be applied to this card
+ * @param title optional title to be placed above [subtitle] and [content], below [header]
+ * @param subtitle optional subtitle to be placed above [content], below [title]
+ * @param header optional header image to be placed at the top of the card. This image should
+ *   typically fill the max width available, for example using
+ *   [androidx.compose.ui.layout.ContentScale.FillWidth]. Headers are constrained to a maximum
+ *   aspect ratio (1.6) to avoid taking up too much vertical space, so using a modifier such as
+ *   [androidx.compose.foundation.layout.fillMaxSize] will result in an image that fills the maximum
+ *   aspect ratio.
+ * @param leadingIcon optional leading icon to be placed before [content]. This is typically an
+ *   [Icon] tinted with [contentColor] by default.
+ * @param trailingIcon optional trailing icon to be placed after [content]. This is typically an
+ *   [Icon] tinted with [contentColor] by default.
+ * @param shape the [Shape] used to clip this card, and also used to draw the background and border
+ * @param color background color of this card
+ * @param contentColor content color used by components inside [content], [title], [subtitle],
+ *   [leadingIcon], and [trailingIcon].
+ * @param border the border to draw around this card
+ * @param contentPadding the spacing values to apply internally between the container and the
+ *   content. Note that there is additional padding applied around the content / text / icons inside
+ *   a card, this only affects the outermost content padding.
+ * @param interactionSource an optional hoisted [MutableInteractionSource] for observing and
+ *   emitting Interactions for this card. You can use this to change the card's appearance or
+ *   preview the card in different states. Note that if `null` is provided, interactions will still
+ *   happen internally.
+ * @param content the main content / body text to display inside this card. This is recommended to
+ *   be limited to 10 lines of text.
+ */
+@Composable
+public fun Card(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    title: @Composable (() -> Unit)? = null,
+    subtitle: @Composable (() -> Unit)? = null,
+    header: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    shape: Shape = CardDefaults.shape,
+    color: Color = GlimmerTheme.colors.surface,
+    contentColor: Color = calculateContentColor(color),
+    border: BorderStroke? = SurfaceDefaults.border(),
+    contentPadding: PaddingValues = CardDefaults.contentPadding,
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable () -> Unit,
+) {
+    val internalInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+    CardImpl(
+        modifier =
+            modifier
+                .surface(
+                    shape = shape,
+                    color = color,
+                    contentColor = contentColor,
+                    border = border,
+                    interactionSource = internalInteractionSource,
+                )
+                .clickable(interactionSource = internalInteractionSource, onClick = onClick),
+        title = title,
+        subtitle = subtitle,
+        header = header,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        contentPadding = contentPadding,
+        content = content,
+    )
+}
+
+/**
+ * ActionCard is a version of a card that contains a primary [action] that is placed in the center
+ * of the bottom edge of the card. The action should be a [Button], and represents the action that
+ * will be performed when this card is interacted with. The main card itself is not focusable - the
+ * [action] takes the focus instead.
+ *
+ * ActionCard is a component used to group related information into a single digestible unit. An
+ * action card can adapt to display a wide range of content, from simple text blurbs to more complex
+ * summaries with multiple elements. An action card contains text [content], and may also have any
+ * combination of [title], [subtitle], [leadingIcon], and [trailingIcon]. If specified, [title] is
+ * placed on top of the [subtitle], which is placed on top of the [content]. An action card fills
+ * the maximum width available by default.
+ *
+ * For more documentation and samples of the other cards, see [Card].
+ *
+ * @sample androidx.xr.glimmer.samples.ActionCardWithTitleSample
+ * @param action the action for this card. This should be a [Button], and represents the action
+ *   performed when a user interacts with this card. The action is placed overlapping the bottom
+ *   edge of the card.
+ * @param modifier the [Modifier] to be applied to the outer layout containing the card and action
+ * @param title optional title to be placed above [subtitle] and [content], below [header]
+ * @param subtitle optional subtitle to be placed above [content], below [title]
+ * @param header optional header image to be placed at the top of the card. This image should
+ *   typically fill the max width available, for example using
+ *   [androidx.compose.ui.layout.ContentScale.FillWidth]. Headers are constrained to a maximum
+ *   aspect ratio (1.6) to avoid taking up too much vertical space, so using a modifier such as
+ *   [androidx.compose.foundation.layout.fillMaxSize] will result in an image that fills the maximum
+ *   aspect ratio.
+ * @param leadingIcon optional leading icon to be placed before [content]. This is typically an
+ *   [Icon] tinted with [contentColor] by default.
+ * @param trailingIcon optional trailing icon to be placed after [content]. This is typically an
+ *   [Icon] tinted with [contentColor] by default.
+ * @param shape the [Shape] used to clip this card, and also used to draw the background and border
+ * @param color background color of this card
+ * @param contentColor content color used by components inside [content], [title], [subtitle],
+ *   [leadingIcon], and [trailingIcon].
+ * @param border the border to draw around this card
+ * @param contentPadding the spacing values to apply internally between the container and the
+ *   content. Note that there is additional padding applied around the content / text / icons inside
+ *   a card, this only affects the outermost content padding.
+ * @param content the main content / body text to display inside this card. This is recommended to
+ *   be limited to 10 lines of text.
+ */
+@Composable
+public fun ActionCard(
+    action: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    title: @Composable (() -> Unit)? = null,
+    subtitle: @Composable (() -> Unit)? = null,
+    header: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    shape: Shape = CardDefaults.shape,
+    color: Color = GlimmerTheme.colors.surface,
+    contentColor: Color = calculateContentColor(color),
+    border: BorderStroke? = SurfaceDefaults.border(),
+    contentPadding: PaddingValues = CardDefaults.contentPadding,
+    content: @Composable () -> Unit,
+) {
+    // b/436852852 - in a list the button won't be focused until it crosses the focus line.
+    ActionCardLayout(modifier, action) {
+        CardImpl(
+            modifier =
+                Modifier.surface(
+                    shape = shape,
+                    color = color,
+                    contentColor = contentColor,
+                    border = border,
+                ),
+            title = title,
+            subtitle = subtitle,
+            header = header,
+            leadingIcon = leadingIcon,
+            trailingIcon = trailingIcon,
+            contentPadding = contentPadding,
+            content = content,
+        )
+    }
+}
+
+@Composable
+private fun CardImpl(
+    modifier: Modifier,
+    title: @Composable (() -> Unit)?,
+    subtitle: @Composable (() -> Unit)?,
+    header: @Composable (() -> Unit)?,
+    leadingIcon: @Composable (() -> Unit)?,
+    trailingIcon: @Composable (() -> Unit)?,
+    contentPadding: PaddingValues,
+    content: @Composable () -> Unit,
+) {
+    val iconSize = GlimmerTheme.iconSizes.large
+    val typography = GlimmerTheme.typography
+    val componentSpacingValues = GlimmerTheme.componentSpacingValues
+    val innerPadding = componentSpacingValues.small
+    val iconSpacing = componentSpacingValues.medium
+
+    Column(
+        modifier = modifier.defaultMinSize(minHeight = MinimumHeight).padding(contentPadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        header?.let {
+            Box(
+                Modifier.constrainHeightToAspectRatio(HeaderMaximumAspectRatio).clip(HeaderShape),
+                contentAlignment = Alignment.Center,
+            ) {
+                it()
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(innerPadding),
+            verticalAlignment = CenterVertically,
+        ) {
+            if (leadingIcon != null) {
+                Box(
+                    modifier = Modifier.align(Alignment.Top).padding(end = iconSpacing),
+                    contentAlignment = Alignment.TopStart,
+                ) {
+                    CompositionLocalProvider(LocalIconSize provides iconSize, content = leadingIcon)
+                }
+            }
+            Column(
+                Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(TextVerticalSpacing),
+            ) {
+                if (title != null) {
+                    CompositionLocalProvider(
+                        LocalTextStyle provides typography.bodyMedium,
+                        content = title,
+                    )
+                }
+
+                if (subtitle != null) {
+                    CompositionLocalProvider(
+                        LocalTextStyle provides typography.caption,
+                        content = subtitle,
+                    )
+                }
+
+                CompositionLocalProvider(
+                    LocalTextStyle provides typography.bodySmall,
+                    content = content,
+                )
+            }
+            if (trailingIcon != null) {
+                Box(
+                    modifier = Modifier.align(Alignment.Top).padding(start = iconSpacing),
+                    contentAlignment = Alignment.TopEnd,
+                ) {
+                    CompositionLocalProvider(
+                        LocalIconSize provides iconSize,
+                        content = trailingIcon,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActionCardLayout(
+    modifier: Modifier,
+    action: @Composable () -> Unit,
+    card: @Composable () -> Unit,
+) {
+    Layout(contents = listOf(action, card), modifier = modifier) { measurables, constraints ->
+        val actionMeasurables = measurables[0]
+        val cardMeasurables = measurables[1]
+
+        var actionMaxWidth = 0
+        var actionMaxHeight = 0
+        var cardMaxWidth = 0
+        var cardMaxHeight = 0
+
+        val actionPlaceables =
+            actionMeasurables.fastMap {
+                // Measure the action with relaxed constraints
+                val placeable = it.measure(constraints.copyMaxDimensions())
+                actionMaxWidth = max(actionMaxWidth, placeable.width)
+                actionMaxHeight = max(actionMaxHeight, placeable.height)
+                placeable
+            }
+
+        val actionInset = ActionInset.roundToPx()
+
+        // The card is allowed to take up the total height - the height of the overall layout taken
+        // up by the action
+        val heightTakenUpByAction = (actionMaxHeight - actionInset).coerceAtLeast(0)
+
+        // Shrink the height constraints, to account for the action button
+        val cardMinHeightConstraints =
+            (constraints.minHeight - heightTakenUpByAction).coerceAtLeast(0)
+        val cardMaxHeightConstraints =
+            if (constraints.hasBoundedHeight) {
+                (constraints.maxHeight - heightTakenUpByAction).coerceAtLeast(0)
+            } else {
+                constraints.maxHeight
+            }
+        val cardConstraints =
+            constraints.copy(
+                minHeight = cardMinHeightConstraints,
+                maxHeight = cardMaxHeightConstraints,
+            )
+
+        val cardPlaceables =
+            cardMeasurables.fastMap {
+                val placeable = it.measure(cardConstraints)
+                cardMaxWidth = max(cardMaxWidth, placeable.width)
+                cardMaxHeight = max(cardMaxHeight, placeable.height)
+                placeable
+            }
+
+        val layoutWidth = maxOf(actionMaxWidth, cardMaxWidth)
+        val layoutHeight = heightTakenUpByAction + cardMaxHeight
+
+        layout(layoutWidth, layoutHeight) {
+            cardPlaceables.fastForEach {
+                // Horizontally center in the overall space
+                val x = (layoutWidth - it.width) / 2
+                it.placeRelative(x, 0)
+            }
+
+            actionPlaceables.fastForEach {
+                // Horizontally center in the overall space
+                val x = (layoutWidth - it.width) / 2
+                val y = cardMaxHeight - actionInset
+                it.placeRelative(x, y)
+            }
+        }
+    }
+}
+
+/**
+ * Constrains the content's height to a maximum aspect ratio, based on the maximum width.
+ *
+ * This modifier is similar to [androidx.compose.foundation.layout.aspectRatio], but it only
+ * enforces a maximum size, allowing the content to be smaller than the bounds defined by the aspect
+ * ratio. It also only constrains the height based on the width, it does not constrain the width
+ * based on the height.
+ *
+ * @param widthToHeightRatio the maximum aspect ratio allowed for the height. This is defined as the
+ *   ratio of width / height
+ */
+private fun Modifier.constrainHeightToAspectRatio(widthToHeightRatio: Float): Modifier {
+    require(widthToHeightRatio > 0) { "Ratio must be positive" }
+    return this.layout { measurable, constraints ->
+        // We only want to constrain height, based on width. If width is unbounded and there is a
+        // bounded height, we don't want to constrain the width based on height. So do nothing if
+        // we don't have a constrained width
+        if (!constraints.hasBoundedWidth) {
+            val placeable = measurable.measure(constraints)
+            return@layout layout(placeable.width, placeable.height) {
+                placeable.placeRelative(0, 0)
+            }
+        }
+
+        val height =
+            (constraints.maxWidth / widthToHeightRatio)
+                .toInt()
+                // Handle the case where the width is more than ratio times larger than available
+                // height
+                .coerceAtMost(constraints.maxHeight)
+
+        val newConstraints =
+            constraints.copy(
+                // Relax minimum height to let the content be smaller than constraints.minHeight if
+                // the aspect ratio results in a height smaller than min height
+                minHeight = 0,
+                maxHeight = height,
+            )
+
+        val placeable = measurable.measure(newConstraints)
+
+        // We relaxed the constraints earlier, but we still need to respect the incoming constraints
+        // ourselves.
+        val layoutHeight = placeable.height.coerceIn(constraints.minHeight, constraints.maxHeight)
+
+        layout(placeable.width, layoutHeight) {
+            // Center the content within the final layout height if needed
+            val y = (layoutHeight - placeable.height) / 2
+            placeable.placeRelative(0, y)
+        }
+    }
+}
+
+/** Default values used for [Card] */
+public object CardDefaults {
+    /**
+     * Default content padding used for a [Card]
+     *
+     * This affects the outermost content padding applied around header images and the content
+     * container. Note that there is additional padding applied around the content / text / icons
+     * inside a card, this only represents the outer padding for the entire content.
+     */
+    public val contentPadding: PaddingValues
+        @Composable get() = PaddingValues(GlimmerTheme.componentSpacingValues.medium)
+
+    /** The default shape of [Card], which determines its corner radius. */
+    public val shape: Shape
+        @Composable get() = GlimmerTheme.shapes.medium
+}
+
+/** Default minimum height for a [Card] */
+private val MinimumHeight = 80.dp
+
+/** Spacing between title / subtitle / body text */
+private val TextVerticalSpacing = 3.dp
+
+/** Shape used to clip the header image */
+private val HeaderShape = RoundedCornerShape(24.dp)
+
+/**
+ * Width / height aspect ratio for header images, to prevent the images from taking up too much
+ * vertical space
+ */
+private const val HeaderMaximumAspectRatio = 1.6f
+
+/** How far the action button is inset from the underlying card's edge */
+private val ActionInset = 16.dp
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/deptheffect-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/deptheffect-source.md
@@ -1,0 +1,225 @@
+When simulating depth on AI glasses using shadows, refer to the following source
+code in `DepthEffect.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.ShadowScope
+import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.shadow.DropShadowPainter
+import androidx.compose.ui.graphics.shadow.Shadow
+import androidx.compose.ui.graphics.shadow.lerp
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.requireGraphicsContext
+import androidx.compose.ui.platform.InspectorInfo
+
+/**
+ * The depth effect establishes a sense of hierarchy by using shadows to occlude content underneath.
+ * It consists of two shadow layers, [layer1] and [layer2]. [layer2] is drawn on top of [layer1]:
+ *
+ *     _________________
+ *    |    _________    |
+ *    |   | content |   |
+ *    |   |_________|   |
+ *    |   ___________   |
+ *    |  |  layer 2  |  |
+ *    |  |___________|  |
+ *    |  _____________  |
+ *    | |   layer 1   | |
+ *    | |_____________| |
+ *    |_________________|
+ *
+ * [GlimmerTheme.depthEffectLevels] provides theme defined depth effect levels that should be used
+ * to add depth to surfaces.
+ *
+ * Higher level components apply the depth effect automatically when needed. The depth effect can
+ * also be configured through [surface]. To manually render depth shadows for advanced use-cases,
+ * see the [depthEffect] [Modifier].
+ *
+ * @property layer1 the 'base' [Shadow] layer, drawn first
+ * @property layer2 the second [Shadow] layer, drawn on top of [layer1]
+ */
+@Immutable
+public class DepthEffect(public val layer1: Shadow, public val layer2: Shadow) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DepthEffect) return false
+
+        if (layer1 != other.layer1) return false
+        if (layer2 != other.layer2) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = layer1.hashCode()
+        result = 31 * result + layer2.hashCode()
+        return result
+    }
+}
+
+/**
+ * Renders shadows for the provided [depthEffect].
+ *
+ * @param depthEffect Depth effect to render shadows for. If `null`, no shadows will be rendered.
+ * @param shape [Shape] of the shadows
+ */
+public fun Modifier.depthEffect(depthEffect: DepthEffect?, shape: Shape): Modifier {
+    if (depthEffect == null) return this
+    return this then DepthEffectElement(depthEffect, shape)
+}
+
+/**
+ * Renders depth effect shadows by lerping between the provided [from] and [to] depth effects using
+ * [progress]. This allows for efficient animation - to render a static depth effect, see the other
+ * overload.
+ *
+ * @param from Depth effect to render shadows for when [progress] is 0.
+ * @param to Depth effect to render shadows for when [progress] is 1.
+ * @param shape [Shape] of the shadows
+ * @param progress progress of the animation between [from] and [to], from 0 to 1. Values may go
+ *   outside these bounds for overshoot / undershoot.
+ */
+// TODO: can be simplified with style API in the future
+internal fun Modifier.depthEffect(
+    from: DepthEffect?,
+    to: DepthEffect?,
+    shap>e: Shape,
+    progress: () - Float,
+): Modifier {
+    // dropShadow draws the shadow, and then the content on top. So in order to get layer2 to
+    // render on top of layer1, we draw layer1 first - this means that layer1's dropShadow will
+    // draw its shadow, and then its content on top (since the 'content' includes children
+    // modifiers, this includes layer2's shadow).
+    return this.dropShadow(shape) {
+            val shadow = lerp(from?.layer1, to?.layer1, progress())
+            if (shadow != null) {
+                updateFrom(shadow)
+            }
+        }
+        .dropShadow(shape) {
+            val shadow = lerp(from?.layer2, to?.layer2, progress())
+            if (shadow != null) {
+                updateFrom(shadow)
+            }
+        }
+}
+
+private fun ShadowScope.updateFrom(shadow: Shadow) {
+    this.radius = shadow.radius.toPx()
+    this.spread = shadow.spread.toPx()
+    this.offset = Offset(shadow.offset.x.toPx(), shadow.offset.y.toPx())
+    this.color = shadow.color
+    this.brush = shadow.brush
+    this.alpha = shadow.alpha
+    this.blendMode = shadow.blendMode
+}
+
+private class DepthEffectElement(private val depthEffect: DepthEffect, private< val shape: Sha>pe) :
+    ModifierNodeElementDepthEffectNode() {
+
+    override fun create(): DepthEffectNode = DepthEffectNode(depthEffect, shape)
+
+    override fun update(node: DepthEffectNode) {
+        node.update(depthEffect, shape)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DepthEffectElement) return false
+
+        if (depthEffect != other.depthEffect) return false
+        if (shape != other.shape) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = depthEffect.hashCode()
+        result = 31 * result + shape.hashCode()
+        return result
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "depthEffect"
+        properties["depthEffect"] = depthEffect
+        properties["shape"] = shape
+    }
+}
+
+/**
+ * Renders shadows for the provided [shape] and [depthEffect].
+ *
+ * @param depthEffect Depth effect to render shadows for.
+ * @param shape [Shape] of the shadows.
+ */
+internal class DepthEffectNode(private var depthEffect: DepthEffect, private var shape: Shape) :
+    Modifier.Node(), DrawModifierNode {
+
+    private var layer1ShadowPainter: DropShadowPainter? = null
+    private var layer2ShadowPainter: DropShadowPainter? = null
+
+    fun update(depthEffect: DepthEffect, shape: Shape) {
+        if (this.depthEffect.layer1 != depthEffect.layer1) layer1ShadowPainter = null
+        if (this.depthEffect.layer2 != depthEffect.layer2) layer2ShadowPainter = null
+        if (this.shape != shape) {
+            layer1ShadowPainter = null
+            layer2ShadowPainter = null
+        }
+        this.shape = shape
+        this.depthEffect = depthEffect
+    }
+
+    override fun ContentDrawScope.draw() {
+        drawDepthEffect()
+        drawContent()
+    }
+
+    internal fun ContentDrawScope.drawDepthEffect(alpha: Float = DefaultAlpha) {
+        // In order to get layer2 to render on top of layer1, we draw layer1 first.
+        with(obtainLayer1ShadowPainter()) { draw(size, alpha = alpha) }
+        with(obtainLayer2ShadowPainter()) { draw(size, alpha = alpha) }
+    }
+
+    private fun obtainLayer1ShadowPainter(): DropShadowPainter =
+        layer1ShadowPainter
+            ?: requireGraphicsContext()
+                .shadowContext
+                .createDropShadowPainter(shape, depthEffect.layer1)
+                .also { layer1ShadowPainter = it }
+
+    private fun obtainLayer2ShadowPainter(): DropShadowPainter =
+        layer2ShadowPainter
+            ?: requireGraphicsContext()
+                .shadowContext
+                .createDropShadowPainter(shape,ayer2)
+                .also { layer2ShadowPainter = it }
+}
+DepthEffect.kt
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/deptheffectlevels-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/deptheffectlevels-source.md
@@ -1,0 +1,105 @@
+When simulating depth on AI glasses using shadows, refer to the following source
+code in `DepthEffectLevels.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.shadow.Shadow
+import androidx.compose.ui.unit.dp
+
+/**
+ * Jetpack Compose Glimmer components can use [DepthEffect] to establish a sense of hierarchy.
+ * [DepthEffectLevels] contains different levels of [DepthEffect] to express this hierarchy. Higher
+ * levels contain larger shadows, and represent components with a higher z-order than lower levels.
+ * In their baseline state (not focused) most components should have no (`null`) [DepthEffect].
+ *
+ * @property level1 the lowest level of [DepthEffect]. This level will have the smallest shadows.
+ * @property level2 a level of [DepthEffect] higher than [level1] and lower than [level3].
+ * @property level3 a level of [DepthEffect] higher than [level2] and lower than [level4].
+ * @property level4 a level of [DepthEffect] higher than [level3] and lower than [level5].
+ * @property level5 the highest level of [DepthEffect]. This level will have the largest shadows.
+ * @see DepthEffect
+ * @see depthEffect
+ */
+@Immutable
+public class DepthEffectLevels(
+    public val level1: DepthEffect = DepthEffectLevel1,
+    public val level2: DepthEffect = DepthEffectLevel2,
+    public val level3: DepthEffect = DepthEffectLevel3,
+    public val level4: DepthEffect = DepthEffectLevel4,
+    public val level5: DepthEffect = DepthEffectLevel5,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DepthEffectLevels) return false
+
+        if (level1 != other.level1) return false
+        if (level2 != other.level2) return false
+        if (level3 != other.level3) return false
+        if (level4 != other.level4) return false
+        if (level5 != other.level5) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = level1.hashCode()
+        result = 31 * result + level2.hashCode()
+        result = 31 * result + level3.hashCode()
+        result = 31 * result + level4.hashCode()
+        result = 31 * result + level5.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "DepthEffectLevels(level1=$level1, level2=$level2, level3=$level3, level4=$level4, level5=$level5)"
+    }
+}
+
+private val DepthEffectLevel1 =
+    DepthEffect(
+        layer1 = Shadow(radius = 12.dp, color = Color.Black, spread = 6.dp, alpha = 0.90f),
+        layer2 = Shadow(radius = 6.dp, color = Color.Black, spread = 2.dp),
+    )
+private val DepthEffectLevel2 =
+    DepthEffect(
+        layer1 = Shadow(radius = 23.dp, color = Color.Black, spread = 13.dp, alpha = 0.90f),
+        layer2 = Shadow(radius = 8.dp, color = Color.Black, spread = 5.dp),
+    )
+private val DepthEffectLevel3 =
+    DepthEffect(
+        layer1 = Shadow(radius = 34.dp, color = Color.Black, spread = 19.dp, alpha = 0.90f),
+        layer2 = Shadow(radius = 9.dp, color = Color.Black, spread = 7.dp),
+    )
+private val DepthEffectLevel4 =
+    DepthEffect(
+        layer1 = Shadow(radius = 45.dp, color = Color.Black, spread = 26.dp, alpha = 0.90f),
+        layer2 = Shadow(radius = 11.dp, color = Color.Black, spread = 10.dp),
+    )
+private val DepthEffectLevel5 =
+    DepthEffect(
+        layer1 = Shadow(radius = 56.dp, color = Color.Black, spread = 32.dp, alpha = 0.90f),
+        layer2 = Shadow(radius = 12.dp, color = Color.Black, spread = 12.dp),
+    )
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/glimmersansflextypography-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/glimmersansflextypography-source.md
@@ -1,0 +1,270 @@
+When creating a `Typography` instance with the Google Sans Flex configuration,
+refer to the following source code in `GoogleSansFlexTypography.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("MentionsGoogle")
+
+package androidx.xr.glimmer.googlefonts
+
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontVariation
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.googlefonts.Font
+import androidx.compose.ui.text.googlefonts.GoogleFont
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.unit.sp
+import androidx.xr.glimmer.Typography
+
+/**
+ * Returns a [Typography] instance configured with Google Sans Flex and customized with the
+ * recommended settings for Jetpack Compose Glimmer.
+ *
+ * Note: Google Sans Flex is a variable font. It is recommended to configure attributes such as
+ * weight, slant, and grade by using [FontVariation.Settings] (e.g. [FontVariation.weight]) rather
+ * than the [TextStyle] properties.
+ *
+ * @sample androidx.xr.glimmer.googlefonts.samples.GoogleSansFlexTypographySample
+ * @param titleLarge the [TextStyle] for [Typography.titleLarge]
+ * @param titleLargeVariationSettings the [FontVariation.Settings] for [Typography.titleLarge].
+ * @param titleMedium the [TextStyle] for [Typography.titleMedium].
+ * @param titleMediumVariationSettings the [FontVariation.Settings] for [Typography.titleMedium].
+ * @param titleSmall the [TextStyle] for [Typography.titleSmall].
+ * @param titleSmallVariationSettings the [FontVariation.Settings] for [Typography.titleSmall].
+ * @param bodyLarge the [TextStyle] for [Typography.bodyLarge].
+ * @param bodyLargeVariationSettings the [FontVariation.Settings] for [Typography.bodyLarge].
+ * @param bodyMedium the [TextStyle] for [Typography.bodyMedium].
+ * @param bodyMediumVariationSettings the [FontVariation.Settings] for [Typography.bodyMedium].
+ * @param bodySmall the [TextStyle] for [Typography.bodySmall].
+ * @param bodySmallVariationSettings the [FontVariation.Settings] for [Typography.bodySmall].
+ * @param caption the [TextStyle] for [Typography.caption].
+ * @param captionVariationSettings the [FontVariation.Settings] for [Typography.caption].
+ */
+@Suppress("MentionsGoogle")
+public fun createGoogleSansFlexTypography(
+    titleLarge: TextStyle = GoogleSansFlexTypographyDefaults.TitleLarge,
+    titleLargeVariationSettings: FontVariation.Settings =
+        GoogleSansFlexTypographyDefaults.TitleLargeVariationSettings,
+    titleMedium: TextStyle = GoogleSansFlexTypographyDefaults.TitleMedium,
+    titleMediumVariationSettings: FontVariation.Settings =
+        GoogleSansFlexTypographyDefaults.TitleMediumVariationSettings,
+    titleSmall: TextStyle = GoogleSansFlexTypographyDefaults.TitleSmall,
+    titleSmallVariationSettings: FontVariation.Settings =
+        GoogleSansFlexTypographyDefaults.TitleSmallVariationSettings,
+    bodyLarge: TextStyle = GoogleSansFlexTypographyDefaults.BodyLarge,
+    bodyLargeVariationSettings: FontVariation.Settings =
+        GoogleSansFlexTypographyDefaults.BodyLargeVariationSettings,
+    bodyMedium: TextStyle = GoogleSansFlexTypographyDefaults.BodyMedium,
+    bodyMediumVariationSettings: FontVariation.Settings =
+        GoogleSansFlexTypographyDefaults.BodyMediumVariationSettings,
+    bodySmall: TextStyle = GoogleSansFlexTypographyDefaults.BodySmall,
+    bodySmallVariationSettings: FontVariation.Settings =
+        GoogleSansFlexTypographyDefaults.BodySmallVariationSettings,
+    caption: TextStyle = GoogleSansFlexTypographyDefaults.Caption,
+    captionVariationSettings: FontVariation.Settings =
+        GoogleSansFlexTypographyDefaults.CaptionVariationSettings,
+): Typography {
+    val titleLargeFontFamily = FontFamily(GoogleSansFlexFont, titleLargeVariationSettings)
+    val titleMediumFontFamily = FontFamily(GoogleSansFlexFont, titleMediumVariationSettings)
+    val titleSmallFontFamily = FontFamily(GoogleSansFlexFont, titleSmallVariationSettings)
+    val bodyLargeFontFamily = FontFamily(GoogleSansFlexFont, bodyLargeVariationSettings)
+    val bodyMediumFontFamily = FontFamily(GoogleSansFlexFont, bodyMediumVariationSettings)
+    val bodySmallFontFamily = FontFamily(GoogleSansFlexFont, bodySmallVariationSettings)
+    val captionFontFamily = FontFamily(GoogleSansFlexFont, captionVariationSettings)
+
+    return Typography(
+        titleLarge = titleLarge.copy(fontFamily = titleLargeFontFamily),
+        titleMedium = titleMedium.copy(fontFamily = titleMediumFontFamily),
+        titleSmall = titleSmall.copy(fontFamily = titleSmallFontFamily),
+        bodyLarge = bodyLarge.copy(fontFamily = bodyLargeFontFamily),
+        bodyMedium = bodyMedium.copy(fontFamily = bodyMediumFontFamily),
+        bodySmall = bodySmall.copy(fontFamily = bodySmallFontFamily),
+        caption = caption.copy(fontFamily = captionFontFamily),
+    )
+}
+
+/** Default variable font configurations for using Google Sans Flex in Jetpack Compose Glimmer */
+@Suppress("MentionsGoogle")
+public object GoogleSansFlexTypographyDefaults {
+    private val RoundVariationSetting = FontVariation.Setting("ROND", 100.0f)
+
+    /** Default [TextStyle] for [Typography.titleLarge]. */
+    public val TitleLarge: TextStyle =
+        TextStyle(
+            fontWeight = FontWeight.Normal,
+            fontSize = 30.sp,
+            lineHeight = 36.sp,
+            letterSpacing = DefaultLetterSpacing,
+            lineHeightStyle = DefaultLineHeightStyle,
+        )
+
+    /** Default [FontVariation.Settings] for [Typography.titleLarge]. */
+    public val TitleLargeVariationSettings: FontVariation.Settings =
+        FontVariation.Settings(
+            FontVariation.grade(0),
+            FontVariation.weight(750),
+            FontVariation.slant(0f),
+            FontVariation.width(100f),
+            FontVariation.opticalSizing(9.sp),
+            RoundVariationSetting,
+        )
+
+    /** Default [TextStyle] for [Typography.titleMedium]. */
+    public val TitleMedium: TextStyle =
+        TextStyle(
+            fontWeight = FontWeight.Normal,
+            fontSize = 24.sp,
+            lineHeight = 28.sp,
+            letterSpacing = DefaultLetterSpacing,
+            lineHeightStyle = DefaultLineHeightStyle,
+        )
+
+    /** Default [FontVariation.Settings] for [Typography.titleMedium]. */
+    public val TitleMediumVariationSettings: FontVariation.Settings =
+        FontVariation.Settings(
+            FontVariation.grade(0),
+            FontVariation.weight(750),
+            FontVariation.slant(0f),
+            FontVariation.width(100f),
+            FontVariation.opticalSizing(9.sp),
+            RoundVariationSetting,
+        )
+
+    /** Default [TextStyle] for [Typography.titleSmall]. */
+    public val TitleSmall: TextStyle =
+        TextStyle(
+            fontWeight = FontWeight.Normal,
+            fontSize = 20.sp,
+            lineHeight = 28.sp,
+            letterSpacing = DefaultLetterSpacing,
+            lineHeightStyle = DefaultLineHeightStyle,
+        )
+
+    /** Default [FontVariation.Settings] for [Typography.titleSmall]. */
+    public val TitleSmallVariationSettings: FontVariation.Settings =
+        FontVariation.Settings(
+            FontVariation.grade(0),
+            FontVariation.weight(750),
+            FontVariation.slant(0f),
+            FontVariation.width(100f),
+            FontVariation.opticalSizing(9.sp),
+            RoundVariationSetting,
+        )
+
+    /** Default [TextStyle] for [Typography.bodyLarge]. */
+    public val BodyLarge: TextStyle =
+        TextStyle(
+            fontWeight = FontWeight.Normal,
+            fontSize = 30.sp,
+            lineHeight = 36.sp,
+            letterSpacing = DefaultLetterSpacing,
+            lineHeightStyle = DefaultLineHeightStyle,
+        )
+
+    /** Default [FontVariation.Settings] for [Typography.bodyLarge]. */
+    public val BodyLargeVariationSettings: FontVariation.Settings =
+        FontVariation.Settings(
+            FontVariation.grade(0),
+            FontVariation.weight(520),
+            FontVariation.slant(0f),
+            FontVariation.width(100f),
+            FontVariation.opticalSizing(9.sp),
+            RoundVariationSetting,
+        )
+
+    /** Default [TextStyle] for [Typography.bodyMedium]. */
+    public val BodyMedium: TextStyle =
+        TextStyle(
+            fontWeight = FontWeight.Normal,
+            fontSize = 24.sp,
+            lineHeight = 36.sp,
+            letterSpacing = DefaultLetterSpacing,
+            lineHeightStyle = DefaultLineHeightStyle,
+        )
+
+    /** Default [FontVariation.Settings] for [Typography.bodyMedium]. */
+    public val BodyMediumVariationSettings: FontVariation.Settings =
+        FontVariation.Settings(
+            FontVariation.grade(0),
+            FontVariation.weight(520),
+            FontVariation.slant(0f),
+            FontVariation.width(100f),
+            FontVariation.opticalSizing(9.sp),
+            RoundVariationSetting,
+        )
+
+    /** Default [TextStyle] for [Typography.bodySmall]. */
+    public val BodySmall: TextStyle =
+        TextStyle(
+            fontWeight = FontWeight.Normal,
+            fontSize = 20.sp,
+            lineHeight = 28.sp,
+            letterSpacing = DefaultLetterSpacing,
+            lineHeightStyle = DefaultLineHeightStyle,
+        )
+
+    /** Default [FontVariation.Settings] for [Typography.bodySmall]. */
+    public val BodySmallVariationSettings: FontVariation.Settings =
+        FontVariation.Settings(
+            FontVariation.grade(0),
+            FontVariation.weight(520),
+            FontVariation.slant(0f),
+            FontVariation.width(100f),
+            FontVariation.opticalSizing(9.sp),
+            RoundVariationSetting,
+        )
+
+    /** Default [TextStyle] for [Typography.caption]. */
+    public val Caption: TextStyle =
+        TextStyle(
+            fontWeight = FontWeight.Normal,
+            fontSize = 18.sp,
+            lineHeight = 24.sp,
+            letterSpacing = DefaultLetterSpacing,
+            lineHeightStyle = DefaultLineHeightStyle,
+        )
+
+    /** Default [FontVariation.Settings] for [Typography.caption]. */
+    public val CaptionVariationSettings: FontVariation.Settings =
+        FontVariation.Settings(
+            FontVariation.grade(0),
+            FontVariation.weight(650),
+            FontVariation.slant(0f),
+            FontVariation.width(100f),
+            FontVariation.opticalSizing(9.sp),
+            RoundVariationSetting,
+        )
+}
+
+private val GoogleSansFlexFont = GoogleFont("Google Sans Flex")
+
+private val DefaultLetterSpacing = 0.sp
+
+private val DefaultLineHeightStyle: LineHeightStyle =
+    LineHeightStyle(
+        alignment = LineHeightStyle.Alignment.Proportional,
+        trim = LineHeightStyle.Trim.FirstLineTop,
+    )
+
+private fun FontFamily(font: GoogleFont, variationSettings: FontVariation.Settings): FontFamily =
+    FontFamily(Font(googleFont = font, variationSettings = variationSettings))
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/glimmertheme-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/glimmertheme-source.md
@@ -1,0 +1,183 @@
+When implementing Glimmer styles, refer to the following source code in
+`GlimmerTheme.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.IndicationNodeFactory
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocal
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.node.DelegatableNode
+import androidx.xr.glimmer.GlimmerTheme.Companion.colors
+import androidx.xr.glimmer.GlimmerTheme.Companion.depthEffectLevels
+import androidx.xr.glimmer.GlimmerTheme.Companion.iconSizes
+import androidx.xr.glimmer.GlimmerTheme.Companion.shapes
+
+/**
+ * Jetpack Compose Glimmer contains different theme subsystems to allow visual customization across
+ * an application.
+ *
+ * Components use properties provided here when retrieving default values.
+ *
+ * Any values that are not set will inherit the current value from the theme, falling back to the
+ * defaults if there is no parent GlimmerTheme. This allows using a GlimmerTheme at the top of your
+ * application, and then separate GlimmerTheme(s) for different screens / parts of your UI,
+ * overriding only the parts of the theme definition that need to change.
+ *
+ * @param colors [Colors] used by components within this hierarchy
+ * @param typography [Typography] used by components within this hierarchy
+ * @param componentSpacingValues [ComponentSpacingValues] used by components within this hierarchy
+ * @param content The content that can retrieve values from this theme
+ */
+@Composable
+public fun GlimmerTheme(
+    colors: Colors = GlimmerTheme.colors,
+    typography: Typography = GlimmerTheme.typography,
+    componentSpacingValues: ComponentSpacingValues = GlimmerTheme.componentSpacingValues,
+    conte>nt: @Composable () - Unit,
+) {
+    val theme = GlimmerTheme(colors, typography, componentSpacingValues)
+    CompositionLocalProvider(
+        _localGlimmerTheme provides theme,
+        // TODO: b/413429405
+        LocalIndication provides NoIndication,
+        LocalTextStyle provides typography.bodySmall,
+        LocalIconSize provides theme.iconSizes.medium,
+        content = content,
+    )
+}
+
+/**
+ * Jetpack Compose Glimmer contains different theme subsystems to allow visual customization across
+ * an application.
+ *
+ * Components use properties provided here when retrieving default values.
+ *
+ * @property colors [Colors] used by Jetpack Compose Glimmer components
+ * @property typography [Typography] used by Jetpack Compose Glimmer components. It is recommended
+ *   to use `createGoogleSansFlexTypography()` from `androidx.xr.glimmer:glimmer-google-fonts` to
+ *   create this.
+ * @property componentSpacingValues [ComponentSpacingValues] used by Jetpack Compose Glimmer
+ *   components
+ * @property shapes [Shapes] used by Jetpack Compose Glimmer components
+ * @property depthEffectLevels [DepthEffectLevels] used by Jetpack Compose Glimmer components
+ * @property iconSizes [IconSizes] used by icons
+ */
+@Immutable
+public class GlimmerTheme(
+    public val colors: Colors = Colors(),
+    public val typography: Typography = Typography(),
+    public val componentSpacingValues: ComponentSpacingValues = ComponentSpacingValues(),
+) {
+    public val shapes: Shapes = _shapes
+    public val depthEffectLevels: DepthEffectLevels = _depthEffectLevels
+    public val iconSizes: IconSizes = _iconSizes
+
+    public companion object {
+        /** Retrieves the current [Colors] at the call site's position in the hierarchy. */
+        public val colors: Colors
+            @Composable @ReadOnlyComposable get() = LocalGlimmerTheme.current.colors
+
+        /** Retrieves the current [Typography] at the call site's position in the hierarchy. */
+        public val typography: Typography
+            @Composable @ReadOnlyComposable get() = LocalGlimmerTheme.current.typography
+
+        /**
+         * Retrieves the current [ComponentSpacingValues] at the call site's position in the
+         * hierarchy.
+         */
+        public val componentSpacingValues: ComponentSpacingValues
+            @Composable @ReadOnlyComposable get() = LocalGlimmerTheme.current.componentSpacingValues
+
+        /** Retrieves the current [Shapes] at the call site's position in the hierarchy. */
+        public val shapes: Shapes
+            @Composable @ReadOnlyComposable get() = LocalGlimmerTheme.current.shapes
+
+        /**
+         * Retrieves the current [DepthEffectLevels] at the call site's position in the hierarchy.
+         */
+        public val depthEffectLevels: DepthEffectLevels
+            @Composable @ReadOnlyComposable get() = LocalGlimmerTheme.current.depthEffectLevels
+
+        /** Retrieves the current [IconSizes] at the call site's position in the hierarchy. */
+        public val iconSizes: IconSizes
+            @Composable @ReadOnlyComposable get() = LocalGlimmerTheme.current.iconSizes
+
+        /**
+         * [CompositionLocal] providing [GlimmerTheme] throughout the hierarchy. You can use
+         * properties in the companion object to access specific subsystems, for example [colors].
+         * To provide a new value for this, use [GlimmerTheme]. This API is exposed to allow
+         * retrieving values from inside CompositionLocalConsumerModifierNode implementations - in
+         * most cases you should use [colors] and other properties directly.
+         */
+        pu<blic val Loc>alGlimmerTheme: CompositionLocalGlimmerTheme
+            get() = _localGlimmerTheme
+
+        /**
+         * Cached Shapes instance to be used across [GlimmerTheme] instances - currently shapes are
+         * not user-configurable.
+         */
+        private val _shapes = Shapes()
+
+        /**
+         * Cached [DepthEffectLevels] instance to be used across [GlimmerTheme] instances -
+         * currently depth effect levels are not user-configurable.
+         */
+        private val _depthEffectLevels = DepthEffectLevels()
+
+        /**
+         * Cached IconSizes instance to be used across [GlimmerTheme] instances - currently icon
+         * sizes are not user-configurable.
+         */
+        internal val _iconSizes = IconSizes()
+    }
+
+    internal var defaultSurfaceBorderCached: BorderStroke? = null
+}
+
+private object NoIndication : IndicationNodeFactory {
+    override fun create(interactionSource: InteractionSource): DelegatableNode {
+        return object : Modifier.Node() {}
+    }
+
+    override fun equals(other: Any?): Boolean = other === this
+
+    override fun hashCode(): Int = -5
+}
+
+/** Use [GlimmerTheme.LocalGlimmerTheme] to access this publicly. */
+@Suppress("CompositionLocalNaming")
+priv<ate val _loc>alGlimmerTheme: ProvidableCompositionLocalGlimmerTheme =
+    stLocalOf {
+        GlimmerTheme()
+    }
+GlimmerTheme.kt
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/icon-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/icon-source.md
@@ -1,0 +1,389 @@
+When creating a Glimmer Icon component, refer to the following source code in
+`Icon.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.structuralEqualityPolicy
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.CacheDrawModifierNode
+import androidx.compose.ui.draw.paint
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorProducer
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.toolingGraphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.node.DelegatingNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+
+/**
+ * An icon component that draws [imageVector], with a default size of [LocalIconSize], and applies a
+ * content color tint. Icon is an opinionated component designed to be used with single-color icons
+ * so that they can be tinted correctly for the component they are placed in. The recommended icon
+ * sizes can be retrieved using [GlimmerTheme.Companion.iconSizes]. A size can be set explicitly
+ * using [size], and components can use [LocalIconSize] to set the preferred size for any Icons
+ * inside the component. The content color used to tint this icon is provided by [surface]. To set a
+ * custom tint color, use the Icon overload with a tint parameter. For multicolored icons and icons
+ * that should not be tinted, use the overload and set [Color.Unspecified] as the tint color. For
+ * generic images that should not be tinted, and should not use the provided icon size, use the
+ * generic [androidx.compose.foundation.Image] instead.
+ *
+ * @param imageVector [ImageVector] to draw inside this icon
+ * @param contentDescription text used by accessibility services to describe what this icon
+ *   represents. This should always be provided unless this icon is used for decorative purposes,
+ *   and does not represent a meaningful action that a user can take. This text should be localized,
+ *   such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier the [Modifier] to be applied to this icon
+ * @see LocalIconSize
+ * @see GlimmerTheme.Companion.iconSizes
+ */
+@Composable
+public fun Icon(
+    imageVector: ImageVector,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        painter = rememberVectorPainter(imageVector),
+        contentDescription = contentDescription,
+        modifier = modifier,
+    )
+}
+
+/**
+ * An icon component that draws [imageVector], with a default size of [LocalIconSize], and applies a
+ * tint of [tint]. Icon is an opinionated component designed to be used with single-color icons so
+ * that they can be tinted correctly for the component they are placed in. The recommended icon
+ * sizes can be retrieved using [GlimmerTheme.Companion.iconSizes]. A size can be set explicitly
+ * using [size], and components can use [LocalIconSize] to set the preferred size for any Icons
+ * inside the component. Use the other overload of Icon without a [tint] parameter to apply the
+ * recommended content color provided by a [surface]. For multicolored icons and icons that should
+ * not be tinted, set [tint] to [Color.Unspecified]. For generic images that should not be tinted,
+ * and should not use the provided icon size, use the generic [androidx.compose.foundation.Image]
+ * instead.
+ *
+ * @param imageVector [ImageVector] to draw inside this icon
+ * @param tint tint to be applied to [imageVector]. If [Color.Unspecified] is provided, then no tint
+ *   is applied.
+ * @param contentDescription text used by accessibility services to describe what this icon
+ *   represents. This should always be provided unless this icon is used for decorative purposes,
+ *   and does not represent a meaningful action that a user can take. This text should be localized,
+ *   such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier the [Modifier] to be applied to this icon
+ * @see LocalIconSize
+ * @see GlimmerTheme.Companion.iconSizes
+ */
+@Composable
+public fun Icon(
+    imageVector: ImageVector,
+    tint: Color,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        painter = rememberVectorPainter(imageVector),
+        tint =
+            if (tint.isSpecified) {
+                { tint }
+            } else null,
+        contentDescription = contentDescription,
+        modifier = modifier,
+    )
+}
+
+/**
+ * An icon component that draws [bitmap], with a default size of [LocalIconSize], and applies a
+ * content color tint. Icon is an opinionated component designed to be used with single-color icons
+ * so that they can be tinted correctly for the component they are placed in. The recommended icon
+ * sizes can be retrieved using [GlimmerTheme.Companion.iconSizes]. A size can be set explicitly
+ * using [size], and components can use [LocalIconSize] to set the preferred size for any Icons
+ * inside the component. The content color used to tint this icon is provided by [surface]. To set a
+ * custom tint color, use the Icon overload with a tint parameter. For multicolored icons and icons
+ * that should not be tinted, use the overload and set [Color.Unspecified] as the tint color. For
+ * generic images that should not be tinted, and should not use the provided icon size, use the
+ * generic [androidx.compose.foundation.Image] instead.
+ *
+ * @param bitmap [ImageBitmap] to draw inside this icon
+ * @param contentDescription text used by accessibility services to describe what this icon
+ *   represents. This should always be provided unless this icon is used for decorative purposes,
+ *   and does not represent a meaningful action that a user can take. This text should be localized,
+ *   such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier the [Modifier] to be applied to this icon
+ * @see LocalIconSize
+ * @see GlimmerTheme.Companion.iconSizes
+ */
+@Composable
+public fun Icon(bitmap: ImageBitmap, contentDescription: String?, modifier: Modifier = Modifier) {
+    val painter = remember(bitmap) { BitmapPainter(bitmap) }
+    Icon(painter = painter, contentDescription = contentDescription, modifier = modifier)
+}
+
+/**
+ * An icon component that draws [bitmap], with a default size of [LocalIconSize], and applies a tint
+ * of [tint]. Icon is an opinionated component designed to be used with single-color icons so that
+ * they can be tinted correctly for the component they are placed in. The recommended icon sizes can
+ * be retrieved using [GlimmerTheme.Companion.iconSizes]. A size can be set explicitly using [size],
+ * and components can use [LocalIconSize] to set the preferred size for any Icons inside the
+ * component. Use the other overload of Icon without a [tint] parameter to apply the recommended
+ * content color provided by a [surface]. For multicolored icons and icons that should not be
+ * tinted, set [tint] to [Color.Unspecified]. For generic images that should not be tinted, and
+ * should not use the provided icon size, use the generic [androidx.compose.foundation.Image]
+ * instead.
+ *
+ * @param bitmap [ImageBitmap] to draw inside this icon
+ * @param tint tint to be applied to [bitmap]. If [Color.Unspecified] is provided, then no tint is
+ *   applied.
+ * @param contentDescription text used by accessibility services to describe what this icon
+ *   represents. This should always be provided unless this icon is used for decorative purposes,
+ *   and does not represent a meaningful action that a user can take. This text should be localized,
+ *   such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier the [Modifier] to be applied to this icon
+ * @see LocalIconSize
+ * @see GlimmerTheme.Companion.iconSizes
+ */
+@Composable
+public fun Icon(
+    bitmap: ImageBitmap,
+    tint: Color,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+) {
+    val painter = remember(bitmap) { BitmapPainter(bitmap) }
+    Icon(
+        painter = painter,
+        tint =
+            if (tint.isSpecified) {
+                { tint }
+            } else null,
+        contentDescription = contentDescription,
+        modifier = modifier,
+    )
+}
+
+/**
+ * An icon component that draws [painter], with a default size of [LocalIconSize], and applies a
+ * content color tint. Icon is an opinionated component designed to be used with single-color icons
+ * so that they can be tinted correctly for the component they are placed in. The recommended icon
+ * sizes can be retrieved using [GlimmerTheme.Companion.iconSizes]. A size can be set explicitly
+ * using [size], and components can use [LocalIconSize] to set the preferred size for any Icons
+ * inside the component. The content color used to tint this icon is provided by [surface]. To set a
+ * custom tint color, use the Icon overload with a tint parameter. For multicolored icons and icons
+ * that should not be tinted, use the overload and set `null` for the tint parameter. For generic
+ * images that should not be tinted, and should not use the provided icon size, use the generic
+ * [androidx.compose.foundation.Image] instead.
+ *
+ * @param painter [Painter] to draw inside this icon
+ * @param contentDescription text used by accessibility services to describe what this icon
+ *   represents. This should always be provided unless this icon is used for decorative purposes,
+ *   and does not represent a meaningful action that a user can take. This text should be localized,
+ *   such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier the [Modifier] to be applied to this icon
+ * @see LocalIconSize
+ * @see GlimmerTheme.Companion.iconSizes
+ */
+@Composable
+public fun Icon(painter: Painter, contentDescription: String?, modifier: Modifier = Modifier) {
+    Icon(
+        painter = painter,
+        useContentColor = true,
+        tint = null,
+        contentDescription = contentDescription,
+        modifier = modifier,
+    )
+}
+
+/**
+ * An icon component that draws [painter], with a default size of [LocalIconSize], and applies a
+ * tint of [tint]. Icon is an opinionated component designed to be used with single-color icons so
+ * that they can be tinted correctly for the component they are placed in. The recommended icon
+ * sizes can be retrieved using [GlimmerTheme.Companion.iconSizes]. A size can be set explicitly
+ * using [size], and components can use [LocalIconSize] to set the preferred size for any Icons
+ * inside the component. Use the other overload of Icon without a [tint] parameter to apply the
+ * recommended content color provided by a [surface]. For multicolored icons and icons that should
+ * not be tinted, set [tint] to `null`. For generic images that should not be tinted, and should not
+ * use the provided icon size, use the generic [androidx.compose.foundation.Image] instead.
+ *
+ * @param painter [Painter] to draw inside this icon
+ * @param tint tint to be applied to [painter]. If null, then no tint is applied.
+ * @param contentDescription text used by accessibility services to describe what this icon
+ *   represents. This should always be provided unless this icon is used for decorative purposes,
+ *   and does not represent a meaningful action that a user can take. This text should be localized,
+ *   such as by using [androidx.compose.ui.res.stringResource] or similar
+ * @param modifier the [Modifier] to be applied to this icon
+ * @see LocalIconSize
+ * @see GlimmerTheme.Companion.iconSizes
+ */
+@Composable
+public fun Icon(
+    painter: Painter,
+    tint: ColorProducer?,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        painter = painter,
+        useContentColor = false,
+        tint = tint,
+        contentDescription = contentDescription,
+        modifier = modifier,
+    )
+}
+
+/**
+ * CompositionLocal containing the preferred size of an icon. This value will be used by [Icon] by
+ * default - it can be overridden with a [size] modifier.
+ */
+public val LocalIconSize: ProvidableCompositionLocal<Dp> =
+    compositionLocalOf(structuralEqualityPolicy()) { GlimmerTheme._iconSizes.medium }
+
+@Composable
+private fun Icon(
+    painter: Painter,
+    useContentColor: Boolean,
+    tint: ColorProducer?,
+    contentDescription: String?,
+    modifier: Modifier,
+) {
+    val colorFilter =
+        if (useContentColor || tint != null) {
+            IconColorFilterElement(
+                useContentColor = useContentColor,
+                tint = tint,
+                painter = painter,
+            )
+        } else {
+            Modifier
+        }
+    val semantics =
+        if (contentDescription != null) {
+            Modifier.semantics {
+                this.contentDescription = contentDescription
+                this.role = Role.Image
+            }
+        } else {
+            Modifier
+        }
+    Box(
+        modifier
+            .toolingGraphicsLayer()
+            .size(LocalIconSize.current)
+            .then(colorFilter)
+            .paint(painter, contentScale = ContentScale.Fit)
+            .then(semantics)
+    )
+}
+
+@Suppress("ModifierNodeInspectableProperties")
+private class IconColorFilterElement(
+    private val useContentColor: Boolean,
+    private val tint: ColorProducer?,
+    private val painter: Painter,
+) : ModifierNodeElement<IconColorFilterNode>() {
+    override fun create() = IconColorFilterNode(useContentColor, tint, painter)
+
+    override fun update(node: IconColorFilterNode) {
+        node.update(useContentColor, tint, painter)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is IconColorFilterElement) return false
+
+        if (useContentColor != other.useContentColor) return false
+        if (tint != other.tint) return false
+        if (painter != other.painter) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = useContentColor.hashCode()
+        result = 31 * result + (tint?.hashCode() ?: 0)
+        result = 31 * result + painter.hashCode()
+        return result
+    }
+}
+
+private class IconColorFilterNode(
+    private var useContentColor: Boolean,
+    private var tint: ColorProducer?,
+    private var painter: Painter,
+) : DelegatingNode() {
+    val cacheDrawNode =
+        delegate(
+            CacheDrawModifierNode {
+                val layer = obtainGraphicsLayer()
+                layer.apply { record { drawContent() } }
+                var cachedTintColor = Color.Unspecified
+                var cachedColorFilter: ColorFilter? = null
+                onDrawWithContent {
+                    val tintColor =
+                        if (useContentColor) {
+                            currentContentColor()
+                        } else {
+                            tint?.invoke() ?: Color.Unspecified
+                        }
+                    if (cachedTintColor != tintColor) {
+                        cachedTintColor = tintColor
+                        cachedColorFilter =
+                            if (tintColor.isSpecified) ColorFilter.tint(tintColor) else null
+                        layer.colorFilter = cachedColorFilter
+                    }
+                    drawLayer(graphicsLayer = layer)
+                }
+            }
+        )
+
+    fun update(useContentColor: Boolean, tint: ColorProducer?, painter: Painter) {
+        val painterChanged = this.painter != painter
+        if (this.useContentColor != useContentColor || this.tint != tint || painterChanged) {
+            this.useContentColor = useContentColor
+            this.tint = tint
+            this.painter = painter
+            if (painterChanged) {
+                cacheDrawNode.invalidateDrawCache()
+            } else {
+                cacheDrawNode.invalidateDraw()
+            }
+        }
+    }
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/iconbutton-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/iconbutton-source.md
@@ -1,0 +1,136 @@
+When creating a Glimmer Icon component, refer to the following source code in
+`IconButton.kt` for icon buttons:
+
+
+```kotlin
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * IconButton is a component used for exposing supplementary actions with a single tap.
+ *
+ * Icon buttons are used when a compact button is required, such as in a toolbar or image list.
+ *
+ * [content] should typically be an [Icon]. If using a custom icon, note that the typical size for
+ * the internal icon is 32 x 32 dp. Container has an overall minimum size of 48 x 48 dp.
+ *
+ * @param onClick called when this icon button is clicked
+ * @param modifier the [Modifier] to be applied to this icon button
+ * @param enabled controls the enabled state of this icon button. When `false`, this icon button
+ *   will not respond to user input
+ * @param shape the [Shape] used to clip this icon button
+ * @param color background color of this icon button
+ * @param contentColor content color used by components inside [content]
+ * @param border the border to draw around this icon button
+ * @param contentPadding the spacing values to apply internally between the container and the
+ *   content
+ * @param interactionSource an optional hoisted [MutableInteractionSource] for observing and
+ *   emitting Interactions for this icon button. You can use this to change the icon button's
+ *   appearance or preview the icon button in different states. Note that if `null` is provided,
+ *   interactions will still happen internally.
+ * @param content the content of this icon button, typically an [Icon]
+ * @sample androidx.xr.glimmer.samples.IconButtonSample
+ */
+@Composable
+public fun IconButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    shape: Shape = GlimmerTheme.shapes.large,
+    color: Color = GlimmerTheme.colors.surface,
+    contentColor: Color = calculateContentColor(color),
+    border: BorderStroke? = SurfaceDefaults.border(),
+    contentPadding: PaddingValues = IconButtonDefaults.contentPadding,
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable () -> Unit,
+) {
+    val depthEffect =
+        SurfaceDepthEffect(
+            depthEffect = null,
+            focusedDepthEffect = GlimmerTheme.depthEffectLevels.level1,
+        )
+
+    val internalInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+
+    Box(
+        modifier
+            .semantics { role = Role.Button }
+            .surface(
+                enabled = enabled,
+                shape = shape,
+                color = color,
+                contentColor = contentColor,
+                depthEffect = depthEffect,
+                border = border,
+                interactionSource = internalInteractionSource,
+            )
+            .clickable(
+                enabled = enabled,
+                interactionSource = internalInteractionSource,
+                onClick = onClick,
+            )
+            .defaultMinSize(IconButtonDefaults.minimumSize)
+            .padding(contentPadding),
+        contentAlignment = Alignment.Center,
+    ) {
+        CompositionLocalProvider(
+            LocalIconSize provides IconButtonDefaults.iconSize,
+            content = content,
+        )
+    }
+}
+
+/** Default values used for [IconButton]. */
+public object IconButtonDefaults {
+    /** Default content padding for an [IconButton]. */
+    @get:Composable
+    public val contentPadding: PaddingValues
+        get() = PaddingValues(GlimmerTheme.componentSpacingValues.small)
+
+    /** Minimum size for icon-only buttons: [IconButton], [IconToggleButton]. */
+    internal val minimumSize: Dp
+        get() = 48.dp
+
+    /** Default icon size for icon-only buttons: [IconButton], [IconToggleButton]. */
+    @get:Composable
+    internal val iconSize: Dp
+        get() = GlimmerTheme.iconSizes.small
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/iconsizes-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/iconsizes-source.md
@@ -1,0 +1,78 @@
+When creating a Glimmer Icon component, refer to the following source code in
+`IconSizes.kt` for setting icon sizes:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * A set of named icon sizes.
+ *
+ * Sizes can be provided using [LocalIconSize] to set the size for [Icon]s within a component, or
+ * they can be set explicitly using [androidx.compose.foundation.layout.size].
+ *
+ * @property small the size of a small icon.
+ * @property medium the size of a medium icon. This is the default icon size.
+ * @property large the size of a large icon.
+ * @see Icon
+ * @see LocalIconSize
+ */
+@Immutable
+public class IconSizes(
+    public val small: Dp = 32.dp,
+    public val medium: Dp = 40.dp,
+    public val large: Dp = 48.dp,
+) {
+
+    /** Returns a copy of this IconSizes, optionally overriding some of the values. */
+    public fun copy(
+        small: Dp = this.small,
+        medium: Dp = this.medium,
+        large: Dp = this.large,
+    ): IconSizes = IconSizes(small = small, medium = medium, large = large)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is IconSizes) return false
+
+        if (small != other.small) return false
+        if (medium != other.medium) return false
+        if (large != other.large) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = small.hashCode()
+        result = 31 * result + medium.hashCode()
+        result = 31 * result + large.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "IconSizes(small=$small, medium=$medium, large=$large)"
+    }
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/list-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/list-source.md
@@ -1,0 +1,394 @@
+When creating a Glimmer List component, refer to the following source code in
+`List.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer.list
+
+import androidx.compose.foundation.OverscrollEffect
+import androidx.compose.foundation.gestures.FlingBehavior
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.layout.LazyLayout
+import androidx.compose.foundation.rememberOverscrollEffect
+import androidx.compose.foundation.scrollableArea
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastMap
+import androidx.xr.glimmer.GlimmerTheme
+import androidx.xr.glimmer.edgeScrim
+import kotlin.math.max
+
+/**
+ * This is a scrolling list component that only composes and lays out the currently visible items.
+ * It is based on [androidx.compose.foundation.lazy.LazyColumn], but with extra functionality and
+ * customized behavior required for Jetpack Compose Glimmer. For Jetpack Compose Glimmer
+ * applications, it is recommended to use [VerticalList] instead of
+ * [androidx.compose.foundation.lazy.LazyColumn], as it is specifically designed to provide seamless
+ * focus-based navigation, visual scrim edge effects and support for focus-aware snap behavior.
+ *
+ * The [content] block defines a DSL which allows you to emit items of different types. For example,
+ * you can use [ListScope.item] to add a single item and [ListScope.items] to add a list of items.
+ *
+ * See the other [VerticalList] overload for a variant with a title slot.
+ *
+ * @sample androidx.xr.glimmer.samples.VerticalListSample
+ * @param modifier the modifier to apply to this layout.
+ * @param state the state object to be used to control or observe the list's state.
+ * @param contentPadding a padding around the whole content. This will add padding for the content
+ *   after it has been clipped, which is not possible via [modifier] param. You can use it to add a
+ *   padding before the first item or after the last one.
+ * @param userScrollEnabled If user gestures are enabled.
+ * @param overscrollEffect the [OverscrollEffect] that will be used to render overscroll for this
+ *   layout. Note that the [OverscrollEffect.node] will be applied internally as well - you do not
+ *   need to use Modifier.overscroll separately.
+ * @param flingBehavior logic describing fling and snapping behavior when drag has finished.
+ * @param reverseLayout reverses the direction of scrolling and layout.
+ * @param horizontalAlignment aligns items horizontally.
+ * @param verticalArrangement is arrangement for items. This only applies if the content is smaller
+ *   than the viewport.
+ * @param content a block which describes the content. Inside this block you can use methods like
+ *   [ListScope.item] to add a single item or [ListScope.items] to add a list of items.
+ */
+@Composable
+public fun VerticalList(
+    modifier: Modifier = Modifier,
+    state: ListState = rememberListState(),
+    contentPadding: PaddingValues = VerticalListDefaults.contentPadding,
+    userScrollEnabled: Boolean = true,
+    overscrollEffect: OverscrollEffect? = rememberOverscrollEffect(),
+    flingBehavior: FlingBehavior = VerticalListDefaults.flingBehavior(state),
+    reverseLayout: Boolean = false,
+    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
+    verticalArrangement: Arrangement.Vertical = VerticalListDefaults.verticalArrangement,
+    content: ListScope.() -> Unit,
+): Unit =
+    List(
+        orientation = Orientation.Vertical,
+        modifier = modifier,
+        state = state,
+        reverseLayout = reverseLayout,
+        contentPadding = contentPadding,
+        userScrollEnabled = userScrollEnabled,
+        overscrollEffect = overscrollEffect,
+        flingBehavior = flingBehavior,
+        horizontalAlignment = horizontalAlignment,
+        verticalArrangement = verticalArrangement,
+        verticalAlignment = null,
+        horizontalArrangement = null,
+        content = content,
+    )
+
+/**
+ * This is a scrolling list component that only composes and lays out the currently visible items.
+ * It is based on [androidx.compose.foundation.lazy.LazyColumn], but with extra functionality and
+ * customized behavior required for Jetpack Compose Glimmer. Jetpack Compose Glimmer applications
+ * should always use VerticalList instead of LazyColumn to ensure correct behavior.
+ *
+ * The [content] block defines a DSL which allows you to emit items of different types. For example,
+ * you can use [ListScope.item] to add a single item and [ListScope.items] to add a list of items.
+ *
+ * This overload of `VerticalList` contains a `title` slot. The title is expected to be a
+ * [androidx.xr.glimmer.TitleChip]. It is positioned at the top center and visually overlaps the
+ * list content. The list is vertically offset to start from the title's vertical center. When the
+ * list is scrolled, the title remains static.
+ *
+ * See the other [VerticalList] overload for a variant with no title slot.
+ *
+ * @sample androidx.xr.glimmer.samples.VerticalListWithTitleChipSample
+ * @param title a composable slot for the list title, expected to be a
+ *   [androidx.xr.glimmer.TitleChip]. It overlaps the list, positioned at the top-center, and
+ *   remains stuck to the top when the list is scrolled.
+ * @param modifier applies to the layout that contains both list and title.
+ * @param state the state object to be used to control or observe the list's state.
+ * @param contentPadding a padding around the whole content. This will add padding for the content
+ *   after it has been clipped, which is not possible via [modifier] param. You can use it to add a
+ *   padding before the first item or after the last one. The list is vertically offset to start
+ *   from the title's vertical center, so custom content paddings must provide sufficient space to
+ *   avoid content being obscured.
+ * @param userScrollEnabled If user gestures are enabled.
+ * @param overscrollEffect the [OverscrollEffect] that will be used to render overscroll for this
+ *   layout. Note that the [OverscrollEffect.node] will be applied internally as well - you do not
+ *   need to use Modifier.overscroll separately.
+ * @param flingBehavior logic describing fling and snapping behavior when drag has finished.
+ * @param reverseLayout reverses the direction of scrolling and layout.
+ * @param horizontalAlignment aligns items horizontally.
+ * @param verticalArrangement is arrangement for items. This only applies if the content is smaller
+ *   than the viewport.
+ * @param content a block which describes the content. Inside this block you can use methods like
+ *   [ListScope.item] to add a single item or [ListScope.items] to add a list of items.
+ */
+@Suppress(
+    // The main trailing lambda is [content], but it's DSL.
+    "ComposableLambdaParameterNaming",
+    "ComposableLambdaParameterPosition",
+)
+@Composable
+public fun VerticalList(
+    title: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    state: ListState = rememberListState(),
+    contentPadding: PaddingValues = VerticalListDefaults.contentPaddingWithTitle,
+    userScrollEnabled: Boolean = true,
+    overscrollEffect: OverscrollEffect? = rememberOverscrollEffect(),
+    flingBehavior: FlingBehavior = VerticalListDefaults.flingBehavior(state),
+    reverseLayout: Boolean = false,
+    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
+    verticalArrangement: Arrangement.Vertical = VerticalListDefaults.verticalArrangement,
+    content: ListScope.() -> Unit,
+) {
+    VerticalListWithTitleLayout(
+        modifier = modifier,
+        title = title,
+        list = {
+            VerticalList(
+                state = state,
+                contentPadding = contentPadding,
+                userScrollEnabled = userScrollEnabled,
+                overscrollEffect = overscrollEffect,
+                flingBehavior = flingBehavior,
+                reverseLayout = reverseLayout,
+                horizontalAlignment = horizontalAlignment,
+                verticalArrangement = verticalArrangement,
+                content = content,
+            )
+        },
+    )
+}
+
+/** Contains the default values used by [VerticalList]. */
+public object VerticalListDefaults {
+    /**
+     * Recommended value for the distance between items.
+     *
+     * @see [verticalArrangement] for the default arrangement that uses this spacing.
+     */
+    public val itemSpacing: Dp
+        @Composable get() = GlimmerTheme.componentSpacingValues.extraLarge
+
+    /** The maximum height of the fade effects on the sides of the list. */
+    public val ScrimMaxHeight: Dp = 46.dp
+
+    /** Recommended content padding values for lists without a title. */
+    public val contentPadding: PaddingValues
+        @Composable get() = PaddingValues(vertical = itemSpacing, horizontal = 0.dp)
+
+    /** Recommended content padding values for lists with a title. */
+    public val contentPaddingWithTitle: PaddingValues
+        @Composable get() = PaddingValues(top = ScrimMaxHeight, bottom = itemSpacing)
+
+    /** Recommended values for the vertical arrangement. */
+    public val verticalArrangement: Arrangement.Vertical
+        @Composable get() = Arrangement.spacedBy(itemSpacing)
+
+    /**
+     * Creates and remembers the default fling behavior for a [VerticalList] that aligns the focus
+     * position with list scroll.
+     *
+     * @param state The [ListState] to observe for layout and focus information.
+     * @return A [FlingBehavior] instance that provides focus-aware snapping.
+     */
+    @Composable
+    public fun flingBehavior(state: ListState): FlingBehavior {
+        val snapLayoutInfoProvider = remember(state) { SnapLayoutInfoProvider(state) }
+        return rememberSnapFlingBehavior(snapLayoutInfoProvider)
+    }
+}
+
+@Composable
+private fun VerticalListWithTitleLayout(
+    modifier: Modifier = Modifier,
+    title: @Composable () -> Unit,
+    list: @Composable () -> Unit,
+) {
+    Layout(modifier = modifier, contents = listOf(list, title)) { measurables, constraints ->
+        // The title parameter is provided by users, requiring iteration through all measurables.
+        // The list parameter is provided by us, allowing to guarantee that it contains only
+        // a single measurable.
+        val listMeasurable = measurables[0][0]
+        val titleMeasurables = measurables[1]
+        // Measure title(s) first.
+        var titleMaxHeight = 0
+        var titleMaxWidth = 0
+        val titleConstraints = constraints.copyMaxDimensions()
+        val titlePlaceables =
+            titleMeasurables.fastMap { measurable ->
+                val placeable = measurable.measure(titleConstraints)
+                titleMaxHeight = max(titleMaxHeight, placeable.height)
+                titleMaxWidth = max(titleMaxWidth, placeable.width)
+                placeable
+            }
+
+        // List shouldn't use the space above the vertical center of the title.
+        val titleYOffset = titleMaxHeight / 2
+        val maxListHeight = constraints.maxHeight - titleYOffset
+        val minListHeight = minOf(constraints.minHeight, maxListHeight)
+        val listConstraints = constraints.copy(minHeight = minListHeight, maxHeight = maxListHeight)
+        val listPlaceable = listMeasurable.measure(listConstraints)
+
+        val layoutWidth = maxOf(listPlaceable.width, titleMaxWidth)
+        val layoutHeight = listPlaceable.height + titleYOffset
+        layout(width = layoutWidth, height = layoutHeight) {
+            // Place the list first.
+            listPlaceable.placeRelative(
+                x = (layoutWidth - listPlaceable.width) / 2,
+                y = titleYOffset,
+            )
+            // Then place the rest of the titles on top of the list.
+            titlePlaceables.fastForEach { titlePlaceable ->
+                // Each title's center aligned with the top of the list.
+                titlePlaceable.placeRelative(
+                    x = (layoutWidth - titlePlaceable.width) / 2,
+                    y = (titleMaxHeight - titlePlaceable.height) / 2,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * The scrolling list that only composes and lays out the currently visible items. The [content]
+ * block defines a DSL which allows you to emit items of different types. For example, you can use
+ * [ListScope.item] to add a single item and [ListScope.items] to add a list of items.
+ *
+ * @param orientation The orientation in which to layout items in this list.
+ * @param modifier the modifier to apply to this layout.
+ * @param state the state object to be used to control or observe the list's state.
+ * @param contentPadding a padding around the whole content. This will add padding for the content
+ *   after it has been clipped, which is not possible via [modifier] param. You can use it to add a
+ *   padding before the first item or after the last one.
+ * @param userScrollEnabled If user gestures are enabled.
+ * @param overscrollEffect the [OverscrollEffect] that will be used to render overscroll for this
+ *   layout. Note that the [OverscrollEffect.node] will be applied internally as well - you do not
+ *   need to use Modifier.overscroll separately.
+ * @param flingBehavior logic describing fling and snapping behavior when drag has finished.
+ * @param reverseLayout reverses the direction of scrolling and layout.
+ * @param horizontalAlignment aligns items horizontally. It's required and used only if
+ *   [orientation] is [Orientation.Vertical].
+ * @param verticalArrangement is arrangement for items. This only applies if the content is smaller
+ *   than the viewport. It's required and used only if [orientation] is [Orientation.Vertical].
+ * @param verticalAlignment aligns items vertically. It's required and used only if [orientation] is
+ *   [Orientation.Horizontal].
+ * @param horizontalArrangement is arrangement for items. This only applies if the content is
+ *   smaller than the viewport. It's required and used only if [orientation] is
+ *   [Orientation.Vertical].
+ * @param content a block which describes the content. Inside this block you can use methods like
+ *   [ListScope.item] to add a single item or [ListScope.items] to add a list of items.
+ */
+@Composable
+internal fun List(
+    orientation: Orientation,
+    modifier: Modifier,
+    state: ListState,
+    contentPadding: PaddingValues,
+    userScrollEnabled: Boolean,
+    overscrollEffect: OverscrollEffect?,
+    flingBehavior: FlingBehavior,
+    reverseLayout: Boolean,
+    horizontalAlignment: Alignment.Horizontal?,
+    verticalArrangement: Arrangement.Vertical?,
+    verticalAlignment: Alignment.Vertical?,
+    horizontalArrangement: Arrangement.Horizontal?,
+    content: ListScope.() -> Unit,
+) {
+    val itemProvider = rememberGlimmerListItemProviderLambda(state, content)
+
+    val semanticState = rememberGlimmerListSemanticState(state, orientation)
+
+    val scrollEnabled = isScrollEnabled(userScrollEnabled, state)
+
+    val measurePolicy =
+        rememberGlimmerListMeasurePolicy(
+            itemProviderLambda = itemProvider,
+            state = state,
+            contentPadding = contentPadding,
+            reverseLayout = reverseLayout,
+            orientation = orientation,
+            horizontalAlignment = horizontalAlignment,
+            verticalArrangement = verticalArrangement,
+            verticalAlignment = verticalAlignment,
+            horizontalArrangement = horizontalArrangement,
+        )
+
+    val beyondBoundsModifier =
+        if (scrollEnabled) {
+            Modifier.lazyLayoutBeyondBoundsModifier(
+                state = rememberGlimmerListBeyondBoundsState(state),
+                beyondBoundsInfo = state.beyondBoundsInfo,
+                reverseLayout = reverseLayout,
+                orientation = orientation,
+            )
+        } else {
+            Modifier
+        }
+
+    LazyLayout(
+        modifier =
+            modifier
+                .then(state.remeasurementModifier)
+                .then(state.awaitLayoutModifier)
+                .autoFocus(state.autoFocusState)
+                .lazyLayoutSemantics(
+                    itemProviderLambda = itemProvider,
+                    state = semanticState,
+                    orientation = orientation,
+                    userScrollEnabled = scrollEnabled,
+                    reverseScrolling = reverseLayout,
+                )
+                .then(beyondBoundsModifier)
+                .edgeScrim(
+                    state = state.scrollIndicatorState,
+                    orientation = orientation,
+                    maxScrimSize = VerticalListDefaults.ScrimMaxHeight,
+                )
+                .scrollableArea(
+                    state = state,
+                    orientation = orientation,
+                    enabled = scrollEnabled,
+                    interactionSource = state.internalInteractionSource,
+                    overscrollEffect = overscrollEffect,
+                    flingBehavior = flingBehavior,
+                ),
+        itemProvider = itemProvider,
+        measurePolicy = measurePolicy,
+    )
+}
+
+@Composable
+private fun isScrollEnabled(userScrollEnabled: Boolean, state: ListState): Boolean {
+    if (userScrollEnabled) {
+        val derivedState =
+            remember(state) { derivedStateOf { state.canScrollForward || state.canScrollBackward } }
+        return derivedState.value
+    } else {
+        return false
+    }
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/listitem-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/listitem-source.md
@@ -1,0 +1,281 @@
+When creating a Glimmer Icon Sizes component, refer to the following source
+code in `ListItem.kt` for list items:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.dp
+
+/**
+ * ListItem is a component used to represent a single item in a
+ * [androidx.xr.glimmer.list.GlimmerLazyColumn]. A ListItem has a primary label [content], and may
+ * also have any combination of [supportingLabel], [leadingIcon], and [trailingIcon]. The supporting
+ * label is displayed below the primary label and can be used to provide additional information. A
+ * ListItem fills the maximum width available by default.
+ *
+ * This ListItem is focusable - see the other [ListItem] overload for a clickable ListItem.
+ *
+ * A simple ListItem with just a primary label:
+ *
+ * @sample androidx.xr.glimmer.samples.ListItemSample
+ *
+ * A ListItem with a primary and supporting label:
+ *
+ * @sample androidx.xr.glimmer.samples.ListItemWithSupportingLabelSample
+ *
+ * A ListItem with a primary label, a supporting label, and a leading icon:
+ *
+ * @sample androidx.xr.glimmer.samples.ListItemWithSupportingLabelAndLeadingIconSample
+ * @param modifier the [Modifier] to be applied to this list item
+ * @param supportingLabel optional supporting label to be placed underneath the primary label
+ *   [content]
+ * @param leadingIcon optional leading icon to be placed before the primary label [content]. This is
+ *   typically an [Icon] tinted with [contentColor] by default.
+ * @param trailingIcon optional trailing icon to be placed after the primary label [content]. This
+ *   is typically an [Icon] tinted with [contentColor] by default.
+ * @param shape the [Shape] used to clip this list item, and also used to draw the background and
+ *   border
+ * @param color background color of this list item
+ * @param contentColor content color used by components inside [content], [supportingLabel],
+ *   [leadingIcon], and [trailingIcon].
+ * @param border the border to draw around this list item
+ * @param contentPadding the spacing values to apply internally between the container and the
+ *   content
+ * @param interactionSource an optional hoisted [MutableInteractionSource] for observing and
+ *   emitting Interactions for this list item. You can use this to change the list item's appearance
+ *   or preview the list item in different states. Note that if `null` is provided, interactions
+ *   will still happen internally.
+ * @param content the main content / primary label to display inside this list item
+ */
+@Composable
+public fun ListItem(
+    modifier: Modifier = Modifier,
+    supportingLabel: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    shape: Shape = GlimmerTheme.shapes.medium,
+    color: Color = GlimmerTheme.colors.surface,
+    contentColor: Color = calculateContentColor(color),
+    border: BorderStroke? = SurfaceDefaults.border(),
+    contentPadding: PaddingValues = ListItemDefaults.contentPadding,
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable () -> Unit,
+) {
+    ListItemImpl(
+        modifier = modifier,
+        onClick = null,
+        supportingLabel = supportingLabel,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        shape = shape,
+        color = color,
+        contentColor = contentColor,
+        border = border,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content,
+    )
+}
+
+/**
+ * ListItem is a component used to represent a single item in a
+ * [androidx.xr.glimmer.list.GlimmerLazyColumn]. A ListItem has a primary label [content], and may
+ * also have any combination of [supportingLabel], [leadingIcon], and [trailingIcon]. The supporting
+ * label is displayed below the primary label and can be used to provide additional information. A
+ * ListItem fills the maximum width available by default.
+ *
+ * This ListItem is focusable and clickable - see the other [ListItem] overload for a ListItem that
+ * is only focusable.
+ *
+ * A simple clickable ListItem with just a primary label:
+ *
+ * @sample androidx.xr.glimmer.samples.ClickableListItemSample
+ *
+ * A clickable ListItem with a primary and supporting label:
+ *
+ * @sample androidx.xr.glimmer.samples.ClickableListItemWithSupportingLabelSample
+ *
+ * A clickable ListItem with a primary label, a supporting label, and a leading icon:
+ *
+ * @sample androidx.xr.glimmer.samples.ClickableListItemWithSupportingLabelAndLeadingIconSample
+ * @param onClick called when this list item is clicked
+ * @param modifier the [Modifier] to be applied to this list item
+ * @param supportingLabel optional supporting label to be placed underneath the primary label
+ *   [content]
+ * @param leadingIcon optional leading icon to be placed before the primary label [content]. This is
+ *   typically an [Icon] tinted with [contentColor] by default.
+ * @param trailingIcon optional trailing icon to be placed after the primary label [content]. This
+ *   is typically an [Icon] tinted with [contentColor] by default.
+ * @param shape the [Shape] used to clip this list item, and also used to draw the background and
+ *   border
+ * @param color background color of this list item
+ * @param contentColor content color used by components inside [content], [supportingLabel],
+ *   [leadingIcon], and [trailingIcon].
+ * @param border the border to draw around this list item
+ * @param contentPadding the spacing values to apply internally between the container and the
+ *   content
+ * @param interactionSource an optional hoisted [MutableInteractionSource] for observing and
+ *   emitting Interactions for this list item. You can use this to change the list item's appearance
+ *   or preview the list item in different states. Note that if `null` is provided, interactions
+ *   will still happen internally.
+ * @param content the main content / primary label to display inside this list item
+ */
+@Composable
+public fun ListItem(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    supportingLabel: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    shape: Shape = GlimmerTheme.shapes.medium,
+    color: Color = GlimmerTheme.colors.surface,
+    contentColor: Color = calculateContentColor(color),
+    border: BorderStroke? = SurfaceDefaults.border(),
+    contentPadding: PaddingValues = ListItemDefaults.contentPadding,
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable () -> Unit,
+) {
+    ListItemImpl(
+        modifier = modifier,
+        onClick = onClick,
+        supportingLabel = supportingLabel,
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        shape = shape,
+        color = color,
+        contentColor = contentColor,
+        border = border,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content,
+    )
+}
+
+@Composable
+private fun ListItemImpl(
+    modifier: Modifier,
+    onClick: (() -> Unit)?,
+    supportingLabel: @Composable (() -> Unit)?,
+    leadingIcon: @Composable (() -> Unit)?,
+    trailingIcon: @Composable (() -> Unit)?,
+    shape: Shape,
+    color: Color,
+    contentColor: Color,
+    border: BorderStroke?,
+    contentPadding: PaddingValues,
+    interactionSource: MutableInteractionSource?,
+    content: @Composable () -> Unit,
+) {
+    val iconSize = GlimmerTheme.iconSizes.large
+    val typography = GlimmerTheme.typography
+    val innerPadding = GlimmerTheme.componentSpacingValues.small
+    val internalInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+
+    val surfaceModifier =
+        Modifier.surface(
+                shape = shape,
+                color = color,
+                contentColor = contentColor,
+                // TODO(b/532516157): Reenable depthEffect after b/446294492 is fixed.
+                depthEffect = null,
+                border = border,
+                interactionSource = internalInteractionSource,
+            )
+            .then(
+                if (onClick != null) {
+                    Modifier.clickable(
+                        interactionSource = internalInteractionSource,
+                        onClick = onClick,
+                    )
+                } else {
+                    Modifier.focusable(interactionSource = internalInteractionSource)
+                }
+            )
+
+    Row(
+        modifier =
+            modifier
+                .then(surfaceModifier)
+                .fillMaxWidth()
+                .defaultMinSize(minHeight = MinimumHeight)
+                .padding(contentPadding),
+        verticalAlignment = CenterVertically,
+    ) {
+        if (leadingIcon != null) {
+            Box(modifier = Modifier.align(Alignment.Top), contentAlignment = Alignment.TopStart) {
+                CompositionLocalProvider(LocalIconSize provides iconSize, content = leadingIcon)
+            }
+        }
+        Column(Modifier.weight(1f).padding(horizontal = innerPadding)) {
+            if (supportingLabel == null) {
+                CompositionLocalProvider(
+                    LocalTextStyle provides typography.bodySmall,
+                    content = content,
+                )
+            } else {
+                CompositionLocalProvider(
+                    LocalTextStyle provides typography.titleSmall,
+                    content = content,
+                )
+                CompositionLocalProvider(
+                    LocalTextStyle provides typography.bodySmall,
+                    content = supportingLabel,
+                )
+            }
+        }
+        if (trailingIcon != null) {
+            Box(modifier = Modifier.align(Alignment.Top), contentAlignment = Alignment.TopEnd) {
+                CompositionLocalProvider(LocalIconSize provides iconSize, content = trailingIcon)
+            }
+        }
+    }
+}
+
+/** Default values used for [ListItem] */
+public object ListItemDefaults {
+    /** Default content padding used for a [ListItem] */
+    public val contentPadding: PaddingValues
+        @Composable get() = PaddingValues(GlimmerTheme.componentSpacingValues.large)
+}
+
+/** Default minimum height for a [ListItem] */
+private val MinimumHeight = 80.dp
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/liststate-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/liststate-source.md
@@ -1,0 +1,420 @@
+When creating a Glimmer List component, refer to the following source code in
+`ListState.kt` for creating a state for the list:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer.list
+
+import androidx.annotation.IntRange
+import androidx.compose.foundation.MutatePriority
+import androidx.compose.foundation.ScrollIndicatorState
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.ScrollScope
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.lazy.layout.LazyLayoutPinnedItemList
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.annotation.FrequentlyChangingValue
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.neverEqualPolicy
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.layout.AlignmentLine
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.Remeasurement
+import androidx.compose.ui.layout.RemeasurementModifier
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.xr.glimmer.list.ListState.Companion.Saver
+import kotlin.math.abs
+
+/**
+ * Creates a [ListState] that is remembered across compositions.
+ *
+ * Changes to the provided initial values will **not** result in the state being recreated or
+ * changed in any way if it has already been created.
+ *
+ * @param initialFirstVisibleItemIndex the initial value for [ListState.firstVisibleItemIndex]
+ * @param initialFirstVisibleItemScrollOffset the initial value for
+ *   [ListState.firstVisibleItemScrollOffset]
+ */
+@Composable
+public fun rememberListState(
+    initialFirstVisibleItemIndex: Int = 0,
+    initialFirstVisibleItemScrollOffset: Int = 0,
+): ListState =
+    rememberSaveable(saver = ListState.Saver) {
+        ListState(initialFirstVisibleItemIndex, initialFirstVisibleItemScrollOffset)
+    }
+
+/**
+ * A state object that can be hoisted to control and observe scrolling.
+ *
+ * In most cases, this will be created via [rememberListState].
+ *
+ * @param firstVisibleItemIndex the initial value for [ListState.firstVisibleItemIndex]
+ * @param firstVisibleItemScrollOffset the initial value for
+ *   [ListState.firstVisibleItemScrollOffset]
+ */
+public class ListState(firstVisibleItemIndex: Int = 0, firstVisibleItemScrollOffset: Int = 0) :
+    ScrollableState {
+
+    private val backingState = ScrollableState { -onScroll(-it) }
+
+    // TODO: b/414961654 - Consider making this abstraction around "anchor item".
+    /** The holder class for the current scroll position. */
+    private val scrollPosition =
+        GlimmerListScrollPosition(firstVisibleItemIndex, firstVisibleItemScrollOffset)
+
+    /** Backing state for [layoutInfo] */
+    internal val layoutInfoState = mutableStateOf(EmptyLazyListMeasureResult, neverEqualPolicy())
+
+    private val density: Density
+        get() = layoutInfoState.value.density
+
+    /**
+     * This field is used to save information about the number of "beyond bounds items" that we want
+     * to compose. These items are not within the visible bounds of the lazy layout, but we compose
+     * them because they are explicitly requested through the
+     * [beyond bounds layout API][androidx.compose.ui.layout.BeyondBoundsLayout].
+     */
+    internal val beyondBoundsInfo = LazyLayoutBeyondBoundsInfo()
+
+    /** Includes information for requesting focus for children as the list scrolls. */
+    internal val autoFocusState = GlimmerListAutoFocusState()
+
+    /** Stores currently pinned items which are always composed. */
+    internal val pinnedItems = LazyLayoutPinnedItemList()
+
+    internal val internalInteractionSource: MutableInteractionSource = MutableInteractionSource()
+
+    /**
+     * The scroll amount was provided in `onScroll` to be consumed during the current measure pass.
+     *
+     * Scrolling forward is negative.
+     */
+    internal var incomingScroll: Float = 0f
+        private set
+
+    /**
+     * This value retains the scroll amount that we want to carry over between measure passes. It
+     * represents the amount of scroll from previous passes that wasn't consumed back then but is
+     * awaiting to be consumed later. Together with [incomingScroll], this represents the total
+     * scroll available to the list during the current measure pass.
+     *
+     * This variable exists because the layout uses integer pixels while [onScroll] operates with
+     * fractional floats. Consequently, the list might receive tiny fractions of scroll input which,
+     * when aggregated, should equate to a few pixels of scrolling. However, because these small
+     * fractions are spread across many [onScroll] invocations, the list ignores them, making it
+     * feel unresponsive during slow, gentle touches. To avoid this, instead of ignoring these tiny
+     * scroll increments, the list accumulates them so they can be added to the next scroll part and
+     * actually consumed in a subsequent pass.
+     *
+     * Note that this value can sometimes be opposite to the scroll direction. This occurs because
+     * the [Float] -> [Int] rounding causes us to consume more than was provided. To compensate, we
+     * add a negative value to [incomingScroll] the next time.
+     *
+     * Scrolling forward is negative.
+     */
+    internal var carryOverScroll: Float = 0f
+        private set
+
+    /**
+     * This value is updated after the measure pass inside [applyMeasureResult] and defines how much
+     * of the [incomingScroll] was actually used.
+     */
+    private var consumedScroll: Float = 0f
+
+    internal val nearestRange: kotlin.ranges.IntRange by
+        LazyLayoutNearestRangeState(0, NearestItemsSlidingWindowSize, NearestItemsExtraItemCount)
+
+    /**
+     * The [Remeasurement] object associated with our layout. It allows us to remeasure
+     * synchronously during scroll.
+     */
+    internal var remeasurement: Remeasurement? = null
+        private set
+
+    /** The modifier which provides [remeasurement]. */
+    internal val remeasurementModifier =
+        object : RemeasurementModifier {
+            override fun onRemeasurementAvailable(remeasurement: Remeasurement) {
+                this@ListState.remeasurement = remeasurement
+            }
+        }
+
+    /**
+     * Provides a modifier which allows to delay some interactions (e.g. scroll) until layout is
+     * ready.
+     */
+    internal val awaitLayoutModifier = AwaitFirstLayoutModifier()
+
+    /**
+     * The index of the first item that is visible within the scrollable viewport area not including
+     * items in the content padding region. For the first visible item that includes items in the
+     * content padding please use [ListLayoutInfo.visibleItemsInfo].
+     *
+     * Note that this property is observable and if you use it in the composable function it will be
+     * recomposed on every change causing potential performance issues.
+     */
+    public val firstVisibleItemIndex: Int
+        @FrequentlyChangingValue get() = scrollPosition.index
+
+    /**
+     * The scroll offset of the first visible item. Scrolling forward is positive - i.e., the amount
+     * that the item is offset backwards.
+     *
+     * Note that this property is observable and if you use it in the composable function it will be
+     * recomposed on every scroll causing potential performance issues.
+     */
+    public val firstVisibleItemScrollOffset: Int
+        @FrequentlyChangingValue get() = scrollPosition.scrollOffset
+
+    /**
+     * The object of [ListLayoutInfo] calculated during the last layout pass. For example, you can
+     * use it to calculate what items are currently visible.
+     *
+     * Note that this property is observable and is updated after every scroll or remeasure. If you
+     * use it in the composable function it will be recomposed on every change causing potential
+     * performance issues including infinity recomposition loop. Therefore, avoid using it in the
+     * composition.
+     *
+     * If you want to run some side effects like sending an analytics event or updating a state
+     * based on this value consider using "snapshotFlow":
+     */
+    public val layoutInfo: ListLayoutInfo
+        @FrequentlyChangingValue get() = layoutInfoState.value
+
+    /**
+     * [InteractionSource] that will be used to dispatch drag events when this list is being
+     * dragged. If you want to know whether the fling (or animated scroll) is in progress, use
+     * [isScrollInProgress].
+     */
+    public val interactionSource: InteractionSource
+        get() = internalInteractionSource
+
+    /** Snaps to the requested scroll position. */
+    internal fun snapToItemIndexInternal(index: Int, scrollOffset: Int) {
+        scrollPosition.requestPositionAndForgetLastKnownKey(index, scrollOffset)
+        remeasurement?.forceRemeasure()
+    }
+
+    /**
+     * When the user provided custom keys for the items we can try to detect when there were items
+     * added or removed before our current first visible item and keep this item as the first
+     * visible one even given that its index has been changed.
+     */
+    internal fun updateScrollPositionIfTheFirstItemWasMoved(
+        itemProvider: GlimmerListItemProvider,
+        firstItemIndex: Int,
+    ): Int = scrollPosition.updateScrollPositionIfTheFirstItemWasMoved(itemProvider, firstItemIndex)
+
+    /**
+     * Called during the measurement pass once the dispatched [incomingScroll] has been handled and
+     * the new item positions are known.
+     *
+     * @param result lazy list measuring results.
+     * @param consumedScroll defines how much scroll was consumed during the measure pass.
+     * @param scrollToCarryOver tracks the amount of scrolling that the internal logic has reported
+     *   as consumed, but wants to save for later measurement. Also, if the list consumes more
+     *   scroll than it was given (for example, due to rounding errors), this value can be set to a
+     *   negative amount to balance it out in the next pass. This value should never be larger than
+     *   [consumedScroll].
+     */
+    internal fun applyMeasureResult(
+        result: GlimmerListMeasureResult,
+        consumedScroll: Float,
+        scrollToCarryOver: Float,
+    ) {
+        this.consumedScroll = consumedScroll
+        this.carryOverScroll = scrollToCarryOver
+
+        canScrollBackward = result.canScrollBackward
+        canScrollForward = result.canScrollForward
+        layoutInfoState.value = result
+
+        scrollPosition.updateFromMeasureResult(result)
+    }
+
+    internal fun onScroll(distance: Float): Float {
+        if (distance < 0 && !canScrollForward || distance > 0 && !canScrollBackward) {
+            return 0f
+        }
+
+        // Fast path. Skip measure pass.
+        if (abs(distance + carryOverScroll) <= 0.5f) {
+            // Inside measuring we do `scrollToBeConsumed.roundToInt()` so there will be no scroll
+            // if we have less than 0.5 pixels. So just accumulate it for the next pass.
+            carryOverScroll += distance
+            return distance
+        }
+
+        incomingScroll = distance
+        // The `forceRemeasure()` invocation triggers the measure pass where [incomingScroll]
+        // will be used to update [consumedScroll] and [carryOverScroll] values.
+        remeasurement?.forceRemeasure()
+        // It's important to reset this value because there are measure passes
+        // triggered from outside scrolling. They read this value as well.
+        // So, after we used it, we need to reset it to zero.
+        incomingScroll = 0f
+
+        return consumedScroll
+    }
+
+    override suspend fun scroll(
+        scrollPriority: MutatePriority,
+        block: suspend ScrollScope.() -> Unit,
+    ) {
+        awaitLayoutModifier.waitForFirstLayout()
+        backingState.scroll(scrollPriority, block)
+    }
+
+    override fun dispatchRawDelta(delta: Float): Float = backingState.dispatchRawDelta(delta)
+
+    override val isScrollInProgress: Boolean
+        get() = backingState.isScrollInProgress
+
+    @get:Suppress("GetterSetterNames")
+    override var canScrollForward: Boolean by mutableStateOf(false)
+        private set
+
+    @get:Suppress("GetterSetterNames")
+    override var canScrollBackward: Boolean by mutableStateOf(false)
+        private set
+
+    override val scrollIndicatorState: ScrollIndicatorState
+        get() = _scrollIndicatorState
+
+    private val _scrollIndicatorState =
+        object : ScrollIndicatorState {
+            override val scrollOffset: Int
+                @FrequentlyChangingValue
+                get() =
+                    with(layoutInfoState.value) {
+                        if (this === EmptyLazyListMeasureResult) {
+                            Int.MAX_VALUE
+                        } else {
+                            this@ListState.firstVisibleItemIndex * visibleItemsAverageSize +
+                                this@ListState.firstVisibleItemScrollOffset
+                        }
+                    }
+
+            override val contentSize: Int
+                @FrequentlyChangingValue
+                get() =
+                    with(layoutInfoState.value) {
+                        if (this === EmptyLazyListMeasureResult) {
+                            Int.MAX_VALUE
+                        } else {
+                            // Approximate size of all content
+                            (totalItemsCount * visibleItemsAverageSize) -
+                                // Subtract the final trailing spacing that is not shown
+                                (if (totalItemsCount > 0) mainAxisItemSpacing else 0) +
+                                // Add the inner paddings (which are separate from the item sizes)
+                                beforeContentPadding +
+                                afterContentPadding
+                        }
+                    }
+
+            override val viewportSize: Int
+                get() =
+                    with(layoutInfoState.value) {
+                        if (this === EmptyLazyListMeasureResult) {
+                            Int.MAX_VALUE
+                        } else {
+                            mainAxisViewportSize
+                        }
+                    }
+        }
+
+    /**
+     * Instantly brings the item at [index] to the top of the viewport, offset by [scrollOffset]
+     * pixels.
+     *
+     * @param index the index to which to scroll. Must be non-negative.
+     * @param scrollOffset the offset that the item should end up after the scroll. Note that
+     *   positive offset refers to forward scroll, so in a top-to-bottom list, positive offset will
+     *   scroll the item further upward (taking it partly offscreen).
+     */
+    public suspend fun scrollToItem(@IntRange(from = 0) index: Int, scrollOffset: Int = 0) {
+        scroll { snapToItemIndexInternal(index, scrollOffset) }
+    }
+
+    /**
+     * Animate (smooth scroll) to the given item.
+     *
+     * @param index the index to which to scroll. Must be non-negative.
+     * @param scrollOffset the offset that the item should end up after the scroll. Note that
+     *   positive offset refers to forward scroll, so in a top-to-bottom list, positive offset will
+     *   scroll the item further upward (taking it partly offscreen).
+     */
+    public suspend fun animateScrollToItem(@IntRange(from = 0) index: Int, scrollOffset: Int = 0) {
+        scroll {
+            GlimmerListScrollScope(this@ListState, this)
+                .animateScrollToItem(index, scrollOffset, NumberOfItemsToTeleport, density)
+        }
+    }
+
+    public companion object {
+        /** The default [Saver] implementation for [ListState]. */
+        public val Saver: Saver<ListState, Any> =
+            listSaver(
+                save = { listOf(it.firstVisibleItemIndex, it.firstVisibleItemScrollOffset) },
+                restore = {
+                    ListState(firstVisibleItemIndex = it[0], firstVisibleItemScrollOffset = it[1])
+                },
+            )
+    }
+}
+
+private val EmptyLazyListMeasureResult =
+    GlimmerListMeasureResult(
+        firstVisibleItem = null,
+        firstVisibleItemScrollOffset = 0,
+        canScrollForward = false,
+        consumedScroll = 0f,
+        measureResult =
+            object : MeasureResult {
+                override val width: Int = 0
+                override val height: Int = 0
+
+                @Suppress("PrimitiveInCollection")
+                override val alignmentLines: Map<AlignmentLine, Int> = emptyMap()
+
+                override fun placeChildren() {}
+            },
+        visibleItemsInfo = emptyList(),
+        viewportStartOffset = 0,
+        viewportEndOffset = 0,
+        totalItemsCount = 0,
+        reverseLayout = false,
+        orientation = Orientation.Vertical,
+        afterContentPadding = 0,
+        mainAxisItemSpacing = 0,
+        remeasureNeeded = false,
+        density = Density(1f),
+        childConstraints = Constraints(),
+    )
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/material-hct-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/material-hct-source.md
@@ -1,0 +1,217 @@
+Use the following calculation metrics for color contrast in `hct.ts`:
+
+```typescript
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A color system built using CAM16 hue and chroma, and L* from
+ * L*a*b*.
+ *
+ * Using L* creates a link between the color system, contrast, and thus
+ * accessibility. Contrast ratio depends on relative luminance, or Y in the XYZ
+ * color space. L*, or perceptual luminance can be calculated from Y.
+ *
+ * Unlike Y, L* is linear to human perception, allowing trivial creation of
+ * accurate color tones.
+ *
+ * Unlike contrast ratio, measuring contrast in L* is linear, and simple to
+ * calculate. A difference of 40 in HCT tone guarantees a contrast ratio >= 3.0,
+ * and a difference of 50 guarantees a contrast ratio >= 4.5.
+ */
+
+import * as utils from '../utils/color_utils.js';
+
+import {Cam16} from './cam16.js';
+import {HctSolver} from './hct_solver.js';
+import {ViewingConditions} from './viewing_conditions.js';
+
+
+/**
+ * HCT, hue, chroma, and tone. A color system that provides a perceptually
+ * accurate color measurement system that can also accurately render what colors
+ * will appear as in different lighting environments.
+ */
+export class Hct {
+  /**
+   * @param hue 0 <= hue < 360; invalid values are corrected.
+   * @param chroma 0 <= chroma < ?; Informally, colorfulness. The color
+   *     returned may be lower than the requested chroma. Chroma has a different
+   *     maximum for any given hue and tone.
+   * @param tone 0 <= tone <= 100; invalid values are corrected.
+   * @return HCT representation of a color in default viewing conditions.
+   */
+
+  internalHue: number;
+  internalChroma: number;
+  internalTone: number;
+
+  static from(hue: number, chroma: number, tone: number) {
+    return new Hct(HctSolver.solveToInt(hue, chroma, tone));
+  }
+
+  /**
+   * @param argb ARGB representation of a color.
+   * @return HCT representation of a color in default viewing conditions
+   */
+  static fromInt(argb: number) {
+    return new Hct(argb);
+  }
+
+  toInt(): number {
+    return this.argb;
+  }
+
+  /**
+   * A number, in degrees, representing ex. red, orange, yellow, etc.
+   * Ranges from 0 <= hue < 360.
+   */
+  get hue(): number {
+    return this.internalHue;
+  }
+
+  /**
+   * @param newHue 0 <= newHue < 360; invalid values are corrected.
+   * Chroma may decrease because chroma has a different maximum for any given
+   * hue and tone.
+   */
+  set hue(newHue: number) {
+    this.setInternalState(
+        HctSolver.solveToInt(
+            newHue,
+            this.internalChroma,
+            this.internalTone,
+            ),
+    );
+  }
+
+  get chroma(): number {
+    return this.internalChroma;
+  }
+
+  /**
+   * @param newChroma 0 <= newChroma < ?
+   * Chroma may decrease because chroma has a different maximum for any given
+   * hue and tone.
+   */
+  set chroma(newChroma: number) {
+    this.setInternalState(
+        HctSolver.solveToInt(
+            this.internalHue,
+            newChroma,
+            this.internalTone,
+            ),
+    );
+  }
+
+  /** Lightness. Ranges from 0 to 100. */
+  get tone(): number {
+    return this.internalTone;
+  }
+
+  /**
+   * @param newTone 0 <= newTone <= 100; invalid valids are corrected.
+   * Chroma may decrease because chroma has a different maximum for any given
+   * hue and tone.
+   */
+  set tone(newTone: number) {
+    this.setInternalState(
+        HctSolver.solveToInt(
+            this.internalHue,
+            this.internalChroma,
+            newTone,
+            ),
+    );
+  }
+
+  /** Sets a property of the Hct object. */
+  setValue(propertyName: string, value: number) {
+    (this as any)[propertyName] = value;
+  }
+
+  toString(): string {
+    return `HCT(${this.hue.toFixed(0)}, ${this.chroma.toFixed(0)}, ${
+        this.tone.toFixed(0)})`;
+  }
+
+  static isBlue(hue: number): boolean {
+    return hue >= 250 && hue < 270;
+  }
+
+  static isYellow(hue: number): boolean {
+    return hue >= 105 && hue < 125;
+  }
+
+  static isCyan(hue: number): boolean {
+    return hue >= 170 && hue < 207;
+  }
+
+  private constructor(private argb: number) {
+    const cam = Cam16.fromInt(argb);
+    this.internalHue = cam.hue;
+    this.internalChroma = cam.chroma;
+    this.internalTone = utils.lstarFromArgb(argb);
+    this.argb = argb;
+  }
+
+  private setInternalState(argb: number) {
+    const cam = Cam16.fromInt(argb);
+    this.internalHue = cam.hue;
+    this.internalChroma = cam.chroma;
+    this.internalTone = utils.lstarFromArgb(argb);
+    this.argb = argb;
+  }
+
+  /**
+   * Translates a color into different [ViewingConditions].
+   *
+   * Colors change appearance. They look different with lights on versus off,
+   * the same color, as in hex code, on white looks different when on black.
+   * This is called color relativity, most famously explicated by Josef Albers
+   * in Interaction of Color.
+   *
+   * In color science, color appearance models can account for this and
+   * calculate the appearance of a color in different settings. HCT is based on
+   * CAM16, a color appearance model, and uses it to make these calculations.
+   *
+   * See [ViewingConditions.make] for parameters affecting color appearance.
+   */
+  inViewingConditions(vc: ViewingConditions): Hct {
+    // 1. Use CAM16 to find XYZ coordinates of color in specified VC.
+    const cam = Cam16.fromInt(this.toInt());
+    const viewedInVc = cam.xyzInViewingConditions(vc);
+
+    // 2. Create CAM16 of those XYZ coordinates in default VC.
+    const recastInVc = Cam16.fromXyzInViewingConditions(
+        viewedInVc[0],
+        viewedInVc[1],
+        viewedInVc[2],
+        ViewingConditions.make(),
+    );
+
+    // 3. Create HCT from:
+    // - CAM16 using default VC with XYZ coordinates in specified VC.
+    // - L* converted from Y in XYZ coordinates in specified VC.
+    const recastHct = Hct.from(
+        recastInVc.hue,
+        recastInVc.chroma,
+        utils.lstarFromY(viewedInVc[1]),
+    );
+    return recastHct;
+  }
+}
+```

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/projectedcontext-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/projectedcontext-source.md
@@ -1,0 +1,265 @@
+When using a Projected Context to launch the Glasses Projected activity on the
+Projected Device, refer to the following source code in `ProjectedContext.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.projected
+
+import android.app.ActivityOptions
+import android.companion.virtual.VirtualDeviceManager
+import android.content.Context
+import android.hardware.display.DisplayManager
+import android.hardware.display.DisplayManager.EVENT_TYPE_DISPLAY_ADDED
+import android.hardware.display.DisplayManager.EVENT_TYPE_DISPLAY_CHANGED
+import android.hardware.display.DisplayManager.EVENT_TYPE_DISPLAY_REMOVED
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.annotation.VisibleForTesting
+import androidx.xr.projected.experimental.ExperimentalProjectedApi
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+/**
+ * Helper for accessing Projected device [Context] and its features.
+ *
+ * Projected device is an XR device connected to an Android device (host). Host can project the
+ * application content to the Projected device and let users interact with it.
+ *
+ * The Projected device context will ensure Projected device system services are returned, when
+ * queried for system services from this object.
+ *
+ * Note: The application context's deviceId can switch between the Projected and host deviceId
+ * depending on which activity was most recently in the foreground. Prefer using the Activity
+ * context to minimize the risk of running into this problem.
+ */
+@ExperimentalProjectedApi
+public object ProjectedContext {
+
+    private const val TAG = "ProjectedContext"
+
+    @VisibleForTesting internal const val PROJECTED_DEVICE_NAME = "ProjectionDevice"
+    @VisibleForTesting internal const val PROJECTED_DISPLAY_NAME = "ProjectionDisplay"
+
+    /**
+     * Explicitly create the Projected device context from any context object.
+     *
+     * @throws IllegalStateException if the projected device was not found.
+     */
+    @JvmStatic
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    public fun createProjectedDeviceContext(context: Context): Context {
+        val deviceId =
+            getProjectedDeviceId(context)
+                ?: throw IllegalStateException("Projected device not found.")
+        return context.createDeviceContext(deviceId)
+    }
+
+    /**
+     * Explicitly create the host device context from any context object. The host is the device
+     * that connects to a Projected device.
+     *
+     * If an application is using a Projected device context and it wants to use system services
+     * from the host (e.g. phone), it needs to use the host device context.
+     */
+    @JvmStatic
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    public fun createHostDeviceContext(context: Context): Context =
+        context.createDeviceContext(Context.DEVICE_ID_DEFAULT)
+
+    /**
+     * Returns the name of the Projected device or null if either virtual device wasn't found or the
+     * name of the virtual device wasn't set.
+     *
+     * @throws IllegalArgumentException If another context is used (e.g. the host context).
+     */
+    @JvmStatic
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    public fun getProjectedDeviceName(context: Context): String? =
+        // TODO: b/424812882 - Turn this into a lint check with an annotation.
+        if (isProjectedDeviceContext(context)) {
+            getVirtualDevice(context)?.name
+        } else {
+            throw IllegalArgumentException(
+                "Provided context is not the Projected device context. Can't get the device name."
+            )
+        }
+
+    /** Returns whether the provided context is the Projected device context. */
+    @JvmStatic
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    public fun isProjectedDeviceContext(context: Context): Boolean =
+        getVirtualDevice(context)?.name?.startsWith(PROJECTED_DEVICE_NAME) == true
+
+    /**
+     * Creates [ActivityOptions] that should be used to start an activity on the Projected device.
+     *
+     * @param context any [Context] object. If the provided context is not a Projected device
+     *   context, a Projected device context will be created automatically and used to create
+     *   Projected [ActivityOptions].
+     * @throws IllegalStateException if the projected display was not found or if the Projected
+     *   device doesn't have any displays.
+     */
+    @JvmStatic
+    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+    public fun createProjectedActivityOptions(context: Context): ActivityOptions {
+        val projectedDeviceContext =
+            if (isProjectedDeviceContext(context)) {
+                context
+            } else {
+                createProjectedDeviceContext(context)
+            }
+
+        val projectedDisplayIds = getProjectedDisplayIds(projectedDeviceContext)
+
+        check(projectedDisplayIds.isNotEmpty()) { "Projected device doesn't have any displays." }
+
+        val projectedDisplay =
+            context.getSystemService(DisplayManager::class.java).displays.find {
+                it.name == PROJECTED_DISPLAY_NAME && projectedDisplayIds.contains(it.displayId)
+            } ?: throw IllegalStateException("No projected display found.")
+
+        return ActivityOptions.makeBasic().setLaunchDisplayId(projectedDisplay.displayId)
+    }
+
+    /**
+     * Observe whether a Projected device is connected to the host.
+     *
+     * @param context The context used to access the [VirtualDeviceManager]. It can be any context
+     *   object.
+     * @param coroutineContext The CoroutineContext that includes CoroutineDispatcher which is where
+     *   the Projected device connectivity observer is executed on.
+     * @throws IllegalArgumentException if provided coroutineContext doesn't include
+     *   CoroutineDispatcher.
+     */
+    @JvmStatic
+    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    public fun isProjectedDeviceConnected(
+        context: Context,
+        coroutineContext: CoroutineContext,
+    ): Flow<Boolean> =
+        callbackFlow {
+                @OptIn(ExperimentalStdlibApi::class)
+                val coroutineDispatcher =
+                    coroutineContext[CoroutineDispatcher]
+                        ?: throw IllegalArgumentException(
+                            "CoroutineContext must contain a CoroutineDispatcher."
+                        )
+
+                fun checkAndSend() {
+                    trySend(isProjectedDisplayAvailable(context))
+                }
+
+                val virtualDeviceListener =
+                    object : VirtualDeviceManager.VirtualDeviceListener {
+                        override fun onVirtualDeviceCreated(deviceId: Int) {
+                            checkAndSend()
+                        }
+
+                        override fun onVirtualDeviceClosed(deviceId: Int) {
+                            checkAndSend()
+                        }
+                    }
+
+                val displayListener =
+                    object : DisplayManager.DisplayListener {
+                        override fun onDisplayAdded(displayId: Int) {
+                            checkAndSend()
+                        }
+
+                        override fun onDisplayChanged(displayId: Int) {
+                            checkAndSend()
+                        }
+
+                        override fun onDisplayRemoved(displayId: Int) {
+                            checkAndSend()
+                        }
+                    }
+
+                checkAndSend()
+
+                val virtualDeviceManager =
+                    context.getSystemService(VirtualDeviceManager::class.java)
+                virtualDeviceManager.registerVirtualDeviceListener(
+                    coroutineDispatcher.asExecutor(),
+                    virtualDeviceListener,
+                )
+
+                val displayManager = context.getSystemService(DisplayManager::class.java)
+                val eventFilter =
+                    EVENT_TYPE_DISPLAY_ADDED or
+                        EVENT_TYPE_DISPLAY_CHANGED or
+                        EVENT_TYPE_DISPLAY_REMOVED
+                displayManager.registerDisplayListener(
+                    coroutineDispatcher.asExecutor(),
+                    eventFilter,
+                    displayListener,
+                )
+
+                awaitClose {
+                    virtualDeviceManager.unregisterVirtualDeviceListener(virtualDeviceListener)
+                    displayManager.unregisterDisplayListener(displayListener)
+                }
+            }
+            .distinctUntilChanged()
+
+    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+    private fun isProjectedDisplayAvailable(context: Context): Boolean {
+        val projectedDeviceContext =
+            try {
+                createProjectedDeviceContext(context)
+            } catch (e: IllegalStateException) {
+                return false
+            }
+        val projectedDisplayIds = getProjectedDisplayIds(projectedDeviceContext)
+        if (projectedDisplayIds.isEmpty()) {
+            return false
+        }
+        val displayManager = context.getSystemService(DisplayManager::class.java)
+        return displayManager.displays.any {
+            it.name == PROJECTED_DISPLAY_NAME && projectedDisplayIds.contains(it.displayId)
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun getProjectedDeviceId(context: Context) =
+        context
+            .getSystemService(VirtualDeviceManager::class.java)
+            .virtualDevices
+            // TODO: b/424824481 - Replace the name matching with a better method.
+            .find { it.name?.startsWith(PROJECTED_DEVICE_NAME) ?: false }
+            ?.deviceId
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun getVirtualDevice(context: Context) =
+        context.getSystemService(VirtualDeviceManager::class.java).virtualDevices.find {
+            it.deviceId == context.deviceId
+        }
+
+    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+    private fun getProjectedDisplayIds(context: Context) =
+        getVirtualDevice(context)?.displayIds ?: IntArray(size = 0)
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/stack-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/stack-source.md
@@ -1,0 +1,369 @@
+When creating a Glimmer Stack component, refer to the following source code in
+`Stack.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer.stack
+
+import androidx.compose.animation.core.VisibilityThreshold
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.pager.PagerDefaults
+import androidx.compose.foundation.pager.PagerSnapDistance
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.VerticalPager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.referentialEqualityPolicy
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastFirstOrNull
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.lerp
+import androidx.compose.ui.zIndex
+import androidx.xr.glimmer.internal.SingleItemScrollConstraintConnection
+import kotlin.math.roundToInt
+
+/**
+ * [VerticalStack] is a lazy, vertically scrollable layout that arranges its items in a visually
+ * overlapping, three-dimensional sequence, which resembles a deck of cards. The primary item is
+ * prominently displayed in the foreground. Subsequent items are positioned behind the primary item
+ * along the z-axis with a small portion of the next item revealed to indicate depth and upcoming
+ * content.
+ *
+ * As the user scrolls vertically, the active foreground item transitions out of view, allowing the
+ * item immediately beneath it to slide into the prominent foreground position. Items always
+ * snap-animate into the foreground position after the user's gesture ends.
+ *
+ * Note: When displaying text within a [VerticalStack], it is strongly recommended to set
+ * [androidx.compose.ui.text.TextStyle.textMotion] to
+ * [androidx.compose.ui.text.style.TextMotion.Animated]. This ensures smooth rendering during layout
+ * animations or scaling transitions, preventing pixel-snapping artifacts.
+ *
+ * @sample androidx.xr.glimmer.samples.VerticalStackSample
+ * @param modifier the modifier to apply to this layout.
+ * @param state the state of the stack.
+ * @param content a block that describes the content. Inside this block you can use methods like
+ *   [StackScope.item] to add a single item or [StackScope.items] to add a collection of items.
+ */
+@Composable
+public fun VerticalStack(
+    modifier: Modifier = Modifier,
+    state: StackState = rememberStackState(),
+    content: StackScope.() -> Unit,
+) {
+    val latestContent = rememberUpdatedState(content)
+    val stackItemHolderState =
+        remember(state) {
+            // Re-run the DSL to parse items only when the content lambda instance changes.
+            derivedStateOf(referentialEqualityPolicy()) {
+                    StackItemHolder(state, latestContent.value).also {
+                        // Set the item count on the StackState immediately when the derived state
+                        // re-evaluates (i.e., when content changes), even before recomposition.
+                        state.itemCount = it.itemCount
+                    }
+                }
+                .also {
+                    // This second assignment is necessary to force the derivedStateOf lambda above
+                    // (which is executed lazily) to execute synchronously inside this block.
+                    state.itemCount = it.value.itemCount
+                }
+        }
+
+    val singleItemScrollConstraintConnection =
+        remember(state.pagerState) { SingleItemScrollConstraintConnection(state.pagerState) }
+
+    VerticalPager(
+        state = state.pagerState,
+        modifier =
+            modifier
+                .then(StackInitialFocusElement(state))
+                .stackScrim()
+                .nestedScroll(singleItemScrollConstraintConnection),
+        contentPadding = PaddingValues(bottom = RevealAreaSize),
+        key = { page -> stackItemHolderState.value.getKey(page) },
+        beyondViewportPageCount = MaxNextVisibleItemCount,
+        flingBehavior =
+            PagerDefaults.flingBehavior(
+                state = state.pagerState,
+                pagerSnapDistance = PagerSnapDistance.atMost(1),
+                snapAnimationSpec = SnapAnimationSpec,
+            ),
+    ) { page ->
+        val stackItemHolder = stackItemHolderState.value
+        stackItemHolder.withInterval(page) { localIndex, itemInterval ->
+            val key =
+                itemInterval.getKeyOrDefault(globalIndex = page, localIntervalIndex = localIndex)
+            val itemScope = itemInterval.getOrCreateItemScope(key)
+            itemScope.index = page
+            StackItemLayout(page = page, state = state, itemScope = itemScope) {
+                itemInterval.item(itemScope, localIndex)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StackItemLayout(
+    page: Int,
+    state: StackState,
+    itemScope: StackItemScopeImpl,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val focusRequester = remember { FocusRequester() }
+    Layout(
+        content = content,
+        modifier =
+            modifier
+                .zIndex(-page.toFloat())
+                .onPlaced { itemScope.coordinates = it }
+                .maskItemsBelow(state, itemScope)
+                .focusRequester(focusRequester)
+                .onFocusChanged { state.onItemFocusChanged(page, it) },
+    ) { measurables, constraints ->
+        var maxWidth = 0
+        var maxHeight = 0
+        val placeables =
+            measurables.fastMap {
+                it.measure(constraints).also { placeable ->
+                    maxWidth = maxOf(maxWidth, placeable.width)
+                    maxHeight = maxOf(maxHeight, placeable.height)
+                }
+            }
+
+        if (!isLookingAhead) {
+            state.layoutInfoInternal.updateMeasuredHeight(index = page, height = maxHeight)
+        }
+
+        layout(maxWidth, maxHeight) {
+            placeables.fastForEach { placeable ->
+                placeable.placeRelativeWithLayer(x = 0, y = 0) {
+                    val revealHeight = RevealAreaSize.roundToPx()
+                    val topItem = state.topItem
+                    when {
+                        page.isTopItem(topItem = topItem) -> {
+                            translationY =
+                                state.topItemTranslationY(
+                                    revealHeight = revealHeight,
+                                    topItemHeight = placeable.height,
+                                )
+
+                            state.notifyAutoFocus(page, focusRequester)
+                        }
+
+                        page.isNextItem(topItem = topItem) -> {
+                            translationY =
+                                state.nextItemTranslationY(
+                                    revealHeight = revealHeight,
+                                    topItem = topItem,
+                                    nextItemHeight = placeable.height,
+                                )
+                            val scale = state.nextItemScale()
+                            scaleX = scale
+                            scaleY = scale
+
+                            state.notifyAutoFocus(page, focusRequester)
+                        }
+
+                        page.isNextNextItem(topItem = topItem) -> {
+                            translationY =
+                                state.nextNextItemTranslationY(
+                                    revealHeight = revealHeight,
+                                    topItem = topItem,
+                                    nextNextItemHeight = placeable.height,
+                                )
+                            scaleX = NextItemMinScale
+                            scaleY = NextItemMinScale
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Masks the items following the current item (items that are below the current item on Z-axis) if
+ * the item's decoration fills the viewport width.
+ */
+private fun Modifier.maskItemsBelow(state: StackState, itemScope: StackItemScopeImpl): Modifier =
+    this.drawWithContent {
+        val viewportSize = state.layoutInfoInternal.viewportSize
+        val viewportWidth = viewportSize.width.toFloat()
+
+        if (itemScope.maskWidth >= (viewportWidth - DecorationWidthNoiseThresholdPx)) {
+            // Only apply the mask to the items below (Z-axis) if the mask fills the viewport width.
+            val viewportHeight = viewportSize.height.toFloat()
+            drawRect(
+                Color.Black,
+                blendMode = BlendMode.DstOut,
+                // The coordinate space here is for the item's layout, which changes position in the
+                // stack viewport depending on the scroll position. We need to deduct the viewport
+                // height to make the starting Y offset negative, so that the mask region extends
+                // upwards to the top of the stack viewport.
+                topLeft = Offset(x = 0f, y = itemScope.maskBottomY - viewportHeight),
+                size = Size(width = viewportWidth, height = viewportHeight),
+            )
+        }
+
+        drawContent()
+    }
+
+/**
+ * The translation Y of the top item in pixels, which is always equal to the snapped position
+ * offset.
+ */
+private fun StackState.topItemTranslationY(revealHeight: Int, topItemHeight: Int) =
+    calculateTopPositionOffset(topItemHeight, revealHeight)
+
+/** The current translation Y of the next item in pixels. */
+private fun StackState.nextItemTranslationY(
+    revealHeight: Int,
+    topItem: Int,
+    nextItemHeight: Int,
+): Float {
+    val nextPageOffset = pagerState.pageOffset(topItem + 1)
+    val progress = topItemOffsetFraction
+    val topItemHeight = layoutInfoInternal.measuredTopItemHeight
+
+    val topPageTopPositionOffset = calculateTopPositionOffset(topItemHeight, revealHeight)
+    val nextPageTopPositionOffset = calculateTopPositionOffset(nextItemHeight, revealHeight)
+
+    val topItemBottom = topPageTopPositionOffset + topItemHeight
+    // startOffset is the initial offset of the next item when it's revealed below the top item.
+    val startOffset =
+        calculateInitialBehindPosition(
+            itemAboveBottom = topItemBottom + revealHeight,
+            itemBehindHeight = nextItemHeight,
+        )
+
+    val currentOffset =
+        lerp(start = startOffset, stop = nextPageTopPositionOffset, fraction = progress)
+
+    return currentOffset - nextPageOffset
+}
+
+/** The current scale of the next item. */
+private fun StackState.nextItemScale(): Float {
+    val progress = topItemOffsetFraction
+    return lerp(start = NextItemMinScale, stop = 1f, fraction = progress)
+}
+
+/** The current translation Y of the next-next item in pixels. */
+private fun StackState.nextNextItemTranslationY(
+    revealHeight: Int,
+    topItem: Int,
+    nextNextItemHeight: Int,
+): Float {
+    val nextNextPageOffset = pagerState.pageOffset(topItem + 2)
+    val nextItemHeight = layoutInfoInternal.measuredNextItemHeight
+
+    // Calculate where the next item *would* be if it were currently the top item.
+    val nextItemTopPositionOffset = calculateTopPositionOffset(nextItemHeight, revealHeight)
+    val nextItemTopPositionBottom = nextItemTopPositionOffset + nextItemHeight
+
+    // Calculate the static target position the next-next item.
+    // We add revealHeight to nextItemBottom to ensure the item waits at the exact position
+    // where it will need to be when it transitions to being the next item.
+    val offset =
+        calculateInitialBehindPosition(
+            itemAboveBottom = nextItemTopPositionBottom + revealHeight,
+            itemBehindHeight = nextNextItemHeight,
+        )
+
+    return offset - nextNextPageOffset
+}
+
+/**
+ * Calculates the offset from the top of the viewport for an item of a given height for the item's
+ * top snapped position. Items are aligned to the bottom of the stack layout.
+ */
+private fun StackState.calculateTopPositionOffset(itemHeight: Int, revealHeight: Int): Float {
+    val viewportHeight = layoutInfoInternal.viewportSize.height
+    return (viewportHeight - itemHeight - revealHeight).coerceAtLeast(0).toFloat()
+}
+
+/** Calculates the initial offset for an item when it is positioned behind the item above it. */
+private fun calculateInitialBehindPosition(itemAboveBottom: Float, itemBehindHeight: Int): Float =
+    itemAboveBottom - itemBehindHeight * NextItemPositioningScale
+
+/**
+ * The main axis offset of the item in pixels from the top of the viewport.
+ *
+ * If the page is in the visible list (inside the viewport), we return its exact offset. If it's not
+ * in the list but is composed (due to beyondViewportPageCount), we calculate where it *should* be
+ * based on the current page and offset fraction.
+ *
+ * Note: this method assumes that the Pager's layoutInfo is already available.
+ */
+private fun PagerState.pageOffset(page: Int): Int {
+    val layoutInfo = layoutInfo
+
+    // First check if the page is already visible.
+    val visiblePage = layoutInfo.visiblePagesInfo.fastFirstOrNull { it.index == page }
+    if (visiblePage != null) return visiblePage.offset
+
+    // Calculate the distance in "pages" from the current snap position.
+    // (page - currentPage) gives the index distance.
+    // (- currentPageOffsetFraction) accounts for the sub-page scroll.
+    val offsetFromCurrentPage = page - currentPage - currentPageOffsetFraction
+    val stride = layoutInfo.pageSize + layoutInfo.pageSpacing
+    return (offsetFromCurrentPage * stride).roundToInt()
+}
+
+/** The size of the area where the items beneath the top of the stack item are revealed. */
+internal val RevealAreaSize = 18.dp
+
+/** The maximum number of items that can be visible at the same time in addition to the top item. */
+private const val MaxNextVisibleItemCount = 2
+
+/**
+ * The scale of the next item when it is fully behind the top item, and the default scale of the
+ * item behind it (the next-next item).
+ */
+private const val NextItemMinScale = 0.94f
+
+/** The scale factor that's between 1.0 and [NextItemMinScale], which is used in positioning. */
+private const val NextItemPositioningScale = 0.97f // (1f + NextItemMinScale) / 2f
+
+/** The animation spec used for snapping stack items. */
+private val SnapAnimationSpec =
+    spring(
+        dampingRatio = 0.56f,
+        stiffness = 118f,
+        visibilityThreshold = Int.VisibilityThreshold.toFloat(),
+    )
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/stackitemscope-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/stackitemscope-source.md
@@ -1,0 +1,440 @@
+When creating a Glimmer Stack component, refer to the following source code in
+`StackItemScope.kt` for setting the stack item scope:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer.stack
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.PathMeasure
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.DelegatingNode
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.LayoutAwareModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.toSize
+import androidx.compose.ui.util.fastForEach
+import androidx.xr.glimmer.DepthEffectNode
+import androidx.xr.glimmer.GlimmerTheme.Companion.LocalGlimmerTheme
+import kotlin.math.abs
+
+/** Receiver scope used by item content in [VerticalStack]. */
+@Stable
+public sealed interface StackItemScope {
+
+    /**
+     * Adds a decoration shape for this item, which is used in graphical effects applied to stack
+     * items, e.g., item masking and depth effects. For each distinct shape inside a stack item,
+     * this modifier should be applied to match that shape's bounds. For simple items with just one
+     * shape (such as a card), only one modifier is needed.
+     *
+     * Applying this modifier is optional but highly recommended. If not applied, the item will
+     * render normally but will not have the expected depth effect or masking behavior. Omitting
+     * this modifier is a valid use case when no visual item decoration effects are desired.
+     *
+     * @sample androidx.xr.glimmer.samples.VerticalStackSample
+     * @sample androidx.xr.glimmer.samples.VerticalStackWithMultipleShapesSample
+     * @param shape The shape of the element this modifier is applied to.
+     */
+    public fun Modifier.itemDecoration(shape: Shape): Modifier =
+        this then ItemDecorationElement(this@StackItemScope as StackItemScopeImpl, shape)
+}
+
+internal class ItemDecorationElement
+internal constructor(private val stackItemScope: StackItemScopeImpl, private val shape: Shape) :
+    ModifierNodeElement<ItemDecorationNode>() {
+
+    override fun create(): ItemDecorationNode = ItemDecorationNode(stackItemScope, shape)
+
+    override fun update(node: ItemDecorationNode) {
+        node.update(stackItemScope, shape)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ItemDecorationElement) return false
+
+        if (stackItemScope != other.stackItemScope) return false
+        if (shape != other.shape) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = stackItemScope.hashCode()
+        result = 31 * result + shape.hashCode()
+        return result
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "stackItemDecoration"
+        properties["shape"] = shape
+    }
+}
+
+internal class StackItemScopeImpl(internal val state: StackState) : StackItemScope {
+
+    internal var index = -1
+    internal val decorations = mutableListOf<ItemDecorationNode>()
+    internal var coordinates: LayoutCoordinates? = null
+
+    internal var maskWidth by mutableFloatStateOf(0f)
+        private set
+
+    internal var maskBottomY by mutableFloatStateOf(0f)
+        private set
+
+    internal fun recalculateMask() {
+        // First find the max width to avoid unnecessary calls to calculateMaskBottomYInItem.
+        var maxDecorationWidth = 0f
+        decorations.fastForEach { decoration ->
+            val width = decoration.outline?.bounds?.width ?: 0f
+            if (width > maxDecorationWidth) {
+                maxDecorationWidth = width
+            }
+        }
+
+        if (maxDecorationWidth <= 0f) {
+            maskWidth = 0f
+            maskBottomY = 0f
+            return
+        }
+
+        var selectedDecoration: ItemDecorationNode? = null
+        var selectedDecorationMaskBottomY = 0f
+
+        decorations.fastForEach { decoration ->
+            val outline = decoration.outline ?: return@fastForEach
+            val bounds = outline.bounds
+
+            // Skip decorations that are narrower than the max found.
+            if (abs(bounds.width - maxDecorationWidth) > DecorationWidthNoiseThresholdPx) {
+                return@fastForEach
+            }
+
+            val decorationMaskBottomY = decoration.calculateMaskBottomYInItem()
+            if (selectedDecoration == null) {
+                selectedDecoration = decoration
+                selectedDecorationMaskBottomY = decorationMaskBottomY
+            } else {
+                // Tie-breaking: prefer higher widest point (smaller Y).
+                if (decorationMaskBottomY < selectedDecorationMaskBottomY) {
+                    selectedDecoration = decoration
+                    selectedDecorationMaskBottomY = decorationMaskBottomY
+                }
+            }
+        }
+
+        maskWidth = selectedDecoration?.outline?.bounds?.width ?: 0f
+        maskBottomY = selectedDecorationMaskBottomY
+    }
+}
+
+internal class ItemDecorationNode(
+    private var stackItemScope: StackItemScopeImpl,
+    private var shape: Shape,
+) :
+    DelegatingNode(),
+    LayoutAwareModifierNode,
+    CompositionLocalConsumerModifierNode,
+    DrawModifierNode {
+
+    internal var size = Size.Zero
+    internal var outline: Outline? = null
+    internal var offset: Offset = Offset.Zero
+
+    private var depthEffectNode: DepthEffectNode? = null
+    private var coordinates: LayoutCoordinates? = null
+
+    private var lastOutlineForCachedMaskBottomY: Outline? = null
+    private var cachedMaskBottomY: Float = 0f
+
+    private var minX = FloatArray(0)
+    private var maxX = FloatArray(0)
+    private var pathMeasure: PathMeasure? = null
+
+    override fun onAttach() {
+        depthEffectNode = delegate(DepthEffectNode(currentValueOfDepth(), shape))
+        stackItemScope.decorations.add(this)
+        if (size != Size.Zero) {
+            // If this node is reused, update the decoration in case there is no remeasure.
+            updateDecoration()
+        }
+    }
+
+    override fun onRemeasured(size: IntSize) {
+        this.size = size.toSize()
+        updateDecoration()
+    }
+
+    override fun onPlaced(coordinates: LayoutCoordinates) {
+        this.coordinates = coordinates
+        offset = calculateDecorationOffset()
+        stackItemScope.recalculateMask()
+    }
+
+    override fun onDetach() {
+        stackItemScope.decorations.remove(this)
+        depthEffectNode?.let { undelegate(it) }
+    }
+
+    override fun ContentDrawScope.draw() {
+        val index = stackItemScope.index
+        if (index == -1) return
+        val state = stackItemScope.state
+        val topItem = state.topItem
+        val offsetFraction = state.topItemOffsetFraction
+
+        val contentAlpha =
+            calculateContentAlpha(index = index, topItem = topItem, offsetFraction = offsetFraction)
+
+        // Apply alpha to the depth separately from the content so that the shadows are not clipped.
+        depthEffectNode?.apply { drawDepthEffect(alpha = contentAlpha) }
+
+        // Draw item content with a scrim based on the current alpha.
+        drawContent()
+
+        val scrimAlpha =
+            calculateScrimAlpha(index = index, topItem = topItem, offsetFraction = offsetFraction)
+        val scrimColor = getScrimColor(index = index, topItem = topItem)
+        val outline = getDecorationOutline()
+        scrimColor?.let {
+            // If there is a scrim color, apply it on top of the item.
+            drawOutline(outline = outline, color = it, alpha = scrimAlpha)
+        }
+
+        if (contentAlpha < 1f) {
+            drawOutline(
+                outline = outline,
+                blendMode = BlendMode.DstOut,
+                color = Color.Black,
+                alpha = 1f - contentAlpha,
+            )
+        }
+    }
+
+    fun update(stackItemScope: StackItemScopeImpl, shape: Shape) {
+        depthEffectNode?.update(currentValueOfDepth(), shape)
+        if (this.stackItemScope != stackItemScope || this.shape != shape) {
+            this.stackItemScope.decorations.remove(this)
+            stackItemScope.decorations.add(this)
+            this.stackItemScope = stackItemScope
+            this.shape = shape
+            updateDecoration()
+        }
+    }
+
+    internal fun getOrCalculateMaskBottomY(): Float {
+        if (outline !== lastOutlineForCachedMaskBottomY) {
+            cachedMaskBottomY = outline?.calculateMaskBottomY() ?: 0f
+            lastOutlineForCachedMaskBottomY = outline
+        }
+        return cachedMaskBottomY
+    }
+
+    private fun ContentDrawScope.getDecorationOutline(): Outline {
+        outline?.let {
+            return it
+        }
+        return shape.createOutline(size, layoutDirection, this).also { outline = it }
+    }
+
+    private fun updateDecoration() {
+        if (size == Size.Zero || !isAttached) return
+
+        offset = calculateDecorationOffset()
+        outline = createOutline()
+
+        stackItemScope.recalculateMask()
+    }
+
+    private fun createOutline(): Outline {
+        val density = currentValueOf(LocalDensity)
+        val layoutDirection = currentValueOf(LocalLayoutDirection)
+        return shape.createOutline(size, layoutDirection, density)
+    }
+
+    private fun calculateDecorationOffset(): Offset =
+        coordinates?.let { decorationCoordinates ->
+            stackItemScope.coordinates?.localPositionOf(
+                sourceCoordinates = decorationCoordinates,
+                relativeToSource = Offset.Zero,
+            )
+        } ?: Offset.Zero
+
+    private fun calculateContentAlpha(index: Int, topItem: Int, offsetFraction: Float): Float =
+        when {
+            index.isTopItem(topItem = topItem) -> 1f - offsetFraction
+            index.isNextItem(topItem = topItem) -> 1f
+            index.isNextNextItem(topItem = topItem) -> offsetFraction
+            else -> 0f
+        }
+
+    private fun calculateScrimAlpha(index: Int, topItem: Int, offsetFraction: Float): Float =
+        when {
+            index.isNextItem(topItem = topItem) -> (1f - offsetFraction) * MaxItemScrimAlpha
+            index.isNextNextItem(topItem = topItem) -> MaxItemScrimAlpha
+            else -> 0f
+        }
+
+    private fun getScrimColor(index: Int, topItem: Int): Color? =
+        when {
+            index.isNextItem(topItem = topItem) -> SurfaceLow
+            index.isNextNextItem(topItem = topItem) -> SurfaceLow
+            else -> null
+        }
+
+    private fun currentValueOfDepth() = currentValueOf(LocalGlimmerTheme).depthEffectLevels.level1
+
+    /**
+     * Returns the Y coordinate within [Outline] where the bottom boundary of the mask should be.
+     */
+    private fun Outline.calculateMaskBottomY(): Float =
+        when (this) {
+            is Outline.Rectangle -> 0f
+            is Outline.Rounded ->
+                // The mask's bottom is where the top corners of the round rect start curving.
+                roundRect.top +
+                    maxOf(roundRect.topLeftCornerRadius.y, roundRect.topRightCornerRadius.y)
+            is Outline.Generic -> calculateYAtWidestPoint(this)
+        }
+
+    /**
+     * Returns the Y coordinate within [Outline] where the outline is the widest.
+     *
+     * This uses a heuristic approach by sampling points along the path perimeter using
+     * [PathMeasure] and aggregating them into vertical buckets to determine the min/max X for a
+     * given Y. Shapes with sharp horizontal features might have their width slightly under-reported
+     * depending on sampling phase.
+     */
+    private fun calculateYAtWidestPoint(outline: Outline.Generic): Float {
+        val bounds = outline.bounds
+        val height = bounds.height
+        if (height <= 0f) return 0f
+
+        // 1 bucket every 2 pixels clamped to a reasonable range.
+        val resolution =
+            (height / 2)
+                .toInt()
+                .coerceIn(
+                    minimumValue = MinWidestPointSearchResolution,
+                    maximumValue = MaxWidestPointSearchResolution,
+                )
+
+        if (minX.size < resolution || maxX.size < resolution) {
+            // Allocate for max resolution to avoid reallocating the arrays on size changes.
+            minX = FloatArray(MaxWidestPointSearchResolution)
+            maxX = FloatArray(MaxWidestPointSearchResolution)
+        }
+
+        minX.fill(Float.POSITIVE_INFINITY, fromIndex = 0, toIndex = resolution)
+        maxX.fill(Float.NEGATIVE_INFINITY, fromIndex = 0, toIndex = resolution)
+
+        val measure = pathMeasure ?: PathMeasure().also { pathMeasure = it }
+        measure.setPath(outline.path, forceClosed = true)
+        val length = measure.length
+        if (length == 0f) return 0f
+
+        // 2 samples per bucket.
+        val totalSamples = resolution * 2
+        val stepSize = length / totalSamples
+
+        // Scale for converting Y to a bucket index.
+        val indexScale = (resolution - 1) / height
+        val boundsTop = bounds.top
+
+        var distance = 0f
+        while (distance <= length) {
+            val position = measure.getPosition(distance)
+            val x = position.x
+            val y = position.y
+
+            val relativeY = y - boundsTop
+            val bucketIndex = (relativeY * indexScale).toInt().coerceIn(0, resolution - 1)
+
+            if (x < minX[bucketIndex]) minX[bucketIndex] = x
+            if (x > maxX[bucketIndex]) maxX[bucketIndex] = x
+
+            distance += stepSize
+        }
+
+        // Default to the vertical center if no points are processed or path is empty.
+        var selectedIndex = resolution / 2
+        var maxFoundWidth = -1f
+        for (i in 0 until resolution) {
+            if (minX[i] == Float.POSITIVE_INFINITY || maxX[i] == Float.NEGATIVE_INFINITY) continue
+            val width = maxX[i] - minX[i]
+            // If widths are effectively equal, we preserve the lower index.
+            if (width > maxFoundWidth + DecorationWidthNoiseThresholdPx) {
+                maxFoundWidth = width
+                selectedIndex = i
+            }
+        }
+
+        return boundsTop + (height * selectedIndex / resolution.toFloat())
+    }
+}
+
+/**
+ * Calculates the Y coordinate within the stack item where the bottom boundary of the mask should
+ * be.
+ */
+private fun ItemDecorationNode.calculateMaskBottomYInItem(): Float =
+    offset.y + getOrCalculateMaskBottomY()
+
+/** Returns whether the index is of the top of the stack item. */
+internal fun Int.isTopItem(topItem: Int) = this == topItem
+
+/** Returns whether the index is of the next item that follows the top of the stack item. */
+internal fun Int.isNextItem(topItem: Int) = this == topItem + 1
+
+/** Returns whether the index is of the next-next item after the top of the stack item. */
+internal fun Int.isNextNextItem(topItem: Int) = this == topItem + 2
+
+/**
+ * Tolerance in pixels used to account for floating-point and heuristic estimation inaccuracies when
+ * comparing decoration widths.
+ */
+internal const val DecorationWidthNoiseThresholdPx = 0.5f
+
+private val SurfaceLow = Color(0xFF4F4F4F)
+private const val MaxItemScrimAlpha = 0.5f
+private const val MinWidestPointSearchResolution = 20
+private const val MaxWidestPointSearchResolution = 200
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/stackstate-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/stackstate-source.md
@@ -1,0 +1,325 @@
+When creating a Glimmer Stack component, refer to the following source code in
+`StackState.kt` for creating a state for the stack:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer.stack
+
+import androidx.annotation.IntRange
+import androidx.collection.MutableIntIntMap
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.MutatePriority
+import androidx.compose.foundation.gestures.ScrollScope
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.annotation.FrequentlyChangingValue
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.FocusState
+import androidx.compose.ui.unit.IntSize
+
+/**
+ * Creates and remembers a [StackState] for a [VerticalStack].
+ *
+ * The returned [StackState] is remembered across compositions and can be used to control or observe
+ * the state of a [VerticalStack]. It's essential to pass this state to the `state` parameter of the
+ * corresponding [VerticalStack] composable.
+ *
+ * Note: Properties of the state will only be correctly populated after the [VerticalStack] it is
+ * associated with has been composed for the first time.
+ *
+ * Warning: A single [StackState] instance must not be shared across multiple [VerticalStack]
+ * composables.
+ *
+ * @param initialTopItem The index of the item to show at the top of the stack initially. Must be
+ *   non-negative. Defaults to 0.
+ * @see StackState
+ * @see VerticalStack
+ */
+@Composable
+public fun rememberStackState(@IntRange(from = 0) initialTopItem: Int = 0): StackState =
+    rememberSaveable(saver = StackState.Saver) { StackState(initialTopItem) }
+
+/**
+ * The [VerticalStack] state that allows programmatic control and observation of the stack's state.
+ *
+ * A [StackState] object can be created and remembered using [rememberStackState].
+ *
+ * Note: Properties of the state will only be correctly populated after the [VerticalStack] it is
+ * associated with has been composed for the first time.
+ *
+ * Warning: A single [StackState] instance must not be shared across multiple [VerticalStack]
+ * composables.
+ *
+ * @param initialTopItem The index of the item to show at the top of the stack initially. Must be
+ *   non-negative. Defaults to 0.
+ * @see rememberStackState
+ * @see VerticalStack
+ */
+// TODO(b/413429531): add ScrollIndicatorState.
+@Stable
+public class StackState(@IntRange(from = 0) initialTopItem: Int = 0) : ScrollableState {
+
+    init {
+        require(initialTopItem >= 0) { "initialTopItem must be non-negative" }
+    }
+
+    internal var itemCount by mutableIntStateOf(0)
+
+    internal val pagerState = PagerState(currentPage = initialTopItem, pageCount = { itemCount })
+
+    /** The index of the item that's currently at the top of the stack, defaults to 0. */
+    public val topItem: Int
+        get() = topItemState.value
+
+    /**
+     * Backing state for [topItem] derived from [PagerState.currentPage] and
+     * [PagerState.currentPageOffsetFraction].
+     *
+     * In Stack, an item is considered the top of the stack item until it completely moves off the
+     * viewport (when scrolling forward), or until the previous item enters the viewport (when
+     * scrolling backward).
+     */
+    internal val topItemState = derivedStateOf {
+        if (pagerState.currentPageOffsetFraction >= 0) pagerState.currentPage
+        else pagerState.currentPage - 1
+    }
+
+    /**
+     * The offset of the top item as a fraction of the stack item container size. The value
+     * indicates how much the item is offset from the snapped position. This value ranges between
+     * 0.0 (snapped position) and 1.0 (lower bound of the top item is at the top of the viewport).
+     */
+    public val topItemOffsetFraction: Float
+        @FrequentlyChangingValue
+        get() {
+            // In Pager, [PagerState.currentPage] changes to the next page when the current page
+            // scrolls more than half way off the viewport, which is also when
+            // [PagerState.currentPageOffsetFraction] reaches 0.5. Similarly, when scrolling back,
+            // the [PagerState.currentPage] switches to the previous page when
+            // [PagerState.currentPageOffsetFraction] reaches -0.5. In other words, the current
+            // page's offset fraction ranges between -0.5 and 0.5. In Stack, an item is considered
+            // the top of the stack item until it completely moves off the viewport when scrolling
+            // forward, or until the previous item enters the viewport when scrolling backward. In
+            // other words, the top item's offset fraction ranges between 0 (at the snapped
+            // position) to 1.0 (at the top of the viewport).
+            val currentPageOffsetFraction = pagerState.currentPageOffsetFraction
+            return if (currentPageOffsetFraction >= 0) currentPageOffsetFraction
+            else currentPageOffsetFraction + 1f
+        }
+
+    /**
+     * [InteractionSource] that's used to dispatch drag events when this stack is being dragged. To
+     * know whether a fling (or animated scroll) is in progress, use [isScrollInProgress].
+     */
+    public val interactionSource: InteractionSource
+        get() = pagerState.interactionSource
+
+    /**
+     * Contains useful information about the currently displayed layout of this stack. The
+     * information is available after the first measure pass.
+     */
+    // TODO(b/446933128): when making layoutInfo public, consider making it a State.
+    internal val layoutInfoInternal = StackLayoutInfoImpl(pagerState, topItemState)
+
+    private var hasFocus: Boolean = false
+    private var focusedItem: Int = initialTopItem
+
+    /**
+     * Scroll (jump immediately) to a given [item] index.
+     *
+     * @param item The index of the destination item
+     */
+    public suspend fun scrollToItem(item: Int) {
+        if (itemCount == 0) return
+        pagerState.scrollToPage(item.coerceIn(0, itemCount - 1))
+    }
+
+    /**
+     * Scroll animate to a given [item]'s closest snap position. If the [item] is too far away from
+     * [topItem], not all the items in the range will be composed. Instead, the stack will jump to a
+     * nearer item, then compose and animate the rest of the items until the destination [item].
+     *
+     * @param item The index of the destination item
+     * @param animationSpec An [AnimationSpec] to move between items
+     */
+    public suspend fun animateScrollToItem(
+        item: Int,
+        animationSpec: AnimationSpec<Float> = spring(),
+    ) {
+        if (itemCount == 0) return
+        pagerState.animateScrollToPage(
+            item.coerceIn(0, itemCount - 1),
+            pageOffsetFraction = 0f,
+            animationSpec,
+        )
+    }
+
+    override suspend fun scroll(
+        scrollPriority: MutatePriority,
+        block: suspend ScrollScope.() -> Unit,
+    ) {
+        if (itemCount == 0) return
+        pagerState.scroll(scrollPriority, block)
+    }
+
+    override fun dispatchRawDelta(delta: Float): Float {
+        if (itemCount == 0) return 0f
+        return pagerState.dispatchRawDelta(delta)
+    }
+
+    override val isScrollInProgress: Boolean
+        get() = pagerState.isScrollInProgress
+
+    @get:Suppress("GetterSetterNames")
+    override val canScrollForward: Boolean
+        get() = pagerState.currentPage < pagerState.pageCount - 1
+
+    @get:Suppress("GetterSetterNames")
+    override val canScrollBackward: Boolean
+        get() = pagerState.currentPage > 0
+
+    @get:Suppress("GetterSetterNames")
+    override val lastScrolledForward: Boolean
+        get() = pagerState.lastScrolledForward
+
+    @get:Suppress("GetterSetterNames")
+    override val lastScrolledBackward: Boolean
+        get() = pagerState.lastScrolledBackward
+
+    /** Callback for top-level (pager-level) focus state changes. */
+    internal fun onTopLevelFocusChanged(focusState: FocusState) {
+        hasFocus = focusState.hasFocus
+    }
+
+    /** Callback for item-level focus state changes for the item at [index]. */
+    internal fun onItemFocusChanged(index: Int, focusState: FocusState) {
+        if (focusState.isFocused) focusedItem = index
+    }
+
+    /**
+     * Moves focus to [index] either to the current top item or the next item depending on whether
+     * the top item has moved past [FocusMoveThreshold] and if the item is not already in focus.
+     *
+     * If the stack doesn't already have focus, the auto focus logic doesn't apply.
+     */
+    internal fun notifyAutoFocus(index: Int, focusRequester: FocusRequester) {
+        if (!hasFocus) {
+            // Do not move focus if the stack doesn't already have focus.
+            return
+        }
+
+        val topItemValue = topItem
+        val intendedFocusedItem =
+            if (topItemOffsetFraction < FocusMoveThreshold) topItemValue
+            else (topItemValue + 1).coerceAtMost(itemCount - 1)
+
+        if (intendedFocusedItem != index) {
+            // The intended focused item is not the item at the requested index.
+            return
+        }
+
+        if (intendedFocusedItem == focusedItem) {
+            // No need to move focus if the intended focused item is already in focus.
+            return
+        }
+
+        focusRequester.requestFocus()
+    }
+
+    public companion object {
+        /** The default [Saver] implementation for [StackState]. */
+        public val Saver: Saver<StackState, *> =
+            Saver(save = { it.topItem }, restore = { StackState(it) })
+    }
+}
+
+/**
+ * Contains useful information about the currently displayed layout of a [VerticalStack]. This
+ * information is available after the first measure pass.
+ *
+ * Use [StackState.layoutInfoInternal] to retrieve this.
+ */
+@Stable
+internal sealed interface StackLayoutInfo {
+    // TODO(b/446933128): decide what properties should be exposed as public States.
+}
+
+/** The default implementation of [StackLayoutInfo]. */
+internal class StackLayoutInfoImpl
+internal constructor(private val pagerState: PagerState, private val topItemState: State<Int>) :
+    StackLayoutInfo {
+
+    /** The overall size of this stack's viewport. */
+    internal val viewportSize: IntSize
+        get() = pagerState.layoutInfo.viewportSize
+
+    /** The measured height of the top of the stack item. */
+    internal val measuredTopItemHeight: Int
+        get() = measuredHeights.getOrDefault(topItemState.value, defaultValue = 0)
+
+    /** The measured height of the item following the top of the stack item. */
+    internal val measuredNextItemHeight: Int
+        get() = measuredHeights.getOrDefault(topItemState.value + 1, defaultValue = 0)
+
+    /** The measured height of the item following the next item in the stack. */
+    internal val measuredNextNextItemHeight: Int
+        get() = measuredHeights.getOrDefault(topItemState.value + 2, defaultValue = 0)
+
+    /** The backing storage for measured item heights keyed by item index. */
+    // TODO(b/446933128): remove this once PageInfo exposes page sizes.
+    private val measuredHeights: MutableIntIntMap = MutableIntIntMap()
+
+    /**
+     * Updates the measured height of the item at the specified index and trims heights for items
+     * outside of the close range to the top item.
+     */
+    internal fun updateMeasuredHeight(index: Int, height: Int) {
+        measuredHeights.put(index, height)
+
+        // Clean up measured heights for items that are not in the close range to the top item.
+        // TODO(b/446933128): find a way to access currentPage inside of withoutReadObservation.
+        val currentPage = pagerState.currentPage
+        Snapshot.withoutReadObservation {
+            val itemCount = pagerState.pageCount
+            val itemRange = currentPage - 2..(currentPage + 3).coerceAtMost(itemCount - 1)
+            measuredHeights.removeIf { index, _ -> index !in itemRange }
+        }
+    }
+}
+
+/**
+ * The threshold of [StackState.topItemOffsetFraction] past which focus should automatically move to
+ * the next item.
+ */
+private const val FocusMoveThreshold = 0.6f
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/surface-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/surface-source.md
@@ -1,0 +1,749 @@
+When using surfaces to build a custom component, refer to the following source
+code in `Surface.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer
+
+import android.graphics.RuntimeShader
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.FocusInteraction
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shader
+import androidx.compose.ui.graphics.ShaderBrush
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.node.requireGraphicsContext
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.intellij.lang.annotations.Language
+
+/**
+ * A surface is a fundamental building block in Glimmer. A surface represents a distinct visual area
+ * or 'physical' boundary for components such as buttons and cards. A [surface] implements shared
+ * visual decoration for Jetpack Compose Glimmer components:
+ * 1) Clipping: a surface clips its children to the shape specified by [shape]
+ * 2) Border: a surface draws an inner [border] to emphasize the boundary of the component. When
+ *    focused, a surface draws a wider border with a focused highlight on top to indicate the focus
+ *    state.
+ * 3) Background: a surface has a background color of [color].
+ * 4) Depth effect: a surface can have different [DepthEffect] shadows for different states, as
+ *    specified by [depthEffect].
+ * 5) Content color: a surface provides a [contentColor] for text and icons inside the surface. By
+ *    default this is calculated from the provided background color.
+ * 6) Interaction states: when focused, a surface displays draws a wider border with a focused
+ *    highlight on top. When pressed, a surface draws a pressed overlay. This happens for
+ *    interactions emitted from [interactionSource].
+ *
+ * Use surface on its own for decorative elements that cannot be interacted with by a user:
+ *
+ * @sample androidx.xr.glimmer.samples.SurfaceSample
+ *
+ * In most cases surfaces should be interactive, to allow users to consistently move focus and
+ * navigate between components. You can use [androidx.compose.foundation.focusable] for focus-only
+ * surfaces, or [androidx.compose.foundation.clickable] and other modifiers for surfaces with
+ * actions. To ensure the surface correctly reflects the interaction states, provide the same
+ * [InteractionSource] to all modifiers.
+ *
+ * For example, to create a clickable surface:
+ *
+ * @sample androidx.xr.glimmer.samples.ClickableSurfaceSample
+ *
+ * Similarly, to create a focusable surface:
+ *
+ * @sample androidx.xr.glimmer.samples.FocusableSurfaceSample
+ * @param enabled controls the enabled state of this surface. When `false`, a disabled overlay
+ *   visual will be drawn on top of the surface. Note that this only affects the visual decoration;
+ *   it does not intercept input or block interaction states (such as focus or press) from the
+ *   [interactionSource].
+ * @param shape the [Shape] used to clip this surface, and also used to draw the background and
+ *   border
+ * @param color the background [Color] for this surface
+ * @param contentColor the [Color] for content inside this surface
+ * @param depthEffect the [SurfaceDepthEffect] for this surface, representing the [DepthEffect]
+ *   shadows rendered in different states.
+ * @param border an optional inner border for this surface
+ * @param interactionSource the [InteractionSource] that emits [Interaction]s for this surface. For
+ *   interactive surfaces, the [InteractionSource] instance provided to this surface must be shared
+ *   with the modifier responsible for emitting [Interaction]s, such as
+ *   [androidx.compose.foundation.focusable] or [androidx.compose.foundation.clickable].
+ */
+@Composable
+public fun Modifier.surface(
+    enabled: Boolean = true,
+    shape: Shape = GlimmerTheme.shapes.medium,
+    color: Color = GlimmerTheme.colors.surface,
+    contentColor: Color = calculateContentColor(color),
+    depthEffect: SurfaceDepthEffect? = null,
+    border: BorderStroke? = SurfaceDefaults.border(),
+    interactionSource: InteractionSource? = null,
+): Modifier {
+    return this.surfaceDepthEffect(depthEffect, shape, interactionSource)
+        .clip(shape)
+        .contentColorProvider(contentColor)
+        .then(
+            SurfaceNodeElement(
+                enabled = enabled,
+                shape = shape,
+                border = border,
+                interactionSource = interactionSource,
+            )
+        )
+        .background(color = color, shape = shape)
+}
+
+/**
+ * Represents the [DepthEffect] used by a [surface] in different states.
+ *
+ * Focused [surface]s with a [focusedDepthEffect] will have a higher zIndex set so they can draw
+ * their focused depth effect over siblings.
+ *
+ * @property [depthEffect] the [DepthEffect] used when the [surface] is in its default state (no
+ *   other interactions are ongoing)
+ * @property [focusedDepthEffect] the [DepthEffect] used when the [surface] is focused
+ */
+@Immutable
+public class SurfaceDepthEffect(
+    public val depthEffect: DepthEffect?,
+    public val focusedDepthEffect: DepthEffect?,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SurfaceDepthEffect) return false
+
+        if (depthEffect != other.depthEffect) return false
+        if (focusedDepthEffect != other.focusedDepthEffect) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = depthEffect?.hashCode() ?: 0
+        result = 31 * result + (focusedDepthEffect?.hashCode() ?: 0)
+        return result
+    }
+}
+
+/** Default values used for [surface]. */
+public object SurfaceDefaults {
+    /**
+     * Create the default [BorderStroke] used for a [surface]. Use the other overload in order to
+     * change the width or color.
+     */
+    @Composable
+    public fun border(): BorderStroke {
+        return GlimmerTheme.LocalGlimmerTheme.current.defaultSurfaceBorder
+    }
+
+    /**
+     * Create the default [BorderStroke] used for a [surface], with optional overrides for [width]
+     * and [color].
+     *
+     * @param width width of the border in [Dp]. Use [Dp.Hairline] for one-pixel border.
+     * @param color color to paint the border with
+     */
+    @Composable
+    public fun border(
+        width: Dp = DefaultSurfaceBorderWidth,
+        color: Color = GlimmerTheme.colors.outline,
+    ): BorderStroke {
+        return BorderStroke(width, color)
+    }
+
+    /** Returns the default (cached) border for a [surface]. */
+    internal val GlimmerTheme.defaultSurfaceBorder: BorderStroke
+        get() {
+            return defaultSurfaceBorderCached
+                ?: BorderStroke(DefaultSurfaceBorderWidth, colors.outline).also {
+                    defaultSurfaceBorderCached = it
+                }
+        }
+}
+
+/**
+ * Surface node responsible for drawing the border, focused border and highlight, and pressed
+ * overlay.
+ */
+private class SurfaceNodeElement(
+    private val enabled: Boolean,
+    private val shape: Shape,
+    private val border: BorderStroke?,
+    private val interactionSource: InteractionSource?,
+) : ModifierNodeElement<SurfaceNode>() {
+    override fun create(): SurfaceNode =
+        SurfaceNode(
+            enabled = enabled,
+            shape = shape,
+            border = border,
+            interactionSource = interactionSource,
+        )
+
+    override fun update(node: SurfaceNode) =
+        node.update(
+            enabled = enabled,
+            shape = shape,
+            border = border,
+            interactionSource = interactionSource,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SurfaceNodeElement) return false
+
+        if (enabled != other.enabled) return false
+        if (shape != other.shape) return false
+        if (border != other.border) return false
+        if (interactionSource != other.interactionSource) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = enabled.hashCode()
+        result = 31 * result + shape.hashCode()
+        result = 31 * result + (border?.hashCode() ?: 0)
+        result = 31 * result + (interactionSource?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "surface"
+        properties["enabled"] = enabled
+        properties["shape"] = shape
+        properties["border"] = border
+        properties["interactionSource"] = interactionSource
+    }
+}
+
+private class SurfaceNode(
+    private var enabled: Boolean,
+    private var shape: Shape,
+    private var border: BorderStroke?,
+    private var interactionSource: InteractionSource?,
+) : DrawModifierNode, Modifier.Node() {
+
+    override val shouldAutoInvalidate = false
+
+    // Cache borders and highlight for unfocused and focused states. This means we
+    // can avoid recreating these for a given surface, if the border and shape never
+    // change. Changing between unfocused and focus states only requires a draw
+    // invalidation, as the borders are already cached.
+
+    // Unfocused border
+    private val unfocusedBorderLogic: BorderLogic = BorderLogic()
+    private val unfocusedBorderWidth: () -> Dp = { border?.width ?: 0.dp }
+    // Focused border - this consists of two layers. A 'base' layer (which is the
+    // unfocused border with a different size) and the highlight we draw on top of
+    // this base layer. We need to increase the size of the underlying border to
+    // make sure that the highlight area fully matches the underlying border, to
+    // avoid inconsistent areas of coverage due to the transparency of the
+    // highlight.
+    private var focusedBorderLogic: BorderLogic? = null
+    private var focusedHighlightBorderLogic: BorderLogic? = null
+    private var focusedBorderWidth: (() -> Dp)? = null
+
+    // Highlight shader / brush
+    var shader: Shader? = null
+    var shaderBrush: Brush? = null
+
+    // Graphics Layer
+    private var unfocusedBorderLayer: GraphicsLayer? = null
+    private var unfocusedGraphicsLayerProvider: (() -> GraphicsLayer)? = null
+
+    private var focusedBorderLayer: GraphicsLayer? = null
+    private var focusedGraphicsLayerProvider: (() -> GraphicsLayer)? = null
+
+    private var focusedHighlightBorderLayer: GraphicsLayer? = null
+    private var focusedHighlightGraphicsLayerProvider: (() -> GraphicsLayer)? = null
+
+    private var interactionCollectionJob: Job? = null
+
+    // Enter / exit animation progress for the width and fade effect applied to the highlight
+    private var _focusedHighlightProgress: Animatable<Float, AnimationVector1D>? = null
+    private val focusedHighlightProgress
+        get() = _focusedHighlightProgress?.value ?: 0f
+
+    // Rotation progress applied to the highlight
+    private var _focusedHighlightRotationProgress: Animatable<Float, AnimationVector1D>? = null
+    private val focusedHighlightRotationProgress
+        get() = _focusedHighlightRotationProgress?.value ?: 0f
+
+    private var pressedOverlayAlpha: Animatable<Float, AnimationVector1D>? = null
+    // Job that runs for a minimum duration to make sure quick presses are still visible
+    private var minimumPressDuration: Job? = null
+    private var pressReleaseAnimation: Job? = null
+
+    fun update(
+        enabled: Boolean,
+        shape: Shape,
+        border: BorderStroke?,
+        interactionSource: InteractionSource?,
+    ) {
+        if (this.enabled != enabled) {
+            this.enabled = enabled
+            invalidateDraw()
+        }
+        if (this.shape != shape) {
+            this.shape = shape
+            invalidateDraw()
+        }
+        if (this.border != border) {
+            this.border = border
+            invalidateDraw()
+        }
+        if (this.interactionSource != interactionSource) {
+            this.interactionSource = interactionSource
+            observeInteractions()
+        }
+    }
+
+    override fun onAttach() {
+        observeInteractions()
+    }
+
+    var isFocused = false
+        set(value) {
+            if (field != value) {
+                field = value
+                if (value) {
+                    startFocusAnimation()
+                } else {
+                    stopFocusAnimation()
+                }
+                // No need to invalidate the border cache - we build it ahead of time to account for
+                // focus changes. Just invalidate draw so we can switch to drawing the correct
+                // border.
+                invalidateDraw()
+            }
+        }
+
+    var isPressed = false
+        set(value) {
+            if (field != value) {
+                field = value
+                if (value) {
+                    pressedOverlayAlpha = pressedOverlayAlpha ?: Animatable(0f)
+                    pressReleaseAnimation?.cancel()
+                    minimumPressDuration?.cancel()
+
+                    minimumPressDuration =
+                        coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                            delay(PressedOverlayMinimumDurationMillis)
+                        }
+                    coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                        pressedOverlayAlpha?.animateTo(
+                            PressedOverlayAlpha,
+                            PressedOverlayEnterAnimationSpec,
+                        )
+                    }
+                } else {
+                    pressedOverlayAlpha?.let { progress ->
+                        pressReleaseAnimation =
+                            coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                                minimumPressDuration?.join()
+                                progress.animateTo(0f, PressedOverlayExitAnimationSpec)
+                            }
+                    }
+                }
+                invalidateDraw()
+            }
+        }
+
+    private fun observeInteractions() {
+        interactionCollectionJob?.cancel()
+        interactionCollectionJob = null
+        isFocused = false
+        isPressed = false
+        interactionSource?.let { source ->
+            interactionCollectionJob =
+                coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                    var focusCount = 0
+                    var pressCount = 0
+                    source.interactions.collect { interaction ->
+                        when (interaction) {
+                            is FocusInteraction.Focus -> focusCount++
+                            is FocusInteraction.Unfocus -> focusCount--
+                            is PressInteraction.Press -> pressCount++
+                            is PressInteraction.Release -> pressCount--
+                            is PressInteraction.Cancel -> pressCount--
+                        }
+                        isFocused = focusCount > 0
+                        isPressed = pressCount > 0
+                    }
+                }
+        }
+    }
+
+    private fun startFocusAnimation() {
+        _focusedHighlightProgress = _focusedHighlightProgress ?: Animatable(0f)
+        _focusedHighlightRotationProgress = _focusedHighlightRotationProgress ?: Animatable(0f)
+        coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            _focusedHighlightProgress?.snapTo(0f)
+            _focusedHighlightProgress?.animateTo(
+                targetValue = 1f,
+                animationSpec = FocusedEnterAnimationSpec,
+            )
+        }
+        coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            _focusedHighlightRotationProgress?.snapTo(0f)
+            _focusedHighlightRotationProgress?.animateTo(
+                targetValue = 1f,
+                animationSpec = FocusedHighlightRotationAnimationSpec,
+            )
+        }
+    }
+
+    private fun stopFocusAnimation() {
+        coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            _focusedHighlightProgress?.animateTo(
+                targetValue = 0f,
+                animationSpec = FocusedExitAnimationSpec,
+            )
+            if (isActive) {
+                _focusedHighlightRotationProgress?.snapTo(0f)
+            }
+        }
+    }
+
+    override fun ContentDrawScope.draw() {
+        val outline = shape.createOutline(size, layoutDirection, this)
+        drawContent()
+        val pressedOverlayColor = PressedOverlayColor.copy(alpha = pressedOverlayAlpha?.value ?: 0f)
+        drawRect(color = pressedOverlayColor)
+        if (border != null) {
+            val progress = focusedHighlightProgress
+            val gContext = requireGraphicsContext()
+            if (progress > 0f) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    val rotationProgressRadians =
+                        (FocusedHighlightRotationEndAngleRadians -
+                            FocusedHighlightRotationStartAngleRadians) *
+                            focusedHighlightRotationProgress
+                    val rotationRadians =
+                        FocusedHighlightRotationStartAngleRadians + rotationProgressRadians
+                    shader =
+                        HighlightShaderHelper.configureShader(
+                            shader = shader,
+                            size = size,
+                            rotationRadians = rotationRadians.toFloat(),
+                            progress = progress,
+                        )
+                    shaderBrush = shaderBrush ?: ShaderBrush(shader!!)
+                }
+                focusedBorderLogic = focusedBorderLogic ?: BorderLogic()
+                focusedHighlightBorderLogic = focusedHighlightBorderLogic ?: BorderLogic()
+                focusedBorderWidth =
+                    focusedBorderWidth
+                        ?: {
+                            val b = border
+                            if (b != null) {
+                                lerp(
+                                    b.width,
+                                    FocusedSurfaceBorderWidth,
+                                    // Capture class property instead of function-local progress to
+                                    // make sure this will read the animation state when the lambda
+                                    // is invoked and not capture a stale variable
+                                    focusedHighlightProgress,
+                                )
+                            } else {
+                                0.dp
+                            }
+                        }
+                focusedBorderLogic!!.drawBorder(
+                    this,
+                    focusedBorderWidth!!,
+                    border!!.brush,
+                    focusedGraphicsLayerProvider
+                        ?: {
+                                focusedBorderLayer
+                                    ?: gContext.createGraphicsLayer().also {
+                                        focusedBorderLayer = it
+                                    }
+                            }
+                            .also { focusedGraphicsLayerProvider = it },
+                    outline,
+                )
+
+                shaderBrush?.let {
+                    focusedHighlightBorderLogic!!.drawBorder(
+                        this,
+                        focusedBorderWidth!!,
+                        it,
+                        focusedHighlightGraphicsLayerProvider
+                            ?: {
+                                    focusedHighlightBorderLayer
+                                        ?: gContext.createGraphicsLayer().also {
+                                            focusedHighlightBorderLayer = it
+                                        }
+                                }
+                                .also { focusedHighlightGraphicsLayerProvider = it },
+                        outline,
+                    )
+                }
+            } else {
+                unfocusedBorderLogic.drawBorder(
+                    this,
+                    unfocusedBorderWidth,
+                    border!!.brush,
+                    unfocusedGraphicsLayerProvider
+                        ?: {
+                                unfocusedBorderLayer
+                                    ?: gContext.createGraphicsLayer().also {
+                                        unfocusedBorderLayer = it
+                                    }
+                            }
+                            .also { unfocusedGraphicsLayerProvider = it },
+                    outline,
+                )
+            }
+        }
+        if (!enabled) {
+            drawRect(DisabledOverlayColor)
+        }
+    }
+
+    override fun onDetach() {
+        _focusedHighlightProgress = null
+        _focusedHighlightRotationProgress = null
+        pressedOverlayAlpha = null
+
+        unfocusedGraphicsLayerProvider = null
+        val gContext = requireGraphicsContext()
+        unfocusedBorderLayer?.let {
+            gContext.releaseGraphicsLayer(it)
+            unfocusedBorderLayer = null
+        }
+
+        focusedGraphicsLayerProvider = null
+        focusedBorderLayer?.let {
+            gContext.releaseGraphicsLayer(it)
+            focusedBorderLayer = null
+        }
+
+        focusedHighlightGraphicsLayerProvider = null
+        focusedHighlightBorderLayer?.let {
+            gContext.releaseGraphicsLayer(it)
+            focusedHighlightBorderLayer = null
+        }
+    }
+}
+
+/**
+ * Renders and animates a [surface]'s [depthEffect] for a given [shape], by observing
+ * [interactionSource].
+ */
+@Composable
+private fun Modifier.surfaceDepthEffect(
+    depthEffect: SurfaceDepthEffect?,
+    shape: Shape,
+    interactionSource: InteractionSource?,
+): Modifier {
+    if (depthEffect == null) return this
+    val focusedProgress = remember { Animatable(0f) }
+    // If focused and there is focused depth effect, we need to draw the surface on top of
+    // other siblings to make sure the depth effect occludes siblings.
+    val zIndex by remember {
+        // Derived to avoid invalidating layout each frame of the animation
+        derivedStateOf {
+            if (depthEffect.focusedDepthEffect != null && focusedProgress.value >= 0.5f) 1f else 0f
+        }
+    }
+    if (interactionSource != null) {
+        LaunchedEffect(interactionSource) {
+            interactionSource.interactions.collect { interaction ->
+                when (interaction) {
+                    is FocusInteraction.Focus ->
+                        launch(start = CoroutineStart.UNDISPATCHED) {
+                            focusedProgress.animateTo(1f, FocusedEnterAnimationSpec)
+                        }
+
+                    is FocusInteraction.Unfocus ->
+                        launch(start = CoroutineStart.UNDISPATCHED) {
+                            focusedProgress.animateTo(0f, FocusedExitAnimationSpec)
+                        }
+                }
+            }
+        }
+    }
+
+    return layout { measurable, constraints ->
+            val placeable = measurable.measure(constraints)
+            layout(placeable.width, placeable.height) { placeable.place(0, 0, zIndex = zIndex) }
+        }
+        .depthEffect(
+            from = depthEffect.depthEffect,
+            to = depthEffect.focusedDepthEffect,
+            shape = shape,
+            progress = { focusedProgress.value },
+        )
+}
+
+/** Default border width for a [surface]. */
+private val DefaultSurfaceBorderWidth = 2.dp
+
+/** Focused border width for a [surface]. */
+private val FocusedSurfaceBorderWidth = 5.dp
+
+/** Enter animation for focus highlight and depth effect */
+private val FocusedEnterAnimationSpec: AnimationSpec<Float> =
+    spring(dampingRatio = 1f, stiffness = 600f)
+
+/** Exit animation for focus highlight and depth effect */
+private val FocusedExitAnimationSpec: AnimationSpec<Float> =
+    spring(dampingRatio = 1f, stiffness = 100f)
+
+private val FocusedHighlightRotationAnimationSpec: AnimationSpec<Float> =
+    tween(durationMillis = 700, easing = LinearOutSlowInEasing, delayMillis = 40)
+
+private val FocusedHighlightRotationStartAngleRadians: Double = Math.toRadians(-100.0)
+
+private val FocusedHighlightRotationEndAngleRadians: Double = Math.toRadians(35.0)
+
+private val PressedOverlayColor = Color.White
+
+internal val DisabledOverlayColor = Color(0x8F191919)
+
+private const val PressedOverlayAlpha = 0.16f
+
+private val PressedOverlayEnterAnimationSpec: AnimationSpec<Float> =
+    spring(dampingRatio = 0.84f, stiffness = 8000f)
+
+private val PressedOverlayExitAnimationSpec: AnimationSpec<Float> =
+    spring(dampingRatio = 0.85f, stiffness = 50f)
+
+private const val PressedOverlayMinimumDurationMillis = 300L
+
+@Language(value = "AGSL")
+private const val FocusedHighlightShader =
+    """
+/**
+ * Rotating linear gradient shader, where rotation is controlled by iRotation uniform.
+ * This is essentially the same as:
+ * LinearGradientShader(
+ *     colors = FocusedHighlightColors,
+ *     colorStops = FocusedHighlightColorStops,
+ *     from = Offset.Zero,
+ *     to = Offset(size.width, size.height),
+ * )
+ * But allowing for efficient rotation, instead of needing to create a new shader / brush every
+ * frame with new coordinates.
+ */
+// Width / height
+uniform float2 iResolution;
+// Rotation in radians. 0 radians means a horizontal gradient.
+// Positive values will have the effect of rotating the gradient clockwise.
+uniform float iRotation;
+// Alpha animation progress from 0 to 1. This will be applied to the color stops so that each
+// color stop will fade in.
+uniform float iAlphaProgress;
+
+half4 main(float2 fragCoord) {
+    // Horizontal gradient
+    half4 colors[4];
+    colors[0] = half4(1.0, 1.0, 1.0, 1.0 * iAlphaProgress); // White with 100% alpha
+    colors[1] = half4(1.0, 1.0, 1.0, 0.2 * iAlphaProgress); // White with 20% alpha
+    colors[2] = half4(1.0, 1.0, 1.0, 0.2 * iAlphaProgress); // White with 20% alpha
+    colors[3] = half4(1.0, 1.0, 1.0, 0.8 * iAlphaProgress); // White with 80% alpha
+
+    // Stops for the horizontal gradient
+    float stops[4];
+    stops[0] = 0.0;
+    stops[1] = 0.3;
+    stops[2] = 0.66;
+    stops[3] = 1.0;
+
+    // Normalize
+    half2 uv = fragCoord.xy / iResolution.xy;
+
+    // Offset around a rotational center
+    half2 rotationCenter = half2(0.5, 0.5);
+    uv -= rotationCenter;
+
+    // Rotate
+    // We rotate in the opposite direction as we are rotating the coordinate we sample the gradient
+    // from. To create the effect of a gradient 'moving' clockwise, we need to move the
+    // coordinate in the opposite direction (counter-clockwise).
+    float2x2 matrix = float2x2(cos(-iRotation),-sin(-iRotation),sin(-iRotation),cos(-iRotation));
+    uv *= matrix;
+
+    // Translate back into [0,1] space
+    uv += rotationCenter;
+
+    // Blend through stops using the x coordinate, since we have a horizontal gradient
+    half4 color = mix(colors[0], colors[1], smoothstep(stops[0], stops[1], uv.x));
+    color = mix(color, colors[2], smoothstep(stops[1], stops[2], uv.x));
+    color = mix(color, colors[3], smoothstep(stops[2], stops[3], uv.x));
+
+    return color;
+}
+"""
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+private object HighlightShaderHelper {
+    @JvmStatic
+    fun configureShader(
+        shader: Shader?,
+        size: Size,
+        rotationRadians: Float,
+        progress: Float,
+    ): Shader {
+        val shader = shader as? RuntimeShader ?: RuntimeShader(FocusedHighlightShader)
+        shader.setFloatUniform("iResolution", size.width, size.height)
+        shader.setFloatUniform("iRotation", rotationRadians)
+        shader.setFloatUniform("iAlphaProgress", progress)
+        return shader
+    }
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/titlechip-samples-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/titlechip-samples-source.md
@@ -1,0 +1,101 @@
+When creating a Glimmer Title Chip component, refer to the following
+implementation samples in `TitleChipSamples.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer.samples
+
+import androidx.annotation.Sampled
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.xr.glimmer.Card
+import androidx.xr.glimmer.GlimmerTheme
+import androidx.xr.glimmer.Icon
+import androidx.xr.glimmer.Text
+import androidx.xr.glimmer.TitleChip
+import androidx.xr.glimmer.TitleChipDefaults
+import androidx.xr.glimmer.list.GlimmerLazyColumn
+
+@Composable
+fun TitleChipSampleUsage() {
+    GlimmerLazyColumn(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxSize().wrapContentSize(Alignment.Center),
+    ) {
+        item { TitleChipSample() }
+        item { TitleChipWithLeadingIconSample() }
+        item { TitleChipWithCardSample() }
+    }
+}
+
+@Sampled
+@Composable
+fun TitleChipSample() {
+    TitleChip { Text("Messages") }
+}
+
+@Sampled
+@Composable
+fun TitleChipWithLeadingIconSample() {
+    TitleChip(leadingIcon = { Icon(FavoriteIcon, "Localized description") }) { Text("Messages") }
+}
+
+@Sampled
+@Composable
+fun TitleChipWithCardSample() {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        TitleChip { Text("Title Chip") }
+        Spacer(Modifier.height(TitleChipDefaults.associatedContentSpacing))
+        Card(
+            title = { Text("Title") },
+            subtitle = { Text("Subtitle") },
+            leadingIcon = { Icon(FavoriteIcon, "Localized description") },
+        ) {
+            Text("Card Content")
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun TitleChipPreview() {
+    GlimmerTheme { TitleChipSample() }
+}
+
+@Preview
+@Composable
+private fun TitleChipWithLeadingIconPreview() {
+    GlimmerTheme { TitleChipWithLeadingIconSample() }
+}
+
+@Preview
+@Composable
+private fun TitleChipWithCardPreview() {
+    GlimmerTheme { TitleChipWithCardSample() }
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/titlechip-source.md
+++ b/platforms/android/.agents/skills/display-glasses-with-jetpack-compose-glimmer/references/titlechip-source.md
@@ -1,0 +1,135 @@
+When creating a Glimmer Title Chip component, refer to the following source code
+in `TitleChip.kt`:
+
+
+```kotlin
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.xr.glimmer
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Title Chip is a component used to provide context for associated content, such as a [Card]. They
+ * are designed for brief information, typically a short title, name, or status. Title chips are not
+ * focusable, and not interactable.
+ *
+ * @sample androidx.xr.glimmer.samples.TitleChipSample
+ *
+ * Title chips may have a leading icon to provide more context:
+ *
+ * @sample androidx.xr.glimmer.samples.TitleChipWithLeadingIconSample
+ *
+ * To use a title chip with another component, place the title chip
+ * [TitleChipDefaults.associatedContentSpacing] above the other component. For example, to use a
+ * title chip with a card:
+ *
+ * @sample androidx.xr.glimmer.samples.TitleChipWithCardSample
+ * @param modifier the [Modifier] to be applied to this title chip
+ * @param leadingIcon optional leading icon to be placed before the [content]. This is typically an
+ *   [Icon] tinted with [contentColor] by default.
+ * @param shape the [Shape] used to clip this title chip, and also used to draw the background and
+ *   border
+ * @param color background color of this title chip
+ * @param contentColor content color used by components inside [content] and [leadingIcon].
+ * @param border the border to draw around this title chip
+ * @param contentPadding the spacing values to apply internally between the container and the
+ *   content
+ * @param content the main content, typically [Text], to display inside this title chip
+ */
+@Composable
+public fun TitleChip(
+    modifier: Modifier = Modifier,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    shape: Shape = GlimmerTheme.shapes.large,
+    color: Color = GlimmerTheme.colors.surface,
+    contentColor: Color = calculateContentColor(color),
+    border: BorderStroke? = SurfaceDefaults.border(),
+    contentPadding: PaddingValues = TitleChipDefaults.contentPadding,
+    content: @Composable RowScope.() -> Unit,
+) {
+    val iconSize = GlimmerTheme.iconSizes.small
+    val horizontalInnerContentPadding = GlimmerTheme.componentSpacingValues.extraSmall
+
+    CompositionLocalProvider(LocalTextStyle provides GlimmerTheme.typography.caption) {
+        Row(
+            modifier
+                .surface(
+                    shape = shape,
+                    color = color,
+                    contentColor = contentColor,
+                    depthEffect = null,
+                    border = border,
+                )
+                .defaultMinSize(minHeight = MinimumHeight)
+                .widthIn(max = MaximumWidth)
+                .padding(contentPadding),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (leadingIcon != null) {
+                CompositionLocalProvider(LocalIconSize provides iconSize, content = leadingIcon)
+            }
+            Spacer(Modifier.width(horizontalInnerContentPadding))
+            content()
+            Spacer(Modifier.width(horizontalInnerContentPadding))
+        }
+    }
+}
+
+/** Default values used for [TitleChip]. */
+public object TitleChipDefaults {
+    /** Default content padding for a [TitleChip]. */
+    public val contentPadding: PaddingValues
+        @Composable get() = PaddingValues(GlimmerTheme.componentSpacingValues.extraSmall)
+
+    /**
+     * Default spacing between the bottom of a [TitleChip] and content associated with this title
+     * chip, such as a [Card]. For example this can be used with a
+     * [androidx.compose.foundation.layout.Spacer], or with [padding].
+     *
+     * @sample androidx.xr.glimmer.samples.TitleChipWithCardSample
+     */
+    public val associatedContentSpacing: Dp
+        @Composable get() = GlimmerTheme.componentSpacingValues.medium
+}
+
+/** Default minimum height for a [TitleChip] */
+private val MinimumHeight = 44.dp
+
+/** Default maximum width for a [TitleChip] */
+private val MaximumWidth = 352.dp
+```
+
+<br />

--- a/platforms/android/.agents/skills/edge-to-edge/SKILL.md
+++ b/platforms/android/.agents/skills/edge-to-edge/SKILL.md
@@ -1,0 +1,426 @@
+---
+name: edge-to-edge
+description: Use this skill to migrate your Jetpack Compose app to add adaptive edge-to-edge
+  support and troubleshoot common issues. Use this skill to fix UI components (like
+  buttons or lists) that are obscured by or overlapping with the navigation bar or
+  status bar, fix IME insets, and fix system bar legibility.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-04-01'
+  keywords:
+  - android
+  - compose
+  - system bars
+  - edge-to-edge
+  - status bar
+  - navigation bar
+---
+
+## Prerequisites
+
+- Project **MUST** use Android Jetpack Compose.
+- Project **MUST** target SDK 35 or later. If the SDK is lower than 35, increase the SDK to 35.
+
+## Step 1: plan
+
+1. Locate and analyze all Activity classes to detect which have existing edge-to-edge support. For every Activity without edge-to-edge, plan to make each Activity edge-to-edge.
+2. In each Activity, Locate and analyze all lists and FAB components to detect which have existing edge-to-edge support. For every component without edge-to-edge support, plan to make each of these components edge-to-edge.
+3. In each Activity, scan for `TextField`, `OutlinedTextField`, or `BasicTextField`. If found, then you **MUST** verify the IME doesn't hide the input field by following the IME section of this skill.
+
+## Step 2: add edge-to-edge support
+
+1. Add `enableEdgeToEdge` before `setContent` in `onCreate` in each Activity that does not already call `enableEdgeToEdge`.
+2. Add `android:windowSoftInputMode="adjustResize"` in the AndroidManifest.xml for all Activities that use a soft keyboard.
+
+## Step 3: apply insets
+
+- The app **MUST** apply system insets, or align content to rulers, so critical
+  UI remains tappable. Choose only one method to avoid double padding:
+
+  1. **PREFERRED:** When available, use `Scaffold`s and pass `PaddingValues` to the content lambda.
+
+
+  ```kotlin
+  Scaffold { innerPadding ->
+      // innerPadding accounts for system bars and any Scaffold components
+      LazyColumn(
+          modifier = Modifier
+              .fillMaxSize()
+              .consumeWindowInsets(innerPadding),
+          contentPadding = innerPadding
+      ) { /* Content */ }
+  }
+  ```
+
+  <br />
+
+  1. **PREFERRED:** When available, use the automatic inset handling or padding modifiers in material components.
+
+     - Material 3 Components manages safe areas for its own components, including:
+       - `TopAppBar`
+       - `SmallTopAppBar`
+       - `CenterAlignedTopAppBar`
+       - `MediumTopAppBar`
+       - `LargeTopAppBar`
+       - `BottomAppBar`
+       - `ModalDrawerSheet`
+       - `DismissibleDrawerSheet`
+       - `PermanentDrawerSheet`
+       - `ModalBottomSheet`
+       - `NavigationBar`
+       - `NavigationRail`
+     - For Material 2 Components, use the `windowInsets`parameter to apply insets manually for `BottomAppBar`, `TopAppBar` and `BottomNavigation`. **DO NOT** apply padding to the parent container; instead, pass insets directly to the App Bar component. Applying padding to the parent container prevents the App Bar background from drawing into the system bar area. For example, for `TopAppBar`, choose only one of the following options:
+       1. **PREFERRED:** `TopAppBar(windowInsets = AppBarDefaults.topAppBarWindowInsets)`
+       2. `TopAppBar(windowInsets = WindowInsets.systemBars.exclude(WindowInsets.navigationBars))`
+       3. `TopAppBar(windowInsets = WindowInsets.systemBars.add(WindowInsets.captionBar))`
+  2. For components outside a Scaffold, use padding modifiers, such as `Modifier.safeDrawingPadding()` or `Modifier.windowInsetsPadding(WindowInsets.safeDrawing)`.
+
+
+     ```kotlin
+     Box(
+         modifier = Modifier
+             .fillMaxSize()
+             .safeDrawingPadding()
+     ) {
+         Button(
+             onClick = {},
+             modifier = Modifier.align(Alignment.BottomCenter)
+         ) {
+             Text("Login")
+         }
+     }
+     ```
+
+     <br />
+
+  3. For deeply nested components with excessive padding, use `WindowInsetsRulers` (e.g. `Modifier.fitInside(WindowInsetsRulers.SafeDrawing.current)`). See the *IME* section for a code sample.
+
+  4. When you need an element (e.g. a custom header or decorative scrim) to
+     equal the dimensions of a system bar, use inset size modifiers (e.g.
+     `Modifier.windowInsetsTopHeight(WindowInsets.systemBars)`).
+     See the *Lists* section for a code sample.
+
+## Adaptive Scaffolds
+
+- `NavigationSuiteScaffold` manages safe areas for its own components, like the `NavigationRail` or `NavigationBar`. However, the adaptive scaffolds (e.g. `NavigationSuiteScaffold`, `ListDetailPaneScaffold`) don't propagate PaddingValues to their inner contents. You **MUST** apply insets to **individual** screens or components (e.g., list `contentPadding` or FAB padding) as described in *Step 3* . **DO NOT** apply `safeDrawingPadding` or similar modifiers to the `NavigationSuiteScaffold` parent. This clips and prevents an edge-to-edge screen.
+
+## IME
+
+- For each Activity with a soft keyboard, check that `android:windowSoftInputMode="adjustResize"` is set in the AndroidManifest.xml. DO NOT use `SOFT_INPUT_ADJUST_RESIZE` because it is deprecated. Then, maintain focus on the input field. Choose one:
+  - 1. **PREFERRED:** Add `Modifier.fitInside(WindowInsetsRulers.Ime.current)` to the content container. This is preferred over `imePadding()` because it reduces jank and extra padding caused by forgetting to consume insets upstream in the hierarchy.
+  - 2. Add `imePadding` to the content container. The padding modifier **MUST** be placed before `Modifier.verticalScroll()`. Do NOT use `Modifier.imePadding()` if the parent already accounts for the IME with `contentWindowInsets` (e.g. `contentWindowInsets =
+    WindowInsets.safeDrawing`). Doing so will cause double padding.
+
+### IMEs with Scaffolds code patterns
+
+#### RIGHT
+
+RIGHT because `contentWindowInsets` contains IME insets, which are passed to the
+content lambda as `innerPadding`.
+
+
+```kotlin
+// RIGHT
+Scaffold(contentWindowInsets = WindowInsets.safeDrawing) { innerPadding ->
+    Column(
+        modifier = Modifier
+            .padding(innerPadding)
+            .consumeWindowInsets(innerPadding)
+            .verticalScroll(rememberScrollState())
+    ) { /* Content */ }
+}
+```
+
+<br />
+
+*** ** * ** ***
+
+RIGHT because `fitInside` fits the content to the IME insets regardless of
+`contentWindowInsets`.
+
+
+```kotlin
+// RIGHT
+Scaffold() { innerPadding ->
+    Column(
+        modifier = Modifier
+            .padding(innerPadding)
+            .consumeWindowInsets(innerPadding)
+            .fitInside(WindowInsetsRulers.Ime.current)
+            .verticalScroll(rememberScrollState())
+    ) { /* Content */ }
+}
+```
+
+<br />
+
+*** ** * ** ***
+
+RIGHT because the default `contentWindowInsets` does not contain IME insets, and
+`imePadding()` applies IME insets:
+
+
+```kotlin
+// RIGHT
+Scaffold() { innerPadding ->
+    Column(
+        modifier = Modifier
+            .padding(innerPadding)
+            .consumeWindowInsets(innerPadding)
+            .imePadding()
+            .verticalScroll(rememberScrollState())
+    ) { /* Content */ }
+}
+```
+
+<br />
+
+#### WRONG
+
+WRONG because there will be excess padding when the IME opens. IME insets are
+applied twice, once with innerPadding, which contains IME insets from the passed
+`contentWindowInsets` values, and once with `imePadding`:
+
+
+```kotlin
+// WRONG
+Scaffold( contentWindowInsets = WindowInsets.safeDrawing ) { innerPadding ->
+    Column(
+        modifier = Modifier
+            .padding(innerPadding)
+            .imePadding()
+            .verticalScroll(rememberScrollState())
+    ) { /* Content */ }
+}
+```
+
+<br />
+
+*** ** * ** ***
+
+WRONG because the IME will cover up the content. Scaffold's default
+`contentWindowInsets` does NOT contain IME insets.
+
+
+```kotlin
+// WRONG
+Scaffold() { innerPadding ->
+    Column(
+        modifier = Modifier
+            .padding(innerPadding)
+            .verticalScroll(rememberScrollState())
+    ) { /* Content */ }
+}
+```
+
+<br />
+
+### IMEs without Scaffolds code patterns
+
+#### RIGHT
+
+The following code samples WILL NOT cause excessive padding.
+
+
+```kotlin
+// RIGHT
+Box(
+    // Insets consumed
+    modifier = Modifier.safeDrawingPadding() // or imePadding(), safeContentPadding(), safeGesturesPadding()
+) {
+    Column(
+        modifier = Modifier.imePadding()
+    ) { /* Content */ }
+}
+```
+
+<br />
+
+*** ** * ** ***
+
+
+```kotlin
+// RIGHT
+Box(
+    // Insets consumed
+    modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing) // or WindowInsets.ime, WindowInsets.safeContent, WindowInsets.safeGestures
+) {
+    Column(
+        modifier = Modifier.imePadding()
+    ) { /* Content */ }
+}
+```
+
+<br />
+
+*** ** * ** ***
+
+
+```kotlin
+// RIGHT
+Box(
+    // Insets not consumed, but irrelevant due to fitInside
+    modifier = Modifier.padding(WindowInsets.safeDrawing.asPaddingValues()) // or WindowInsets.ime.asPaddingValues(), WindowInsets.safeContent.asPaddingValues(), WindowInsets.safeGestures.asPaddingValues()
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .fitInside(WindowInsetsRulers.Ime.current)
+    ) { /* Content */ }
+}
+```
+
+<br />
+
+#### WRONG
+
+The following code sample WILL cause excessive padding because IME insets are
+applied twice:
+
+
+```kotlin
+// WRONG
+Box(
+    // Insets not consumed
+    modifier = Modifier.padding(WindowInsets.safeDrawing.asPaddingValues()) // or WindowInsets.ime.asPaddingValues(), WindowInsets.safeContent.asPaddingValues(), WindowInsets.safeGestures.asPaddingValues()
+) {
+    Column(
+        modifier = Modifier.imePadding()
+    ) { /* Content */ }
+}
+```
+
+<br />
+
+## Navigation Bar Contrast \& System Bar Icons
+
+- If the Activity uses `enableEdgeToEdge` from `WindowCompat`, you **MUST** set
+  `isAppearanceLightNavigationBars` and `isAppearanceLightStatusBars` to the
+  inverse of the device theme for apps that support light and dark theme so the
+  system bar icons are legible. It's recommended to do this in your theme file.
+  DO NOT do this if the Activities use `enableEdgeToEdge` from `ComponentActivity`
+  because it handles the icon colors automatically.
+
+
+  ```kotlin
+  // Only use if calling `enableEdgeToEdge` from `WindowCompat`.
+  // Apply to your theme file.
+  @Composable
+  fun MyTheme(
+      darkTheme: Boolean = isSystemInDarkTheme(),
+      content: @Composable () -> Unit
+  ) {
+      val view = LocalView.current
+      if (!view.isInEditMode) {
+          SideEffect {
+              val window = (view.context as? Activity)?.window ?: return@SideEffect
+              val controller = WindowCompat.getInsetsController(window, view)
+
+              // Dark icons for Light Mode (!darkTheme), Light icons for Dark Mode
+              controller.isAppearanceLightStatusBars = !darkTheme
+              controller.isAppearanceLightNavigationBars = !darkTheme
+          }
+      }
+
+      MaterialTheme(content = content)
+  }
+  ```
+
+  <br />
+
+- If any screen uses a `Scaffold` or a `NavigationSuiteScaffold` with a bottom
+  bar (e.g., `BottomAppBar`, `NavigationBar`), set
+  `window.isNavigationBarContrastEnforced = false` in the corresponding Activity
+  for SDK 29+. This prevents the system from adding a translucent background to
+  the navigation bar, verifying your bottom bar colors extend to the bottom of the
+  screen.
+
+## Lists
+
+- Apply inset padding (like `Scaffold`'s `innerPadding`) to the `contentPadding` parameter of scrollable components (e.g. `LazyColumn`, `LazyRow`). DO NOT apply it as a `Modifier.padding()` to the list's parent container, as this clips the content and prevents it from scrolling behind the system bars.
+- Create a translucent composable covering the system bar so that the icons are still legible.
+
+
+```kotlin
+class SystemBarProtectionSnippets : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // enableEdgeToEdge sets window.isNavigationBarContrastEnforced = true
+        // which is used to add a translucent scrim to three-button navigation
+        enableEdgeToEdge()
+
+        setContent {
+            MyTheme {
+                // Main content
+                MyContent()
+
+                // After drawing main content, draw status bar protection
+                StatusBarProtection()
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusBarProtection(
+    color: Color = MaterialTheme.colorScheme.surfaceContainer,
+) {
+    Spacer(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(
+                with(LocalDensity.current) {
+                    (WindowInsets.statusBars.getTop(this) * 1.2f).toDp()
+                }
+            )
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(
+                        color.copy(alpha = 1f),
+                        color.copy(alpha = 0.8f),
+                        Color.Transparent
+                    )
+                )
+            )
+    )
+}
+```
+
+<br />
+
+## Dialogs
+
+If both the following conditions are true, then the Dialog is full screen and
+must be made edge-to-edge:
+1. The `DialogProperties` contains `usePlatformDefaultWidth = false`.
+2. The Dialog calls `Modifier.fillMaxSize()`.
+
+To make a full screen Dialog edge-to-edge, set `decorFitsSystemWindows = false`
+in the `DialogProperties`.
+
+
+```kotlin
+Dialog(
+    onDismissRequest = { /* Handle dismiss */ },
+    properties = DialogProperties(
+        // 1. Allows the dialog to span the full width of the screen
+        usePlatformDefaultWidth = false,
+        // 2. Allows the dialog to draw behind status and navigation bars
+        decorFitsSystemWindows = false
+    )
+) { /* Content */ }
+```
+
+<br />
+
+## Checklist
+
+- \[ \] Does every `Activity` call `enableEdgeToEdge()`?
+- \[ \] Is `adjustResize` set in the `AndroidManifest.xml`?
+- \[ \] Does every `TextField`, `OutlinedTextField`, or `BasicTextField` have a parent with `imePadding()`, `fitInside`, `Modifier.safeDrawingPadding()`, `Modifier.safeContentPadding()`, `Modifier.safeGesturesPadding()`, or `contentWindowInsets` set to `WindowInsets.safeDrawing` or `WindowInsets.ime`?
+- \[\] Does the first and last list item draw away from the system bars by passing insets to `contentPadding`?
+- \[\] Do FABs draw above the navigation bars by either being inside a Scaffold or by applying `Modifier.safeDrawingPadding()`?
+- \[\] Does the project build? Run `./gradlew build` to be sure.

--- a/platforms/android/.agents/skills/engage-sdk-integration/SKILL.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: engage-sdk-integration
+description: Helps developers integrate, debug, and resolve Play Engage SDK implementation
+  issues. Use when adding Engage SDK support, generating publishing code, mapping
+  data classes to entities, or fixing SDK-related errors.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-07-09'
+  keywords:
+  - android
+  - engage
+  - engage sdk
+  - play engage library
+  - google play
+---
+
+This skill guides you through integrating the Play Engage SDK into an Android
+app. It ensures that the code follows the mandatory structure and uses the
+required Engage entities for each vertical.
+
+## Workflow
+
+Follow these steps to assist the developer:
+
+1. **Identify Vertical and Cluster:**
+
+   - Ask the developer which vertical their app belongs to based on **[references/schemas/](references/schemas)**.
+   - Check if the integration is for TV or Mobile. Read the TV-specific sections in [patterns.md](references/patterns.md) as well if the integration is for TV.
+   - Use `{VERTICAL}.md` in the **[references/schemas/](references/schemas)** directory to identify the corresponding Engage entities and the `client` class name. The `client` field in the JSON provides the full class name. (e.g., `com.google.android.engage.food.service.AppEngageFoodClient`).
+   - **Note:** Initializing the client class requires a `Context` parameter (e.g., `AppEngageFoodClient(context)`).
+   - Always refer to [common.md](references/common.md) for common entities.
+   - Ask which cluster type they want to publish from the supported cluster types for that vertical.
+   - Find the method to call from `{VERTICAL}.md` in the **[references/schemas/](references/schemas)** directory for the specified cluster. Each method will specify the request it expects.
+   - Get the request structure from [requests.md](references/requests.md) and clusters from [clusters.md](references/clusters.md). Then suggest and use sources to fill the fields in the request structure correctly, along with the required entities and clusters.
+2. **Generate Structured Boilerplate Code:**
+
+   - Create a new directory for all Engage-related code. Name the directory to match the naming convention of the existing codebase.
+   - Generate the following classes using templates in [patterns.md](references/patterns.md):
+     - `Constants`: Holds constant values like attempt counts, publish types.
+     - `ItemToEntityConverter`: Converts app's local models to Engage's Entity models.
+     - `ClusterRequestFactory`: Constructs the publish requests.
+     - `EngageWorker`: Handles the actual publishing and publish errors using WorkManager.
+     - `EngagePublisher`: Orchestrates periodic and one-time jobs.
+     - `EngageBroadcastReceiver`: Listens for AppEngageService intents and starts a one-time publish job from `EngagePublisher`. **Important** : Implement both **static registration** and **dynamic registration** patterns, including the companion object `register` method inside the `EngageBroadcastReceiver` class.
+3. **Suggest Entity Mapping:**
+
+   - Ask the developer to provide their local model schema(e.g., a data class or a JSON snippet).
+   - If they haven't provided one, share entities from `{VERTICAL}.md` in the **[references/schemas/](references/schemas)** directory as a guide.
+   - Once the local model is identified, suggest a mapping to the corresponding Engage entity.
+   - Generate the conversion logic using the `ItemToEntityConverter` pattern in [patterns.md](references/patterns.md) and add it to the generated `{ENGAGE_CODE_DIR}/ItemToEntityConverter`
+4. **Suggest Data Source:**
+
+   - Ask the developer to provide the source of actual data you'll publish.
+   - Once the source of data is identified, use the source of data to fetch data in app's local model schema.
+   - Use `{ENGAGE_CODE_DIR}/ItemToEntityConverter` to convert this data to Engage entity.
+   - Use obtained Engage entity model data with `{ENGAGE_CODE_DIR}/
+     ClusterRequestFactory` to get cluster requests.
+   - Call corresponding cluster publishing method obtained from `{VERTICAL}.md` in the **[references/schemas/](references/schemas)** directory with the obtained request in previous step in `{ENGAGE_CODE_DIR}/EngageWorker`.
+5. **Gradle and Manifest Updates:**
+
+   - Suggest updates to `build.gradle` and `AndroidManifest.xml`.
+   - For mobile apps, use [patterns.md](references/patterns.md).
+   - For TV apps, use the TV-specific sections in [patterns.md](references/patterns.md).
+   - Provide the necessary `implementation` dependencies for `build.gradle` or `build.gradle.kts` from [patterns.md](references/patterns.md).
+   - Provide the `<receiver>` and `<service>` declarations for `AndroidManifest.xml`.
+   - Note: There's no separate import according to vertical except TV. For each vertical other than TV 'com.google.android.engage:engage-core:1.5.12' is enough.
+6. **Debugging:**
+
+   - Perform a Gradle sync.
+   - If errors occur, follow this resolution order:
+     - Fix import errors. For package `com.google.android.engage` or classes starting with `AppEngage`, verify the package name in the `{VERTICAL}.md` in **[references/schemas/](references/schemas)** directory or [common.md](references/common.md).
+     - Fix any other errors.
+   - Execute a full Gradle build and resolve any remaining compilation issues. Repeat this step until the Gradle build is successful.
+7. **User Checklist:**
+   At the end of code generation, notify the user to go through this checklist
+   to verify that the integration is complete and as intended:
+   \[ \] Verify that all the engage related files are created in
+   `{ENGAGE_CODE_DIR}/`:
+   - `Constants`
+   - `ItemToEntityConverter`
+   - `ClusterRequestFactory`
+   - `EngageWorker`
+   - `{cluster_type}Publisher`
+   - `EngageBroadcastReceiver`
+   \[ \] Verify that app's local model is converted to Engage entity by populating
+   the fields correctly in the model in `{ENGAGE_CODE_DIR}/
+   ItemToEntityConverter`.
+   \[ \] Verify that `{ENGAGE_CODE_DIR}/EngageWorker` uses the data source
+   identified in Step 4.
+   \[ \] Verify that `EngageBroadcastReceiver.register(context)` is called within
+   the `Application` class or `MainActivity` to register the receiver
+   dynamically.
+   \[ \] Verify that `AndroidManifest.xml` contains the static `<receiver>`
+   declaration for `EngageBroadcastReceiver` with the necessary intent actions.
+
+   - **Important** : Explicitly instruct the developer to call `EngageBroadcastReceiver.register(context)` inside their custom `Application` class `onCreate()` (or their main activity `onCreate()`) to dynamically register the receiver. Stress that **both** static and dynamic registrations are required for the integration to function.
+
+## Reference Materials
+
+- **FAQ:** [Engage FAQ](references/android/guide/playcore/engage/faq.md) - Refer to this document for answers to frequently
+  asked questions from developers.
+
+- **Vertical-Specific Guides:**
+
+  - [Food Vertical](references/android/guide/playcore/engage/food.md)
+  - [Watch Vertical](references/android/guide/playcore/engage/watch.md)
+  - [Listen Vertical](references/android/guide/playcore/engage/listen.md)
+  - [Read Vertical](references/android/guide/playcore/engage/read.md)
+  - [Shopping Vertical](references/android/guide/playcore/engage/shopping.md)
+  - [Social Vertical](references/android/guide/playcore/engage/social.md)
+  - [Travel Vertical](references/android/guide/playcore/engage/travel.md)
+  - [Health \& Fitness Vertical](references/android/guide/playcore/engage/healthandfitness.md)
+  - [Other Verticals](references/android/guide/playcore/engage/otherverticals.md)
+  - [TV Getting Started](references/android/guide/playcore/engage/tv/getting-started.md)
+  - [TV Recommendations](references/android/guide/playcore/engage/tv/recommendations.md)
+  - [TV Continue Watching](references/android/guide/playcore/engage/tv/continue-watching/index.md)
+  - [TV Entitlements](references/android/guide/playcore/engage/tv/entitlements.md)
+- **Vertical-Specific Schemas:**
+
+  - [Food Schema](references/schemas/food.md)
+  - [Watch Schema](references/schemas/watch.md)
+  - [Listen Schema](references/schemas/listen.md)
+  - [Read Schema](references/schemas/read.md)
+  - [Shopping Schema](references/schemas/shopping.md)
+  - [Social Schema](references/schemas/social.md)
+  - [Travel Schema](references/schemas/travel.md)
+  - [TV Schema](references/schemas/tv.md)
+  - [Other Schema](references/schemas/other.md)

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/faq.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/faq.md
@@ -1,0 +1,439 @@
+## Publish FAQs
+
+#### Who manages the content publishing job?
+
+The app developer manages the content publishing job and sends requests to the
+Engage Service. In this way, developer partners have more control over when and
+how to publish content to the users. This avoids waking up the partner app too
+frequently to publish content.
+
+#### Does a developer need to publish all cluster types?
+
+While technically developers are free to publish just one cluster, we **strongly
+advise** including more. Otherwise, developers miss the opportunity to drive
+better engagement with their content. We **highly recommend** publishing all
+cluster types for each vertical.
+
+#### How often should the developer partner be publishing data using the work manager while the app is running?
+
+This is to be decided by the developer partner. Google recommends publishing
+once or twice per day for general recommendation content, and to use an
+event-driven methodology for shopping cart, reorder, and other continuation
+content (for example, start the worker as a callback of the user adding items
+to the cart or the user stopping a movie halfway).
+For **social** apps, it's critical to publish updated recommendation clusters
+**after each app usage**. Social app users are more interested in the most
+recent recommendations and ideally would like to see a post at most once.
+
+#### When should the developer call delete APIs?
+
+Delete APIs should only be called when there is no content to publish. **Don't**
+call delete and publish APIs subsequently to replace content; the publish
+APIs remove the earlier content automatically.
+
+## Broadcast Intent FAQs
+
+#### Why do Android app developers need to register for broadcast intents?
+
+In order to serve fresh content to the user, you should use broadcast intents to
+trigger a data sync in cases where users might not use the app frequently.
+
+#### Unable to test broadcast intent
+
+The verification app doesn't support testing broadcast intent with
+permission. You have to remove permissions while testing and
+add them back before switching the SDK to prod version in [Step 6](https://developer.android.com/guide/playcore/engage/workflow#switch-to-prod).
+
+#### Background execution not allowed
+
+While registering the broadcast intent, you may come across the following error:
+
+    Background execution not allowed: receiving Intent
+    { act=com.google.android.engage.action.PUBLISH_RECOMMENDATION .. }
+
+You need to register the broadcast receivers dynamically.
+
+    class AppEngageBroadcastReceiver extends BroadcastReceiver {
+    // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+    // is received
+    }
+
+    public static void registerBroadcastReceivers(Context context) {
+
+    context = context.getApplicationContext();
+
+    // Register Recommendation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION,
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null));
+    ...
+
+    }
+
+## Workflow FAQs
+
+While integrating with the SDK, you may come across the following errors:
+
+#### Validation errors at the app, cluster, entity level
+
+Summaries at the app, cluster, and entity levels display a count of
+validation errors. These errors correspond to missing required fields or
+invalid values provided. Error messages show up in red beneath each relevant
+field. Fix all validation errors and check for correctness before sharing
+the APK.
+
+#### Testing Deep links
+
+The deep links are associated with the package name. A good way to test
+deep links is using the adb tool.
+
+    adb shell am start -W -a android.intent.action.VIEW -d <DEEPLINK URI> <PACKAGE NAME>
+
+#### How can I calculate the impact of the integration?
+
+The deep links are a great way to track the attribution. The deep link URLs
+that take users to your app can be included with additional tracking params.
+For example - "http://xx/deeplink?source_tag=engage".
+
+Developers can add their own tracking params and provide attribution to
+calculate impact.
+
+## Engage for TV 2.0 FAQs
+
+### General Questions
+
+#### What is Engage?
+
+Engage takes the "pick up where you left off" experience to the next level! It's
+a significant upgrade that allows viewers to seamlessly resume their content
+across a wider range of devices. Imagine starting a movie on your Google TV and
+then effortlessly continuing it on your phone during your commute -- that's the
+power of Engage.
+
+This new system is designed to boost viewer engagement and retention by
+providing a smooth, frictionless experience across the entire Google ecosystem.
+
+#### Is Video Discovery API the same as Engage?
+
+Yes, they are the same. The Engage SDK is a library that includes support for
+the continue watching row. Engage supports more content entity types than video,
+which is why the integration is no longer named "Video Discovery".
+
+#### What are the benefits of using Engage?
+
+Answer: Engage makes it easier than ever for viewers to pick up where they left
+off on your content, no matter what device they're using. Here's how it works:
+
+- Seamless experience across Google: Start watching on your Google TV, and continue seamlessly on your Android phone, iPhone, or Android tablet. It even works on devices where you haven't installed the app yet!
+- Increased engagement and retention: Engage helps bring users back to your app, even on new devices. By letting users resume their favorite shows, you increase the chances they'll keep watching.
+- Wider reach: Beyond Google TV, Engage works across other Android media experiences, like Play Collections and other Google media apps.
+- Backward compatible: If you're already using the older "[Watch Next](https://developer.android.com/training/tv/discovery/watch-next-add-programs)" feature, no problem! Engage is backward compatible, so your existing integration will still work.
+
+Important Note: All new Continue Watching integrations must use Engage. The
+older "Cross Device Play Next" system is being phased out.
+
+#### What surfaces support Engage?
+
+1. Google TV
+2. Android TV (on-device only but supports Engage SDK)
+3. Google TV Android mobile app
+4. Google TV iOS mobile app
+5. Play Collections
+6. Google entertainment space
+7. iOS devices (with REST API integration).
+
+#### Is Engage SDK for Continue Watching?
+
+Yes, the Engage SDK supports content for the continue watching row. It is
+required to integrate with Engage.
+
+#### Is Engage available for everyone?
+
+Engage is being rolled out in phases.
+
+- Early Access: We're initially granting access to a select group of partners through an Early Access Program (EAP).
+- Expanding Access: We're working hard to make Engage available to all developers soon.
+
+For a smooth and successful launch, we have safeguards in place to manage the
+rollout. This involves both an allowlist on the Engage side and a separate check
+within the Engage SDK. Whether you are an EAP partner or wants to be onboard
+soon, please contact us so that we can set up the access permissions before you
+begin with Engage SDK integration.
+
+#### Is there a recommended image size we should provide?
+
+Image requirements have been updated in the [Create Entities](https://developer.android.com/guide/playcore/engage/watch#image-specs)
+section.
+
+#### With this new API documentation, will the Continue Watching data pulled by the Google server from the client and will it be reflected in all the devices?
+
+The new API offers significant improvements for content on the continue watching
+row, including:
+
+- **Seamless experience across Google TVs:** Users can start watching on one
+  Google TV and resume on any other Google TV logged in with the same account.
+  This feature also works with older Android TV versions.
+
+- **Mobile app integration:** Content from Engage is surfaced on the Google TV
+  mobile app for Android and iOS, allowing users to seamlessly switch between
+  their TV and mobile devices.
+
+- **Enhanced user retention:** Even on devices without the app installed or
+  where the user isn't logged in, content in the continue watching row
+  encourages users to re-engage with your app, boosting retention.
+
+- **Expansion to other platforms:** Engage extends to other Google media
+  platforms like Android, Play Collections, tablets, and other Google media
+  apps \& surfaces on Android, maximizing user engagement across devices.
+
+#### What is the limit on the number of entities I can publish to the Continuation cluster?
+
+Each developer partner is limited to a maximum of 5 entities in the Continuation
+cluster. This limit is for fair distribution of content on the "continue
+watching" row on Google TV, which is a shared space for multiple media
+providers.
+
+#### What happens if I try to publish more than 5 entities?
+
+Engage SDK will reject your publish request if it exceeds the 5-entity limit.
+You'll need to reduce the number of entities in your request to successfully
+publish. You should only include the entities where the users have left off
+watching, so in most cases, there will be only a few such entities. When there
+are more than 5 such entities, you could choose the more recent ones to publish.
+
+#### Why is there a limit on the number of entities?
+
+The continue watching row on Google TV displays content from various media
+providers. Limiting the number of entities per provider so that users see a
+diverse selection of content from all their favorite sources, promoting a fair
+and balanced user experience.
+
+### Verification App Questions
+
+#### Is it mandatory to test my app with the verification app before submission?
+
+Yes, testing your app with the verification app is essential before submitting
+your APK.
+
+While we understand you might be confident in your implementation, the Engage
+integration has many intricate components. The verification app acts as a safety
+net, catching potential issues early on and saving you valuable time and effort
+in the long run.
+
+Think of it as a quick checkup that helps guarantee a smooth launch and a great
+user experience.
+
+By identifying and addressing any problems beforehand, you can avoid the
+frustration of rejections and resubmissions.
+
+To submit your APK, you'll need to include a screenshot showing that your app
+has passed the verification process.
+
+#### What are some common mistakes to watch out for during integration?
+
+The verification app is designed to catch potential issues with your Engage
+integration. Here are some common mistakes that developers often encounter:
+
+For all content types (movies, TV episodes, live streams, video clips):
+
+- Missing Links: Make sure you provide valid platform-specific URIs (links) for your content. These links tell the system where to find your content on each platform.
+- Missing Titles: Don't forget to include titles for all your content. This helps users identify what they were watching.
+- Image Aspect Ratios: Verify all images associated with your content have an aspect ratio close to 16:9. This makes sure your images display correctly on different screens.
+
+For TV Episodes:
+
+- Complete Episode Information: Make sure to include the show title, episode number, and season number. This helps organize episodes and allows users to navigate within a series.
+- Accurate Playback Position: Double-check that the last playback position is less than or equal to the total duration of the episode. This makes sure users resume from the correct spot.
+
+For Movies:
+
+- Accurate Playback Position: Similar to TV episodes, verify the last playback position is accurate.
+
+For Live Streaming Videos:
+
+- Broadcaster Information: Include the broadcaster's name for live streams.
+
+For Video Clips:
+
+- Creator Information: Specify the creator of the video clip.
+
+Remember: The verification app will flag these issues, allowing you to fix them
+before submitting your app. This saves you time and ensures a smoother
+experience for your users.
+
+### Account and Profile Questions
+
+#### My app uses anonymous user logins. Is AccountProfile still required for Engage?
+
+`AccountProfile` is designed for apps that use individual user accounts.
+However, we understand that some apps, like yours, may rely on anonymous logins.
+Here's how Engage works in this scenario:
+
+- `AccountProfile` is technically required, but you can still integrate Engage even if your app doesn't have a user account system.
+- Limited to on-device use: The cross-device capabilities of Engage relies on identifying users across different devices. Since anonymous logins don't provide this, the feature will be limited to the user's current device.
+- How to configure: To set this up, you'll need to disable cross-device syncing. This makes sure that continuation entries only appear on the specific device where the content was started.
+
+In summary: While you can integrate Engage with anonymous logins, users will
+only be able to resume content on the same device.
+
+#### Can I use AccountProfile with only `accountId` and no `profileId`, even when my app supports both accountId and `profileId`?
+
+AccountProfile requires both `accountId` and `profileId` to function correctly.
+Here's why:
+
+- Consistent identification: `accountId` identifies the user, while `profileId` distinguishes between different profiles within that user's account (if applicable). Providing both makes sure that Engage accurately tracks and displays content for each individual profile.
+- Preventing errors: Using `accountId` and `profileId` inconsistently across different API calls can lead to unexpected behavior and errors. For example, if you include both when adding content to Engage but only use `accountId` when deleting content, the system may not be able to correctly identify and remove the intended items.
+
+#### Is `profileId` required for Engage?
+
+- `accountId` is required. This identifies the user across devices.
+- `profileId` is crucial for a good user experience. While technically optional, `profileId` is strongly recommended if your service supports multiple profiles (like many streaming services do). Why is it so important? Because without `profileId`, the continue watching row may show content from other profiles on the same account. This can lead to a confusing and frustrating experience for your users.
+- In short: Providing `profileId` makes sure that content provided to the continue watching row accurately reflects each individual's viewing history. Unless your app doesn't support the concept of profile within an account, you should provide it.
+
+#### How does Google use the `profileId` on their side?
+
+If the service offers different profiles to watch content, `accountId` and
+`profileId` would be used to associate the content watched on the device to the
+signed-in Google Account on the device. Google would record the ContinueWatching
+data against the combination of `accountId` and `profileId`. Any Google device
+that has that same Google Account logged in, would get the latest updated data
+from the same associated `accountId` and `profileId`, in its ContinueWatching
+row.
+
+#### Is account linking required to implement Engage?
+
+Account Linking is not needed. It is being deprioritized and all related use
+cases will be covered by the new Device Entitlements API.
+
+### Sync Across Devices Questions
+
+#### What does "sync across devices" mean when users give consent?
+
+With the user's "sync across device" consent, the content they're watching will
+be saved to Google TV servers, letting them seamlessly pick up where they left
+off on any signed-in device. Without consent, their watch history remains local
+to the current device.
+
+#### Can we set "sync across devices" to false?
+
+The `setUserConsentToSyncAcrossDevices` flag controls whether a user's
+ContinuationCluster data is synchronized across their devices (TV, phone,
+tablet, etc.). If this flag is set to false, then continue watching content is
+only surfaced on same device.
+
+To get the most out of our cross-device feature, we strongly advise your app to
+obtain user consent and set SyncAcrossDevices to true.
+
+#### How is user consent for sharing watch history obtained on non-Android
+
+devices? What data points are shared to 3P servers from non-Android devices?
+
+The consent is collected at the user level (profile or account level). Once
+consent is obtained, the continue watching payloads based on engagement can be
+sent anywhere so Google can reflect the users' ubiquity resumption state across
+all entities that they have partial or next engagement with, on any device
+(without having to re-ask consent on every device or platform). Partners will
+send the users latest continue watching state (as per spec) associated with
+profile ID (that was deposited on android).
+
+### REST API Questions
+
+#### Is there documentation on the REST API?
+
+The ETA for REST API is March 2025, this is documented in Engage Developer Docs.
+
+### Legacy Watch Next Questions
+
+#### Is Engage replacing the Watch Next API?
+
+Engage will be backward compatible on all Android TV devices that support the
+Watch Next API. To integrate on Google TV and other surfaces that support
+Engage, developers should use the Engage SDK.
+
+### Testing and Integration Questions
+
+#### What is the difference between LastPlayBackPositionTimeMillis and duration?
+
+LastPlayBackPositionTimeMillis should reflect the playback duration in
+milliseconds where the user stopped watching (e.g., 605000 ms for 10 minutes and
+5 seconds). It should never be greater than the entity's total duration.
+
+Whereas, **LastEngagementTime** is the timestamp when the user last engaged with
+the content.
+
+#### What are the test cases we should perform?
+
+The following are test cases for Google TV that our QA performs. Similar test
+cases can be performed on other surfaces as well.
+
+1. Watch a video, which is longer than 20 minutes for about 5 minutes. Exit app. The video card should be displayed in the continue watching row. Note: We only display 5 cards per 3p app in CW
+2. Selecting the newly appeared card in the continue watching row should continue playing the video from the right point in the video.Note: Any New or old content should resume playback from where it was left off last
+3. Changing accounts on the GTV device should change the cards on the continue watching row. Only videos from the current account should show up. Sorted in recent order. 3p app profile CW will be intermixed. Note: CW for GoogleAccount2 will show 3P contents that GoogleAccount2 was engaged watching
+4. Exit the app with BACK button \> Verify card is displayed in the "Continue watching" row
+5. Hide the video in the continue watching row, it shouldn't show again Test if hidden content stays hidden beyond 24 hours and even after the app opens after 24 hrs. Confirm hiding one item does not hide multiple items.
+6. Content availability in the continue watching row with full metadata: Card image, App name, title, season episode # for TV contents
+7. Check Progress displays in the progress bar
+8. User watched the content until ending credits - content does not display in the continue watching row
+9. Confirm no unwatched items show up in the continue watching row
+10. Confirm that the CW items are arranged chronologically based on when watch activity happened and not when the app was last opened or last day
+11. Confirm that episode and season details on CW card match what was watched on episodic content
+12. Confirm completed (items at credits or beyond) items don't show up in the continue watching row
+13. Turn off the device halfway through watching the episode/movie/show. "Turn off the device halfway through watching the episode/movie/show. Verify on turning on the device and on other TV, CW displays the right card , at the right position and progress bar"
+14. Turn off the device after completely watching episode 1, verify
+15. episode 1 drops and doesn't reappear in continue watching row \[on second device and on turning on the test device\]
+    1. episode 2 (if available), should appear in continue watching row \[on second device and on turning on the test device\]
+16. First scenario: TV1: GoogleAccount: mom, 3p account / profile: account 1 / profile_1. Watch content and verify CW data displays contents watched by 3P account_1/profile_1
+17. TV2: GoogleAccount: mom. Verify CW data from the first scenario. Now login
+    to the 3p app as a different account. 3p account / profile: account_2 /
+    profile_2. Watch content and verify CW data displays contents watched by 3p
+    account_2/profile_2
+
+18. GoogleAccount: mom. New device case /3P app not installed. On a new
+    device(FDR the device), Verify CW displays data from the last used 3P app
+    that was used by the GoogleAccount. Note: CW row shouldn't show 3P contents
+    if the GAIA is not yet associated with a 3P profile on other device
+
+    1. GoogleAccount: mom. New device case /3P app installed but not logged in. On a new device(FDR the device), Verify CW displays data from the last used 3P app that was used by the GoogleAccount.
+19.
+
+    > [!NOTE]
+    > **Note:** When the app is installed and logged in, the CW state would reflect the active 3P user logged into the 3P app.
+
+    1. Note: the continue watching row shouldn't show 3P contents if the GoogleAccount is not yet associated with a 3P profile
+
+#### We are not seeing continuation content showing up on Google TV iOS app. What happened?
+
+You will need to send iOS deeplinks for content to appear in the continue
+watching row on iOS devices.
+
+#### How often should I update content information for the continue watching row? Should I update it frequently, like every 15 seconds?
+
+No, frequent updates are not recommended. Here's why:
+
+- Performance Impact: Continuously sending updates puts unnecessary strain on our servers, potentially slowing down the system for everyone.
+- Unnecessary Data: While a user is actively watching, their playback position changes constantly. Sending updates every few seconds creates a lot of redundant data that isn't helpful for resuming playback.
+
+When to update content information for the continue watching row:
+
+Focus on capturing meaningful changes in the user's viewing progress. Here are
+the key scenarios:
+
+- Playback Paused or Stopped: When a user pauses or stops watching, send an update to store their current position.
+- App Closed or Backgrounded: If a user exits the app or switches to another app while watching a video, send an update to save their progress.
+- When user removes an item from their continue watching row within app
+
+How to efficiently update:
+
+Instead of timed updates, utilize events within your video player or app
+lifecycle to trigger updates. For example:
+
+- `onPause`, `onStop`: When the video playback pauses or stops.
+- `onAppClose`, `onAppBackgrounded`: When the app closes or moves to the background.
+
+By following these guidelines, you'll ensure efficient use of resources while
+still providing a seamless experience in the continue watching row for your
+users.
+
+> [!NOTE]
+> **Note:** Please contact [`engage-developers@google.com`](mailto:engage-developers@google.com) if you have any questions that are not covered here.

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/food.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/food.md
@@ -1,0 +1,1132 @@
+Boost app engagement by reaching your users where they are. Integrate Engage SDK
+to deliver personalized recommendations and continuation content directly to
+users across multiple on-device surfaces, like
+**[Collections](https://android-developers.googleblog.com/2024/07/introducing-collections-powered-by-engage-sdk.html)** , **[Entertainment
+Space](https://blog.google/products/android/entertainment-space/)** , and the Play Store. The integration adds
+less than 50 KB (compressed) to the average APK and takes most apps about a
+week of developer time. Learn more at our **[business
+site](http://play.google.com/console/about/programs/EngageSDK)**.
+
+This guide contains instructions for developer partners to deliver food content
+(food ordering, food or restaurant reviews \& discovery, meal subscriptions,
+recipes) to Engage content surfaces.
+
+## Integration detail
+
+### Terminology
+
+This integration includes the following five cluster types: **Recommendation** ,
+**Featured** , **Food Shopping Cart** , **Food Shopping List** , and **Reorder**.
+
+- **Recommendation** clusters show personalized food-related suggestions from an
+  individual developer partner. These recommendations can be personalized to the
+  user or generalized (for example, new on sale). Use them to surface recipes,
+  stores, dishes, groceries, and so on as you see fit.
+
+  - A Recommendation cluster can be made of `ProductEntity`, `StoreEntity`, or `RecipeEntity` listings, but not a mix of different entity types.
+
+  ![](https://developer.android.com/static/images/guide/playcore/engage/food-entities.png) **Figure :**\`ProductEntity\`, \`StoreEntity\`, and \`RecipeEntity\`. (\*UI for illustrative purposes only)
+- The **Featured** cluster showcases a selection of entities from multiple
+  developer partners in one UI grouping. There will be a single Featured
+  cluster, which is surfaced near the top of the UI with a priority placement
+  above all Recommendation clusters. Each developer partner will be allowed to
+  broadcast up to 10 entities in the Featured cluster.
+
+  ![](https://developer.android.com/static/images/guide/playcore/engage/food-featured.png) **Figure :** Featured cluster with the \`RecipeEntity\`. (\*UI for illustrative purposes only)
+- The **Food Shopping Cart** cluster shows a sneak peek of grocery shopping
+  carts from multiple developer partners in one UI grouping, prompting users to
+  complete their outstanding carts. There is a single Food Shopping Cart
+  cluster.
+
+  - Food Shopping Cart Cluster must show the total count of items in the
+    cart and may also include images for X items in the user's cart.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/food-shopping-cart.png) **Figure:** Food Shopping Cart cluster from a single partner. (\*UI for illustrative purposes only)
+- The **Food Shopping List** cluster shows a sneak peek of the grocery shopping
+  lists from multiple developer partners in one UI grouping, prompting users to
+  return to the corresponding app to update and complete their lists. There is a
+  single Food Shopping List cluster.
+
+  ![](https://developer.android.com/static/images/guide/playcore/engage/food-shopping-list.png) **Figure:** Food Shopping List cluster from a single partner. (\*UI for illustrative purposes only)
+- The **Reorder** cluster shows a sneak peek of the previous orders from
+  multiple developer partners in one UI grouping, prompting users to reorder.
+  There is a single Reorder cluster.
+
+  - Reorder cluster must show the total count of items in the
+    user's previous order and must also include one of the following:
+
+    - Images for X items in the user's previous order.
+    - Labels for X items in the user's previous order.
+
+  ![](https://developer.android.com/static/images/guide/playcore/engage/food-reorder-cluster.png) **Figure:** Food Reorder cluster from a single partner. (\*UI for illustrative purposes only)
+
+### Pre-work
+
+Minimum API level: 19
+
+Add the `com.google.android.engage:engage-core` library to your app:
+
+    dependencies {
+        // Make sure you also include that repository in your project's build.gradle file.
+        implementation 'com.google.android.engage:engage-core:1.6.0'
+    }
+
+### Summary
+
+The design is based on an implementation of a [bound
+service](https://developer.android.com/guide/components/bound-services).
+
+The data a client can publish is subject to the following limits for different
+cluster types:
+
+| Cluster type | Cluster limits | Maximum entity limits in a cluster |
+|---|---|---|
+| Recommendation Cluster(s) | At most 7 | At most 50 (`ProductEntity`, `RecipeEntity`, or `StoreEntity`) |
+| Featured Cluster | At most 1 | At most 20 (`ProductEntity`, `RecipeEntity`, or `StoreEntity`) |
+| Food Shopping Cart Cluster | At most 1 | At most 3 `FoodShoppingCart` |
+| Food Shopping List Cluster | At most 1 | At most 3 `FoodShoppingList` |
+| Food Reorder Cluster | At most 1 | At most 1 `ReorderEntity` |
+
+### Step 1: Provide entity data
+
+The SDK has defined different entities to represent each item type. We support
+the following entities for the Food category:
+
+1. `ProductEntity`
+2. `StoreEntity`
+3. `RecipeEntity`
+4. `FoodShoppingCart`
+5. `FoodShoppingList`
+6. `FoodReorderCluster`
+
+The charts below outline available attributes and requirements for each type.
+
+#### `ProductEntity`
+
+The `ProductEntity` object represents an individual item (such as a grocery
+item, dish from a restaurant, or a promotion) that developer partners want to
+publish.
+
+<br />
+
+![](https://developer.android.com/static/images/guide/playcore/engage/food-product-entity.png) **Figure :** Attributes of `ProductEntity`
+
+<br />
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Poster images | **Required** | At least one image must be provided. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/food#image-specs) for guidance. |
+| Action Uri | **Required** | The deep link to the page in the app displaying details about the product. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | Optional | The name of the product. | Free text **Recommended text size: under 90 chars** (Text that is too long may show ellipses) |
+| Price - current | Conditionally required | The current price of the product. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - strikethrough | Optional | The original price of the entity, which is struck-through in the UI. | Free text |
+| Callout | Optional | Callout to feature a promo, event, or update for the product, if available. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Callout fine print | Optional | Fine print text for the callout. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| **Rating (Optional) - Note: All ratings are displayed using our standard star rating system.** ||||
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the product. **Note:** Provide this field if your app controls how the count is displayed to the users. Use a concise string. For example, if the count is 1,000,000, consider using an abbreviation like 1M so that the count isn't truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the product. **Note:** Provide this field if you don't handle the display abbreviation logic yourself. If both Count and Count Value are present, Count is displayed to users. | Long |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `StoreEntity`
+
+The `StoreEntity` object represents an individual store that developer partners
+want to publish, such as a restaurant or a grocery store.
+
+<br />
+
+![](https://developer.android.com/static/images/guide/playcore/engage/food-store-entity.png) **Figure :** Attributes of `StoreEntity`
+
+<br />
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Poster images | **Required** | At least one image must be provided. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/food#image-specs) for guidance. |
+| Action Uri | **Required** | The deep link to the page in the app displaying details about the store. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | Optional | The name of the store. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Location | Optional | The location of the store. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Callout | Optional | Callout to feature a promo, event, or update for the store, if available. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Callout fine print | Optional | Fine print text for the callout. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Description | Optional | A description of the store. | Free text **Recommended text size: under 90 chars** (Text that is too long may show ellipses) |
+| Category | Optional | Category of a store, in the context of dining places, it can be cuisine like "french", "new american", "ramen", "fine dining". | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| **Note: All ratings is displayed using our standard star rating system.** ||||
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the store. **Note:** Provide this field if your app wants to control how this is displayed to the users. Provide the concise string that can be displayed to the user. For example, if the count is 1,000,000, consider using abbreviations like 1M, so that it won't be truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the store. **Note:** Provide this field if you don't want to handle the display abbreviation logic yourself. If both Count and Count Value are present, we will use the Count to display to users | Long |
+
+#### `RecipeEntity`
+
+The `RecipeEntity` object represents a recipe item that developer partners want
+to publish.
+
+<br />
+
+![](https://developer.android.com/static/images/guide/playcore/engage/food-recipe-entity.png) **Figure :** Attributes of `RecipeEntity`
+
+<br />
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Poster images | **Required** | At least one image must be provided. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/food#image-specs) for guidance. |
+| Action Uri | **Required** | The deep link to the page in the app displaying details about the recipe. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | Optional | The name of the recipe. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Author | Optional | The author of the recipe. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Cook/Preparation time | Optional | The cooking time of the recipe. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Callout | Optional | Callout to feature a promo, event, or update for the recipe, if available. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Category | Optional | The category of the recipe. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Description | Optional | A description of the recipe. | Free text **Recommended text size: under 90 chars** (Text that is too long may show ellipses) |
+| **Note: All ratings are displayed using our standard star rating system.** ||||
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the recipe. **Note:** Provide this field if your app wants to control how this is displayed to the users. Provide the concise string that can be displayed to the user. For example, if the count is 1,000,000, consider using abbreviations like 1M, so that it won't be truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the recipe. **Note:** Provide this field if you don't want to handle the display abbreviation logic yourself. If both Count and Count Value are present, we will use the Count to display to users | Long |
+
+#### `FoodShoppingCart`
+
+<br />
+
+![](https://developer.android.com/static/images/guide/playcore/engage/food-shopping-cart-attributes.png) **Figure:** Food Shopping Cart cluster attributes.
+
+<br />
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | The deep link to the shopping cart in the partner's app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Number of items | **Required** | The number of items (not just number of products) in the shopping cart. **For example: If there are 3 oranges and 1 apple in the cart, this number should be 4.** | Integer \>= 1 |
+| Last user interaction timestamp | **Required** | Number of milliseconds elapsed from the epoch, identifying the last time when user interacted with the shopping cart. | Epoch timestamp in milliseconds |
+| Title | Optional | The title of the cart (for example, *Your cart*). **If no title is provided by the developer, *Your cart* is the default.** | Free text **Recommended text size: under 25 chars** (Text that is too long may show ellipses) |
+| Action Text | Optional | The call to action text of the button on the Shopping Cart (for example, *Your Shopping Bag*). **If no action text is provided by the developer, *View Cart* is the default.** This attribute is supported in version 1.1.0 onwards. | String |
+| Cart images | Optional | Images of each product in the cart. **Up to 10 images can be provided in order of priority; the actual number of images displayed depends on the device form factor.** | See [Image Specifications](https://developer.android.com/guide/playcore/engage/food#image-specs) for guidance. |
+| Item labels | Optional | The list of labels for items on the shopping list. **The actual number of labels displayed depends on the device form factor.** | List of free text labels **Recommended text size: under 20 chars** (Text that is too long may show ellipses) |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `FoodShoppingList`
+
+<br />
+
+![](https://developer.android.com/static/images/guide/playcore/engage/food-shopping-list.png) **Figure:** Food Shopping List cluster.
+
+<br />
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | The deep link to the shopping list in the partner's app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Number of items | **Required** | The number of items in the shopping list. | Integer \>= 1 |
+| Last user interaction timestamp | **Required** | Number of milliseconds elapsed from the epoch, identifying the last time when user interacted with the shopping list. | Epoch timestamp in milliseconds |
+| Title | Optional | The title of the list (for example, *Your Grocery List*). **If no title is provided by the developer, *Shopping list* is the default.** | Free text **Recommended text size: under 25 chars** (Text that is too long may show ellipses) |
+| Item labels | **Required** | The list of labels for items on the shopping list. **At least 1 label must be provided and up to 10 labels can be provided in order of priority; the actual number of labels displayed depends on the device form factor.** | List of free text labels **Recommended text size: under 20 chars** (Text that is too long may show ellipses) |
+
+#### `FoodReorderCluster`
+
+<br />
+
+![](https://developer.android.com/static/images/guide/playcore/engage/food-reorder-cluster.png) **Figure:** Food Reorder cluster.
+
+<br />
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | The deep link to reorder in the partner's app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Action Text | Optional | The call to action text of the button on the Reorder (for example, *Order again*). **If no action text is provided by the developer, *Reorder* is the default.** This attribute is supported in version 1.1.0 onwards. | String |
+| Number of items | **Required** | The number of items (not just number of products) in the previous order. **For example: If there were 3 small coffees and 1 croissant in the previous order, this number should be 4.** | Integer \>= 1 |
+| Title | **Required** | The title of the reorder item. | Free text **Recommended text size: under 40 chars** (Text that is too long may show ellipses) |
+| Item labels | Optional (If not provided, poster images should be provided) | The list of item labels for the previous order. **Up to 10 labels can be provided in order of priority; the actual number of labels displayed depends on the device form factor.** | List of free text **Recommended text size per label: under 20 chars** (Text that is too long may show ellipses) |
+| Poster images | Optional (If not provided, item labels should be provided) | Images of the items in the previous order. **Up to 10 images can be provided in order of priority; the actual number of images displayed depends on the device form factor.** | See [Image Specifications](https://developer.android.com/guide/playcore/engage/food#image-specs) for guidance. |
+
+#### Image specifications
+
+Required specifications for image assets are listed below:
+
+| Aspect ratio | Minimum pixels | Recommended pixels |
+|---|---|---|
+| Square (1x1) **Preferred** | 300x300 | 1200x1200 |
+| Landscape (1.91x1) | 600x314 | 1200x628 |
+| Portrait (4x5) | 480x600 | 960x1200 |
+
+*File formats*
+
+PNG, JPG, static GIF, WebP
+
+*Maximum file size*
+
+5120 KB
+
+*Additional recommendations*
+
+- **Image safe area:** Put your important content in the center 80% of the image.
+- Use a transparent background so that the image can be properly displayed in Dark and Light theme settings.
+
+### Step 2: Provide Cluster data
+
+It is recommended to have the content publish job executed in the background
+(for example, using [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager))
+and scheduled on a regular basis or on an event basis (for example, every time
+the user opens the app or when the user just added something to their cart).
+
+`AppEngageFoodClient` is responsible for publishing food clusters.
+
+There are following APIs to publish clusters in the client:
+
+- `isServiceAvailable`
+- `publishRecommendationClusters`
+- `publishFeaturedCluster`
+- `publishFoodShoppingCarts`
+- `publishFoodShoppingLists`
+- `publishReorderCluster`
+- `publishUserAccountManagementRequest`
+- `updatePublishStatus`
+- `deleteRecommendationsClusters`
+- `deleteFeaturedCluster`
+- `deleteFoodShoppingCartCluster`
+- `deleteFoodShoppingListCluster`
+- `deleteReorderCluster`
+- `deleteUserManagementCluster`
+- `deleteClusters`
+
+#### `isServiceAvailable`
+
+This API is used to check if the service is available for integration and
+whether the content can be presented on the device.
+
+##### For Engage SDK v1.6.0 and higher (Recommended)
+
+You can check the service availability for every cluster type that you intend to
+publish. The `isServiceAvailable` API accepts a request object,
+`ServiceAvailabilityRequest`, which contains the cluster types for which service
+availability needs to be checked. You can find the `ClusterType` enum values
+required for `ServiceAvailabilityRequest` from the following table.
+
+| Cluster Type | Cluster Type Constant | Integer Value |
+|---|---|---|
+| Unknown | `TYPE_UNKNOWN` | 0 |
+| Recommendation Cluster | `TYPE_RECOMMENDATION` | 1 |
+| Featured Cluster | `TYPE_FEATURED` | 2 |
+| Continuation Cluster | `TYPE_CONTINUATION` | 3 |
+| Food Reorder Cluster | `TYPE_FOOD_REORDER` | 5 |
+| Food Shopping Cart Cluster | `TYPE_FOOD_SHOPPING_CART` | 6 |
+| Food Shopping List Cluster | `TYPE_FOOD_SHOPPING_LIST` | 7 |
+| User Management Cluster | `TYPE_ENGAGEMENT` | 8 |
+| Subscription Cluster | `TYPE_SUBSCRIPTION` | 12 |
+
+### Kotlin
+
+    val request = ServiceAvailabilityRequest.Builder()
+        .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+        .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+        .build()
+
+    client.isServiceAvailable(request).addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            val availabilityMap = task.result
+            if (availabilityMap[ClusterType.TYPE_CONTINUATION] == true) {
+                // Proceed with publishing continuation content
+            }
+            if (availabilityMap[ClusterType.TYPE_RECOMMENDATION] == true) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    }
+
+### Java
+
+    ServiceAvailabilityRequest request =
+        new ServiceAvailabilityRequest.Builder()
+            .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+            .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+            .build();
+
+    client.isServiceAvailable(request).addOnCompleteListener(task -> {
+        if (task.isSuccessful()) {
+            Map<Integer, Boolean> availabilityMap = task.getResult();
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_CONTINUATION))) {
+                // Proceed with publishing continuation content
+            }
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_RECOMMENDATION))) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    });
+
+###### Conditional Service Availability Feature
+
+Some integrated apps request a special configuration that enables and disables
+the Engage service intermittently in order to reduce their serving cost. This
+intermittent content ingestion strategy, although possible, negatively affects
+the user and the product -- stale content will not be presented and some surfaces
+will not be served at all.
+
+Starting with v1.6.0, the Engage SDK allows checking availability for specific
+cluster types. This provides more flexibility so that if the intermittent
+content strategy was adopted by a given application, some cluster types can
+follow that intermittent strategy while other cluster types are always enabled
+(i.e. continuation clusters).
+
+If the Engage service should not be 'continuously' enabled on all supported
+devices for whatever reason, and is configured for intermittent ingestion for
+any set of devices, all continuation cluster publications (e.g. Food Shopping
+Cart, Food Shopping List, and Reorder) will be still enabled by default
+configuration, and the rest of the cluster types will be enabled and disabled
+intermittently. If intermittent ingestion applies to you but this default
+configuration is not suitable for your needs, please contact
+engage-developers@google.com.
+
+##### For SDK versions prior to v1.6.0 (Deprecated)
+
+### Kotlin
+
+    client.isServiceAvailable.addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            // Handle IPC call success
+            if(task.result) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    }
+
+### Java
+
+    client.isServiceAvailable().addOnCompleteListener(task - > {
+        if (task.isSuccessful()) {
+            // Handle success
+            if(task.getResult()) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    });
+
+> [!NOTE]
+> **Note:** We highly recommend keeping a periodic job running to check if the service becomes available at a later point in time. The availability of the service may change with Android version upgrades, app upgrades, installs, and uninstalls. By ensuring periodic job checks at a certain time interval, data can be published once the service becomes available.
+
+#### `publishRecommendationClusters`
+
+This API is used to publish a list of `RecommendationCluster` objects.
+
+A `RecommendationCluster` object can have the following attributes:
+
+| Attribute | Requirement | Description |
+|---|---|---|
+| List of ProductEntity, StoreEntity, or RecipeEntity | **Required** | A list of entities that make up the recommendations for this Recommendation Cluster. Entities in a single cluster must be of the same type. |
+| Title | **Required** | The title for the Recommendation Cluster (for example, *Big savings on Thanksgiving menu*). **Recommended text size: under 25 chars** (Text that is too long may show ellipses) |
+| Subtitle | Optional | The subtitle for the Recommendation Cluster. |
+| Action Uri | Optional | The deep link to the page in the partner app where users can see the complete list of recommendations. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishRecommendationClusters(
+                PublishRecommendationClustersRequest.Builder()
+                    .addRecommendationCluster(
+                        RecommendationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .setTitle("Big savings on Thanksgiving menu")
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishRecommendationClusters(
+                new PublishRecommendationClustersRequest.Builder()
+                    .addRecommendationCluster(
+                        new RecommendationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .setTitle("Big savings on Thanksgiving menu")
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- All existing Recommendation Cluster data is removed.
+- Data from the request is parsed and stored in new Recommendation Clusters.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishFeaturedCluster`
+
+This API is used to publish a `FeaturedCluster` object.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishFeaturedCluster(
+                PublishFeaturedClusterRequest.Builder()
+                    .setFeaturedCluster(
+                        FeaturedCluster.Builder()
+                            ...
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishFeaturedCluster(
+                new PublishFeaturedClusterRequest.Builder()
+                    .setFeaturedCluster(
+                        new FeaturedCluster.Builder()
+                            ...
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `FeaturedCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Featured Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishFoodShoppingCarts`
+
+This API is used to publish a list of `FoodShoppingCart` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishFoodShoppingCarts(
+                PublishFoodShoppingCartsRequest.Builder()
+                    .addFoodShoppingCart(
+                        FoodShoppingCart.Builder()
+                            ...
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishFoodShoppingCarts(
+                new PublishFoodShoppingCartsRequest.Builder()
+                    .addFoodShoppingCart(
+                        new FoodShoppingCart.Builder()
+                            ...
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `FoodShoppingCart` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Shopping Cart Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishFoodShoppingLists`
+
+This API is used to publish a list of `FoodShoppingList` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishFoodShoppingLists(
+                PublishFoodShoppingListsRequest.Builder()
+                    .addFoodShoppingList(
+                        FoodShoppingListEntity.Builder()
+                            ...
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishFoodShoppingLists(
+                new PublishFoodShoppingListsRequest.Builder()
+                    .addFoodShoppingList(
+                        new FoodShoppingListEntity.Builder()
+                            ...
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `FoodShoppingList` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Shopping List Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishReorderCluster`
+
+This API is used to publish a `FoodReorderCluster` object.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishReorderCluster(
+                PublishReorderClusterRequest.Builder()
+                    .setReorderCluster(
+                        FoodReorderCluster.Builder()
+                            ...
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishReorderCluster(
+                new PublishReorderClusterRequest.Builder()
+                    .setReorderCluster(
+                        new FoodReorderCluster.Builder()
+                            ...
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `FoodReorderCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Reorder Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishUserAccountManagementRequest`
+
+This API is used to publish a Sign In card . The signin action directs users to
+the app's sign in page so that the app can publish content (or provide more
+personalized content)
+
+The following metadata is part of the Sign In Card -
+
+| Attribute | Requirement | Description |
+|---|---|---|
+| Action Uri | Required | Deeplink to Action (i.e. navigates to app sign in page) |
+| Image | Optional - If not provided, Title must be provided | Image Shown on the Card 16x9 aspect ratio images with a resolution of 1264x712 |
+| Title | Optional - If not provided, Image must be provided | Title on the Card |
+| Action Text | Optional | Text Shown on the CTA (i.e. Sign in) |
+| Subtitle | Optional | Optional Subtitle on the Card |
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    var SIGN_IN_CARD_ENTITY =
+          SignInCardEntity.Builder()
+              .addPosterImage(
+                  Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build()
+
+    client.publishUserAccountManagementRequest(
+                PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+### Java
+
+    SignInCardEntity SIGN_IN_CARD_ENTITY =
+          new SignInCardEntity.Builder()
+              .addPosterImage(
+                  new Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build();
+
+    client.publishUserAccountManagementRequest(
+                new PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `UserAccountManagementCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated UserAccountManagementCluster Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `updatePublishStatus`
+
+If for any internal business reason, none of the clusters is published,
+we **strongly recommend** updating the publish status using the
+**updatePublishStatus** API.
+This is important because :
+
+- Providing the status in all scenarios, even when the content is published (STATUS == PUBLISHED), is critical to populate dashboards that use this explicit status to convey the health and other metrics of your integration.
+- If no content is published but the integration status isn't broken (STATUS == NOT_PUBLISHED), Google can avoid triggering alerts in the app health dashboards. It confirms that content is not published due to an **expected** situation from the provider's standpoint.
+- It helps developers provide insights into when the data is published versus not.
+- Google may use the status codes to nudge the user to do certain actions in the app so they can see the app content or overcome it.
+
+The list of eligible publish status codes are :
+
+    // Content is published
+    AppEngagePublishStatusCode.PUBLISHED,
+
+    // Content is not published as user is not signed in
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN,
+
+    // Content is not published as user is not subscribed
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SUBSCRIPTION,
+
+    // Content is not published as user location is ineligible
+    AppEngagePublishStatusCode.NOT_PUBLISHED_INELIGIBLE_LOCATION,
+
+    // Content is not published as there is no eligible content
+    AppEngagePublishStatusCode.NOT_PUBLISHED_NO_ELIGIBLE_CONTENT,
+
+    // Content is not published as the feature is disabled by the client
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_FEATURE_DISABLED_BY_CLIENT,
+
+    // Content is not published as the feature due to a client error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR,
+
+    // Content is not published as the feature due to a service error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR,
+
+    // Content is not published due to some other reason
+    // Reach out to engage-developers@ before using this enum.
+    AppEngagePublishStatusCode.NOT_PUBLISHED_OTHER
+
+If the content is not published due to a user not logged in,
+Google would recommend publishing the Sign In Card.
+If for any reason providers are not able to publish the Sign In Card
+then we recommend calling the **updatePublishStatus** API
+with the status code **NOT_PUBLISHED_REQUIRES_SIGN_IN**
+
+### Kotlin
+
+    client.updatePublishStatus(
+       PublishStatusRequest.Builder()
+         .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+         .build())
+
+### Java
+
+    client.updatePublishStatus(
+        new PublishStatusRequest.Builder()
+            .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+            .build());
+
+#### `deleteRecommendationClusters`
+
+This API is used to delete the content of Recommendation Clusters.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteRecommendationClusters()
+
+### Java
+
+    client.deleteRecommendationClusters();
+
+When the service receives the request, it removes the existing data from the
+Recommendation Clusters. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteFeaturedCluster`
+
+This API is used to delete the content of Featured Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteFeaturedCluster()
+
+### Java
+
+    client.deleteFeaturedCluster();
+
+When the service receives the request, it removes the existing data from the
+Featured Cluster. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteFoodShoppingCartCluster`
+
+This API is used to delete the content of Food Shopping Cart Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteFoodShoppingCartCluster()
+
+### Java
+
+    client.deleteFoodShoppingCartCluster();
+
+When the service receives the request, it removes the existing data from the
+Food Shopping Cart Cluster. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is availaile from version 1.1.0 onwards.
+
+#### `deleteFoodShoppingListCluster`
+
+This API is used to delete the content of Food Shopping List Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteFoodShoppingListCluster()
+
+### Java
+
+    client.deleteFoodShoppingListCluster();
+
+When the service receives the request, it removes the existing data from the
+Food Shopping List Cluster. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteReorderCluster`
+
+This API is used to delete the content of FoodReorderCluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteReorderCluster()
+
+### Java
+
+    client.deleteReorderCluster();
+
+When the service receives the request, it removes the existing data from the
+Reorder Cluster. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteUserManagementCluster`
+
+This API is used to delete the content of UserAccountManagement Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteUserManagementCluster()
+
+### Java
+
+    client.deleteUserManagementCluster();
+
+When the service receives the request, it removes the existing data from the
+UserAccountManagement Cluster. In case of an error, the entire request is
+rejected and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteClusters`
+
+This API is used to delete the content of a given cluster type.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteClusters(
+        DeleteClustersRequest.Builder()
+          .addClusterType(ClusterType.TYPE_FEATURED)
+          .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+          ...
+          .build())
+
+### Java
+
+    client.deleteClusters(
+                new DeleteClustersRequest.Builder()
+                    .addClusterType(ClusterType.TYPE_FEATURED)
+                    .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+                    ...
+                    .build());
+
+When the service receives the request, it removes the existing data from all
+clusters matching the specified cluster types. Clients can choose to pass one or
+many cluster types. In case of an error, the entire request is rejected and the
+existing state is maintained.
+
+#### Error handling
+
+It is highly recommended to listen to the task result from the publish APIs such
+that a follow-up action can be taken to recover and resubmit an successful task.
+
+    client.publishRecommendationClusters(
+                  new PublishRecommendationClustersRequest.Builder()
+                      .addRecommendationCluster(...)
+                      .build())
+              .addOnCompleteListener(
+                  task -> {
+                    if (task.isSuccessful()) {
+                      // do something
+                    } else {
+                      Exception exception = task.getException();
+                      if (exception instanceof AppEngageException) {
+                        @AppEngageErrorCode
+                        int errorCode = ((AppEngageException) exception).getErrorCode();
+                        if (errorCode == AppEngageErrorCode.SERVICE_NOT_FOUND) {
+                          // do something
+                        }
+                      }
+                    }
+                  });
+
+The error is returned as an `AppEngageException` with the cause included as an
+error code.
+
+| Error code | Error name | Note |
+|---|---|---|
+| `1` | `SERVICE_NOT_FOUND` | The service is not available on the given device. |
+| `2` | `SERVICE_NOT_AVAILABLE` | The service is available on the given device, but it is not available at the time of the call (for example, it is explicitly disabled). |
+| `3` | `SERVICE_CALL_EXECUTION_FAILURE` | The task execution failed due to threading issues. In this case, it can be retried. |
+| `4` | `SERVICE_CALL_PERMISSION_DENIED` | The caller is not allowed to make the service call. |
+| `5` | `SERVICE_CALL_INVALID_ARGUMENT` | The request contains invalid data (for example, more than the allowed number of clusters). |
+| `6` | `SERVICE_CALL_INTERNAL` | There is an error on the service side. |
+| `7` | `SERVICE_CALL_RESOURCE_EXHAUSTED` | The service call is made too frequently. |
+
+### Step 3: Handle broadcast intents
+
+In addition to making publish content API calls through a job, it is also
+required to set up a
+[`BroadcastReceiver`](https://developer.android.com/reference/android/content/BroadcastReceiver) to receive
+the request for a content publish.
+
+The goal of broadcast intents is mainly for app reactivation and forcing data
+sync. Broadcast intents are not designed to be sent very frequently. It is only
+triggered when the Engage Service determines the content might be stale (for
+example, a week old). That way, there is more confidence that the user can have
+a fresh content experience, even if the application has not been executed for a
+long period of time.
+
+The `BroadcastReceiver` must be set up in the following two ways:
+
+- Dynamically register an instance of the `BroadcastReceiver` class using
+  `Context.registerReceiver()`. This enables communication from applications
+  that are still live in memory.
+
+### Kotlin
+
+    class AppEngageBroadcastReceiver : BroadcastReceiver(){
+      // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION
+      // broadcast is received
+      // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is
+      // received
+      // Trigger food shopping cart cluster publish when PUBLISH_FOOD_SHOPPING_CART broadcast
+      // is received
+      // Trigger food shopping list cluster publish when PUBLISH_FOOD_SHOPPING_LIST broadcast
+      // is received
+      // Trigger reorder cluster publish when PUBLISH_REORDER_CLUSTER broadcast is
+      // received
+    }
+
+    fun registerBroadcastReceivers(context: Context){
+      var  context = context
+      context = context.applicationContext
+
+    // Register Recommendation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_RECOMMENDATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Featured Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_FEATURED),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register food Shopping Cart Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_FOOD_SHOPPING_CART),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register food Shopping List Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_FOOD_SHOPPING_LIST),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Reorder Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_REORDER_CLUSTER),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+    }
+
+### Java
+
+    class AppEngageBroadcastReceiver extends BroadcastReceiver {
+    // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+    // is received
+
+    // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is received
+
+    // Trigger food shopping cart cluster publish when PUBLISH_FOOD_SHOPPING_CART broadcast is
+    // received
+
+    // Trigger food shopping list cluster publish when PUBLISH_FOOD_SHOPPING_LIST broadcast is
+    // received
+
+    // Trigger reorder cluster publish when PUBLISH_REORDER_CLUSTER broadcast is
+    // received
+    }
+
+    public static void registerBroadcastReceivers(Context context) {
+
+    context = context.getApplicationContext();
+
+    // Register Recommendation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Featured Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register food Shopping Cart Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.shopping.service.Intents.ACTION_PUBLISH_FOOD_SHOPPING_CART),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register food Shopping List Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.shopping.service.Intents.ACTION_PUBLISH_FOOD_SHOPPING_LIST),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Reorder Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.shopping.service.Intents.ACTION_PUBLISH_REORDER_CLUSTER),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    }
+
+- Statically declare an implementation with the `<receiver>` tag in your
+  `AndroidManifest.xml` file. This allows the application to receive broadcast
+  intents when it is not running, and also allows the application to publish
+  the content.
+
+    <application>
+       <receiver
+          android:name=".AppEngageBroadcastReceiver"
+          android:permission="com.google.android.engage.REQUEST_ENGAGE_DATA"
+          android:exported="true"
+          android:enabled="true">
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_RECOMMENDATION" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_FEATURED" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.food.PUBLISH_FOOD_SHOPPING_CART" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.food.PUBLISH_FOOD_SHOPPING_LIST" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.food.PUBLISH_REORDER_CLUSTER" />
+          </intent-filter>
+       </receiver>
+    </application>
+
+The following [intents](https://developer.android.com/reference/android/content/Intent) will be sent by the
+service:
+
+- `com.google.android.engage.action.PUBLISH_RECOMMENDATION` It is recommended to start a `publishRecommendationClusters` call when receiving this intent.
+- `com.google.android.engage.action.PUBLISH_FEATURED` It is recommended to start a `publishFeaturedCluster` call when receiving this intent.
+- `com.google.android.engage.action.food.PUBLISH_FOOD_SHOPPING_CART` It is recommended to start a `publishFoodShoppingCarts` call when receiving this intent.
+- `com.google.android.engage.action.food.PUBLISH_FOOD_SHOPPING_LIST` It is recommended to start a `publishFoodShoppingLists` call when receiving this intent.
+- `com.google.android.engage.action.food.PUBLISH_REORDER_CLUSTER` It is recommended to start a `publishReorderCluster` call when receiving this intent.
+
+## Integration workflow
+
+For a step-by-step guide on verifying your integration after it is complete, see
+[Engage developer integration workflow](https://developer.android.com/guide/playcore/engage/workflow).
+
+## FAQs
+
+See [Engage SDK Frequently Asked Questions](https://developer.android.com/guide/playcore/engage/faq) for
+FAQs.
+
+## Contact
+
+Contact [`engage-developers@google.com`](mailto:engage-developers@google.com) if there are any questions during
+the integration process. Our team will reply as soon as possible.
+
+## Next steps
+
+After completing this integration, your next steps are as follows:
+
+- Send an email to [`engage-developers@google.com`](mailto:engage-developers@google.com) and attach your integrated APK that is ready for testing by Google.
+- Google will perform a verification and review internally to make sure the integration works as expected. If changes are needed, Google will contact you with any necessary details.
+- When testing is complete and no changes are needed, Google will contact you to notify you that you can start publishing the updated and integrated APK to the Play Store.
+- After Google has confirmed that your updated APK has been published to the Play Store, your **Recommendation** , **Featured** , **Shopping Cart** , **Shopping List** , and **Reorder** clusters will be published and visible to users.

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/healthandfitness.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/healthandfitness.md
@@ -1,0 +1,1038 @@
+Boost app engagement by reaching your users where they are. Integrate Engage SDK
+to deliver personalized recommendations and continuation content directly to
+users across multiple on-device surfaces, like
+**[Collections](https://android-developers.googleblog.com/2024/07/introducing-collections-powered-by-engage-sdk.html)** , **[Entertainment
+Space](https://blog.google/products/android/entertainment-space/)** , and the Play Store. The integration adds
+less than 50 KB (compressed) to the average APK and takes most apps about a
+week of developer time. Learn more at our **[business
+site](http://play.google.com/console/about/programs/EngageSDK)**.
+
+This guide contains instructions for developer partners to deliver health and
+fitness content to Engage content surfaces.
+
+## Integration detail
+
+### Terminology
+
+This integration includes the following three cluster types: **Recommendation** ,
+**Featured** , and **Continuation**.
+
+- **Recommendation** clusters show personalized health and fitness suggestions
+  from an individual developer partner. These recommendations can be
+  personalized to the user or generalized (for example, trending fitness \&
+  health). Use these to surface articles or people related to health and
+  fitness.
+
+  - A Recommendation cluster can be made of `ArticleEntity`, `PersonEntity`, or `EventEntity` but not a mix of different entity types.
+
+  Your recommendations take the following structure:
+  - **Recommendation Cluster:** A UI view that contains a group of
+    recommendations from the same developer partner.
+
+  - **Entity:** An object representing a single item in a cluster. This
+    integration offers some entities that would be surfaced using the
+    Recommendation Cluster:
+
+    - **ArticleEntity**: ArticleEntity represents a recommendation for
+      text-based content related to health \& fitness. It can be used for
+      articles, blogposts, marketing content, news snippets, etc.
+
+      ![](https://developer.android.com/static/images/guide/playcore/engage/article-entity-health-and-fitness.png) **Figure 1:** UI showing a single ArticleEntity within Recommendations cluster.
+    - **PersonEntity**: PersonEntity represents a person. The
+      recommendations could be to highlight a coach or any person related
+      to health and fitness, etc.
+
+      ![](https://developer.android.com/static/images/guide/playcore/engage/person-entity-health-and-fitness.png) **Figure 2:** UI showing a single PersonEntity within Recommendations cluster.
+    - **EventEntity**: EventEntity represents an event happening in the
+      future. Event start time is a critical piece of information that
+      needs to be conveyed to the users This entity could be used for
+      surfacing events like blood donation camp, training sessions, gym or
+      yoga classes etc. related to health and fitness.
+
+      ![](https://developer.android.com/static/images/guide/playcore/engage/event-entity-health-and-fitness.png) **Figure 3:** UI showing a single EventEntity within Recommendations cluster.
+- The **Continuation** cluster shows content recently engaged by users from
+  multiple developer partners in a single UI grouping. Each developer partner
+  will be allowed to broadcast a maximum of 10 entities in the Continuation
+  cluster.
+
+  Your continuation content can take the following structure:
+  - **ArticleEntity**: ArticleEntity represents a recommendation for
+    text-based content that is related to health \& fitness. This entity can
+    be used to represent unfinished news articles or other content that the
+    user would like to continue consuming from where they left it. Ex: News
+    snippet, blogpost snippet about health or fitness related topics.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/article-entity-continuation-health-and-fitness.png) **Figure 6.** UI showing a single ArticleEntity within a Continuation cluster.
+  - **EventReservationEntity**: EventReservationEntity represents
+    reservation for an event and helps users track upcoming or ongoing
+    fitness and health events reservations. Ex: Training sessions
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/event-reservation-entity-health-and-fitness.png) **Figure 8.** UI showing a single EventReservationEntity within a Continuation cluster.
+- The **Featured** cluster showcases a selection of entities from multiple
+  developer partners in one UI grouping. There will be a single Featured
+  cluster, which is surfaced near the top of the UI with a priority placement
+  above all Recommendation clusters. Each developer partner will be allowed to
+  broadcast up to 10 entities in the Featured cluster.
+
+  - **GenericFeaturedEntity**: GenericFeaturedEntity differs from
+    Recommendation item in that Featured item should be used for a single
+    top content from developers and should represent the single most
+    important content that will be interesting and relevant to users.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/featured-item-health-and-fitness.png) **Figure 12:** UI showing a single hero GenericFeaturedEntity card within a Featured cluster
+
+### Pre-work
+
+Minimum API level: 19
+
+Add the `com.google.android.engage:engage-core` library to your app:
+
+    dependencies {
+        // Make sure you also include that repository in your project's build.gradle file.
+        implementation 'com.google.android.engage:engage-core:1.6.0'
+    }
+
+### Summary
+
+The design is based on an implementation of a
+[bound service](https://developer.android.com/guide/components/bound-services).
+
+The data a client can publish is subject to the following limits for different
+cluster types:
+
+| Cluster type | Cluster limits | Minimum entity limits in a cluster | Maximum entity limits in a cluster |
+|---|---|---|---|
+| Recommendation Cluster(s) | At most 7 | At least 1 | At most 50 (`ArticleEntity`, `PersonEntity`, or `EventEntity`) |
+| Continuation Cluster | At most 1 | At least 1 | At most 20 (`ArticleEntity`, or `EventReservationEntity`) |
+| Featured Cluster | At most 1 | At least 1 | At most 20 (`GenericFeaturedEntity`) |
+
+### Step 1: Provide entity data
+
+The SDK has defined different entities to represent each item type. We support
+the following entities for the Health \& Fitness category:
+
+1. `GenericFeaturedEntity`
+2. `ArticleEntity`
+3. `PersonEntity`
+4. `EventEntity`
+5. `EventReservationEntity`
+
+The charts below outline available attributes and requirements for each type.
+
+#### `GenericFeaturedEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Poster images | **Required** | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** If a badge is provided, please ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| Title | Optional | Title of the entity. | Free text **Recommended text size: 50 chars** |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. Special UX treatment on top of image/video, for example as badge overlay on the image - "Live update" - Article read duration |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Enums See the [Content Category section](https://developer.android.com/guide/playcore/engage/healthandfitness#content-category) for guidance. |
+
+#### `ArticleEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | Free text **Recommended text size: Max 50 chars** |
+| Poster images | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** Image is highly recommended. If a badge is provided, please ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| Source - Title | Optional | The name of the author, organization, or reporter | Free text **Recommended text size: Under 25 chars** |
+| Source - Image | Optional | An image of the source like the author, the organization, reporter | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. Special UX treatment on top of image/video, for example as badge overlay on the image - "Live update" - Article read duration |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| Content Publish Time | Optional | This is the epoch timestamp in milliseconds on when the content was published / updated in the app. | Epoch timestamp in milliseconds |
+| Last Engagement Time | Conditionally Required | The epoch timestamp in milliseconds when the user interacted with this entity last time. **Note:** This field is required if this entity is part of the continuation cluster. | Epoch timestamp in milliseconds |
+| Progress Percentage | Conditionally Required | The percentage of the full content consumed by the user to date. **Note:** This field is required if this entity is part of the continuation cluster. | An int value between 0\~100 inclusive. |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Enums See the [Content Category section](https://developer.android.com/guide/playcore/engage/healthandfitness#content-category) for guidance. |
+
+#### `PersonEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Profile - Name | **Required** | Profile name or id or handle, eg "John Doe", "@TeamPixel", etc. | String **Recommended text size: Max 50 chars** |
+| Profile - Avatar | **Required** | Profile picture or avatar image of the user. **Note:**Must be Square 1:1 image. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| Profile - Additional Text | Optional | Free text like the profile handle. | Free text **Recommended text size: Max 15 chars** |
+| Profile - Additional Image | Optional | Small image like a verified badge. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| Header image | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** Image is highly recommended. If a badge is provided, please ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| Popularity - Count | Optional | Indicate the number of followers or popularity value, for example - "3.7 M". **Note:** If both Count and Count Value are provided, Count will be used | String **Recommended text size: max 20 chars for count + label combined** |
+| Popularity - Count Value | Optional | The number of followers or popularity value. **Note:** Provide Count Value if your app doesn't want to handle logic on how a large number should be optimized for different display sizes. If both Count and Count Value are provided, Count will be used. | Long |
+| Popularity - Label | Optional | Indicate what the popularity label is. For example - "Likes". | String **Recommended text size: Max 20 chars for count + label combined** |
+| Popularity - Visual | Optional | Indicate what the interaction is for. For example - Image showing Likes icon, Emojis. Can provide more than 1 image, though not all may not be shown on all form factors. **Note:** Must be Square 1:1 image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| Rating - Max value | Required | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Required | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the entity. **Note:** Provide this field if your app controls how the count is displayed to the users. Use a concise string. For example, if the count is 1,000,000, consider using an abbreviation like 1M so that the count isn't truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the entity. **Note:** Provide this field if you don't handle the display abbreviation logic yourself. If both Count and Count Value are present, Count is displayed to users. | Long |
+| Location - Country | Optional | The country where the person is located or serving. | Free text **Recommended text size: max \~20 chars** |
+| Location - City | Optional | The city where the person is located or serving. | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | Optional | The address where the person is located or serving will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Location - Street Address | Optional | The street address (if applicable) where the person is located or serving. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state (if applicable) where the person is located or serving. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) where the person is located or serving. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) where the person is located or serving. | Free text **Recommended text size: max \~20 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Eligible Enums - TYPE_HEALTH_AND_FITENESS (Example - Yoga/fitness trainer) - TYPE_HOME_AND_AUTO (Example - Plumber) - TYPE_SPORTS (Example - Player) - TYPE_DATING See the [Content Category section](https://developer.android.com/guide/playcore/engage/healthandfitness#content-category) for guidance. |
+
+#### `EventEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | String **Recommended text size: Max 50 chars** |
+| Start time | **Required** | The epoch timestamp when the event is expected to start. **Note:**This will be represented in milliseconds. | Epoch timestamp in milliseconds |
+| Event mode | **Required** | A field to indicate whether the event will be virtual, in-person or both. | Enum: VIRTUAL, IN_PERSON, or HYBRID |
+| Poster images | **Required** | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** Image is highly recommended. If a badge is provided, please ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| Location - Country | Conditionally Required | The country in which the event is happening. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - City | Conditionally Required | The city in which the event is happening. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | Conditionally Required | The address or venue name where the event will take place that should be displayed to the user. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - Street Address | Optional | The street address (if applicable) of the location at which event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state or province (if applicable) in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) of the location in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| End time | Optional | The epoch timestamp when the event is expected to end. **Note:**This will be represented in milliseconds. | Epoch timestamp in milliseconds |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| Price - CurrentPrice | Conditionally required | The current price of the ticket/pass for the event. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the ticket/pass for the event. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Eligible Enums - TYPE_MOVIES_AND_TV_SHOWS (Example - Cinema) - TYPE_DIGITAL_GAMES (Example - eSports) - TYPE_MUSIC (Example - Concert) - TYPE_TRAVEL_AND_LOCAL (Example - Tour, festival) - TYPE_HEALTH_AND_FITENESS (Example - Yoga class) - TYPE_EDUCATION (Example - Class) - TYPE_SPORTS (Example - Football game) - TYPE_DATING (Example - meetup) See the [Content Category section](https://developer.android.com/guide/playcore/engage/healthandfitness#content-category) for guidance. |
+
+#### `EventReservationEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | String **Recommended text size: Max 50 chars** |
+| Start time | **Required** | The epoch timestamp when the event is expected to start. **Note:**This will be represented in milliseconds. | Epoch timestamp in milliseconds |
+| Event mode | **Required** | A field to indicate whether the event will be virtual, in-person or both. | Enum: VIRTUAL, IN_PERSON, or HYBRID |
+| Location - Country | Conditionally Required | The country in which the event is happening. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - City | Conditionally Required | The city in which the event is happening. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | Conditionally Required | The address or venue name where the event will take place that should be displayed to the user. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - Street Address | Optional | The street address (if applicable) of the location at which event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state or province (if applicable) in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) of the location in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Poster images | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** Image is highly recommended. If a badge is provided, please ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| End time | Optional | The epoch timestamp when the event is expected to end. **Note:**This will be represented in milliseconds. | Epoch timestamp in milliseconds |
+| Service Provider - Name | Optional | The name of the service provider. **Note:**Either text or image is required for the service provider. | Free text. For example, name of the event organizer/tour |
+| Service Provider - Image | Optional | The logo/image of the service provider. **Note:**Either text or image is required for the service provider. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/healthandfitness#image-specs) for guidance. |
+| Reservation ID | Optional | The reservation ID for the event reservation. | Free text |
+| Price - CurrentPrice | Conditionally required | The current price of the ticket/pass for the event. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the ticket/pass for the event. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the event. **Note:** Provide this field if your app wants to control how this is displayed to the users. Please provide the concise string that can be displayed to the user. For example, if the count is 1,000,000, consider using abbreviations like 1M, so that it won't be truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the event. **Note:** Provide this field if you don't want to handle the display abbreviation logic yourself. If both Count and Count Value are present, we will use the Count to display to users | Long |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Eligible Enums - TYPE_MOVIES_AND_TV_SHOWS (Example - Cinema) - TYPE_DIGITAL_GAMES (Example - eSports) - TYPE_MUSIC (Example - Concert) - TYPE_TRAVEL_AND_LOCAL (Example - Tour, festival) - TYPE_HEALTH_AND_FITENESS (Example - Yoga class) - TYPE_EDUCATION (Example - Class) - TYPE_SPORTS (Example - Football game) - TYPE_DATING (Example - meetup) See the [Content Category section](https://developer.android.com/guide/playcore/engage/healthandfitness#content-category) for guidance. |
+
+#### Image specifications
+
+Required specifications for image assets are listed in this table:
+
+| Aspect ratio | Minimum pixels | Recommended pixels |
+|---|---|---|
+| Square (1x1) **Preferred** | 300x300 | 1200x1200 |
+| Landscape (1.91x1) | 600x314 | 1200x628 |
+| Portrait (4x5) | 480x600 | 960x1200 |
+
+The images are required to be hosted on public CDNs so that Google can access
+them.
+
+*File formats*
+
+PNG, JPG, static GIF, WebP
+
+*Maximum file size*
+
+5120 KB
+
+*Additional recommendations*
+
+- **Image safe area:** Put your important content in the center 80% of the image.
+- Use a transparent background so that the image can be properly displayed in Dark and Light theme settings.
+
+#### Content Category
+
+The content category allows apps to publish content belonging to multiple
+categories. This maps the content with some of the predefined categories namely:
+
+- `TYPE_EDUCATION`
+- `TYPE_SPORTS`
+- `TYPE_MOVIES_AND_TV_SHOWS`
+- `TYPE_BOOKS`
+- `TYPE_AUDIOBOOKS`
+- `TYPE_MUSIC`
+- `TYPE_DIGITAL_GAMES`
+- `TYPE_TRAVEL_AND_LOCAL`
+- `TYPE_HOME_AND_AUTO`
+- `TYPE_BUSINESS`
+- `TYPE_NEWS`
+- `TYPE_FOOD_AND_DRINK`
+- `TYPE_SHOPPING`
+- `TYPE_HEALTH_AND_FITENESS`
+- `TYPE_MEDICAL`
+- `TYPE_PARENTING`
+- `TYPE_DATING`
+
+The images are required to be hosted on public CDNs so that Google can access
+them.
+
+*Guidelines to use the content categories*
+
+1. Some entities like **ArticleEntity** and **GenericFeaturedEntity** are eligible to use any of the content categories. For other entities like **EventEntity** , **EventReservationEntity** , **PersonEntity**, only a subset of these categories are eligible. Check the list of categories eligible for an entity type before populating the list.
+2. Use the specific entity type for some content categories over a combination
+   of the Generic entities and the ContentCategory:
+
+   - TYPE_MOVIES_AND_TV_SHOWS - Check out the entities from [Watch integration guide](https://developer.android.com/guide/playcore/engage/watch) before using the generic entities.
+   - TYPE_BOOKS - Check out the [EbookEntity](https://developer.android.com/guide/playcore/engage/read#ebookentity) before using the generic entities.
+   - TYPE_AUDIOBOOKS - Check out [AudiobookEntity](https://developer.android.com/guide/playcore/engage/read#audiobookentity) before using the generic entities.
+   - TYPE_SHOPPING - Check out [ShoppingEntity](https://developer.android.com/guide/playcore/engage/shopping#shoppingEntity) before using the generic entities.
+   - TYPE_FOOD_AND_DRINK - Check out entities from [Food Integration guide](https://developer.android.com/guide/playcore/engage/food) before using the generic entities.
+3. The ContentCategory field is optional and should be left blank if the
+   content doesn't belong to any of the categories mentioned earlier.
+
+4. In case multiple content categories are provided, provide them in the order
+   of relevance to the content with the most relevant content category placed
+   first in the list.
+
+### Step 2: Provide Cluster data
+
+It is recommended to have the content publish job executed in the background
+(for example, using [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager))
+and scheduled on a regular basis or on an event basis (for example, every time
+the user opens the app or when the user just added something to their cart).
+
+`AppEngagePublishClient` is responsible for publishing clusters.
+
+There are following APIs to publish clusters in the client:
+
+- `isServiceAvailable`
+- `publishRecommendationClusters`
+- `publishFeaturedCluster`
+- `publishContinuationCluster`
+- `publishUserAccountManagementRequest`
+- `updatePublishStatus`
+- `deleteRecommendationsClusters`
+- `deleteFeaturedCluster`
+- `deleteContinuationCluster`
+- `deleteUserManagementCluster`
+- `deleteClusters`
+
+#### `isServiceAvailable`
+
+This API is used to check if the service is available for integration and
+whether the content can be presented on the device.
+
+##### For Engage SDK v1.6.0 and higher (Recommended)
+
+You can check the service availability for every cluster type that you intend to
+publish. The `isServiceAvailable` API accepts a request object,
+`ServiceAvailabilityRequest`, which contains the cluster types for which service
+availability needs to be checked. You can find the `ClusterType` enum values
+required for `ServiceAvailabilityRequest` from the following table.
+
+| Cluster Type | Cluster Type Constant | Integer Value |
+|---|---|---|
+| Unknown | `TYPE_UNKNOWN` | 0 |
+| Recommendation Cluster | `TYPE_RECOMMENDATION` | 1 |
+| Featured Cluster | `TYPE_FEATURED` | 2 |
+| Continuation Cluster | `TYPE_CONTINUATION` | 3 |
+| User Management Cluster | `TYPE_ENGAGEMENT` | 8 |
+| Subscription Cluster | `TYPE_SUBSCRIPTION` | 12 |
+
+### Kotlin
+
+    val request = ServiceAvailabilityRequest.Builder()
+        .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+        .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+        .build()
+
+    client.isServiceAvailable(request).addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            val availabilityMap = task.result
+            if (availabilityMap[ClusterType.TYPE_CONTINUATION] == true) {
+                // Proceed with publishing continuation content
+            }
+            if (availabilityMap[ClusterType.TYPE_RECOMMENDATION] == true) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    }
+
+### Java
+
+    ServiceAvailabilityRequest request =
+        new ServiceAvailabilityRequest.Builder()
+            .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+            .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+            .build();
+
+    client.isServiceAvailable(request).addOnCompleteListener(task -> {
+        if (task.isSuccessful()) {
+            Map<Integer, Boolean> availabilityMap = task.getResult();
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_CONTINUATION))) {
+                // Proceed with publishing continuation content
+            }
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_RECOMMENDATION))) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    });
+
+###### Conditional Service Availability Feature
+
+Some integrated apps request a special configuration that enables and disables
+the Engage service intermittently in order to reduce their serving cost. This
+intermittent content ingestion strategy, although possible, negatively affects
+the user and the product -- stale content will not be presented and some surfaces
+will not be served at all.
+
+Starting with v1.6.0, the Engage SDK allows checking availability for specific
+cluster types. This provides more flexibility so that if the intermittent
+content strategy was adopted by a given application, some cluster types can
+follow that intermittent strategy while other cluster types are always enabled
+(i.e. continuation clusters).
+
+If the Engage service should not be 'continuously' enabled on all supported
+devices for whatever reason, and is configured for intermittent ingestion for
+any set of devices, all continuation cluster publications (e.g. Continue
+Reading and Event Reservations) will be still enabled by default
+configuration, and the rest of the cluster types will be enabled and disabled
+intermittently. If intermittent ingestion applies to you but this default
+configuration is not suitable for your needs, please contact
+engage-developers@google.com.
+
+##### For SDK versions prior to v1.6.0 (Deprecated)
+
+### Kotlin
+
+    client.isServiceAvailable.addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            // Handle IPC call success
+            if(task.result) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    }
+
+### Java
+
+    client.isServiceAvailable().addOnCompleteListener(task - > {
+        if (task.isSuccessful()) {
+            // Handle success
+            if(task.getResult()) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    });
+
+> [!NOTE]
+> **Note:** We highly recommend keeping a periodic job running to check if the service becomes available at a later point in time. The availability of the service may change with Android version upgrades, app upgrades, installs, and uninstalls. By ensuring periodic job checks at a certain time interval, data can be published once the service becomes available.
+
+#### `publishRecommendationClusters`
+
+This API is used to publish a list of `RecommendationCluster` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishRecommendationClusters(
+          PublishRecommendationClustersRequest.Builder()
+            .addRecommendationCluster(
+              RecommendationCluster.Builder()
+                .addEntity(entity1)
+                .addEntity(entity2)
+                .setTitle("Top Picks For You")
+                .build()
+            )
+            .build()
+        )
+
+### Java
+
+    client.publishRecommendationClusters(
+                new PublishRecommendationClustersRequest.Builder()
+                    .addRecommendationCluster(
+                        new RecommendationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .setTitle("Top Picks For You")
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `RecommendationCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Recommendation Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishFeaturedCluster`
+
+This API is used to publish a list of `FeaturedCluster` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishFeaturedCluster(
+        PublishFeaturedClusterRequest.Builder()
+          .setFeaturedCluster(
+            FeaturedCluster.Builder()
+              .addEntity(entity1)
+              .addEntity(entity2)
+              .build())
+          .build())
+
+### Java
+
+    client.publishFeaturedCluster(
+                new PublishFeaturedClustersRequest.Builder()
+                    .addFeaturedCluster(
+                        new FeaturedCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `FeaturedCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Featured Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishContinuationCluster`
+
+This API is used to publish a `ContinuationCluster` object.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishContinuationCluster(
+        PublishContinuationClusterRequest.Builder()
+          .setContinuationCluster(
+            ContinuationCluster.Builder()
+              .addEntity(entity1)
+              .addEntity(entity2)
+              .build())
+          .build())
+
+### Java
+
+    client.publishContinuationCluster(
+                new PublishContinuationClusterRequest.Builder()
+                    .setContinuationCluster(
+                        new ContinuationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `ContinuationCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Continuation Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishUserAccountManagementRequest`
+
+This API is used to publish a Sign In card . The signin action directs users to
+the app's sign in page so that the app can publish content (or provide more
+personalized content)
+
+The following metadata is part of the Sign In Card -
+
+| Attribute | Requirement | Description |
+|---|---|---|
+| Action Uri | Required | Deeplink to Action (i.e. navigates to app sign in page) |
+| Image | Optional - If not provided, Title must be provided | Image Shown on the Card 16x9 aspect ratio images with a resolution of 1264x712 |
+| Title | Optional - If not provided, Image must be provided | Title on the Card |
+| Action Text | Optional | Text Shown on the CTA (i.e. Sign in) |
+| Subtitle | Optional | Optional Subtitle on the Card |
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    var SIGN_IN_CARD_ENTITY =
+          SignInCardEntity.Builder()
+              .addPosterImage(
+                  Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build()
+
+    client.publishUserAccountManagementRequest(
+                PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+### Java
+
+    SignInCardEntity SIGN_IN_CARD_ENTITY =
+          new SignInCardEntity.Builder()
+              .addPosterImage(
+                  new Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build();
+
+    client.publishUserAccountManagementRequest(
+                new PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `UserAccountManagementCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated UserAccountManagementCluster Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `updatePublishStatus`
+
+If for any internal business reason, none of the clusters is published, we
+**strongly recommend** updating the publish status using the
+**updatePublishStatus** API. This is important because :
+
+- Providing the status in all scenarios, even when the content is published (STATUS == PUBLISHED), is critical to populate dashboards that use this explicit status to convey the health and other metrics of your integration.
+- If no content is published but the integration status isn't broken (STATUS == NOT_PUBLISHED), Google can avoid triggering alerts in the app health dashboards. It confirms that content is not published due to an **expected** situation from the provider's standpoint.
+- It helps developers provide insights into when the data is published versus not.
+- Google may use the status codes to nudge the user to do certain actions in the app so they can see the app content or overcome it.
+
+The list of eligible publish status codes are :
+
+    // Content is published
+    AppEngagePublishStatusCode.PUBLISHED,
+
+    // Content is not published as user is not signed in
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN,
+
+    // Content is not published as user is not subscribed
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SUBSCRIPTION,
+
+    // Content is not published as user location is ineligible
+    AppEngagePublishStatusCode.NOT_PUBLISHED_INELIGIBLE_LOCATION,
+
+    // Content is not published as there is no eligible content
+    AppEngagePublishStatusCode.NOT_PUBLISHED_NO_ELIGIBLE_CONTENT,
+
+    // Content is not published as the feature is disabled by the client
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_FEATURE_DISABLED_BY_CLIENT,
+
+    // Content is not published as the feature due to a client error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR,
+
+    // Content is not published as the feature due to a service error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR,
+
+    // Content is not published due to some other reason
+    // Reach out to engage-developers@ before using this enum.
+    AppEngagePublishStatusCode.NOT_PUBLISHED_OTHER
+
+If the content is not published due to a user not logged in, Google would
+recommend publishing the Sign In Card. If for any reason providers are not able
+to publish the Sign In Card then we recommend calling the
+**updatePublishStatus** API with the status code
+**NOT_PUBLISHED_REQUIRES_SIGN_IN**
+
+### Kotlin
+
+    client.updatePublishStatus(
+       PublishStatusRequest.Builder()
+         .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+         .build())
+
+### Java
+
+    client.updatePublishStatus(
+        new PublishStatusRequest.Builder()
+            .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+            .build());
+
+#### `deleteRecommendationClusters`
+
+This API is used to delete the content of Recommendation Clusters.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteRecommendationClusters()
+
+### Java
+
+    client.deleteRecommendationClusters();
+
+When the service receives the request, it removes the existing data from the
+Recommendation Clusters. In case of an error, the entire request is rejected and
+the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteFeaturedCluster`
+
+This API is used to delete the content of Featured Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteFeaturedCluster()
+
+### Java
+
+    client.deleteFeaturedCluster();
+
+When the service receives the request, it removes the existing data from the
+Featured Cluster. In case of an error, the entire request is rejected and the
+existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteContinuationCluster`
+
+This API is used to delete the content of Continuation Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteContinuationCluster()
+
+### Java
+
+    client.deleteContinuationCluster();
+
+When the service receives the request, it removes the existing data from the
+Continuation Cluster. In case of an error, the entire request is rejected and
+the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteUserManagementCluster`
+
+This API is used to delete the content of UserAccountManagement Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteUserManagementCluster()
+
+### Java
+
+    client.deleteUserManagementCluster();
+
+When the service receives the request, it removes the existing data from the
+UserAccountManagement Cluster. In case of an error, the entire request is
+rejected and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteClusters`
+
+This API is used to delete the content of a given cluster type.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteClusters(
+        DeleteClustersRequest.Builder()
+          .addClusterType(ClusterType.TYPE_CONTINUATION)
+          .addClusterType(ClusterType.TYPE_FEATURED)
+          .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+          .build())
+
+### Java
+
+    client.deleteClusters(
+                new DeleteClustersRequest.Builder()
+                    .addClusterType(ClusterType.TYPE_CONTINUATION)
+                    .addClusterType(ClusterType.TYPE_FEATURED)
+                    .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+                    .build());
+
+When the service receives the request, it removes the existing data from all
+clusters matching the specified cluster types. Clients can choose to pass one or
+many cluster types. In case of an error, the entire request is rejected and the
+existing state is maintained.
+
+#### Error handling
+
+It is highly recommended to listen to the task result from the publish APIs such
+that a follow-up action can be taken to recover and resubmit an successful task.
+
+### Kotlin
+
+    client.publishRecommendationClusters(
+            PublishRecommendationClustersRequest.Builder()
+              .addRecommendationCluster(..)
+              .build())
+          .addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+              // do something
+            } else {
+              val exception = task.exception
+              if (exception is AppEngageException) {
+                @AppEngageErrorCode val errorCode = exception.errorCode
+                if (errorCode == AppEngageErrorCode.SERVICE_NOT_FOUND) {
+                  // do something
+                }
+              }
+            }
+          }
+
+### Java
+
+    client.publishRecommendationClusters(
+                  new PublishRecommendationClustersRequest.Builder()
+                      .addRecommendationCluster(...)
+                      .build())
+              .addOnCompleteListener(
+                  task -> {
+                    if (task.isSuccessful()) {
+                      // do something
+                    } else {
+                      Exception exception = task.getException();
+                      if (exception instanceof AppEngageException) {
+                        @AppEngageErrorCode
+                        int errorCode = ((AppEngageException) exception).getErrorCode();
+                        if (errorCode == AppEngageErrorCode.SERVICE_NOT_FOUND) {
+                          // do something
+                        }
+                      }
+                    }
+                  });
+
+The error is returned as an `AppEngageException` with the cause included as an
+error code.
+
+| Error code | Error name | Note |
+|---|---|---|
+| `1` | `SERVICE_NOT_FOUND` | The service is not available on the given device. |
+| `2` | `SERVICE_NOT_AVAILABLE` | The service is available on the given device, but it is not available at the time of the call (for example, it is explicitly disabled). |
+| `3` | `SERVICE_CALL_EXECUTION_FAILURE` | The task execution failed due to threading issues. In this case, it can be retried. |
+| `4` | `SERVICE_CALL_PERMISSION_DENIED` | The caller is not allowed to make the service call. |
+| `5` | `SERVICE_CALL_INVALID_ARGUMENT` | The request contains invalid data (for example, more than the allowed number of clusters). |
+| `6` | `SERVICE_CALL_INTERNAL` | There is an error on the service side. |
+| `7` | `SERVICE_CALL_RESOURCE_EXHAUSTED` | The service call is made too frequently. |
+
+### Step 3: Handle broadcast intents
+
+In addition to making publish content API calls through a job, it is also
+required to set up a
+[`BroadcastReceiver`](https://developer.android.com/reference/android/content/BroadcastReceiver) to receive
+the request for a content publish.
+
+The goal of broadcast intents is mainly for app reactivation and forcing data
+sync. Broadcast intents are not designed to be sent very frequently. It is only
+triggered when the Engage Service determines the content might be stale (for
+example, a week old). That way, there is more confidence that the user can have
+a fresh content experience, even if the application has not been executed for a
+long period of time.
+
+The `BroadcastReceiver` must be set up in the following two ways:
+
+- Dynamically register an instance of the `BroadcastReceiver` class using
+  `Context.registerReceiver()`. This enables communication from applications
+  that are still live in memory.
+
+### Kotlin
+
+    class AppEngageBroadcastReceiver : BroadcastReceiver(){
+      // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+      // is received
+      // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is received
+      // Trigger continuation cluster publish when PUBLISH_CONTINUATION broadcast is
+      // received
+    }
+
+    fun registerBroadcastReceivers(context: Context){
+      var  context = context
+      context = context.applicationContext
+
+    // Register Recommendation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_RECOMMENDATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Featured Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_FEATURED),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Continuation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_CONTINUATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+    }
+
+### Java
+
+    class AppEngageBroadcastReceiver extends BroadcastReceiver {
+    // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+    // is received
+
+    // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is received
+
+    // Trigger continuation cluster publish when PUBLISH_CONTINUATION broadcast is
+    // received
+    }
+
+    public static void registerBroadcastReceivers(Context context) {
+
+    context = context.getApplicationContext();
+
+    // Register Recommendation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Featured Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Continuation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_CONTINUATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    }
+
+- Statically declare an implementation with the `<receiver>` tag in your
+  `AndroidManifest.xml` file. This allows the application to receive broadcast
+  intents when it is not running, and also allows the application to publish
+  the content.
+
+    <application>
+       <receiver
+          android:name=".AppEngageBroadcastReceiver"
+          android:permission="com.google.android.engage.REQUEST_ENGAGE_DATA"
+          android:exported="true"
+          android:enabled="true">
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_RECOMMENDATION" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_FEATURED" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_CONTINUATION" />
+          </intent-filter>
+       </receiver>
+    </application>
+
+The following [intents](https://developer.android.com/reference/android/content/Intent) is sent by the
+service:
+
+- `com.google.android.engage.action.PUBLISH_RECOMMENDATION` It is recommended to start a `publishRecommendationClusters` call when receiving this intent.
+- `com.google.android.engage.action.PUBLISH_FEATURED` It is recommended to start a `publishFeaturedCluster` call when receiving this intent.
+- `com.google.android.engage.action.PUBLISH_CONTINUATION` It is recommended to start a `publishContinuationCluster` call when receiving this intent.
+
+## Integration workflow
+
+For a step-by-step guide on verifying your integration after it is complete, see
+[Engage developer integration workflow](https://developer.android.com/guide/playcore/engage/workflow).
+
+## FAQs
+
+See [Engage SDK Frequently Asked Questions](https://developer.android.com/guide/playcore/engage/faq) for
+FAQs.
+
+## Contact
+
+Contact
+[`engage-developers@google.com`](mailto:engage-developers@google.com) if there are
+any questions during the integration process.
+
+## Next steps
+
+After completing this integration, your next steps are as follows:
+
+- Send an email to [`engage-developers@google.com`](mailto:engage-developers@google.com) and attach your integrated APK that is ready for testing by Google.
+- Google performs a verification and reviews internally to make sure the integration works as expected. If changes are needed, Google contacts you with any necessary details.
+- When testing is complete and no changes are needed, Google contacts you to notify you that you can start publishing the updated and integrated APK to the Play Store.
+- After Google has confirmed that your updated APK has been published to the Play Store, your **Recommendation** , **Featured** , and **Continuation** clusters may be published and visible to users.

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/listen.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/listen.md
@@ -1,0 +1,1033 @@
+Boost app engagement by reaching your users where they are. Integrate Engage SDK
+to deliver personalized recommendations and continuation content directly to
+users across multiple on-device surfaces, like
+**[Collections](https://android-developers.googleblog.com/2024/07/introducing-collections-powered-by-engage-sdk.html)** , **[Entertainment
+Space](https://blog.google/products/android/entertainment-space/)** , and the Play Store. The integration adds
+less than 50 KB (compressed) to the average APK and takes most apps about a
+week of developer time. Learn more at our **[business
+site](http://play.google.com/console/about/programs/EngageSDK)**.
+
+This guide contains instructions for developer partners to deliver audio content
+(music, podcasts, audiobooks, live radio) to Engage content surfaces.
+
+## Integration detail
+
+### Terminology
+
+This integration includes the following three cluster types: **Recommendation** ,
+**Continuation** , and **Featured**.
+
+- **Recommendation** clusters show personalized suggestions for content to read
+  from an individual developer partner.
+
+  Your recommendations take the following structure:
+  - **Recommendation Cluster:** A UI view that contains a group of
+    recommendations from the same developer partner.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/listen-term-1.png) **Figure 1.** Entertainment Space UI showing a Recommendation Cluster from a single partner.
+  - **Entity:** An object representing a single item in a cluster. An entity
+    can be a playlist, an audiobook, a podcast, and more. See the [Provide
+    entity data](https://developer.android.com/guide/playcore/engage/listen#provide-entity-data) section for a list of supported entity
+    types.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/listen-term-2.png) **Figure 2.** Entertainment Space UI showing a single Entity within a single partner's Recommendation Cluster.
+- The **Continuation** cluster shows audio content recently engaged by users
+  from multiple developer partners in a single UI grouping. Each developer
+  partner will be allowed to broadcast a maximum of 10 entities in the
+  Continuation cluster.
+
+  ![](https://developer.android.com/static/images/guide/playcore/engage/listen-term-3.png) **Figure 3.** Entertainment Space UI showing a Continuation cluster with unfinished recommendations from multiple partners (only one recommendation is currently visible).
+- The **Featured** cluster showcases a selection of items from multiple
+  developer partners in a single UI grouping. There will be a single Featured
+  cluster, which will be surfaced near the top of the UI with a priority
+  placement above all Recommendation clusters. Each developer partner will be
+  allowed to broadcast up to 10 entities in the Featured cluster.
+
+  ![](https://developer.android.com/static/images/guide/playcore/engage/listen-term-4.png) **Figure 4.** Entertainment Space UI showing a Featured cluster with recommendations from multiple partners (only one recommendation is currently visible).
+
+### Pre-work
+
+Minimum API level: 19
+
+Add the `com.google.android.engage:engage-core` library to your app:
+
+    dependencies {
+        // Make sure you also include that repository in your project's build.gradle file.
+        implementation 'com.google.android.engage:engage-core:1.6.0'
+    }
+
+### Summary
+
+The design is based on an implementation of a [bound
+service](https://developer.android.com/guide/components/bound-services).
+
+The data a client can publish is subject to the following limits for different
+cluster types:
+
+| Cluster type | Cluster limits | Maximum entity limits in a cluster |
+|---|---|---|
+| Recommendation Cluster(s) | At most 7 | At most 50 |
+| Continuation Cluster | At most 1 | At most 20 |
+| Featured Cluster | At most 1 | At most 20 |
+
+### Step 1: Provide entity data
+
+The SDK has defined different entities to represent each item type. We support
+the following entities for the Listen category:
+
+1. `MusicAlbumEntity`
+2. `MusicArtistEntity`
+3. `MusicTrackEntity`
+4. `MusicVideoEntity`
+5. `PlaylistEntity`
+6. `PodcastSeriesEntity`
+7. `PodcastEpisodeEntity`
+8. `LiveRadioStationEntity`
+9. `AudiobookEntity`
+
+The charts below outline available attributes and requirements for each type.
+
+#### `MusicAlbumEntity`
+
+The `MusicAlbumEntity` object represents a music album (for example, *Midnights*
+by Taylor Swift).
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** | The title of the music album. |
+| Poster images | **Required** | At least one image must be provided. See [Image Specifications](https://developer.android.com/guide/playcore/engage/listen#image-specs) for guidance. |
+| Info page uri | **Required** | The deep link to the provider app for details about the music album. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Artists | **Required** | List of artists in the music album. |
+| Playback uri | Optional | A deep link that starts playing the album in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Description | Optional | Must be within 200 characters if provided. |
+| Songs count | Optional | The number of songs in the music album. |
+| Genres | Optional | List of genres in the music album. |
+| Album Format | Optional | ALBUM (includes LP and double LP) EP SINGLE Mixtape |
+| Music labels | Optional | List of music labels associated with the album. |
+| Downloaded on Device | Optional | Boolean indicating if the music album is downloaded on device. |
+| Explicit | Optional | A boolean indicating if the content is explicit or not Items that contain explicit material or have a parental advisory warning should be set to TRUE. Explicit items appears with an "E" tag. |
+| Release date | Optional | The release date of the album in epoch milliseconds. |
+| Duration | Optional | The duration of the album in milliseconds. |
+| Last engagement time | Optional | Recommended for items in the Continuation Cluster. May be used for ranking. In epoch milliseconds |
+| Progress percentage complete | Optional | Recommended for items in the Continuation Cluster. Integer between 0 and 100 |
+
+#### `MusicArtistEntity`
+
+The `MusicArtistEntity` object represents a music arist (for example, Adele).
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** | Name of the music artist. |
+| Poster images | **Required** | At least one image must be provided. See [Image Specifications](https://developer.android.com/guide/playcore/engage/listen#image-specs) for guidance. |
+| Info page uri | **Required** | The deep link to the provider app for details about the music artist. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Playback uri | Optional | The deep link which starts playing the artist's songs in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Description | Optional | Must be within 200 characters if provided. |
+| Last engagement time | Optional | Recommended for items in the Continuation Cluster. May be used for ranking. In epoch milliseconds |
+
+#### `MusicTrackEntity`
+
+The `MusicTrackEntity` object represents a music track (for example, *Yellow* by
+Coldplay).
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** | Title of the music track. |
+| Poster images | **Required** | At least one image must be provided. See [Image Specifications](https://developer.android.com/guide/playcore/engage/listen#image-specs) for guidance. |
+| Playback uri | **Required** | A deep link that starts playing the music track in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Artists | **Required** | List of artists for the music track. |
+| Info page uri | Optional | A deep link to the provider app for details about the music track. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Description | Optional | Must be within 200 characters if provided. |
+| Duration | Optional | The duration of the track in milliseconds. |
+| Album | Optional | The name of the album to which the song belongs. |
+| Downloaded on Device | Optional | Boolean indicating if the music track is downloaded on device. |
+| Explicit | Optional | A boolean indicating if the content is explicit or not Items that contain explicit material or have a parental advisory warning should be set to TRUE. Explicit items appears with an "E" tag. |
+| Last engagement time | Optional | Recommended for items in the Continuation Cluster. May be used for ranking. In epoch milliseconds |
+| Progress percentage complete | Optional | Recommended for items in the Continuation Cluster. Integer between 0 and 100 |
+
+#### `MusicVideoEntity`
+
+The `MusicVideoEntity` object represents a music video (for example,
+*The Weeknd - Take My Breath (Official Music Video)*).
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** | Title of the music video. |
+| Poster images | **Required** | At least one image must be provided. See [Image Specifications](https://developer.android.com/guide/playcore/engage/listen#image-specs) for guidance. |
+| Playback uri | **Required** | A deep link that starts playing the music video in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Info page uri | Optional | A deep link to the provider app for details about the music video. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Duration | Optional | The duration of the video in milliseconds. |
+| View count | Optional | The number of views on the video in free text format. |
+| Artists | Optional | List of artists of the music video. |
+| Content rating | Optional | List of content ratings of the track. |
+| Description | Optional | Must be within 200 characters if provided. |
+| Downloaded on Device | Optional | Boolean indicating if the music video is downloaded on device. |
+| Explicit | Optional | A boolean indicating if the content is explicit or not Items that contain explicit material or have a parental advisory warning should be set to TRUE. Explicit items appears with an "E" tag. |
+| Last engagement time | Optional | Recommended for items in the Continuation Cluster. May be used for ranking. In epoch milliseconds |
+| Progress percentage complete | Optional | Recommended for items in the Continuation Cluster. Integer between 0 and 100 |
+
+#### `PlaylistEntity`
+
+The `PlaylistEntity` object represents a music playlist (for example, the US Top
+10 Playlist).
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** | Title of the playlist. |
+| Poster images | **Required** | At least one image must be provided. See [Image Specifications](https://developer.android.com/guide/playcore/engage/listen#image-specs) for guidance. |
+| Playback uri | **Required** | A deep link that starts playing the music playlist in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Info page uri | Optional | A deep link to the provider app for details about the music playlist. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Duration | Optional | The duration of the playlist in milliseconds. |
+| Songs count | Optional | The number of songs in the music playlist. |
+| Description | Optional | Must be within 200 characters if provided. |
+| Downloaded on Device | Optional | Boolean indicating if the playlist is downloaded on device. |
+| Explicit | Optional | A boolean indicating if the content is explicit or not Items that contain explicit material or have a parental advisory warning should be set to TRUE. Explicit items appears with an "E" tag. |
+| Last engagement time | Optional | Recommended for items in the Continuation Cluster. May be used for ranking. In epoch milliseconds |
+| Progress percentage complete | Optional | Recommended for items in the Continuation Cluster. Integer between 0 and 100 |
+
+#### `PodcastSeriesEntity`
+
+The `PodcastSeriesEntity` object represents a podcast series (for example, *This
+American Life*).
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** | Title of the podcast series. |
+| Poster images | **Required** | At least one image must be provided. See [Image Specifications](https://developer.android.com/guide/playcore/engage/listen#image-specs) for guidance. |
+| Info page uri | **Required** | A deep link to the provider app for details about the podcast series. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Playback uri | Optional | A deep link that starts playing the podcast series in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Episode count | Optional | The number of episodes in the podcast series. |
+| Production name | Optional | The name of the production of the podcast series. |
+| Hosts | Optional | List of hosts of the podcast series. |
+| Genres | Optional | List of genres of the podcast series. |
+| Downloaded on device | Optional | Boolean indicating if the podcast is downloaded on the device. |
+| Description | Optional | Must be within 200 characters if provided. |
+| Explicit | Optional | A boolean indicating if the content is explicit or not Items that contain explicit material or have a parental advisory warning should be set to TRUE. Explicit items appears with an "E" tag. |
+| Last engagement time | Optional | Recommended for items in the Continuation Cluster. May be used for ranking. In epoch milliseconds |
+
+#### `PodcastEpisodeEntity`
+
+The `PodcastEpisodeEntity` object represents a podcast series (for example,
+*Spark Bird, Episode 754: This American Life*).
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** | Title of the podcast episode. |
+| Poster images | **Required** | At least one image must be provided. See [Image Specifications](https://developer.android.com/guide/playcore/engage/listen#image-specs) for guidance. |
+| Playback uri | **Required** | A deep link that starts playing the podcast episode in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Podcast series title | **Required** | The name of the podcast series to which the episode belongs. |
+| Duration | **Required** | The duration of the podcast episode in milliseconds. |
+| Publish Date | **Required** | Publish date of the podcast (in epoch milliseconds) |
+| Info page uri | Optional | A deep link to the provider app for details about the podcast episode. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Production name | Optional | The name of the production of the podcast series. |
+| Episode index | Optional | The index of the episode in the series (first index is 1). |
+| Hosts | Optional | List of hosts of the podcast episode. |
+| Genres | Optional | List of genres of the podcast episode. |
+| Downloaded on device | Optional | Boolean indicating if the podcast episode is downloaded on the device. |
+| Description | Optional | Must be within 200 characters if provided. |
+| Video Podcast | Optional | Boolean indicating if the podcast episode has video content |
+| Explicit | Optional | A boolean indicating if the content is explicit or not Items that contain explicit material or have a parental advisory warning should be set to TRUE. Explicit items appears with an "E" tag. |
+| Listen Next Type | Optional | Recommended for Items in the Continuation Cluster TYPE_CONTINUE - Resume on a unfinished audio item. TYPE_NEXT - Continue on a new one of a series. TYPE_NEW - Newly released. |
+| Last engagement time | Optional | Recommended for items in the Continuation Cluster. May be used for ranking. In epoch milliseconds |
+| Progress percentage complete | Optional | Recommended for items in the Continuation Cluster. Integer between 0 and 100 |
+
+#### `LiveRadioStationEntity`
+
+The `LiveRadioStationEntity` object represents a live radio station (for
+example, 98.1 The Breeze).
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** | Title of the live radio station. |
+| Poster images | **Required** | At least one image must be provided. See [Image Specifications](https://developer.android.com/guide/playcore/engage/listen#image-specs) for guidance. |
+| Playback uri | **Required** | A deep link that starts playing the radio station in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Info page uri | Optional | A deep link to the provider app for details about the radio station. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Frequency | Optional | The frequency at which the radio station is broadcasted (for example, "98.1 FM"). |
+| Show title | Optional | The current show that is playing on the radio station. |
+| Hosts | Optional | List of hosts of the radio station. |
+| Description | Optional | Must be within 200 characters if provided. |
+| Last engagement time | Optional | Recommended for items in the Continuation Cluster. May be used for ranking. In epoch milliseconds |
+
+#### `AudiobookEntity`
+
+The `AudiobookEntity` object represents an audiobook (for example, the audiobook
+of *Becoming* by Michelle Obama).
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** |   |
+| Poster images | **Required** | At least one image must be provided. See [Image Specifications](https://developer.android.com/guide/playcore/engage/listen#image-specs) for guidance. |
+| Author | **Required** | At least one author name must be provided. |
+| Action link uri | **Required** | The deep link to the provider app for the audiobook. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Narrator | Optional | At least one narrator's name must be provided. |
+| Publish date | Optional | In epoch milliseconds if provided. |
+| Description | Optional | Must be within 200 characters if provided. |
+| Price | Optional | Free text |
+| Duration | Optional | Must be a positive value if provided. |
+| Genre | Optional | List of genres associated with the book. |
+| Series name | Optional | Name of the series that the audiobook belongs to (for example, *Harry Potter*. |
+| Series unit index | Optional | The index of the audiobook in the series, where 1 is the first audiobook in the series. For example, if *Harry Potter and the Prisoner of Azkaban* is the 3rd book in the series, this should be set to 3. |
+| Continue book type | Optional | TYPE_CONTINUE - Resume on a unfinished book. TYPE_NEXT - Continue on a new one of a series. TYPE_NEW - Newly released. |
+| Last Engagement Time | Conditionally required | Must be provided when the item is in the Continuation cluster. In epoch milliseconds. |
+| Progress Percentage Complete | Conditionally required | Must be provided when the item is in the Continuation cluster. \*Newly\* acquired audiobooks can be a part of the continue reading cluster. Value must be greater than 0 and less than 100. |
+| **DisplayTimeWindow - Set a time window for a content to be shown on the surface** |||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. In epoch milliseconds. |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. In epoch milliseconds. |
+
+#### Image specifications
+
+Required specifications for image assets are listed below:
+
+| Aspect ratio | Requirement | Minimum pixels | Recommended pixels |
+|---|---|---|---|
+| Square (1x1) | **Required** | 300x300 | 1200x1200 |
+| Landscape (1.91x1) | Optional | 600x314 | 1200x628 |
+| Portrait (4x5) | Optional | 480x600 | 960x1200 |
+
+*File formats*
+
+PNG, JPG, static GIF, WebP
+
+*Maximum file size*
+
+5120 KB
+
+*Additional recommendations*
+
+- **Image safe area:** Put your important content in the center 80% of the image.
+
+#### Examples
+
+    MusicAlbumEntity musicAlbumEntity =
+            new MusicAlbumEntity.Builder()
+                .setName(NAME)
+                 .addPosterImage(new Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(960)
+                      .setImageWidthInPixel(408)
+                      .build())
+                .setPlayBackUri("https://play.google/album/play")
+                .setInfoPageUri("https://play.google/album/info")
+                .setDescription("A description of this album.")
+                .addArtist("Artist")
+                .addGenre("Genre")
+                .addMusicLabel("Label")
+                .addContentRating("Rating")
+                .setSongsCount(960)
+                .setReleaseDateEpochMillis(1633032895L)
+                .setDurationMillis(1633L)
+                .build();
+
+    AudiobookEntity audiobookEntity =
+            new AudiobookEntity.Builder()
+                .setName("Becoming")
+                .addPosterImage(new Image.Builder()
+                     .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                     .setImageHeightInPixel(960)
+                     .setImageWidthInPixel(408)
+                      .build())
+                .addAuthor("Michelle Obama")
+                .addNarrator("Michelle Obama")
+                .setActionLinkUri(
+                   Uri.parse("https://play.google/audiobooks/1"))
+                .setDurationMillis(16335L)
+                .setPublishDateEpochMillis(1633032895L)
+                .setDescription("An intimate, powerful, and inspiring memoir")
+                .setPrice("$16.95")
+                .addGenre("biography")
+                .build();
+
+### Step 2: Provide Cluster data
+
+It's recommended to have the content publish job executed in the background
+(for example, using [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager))
+and scheduled on a regular basis or on an event basis (for example, every time
+the user opens the app or when the user just added something to their cart).
+
+`AppEngagePublishClient` is responsible for publishing clusters. Following
+APIs are available in the client:
+
+- `isServiceAvailable`
+- `publishRecommendationClusters`
+- `publishFeaturedCluster`
+- `publishContinuationCluster`
+- `publishUserAccountManagementRequest`
+- `updatePublishStatus`
+- `deleteRecommendationsClusters`
+- `deleteFeaturedCluster`
+- `deleteContinuationCluster`
+- `deleteUserManagementCluster`
+- `deleteClusters`
+
+#### `isServiceAvailable`
+
+This API is used to check if the service is available for integration and
+whether the content can be presented on the device.
+
+##### For Engage SDK v1.6.0 and higher (Recommended)
+
+You can check the service availability for every cluster type that you intend to
+publish. The `isServiceAvailable` API accepts a request object,
+`ServiceAvailabilityRequest`, which contains the cluster types for which service
+availability needs to be checked. You can find the `ClusterType` enum values
+required for `ServiceAvailabilityRequest` from the following table.
+
+| Cluster Type | Cluster Type Constant | Integer Value |
+|---|---|---|
+| Unknown | `TYPE_UNKNOWN` | 0 |
+| Recommendation Cluster | `TYPE_RECOMMENDATION` | 1 |
+| Featured Cluster | `TYPE_FEATURED` | 2 |
+| Continuation Cluster | `TYPE_CONTINUATION` | 3 |
+| User Management Cluster | `TYPE_ENGAGEMENT` | 8 |
+| Subscription Cluster | `TYPE_SUBSCRIPTION` | 12 |
+
+### Kotlin
+
+    val request = ServiceAvailabilityRequest.Builder()
+        .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+        .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+        .build()
+
+    client.isServiceAvailable(request).addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            val availabilityMap = task.result
+            if (availabilityMap[ClusterType.TYPE_CONTINUATION] == true) {
+                // Proceed with publishing continuation content
+            }
+            if (availabilityMap[ClusterType.TYPE_RECOMMENDATION] == true) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    }
+
+### Java
+
+    ServiceAvailabilityRequest request =
+        new ServiceAvailabilityRequest.Builder()
+            .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+            .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+            .build();
+
+    client.isServiceAvailable(request).addOnCompleteListener(task -> {
+        if (task.isSuccessful()) {
+            Map<Integer, Boolean> availabilityMap = task.getResult();
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_CONTINUATION))) {
+                // Proceed with publishing continuation content
+            }
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_RECOMMENDATION))) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    });
+
+###### Conditional Service Availability Feature
+
+Some integrated apps request a special configuration that enables and disables
+the Engage service intermittently in order to reduce their serving cost. This
+intermittent content ingestion strategy, although possible, negatively affects
+the user and the product -- stale content will not be presented and some surfaces
+will not be served at all.
+
+Starting with v1.6.0, the Engage SDK allows checking availability for specific
+cluster types. This provides more flexibility so that if the intermittent
+content strategy was adopted by a given application, some cluster types can
+follow that intermittent strategy while other cluster types are always enabled
+(i.e. continuation clusters).
+
+If the Engage service should not be 'continuously' enabled on all supported
+devices for whatever reason, and is configured for intermittent ingestion for
+any set of devices, all continuation cluster publications (e.g. Continue
+Listening) will be still enabled by default configuration, and the rest of
+the cluster types will be enabled and disabled intermittently. If
+intermittent ingestion applies to you but this default configuration is not
+suitable for your needs, please contact engage-developers@google.com.
+
+##### For SDK versions prior to v1.6.0 (Deprecated)
+
+### Kotlin
+
+    client.isServiceAvailable.addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            // Handle IPC call success
+            if(task.result) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    }
+
+### Java
+
+    client.isServiceAvailable().addOnCompleteListener(task - > {
+        if (task.isSuccessful()) {
+            // Handle success
+            if(task.getResult()) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    });
+
+> [!NOTE]
+> **Note:** We highly recommend keeping a periodic job running to check if the service becomes available at a later point in time. The availability of the service may change with Android version upgrades, app upgrades, installs, and uninstalls. By ensuring periodic job checks at a certain time interval, data can be published once the service becomes available.
+
+#### `publishRecommendationClusters`
+
+This API is used to publish a list of `RecommendationCluster` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishRecommendationClusters(
+                PublishRecommendationClustersRequest.Builder()
+                    .addRecommendationCluster(
+                        RecommendationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .setTitle("Trending music")
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishRecommendationClusters(
+                new PublishRecommendationClustersRequest.Builder()
+                    .addRecommendationCluster(
+                        new RecommendationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .setTitle("Trending music")
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `RecommendationCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Recommendation Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishFeaturedCluster`
+
+This API is used to publish a list of `FeaturedCluster` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishFeaturedCluster(
+                PublishFeaturedClusterRequest.Builder()
+                    .setFeaturedCluster(
+                        FeaturedCluster.Builder()
+                            ...
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishFeaturedCluster(
+                new PublishFeaturedClusterRequest.Builder()
+                    .setFeaturedCluster(
+                        new FeaturedCluster.Builder()
+                            ...
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `FeaturedCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Featured Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishContinuationCluster`
+
+This API is used to publish a `ContinuationCluster` object.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishContinuationCluster(
+                PublishContinuationClusterRequest.Builder()
+                    .setContinuationCluster(
+                        ContinuationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishContinuationCluster(
+                PublishContinuationClusterRequest.Builder()
+                    .setContinuationCluster(
+                        ContinuationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .build())
+                    .build())
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `ContinuationCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Continuation Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishUserAccountManagementRequest`
+
+This API is used to publish a Sign In card . The signin action directs users to
+the app's sign in page so that the app can publish content (or provide more
+personalized content)
+
+The following metadata is part of the Sign In Card -
+
+| Attribute | Requirement | Description |
+|---|---|---|
+| Action Uri | Required | Deeplink to Action (i.e. navigates to app sign in page) |
+| Image | Optional - If not provided, Title must be provided | Image Shown on the Card 16x9 aspect ratio images with a resolution of 1264x712 |
+| Title | Optional - If not provided, Image must be provided | Title on the Card |
+| Action Text | Optional | Text Shown on the CTA (i.e. Sign in) |
+| Subtitle | Optional | Optional Subtitle on the Card |
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    var SIGN_IN_CARD_ENTITY =
+          SignInCardEntity.Builder()
+              .addPosterImage(
+                  Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build()
+
+    client.publishUserAccountManagementRequest(
+                PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+### Java
+
+    SignInCardEntity SIGN_IN_CARD_ENTITY =
+          new SignInCardEntity.Builder()
+              .addPosterImage(
+                  new Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build();
+
+    client.publishUserAccountManagementRequest(
+                new PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `UserAccountManagementCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated UserAccountManagementCluster Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `updatePublishStatus`
+
+If for any internal business reason, none of the clusters is published,
+we **strongly recommend** updating the publish status using the
+**updatePublishStatus** API.
+This is important because :
+
+- Providing the status in all scenarios, even when the content is published (STATUS == PUBLISHED), is critical to populate dashboards that use this explicit status to convey the health and other metrics of your integration.
+- If no content is published but the integration status isn't broken (STATUS == NOT_PUBLISHED), Google can avoid triggering alerts in the app health dashboards. It confirms that content is not published due to an **expected** situation from the provider's standpoint.
+- It helps developers provide insights into when the data is published versus not.
+- Google may use the status codes to nudge the user to do certain actions in the app so they can see the app content or overcome it.
+
+The list of eligible publish status codes are :
+
+    // Content is published
+    AppEngagePublishStatusCode.PUBLISHED,
+
+    // Content is not published as user is not signed in
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN,
+
+    // Content is not published as user is not subscribed
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SUBSCRIPTION,
+
+    // Content is not published as user location is ineligible
+    AppEngagePublishStatusCode.NOT_PUBLISHED_INELIGIBLE_LOCATION,
+
+    // Content is not published as there is no eligible content
+    AppEngagePublishStatusCode.NOT_PUBLISHED_NO_ELIGIBLE_CONTENT,
+
+    // Content is not published as the feature is disabled by the client
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_FEATURE_DISABLED_BY_CLIENT,
+
+    // Content is not published as the feature due to a client error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR,
+
+    // Content is not published as the feature due to a service error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR,
+
+    // Content is not published due to some other reason
+    // Reach out to engage-developers@ before using this enum.
+    AppEngagePublishStatusCode.NOT_PUBLISHED_OTHER
+
+If the content is not published due to a user not logged in,
+Google would recommend publishing the Sign In Card.
+If for any reason providers are not able to publish the Sign In Card
+then we recommend calling the **updatePublishStatus** API
+with the status code **NOT_PUBLISHED_REQUIRES_SIGN_IN**
+
+### Kotlin
+
+    client.updatePublishStatus(
+       PublishStatusRequest.Builder()
+         .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+         .build())
+
+### Java
+
+    client.updatePublishStatus(
+        new PublishStatusRequest.Builder()
+            .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+            .build());
+
+#### `deleteRecommendationClusters`
+
+This API is used to delete the content of Recommendation Clusters.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteRecommendationClusters()
+
+### Java
+
+    client.deleteRecommendationClusters();
+
+When the service receives the request, it removes the existing data from the
+Recommendation Clusters. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteFeaturedCluster`
+
+This API is used to delete the content of Featured Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteFeaturedCluster()
+
+### Java
+
+    client.deleteFeaturedCluster();
+
+When the service receives the request, it removes the existing data from the
+Featured Cluster. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteContinuationCluster`
+
+This API is used to delete the content of Continuation Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteContinuationCluster()
+
+### Java
+
+    client.deleteContinuationCluster();
+
+When the service receives the request, it removes the existing data from the
+Continuation Cluster. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteUserManagementCluster`
+
+This API is used to delete the content of UserAccountManagement Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteUserManagementCluster()
+
+### Java
+
+    client.deleteUserManagementCluster();
+
+When the service receives the request, it removes the existing data from the
+UserAccountManagement Cluster. In case of an error, the entire request is
+rejected and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteClusters`
+
+This API is used to delete the content of a given cluster type.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteClusters(
+        DeleteClustersRequest.Builder()
+          .addClusterType(ClusterType.TYPE_FEATURED)
+          .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+          ...
+          .build())
+
+### Java
+
+    client.deleteClusters(
+                new DeleteClustersRequest.Builder()
+                    .addClusterType(ClusterType.TYPE_FEATURED)
+                    .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+                    ...
+                    .build());
+
+When the service receives the request, it removes the existing data from all
+clusters matching the specified cluster types. Clients can choose to pass one or
+many cluster types. In case of an error, the entire request is rejected and the
+existing state is maintained.
+
+#### Error handling
+
+It is highly recommended to listen to the task result from the publish APIs such
+that a follow-up action can be taken to recover and resubmit an successful task.
+
+    client.publishRecommendationClusters(
+                  new PublishRecommendationClustersRequest.Builder()
+                      .addRecommendationCluster(...)
+                      .build())
+              .addOnCompleteListener(
+                  task -> {
+                    if (task.isSuccessful()) {
+                      // do something
+                    } else {
+                      Exception exception = task.getException();
+                      if (exception instanceof AppEngageException) {
+                        @AppEngageErrorCode
+                        int errorCode = ((AppEngageException) exception).getErrorCode();
+                        if (errorCode == AppEngageErrorCode.SERVICE_NOT_FOUND) {
+                          // do something
+                        }
+                      }
+                    }
+                  });
+
+The error is returned as an `AppEngageException` with the cause included as an
+error code.
+
+| Error code | Error name | Note |
+|---|---|---|
+| `1` | `SERVICE_NOT_FOUND` | The service is not available on the given device. |
+| `2` | `SERVICE_NOT_AVAILABLE` | The service is available on the given device, but it is not available at the time of the call (for example, it is explicitly disabled). |
+| `3` | `SERVICE_CALL_EXECUTION_FAILURE` | The task execution failed due to threading issues. In this case, it can be retried. |
+| `4` | `SERVICE_CALL_PERMISSION_DENIED` | The caller is not allowed to make the service call. |
+| `5` | `SERVICE_CALL_INVALID_ARGUMENT` | The request contains invalid data (for example, more than the allowed number of clusters). |
+| `6` | `SERVICE_CALL_INTERNAL` | There is an error on the service side. |
+| `7` | `SERVICE_CALL_RESOURCE_EXHAUSTED` | The service call is made too frequently. |
+
+### Step 3: Handle broadcast intents
+
+In addition to making publish content API calls through a job, it is also
+required to set up a
+[`BroadcastReceiver`](https://developer.android.com/reference/android/content/BroadcastReceiver) to receive
+the request for a content publish.
+
+The goal of broadcast intents is mainly for app reactivation and forcing data
+sync. Broadcast intents are not designed to be sent very frequently. It is only
+triggered when the Engage Service determines the content might be stale (for
+example, a week old). That way, there is more confidence that the user can have
+a fresh content experience, even if the application has not been executed for a
+long period of time.
+
+The `BroadcastReceiver` must be set up in the following two ways:
+
+- Dynamically register an instance of the `BroadcastReceiver` class using
+  `Context.registerReceiver()`. This enables communication from applications
+  that are still live in memory.
+
+### Kotlin
+
+    class AppEngageBroadcastReceiver : BroadcastReceiver(){
+      // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+      // is received
+      // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is received
+      // Trigger continuation cluster publish when PUBLISH_CONTINUATION broadcast is
+      // received
+    }
+
+    fun registerBroadcastReceivers(context: Context){
+      var  context = context
+      context = context.applicationContext
+
+    // Register Recommendation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_RECOMMENDATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Featured Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_FEATURED),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Continuation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_CONTINUATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+    }
+
+### Java
+
+    class AppEngageBroadcastReceiver extends BroadcastReceiver {
+    // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+    // is received
+
+    // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is received
+
+    // Trigger continuation cluster publish when PUBLISH_CONTINUATION broadcast is
+    // received
+    }
+
+    public static void registerBroadcastReceivers(Context context) {
+
+    context = context.getApplicationContext();
+
+    // Register Recommendation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Featured Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Continuation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_CONTINUATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    }
+
+- Statically declare an implementation with the `<receiver>` tag in your
+  `AndroidManifest.xml` file. This allows the application to receive broadcast
+  intents when it is not running, and also allows the application to publish
+  the content.
+
+    <application>
+       <receiver
+          android:name=".AppEngageBroadcastReceiver"
+          android:permission="com.google.android.engage.REQUEST_ENGAGE_DATA"
+          android:exported="true"
+          android:enabled="true">
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_RECOMMENDATION" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_FEATURED" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_CONTINUATION" />
+          </intent-filter>
+       </receiver>
+    </application>
+
+The following [intents](https://developer.android.com/reference/android/content/Intent) will be sent by the
+service:
+
+- `com.google.android.engage.action.PUBLISH_RECOMMENDATION` It is recommended to start a `publishRecommendationClusters` call when receiving this intent.
+- `com.google.android.engage.action.PUBLISH_FEATURED` It is recommended to start a `publishFeaturedCluster` call when receiving this intent.
+- `com.google.android.engage.action.PUBLISH_CONTINUATION` It is recommended to start a `publishContinuationCluster` call when receiving this intent.
+
+## Integration workflow
+
+For a step-by-step guide on verifying your integration after it is complete, see
+[Engage developer integration workflow](https://developer.android.com/guide/playcore/engage/workflow).
+
+## FAQs
+
+See [Engage SDK Frequently Asked Questions](https://developer.android.com/guide/playcore/engage/faq) for
+FAQs.
+
+## Contact
+
+Contact
+[`engage-developers@google.com`](mailto:engage-developers@google.com) if there are
+any questions during the integration process. Our team will reply as soon as
+possible.
+
+## Next steps
+
+After completing this integration, your next steps are as follows:
+
+- Send an email to [`engage-developers@google.com`](mailto:engage-developers@google.com) and attach your integrated APK that is ready for testing by Google.
+- Google will perform a verification and review internally to make sure the integration works as expected. If changes are needed, Google will contact you with any necessary details.
+- When testing is complete and no changes are needed, Google will contact you to notify you that you can start publishing the updated and integrated APK to the Play Store.
+- After Google has confirmed that your updated APK has been published to the Play Store, your **Recommendation** , **Featured** , and **Continuation** clusters will be published and visible to users.

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/otherverticals.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/otherverticals.md
@@ -1,0 +1,1284 @@
+Boost app engagement by reaching your users where they are. Integrate Engage SDK
+to deliver personalized recommendations and continuation content directly to
+users across multiple on-device surfaces, like
+**[Collections](https://android-developers.googleblog.com/2024/07/introducing-collections-powered-by-engage-sdk.html)** , **[Entertainment
+Space](https://blog.google/products/android/entertainment-space/)** , and the Play Store. The integration adds
+less than 50 KB (compressed) to the average APK and takes most apps about a
+week of developer time. Learn more at our **[business
+site](http://play.google.com/console/about/programs/EngageSDK)**.
+
+This document contains instructions for developer partners to integrate new
+content like reservations, events, lodging, places of interest, people and other
+content that might not belong to any of these categories.
+
+## Integration detail
+
+### Terminology
+
+This integration includes the following three cluster types: **Recommendation** ,
+**Featured** , and **Continuation**.
+
+- **Recommendation** clusters show personalized suggestions from an individual
+  developer partner. It is a UI view that contains a group of recommendations
+  from the same developer partner.
+
+  - **ArticleEntity**: ArticleEntity that represents a text-based
+    recommendation for content that is relevant to more than one category
+    of content. ArticleEntity item allows developers to provide a variety of
+    text and image content with more metadata to articulate the information
+    to the users compared to GenericFeaturedEntity. Ex: Marketing content,
+    News snippet
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/article-entity-travel.png) **Figure 1:** UI showing a single ArticleEntity within Recommendations cluster.
+  - **EventEntity**: EventEntity represents an event happening in the
+    future. Event start time is a critical piece of information that
+    needs to be conveyed to the users.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/event-entity-travel.png) **Figure 2:** UI showing a single EventEntity within Recommendations cluster.
+  - **LodgingEntity**: LodgingEntity represents an accommodation, such
+    as a hotel, apartment, vacation home for short term and long term
+    rental.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/lodging-entity-travel.png) **Figure 3:** UI showing a single LodgingEntity within Recommendations cluster.
+  - **StoreEntity**: StoreEntity represents a store, restaurant, cafe
+    etc. It highlights content where a dining venue or store is the
+    critical piece of information that needs to be conveyed to the
+    users.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/store-entity-travel.png) **Figure 4:** UI showing a single StoreEntity within Recommendations cluster.
+  - **PointOfInterestEntity**: PointOfInterestEntity represents a
+    place of interest like, a gas station, event venue, theme park,
+    museum, tourist attraction, hiking trail etc. It highlights content
+    where location is a critical piece of information that needs to be
+    conveyed to the users. It shouldn't be used for lodging, a store or
+    a dining venue.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/poi-entity-travel.png) **Figure 5:** UI showing a single PointOfInterestEntity within Recommendations cluster.
+  - **PersonEntity**: PersonEntity represents a person. The recommendations
+    could be to highlight a person in categories like health and fitness,
+    sports, dating, etc.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/person-entity-dating.png) **Figure 5:** UI showing a single PersonEntity within Recommendations cluster.
+- The **Continuation** cluster shows content recently engaged by users from
+  multiple developer partners in a single UI grouping. Each developer partner
+  will be allowed to broadcast a maximum of 10 entities in the Continuation
+  cluster.
+
+  Your continuation content can take the following structure:
+  - **ArticleEntity**: ArticleEntity that represents a text-based
+    recommendation for content that is relevant to more than one category
+    of content. This entity can be used to represent unfinished news
+    articles or other content that the user would like to continue consuming
+    from where they left it. Ex: Marketing content, News snippet
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/article-entity-continuation-travel.png) **Figure 6.** UI showing a single ArticleEntity within a Continuation cluster.
+  - **RestaurantReservationEntity**: RestaurantReservationEntity represents
+    a reservation for a restaurant or cafe and helps users track upcoming or
+    ongoing restaurant reservations.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/restaurant-reservation-entity-travel.png) **Figure 7.** UI showing a single RestaurantReservationEntity within a Continuation cluster.
+  - **EventReservationEntity**: EventReservationEntity represents a
+    reservation for an event and helps users track upcoming or ongoing
+    events reservations. Events could include, but not limited to the
+    following:
+
+    - Sports events like reservation for a football match
+    - Gaming events like reservation for eSports
+    - Entertainment events like reservation for movies in a cinema, concert, theater, book signing
+    - Travel or point of interest reservations like guided tours, museum tickets
+    - Social / Seminar / Conferences reservations
+    - Education / Training sessions reservations
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/event-reservation-entity-travel.png) **Figure 8.** UI showing a single EventReservationEntity within a Continuation cluster.
+  - **LodgingReservationEntity**: LodgingEntityReservation represents a
+    reservation for a travel lodging and helps users track upcoming or
+    ongoing hotel or vacation rental reservations.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/lodging-reservation-entity-travel.png) **Figure 9.** UI showing a single LodgingReservationEntity within a Continuation cluster.
+  - **TransportationReservationEntity**: TransportationReservationEntity
+    represents a reservation for transportation by any mode and helps users
+    track reservations for upcoming or ongoing flight, ferry, train, bus,
+    ride-hailing, or cruise.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/transportation-reservation-entity-travel.png) **Figure 10.** UI showing a single TransportationReservationEntity within a Continuation cluster.
+  - **VehicleRentalReservationEntity**: VehicleRentalReservationEntity
+    represents a vehicle rental reservation and helps users track upcoming
+    or ongoing vehicle rental reservations.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/vehicle-rental-reservation-entity-travel.png) **Figure 11.** UI showing a single VehicleRentalReservationEntity within a Continuation cluster.
+- The **Featured** cluster is a UI view that showcases the chosen hero
+  `GenericFeaturedEntity` from many developer partners in one UI grouping.
+  There is a single Featured cluster, which is surfaced near the top of the
+  UI, with a priority placement above all Recommendation clusters. Each
+  developer partner is allowed to broadcast a single entity of a supported
+  type in Featured, with many entities (potentially of different types) from
+  multiple app developers in the Featured cluster.
+
+  - **GenericFeaturedEntity**: GenericFeaturedEntity differs from
+    Recommendation item in that Featured item should be used for a single
+    top content from developers and should represent the single most
+    important content that will be interesting and relevant to users.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/featured-item-health-and-fitness.png) **Figure 12:** UI showing a single hero GenericFeaturedEntity card within a Featured cluster
+
+### Pre-work
+
+Minimum API level: 19
+
+Add the `com.google.android.engage:engage-core` library to your app:
+
+    dependencies {
+        // Make sure you also include that repository in your project's build.gradle file.
+        implementation 'com.google.android.engage:engage-core:1.6.0'
+    }
+
+### Summary
+
+The design is based on an implementation of a
+[bound service](https://developer.android.com/guide/components/bound-services).
+
+The data a client can publish is subject to the following limits for different
+cluster types:
+
+| Cluster type | Cluster limits | Minimum entity limits in a cluster | Maximum entity limits in a cluster |
+|---|---|---|---|
+| Recommendation Cluster(s) | At most 7 | At least 1 | At most 50 (`ArticleEntity`, `EventEntity`, `LodgingEntity`, `StoreEntity`, `PointOfInterestEntity`, or `PersonEntity`) |
+| Continuation Cluster | At most 1 | At least 1 | At most 20 (`ArticleEntity`, `EventReservationEntity`, `LodgingReservationEntity`, `TransportationReservationEntity`, or `VehicleRentalReservationEntity`) |
+| Featured Cluster | At most 1 | At least 1 | At most 20 (`GenericFeaturedEntity`) |
+
+### Step 1: Provide entity data
+
+The SDK has defined different entities to represent each item type. We support
+the following entities for the others category:
+
+1. `GenericFeaturedEntity`
+2. `ArticleEntity`
+3. `EventEntity`
+4. `LodgingEntity`
+5. `StoreEntity`
+6. `PointOfInterestEntity`
+7. `PersonEntity`
+8. `RestaurantReservationEntity`
+9. `EventReservationEntity`
+10. `LodgingReservationEntity`
+11. `TransportationReservationEntity`
+12. `VehicleRentalReservationEntity`
+
+The charts below outline available attributes and requirements for each type.
+
+#### `GenericFeaturedEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Poster images | **Required** | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Title | Optional | Title of the entity. | Free text **Recommended text size: 50 chars** |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. Special UX treatment on top of image/video, for example, as badge overlay on the image - "Live update" - Article read duration |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Enums See the [Content Category section](https://developer.android.com/guide/playcore/engage/otherverticals#content-category) for guidance. |
+
+#### `ArticleEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | Free text **Recommended text size: Max 50 chars** |
+| Poster images | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** Image is highly recommended. If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Source - Title | Optional | The name of the author, organization, or reporter | Free text **Recommended text size: Under 25 chars** |
+| Source - Image | Optional | An image of the source like the author, the organization, reporter | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. Special UX treatment on top of image/video, for example as badge overlay on the image - "Live update" - Article read duration |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Content Publish Time | Optional | This is the epoch timestamp in milliseconds on when the content was published / updated in the app. | Epoch timestamp in milliseconds |
+| Last Engagement Time | Conditionally Required | The epoch timestamp in milliseconds when the user interacted with this entity last time. **Note:** This field is required if this entity is part of the continuation cluster. | Epoch timestamp in milliseconds |
+| Progress Percentage | Conditionally Required | The percentage of the full content consumed by the user to date. **Note:** This field is required if this entity is part of the continuation cluster. | An int value between 0\~100 inclusive. |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Enums See the [Content Category section](https://developer.android.com/guide/playcore/engage/otherverticals#content-category) for guidance. |
+
+#### `EventEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | String **Recommended text size: Max 50 chars** |
+| Start time | **Required** | The epoch timestamp when the event is expected to start. **Note:**This will be represented in milliseconds. | Epoch timestamp in milliseconds |
+| Event mode | **Required** | A field to indicate whether the event will be virtual, in-person or both. | Enum: VIRTUAL, IN_PERSON, or HYBRID |
+| Poster images | **Required** | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** Image is highly recommended. If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Location - Country | Conditionally Required | The country in which the event is happening. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - City | Conditionally Required | The city in which the event is happening. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | Conditionally Required | The address or venue name where the event will take place that should be displayed to the user. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - Street Address | Optional | The street address (if applicable) of the location at which event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state or province (if applicable) in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) of the location in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| End time | Optional | The epoch timestamp when the event is expected to end. **Note:**This will be represented in milliseconds. | Epoch timestamp in milliseconds |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Price - CurrentPrice | Conditionally required | The current price of the ticket/pass for the event. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the ticket/pass for the event. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Eligible Enums - TYPE_MOVIES_AND_TV_SHOWS (Example - Cinema) - TYPE_DIGITAL_GAMES (Example - eSports) - TYPE_MUSIC (Example - Concert) - TYPE_TRAVEL_AND_LOCAL (Example - Tour, festival) - TYPE_HEALTH_AND_FITENESS (Example - Yoga class) - TYPE_EDUCATION (Example - Class) - TYPE_SPORTS (Example - Football game) - TYPE_DATING (Example - meetup) See the [Content Category section](https://developer.android.com/guide/playcore/engage/otherverticals#content-category) for guidance. |
+
+#### `LodgingEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | String **Recommended text size: Max 50 chars** |
+| Poster images | **Required** | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Location - Country | **Required** | The country in which the lodging is happening. | Free text **Recommended text size: max \~20 chars** |
+| Location - City | **Required** | The city in which the lodging is happening. | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | **Required** | The address of the lodging that will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Location - Street Address | Optional | The street address (if applicable) of the lodging. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state or province (if applicable) in which the lodging is located. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) of the lodging. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) of the lodging. | Free text **Recommended text size: max \~20 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| AvailabilityTimeWindow - Start Time | Optional | The epoch timestamp in milliseconds when the lodging is expected to be open/available. | Epoch timestamp in milliseconds |
+| AvailabilityTimeWindow - End Time | Optional | The epoch timestamp in milliseconds until which the lodging is expected to be open/available. | Epoch timestamp in milliseconds |
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the lodging. **Note:** Provide this field if your app controls how the count is displayed to the users. Use a concise string. For example, if the count is 1,000,000, consider using an abbreviation like 1M so that the count isn't truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the lodging. **Note:** Provide this field if you aren't handling the display abbreviation logic yourself. If both Count and Count Value are present, Count is displayed to users. | Long |
+| Price - CurrentPrice | Conditionally required | The current price of the lodging. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the lodging, which is be struck-through in the UI. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+
+#### `StoreEntity`
+
+The `StoreEntity` object represents an individual store that developer partners
+want to publish, such as a restaurant or a grocery store.
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Poster images | **Required** | At least one image must be provided. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | Optional | The name of the store. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Location | Optional | The location of the store. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Callout | Optional | Callout to feature a promo, event, or update for the store, if available. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Callout fine print | Optional | Fine print text for the callout. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Description | Optional | A description of the store. | Free text **Recommended text size: under 90 chars** (Text that is too long may show ellipses) |
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the lodging. **Note:** Provide this field if your app wants to control how this is displayed to the users. Provide the concise string that can be displayed to the user. For example, if the count is 1,000,000, consider using abbreviations like 1M, so that it won't be truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the lodging. **Note:** Provide this field if you don't want to handle the display abbreviation logic yourself. If both Count and Count Value are present, we will use the Count to display to users | Long |
+
+#### `PointOfInterestEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | String **Recommended text size: Max 50 chars** |
+| Poster images | **Required** | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** Image is highly recommended. If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Location - Country | **Required** | The country in which the point of interest is happening. | Free text **Recommended text size: max \~20 chars** |
+| Location - City | **Required** | The city in which the point of interest is happening. | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | **Required** | The address of the point of interest that will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Location - Street Address | Optional | The street address (if applicable) of the point of interest. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state or province (if applicable) in which the point of interest is located. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) of the point of interest. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) of the point of interest. | Free text **Recommended text size: max \~20 chars** |
+| AvailabilityTimeWindow - Start Time | Optional | The epoch timestamp in milliseconds when the point of interest is expected to be open/available. | Epoch timestamp in milliseconds |
+| AvailabilityTimeWindow - End Time | Optional | The epoch timestamp in milliseconds until which the point of interest is expected to be open/available. | Epoch timestamp in milliseconds |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the point of interest. **Note:** Provide this field if your app controls how the count is displayed to the users. Use a concise string. For example, if the count is 1,000,000, consider using an abbreviation like 1M so that the count isn't truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the point of interest. **Note:** Provide this field if you aren't handling display abbreviation logic yourself. If both Count and Count Value are present, Count is displayed to users | Long |
+| Price - CurrentPrice | Conditionally required | The current price of the tickets/entry pass for the point of interest. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the tickets/entry pass for the point of interest. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Eligible Enums - TYPE_TRAVEL_AND_LOCAL - TYPE_MOVIES_AND_TV_SHOWS (Example - theater) - TYPE_MEDICAL (Example - hospital) - TYPE_EDUCATION (Example - school) - TYPE_SPORTS (Example - stadium) See the [Content Category section](https://developer.android.com/guide/playcore/engage/otherverticals#content-category) for guidance. |
+
+#### `PersonEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Profile - Name | **Required** | Profile name or id or handle, eg "John Doe", "@TeamPixel", etc. | String **Recommended text size: Max 50 chars** |
+| Profile - Avatar | **Required** | Profile picture or avatar image of the user. **Note:**Must be Square 1:1 image. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Profile - Additional Text | Optional | Free text like the profile handle. | Free text **Recommended text size: Max 15 chars** |
+| Profile - Additional Image | Optional | Small image like a verified badge. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Header image | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** Image is highly recommended. If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Popularity - Count | Optional | Indicate the number of followers or popularity value, for example - "3.7 M". **Note:** If both Count and Count Value are provided, Count will be used | String **Recommended text size: max 20 chars for count + label combined** |
+| Popularity - Count Value | Optional | The number of followers or popularity value. **Note:** Provide Count Value if your app doesn't want to handle logic on how a large number should be optimized for different display sizes. If both Count and Count Value are provided, Count will be used. | Long |
+| Popularity - Label | Optional | Indicate what the popularity label is. For example - "Likes". | String **Recommended text size: Max 20 chars for count + label combined** |
+| Popularity - Visual | Optional | Indicate what the interaction is for. For example - Image showing Likes icon, Emojis. Can provide more than 1 image, though not all may not be shown on all form factors. **Note:** Must be Square 1:1 image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Rating - Max value | Required | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Required | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the entity. **Note:** Provide this field if your app wants to control how this is displayed to the users. Provide the concise string that can be displayed to the user. For example, if the count is 1,000,000, consider using abbreviations like 1M, so that it won't be truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the entity. **Note:** Provide this field if you don't want to handle the display abbreviation logic yourself. If both Count and Count Value are present, we will use the Count to display to users | Long |
+| Location - Country | Optional | The country where the person is located or serving. | Free text **Recommended text size: max \~20 chars** |
+| Location - City | Optional | The city where the person is located or serving. | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | Optional | The address where the person is located or serving will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Location - Street Address | Optional | The street address (if applicable) where the person is located or serving. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state (if applicable) where the person is located or serving. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) where the person is located or serving. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) where the person is located or serving. | Free text **Recommended text size: max \~20 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Eligible Enums - TYPE_HEALTH_AND_FITENESS (Example - Yoga/fitness trainer) - TYPE_HOME_AND_AUTO (Example - Plumber) - TYPE_SPORTS (Example - Player) - TYPE_DATING See the [Content Category section](https://developer.android.com/guide/playcore/engage/otherverticals#content-category) for guidance. |
+
+#### `RestaurantReservationEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | String **Recommended text size: Max 50 chars** |
+| Reservation Start Time | **Required** | The epoch timestamp in milliseconds when the reservation is expected to start. | Epoch timestamp in milliseconds |
+| Location - Country | **Required** | The country in which the restaurant is happening. | Free text **Recommended text size: max \~20 chars** |
+| Location - City | **Required** | The city in which the restaurant is happening. | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | **Required** | The address of the prestaurant that will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Location - Street Address | Optional | The street address (if applicable) of the restaurant. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state or province (if applicable) in which the restaurant is located. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) of the restaurant. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) of the restaurant. | Free text **Recommended text size: max \~20 chars** |
+| Poster images | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Table Size | Optional | The number of people in the reservation group | Integer \> 0 |
+
+#### `EventReservationEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | String **Recommended text size: Max 50 chars** |
+| Start time | **Required** | The epoch timestamp when the event is expected to start. **Note:**This will be represented in milliseconds. | Epoch timestamp in milliseconds |
+| Event mode | **Required** | A field to indicate whether the event will be virtual, in-person or both. | Enum: VIRTUAL, IN_PERSON, or HYBRID |
+| Location - Country | Conditionally Required | The country in which the event is happening. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - City | Conditionally Required | The city in which the event is happening. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | Conditionally Required | The address or venue name where the event will take place that should be displayed to the user. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - Street Address | Optional | The street address (if applicable) of the location at which event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state or province (if applicable) in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) of the location in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Poster images | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** Image is highly recommended. If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| End time | Optional | The epoch timestamp when the event is expected to end. **Note:**This will be represented in milliseconds. | Epoch timestamp in milliseconds |
+| Service Provider - Name | Optional | The name of the service provider. **Note:**Either text or image is required for the service provider. | Free text. For example, name of the event organizer/tour |
+| Service Provider - Image | Optional | The logo/image of the service provider. **Note:**Either text or image is required for the service provider. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Reservation ID | Optional | The reservation ID for the event reservation. | Free text |
+| Price - CurrentPrice | Conditionally required | The current price of the ticket/pass for the event. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the ticket/pass for the event. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the event. **Note:** Provide this field if your app wants to control how this is displayed to the users. Provide the concise string that can be displayed to the user. For example, if the count is 1,000,000, consider using abbreviations like 1M, so that it won't be truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the event. **Note:** Provide this field if you don't want to handle the display abbreviation logic yourself. If both Count and Count Value are present, we will use the Count to display to users | Long |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Eligible Enums - TYPE_MOVIES_AND_TV_SHOWS (Example - Cinema) - TYPE_DIGITAL_GAMES (Example - eSports) - TYPE_MUSIC (Example - Concert) - TYPE_TRAVEL_AND_LOCAL (Example - Tour, festival) - TYPE_HEALTH_AND_FITENESS (Example - Yoga class) - TYPE_EDUCATION (Example - Class) - TYPE_SPORTS (Example - Football game) - TYPE_DATING (Example - meetup) See the [Content Category section](https://developer.android.com/guide/playcore/engage/otherverticals#content-category) for guidance. |
+
+#### `LodgingReservationEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | Free text. For example, "Your Stay from Dec 12th" **Recommended text size: Max 50 chars** |
+| Check-in Time | **Required** | The epoch timestamp in milliseconds that represents the check in time for the reservation. | Epoch timestamp in milliseconds |
+| Check-out Time | **Required** | The epoch timestamp in milliseconds that represents the check out time for the reservation. | Epoch timestamp in milliseconds |
+| Location - Country | **Required** | The country in which the lodging is located. | Free text **Recommended text size: max \~20 chars** |
+| Location - City | **Required** | The city in which the lodging is located. | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | **Required** | The address of the lodging that will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Location - Street Address | Optional | The street address (if applicable) of the lodging. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state or province (if applicable) in which the lodging is located. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) of the lodging. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) of the lodging. | Free text **Recommended text size: max \~20 chars** |
+| Poster images | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Reservation ID | Optional | The reservation ID for the lodging reservation. | Free text |
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the lodging. **Note:** Provide this field if your app wants to control how this is displayed to the users. Provide the concise string that can be displayed to the user. For example, if the count is 1,000,000, consider using abbreviations like 1M, so that it won't be truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the lodging. **Note:** Provide this field if you don't want to handle the display abbreviation logic yourself. If both Count and Count Value are present, we will use the Count to display to users | Long |
+| Price - CurrentPrice | Conditionally required | The current price of the lodging. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the lodging, which is be struck-through in the UI. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+
+#### `TransportationReservationEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | Free text. For example, "SFO to SAN" **Recommended text size: Max 50 chars** |
+| Transportation Type | **Required** | The mode/type of transportation for the reservation. | Enum: FLIGHT, TRAIN, BUS, or FERRY |
+| Departure Time | **Required** | The epoch timestamp in milliseconds that represents the departure time. | Epoch timestamp in milliseconds |
+| Arrival Time | **Required** | The epoch timestamp in milliseconds that represents the arrival time. | Epoch timestamp in milliseconds |
+| Departure Location - Country | Optional | The country of departure. | Free text **Recommended text size: max \~20 chars** |
+| Departure Location - City | Optional | The city of departure. | Free text **Recommended text size: max \~20 chars** |
+| Departure Location - Display Address | Optional | The location of departure that will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Departure Location - Street Address | Optional | The street address (if applicable) of the departure location. | Free text **Recommended text size: max \~20 chars** |
+| Departure Location - State | Optional | The state or province (if applicable) of the departure location. | Free text **Recommended text size: max \~20 chars** |
+| Departure Location - Zip code | Optional | The zip code (if applicable) of the departure location. | Free text **Recommended text size: max \~20 chars** |
+| Departure Location - Neighborhood | Optional | The neighborhood (if applicable) of the departure location. | Free text **Recommended text size: max \~20 chars** |
+| Arrival Location - Country | Optional | The country of arrival. | Free text **Recommended text size: max \~20 chars** |
+| Arrival Location - City | Optional | The city of arrival. | Free text **Recommended text size: max \~20 chars** |
+| Arrival Location - Display Address | Optional | The location of arrival that will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Arrival Location - Street Address | Optional | The street address (if applicable) of the arrival location. | Free text **Recommended text size: max \~20 chars** |
+| Arrival Location - State | Optional | The state or province (if applicable) of the arrival location. | Free text **Recommended text size: max \~20 chars** |
+| Arrival Location - Zip code | Optional | The zip code (if applicable) of the arrival location. | Free text **Recommended text size: max \~20 chars** |
+| Arrival Location - Neighborhood | Optional | The neighborhood (if applicable) of the arrival location. | Free text **Recommended text size: max \~20 chars** |
+| Service Provider - Name | Optional | The name of the service provider. **Note:**Either text or image is required for the service provider. | Free text. For example, Airline name |
+| Service Provider - Image | Optional | The logo/image of the service provider. **Note:**Either text or image is required for the service provider. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Poster images | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Reservation ID | Optional | The reservation ID for the transportation reservation. | Free text |
+| Price - CurrentPrice | Conditionally required | The current price of the reservation. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the reservation, which is be struck-through in the UI. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+| Transportation Number | Required | The flight number, bus number, train number, or ferry/cruise number. | Free text |
+| Boarding Time | Required | The epoch timestamp that represents the boarding time for the reservation (if applicable) | Epoch timestamp in milliseconds |
+
+#### `VehicleRentalReservationEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | Free text. For example, "Avis Union Square SF" **Recommended text size: Max 50 chars** |
+| Pickup Time | **Required** | The epoch timestamp that represents the pick up time for the reservation. | Epoch timestamp in milliseconds |
+| Return Time | Optional | The epoch timestamp that represents the check out time for the reservation. | Epoch timestamp in milliseconds |
+| Pickup Address - Country | Optional | The country of the pickup location. | Free text **Recommended text size: max \~20 chars** |
+| Pickup Address - City | Optional | The city of the pickup location. | Free text **Recommended text size: max \~20 chars** |
+| Pickup Address - Display Address | Optional | The pickup location that will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Pickup Address - Street Address | Optional | The street address (if applicable) of the pickup location. | Free text **Recommended text size: max \~20 chars** |
+| Pickup Address - State | Optional | The state or province (if applicable) of the pickup location. | Free text **Recommended text size: max \~20 chars** |
+| Pickup Address - Zip code | Optional | The zip code (if applicable) of the pickup location. | Free text **Recommended text size: max \~20 chars** |
+| Pickup Address - Neighborhood | Optional | The neighborhood (if applicable) of the pickup location. | Free text **Recommended text size: max \~20 chars** |
+| Return Address - Country | Optional | The country of return location. | Free text **Recommended text size: max \~20 chars** |
+| Return Address - City | Optional | The city of return location. | Free text **Recommended text size: max \~20 chars** |
+| Return Address - Display Address | Optional | The return location that will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Return Address - Street Address | Optional | The street address (if applicable) of the return location. | Free text **Recommended text size: max \~20 chars** |
+| Return Address - State | Optional | The state or province (if applicable) of the return location. | Free text **Recommended text size: max \~20 chars** |
+| Return Address - Zip code | Optional | The zip code (if applicable) of the return location. | Free text **Recommended text size: max \~20 chars** |
+| Return Address - Neighborhood | Optional | The neighborhood (if applicable) of the return location. | Free text **Recommended text size: max \~20 chars** |
+| Service Provider - Name | Optional | The name of the service provider. **Note:**Either text or image is required for the service provider. | Free text. For example, "Avis Car Rental" |
+| Service Provider - Image | Optional | The logo/image of the service provider. **Note:**Either text or image is required for the service provider. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Poster images | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 | See [Image Specifications](https://developer.android.com/guide/playcore/engage/otherverticals#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Confirmation ID | Optional | The confirmation ID for the vehicle rental reservation. | Free text |
+| Price - CurrentPrice | Conditionally required | The current price of the reservation. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the reservation, which is be struck-through in the UI. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+
+#### Image specifications
+
+Required specifications for image assets are listed in this table:
+
+| Aspect ratio | Minimum pixels | Recommended pixels |
+|---|---|---|
+| Square (1x1) **Preferred** | 300x300 | 1200x1200 |
+| Landscape (1.91x1) | 600x314 | 1200x628 |
+| Portrait (4x5) | 480x600 | 960x1200 |
+
+The images are required to be hosted on public CDNs so that Google can access
+them.
+
+*File formats*
+
+PNG, JPG, static GIF, WebP
+
+*Maximum file size*
+
+5120 KB
+
+*Additional recommendations*
+
+- **Image safe area:** Put your important content in the center 80% of the image.
+- Use a transparent background so that the image can be properly displayed in Dark and Light theme settings.
+
+#### Content Category
+
+The content category allows apps to publish content belonging to multiple
+categories. This maps the content with some of the predefined categories namely:
+
+- `TYPE_EDUCATION`
+- `TYPE_SPORTS`
+- `TYPE_MOVIES_AND_TV_SHOWS`
+- `TYPE_BOOKS`
+- `TYPE_AUDIOBOOKS`
+- `TYPE_MUSIC`
+- `TYPE_DIGITAL_GAMES`
+- `TYPE_TRAVEL_AND_LOCAL`
+- `TYPE_HOME_AND_AUTO`
+- `TYPE_BUSINESS`
+- `TYPE_NEWS`
+- `TYPE_FOOD_AND_DRINK`
+- `TYPE_SHOPPING`
+- `TYPE_HEALTH_AND_FITENESS`
+- `TYPE_MEDICAL`
+- `TYPE_PARENTING`
+- `TYPE_DATING`
+
+The images are required to be hosted on public CDNs so that Google can access
+them.
+
+*Guidelines to use the content categories*
+
+1. Some entities like **ArticleEntity** and **GenericFeaturedEntity** are eligible to use any of the content categories. For other entities like **EventEntity** , **EventReservationEntity** , **PointOfInterestEntity**, only a subset of these categories are eligible. Check the list of categories eligible for an entity type before populating the list.
+2. Use the specific entity type for some content categories over a combination
+   of the Generic entities and the ContentCategory:
+
+   - TYPE_MOVIES_AND_TV_SHOWS - Check out the entities from [Watch integration guide](https://developer.android.com/guide/playcore/engage/watch) before using the generic entities.
+   - TYPE_BOOKS - Check out the [EbookEntity](https://developer.android.com/guide/playcore/engage/read#ebookentity) before using the generic entities.
+   - TYPE_AUDIOBOOKS - Check out [AudiobookEntity](https://developer.android.com/guide/playcore/engage/read#audiobookentity) before using the generic entities.
+   - TYPE_SHOPPING - Check out [ShoppingEntity](https://developer.android.com/guide/playcore/engage/shopping#shoppingEntity) before using the generic entities.
+   - TYPE_FOOD_AND_DRINK - Check out entities from [Food Integration guide](https://developer.android.com/guide/playcore/engage/food) before using the generic entities.
+3. The ContentCategory field is optional and should be left blank if the
+   content doesn't belong to any of the categories mentioned earlier.
+
+4. In case multiple content categories are provided, provide them in the order
+   of relevance to the content with the most relevant content category placed
+   first in the list.
+
+### Step 2: Provide Cluster data
+
+It is recommended to have the content publish job executed in the background
+(for example, using [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager))
+and scheduled on a regular basis or on an event basis (for example, every time
+the user opens the app or when the user just added something to their cart).
+
+`AppEngagePublishClient` is responsible for publishing clusters.
+
+There are following APIs to publish clusters in the client:
+
+- `isServiceAvailable`
+- `publishRecommendationClusters`
+- `publishFeaturedCluster`
+- `publishContinuationCluster`
+- `publishUserAccountManagementRequest`
+- `updatePublishStatus`
+- `deleteRecommendationsClusters`
+- `deleteFeaturedCluster`
+- `deleteContinuationCluster`
+- `deleteUserManagementCluster`
+- `deleteClusters`
+
+#### `isServiceAvailable`
+
+This API is used to check if the service is available for integration and
+whether the content can be presented on the device.
+
+##### For Engage SDK v1.6.0 and higher (Recommended)
+
+You can check the service availability for every cluster type that you intend to
+publish. The `isServiceAvailable` API accepts a request object,
+`ServiceAvailabilityRequest`, which contains the cluster types for which service
+availability needs to be checked. You can find the `ClusterType` enum values
+required for `ServiceAvailabilityRequest` from the following table.
+
+| Cluster Type | Cluster Type Constant | Integer Value |
+|---|---|---|
+| Unknown | `TYPE_UNKNOWN` | 0 |
+| Recommendation Cluster | `TYPE_RECOMMENDATION` | 1 |
+| Featured Cluster | `TYPE_FEATURED` | 2 |
+| Continuation Cluster | `TYPE_CONTINUATION` | 3 |
+| Shopping Cart Cluster | `TYPE_SHOPPING_CART` | 4 |
+| Food Reorder Cluster | `TYPE_FOOD_REORDER` | 5 |
+| Food Shopping Cart Cluster | `TYPE_FOOD_SHOPPING_CART` | 6 |
+| Food Shopping List Cluster | `TYPE_FOOD_SHOPPING_LIST` | 7 |
+| User Management Cluster | `TYPE_ENGAGEMENT` | 8 |
+| Shopping List Cluster | `TYPE_SHOPPING_LIST` | 9 |
+| Shopping Reorder Cluster | `TYPE_SHOPPING_REORDER` | 10 |
+| Shopping Order Tracking Cluster | `TYPE_SHOPPING_ORDER_TRACKING` | 11 |
+| Subscription Cluster | `TYPE_SUBSCRIPTION` | 12 |
+| Continue Search Cluster | `TYPE_CONTINUE_SEARCH` | 13 |
+| Reservation Cluster | `TYPE_RESERVATION` | 14 |
+
+### Kotlin
+
+    val request = ServiceAvailabilityRequest.Builder()
+        .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+        .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+        .build()
+
+    client.isServiceAvailable(request).addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            val availabilityMap = task.result
+            if (availabilityMap[ClusterType.TYPE_CONTINUATION] == true) {
+                // Proceed with publishing continuation content
+            }
+            if (availabilityMap[ClusterType.TYPE_RECOMMENDATION] == true) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    }
+
+### Java
+
+    ServiceAvailabilityRequest request =
+        new ServiceAvailabilityRequest.Builder()
+            .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+            .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+            .build();
+
+    client.isServiceAvailable(request).addOnCompleteListener(task -> {
+        if (task.isSuccessful()) {
+            Map<Integer, Boolean> availabilityMap = task.getResult();
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_CONTINUATION))) {
+                // Proceed with publishing continuation content
+            }
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_RECOMMENDATION))) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    });
+
+###### Conditional Service Availability Feature
+
+Some integrated apps request a special configuration that enables and disables
+the Engage service intermittently in order to reduce their serving cost. This
+intermittent content ingestion strategy, although possible, negatively affects
+the user and the product -- stale content will not be presented and some surfaces
+will not be served at all.
+
+Starting with v1.6.0, the Engage SDK allows checking availability for specific
+cluster types. This provides more flexibility so that if the intermittent
+content strategy was adopted by a given application, some cluster types can
+follow that intermittent strategy while other cluster types are always enabled
+(i.e. continuation clusters).
+
+If the Engage service should not be 'continuously' enabled on all supported
+devices for whatever reason, and is configured for intermittent ingestion for
+any set of devices, all continuation cluster publications (e.g. Continue
+Reading and Reservations) will be still enabled by default configuration,
+and the rest of the cluster types will be enabled and disabled
+intermittently. If intermittent ingestion applies to you but this default
+configuration is not suitable for your needs, please contact
+engage-developers@google.com.
+
+##### For SDK versions prior to v1.6.0 (Deprecated)
+
+### Kotlin
+
+    client.isServiceAvailable.addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            // Handle IPC call success
+            if(task.result) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    }
+
+### Java
+
+    client.isServiceAvailable().addOnCompleteListener(task - > {
+        if (task.isSuccessful()) {
+            // Handle success
+            if(task.getResult()) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    });
+
+> [!NOTE]
+> **Note:** We highly recommend keeping a periodic job running to check if the service becomes available at a later point in time. The availability of the service may change with Android version upgrades, app upgrades, installs, and uninstalls. By ensuring periodic job checks at a certain time interval, data can be published once the service becomes available.
+
+#### `publishRecommendationClusters`
+
+This API is used to publish a list of `RecommendationCluster` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishRecommendationClusters(
+          PublishRecommendationClustersRequest.Builder()
+            .addRecommendationCluster(
+              RecommendationCluster.Builder()
+                .addEntity(entity1)
+                .addEntity(entity2)
+                .setTitle("Top Picks For You")
+                .build()
+            )
+            .build()
+        )
+
+### Java
+
+    client.publishRecommendationClusters(
+                new PublishRecommendationClustersRequest.Builder()
+                    .addRecommendationCluster(
+                        new RecommendationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .setTitle("Top Picks For You")
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `RecommendationCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Recommendation Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishFeaturedCluster`
+
+This API is used to publish a list of `FeaturedCluster` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishFeaturedCluster(
+        PublishFeaturedClusterRequest.Builder()
+          .setFeaturedCluster(
+            FeaturedCluster.Builder()
+              .addEntity(entity1)
+              .addEntity(entity2)
+              .build())
+          .build())
+
+### Java
+
+    client.publishFeaturedCluster(
+                new PublishFeaturedClustersRequest.Builder()
+                    .addFeaturedCluster(
+                        new FeaturedCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `FeaturedCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Featured Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishContinuationCluster`
+
+This API is used to publish a `ContinuationCluster` object.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishContinuationCluster(
+        PublishContinuationClusterRequest.Builder()
+          .setContinuationCluster(
+            ContinuationCluster.Builder()
+              .addEntity(entity1)
+              .addEntity(entity2)
+              .build())
+          .build())
+
+### Java
+
+    client.publishContinuationCluster(
+                new PublishContinuationClusterRequest.Builder()
+                    .setContinuationCluster(
+                        new ContinuationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `ContinuationCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Continuation Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishUserAccountManagementRequest`
+
+This API is used to publish a Sign In card . The signin action directs users to
+the app's sign in page so that the app can publish content (or provide more
+personalized content)
+
+The following metadata is part of the Sign In Card -
+
+| Attribute | Requirement | Description |
+|---|---|---|
+| Action Uri | Required | Deeplink to Action (i.e. navigates to app sign in page) |
+| Image | Optional - If not provided, Title must be provided | Image Shown on the Card 16x9 aspect ratio images with a resolution of 1264x712 |
+| Title | Optional - If not provided, Image must be provided | Title on the Card |
+| Action Text | Optional | Text Shown on the CTA (i.e. Sign in) |
+| Subtitle | Optional | Optional Subtitle on the Card |
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    var SIGN_IN_CARD_ENTITY =
+          SignInCardEntity.Builder()
+              .addPosterImage(
+                  Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build()
+
+    client.publishUserAccountManagementRequest(
+                PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+### Java
+
+    SignInCardEntity SIGN_IN_CARD_ENTITY =
+          new SignInCardEntity.Builder()
+              .addPosterImage(
+                  new Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build();
+
+    client.publishUserAccountManagementRequest(
+                new PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `UserAccountManagementCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated UserAccountManagementCluster Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `updatePublishStatus`
+
+If for any internal business reason, none of the clusters is published, we
+**strongly recommend** updating the publish status using the
+**updatePublishStatus** API. This is important because :
+
+- Providing the status in all scenarios, even when the content is published (STATUS == PUBLISHED), is critical to populate dashboards that use this explicit status to convey the health and other metrics of your integration.
+- If no content is published but the integration status isn't broken (STATUS == NOT_PUBLISHED), Google can avoid triggering alerts in the app health dashboards. It confirms that content is not published due to an **expected** situation from the provider's standpoint.
+- It helps developers provide insights into when the data is published versus not.
+- Google may use the status codes to nudge the user to do certain actions in the app so they can see the app content or overcome it.
+
+The list of eligible publish status codes are :
+
+    // Content is published
+    AppEngagePublishStatusCode.PUBLISHED,
+
+    // Content is not published as user is not signed in
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN,
+
+    // Content is not published as user is not subscribed
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SUBSCRIPTION,
+
+    // Content is not published as user location is ineligible
+    AppEngagePublishStatusCode.NOT_PUBLISHED_INELIGIBLE_LOCATION,
+
+    // Content is not published as there is no eligible content
+    AppEngagePublishStatusCode.NOT_PUBLISHED_NO_ELIGIBLE_CONTENT,
+
+    // Content is not published as the feature is disabled by the client
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_FEATURE_DISABLED_BY_CLIENT,
+
+    // Content is not published as the feature due to a client error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR,
+
+    // Content is not published as the feature due to a service error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR,
+
+    // Content is not published due to some other reason
+    // Reach out to engage-developers@ before using this enum.
+    AppEngagePublishStatusCode.NOT_PUBLISHED_OTHER
+
+If the content is not published due to a user not logged in, Google would
+recommend publishing the Sign In Card. If for any reason providers are not able
+to publish the Sign In Card then we recommend calling the
+**updatePublishStatus** API with the status code
+**NOT_PUBLISHED_REQUIRES_SIGN_IN**
+
+### Kotlin
+
+    client.updatePublishStatus(
+       PublishStatusRequest.Builder()
+         .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+         .build())
+
+### Java
+
+    client.updatePublishStatus(
+        new PublishStatusRequest.Builder()
+            .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+            .build());
+
+#### `deleteRecommendationClusters`
+
+This API is used to delete the content of Recommendation Clusters.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteRecommendationClusters()
+
+### Java
+
+    client.deleteRecommendationClusters();
+
+When the service receives the request, it removes the existing data from the
+Recommendation Clusters. In case of an error, the entire request is rejected and
+the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteFeaturedCluster`
+
+This API is used to delete the content of Featured Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteFeaturedCluster()
+
+### Java
+
+    client.deleteFeaturedCluster();
+
+When the service receives the request, it removes the existing data from the
+Featured Cluster. In case of an error, the entire request is rejected and the
+existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteContinuationCluster`
+
+This API is used to delete the content of Continuation Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteContinuationCluster()
+
+### Java
+
+    client.deleteContinuationCluster();
+
+When the service receives the request, it removes the existing data from the
+Continuation Cluster. In case of an error, the entire request is rejected and
+the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteUserManagementCluster`
+
+This API is used to delete the content of UserAccountManagement Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteUserManagementCluster()
+
+### Java
+
+    client.deleteUserManagementCluster();
+
+When the service receives the request, it removes the existing data from the
+UserAccountManagement Cluster. In case of an error, the entire request is
+rejected and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteClusters`
+
+This API is used to delete the content of a given cluster type.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteClusters(
+        DeleteClustersRequest.Builder()
+          .addClusterType(ClusterType.TYPE_CONTINUATION)
+          .addClusterType(ClusterType.TYPE_FEATURED)
+          .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+          .build())
+
+### Java
+
+    client.deleteClusters(
+                new DeleteClustersRequest.Builder()
+                    .addClusterType(ClusterType.TYPE_CONTINUATION)
+                    .addClusterType(ClusterType.TYPE_FEATURED)
+                    .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+                    .build());
+
+When the service receives the request, it removes the existing data from all
+clusters matching the specified cluster types. Clients can choose to pass one or
+many cluster types. In case of an error, the entire request is rejected and the
+existing state is maintained.
+
+#### Error handling
+
+It is highly recommended to listen to the task result from the publish APIs such
+that a follow-up action can be taken to recover and resubmit an successful task.
+
+### Kotlin
+
+    client.publishRecommendationClusters(
+            PublishRecommendationClustersRequest.Builder()
+              .addRecommendationCluster(..)
+              .build())
+          .addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+              // do something
+            } else {
+              val exception = task.exception
+              if (exception is AppEngageException) {
+                @AppEngageErrorCode val errorCode = exception.errorCode
+                if (errorCode == AppEngageErrorCode.SERVICE_NOT_FOUND) {
+                  // do something
+                }
+              }
+            }
+          }
+
+### Java
+
+    client.publishRecommendationClusters(
+                  new PublishRecommendationClustersRequest.Builder()
+                      .addRecommendationCluster(...)
+                      .build())
+              .addOnCompleteListener(
+                  task -> {
+                    if (task.isSuccessful()) {
+                      // do something
+                    } else {
+                      Exception exception = task.getException();
+                      if (exception instanceof AppEngageException) {
+                        @AppEngageErrorCode
+                        int errorCode = ((AppEngageException) exception).getErrorCode();
+                        if (errorCode == AppEngageErrorCode.SERVICE_NOT_FOUND) {
+                          // do something
+                        }
+                      }
+                    }
+                  });
+
+The error is returned as an `AppEngageException` with the cause included as an
+error code.
+
+| Error code | Error name | Note |
+|---|---|---|
+| `1` | `SERVICE_NOT_FOUND` | The service is not available on the given device. |
+| `2` | `SERVICE_NOT_AVAILABLE` | The service is available on the given device, but it is not available at the time of the call (for example, it is explicitly disabled). |
+| `3` | `SERVICE_CALL_EXECUTION_FAILURE` | The task execution failed due to threading issues. In this case, it can be retried. |
+| `4` | `SERVICE_CALL_PERMISSION_DENIED` | The caller is not allowed to make the service call. |
+| `5` | `SERVICE_CALL_INVALID_ARGUMENT` | The request contains invalid data (for example, more than the allowed number of clusters). |
+| `6` | `SERVICE_CALL_INTERNAL` | There is an error on the service side. |
+| `7` | `SERVICE_CALL_RESOURCE_EXHAUSTED` | The service call is made too frequently. |
+
+### Step 3: Handle broadcast intents
+
+In addition to making publish content API calls through a job, it is also
+required to set up a
+[`BroadcastReceiver`](https://developer.android.com/reference/android/content/BroadcastReceiver) to receive
+the request for a content publish.
+
+The goal of broadcast intents is mainly for app reactivation and forcing data
+sync. Broadcast intents are not designed to be sent very frequently. It is only
+triggered when the Engage Service determines the content might be stale (for
+example, a week old). That way, there is more confidence that the user can have
+a fresh content experience, even if the application has not been executed for a
+long period of time.
+
+The `BroadcastReceiver` must be set up in the following two ways:
+
+- Dynamically register an instance of the `BroadcastReceiver` class using
+  `Context.registerReceiver()`. This enables communication from applications
+  that are still live in memory.
+
+### Kotlin
+
+    class AppEngageBroadcastReceiver : BroadcastReceiver(){
+      // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+      // is received
+      // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is received
+      // Trigger continuation cluster publish when PUBLISH_CONTINUATION broadcast is
+      // received
+    }
+
+    fun registerBroadcastReceivers(context: Context){
+      var  context = context
+      context = context.applicationContext
+
+    // Register Recommendation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_RECOMMENDATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Featured Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_FEATURED),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Continuation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_CONTINUATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+    }
+
+### Java
+
+    class AppEngageBroadcastReceiver extends BroadcastReceiver {
+    // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+    // is received
+
+    // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is received
+
+    // Trigger continuation cluster publish when PUBLISH_CONTINUATION broadcast is
+    // received
+    }
+
+    public static void registerBroadcastReceivers(Context context) {
+
+    context = context.getApplicationContext();
+
+    // Register Recommendation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Featured Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Continuation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_CONTINUATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+    }
+
+- Statically declare an implementation with the `<receiver>` tag in your
+  `AndroidManifest.xml` file. This allows the application to receive broadcast
+  intents when it is not running, and also allows the application to publish
+  the content.
+
+    <application>
+       <receiver
+          android:name=".AppEngageBroadcastReceiver"
+          android:permission="com.google.android.engage.REQUEST_ENGAGE_DATA"
+          android:exported="true"
+          android:enabled="true">
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_RECOMMENDATION" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_FEATURED" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_CONTINUATION" />
+          </intent-filter>
+       </receiver>
+    </application>
+
+The following [intents](https://developer.android.com/reference/android/content/Intent) is sent by the
+service:
+
+- `com.google.android.engage.action.PUBLISH_RECOMMENDATION` It is recommended to start a `publishRecommendationClusters` call when receiving this intent.
+- `com.google.android.engage.action.PUBLISH_FEATURED` It is recommended to start a `publishFeaturedCluster` call when receiving this intent.
+- `com.google.android.engage.action.PUBLISH_CONTINUATION` It is recommended to start a `publishContinuationCluster` call when receiving this intent.
+
+## Integration workflow
+
+For a step-by-step guide on verifying your integration after it is complete, see
+[Engage developer integration workflow](https://developer.android.com/guide/playcore/engage/workflow).
+
+## FAQs
+
+See [Engage SDK Frequently Asked Questions](https://developer.android.com/guide/playcore/engage/faq) for
+FAQs.
+
+## Contact
+
+Contact
+[`engage-developers@google.com`](mailto:engage-developers@google.com) if there are
+any questions during the integration process.
+
+## Next steps
+
+After completing this integration, your next steps are as follows:
+
+- Send an email to [`engage-developers@google.com`](mailto:engage-developers@google.com) and attach your integrated APK that is ready for testing by Google.
+- Google performs a verification and reviews internally to make sure the integration works as expected. If changes are needed, Google contacts you with any necessary details.
+- When testing is complete and no changes are needed, Google contacts you to notify you that you can start publishing the updated and integrated APK to the Play Store.
+- After Google has confirmed that your updated APK has been published to the Play Store, your **Recommendation** , **Featured** , and **Continuation** clusters may be published and visible to users.

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/read.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/read.md
@@ -1,0 +1,893 @@
+> [!IMPORTANT]
+> **Important:** Engage SDK has superseded Media Home, which is now deprecated. If you have an existing Media Home integration, follow the instructions in these guides to migrate your content to Engage SDK, which allows your content to be published to more devices and form factors. Please contact [`engage-developers@google.com`](mailto:engage-developers@google.com) if you have any questions.
+
+Boost app engagement by reaching your users where they are. Integrate Engage SDK
+to deliver personalized recommendations and continuation content directly to
+users across multiple on-device surfaces, like
+**[Collections](https://android-developers.googleblog.com/2024/07/introducing-collections-powered-by-engage-sdk.html)** , **[Entertainment
+Space](https://blog.google/products/android/entertainment-space/)** , and the Play Store. The integration adds
+less than 50 KB (compressed) to the average APK and takes most apps about a
+week of developer time. Learn more at our **[business
+site](http://play.google.com/console/about/programs/EngageSDK)**.
+
+This guide contains instructions for developer partners to deliver reading
+content (eBooks, Audiobooks, Comics/Manga) to Engage content surfaces.
+
+## Integration detail
+
+### Terminology
+
+This integration includes the following three cluster types: **Recommendation** ,
+**Continuation** , and **Featured**.
+
+- **Recommendation** clusters show personalized suggestions for content to read
+  from an individual developer partner.
+
+  Your recommendations take the following structure:
+  - **Recommendation Cluster:** A UI view that contains a group of
+    recommendations from a single developer partner.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/read-term-1.png) **Figure 1.** Entertainment Space UI showing a Recommendation Cluster from a single partner.
+  - **Entity:** An object representing a single item in a cluster. An entity
+    can be an ebook, an audio book, a book series, and more. See the [Provide
+    entity data](https://developer.android.com/guide/playcore/engage/read#provide-entity-data) section for a list of supported entity
+    types.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/read-term-2.png) **Figure 2.** Entertainment Space UI showing a single Entity within a single partner's Recommendation Cluster.
+- The **Continuation** cluster shows unfinished books from multiple developer
+  partners in a single UI grouping. Each developer partner will be allowed to
+  broadcast a maximum of 10 entities in the Continuation cluster.
+
+  ![](https://developer.android.com/static/images/guide/playcore/engage/read-term-3.png) **Figure 3.** Entertainment Space UI showing a Continuation cluster with unfinished recommendations from multiple partners (only one recommendation is currently visible).
+- The **Featured** cluster showcases a selection of items from multiple
+  developer partners in a single UI grouping. There will be a single Featured
+  cluster, which is surfaced near the top of the UI with a priority placement
+  above all Recommendation clusters. Each developer partner will be allowed to
+  broadcast up to 10 entities in the Featured cluster.
+
+  ![](https://developer.android.com/static/images/guide/playcore/engage/read-term-4.png) **Figure 4.** Entertainment Space UI showing a Featured cluster with recommendations from multiple partners (only one recommendation is currently visible).
+
+### Pre-work
+
+Minimum API level: 19
+
+Add the `com.google.android.engage:engage-core` library to your app:
+
+    dependencies {
+        // Make sure you also include that repository in your project's build.gradle file.
+        implementation 'com.google.android.engage:engage-core:1.6.0'
+    }
+
+### Summary
+
+The design is based on an implementation of a [bound
+service](https://developer.android.com/guide/components/bound-services).
+
+The data a client can publish is subject to the following limits for different
+cluster types:
+
+| Cluster type | Cluster limits | Maximum entity limits in a cluster |
+|---|---|---|
+| Recommendation Cluster(s) | At most 7 | At most 50 |
+| Continuation Cluster | At most 1 | At most 20 |
+| Featured Cluster | At most 1 | At most 20 |
+
+### Step 1: Provide entity data
+
+The SDK has defined different entities to represent each item type. We support
+the following entities for the Read category:
+
+1. `EbookEntity`
+2. `AudiobookEntity`
+3. `BookSeriesEntity`
+
+The charts below outline available attributes and requirements for each type.
+
+#### `EbookEntity`
+
+The `EbookEntity` object represents an ebook (for example, the ebook of
+*Becoming* by Michelle Obama).
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** |   |
+| Poster images | **Required** | At least one image must be provided. See [Image Specifications](https://developer.android.com/guide/playcore/engage/read#image-specs) for guidance. |
+| Author | **Required** | At least one author name must be provided. |
+| Action link uri | **Required** | The deep link to the provider app for the ebook. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Publish date | Optional | In epoch milliseconds if provided. |
+| Description | Optional | Must be within 200 characters if provided. |
+| Price | Optional | Free text |
+| Page count | Optional | Must be a positive integer if provided. |
+| Genre | Optional | List of genres associated with the book. |
+| Series name | Optional | Name of the series that the ebook belongs to (for example, *Harry Potter*). |
+| Series unit index | Optional | The index of the ebook in the series, where 1 is the first ebook in the series. For example, if *Harry Potter and the Prisoner of Azkaban* is the 3rd book in the series, this should be set to 3. |
+| Continue book type | Optional | TYPE_CONTINUE - Resume on a unfinished book. TYPE_NEXT - Continue on a new one of a series. TYPE_NEW - Newly released. |
+| Last Engagement Time | Conditionally required | Must be provided when the item is in the Continuation cluster. \*Newly\* acquired ebooks can be a part of the continue reading cluster. In epoch milliseconds. |
+| Progress Percentage Complete | Conditionally required | Must be provided when the item is in the Continuation cluster. Value must be greater than 0 and less than 100. |
+| **DisplayTimeWindow - Set a time window for a content to be shown on the surface** |||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. In epoch milliseconds. |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. In epoch milliseconds. |
+
+#### `AudiobookEntity`
+
+The `AudiobookEntity` object represents an audiobook (for example, the audiobook
+of *Becoming* by Michelle Obama).
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** |   |
+| Poster images | **Required** | At least one image must be provided. See [Image Specifications](https://developer.android.com/guide/playcore/engage/read#image-specs) for guidance. |
+| Author | **Required** | At least one author name must be provided. |
+| Action link uri | **Required** | The deep link to the provider app for the audiobook. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Narrator | Optional | At least one narrator's name must be provided. |
+| Publish date | Optional | In epoch milliseconds if provided. |
+| Description | Optional | Must be within 200 characters if provided. |
+| Price | Optional | Free text |
+| Duration | Optional | Must be a positive value if provided. |
+| Genre | Optional | List of genres associated with the book. |
+| Series name | Optional | Name of the series that the audiobook belongs to (for example, *Harry Potter*. |
+| Series unit index | Optional | The index of the audiobook in the series, where 1 is the first audiobook in the series. For example, if *Harry Potter and the Prisoner of Azkaban* is the 3rd book in the series, this should be set to 3. |
+| Continue book type | Optional | TYPE_CONTINUE - Resume on a unfinished book. TYPE_NEXT - Continue on a new one of a series. TYPE_NEW - Newly released. |
+| Last Engagement Time | Conditionally required | Must be provided when the item is in the Continuation cluster. In epoch milliseconds. |
+| Progress Percentage Complete | Conditionally required | Must be provided when the item is in the Continuation cluster. \*Newly\* acquired audiobooks can be a part of the continue reading cluster. Value must be greater than 0 and less than 100. |
+| **DisplayTimeWindow - Set a time window for a content to be shown on the surface** |||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. In epoch milliseconds. |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. In epoch milliseconds. |
+
+#### `BookSeriesEntity`
+
+The `BookSeriesEntity` object represents a book series (for example, the *Harry
+Potter* book series, which has 7 books).
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** |   |
+| Poster images | **Required** | At least one image must be provided. See [Image Specifications](https://developer.android.com/guide/playcore/engage/read#image-specs) for guidance. |
+| Author | **Required** | At least one author name must be present. |
+| Action link uri | **Required** | The deep link to the provider app for the audiobook or ebook. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Book count | **Required** | Number of books in the series. |
+| Description | Optional | Must be within 200 characters if provided. |
+| Genre | Optional | List of genres associated with the book. |
+| Continue book type | Optional | TYPE_CONTINUE - Resume on a unfinished book. TYPE_NEXT - Continue on a new one of a series. TYPE_NEW - Newly released. |
+| Last Engagement Time | Conditionally required | Must be provided when the item is in the Continuation cluster. In epoch milliseconds. |
+| Progress Percentage Complete | Conditionally required | Must be provided when the item is in the Continuation cluster. \*Newly\* acquired book series can be a part of the continue reading cluster. Value must be greater than 0 and less than 100. |
+| **DisplayTimeWindow - Set a time window for a content to be shown on the surface** |||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. In epoch milliseconds. |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. In epoch milliseconds. |
+
+#### Image specifications
+
+Required specifications for image assets are listed below:
+
+| Aspect ratio | Supported cluster(s) | Minimum pixels | Recommended pixels |
+|---|---|---|---|
+| Square (1x1) | All clusters | 300x300 | 1200x1200 |
+| Landscape (1.91x1) | Featured and continuation | 600x314 | 1200x628 |
+| Portrait (4x5) | Recommendation | 480x600 | 960x1200 |
+
+*File formats*
+
+PNG, JPG, static GIF, WebP
+
+*Maximum file size*
+
+5120 KB
+
+*Additional recommendations*
+
+- **Image safe area:** Put your important content in the center 80% of the image.
+
+#### Example
+
+    AudiobookEntity audiobookEntity =
+            new AudiobookEntity.Builder()
+                .setName("Becoming")
+                .addPosterImage(
+                          new Image.Builder()
+                              .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                              .setImageHeightInPixel(960)
+                              .setImageWidthInPixel(408)
+                              .build())
+                .addAuthor("Michelle Obama")
+                .addNarrator("Michelle Obama")
+                .setActionLinkUri(Uri.parse("https://play.google/audiobooks/1"))
+                .setDurationMillis(16335L)
+                .setPublishDateEpochMillis(1633032895L)
+                .setDescription("An intimate, powerful, and inspiring memoir")
+                .setPrice("$16.95")
+                .addGenre("biography")
+                .build();
+
+### Step 2: Provide Cluster data
+
+It's recommended to have the content publish job executed in the background
+(for example, using [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager))
+and scheduled on a regular basis or on an event basis (for example, every time
+the user opens the app or when the user just added something to their cart).
+
+`AppEngagePublishClient` is responsible for publishing clusters. Following
+APIs are available in the client:
+
+- `isServiceAvailable`
+- `publishRecommendationClusters`
+- `publishFeaturedCluster`
+- `publishContinuationCluster`
+- `publishUserAccountManagementRequest`
+- `updatePublishStatus`
+- `deleteRecommendationsClusters`
+- `deleteFeaturedCluster`
+- `deleteContinuationCluster`
+- `deleteUserManagementCluster`
+- `deleteClusters`
+
+#### `isServiceAvailable`
+
+This API is used to check if the service is available for integration and
+whether the content can be presented on the device.
+
+##### For Engage SDK v1.6.0 and higher (Recommended)
+
+You can check the service availability for every cluster type that you intend to
+publish. The `isServiceAvailable` API accepts a request object,
+`ServiceAvailabilityRequest`, which contains the cluster types for which service
+availability needs to be checked. You can find the `ClusterType` enum values
+required for `ServiceAvailabilityRequest` from the following table.
+
+| Cluster Type | Cluster Type Constant | Integer Value |
+|---|---|---|
+| Unknown | `TYPE_UNKNOWN` | 0 |
+| Recommendation Cluster | `TYPE_RECOMMENDATION` | 1 |
+| Featured Cluster | `TYPE_FEATURED` | 2 |
+| Continuation Cluster | `TYPE_CONTINUATION` | 3 |
+| User Management Cluster | `TYPE_ENGAGEMENT` | 8 |
+| Subscription Cluster | `TYPE_SUBSCRIPTION` | 12 |
+
+### Kotlin
+
+    val request = ServiceAvailabilityRequest.Builder()
+        .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+        .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+        .build()
+
+    client.isServiceAvailable(request).addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            val availabilityMap = task.result
+            if (availabilityMap[ClusterType.TYPE_CONTINUATION] == true) {
+                // Proceed with publishing continuation content
+            }
+            if (availabilityMap[ClusterType.TYPE_RECOMMENDATION] == true) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    }
+
+### Java
+
+    ServiceAvailabilityRequest request =
+        new ServiceAvailabilityRequest.Builder()
+            .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+            .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+            .build();
+
+    client.isServiceAvailable(request).addOnCompleteListener(task -> {
+        if (task.isSuccessful()) {
+            Map<Integer, Boolean> availabilityMap = task.getResult();
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_CONTINUATION))) {
+                // Proceed with publishing continuation content
+            }
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_RECOMMENDATION))) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here such as retry.
+        }
+    });
+
+###### Conditional Service Availability Feature
+
+Some integrated apps request a special configuration that enables and disables
+the Engage service intermittently in order to reduce their serving cost. This
+intermittent content ingestion strategy, although possible, negatively affects
+the user and the product -- stale content will not be presented and some surfaces
+will not be served at all.
+
+Starting with v1.6.0, the Engage SDK allows checking availability for specific
+cluster types. This provides more flexibility so that if the intermittent
+content strategy was adopted by a given application, some cluster types can
+follow that intermittent strategy while other cluster types are always enabled
+(i.e. continuation clusters).
+
+If the Engage service should not be 'continuously' enabled on all supported
+devices for whatever reason, and is configured for intermittent ingestion for
+any set of devices, all continuation cluster publications (e.g. Continue
+Reading) will be still enabled by default
+configuration, and the rest of the cluster types will be enabled and disabled
+intermittently. If intermittent ingestion applies to you but this default
+configuration is not suitable for your needs, please contact
+engage-developers@google.com.
+
+##### For SDK versions prior to v1.6.0 (Deprecated)
+
+### Kotlin
+
+    client.isServiceAvailable.addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            // Handle IPC call success
+            if(task.result) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    }
+
+### Java
+
+    client.isServiceAvailable().addOnCompleteListener(task - > {
+        if (task.isSuccessful()) {
+            // Handle success
+            if(task.getResult()) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    });
+
+> [!NOTE]
+> **Note:** We highly recommend keeping a periodic job running to check if the service becomes available at a later point in time. The availability of the service may change with Android version upgrades, app upgrades, installs, and uninstalls. By ensuring periodic job checks at a certain time interval, data can be published once the service becomes available.
+
+#### `publishRecommendationClusters`
+
+This API is used to publish a list of `RecommendationCluster` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishRecommendationClusters(
+                PublishRecommendationClustersRequest.Builder()
+                    .addRecommendationCluster(
+                        RecommendationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .setTitle("Reconnect with yourself")
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishRecommendationClusters(
+                new PublishRecommendationClustersRequest.Builder()
+                    .addRecommendationCluster(
+                        new RecommendationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .setTitle("Reconnect with yourself")
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `RecommendationCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Recommendation Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishFeaturedCluster`
+
+This API is used to publish a list of `FeaturedCluster` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishFeaturedCluster(
+                PublishFeaturedClusterRequest.Builder()
+                    .setFeaturedCluster(
+                        FeaturedCluster.Builder()
+                            ...
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishFeaturedCluster(
+                new PublishFeaturedClusterRequest.Builder()
+                    .setFeaturedCluster(
+                        new FeaturedCluster.Builder()
+                            ...
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `FeaturedCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Featured Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishContinuationCluster`
+
+This API is used to publish a `ContinuationCluster` object.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishContinuationCluster(
+                PublishContinuationClusterRequest.Builder()
+                    .setContinuationCluster(
+                        ContinuationCluster.Builder()
+                            .addEntity(book_entity1)
+                            .addEntity(book_entity2)
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishContinuationCluster(
+                PublishContinuationClusterRequest.Builder()
+                    .setContinuationCluster(
+                        ContinuationCluster.Builder()
+                            .addEntity(book_entity1)
+                            .addEntity(book_entity2)
+                            .build())
+                    .build())
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `ContinuationCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Continuation Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishUserAccountManagementRequest`
+
+This API is used to publish a Sign In card . The signin action directs users to
+the app's sign in page so that the app can publish content (or provide more
+personalized content)
+
+The following metadata is part of the Sign In Card -
+
+| Attribute | Requirement | Description |
+|---|---|---|
+| Action Uri | Required | Deeplink to Action (i.e. navigates to app sign in page) |
+| Image | Optional - If not provided, Title must be provided | Image Shown on the Card 16x9 aspect ratio images with a resolution of 1264x712 |
+| Title | Optional - If not provided, Image must be provided | Title on the Card |
+| Action Text | Optional | Text Shown on the CTA (i.e. Sign in) |
+| Subtitle | Optional | Optional Subtitle on the Card |
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    var SIGN_IN_CARD_ENTITY =
+          SignInCardEntity.Builder()
+              .addPosterImage(
+                  Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build()
+
+    client.publishUserAccountManagementRequest(
+                PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+### Java
+
+    SignInCardEntity SIGN_IN_CARD_ENTITY =
+          new SignInCardEntity.Builder()
+              .addPosterImage(
+                  new Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build();
+
+    client.publishUserAccountManagementRequest(
+                new PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `UserAccountManagementCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated UserAccountManagementCluster Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `updatePublishStatus`
+
+If for any internal business reason, none of the clusters is published,
+we **strongly recommend** updating the publish status using the
+**updatePublishStatus** API.
+This is important because :
+
+- Providing the status in all scenarios, even when the content is published (STATUS == PUBLISHED), is critical to populate dashboards that use this explicit status to convey the health and other metrics of your integration.
+- If no content is published but the integration status isn't broken (STATUS == NOT_PUBLISHED), Google can avoid triggering alerts in the app health dashboards. It confirms that content is not published due to an **expected** situation from the provider's standpoint.
+- It helps developers provide insights into when the data is published versus not.
+- Google may use the status codes to nudge the user to do certain actions in the app so they can see the app content or overcome it.
+
+The list of eligible publish status codes are :
+
+    // Content is published
+    AppEngagePublishStatusCode.PUBLISHED,
+
+    // Content is not published as user is not signed in
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN,
+
+    // Content is not published as user is not subscribed
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SUBSCRIPTION,
+
+    // Content is not published as user location is ineligible
+    AppEngagePublishStatusCode.NOT_PUBLISHED_INELIGIBLE_LOCATION,
+
+    // Content is not published as there is no eligible content
+    AppEngagePublishStatusCode.NOT_PUBLISHED_NO_ELIGIBLE_CONTENT,
+
+    // Content is not published as the feature is disabled by the client
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_FEATURE_DISABLED_BY_CLIENT,
+
+    // Content is not published as the feature due to a client error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR,
+
+    // Content is not published as the feature due to a service error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR,
+
+    // Content is not published due to some other reason
+    // Reach out to engage-developers@ before using this enum.
+    AppEngagePublishStatusCode.NOT_PUBLISHED_OTHER
+
+If the content is not published due to a user not logged in,
+Google would recommend publishing the Sign In Card.
+If for any reason providers are not able to publish the Sign In Card
+then we recommend calling the **updatePublishStatus** API
+with the status code **NOT_PUBLISHED_REQUIRES_SIGN_IN**
+
+### Kotlin
+
+    client.updatePublishStatus(
+       PublishStatusRequest.Builder()
+         .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+         .build())
+
+### Java
+
+    client.updatePublishStatus(
+        new PublishStatusRequest.Builder()
+            .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+            .build());
+
+#### `deleteRecommendationClusters`
+
+This API is used to delete the content of Recommendation Clusters.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteRecommendationClusters()
+
+### Java
+
+    client.deleteRecommendationClusters();
+
+When the service receives the request, it removes the existing data from the
+Recommendation Clusters. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteFeaturedCluster`
+
+This API is used to delete the content of Featured Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteFeaturedCluster()
+
+### Java
+
+    client.deleteFeaturedCluster();
+
+When the service receives the request, it removes the existing data from the
+Featured Cluster. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteContinuationCluster`
+
+This API is used to delete the content of Continuation Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteContinuationCluster()
+
+### Java
+
+    client.deleteContinuationCluster();
+
+When the service receives the request, it removes the existing data from the
+Continuation Cluster. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteUserManagementCluster`
+
+This API is used to delete the content of UserAccountManagement Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteUserManagementCluster()
+
+### Java
+
+    client.deleteUserManagementCluster();
+
+When the service receives the request, it removes the existing data from the
+UserAccountManagement Cluster. In case of an error, the entire request is
+rejected and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteClusters`
+
+This API is used to delete the content of a given cluster type.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteClusters(
+        DeleteClustersRequest.Builder()
+          .addClusterType(ClusterType.TYPE_FEATURED)
+          .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+          ...
+          .build())
+
+### Java
+
+    client.deleteClusters(
+                new DeleteClustersRequest.Builder()
+                    .addClusterType(ClusterType.TYPE_FEATURED)
+                    .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+                    ...
+                    .build());
+
+When the service receives the request, it removes the existing data from all
+clusters matching the specified cluster types. Clients can choose to pass one or
+many cluster types. In case of an error, the entire request is rejected and the
+existing state is maintained.
+
+#### Error handling
+
+It is highly recommended to listen to the task result from the publish APIs such
+that a follow-up action can be taken to recover and resubmit an successful task.
+
+    client.publishRecommendationClusters(
+                  new PublishRecommendationClustersRequest.Builder()
+                      .addRecommendationCluster(...)
+                      .build())
+              .addOnCompleteListener(
+                  task -> {
+                    if (task.isSuccessful()) {
+                      // do something
+                    } else {
+                      Exception exception = task.getException();
+                      if (exception instanceof AppEngageException) {
+                        @AppEngageErrorCode
+                        int errorCode = ((AppEngageException) exception).getErrorCode();
+                        if (errorCode == AppEngageErrorCode.SERVICE_NOT_FOUND) {
+                          // do something
+                        }
+                      }
+                    }
+                  });
+
+The error is returned as an `AppEngageException` with the cause included as an
+error code.
+
+| Error code | Error name | Note |
+|---|---|---|
+| `1` | `SERVICE_NOT_FOUND` | The service is not available on the given device. |
+| `2` | `SERVICE_NOT_AVAILABLE` | The service is available on the given device, but it is not available at the time of the call (for example, it is explicitly disabled). |
+| `3` | `SERVICE_CALL_EXECUTION_FAILURE` | The task execution failed due to threading issues. In this case, it can be retried. |
+| `4` | `SERVICE_CALL_PERMISSION_DENIED` | The caller is not allowed to make the service call. |
+| `5` | `SERVICE_CALL_INVALID_ARGUMENT` | The request contains invalid data (for example, more than the allowed number of clusters). |
+| `6` | `SERVICE_CALL_INTERNAL` | There is an error on the service side. |
+| `7` | `SERVICE_CALL_RESOURCE_EXHAUSTED` | The service call is made too frequently. |
+
+### Step 3: Handle broadcast intents
+
+In addition to making publish content API calls through a job, it is also
+required to set up a
+[`BroadcastReceiver`](https://developer.android.com/reference/android/content/BroadcastReceiver) to receive
+the request for a content publish.
+
+The goal of broadcast intents is mainly for app reactivation and forcing data
+sync. Broadcast intents are not designed to be sent very frequently. It is only
+triggered when the Engage Service determines the content might be stale (for
+example, a week old). That way, there is more confidence that the user can have
+a fresh content experience, even if the application has not been executed for a
+long period of time.
+
+The `BroadcastReceiver` must be set up in the following two ways:
+
+- Dynamically register an instance of the `BroadcastReceiver` class using
+  `Context.registerReceiver()`. This enables communication from applications
+  that are still live in memory.
+
+### Kotlin
+
+    class AppEngageBroadcastReceiver : BroadcastReceiver(){
+      // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+      // is received
+      // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is received
+      // Trigger continuation cluster publish when PUBLISH_CONTINUATION broadcast is
+      // received
+    }
+
+    fun registerBroadcastReceivers(context: Context){
+      var  context = context
+      context = context.applicationContext
+
+    // Register Recommendation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_RECOMMENDATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Featured Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_FEATURED),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Continuation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_CONTINUATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+    }
+
+### Java
+
+    class AppEngageBroadcastReceiver extends BroadcastReceiver {
+    // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+    // is received
+
+    // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is received
+
+    // Trigger continuation cluster publish when PUBLISH_CONTINUATION broadcast is
+    // received
+    }
+
+    public static void registerBroadcastReceivers(Context context) {
+
+    context = context.getApplicationContext();
+
+    // Register Recommendation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Featured Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Continuation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_CONTINUATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    }
+
+- Statically declare an implementation with the `<receiver>` tag in your
+  `AndroidManifest.xml` file. This allows the application to receive broadcast
+  intents when it is not running, and also allows the application to publish
+  the content.
+
+    <application>
+       <receiver
+          android:name=".AppEngageBroadcastReceiver"
+          android:permission="com.google.android.engage.REQUEST_ENGAGE_DATA"
+          android:exported="true"
+          android:enabled="true">
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_RECOMMENDATION" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_FEATURED" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_CONTINUATION" />
+          </intent-filter>
+       </receiver>
+    </application>
+
+The following [intents](https://developer.android.com/reference/android/content/Intent) will be sent by the
+service:
+
+- `com.google.android.engage.action.PUBLISH_RECOMMENDATION` It is recommended to start a `publishRecommendationClusters` call when receiving this intent.
+- `com.google.android.engage.action.PUBLISH_FEATURED` It is recommended to start a `publishFeaturedCluster` call when receiving this intent.
+- com.google.android.engage.action.PUBLISH_CONTINUATION`It is recommended to start a`publishContinuationCluster\` call when receiving this intent.
+
+## Integration workflow
+
+For a step-by-step guide on verifying your integration after it is complete, see
+[Engage developer integration workflow](https://developer.android.com/guide/playcore/engage/workflow).
+
+## FAQs
+
+See [Engage SDK Frequently Asked Questions](https://developer.android.com/guide/playcore/engage/faq) for
+FAQs.
+
+## Contact
+
+Contact [`engage-developers@google.com`](mailto:engage-developers@google.com) if there are any questions during
+the integration process. Our team will reply as soon as possible.
+
+## Next steps
+
+After completing this integration, your next steps are as follows:
+
+- Send an email to [`engage-developers@google.com`](mailto:engage-developers@google.com) and attach your integrated APK that is ready for testing by Google.
+- Google will perform a verification and review internally to make sure the integration works as expected. If changes are needed, Google will contact you with any necessary details.
+- When testing is complete and no changes are needed, Google will contact you to notify you that you can start publishing the updated and integrated APK to the Play Store.
+- After Google has confirmed that your updated APK has been published to the Play Store, your **Recommendation** , **Featured** , and **Continuation** clusters will be published and visible to users.

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/shopping.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/shopping.md
@@ -1,0 +1,1207 @@
+Boost app engagement by reaching your users where they are. Integrate Engage SDK
+to deliver personalized recommendations and continuation content directly to
+users across multiple on-device surfaces, like
+**[Collections](https://android-developers.googleblog.com/2024/07/introducing-collections-powered-by-engage-sdk.html)** , **[Entertainment
+Space](https://blog.google/products/android/entertainment-space/)** , and the Play Store. The integration adds
+less than 50 KB (compressed) to the average APK and takes most apps about a
+week of developer time. Learn more at our **[business
+site](http://play.google.com/console/about/programs/EngageSDK)**.
+
+This guide contains instructions for developer partners to deliver shopping
+content to Engage content surfaces.
+
+## Integration detail
+
+### Terminology
+
+This integration includes the following five cluster types: **Recommendation** ,
+**Featured** , **Shopping Cart** , **Shopping List** , **Reorder** and
+**Shopping Order Tracking**.
+
+- **Recommendation** clusters show personalized shopping suggestions from an
+  individual developer partner. These recommendations can be personalized to the
+  user or generalized (for example, trending items). Use these to surface
+  products, events, sales, promos, subscriptions as you see fit.
+
+  Your recommendations take the following structure:
+  - **Recommendation Cluster:** A UI view that contains a group of
+    recommendations from the same developer partner.
+
+  - **ShoppingEntity:** An object representing a single item in a cluster.
+
+- The **Featured** cluster showcases a selection of entities from multiple
+  developer partners in one UI grouping. There will be a single Featured
+  cluster, which is surfaced near the top of the UI with a priority placement
+  above all Recommendation clusters. Each developer partner will be allowed to
+  broadcast up to 10 entities in the Featured cluster.
+
+- The **Shopping Cart** cluster shows a sneak peek of shopping carts from many
+  developer partners in one UI grouping, nudging users to complete their
+  outstanding carts. There is a single Shopping Cart cluster, which is
+  surfaced near the top of the UI, with a priority placement above all
+  Recommendation clusters. Each developer partner is allowed to broadcast up to
+  3 `ShoppingCart` instances in the Shopping Cart cluster.
+
+  Your Shopping Cart takes the following structure:
+  - **Shopping Cart Cluster:** A UI view that contains a group of shopping
+    cart previews from many developer partners.
+
+  - **ShoppingCart:** An object representing the shopping cart preview
+    for a single developer partner, to be displayed in the Shopping Cart
+    cluster. The `ShoppingCart` must show the total count of items in the
+    cart and may also include images for some items in the user's cart.
+
+- The **Shopping List** cluster shows a sneak peek of the shopping
+  lists from multiple developer partners in one UI grouping, prompting users to
+  return to the corresponding app to update and complete their lists. There is a
+  single Shopping List cluster.
+
+- The **Reorder** cluster shows a sneak peek of the previous orders from
+  multiple developer partners in one UI grouping, prompting users to reorder.
+  There is a single Reorder cluster.
+
+  - Reorder cluster must show the total count of items in the
+    user's previous order and must also include one of the following:
+
+    - Images for X items in the user's previous order.
+    - Labels for X items in the user's previous order.
+- The **Shopping Order Tracking** cluster shows a sneak peek of pending
+  or recently completed shopping orders from many developer partners in one UI
+  grouping, allowing users to track their orders.
+
+  There is a single ShoppingOrderTracking cluster that is surfaced
+  near the top of the UI, with a priority placement above all Recommendation
+  clusters. Each developer partner is allowed to broadcast multiple
+  ShoppingOrderTrackingEntity items in the Shopping Order Tracking cluster.
+  - Your ShoppingOrderTrackingCluster takes the following structure:
+
+    - **ShoppingOrderTracking Cluster**: A UI view that contains a group of order tracking previews from many developer partners
+    - **ShoppingOrderTrackingEntity**: An object representing a shopping order tracking preview for a single developer partner, to be displayed in the Shopping Order Tracking cluster. The ShoppingOrderTrackingEntity must show the status of the order and the order time. We strongly recommend populating the expected delivery time for ShoppingOrderTrackingEntity, as it's displayed to users when provided.
+
+    > [!NOTE]
+    > **Note:** Provide multiple ShoppingOrderTrackingEntity objects if an order has been split into multiple shipments.
+
+### Pre-work
+
+Minimum API level: 19
+
+Add the `com.google.android.engage:engage-core` library to your app:
+
+    dependencies {
+        // Make sure you also include that repository in your project's build.gradle file.
+        implementation 'com.google.android.engage:engage-core:1.6.0'
+    }
+
+For more information, see [Package visibility in Android
+11](https://developer.android.com/about/versions/11/privacy/package-visibility).
+
+### Summary
+
+The design is based on an implementation of a [bound
+service](https://developer.android.com/guide/components/bound-services).
+
+The data a client can publish is subject to the following limits for different
+cluster types:
+
+| Cluster type | Cluster limits | Maximum entity limits in a cluster |
+|---|---|---|
+| Recommendation Cluster(s) | At most 7 | At most 50 `ShoppingEntity` |
+| Featured Cluster | At most 1 | At most 20 `ShoppingEntity` |
+| Shopping Cart Cluster | At most 1 | At most 3 `ShoppingCart` Multiple carts only expected for apps with separate carts per merchant. |
+| Shopping List Cluster | At most 1 | At most 3 `ShoppingList` |
+| Shopping Reorder Cluster | At most 1 | At most 1 `ReorderEntity` |
+| Shopping Order Tracking Cluster | At most 3 | At most 3 `ShoppingOrderTrackingEntity` |
+
+### Step 1: Provide entity data
+
+The SDK has defined different entities to represent each item type. The
+following entities are supported for the Shopping category:
+
+1. `ShoppingEntity`
+2. `ShoppingCart`
+3. `ShoppingList`
+4. `Reorder`
+5. `ShoppingOrderTracking`
+
+The charts below outline available attributes and requirements for each type.
+
+#### `ShoppingEntity`
+
+The `ShoppingEntity` object represents a product, promotion, deal, subscription,
+or event that developer partners want to publish.
+
+##### `ShoppingEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Poster images | **Required** | At least one image must be provided. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/shopping#image-specs) for guidance. |
+| Action Uri | **Required** | The deep link to the page in the app displaying details about the entity. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | Optional | The name of the entity. | Free text **Recommended text size: under 90 chars** (Text that is too long may show ellipses) |
+| Price - current | Conditionally required | The current price of the entity. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - strikethrough | Optional | The original price of the entity, which is be struck-through in the UI. | Free text |
+| Callout | Optional | Callout to feature a promo, event, or update for the entity, if available. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Callout fine print | Optional | Fine print text for the callout. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| **Rating (Optional) - Note: All ratings are displayed using our standard star rating system.** ||||
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the entity. **Note:** Provide this field if your app controls how the count is displayed to the users. Use a concise string. For example, if the count is 1,000,000, consider using an abbreviation like 1M so that the count isn't truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the entity. **Note:** Provide this field if you don't handle the display abbreviation logic yourself. If both Count and Count Value are present, Count is displayed to users. | Long |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `ShoppingCart`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | The deep link to the shopping cart in the partner's app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Number of items | **Required** | The number of items (not just number of products) in the shopping cart. **For example: If there are 3 identical shirts and 1 hat in the cart, this number should be 4.** | Integer \>= 1 |
+| Action Text | Optional | The call to action text of the button on the Shopping Cart (for example, *Your Shopping Bag*). **If no action text is provided by the developer, *View Cart* is the default.** This attribute is supported in version 1.1.0 onwards. | String |
+| Title | Optional | The title of the cart (for example, *Your Shopping Bag*). **If no title is provided by the developer, *Your cart* is the default.** **If developer partner publishes a separate cart per merchant, please include *merchant name* in the title.** | Free text **Recommended text size: under 25 chars** (Text that is too long may show ellipses) |
+| Cart images | Optional | Images of each product in the cart. **Up to 10 images can be provided in order of priority; the actual number of images displayed depends on the device form factor.** | See [Image Specifications](https://developer.android.com/guide/playcore/engage/shopping#image-specs) for guidance. |
+| Item labels | Optional | The list of labels for items on the shopping list. **The actual number of labels displayed depends on the device form factor.** | List of free text labels **Recommended text size: under 20 chars** (Text that is too long may show ellipses) |
+| Last user interaction timestamp | Optional | Number of milliseconds elapsed from the epoch, identifying the last time when user interacted with the cart. **This will be passed as input by the developer partners publishing separate cart per merchant and maybe used for ranking.** | Epoch timestamp in milliseconds |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `ShoppingList`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | The deep link to the shopping list in the partner's app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Number of items | **Required** | The number of items in the shopping list. | Integer \>= 1 |
+| Title | Optional | The title of the list (for example, *Your Grocery List*). **If no title is provided by the developer, *Shopping list* is the default.** | Free text **Recommended text size: under 25 chars** (Text that is too long may show ellipses) |
+| Item labels | **Required** | The list of labels for items on the shopping list. **At least 1 label must be provided and up to 10 labels can be provided in order of priority; the actual number of labels displayed depends on the device form factor.** | List of free text labels **Recommended text size: under 20 chars** (Text that is too long may show ellipses) |
+| Last user interaction timestamp | **Required** | Number of milliseconds elapsed from the epoch, identifying the last time when user interacted with the shopping list. | Epoch timestamp in milliseconds |
+
+#### `ShoppingReorderCluster`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | The deep link to reorder in the partner's app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Action Text | Optional | The call to action text of the button on the Reorder (for example, *Order again*). **If no action text is provided by the developer, *Reorder* is the default.** This attribute is supported in version 1.1.0 onwards. | String |
+| Number of items | **Required** | The number of items (not just number of products) in the previous order. **For example: If there were 3 small coffees and 1 croissant in the previous order, this number should be 4.** | Integer \>= 1 |
+| Title | **Required** | The title of the reorder item. | Free text **Recommended text size: under 40 chars** (Text that is too long may show ellipses) |
+| Item labels | Optional (If not provided, poster images should be provided) | The list of item labels for the previous order. **Up to 10 labels can be provided in order of priority; the actual number of labels displayed depends on the device form factor.** | List of free text **Recommended text size per label: under 20 chars** (Text that is too long may show ellipses) |
+| Poster images | Optional (If not provided, item labels should be provided) | Images of the items in the previous order. **Up to 10 images can be provided in order of priority; the actual number of images displayed depends on the device form factor.** | See [Image Specifications](https://developer.android.com/guide/playcore/engage/shopping#image-specs) for guidance. |
+
+#### `ShoppingOrderTrackingCluster`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Title | **Required** | A short title of the package/items being tracked or the tracking number. | Free text **Recommended text size: 50 chars (Text that is too long will show ellipses)** |
+| Order Type | **Required** | A short title of the package/items being tracked or the tracking number. | Enum: IN_STORE_PICKUP, SAME_DAY_DELIVERY, MULTI_DAY_DELIVERY |
+| Status | **Required** | The current status of the order. **For example: "Running late", "In transit", "Delayed", "Shipped", "Delivered", "Out of stock", "Order ready"** | Free text **Recommended text size: 25 chars (Text that is too long will show ellipses)** |
+| Order Time | **Required** | The epoch timestamp in milliseconds at which the order was placed. **Order time will be displayed if expected delivery time window is not present** | Epoch timestamp in milliseconds |
+| Action Uri | **Required** | Deep link to the order tracking in the partner's app. | Uri |
+| **OrderDeliveryTimeWindow (Optional) - Set a time window for the order that is being tracked from the time the order was placed to the time of expected/actual delivery.** ||||
+| OrderDeliveryTimeWindow - Start Time | Optional | The epoch timestamp in milliseconds on/after which the order will be delivered or be ready for pickup. | Epoch timestamp in milliseconds |
+| OrderDeliveryTimeWindow - End Time | Optional | The epoch timestamp in milliseconds on/before which the order will be delivered or be ready for pickup. | Epoch timestamp in milliseconds |
+| Poster images | Optional | Image of one item/product that is part of the order. Recommended aspect ratio is 1:1 | See [Image Specifications](https://developer.android.com/guide/playcore/engage/shopping#image-specs) for guidance. |
+| Number of items | Optional | The number of items in the order. | Integer \>= 1 |
+| Description | Optional | A single paragraph of text to describe the items in the order. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Order Value - CurrentPrice | Optional | The current value of the order. | Free text |
+| Order number | Optional | The order number/ID that can be used to uniquely identify the order. | Free text **Recommended text size: max 25 chars** |
+| Tracking number | Optional | The tracking number for the order/parcel delivery in case the order requires a delivery. | Free text **Recommended text size: max 25 chars** |
+
+#### Image specifications
+
+Required specifications for image assets are listed below:
+
+| Aspect ratio | Minimum pixels | Recommended pixels |
+|---|---|---|
+| Square (1x1) **Preferred for non featured clusters** | 300x300 | 1200x1200 |
+| Landscape (1.91x1) **Preferred for featured clusters** | 600x314 | 1200x628 |
+| Portrait (4x5) | 480x600 | 960x1200 |
+
+*File formats*
+
+PNG, JPG, static GIF, WebP
+
+*Maximum file size*
+
+5120 KB
+
+*Additional recommendations*
+
+- **Image safe area:** Put your important content in the center 80% of the image.
+- Use a transparent background so that the image can be properly displayed in Dark and Light theme settings.
+
+### Step 2: Provide Cluster data
+
+It is recommended to have the content publish job executed in the background
+(for example, using [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager))
+and scheduled on a regular basis or on an event basis (for example, every time
+the user opens the app or when the user just added something to their cart).
+
+`AppEngageShoppingClient` is responsible for publishing shopping clusters.
+
+Following APIs are exposed to publish clusters in the client:
+
+- `isServiceAvailable`
+- `publishRecommendationClusters`
+- `publishFeaturedCluster`
+- `publishShoppingCarts`
+- `publishShoppingLists`
+- `publishShoppingReorderCluster`
+- `publishShoppingOrderTrackingCluster`
+- `publishUserAccountManagementRequest`
+- `updatePublishStatus`
+- `deleteRecommendationsClusters`
+- `deleteFeaturedCluster`
+- `deleteShoppingCartCluster`
+- `deleteShoppingListCluster`
+- `deleteShoppingReorderCluster`
+- `deleteShoppingOrderTrackingCluster`
+- `deleteUserManagementCluster`
+- `deleteClusters`
+
+#### `isServiceAvailable`
+
+This API is used to check if the service is available for integration and
+whether the content can be presented on the device.
+
+##### For Engage SDK v1.6.0 and higher (Recommended)
+
+You can check the service availability for every cluster type that you intend to
+publish. The `isServiceAvailable` API accepts a request object,
+`ServiceAvailabilityRequest`, which contains the cluster types for which service
+availability needs to be checked. You can find the `ClusterType` enum values
+required for `ServiceAvailabilityRequest` from the following table.
+
+| Cluster Type | Cluster Type Constant | Integer Value |
+|---|---|---|
+| Unknown | `TYPE_UNKNOWN` | 0 |
+| Recommendation Cluster | `TYPE_RECOMMENDATION` | 1 |
+| Featured Cluster | `TYPE_FEATURED` | 2 |
+| Continuation Cluster | `TYPE_CONTINUATION` | 3 |
+| Shopping Cart Cluster | `TYPE_SHOPPING_CART` | 4 |
+| User Management Cluster | `TYPE_ENGAGEMENT` | 8 |
+| Shopping List Cluster | `TYPE_SHOPPING_LIST` | 9 |
+| Shopping Reorder Cluster | `TYPE_SHOPPING_REORDER` | 10 |
+| Shopping Order Tracking Cluster | `TYPE_SHOPPING_ORDER_TRACKING` | 11 |
+| Subscription Cluster | `TYPE_SUBSCRIPTION` | 12 |
+
+### Kotlin
+
+    val request = ServiceAvailabilityRequest.Builder()
+        .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+        .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+        .build()
+
+    client.isServiceAvailable(request).addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            val availabilityMap = task.result
+            if (availabilityMap[ClusterType.TYPE_CONTINUATION] == true) {
+                // Proceed with publishing continuation content
+            }
+            if (availabilityMap[ClusterType.TYPE_RECOMMENDATION] == true) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    }
+
+### Java
+
+    ServiceAvailabilityRequest request =
+        new ServiceAvailabilityRequest.Builder()
+            .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+            .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+            .build();
+
+    client.isServiceAvailable(request).addOnCompleteListener(task -> {
+        if (task.isSuccessful()) {
+            Map<Integer, Boolean> availabilityMap = task.getResult();
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_CONTINUATION))) {
+                // Proceed with publishing continuation content
+            }
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_RECOMMENDATION))) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    });
+
+###### Conditional Service Availability Feature
+
+Some integrated apps request a special configuration that enables and disables
+the Engage service intermittently in order to reduce their serving cost. This
+intermittent content ingestion strategy, although possible, negatively affects
+the user and the product -- stale content will not be presented and some surfaces
+will not be served at all.
+
+Starting with v1.6.0, the Engage SDK allows checking availability for specific
+cluster types. This provides more flexibility so that if the intermittent
+content strategy was adopted by a given application, some cluster types can
+follow that intermittent strategy while other cluster types are always enabled
+(i.e. continuation clusters).
+
+If the Engage service should not be 'continuously' enabled on all supported
+devices for whatever reason, and is configured for intermittent ingestion for
+any set of devices, all continuation cluster publications (e.g. Shopping
+Cart, Shopping List, Reorder, and Shopping Order Tracking) will be still
+enabled by default configuration, and the rest of the cluster types will be
+enabled and disabled intermittently. If intermittent ingestion applies to
+you but this default configuration is not suitable for your needs, please
+contact engage-developers@google.com.
+
+##### For SDK versions prior to v1.6.0 (Deprecated)
+
+### Kotlin
+
+    client.isServiceAvailable.addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            // Handle IPC call success
+            if(task.result) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    }
+
+### Java
+
+    client.isServiceAvailable().addOnCompleteListener(task - > {
+        if (task.isSuccessful()) {
+            // Handle success
+            if(task.getResult()) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    });
+
+> [!NOTE]
+> **Note:** We highly recommend keeping a periodic job running to check if the service becomes available at a later point in time. The availability of the service may change with Android version upgrades, app upgrades, installs, and uninstalls. By ensuring periodic job checks at a certain time interval, data can be published once the service becomes available.
+
+#### `publishRecommendationClusters`
+
+This API is used to publish a list of `RecommendationCluster` objects.
+
+A `RecommendationCluster` object can have the following attributes:
+
+| Attribute | Requirement | Description |
+|---|---|---|
+| List of ShoppingEntity | **Required** | A list of ShoppingEntity objects that make up the recommendations for this Recommendation Cluster. |
+| Title | **Required** | The title for the Recommendation Cluster. **Recommended text size: under 25 chars** (Text that is too long may show ellipses) |
+| Subtitle | Optional | The subtitle for the Recommendation Cluster. |
+| Action Uri | Optional | The deep link to the page in the partner app where users can see the complete list of recommendations. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishRecommendationClusters(
+                PublishRecommendationClustersRequest.Builder()
+                    .addRecommendationCluster(
+                        RecommendationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .setTitle("Black Friday Deals")
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishRecommendationClusters(
+                new PublishRecommendationClustersRequest.Builder()
+                    .addRecommendationCluster(
+                        new RecommendationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .setTitle("Black Friday Deals")
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- All existing Recommendation Cluster data is removed.
+- Data from the request is parsed and stored in new Recommendation Clusters.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishFeaturedCluster`
+
+This API is used to publish a `FeaturedCluster` object.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishFeaturedCluster(
+                PublishFeaturedClusterRequest.Builder()
+                    .setFeaturedCluster(
+                        FeaturedCluster.Builder()
+                            ...
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishFeaturedCluster(
+                new PublishFeaturedClusterRequest.Builder()
+                    .setFeaturedCluster(
+                        new FeaturedCluster.Builder()
+                            ...
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `FeaturedCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Featured Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishShoppingCarts`
+
+This API is used to publish a list of `ShoppingCart` objects. This is
+applicable to developer partner publishing separate carts per merchant. Include
+merchant name in the title when using this API.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishShoppingCarts(
+                PublishShoppingCartClustersRequest.Builder()
+                    .addShoppingCart(
+                        ShoppingCart.Builder()
+                            ...
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishShoppingCarts(
+                new PublishShoppingCartClustersRequest.Builder()
+                    .addShoppingCart(
+                        new ShoppingCart.Builder()
+                            ...
+                            .build())
+                    .build())
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `ShoppingCart` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Shopping Cart Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishShoppingLists`
+
+This API is used to publish a list of `ShoppingList` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishShoppingLists(
+                PublishShoppingListsRequest.Builder()
+                    .addShoppingList(
+                        ShoppingList.Builder()
+                            ...
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishShoppingLists(
+                new PublishShoppingListsRequest.Builder()
+                    .addShoppingList(
+                        new ShoppingListEntity.Builder()
+                            ...
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `ShoppingList` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Shopping List Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishShoppingReorderCluster`
+
+This API is used to publish a `ShoppingReorderCluster` object.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishShoppingReorderCluster(
+                PublishShoppingReorderClusterRequest.Builder()
+                    .setReorderCluster(
+                        ShoppingReorderCluster.Builder()
+                            ...
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishShoppingReorderCluster(
+                new PublishShoppingReorderClusterRequest.Builder()
+                    .setReorderCluster(
+                        new ShoppingReorderCluster.Builder()
+                            ...
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `ShoppingReorderCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Reorder Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishShoppingOrderTrackingCluster`
+
+This API is used to publish a `ShoppingOrderTrackingCluster` object.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishShoppingOrderTrackingCluster(
+                PublishShoppingOrderTrackingClusterRequest.Builder()
+                    .setShoppingOrderTrackingCluster(
+                        ShoppingOrderTrackingCluster.Builder()
+                            ...
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishShoppingOrderTrackingCluster(
+                new PublishShoppingOrderTrackingClusterRequest.Builder()
+                    .setShoppingOrderTrackingCluster(
+                        new ShoppingOrderTrackingCluster.Builder()
+                            ...
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `ShoppingOrderTrackingCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Shopping Order Tracking Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishUserAccountManagementRequest`
+
+This API is used to publish a Sign In card . The signin action directs users to
+the app's sign in page so that the app can publish content (or provide more
+personalized content)
+
+The following metadata is part of the Sign In Card -
+
+| Attribute | Requirement | Description |
+|---|---|---|
+| Action Uri | Required | Deeplink to Action (i.e. navigates to app sign in page) |
+| Image | Optional - If not provided, Title must be provided | Image Shown on the Card 16x9 aspect ratio images with a resolution of 1264x712 |
+| Title | Optional - If not provided, Image must be provided | Title on the Card |
+| Action Text | Optional | Text Shown on the CTA (i.e. Sign in) |
+| Subtitle | Optional | Optional Subtitle on the Card |
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    var SIGN_IN_CARD_ENTITY =
+          SignInCardEntity.Builder()
+              .addPosterImage(
+                  Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build()
+
+    client.publishUserAccountManagementRequest(
+                PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+### Java
+
+    SignInCardEntity SIGN_IN_CARD_ENTITY =
+          new SignInCardEntity.Builder()
+              .addPosterImage(
+                  new Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build();
+
+    client.publishUserAccountManagementRequest(
+                new PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `UserAccountManagementCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated UserAccountManagementCluster Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `updatePublishStatus`
+
+If for any internal business reason, none of the clusters is published,
+we **strongly recommend** updating the publish status using the
+**updatePublishStatus** API.
+This is important because :
+
+- Providing the status in all scenarios, even when the content is published (STATUS == PUBLISHED), is critical to populate dashboards that use this explicit status to convey the health and other metrics of your integration.
+- If no content is published but the integration status isn't broken (STATUS == NOT_PUBLISHED), Google can avoid triggering alerts in the app health dashboards. It confirms that content is not published due to an **expected** situation from the provider's standpoint.
+- It helps developers provide insights into when the data is published versus not.
+- Google may use the status codes to nudge the user to do certain actions in the app so they can see the app content or overcome it.
+
+The list of eligible publish status codes are :
+
+    // Content is published
+    AppEngagePublishStatusCode.PUBLISHED,
+
+    // Content is not published as user is not signed in
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN,
+
+    // Content is not published as user is not subscribed
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SUBSCRIPTION,
+
+    // Content is not published as user location is ineligible
+    AppEngagePublishStatusCode.NOT_PUBLISHED_INELIGIBLE_LOCATION,
+
+    // Content is not published as there is no eligible content
+    AppEngagePublishStatusCode.NOT_PUBLISHED_NO_ELIGIBLE_CONTENT,
+
+    // Content is not published as the feature is disabled by the client
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_FEATURE_DISABLED_BY_CLIENT,
+
+    // Content is not published as the feature due to a client error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR,
+
+    // Content is not published as the feature due to a service error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR,
+
+    // Content is not published due to some other reason
+    // Reach out to engage-developers@ before using this enum.
+    AppEngagePublishStatusCode.NOT_PUBLISHED_OTHER
+
+If the content is not published due to a user not logged in,
+Google would recommend publishing the Sign In Card.
+If for any reason providers are not able to publish the Sign In Card
+then we recommend calling the **updatePublishStatus** API
+with the status code **NOT_PUBLISHED_REQUIRES_SIGN_IN**
+
+### Kotlin
+
+    client.updatePublishStatus(
+       PublishStatusRequest.Builder()
+         .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+         .build())
+
+### Java
+
+    client.updatePublishStatus(
+        new PublishStatusRequest.Builder()
+            .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+            .build());
+
+#### `deleteRecommendationClusters`
+
+This API is used to delete the content of Recommendation Clusters.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteRecommendationClusters()
+
+### Java
+
+    client.deleteRecommendationClusters();
+
+When the service receives the request, it removes the existing data from the
+Recommendation Clusters. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteFeaturedCluster`
+
+This API is used to delete the content of Featured Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteFeaturedCluster()
+
+### Java
+
+    client.deleteFeaturedCluster();
+
+When the service receives the request, it removes the existing data from the
+Featured Cluster. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteShoppingCartCluster`
+
+This API is used to delete the content of Shopping Cart Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteShoppingCartCluster()
+
+### Java
+
+    client.deleteShoppingCartCluster();
+
+When the service receives the request, it removes the existing data from the
+Shopping Cart Cluster. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteShoppingListCluster`
+
+This API is used to delete the content of Shopping List Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteShoppingListCluster()
+
+### Java
+
+    client.deleteShoppingListCluster();
+
+When the service receives the request, it removes the existing data from the
+Shopping List Cluster. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteShoppingReorderCluster`
+
+This API is used to delete the content of Shopping Reorder Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteShoppingReorderCluster()
+
+### Java
+
+    client.deleteShoppingReorderCluster();
+
+When the service receives the request, it removes the existing data from the
+Shopping Reorder Cluster. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteShoppingOrderTrackingCluster`
+
+This API is used to delete the content of Shopping Order Tracking Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteShoppingOrderTrackingCluster()
+
+### Java
+
+    client.deleteShoppingOrderTrackingCluster();
+
+When the service receives the request, it removes the existing data from the
+Shopping Order Tracking Cluster. In case of an error, the entire request is
+rejected and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This API is available in versions 1.4.0 and higher.
+
+#### `deleteUserManagementCluster`
+
+This API is used to delete the content of UserAccountManagement Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteUserManagementCluster()
+
+### Java
+
+    client.deleteUserManagementCluster();
+
+When the service receives the request, it removes the existing data from the
+UserAccountManagement Cluster. In case of an error, the entire request is
+rejected and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteClusters`
+
+This API is used to delete the content of a given cluster type.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteClusters(
+        DeleteClustersRequest.Builder()
+          .addClusterType(ClusterType.TYPE_FEATURED)
+          .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+          ...
+          .build())
+
+### Java
+
+    client.deleteClusters(
+                new DeleteClustersRequest.Builder()
+                    .addClusterType(ClusterType.TYPE_FEATURED)
+                    .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+                    ...
+                    .build());
+
+When the service receives the request, it removes the existing data from all
+clusters matching the specified cluster types. Clients can choose to pass one or
+many cluster types. In case of an error, the entire request is rejected and the
+existing state is maintained.
+
+#### Error handling
+
+It is highly recommended to listen to the task result from the publish APIs such
+that a follow-up action can be taken to recover and resubmit an successful task.
+
+### Kotlin
+
+    client.publishRecommendationClusters(
+            PublishRecommendationClustersRequest.Builder()
+              .addRecommendationCluster(..)
+              .build())
+          .addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+              // do something
+            } else {
+              val exception = task.exception
+              if (exception is AppEngageException) {
+                @AppEngageErrorCode val errorCode = exception.errorCode
+                if (errorCode == AppEngageErrorCode.SERVICE_NOT_FOUND) {
+                  // do something
+                }
+              }
+            }
+          }
+
+### Java
+
+    client.publishRecommendationClusters(
+                  new PublishRecommendationClustersRequest.Builder()
+                      .addRecommendationCluster(...)
+                      .build())
+              .addOnCompleteListener(
+                  task -> {
+                    if (task.isSuccessful()) {
+                      // do something
+                    } else {
+                      Exception exception = task.getException();
+                      if (exception instanceof AppEngageException) {
+                        @AppEngageErrorCode
+                        int errorCode = ((AppEngageException) exception).getErrorCode();
+                        if (errorCode == AppEngageErrorCode.SERVICE_NOT_FOUND) {
+                          // do something
+                        }
+                      }
+                    }
+                  });
+
+The error is returned as an `AppEngageException` with the cause included as an
+error code.
+
+| Error code | Error name | Note |
+|---|---|---|
+| `1` | `SERVICE_NOT_FOUND` | The service is not available on the given device. |
+| `2` | `SERVICE_NOT_AVAILABLE` | The service is available on the given device, but it is not available at the time of the call (for example, it is explicitly disabled). |
+| `3` | `SERVICE_CALL_EXECUTION_FAILURE` | The task execution failed due to threading issues. In this case, it can be retried. |
+| `4` | `SERVICE_CALL_PERMISSION_DENIED` | The caller is not allowed to make the service call. |
+| `5` | `SERVICE_CALL_INVALID_ARGUMENT` | The request contains invalid data (for example, more than the allowed number of clusters). |
+| `6` | `SERVICE_CALL_INTERNAL` | There is an error on the service side. |
+| `7` | `SERVICE_CALL_RESOURCE_EXHAUSTED` | The service call is made too frequently. |
+
+### Step 3: Handle broadcast intents
+
+In addition to making publish content API calls through a job, it is also
+required to set up a
+[`BroadcastReceiver`](https://developer.android.com/reference/android/content/BroadcastReceiver) to receive
+the request for a content publish.
+
+The goal of broadcast intents is mainly for app reactivation and forcing data
+sync. Broadcast intents are not designed to be sent very frequently. It is only
+triggered when the Engage Service determines the content might be stale (for
+example, a week old). That way, there is more confidence that the user can have
+a fresh content experience, even if the application has not been executed for a
+long period of time.
+
+The `BroadcastReceiver` must be set up in the following two ways:
+
+- Dynamically register an instance of the `BroadcastReceiver` class using
+  `Context.registerReceiver()`. This enables communication from applications
+  that are still live in memory.
+
+### Kotlin
+
+    class AppEngageBroadcastReceiver : BroadcastReceiver(){
+      // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION
+      // broadcast is received
+      // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is
+      // received
+      // Trigger shopping cart cluster publish when PUBLISH_SHOPPING_CART broadcast
+      // is received
+      // Trigger shopping list cluster publish when PUBLISH_SHOPPING_LIST broadcast
+      // is received
+      // Trigger reorder cluster publish when PUBLISH_REORDER_CLUSTER broadcast is
+      // received
+      // Trigger shopping order tracking cluster publish when
+      // PUBLISH_SHOPPING_ORDER_TRACKING_CLUSTER broadcast is received
+    }
+
+    fun registerBroadcastReceivers(context: Context){
+      var  context = context
+      context = context.applicationContext
+
+    // Register Recommendation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_RECOMMENDATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Featured Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_FEATURED),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Shopping Cart Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_SHOPPING_CART),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Shopping List Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_SHOPPING_LIST),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Reorder Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_REORDER_CLUSTER),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Shopping Order Tracking Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_SHOPPING_ORDER_TRACKING_CLUSTER),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+    }
+
+### Java
+
+    class AppEngageBroadcastReceiver extends BroadcastReceiver {
+    // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+    // is received
+
+    // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is received
+
+    // Trigger shopping cart cluster publish when PUBLISH_SHOPPING_CART broadcast is
+    // received
+
+    // Trigger shopping list cluster publish when PUBLISH_SHOPPING_LIST broadcast is
+    // received
+
+    // Trigger reorder cluster publish when PUBLISH_REORDER_CLUSTER broadcast is
+    // received
+
+    // Trigger reorder cluster publish when PUBLISH_SHOPPING_ORDER_TRACKING_CLUSTER
+    // broadcast is received
+    }
+
+    public static void registerBroadcastReceivers(Context context) {
+
+    context = context.getApplicationContext();
+
+    // Register Recommendation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Featured Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Shopping Cart Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.shopping.service.Intents.ACTION_PUBLISH_SHOPPING_CART),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Shopping List Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.shopping.service.Intents.ACTION_PUBLISH_SHOPPING_LIST),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Reorder Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.shopping.service.Intents.ACTION_PUBLISH_REORDER_CLUSTER),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Shopping Order Tracking Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.shopping.service.Intents.ACTION_PUBLISH_SHOPPING_ORDER_TRACKING_CLUSTER),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    }
+
+- Statically declare an implementation with the `<receiver>` tag in your
+  `AndroidManifest.xml` file. This allows the application to receive broadcast
+  intents when it is not running, and also allows the application to publish
+  the content.
+
+    <application>
+       <receiver
+          android:name=".AppEngageBroadcastReceiver"
+          android:permission="com.google.android.engage.REQUEST_ENGAGE_DATA"
+          android:exported="true"
+          android:enabled="true">
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_RECOMMENDATION" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_FEATURED" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.shopping.PUBLISH_SHOPPING_CART" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.shopping.PUBLISH_SHOPPING_LIST" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.shopping.PUBLISH_REORDER_CLUSTER" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.shopping.PUBLISH_SHOPPING_ORDER_TRACKING_CLUSTER" />
+          </intent-filter>
+       </receiver>
+    </application>
+
+The following [intents](https://developer.android.com/reference/android/content/Intent) are sent by the
+service:
+
+- `com.google.android.engage.action.PUBLISH_RECOMMENDATION` It is recommended to start a `publishRecommendationClusters` call when this intent is received.
+- `com.google.android.engage.action.PUBLISH_FEATURED` It is recommended to start a `publishFeaturedCluster` call when this intent is received.
+- `com.google.android.engage.action.shopping.PUBLISH_SHOPPING_CART` It is recommended to start a `publishShoppingCarts` call when this intent is received.
+- `com.google.android.engage.action.shopping.PUBLISH_SHOPPING_LIST` It is recommended to start a `publishShoppingLists` call when this intent is received.
+- `com.google.android.engage.action.shopping.PUBLISH_REORDER_CLUSTER` It is recommended to start a `publishReorderCluster` call when this intent is received.
+- `com.google.android.engage.action.shopping.PUBLISH_SHOPPING_ORDER_TRACKING_CLUSTER` It is recommended to start a `publishShoppingOrderTrackingCluster` call when this intent is received.
+
+## Integration workflow
+
+For a step-by-step guide on verifying your integration after it is complete, see
+[Engage developer integration workflow](https://developer.android.com/guide/playcore/engage/workflow).
+
+## FAQs
+
+See [Engage SDK Frequently Asked Questions](https://developer.android.com/guide/playcore/engage/faq) for
+FAQs.
+
+## Contact
+
+Contact
+[`engage-developers@google.com`](mailto:engage-developers@google.com) if there are
+any questions during the integration process. Our team replies as soon as
+possible.
+
+## Next steps
+
+After completing this integration, your next steps are as follows:
+
+- Send an email to [`engage-developers@google.com`](mailto:engage-developers@google.com) and attach your integrated APK that is ready for testing by Google.
+- Google performs a verification and reviews internally to make sure the integration works as expected. If changes are needed, Google contacts you with any necessary details.
+- When testing is complete and no changes are needed, Google contacts you to notify you that you can start publishing the updated and integrated APK to the Play Store.
+- After Google has confirmed that your updated APK has been published to the Play Store, your **Recommendation** , **Featured** , **Shopping Cart** , **Shopping List** , **Reorder Cluster** and **Shopping Order Tracking Cluster** clusters may be published and visible to users.

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/social.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/social.md
@@ -1,0 +1,702 @@
+Boost app engagement by reaching your users where they are. Integrate Engage SDK
+to deliver personalized recommendations and continuation content directly to
+users across multiple on-device surfaces, like
+**[Collections](https://android-developers.googleblog.com/2024/07/introducing-collections-powered-by-engage-sdk.html)** , **[Entertainment
+Space](https://blog.google/products/android/entertainment-space/)** , and the Play Store. The integration adds
+less than 50 KB (compressed) to the average APK and takes most apps about a
+week of developer time. Learn more at our **[business
+site](http://play.google.com/console/about/programs/EngageSDK)**.
+
+This guide contains instructions for developer partners to deliver social media
+content to Engage content surfaces.
+
+## Integration detail
+
+The following section captures the integration detail.
+
+### Terminology
+
+***Recommendation*** clusters show personalized suggestions from an individual
+developer partner.
+
+Your recommendations take the following structure:
+
+**Recommendation Cluster**: UI view that contains a group of recommendations
+from the same developer partner.
+
+Each Recommendation Cluster consists of one of the following two types of
+entities :
+
+- PortraitMediaEntity
+- SocialPostEntity
+
+**PortraitMediaEntity** must contain 1 portrait image for the post. Profile and
+Interaction related metadata are optional.
+
+- Post
+
+  - Image in portrait mode and Timestamp, or
+  - Image in portrait mode + text content and Timestamp
+- Profile
+
+  - Avatar, Name or Handle, Additional image
+- Interactions
+
+  - Count and label only, or
+  - Count and visual (icon)
+
+**SocialPostEntity** contains profile, post and interaction related metadata.
+
+- Profile
+
+  - Avatar, Name or Handle, additional text, additional image
+- Post
+
+  - Text and Timestamp, or
+  - Rich media (image or rich URL) and Timestamp, or
+  - Text and rich media (image or rich URL) and Timestamp, or
+  - Video preview (thumbnail and duration) and Timestamp
+- Interactions
+
+  - Count \& label only, or
+  - Count \& visual (icon)
+
+### Pre-work
+
+Minimum API level: 19
+
+Add the `com.google.android.engage:engage-core` library to your app:
+
+    dependencies {
+        // Make sure you also include that repository in your project's build.gradle file.
+        implementation 'com.google.android.engage:engage-core:1.6.0'
+    }
+
+### Summary
+
+The design is based on an implementation of a [bound
+service](https://developer.android.com/guide/components/bound-services).
+
+The data a client can publish is subject to the following limits for different
+cluster types:
+
+| Cluster type | Cluster limits | Minimum entity limits in a cluster | Maximum entity limits in a cluster |
+|---|---|---|---|
+| Recommendation Cluster(s) | At most 7 | At least 1 (`PortraitMediaEntity`, or `SocialPostEntity`) | At most 50 (`PortraitMediaEntity`, or `SocialPostEntity`) |
+
+### Step 1: Provide entity data
+
+The SDK has defined different entities to represent each item type. The SDK
+supports the following entities for the Social category:
+
+1. `PortraitMediaEntity`
+2. `SocialPostEntity`
+
+The charts below outline available attributes and requirements for each type.
+
+#### `PortraitMediaEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action URI | **Required** for all surfaces other than Google TV | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | URI |
+| PlatformSpecificPlayback | **Required** for Google TV surface | Deep Link to the entity in the provider app for platforms like Google TV and Mobile. | List of PlatformSpecificPlayback objects |
+| Recommendation Reason | Optional | The justification for recommending the content to the user. | RecommendationReason object |
+| Comments Summary | Optional | Summary of comments for the post. | String |
+| **Post related metadata (Required)** ||||
+| Image(s) | Required | Image(s) should be in **portrait aspect ratio.** The UI may show only 1 image when multiple images are provided. However, the UI may provide visual indication that there are more images in the app. *If the post is a video, the provider should provide a thumbnail of the video to be shown as an image.* | See [Image Specifications](https://developer.android.com/guide/playcore/engage/social#image-specs) for guidance. |
+| Text content | Optional | The main text of a post, update, etc. | String (recommended max 140 chars) |
+| Timestamp | Optional | Time when the post was published. | Epoch timestamp in milliseconds |
+| Is video content | Optional | Is the post a video? | boolean |
+| Video duration | Optional | The duration of the video in milliseconds. | Long |
+| **Profile related metadata (Optional)** ||||
+| Name | Required | Profile name or id or handle, eg "John Doe", "@TeamPixel" | String(recommended max 25 chars) |
+| Avatar | Required | Profile picture or avatar image of the user. **Square 1:1 image** | See [Image Specifications](https://developer.android.com/guide/playcore/engage/social#image-specs) for guidance. |
+| Additional Image | Optional | Profile badge. for example - verified badge **Square 1:1 image** | See [Image Specifications](https://developer.android.com/guide/playcore/engage/social#image-specs) for guidance. |
+| **Interactions related metadata (Optional)** ||||
+| Count | Optional | Indicate the number of interactions, for example - "3.7 M.". **Note:** If both Count and Count Value are provided, Count will be used. **Note:** Partners should use either **Count** or **CountWithOptionalLabel**. | String |
+| CountWithOptionalLabel | Optional | Indicate the number of interactions with an optional label, for example - "3.7 M Likes.". **Note:** If both CountWithOptionalLabel and Count Value are provided, one of them will be used. **Note:** Partners should use either **Count** or **CountWithOptionalLabel**. | String |
+| Count Value | Optional | The number of interactions as a value. **Note:** Provide Count Value instead of Count if your app doesn't handle logic on how a large number should be optimized for different display sizes. If both Count and Count Value are provided, Count is used. | Long |
+| Label | Optional | Indicate what the interaction label is for. For example - "Likes". | String |
+| Visual | Optional | Indicate what the interaction is for. For example - Image showing Likes icon, emoji. Can provide more than 1 image, though not all may not be shown on all form factors. **Note:** Must be Square 1:1 image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/social#image-specs) for guidance. |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `SocialPostEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action URI | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | URI |
+| PlatformSpecificPlayback URIs | **Required** for Google TV surface | Deep Link to the entity in the provider app for platforms like Google TV and Mobile. | List of PlatformSpecificPlayback objects |
+| Recommendation Reason | Optional | The justification for recommending the content to the user. | RecommendationReason object |
+| Comments Summary | Optional | Summary of comments for the post. | String |
+| **Post related metadata (Required)** At least one of TextContent, Image or WebContent is required ||||
+| Image(s) | Optional | Image(s) should be in **portrait aspect ratio.** The UI may show only 1 image when multiple images are provided. However, the UI may provide visual indication that there are more images in the app. *If the post is a video, the provider should provide a thumbnail of the video to be shown as an image.* | See [Image Specifications](https://developer.android.com/guide/playcore/engage/social#image-specs) for guidance. |
+| Text content | Optional | The main text of a post, update, etc. | String (recommended max 140 chars) |
+| **Video Content (Optional)** ||||
+| Duration | Required | The duration of the video in milliseconds. | Long |
+| Image | Required | Preview image of the video content. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/social#image-specs) for guidance. |
+| **Link Preview (Optional)** ||||
+| Link Preview - Title | Required | Text to indicate the title of the web page content | String |
+| Link Preview - Hostname | Required | Text to indicate the web page owner, eg "INSIDER" | String |
+| Link Preview - Image | Optional | Hero image for the web content | See [Image Specifications](https://developer.android.com/guide/playcore/engage/social#image-specs) for guidance. |
+| Timestamp | Optional | Time when the post was published. | Epoch timestamp in milliseconds |
+| **Profile related metadata (Optional)** ||||
+| Name | Required | Profile name or id or handle, eg "John Doe", "@TeamPixel." | String(recommended max 25 chars) |
+| Additional Text | Optional | Could be used as profile id or handle or additional metadata For example "@John-Doe", "5M followers", "You might like", "Trending", "5 new posts" | String(recommended max 40 chars) |
+| Avatar | Required | Profile picture or avatar image of the user. **Square 1:1 image** | See [Image Specifications](https://developer.android.com/guide/playcore/engage/social#image-specs) for guidance. |
+| Additional Image | Optional | Profile badge, for example - verified badge **Square 1:1 image** | See [Image Specifications](https://developer.android.com/guide/playcore/engage/social#image-specs) for guidance. |
+| **Interactions related metadata (Optional)** ||||
+| Count | Required | Indicate the number of interactions, for example - "3.7 M." **Note:** Partners should use either **Count** or **CountWithOptionalLabel**. | String |
+| CountWithOptionalLabel | Required | Indicate the number of interactions with an optional label, for example - "3.7 M Likes." **Note:** Partners should use either **Count** or **CountWithOptionalLabel**. | String |
+| Label | Optional If not provided, **Visual** must be provided. | Indicate what the interaction is for. For example - "Likes." | String (recommended max 20 chars for count + label combined) |
+| Visual | Optional If not provided, **Label** must be provided. | Indicate what the interaction is for. For example - Image showing Likes icon, emoji. Can provide more than 1 image, though not all may not be shown on all form factors. **Square 1:1 image** | See [Image Specifications](https://developer.android.com/guide/playcore/engage/social#image-specs) for guidance. |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### Image specifications
+
+The images are required to be hosted on public CDNs so that Google can access
+them.
+
+*File formats*
+
+PNG, JPG, static GIF, WebP
+
+*Maximum file size*
+
+5120 KB
+
+*Additional recommendations*
+
+- **Image safe area:** Put your important content in the center 80% of the image.
+- Use a transparent background so that the image can be properly displayed in Dark and Light theme settings.
+
+### Step 2: Provide Cluster data
+
+It is recommended to have the content publish job executed in the background
+(for example, using [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager))
+and scheduled on a regular basis or on an event basis (for example, every time
+the user opens the app or when the user just followed a new account)
+
+`AppEngageSocialClient` is responsible for publishing social clusters.
+
+There are following APIs to publish clusters in the client:
+
+- `isServiceAvailable`
+- `publishRecommendationClusters`
+- `publishUserAccountManagementRequest`
+- `updatePublishStatus`
+- `deleteRecommendationsClusters`
+- `deleteUserManagementCluster`
+- `deleteClusters`
+
+#### `isServiceAvailable`
+
+This API is used to check if the service is available for integration and
+whether the content can be presented on the device.
+
+##### For Engage SDK v1.6.0 and higher (Recommended)
+
+You can check the service availability for every cluster type that you intend to
+publish. The `isServiceAvailable` API accepts a request object,
+`ServiceAvailabilityRequest`, which contains the cluster types for which service
+availability needs to be checked. You can find the `ClusterType` enum values
+required for `ServiceAvailabilityRequest` from the following table.
+
+| Cluster Type | Cluster Type Constant | Integer Value |
+|---|---|---|
+| Unknown | `TYPE_UNKNOWN` | 0 |
+| Recommendation Cluster | `TYPE_RECOMMENDATION` | 1 |
+| Featured Cluster | `TYPE_FEATURED` | 2 |
+| Continuation Cluster | `TYPE_CONTINUATION` | 3 |
+| User Management Cluster | `TYPE_ENGAGEMENT` | 8 |
+| Subscription Cluster | `TYPE_SUBSCRIPTION` | 12 |
+
+### Kotlin
+
+    val request = ServiceAvailabilityRequest.Builder()
+        .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+        .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+        .build()
+
+    client.isServiceAvailable(request).addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            val availabilityMap = task.result
+            if (availabilityMap[ClusterType.TYPE_CONTINUATION] == true) {
+                // Proceed with publishing continuation content
+            }
+            if (availabilityMap[ClusterType.TYPE_RECOMMENDATION] == true) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    }
+
+### Java
+
+    ServiceAvailabilityRequest request =
+        new ServiceAvailabilityRequest.Builder()
+            .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+            .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+            .build();
+
+    client.isServiceAvailable(request).addOnCompleteListener(task -> {
+        if (task.isSuccessful()) {
+            Map<Integer, Boolean> availabilityMap = task.getResult();
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_CONTINUATION))) {
+                // Proceed with publishing continuation content
+            }
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_RECOMMENDATION))) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    });
+
+###### Conditional Service Availability Feature
+
+Some integrated apps request a special configuration that enables and disables
+the Engage service intermittently in order to reduce their serving cost. This
+intermittent content ingestion strategy, although possible, negatively affects
+the user and the product -- stale content will not be presented and some surfaces
+will not be served at all.
+
+Starting with v1.6.0, the Engage SDK allows checking availability for specific
+cluster types. If you are interested in opting into this feature for any cluster type,
+please contact engage-developers@google.com.
+
+##### For SDK versions prior to v1.6.0 (Deprecated)
+
+### Kotlin
+
+    client.isServiceAvailable.addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            // Handle IPC call success
+            if(task.result) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    }
+
+### Java
+
+    client.isServiceAvailable().addOnCompleteListener(task - > {
+        if (task.isSuccessful()) {
+            // Handle success
+            if(task.getResult()) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    });
+
+> [!NOTE]
+> **Note:** We highly recommend keeping a periodic job running to check if the service becomes available at a later point in time. The availability of the service may change with Android version upgrades, app upgrades, installs, and uninstalls. By ensuring periodic job checks at a certain time interval, data can be published once the service becomes available.
+
+#### `publishRecommendationClusters`
+
+This API is used to publish a list `RecommendationCluster` objects.
+
+A `RecommendationCluster` object can have the following attributes:
+
+| Attribute | Requirement | Description |
+|---|---|---|
+| List of SocialPostEntity, or PortraitMediaEntity | **Required** | A list of entities that make up the recommendations for this Recommendation Cluster. Entities in a single cluster must be of the same type. |
+| Title | **Required** | The title for the Recommendation Cluster (for example, *Latest from your friends*). **Recommended text size: under 25 chars** (Text that is too long may show ellipses) |
+| Subtitle | Optional | The subtitle for the Recommendation Cluster. |
+| Action Uri | Optional | The deep link to the page in the partner app where users can see the complete list of recommendations. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+> [!IMPORTANT]
+> **Important:** For social apps, it's critical to update recommendations after each app usage. Social app users are more interested in the most recent recommendations and ideally would like to see a post at most once.
+
+### Kotlin
+
+    client.publishRecommendationClusters(
+                PublishRecommendationClustersRequest.Builder()
+                    .addRecommendationCluster(
+                        RecommendationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .setTitle("Latest from your friends")
+                            .build())
+                    .build())
+
+### Java
+
+    client.publishRecommendationClusters(
+                new PublishRecommendationClustersRequest.Builder()
+                    .addRecommendationCluster(
+                        new RecommendationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .setTitle("Latest from your friends")
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- All existing Recommendation Cluster data is removed.
+- Data from the request is parsed and stored in new Recommendation Clusters.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishUserAccountManagementRequest`
+
+This API is used to publish a Sign In card . The signin action directs users to
+the app's sign in page so that the app can publish content (or provide more
+personalized content)
+
+The following metadata is part of the Sign In Card -
+
+| Attribute | Requirement | Description |
+|---|---|---|
+| Action Uri | Required | Deeplink to Action (i.e. navigates to app sign in page) |
+| Image | Optional - If not provided, Title must be provided | Image Shown on the Card 16x9 aspect ratio images with a resolution of 1264x712 |
+| Title | Optional - If not provided, Image must be provided | Title on the Card |
+| Action Text | Optional | Text Shown on the CTA (i.e. Sign in) |
+| Subtitle | Optional | Optional Subtitle on the Card |
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    var SIGN_IN_CARD_ENTITY =
+          SignInCardEntity.Builder()
+              .addPosterImage(
+                  Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build()
+
+    client.publishUserAccountManagementRequest(
+                PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+### Java
+
+    SignInCardEntity SIGN_IN_CARD_ENTITY =
+          new SignInCardEntity.Builder()
+              .addPosterImage(
+                  new Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build();
+
+    client.publishUserAccountManagementRequest(
+                new PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `UserAccountManagementCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated UserAccountManagementCluster Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `updatePublishStatus`
+
+If for any internal business reason, none of the clusters is published,
+we **strongly recommend** updating the publish status using the
+**updatePublishStatus** API.
+This is important because :
+
+- Providing the status in all scenarios, even when the content is published (STATUS == PUBLISHED), is critical to populate dashboards that use this explicit status to convey the health and other metrics of your integration.
+- If no content is published but the integration status isn't broken (STATUS == NOT_PUBLISHED), Google can avoid triggering alerts in the app health dashboards. It confirms that content is not published due to an **expected** situation from the provider's standpoint.
+- It helps developers provide insights into when the data is published versus not.
+- Google may use the status codes to nudge the user to do certain actions in the app so they can see the app content or overcome it.
+
+The list of eligible publish status codes are :
+
+    // Content is published
+    AppEngagePublishStatusCode.PUBLISHED,
+
+    // Content is not published as user is not signed in
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN,
+
+    // Content is not published as user is not subscribed
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SUBSCRIPTION,
+
+    // Content is not published as user location is ineligible
+    AppEngagePublishStatusCode.NOT_PUBLISHED_INELIGIBLE_LOCATION,
+
+    // Content is not published as there is no eligible content
+    AppEngagePublishStatusCode.NOT_PUBLISHED_NO_ELIGIBLE_CONTENT,
+
+    // Content is not published as the feature is disabled by the client
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_FEATURE_DISABLED_BY_CLIENT,
+
+    // Content is not published as the feature due to a client error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR,
+
+    // Content is not published as the feature due to a service error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR,
+
+    // Content is not published due to some other reason
+    // Reach out to engage-developers@ before using this enum.
+    AppEngagePublishStatusCode.NOT_PUBLISHED_OTHER
+
+If the content is not published due to a user not logged in,
+Google would recommend publishing the Sign In Card.
+If for any reason providers are not able to publish the Sign In Card
+then we recommend calling the **updatePublishStatus** API
+with the status code **NOT_PUBLISHED_REQUIRES_SIGN_IN**
+
+### Kotlin
+
+    client.updatePublishStatus(
+       PublishStatusRequest.Builder()
+         .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+         .build())
+
+### Java
+
+    client.updatePublishStatus(
+        new PublishStatusRequest.Builder()
+            .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+            .build());
+
+#### `deleteRecommendationClusters`
+
+This API is used to delete the content of Recommendation Clusters.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteRecommendationClusters()
+
+### Java
+
+    client.deleteRecommendationClusters();
+
+When the service receives the request, it removes the existing data from the
+Recommendation Clusters. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+#### `deleteUserManagementCluster`
+
+This API is used to delete the content of UserAccountManagement Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteUserManagementCluster()
+
+### Java
+
+    client.deleteUserManagementCluster();
+
+When the service receives the request, it removes the existing data from the
+UserAccountManagement Cluster. In case of an error, the entire request is
+rejected and the existing state is maintained.
+
+#### `deleteClusters`
+
+This API is used to delete the content of a given cluster type.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteClusters(
+        DeleteClustersRequest.Builder()
+          .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+          ...
+          .build())
+
+### Java
+
+    client.deleteClusters(
+                new DeleteClustersRequest.Builder()
+                    .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+                    ...
+                    .build());
+
+When the service receives the request, it removes the existing data from all
+clusters matching the specified cluster types. Clients can choose to pass one or
+many cluster types. In case of an error, the entire request is rejected and the
+existing state is maintained.
+
+#### Error handling
+
+It is highly recommended to listen to the task result from the publish APIs such
+that a follow-up action can be taken to recover and resubmit an successful task.
+
+    client.publishRecommendationClusters(
+                  new PublishRecommendationClustersRequest.Builder()
+                      .addRecommendationCluster(...)
+                      .build())
+              .addOnCompleteListener(
+                  task -> {
+                    if (task.isSuccessful()) {
+                      // do something
+                    } else {
+                      Exception exception = task.getException();
+                      if (exception instanceof AppEngageException) {
+                        @AppEngageErrorCode
+                        int errorCode = ((AppEngageException) exception).getErrorCode();
+                        if (errorCode == AppEngageErrorCode.SERVICE_NOT_FOUND) {
+                          // do something
+                        }
+                      }
+                    }
+                  });
+
+The error is returned as an `AppEngageException` with the cause included as an
+error code.
+
+| Error code | Error name | Note |
+|---|---|---|
+| `1` | `SERVICE_NOT_FOUND` | The service is not available on the given device. |
+| `2` | `SERVICE_NOT_AVAILABLE` | The service is available on the given device, but it is not available at the time of the call (for example, it is explicitly disabled). |
+| `3` | `SERVICE_CALL_EXECUTION_FAILURE` | The task execution failed due to threading issues. In this case, it can be retried. |
+| `4` | `SERVICE_CALL_PERMISSION_DENIED` | The caller is not allowed to make the service call. |
+| `5` | `SERVICE_CALL_INVALID_ARGUMENT` | The request contains invalid data (for example, more than the allowed number of clusters). |
+| `6` | `SERVICE_CALL_INTERNAL` | There is an error on the service side. |
+| `7` | `SERVICE_CALL_RESOURCE_EXHAUSTED` | The service call is made too frequently. |
+
+### Step 3: Handle broadcast intents
+
+In addition to making publish content API calls through a job, it is also
+required to set up a
+[`BroadcastReceiver`](https://developer.android.com/reference/android/content/BroadcastReceiver) to receive
+the request for a content publish.
+
+The goal of broadcast intents is mainly for app reactivation and forcing data
+sync. Broadcast intents are not designed to be sent very frequently. It is only
+triggered when the Engage Service determines the content might be stale (for
+example, a week old). That way, there is more confidence that the user can have
+a fresh content experience, even if the application has not been executed for a
+long period of time.
+
+The `BroadcastReceiver` must be set up in the following two ways:
+
+- Dynamically register an instance of the `BroadcastReceiver` class using
+  `Context.registerReceiver()`. This enables communication from applications
+  that are still live in memory.
+
+### Kotlin
+
+    class AppEngageBroadcastReceiver : BroadcastReceiver(){
+      // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION
+      // broadcast is received
+    }
+
+    fun registerBroadcastReceivers(context: Context){
+      var  context = context
+      context = context.applicationContext
+
+    // Register Recommendation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_RECOMMENDATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+    }
+
+### Java
+
+    class AppEngageBroadcastReceiver extends BroadcastReceiver {
+    // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+    // is received
+    }
+
+    public static void registerBroadcastReceivers(Context context) {
+
+    context = context.getApplicationContext();
+
+    // Register Recommendation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+    }
+
+- Statically declare an implementation with the `<receiver>` tag in your
+  `AndroidManifest.xml` file. This allows the application to receive broadcast
+  intents when it is not running, and also allows the application to publish
+  the content.
+
+    <application>
+       <receiver
+          android:name=".AppEngageBroadcastReceiver"
+          android:permission="com.google.android.engage.REQUEST_ENGAGE_DATA"
+          android:exported="true"
+          android:enabled="true">
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_RECOMMENDATION" />
+          </intent-filter>
+       </receiver>
+    </application>
+
+The following [intents](https://developer.android.com/reference/android/content/Intent) will be sent by the
+service:
+
+- `com.google.android.engage.action.PUBLISH_RECOMMENDATION` It is recommended to start a `publishRecommendationClusters` call when receiving this intent.
+
+## Integration workflow
+
+For a step-by-step guide on verifying your integration after it is complete, see
+[Engage developer integration workflow](https://developer.android.com/guide/playcore/engage/workflow).
+
+## FAQs
+
+See [Engage SDK Frequently Asked Questions](https://developer.android.com/guide/playcore/engage/faq) for
+FAQs.
+
+## Contact
+
+Contact
+[`engage-developers@google.com`](mailto:engage-developers@google.com) if there are
+any questions during the integration process. Our team will reply as soon as
+possible.
+
+## Next steps
+
+After completing this integration, your next steps are as follows:
+
+- Send an email to [`engage-developers@google.com`](mailto:engage-developers@google.com) and attach your integrated APK that is ready for testing by Google.
+- Google performs a verification and reviews internally to make sure the integration works as expected. If changes are needed, Google contacts you with any necessary details.
+- When testing is complete and no changes are needed, Google contacts you to notify you that you can start publishing the updated and integrated APK to the Play Store.
+- After Google has confirmed that your updated APK has been published to the Play Store, your **Recommendation**, clusters will be published and visible to users.

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/travel.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/travel.md
@@ -1,0 +1,1396 @@
+Boost app engagement by reaching your users where they are. Integrate Engage SDK
+to deliver personalized recommendations and continuation content directly to
+users across multiple on-device surfaces, like
+**[Collections](https://android-developers.googleblog.com/2024/07/introducing-collections-powered-by-engage-sdk.html)** , **[Entertainment
+Space](https://blog.google/products/android/entertainment-space/)** , and the Play Store. The integration adds
+less than 50 KB (compressed) to the average APK and takes most apps about a
+week of developer time. Learn more at our **[business
+site](http://play.google.com/console/about/programs/EngageSDK)**.
+
+This guide contains instructions for developer partners to deliver travel and
+events content to Engage content surfaces.
+
+## Integration detail
+
+### Terminology
+
+This integration includes the following cluster types: **Recommendation** ,
+**Featured** , **Reservation** and **Continue Search**.
+
+- **Recommendation** clusters show personalized travel \& event suggestions
+  from an individual developer partner. These recommendations can be
+  personalized to the user or generalized (for example, trending items). Use
+  these to surface articles, events, lodging, or places of interest
+  recommendations.
+
+  - A Recommendation cluster can be made of `ArticleEntity`, `EventEntity`, `LodgingEntity`, `PointOfInterestEntity`, or `StoreEntity` listings, but not a mix of different entity types.
+
+  Your recommendations take the following structure:
+  - **Recommendation Cluster:** A UI view that contains a group of
+    recommendations from the same developer partner.
+
+  - **Entity:** An object representing a single item in a cluster. This
+    integration offers some entities that would be surfaced using the
+    Recommendation Cluster:
+
+    - **ArticleEntity**: ArticleEntity represents a recommendation for
+      text-based content related to travel \& events. It can be used for
+      articles, blogposts, marketing content, news snippets, etc.
+
+      ![](https://developer.android.com/static/images/guide/playcore/engage/article-entity-travel.png) **Figure 1:** UI showing a single ArticleEntity within Recommendations cluster.
+    - **EventEntity**: EventEntity represents an event happening in the
+      future. Event start time is a critical piece of information that
+      needs to be conveyed to the users.
+
+      ![](https://developer.android.com/static/images/guide/playcore/engage/event-entity-travel.png) **Figure 2:** UI showing a single EventEntity within Recommendations cluster.
+    - **LodgingEntity**: LodgingEntity represents an accommodation, such
+      as a hotel, apartment, vacation home for short term and long term
+      rental.
+
+      ![](https://developer.android.com/static/images/guide/playcore/engage/lodging-entity-travel.png) **Figure 3:** UI showing a single LodgingEntity within Recommendations cluster.
+    - **StoreEntity**: StoreEntity represents a store, restaurant, cafe
+      etc. It highlights content where a dining venue or store is the
+      critical piece of information that needs to be conveyed to the
+      users.
+
+      ![](https://developer.android.com/static/images/guide/playcore/engage/store-entity-travel.png) **Figure 4:** UI showing a single StoreEntity within Recommendations cluster.
+    - **PointOfInterestEntity**: PointOfInterestEntity represents a
+      place of interest like, a gas station, event venue, theme park,
+      museum, tourist attraction, hiking trail etc. It highlights content
+      where location is a critical piece of information that needs to be
+      conveyed to the users. It shouldn't be used for lodging, a store or
+      a dining venue.
+
+      ![](https://developer.android.com/static/images/guide/playcore/engage/poi-entity-travel.png) **Figure 5:** UI showing a single PointOfInterestEntity within Recommendations cluster.
+- The **Reservation** cluster shows content recently engaged by users from
+  multiple developer partners in a single UI grouping. Each developer partner
+  will be allowed to broadcast a maximum of 10 entities in the Reservation
+  cluster.
+
+  Your reservation content can take the following structure:
+  - **RestaurantReservationEntity**: RestaurantReservationEntity represents
+    a reservation for a restaurant or cafe and helps users track upcoming or
+    ongoing restaurant reservations.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/restaurant-reservation-entity-travel.png) **Figure 6.** UI showing a single RestaurantReservationEntity within a Reservation cluster.
+  - **EventReservationEntity**: EventReservationEntity represents a
+    reservation for an event and helps users track upcoming or ongoing
+    events reservations. Events could include, but not limited to the
+    following:
+
+    - Sports events like reservation for a football match
+    - Gaming events like reservation for eSports
+    - Entertainment events like reservation for movies in a cinema, concert, theater, book signing
+    - Travel or point of interest reservations like guided tours, museum tickets
+    - Social / Seminar / Conferences reservations
+    - Education / Training sessions reservations
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/event-reservation-entity-travel.png) **Figure 7.** UI showing a single EventReservationEntity within a Reservation cluster.
+  - **LodgingReservationEntity**: LodgingEntityReservation represents a
+    reservation for travel lodging and helps users track upcoming or
+    ongoing hotel or vacation rental reservations.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/lodging-reservation-entity-travel.png) **Figure 8.** UI showing a single LodgingReservationEntity within a Reservation cluster.
+  - **TransportationReservationEntity**: TransportationReservationEntity
+    represents reservation for transportation by any mode and helps users
+    track reservations for upcoming or ongoing flight, ferry, train, bus,
+    ride-hailing, or cruise.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/transportation-reservation-entity-travel.png) **Figure 9.** UI showing a single TransportationReservationEntity within a Reservation cluster.
+  - **VehicleRentalReservationEntity**: VehicleRentalReservationEntity
+    represents vehicle rental reservation and helps users track upcoming
+    or ongoing vehicle rental reservations.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/vehicle-rental-reservation-entity-travel.png) **Figure 10.** UI showing a single VehicleRentalReservationEntity within a Reservation cluster.
+- The **Featured** cluster showcases a selection of entities from multiple
+  developer partners in one UI grouping. There will be a single Featured
+  cluster, which is surfaced near the top of the UI with a priority placement
+  above all Recommendation clusters. Each developer partner will be allowed to
+  broadcast up to 10 entities in the Featured cluster.
+
+  - **GenericFeaturedEntity**: GenericFeaturedEntity differs from
+    Recommendation item in that Featured item should be used for a single
+    top content from developers and should represent the single most
+    important content that will be interesting and relevant to users.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/featured-cluster-travel.png) **Figure 11:** UI showing a FeaturedCluster with a list of GenericFeaturedEntity
+- The **Continue Search** cluster helps users resume their previous travel
+  search journey by showcasing a list of search queries that the user has
+  recently searched for across all their travel apps. The cluster will be
+  pinned in second position, after reservations and before featured and
+  recommendation clusters. Each developer partner will be allowed to broadcast
+  up to 3 entities in the Continue Search cluster.
+
+  - **PointOfInterestEntity:** PointOfInterestEntity represents a place of interest like, a gas station, event venue, theme park, museum, tourist attraction, hiking trail etc. It highlights content the user has previously searched for.
+
+### Pre-work
+
+Minimum API level: 19
+
+Add the `com.google.android.engage:engage-core` library to your app:
+
+    dependencies {
+        // Make sure you also include that repository in your project's build.gradle file.
+        implementation 'com.google.android.engage:engage-core:1.6.0'
+    }
+
+### Summary
+
+The design is based on an implementation of a
+[bound service](https://developer.android.com/guide/components/bound-services).
+
+The data a client can publish is subject to the following limits for different
+cluster types:
+
+| Cluster type | Cluster limits | Minimum entity limits in a cluster | Maximum entity limits in a cluster |
+|---|---|---|---|
+| Recommendation Cluster(s) | At most 7 | At least 1 | At most 50 (`ArticleEntity`, `EventEntity`, `LodgingEntity`, `StoreEntity`, or `PointOfInterestEntity`) |
+| Reservation Cluster | At most 1 | At least 1 | At most 20 (`RestaurantReservationEntity`, `EventReservationEntity`, `LodgingReservationEntity`, `TransportationReservationEntity`, or `VehicleRentalReservationEntity`) |
+| Featured Cluster | At most 1 | At least 1 | At most 20 (`GenericFeaturedEntity`) |
+| Continue Search Cluster | At most 1 | At least 1 | At most 3 (`PointOfInterestEntity`) |
+
+### Step 1: Provide entity data
+
+The SDK has defined different entities to represent each item type. We support
+the following entities for the Travel \& Events category:
+
+1. `GenericFeaturedEntity`
+2. `ArticleEntity`
+3. `EventEntity`
+4. `LodgingEntity`
+5. `StoreEntity`
+6. `PointOfInterestEntity`
+7. `RestaurantReservationEntity`
+8. `EventReservationEntity`
+9. `LodgingReservationEntity`
+10. `TransportationReservationEntity`
+11. `VehicleRentalReservationEntity`
+
+The charts below outline available attributes and requirements for each type.
+
+#### `GenericFeaturedEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Poster images | **Required** | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Title | Optional | Title of the entity. | Free text **Recommended text size: 50 chars** |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. Special UX treatment on top of image/video, For example, as badge overlay on the image - "Live update" - Article read duration |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Enums See the [Content Category section](https://developer.android.com/guide/playcore/engage/travel#content-category) for guidance. |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `ArticleEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | Free text **Recommended text size: Max 50 chars** |
+| Poster images | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** Image is highly recommended. If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Source - Title | Optional | The name of the author, organization, or reporter | Free text **Recommended text size: Under 25 chars** |
+| Source - Image | Optional | An image of the source like the author, the organization, reporter | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. Special UX treatment on top of image/video, for example, as badge overlay on the image - "Live update" - Article read duration |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Content Publish Time | Optional | This is the epoch timestamp in milliseconds on when the content was published / updated in the app. | Epoch timestamp in milliseconds |
+| Last Engagement Time | Optional | The epoch timestamp in milliseconds when the user interacted with this entity last time. | Epoch timestamp in milliseconds |
+| Progress Percentage | Optional | The percentage of the full content consumed by the user to date. | An int value between 0\~100 inclusive. |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Enums See the [Content Category section](https://developer.android.com/guide/playcore/engage/travel#content-category) for guidance. |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `EventEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | String **Recommended text size: Max 50 chars** |
+| Localized Start time - Timestamp | **Required** | The epoch timestamp when the event is expected to start. | Joda-Time Instant |
+| Localized Start time - Timezone | **Required** | The timezone in which the event is expected to start. | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| Event mode | **Required** | A field to indicate whether the event will be virtual, in-person or both. | Enum: VIRTUAL, IN_PERSON, or HYBRID |
+| Poster images | **Required** | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** Image is highly recommended. If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Location - Country | Conditionally required | The country in which the event is happening. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - City | Conditionally required | The city in which the event is happening. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | Conditionally required | The address or venue name where the event will take place that should be displayed to the user. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - Street Address | Optional | The street address (if applicable) of the location at which event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state or province (if applicable) in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) of the location in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| End time | Optional | The epoch timestamp when the event is expected to end. **Note:**This will be represented in milliseconds. | Epoch timestamp in milliseconds |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Price - CurrentPrice | Conditionally required | The current price of the ticket/pass for the event. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the ticket/pass for the event. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Eligible Enums - TYPE_MOVIES_AND_TV_SHOWS (Example - Cinema) - TYPE_DIGITAL_GAMES (Example - eSports) - TYPE_MUSIC (Example - Concert) - TYPE_TRAVEL_AND_LOCAL (Example - Tour, festival) - TYPE_HEALTH_AND_FITENESS (Example - Yoga class) - TYPE_EDUCATION (Example - Class) - TYPE_SPORTS (Example - Football game) - TYPE_DATING (Example - meetup) See the [Content Category section](https://developer.android.com/guide/playcore/engage/travel#content-category) for guidance. |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `LodgingEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | String **Recommended text size: Max 50 chars** |
+| Poster images | **Required** | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Location - Country | **Required** | The country in which the lodging is happening. | Free text **Recommended text size: max \~20 chars** |
+| Location - City | **Required** | The city in which the lodging is happening. | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | **Required** | The address that will be displayed to the user. We recommend including the city name and possibly state or country for most use cases. Only include the street address or neighborhood if the user is near the location, the user is familiar with the location, or the city is included in the cluster title. If you include the street address, provide a succinct address, using abbreviations where possible (for example, "St" for "Street", "Ave" for "Avenue"). | Free text **Recommended text size: max \~20 chars** |
+| Location - Street Address | Optional | The street address (if applicable) of the lodging. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state or province (if applicable) in which the lodging is located. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) of the lodging. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) of the lodging. | Free text **Recommended text size: max \~20 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| AvailabilityTimeWindow - Localized Start Time - Timestamp | Optional | The epoch timestamp when the lodging is expected to be open/available. | Joda-Time Instant |
+| AvailabilityTimeWindow - Localized Start Time - Timezone | Optional | The timezone in which the lodging is expected to be open/available. | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| AvailabilityTimeWindow - Localized End Time - Timestamp | Optional | The epoch timestamp until which the lodging is expected to be open/available. | Joda-Time Instant |
+| AvailabilityTimeWindow - Localized End Time - Timezone | Optional | The timezone in which the lodging is expected to be open/available. | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the lodging. **Note:** Provide this field if your app wants to control how this is displayed to the users. Provide the concise string that can be displayed to the user. For example, if the count is 1,000,000, consider using abbreviations like 1M, so that it won't be truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the lodging. **Note:** Provide this field if you don't want to handle the display abbreviation logic yourself. If both Count and Count Value are present, we will use the Count to display to users | Long |
+| Price - CurrentPrice | Conditionally required | The current price of the lodging. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the lodging, which is be struck-through in the UI. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `StoreEntity`
+
+The `StoreEntity` object represents an individual store that developer partners
+want to publish, such as a popular dining place or eatery that are relevant to
+one's travel experience.
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Poster images | **Required** | At least one image must be provided. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | Optional | The name of the store. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Location | Optional | The location of the store. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Callout | Optional | Callout to feature a promo, event, or update for the store, if available. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Callout fine print | Optional | Fine print text for the callout. | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Description | Optional | A description of the store. | Free text **Recommended text size: under 90 chars** (Text that is too long may show ellipses) |
+| Category | Optional | Category of a store, in the context of dining places, it can be cuisine like "french", "new american", "ramen", "fine dining". | Free text **Recommended text size: under 45 chars** (Text that is too long may show ellipses) |
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the lodging. **Note:** Provide this field if your app wants to control how this is displayed to the users. Provide the concise string that can be displayed to the user. For example, if the count is 1,000,000, consider using abbreviations like 1M, so that it won't be truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the lodging. **Note:** Provide this field if you don't want to handle the display abbreviation logic yourself. If both Count and Count Value are present, we will use the Count to display to users | Long |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `PointOfInterestEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | String **Recommended text size: Max 50 chars** |
+| Poster images | Conditionally required | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** Image is required if the entity is part of recommendation cluster. If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Last Engagement Time | Conditionally required | The epoch timestamp when the user last interacted with this entity. **Note:** This field is required if the entity is part of continue search cluster. | Joda-Time Instant |
+| Location - Country | Conditionally required | The country in which the point of interest is happening. **Note:** This field is required if the entity is part of recommendation cluster. | Free text **Recommended text size: max \~20 chars** |
+| Location - City | Conditionally required | The city in which the point of interest is happening. **Note:** This field is required if the entity is part of recommendation cluster. | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | Conditionally required | The address that will be displayed to the user. Provide a succinct address, using abbreviations where possible (for example, "St" for "Street", "Ave" for "Avenue"). This string may be truncated depending on the user's device and settings. Include the city name for clear identification. **Note:** This field is required if the entity is part of recommendation cluster. | Free text **Recommended text size: max \~35 chars** |
+| Location - Street Address | Optional | The street address (if applicable) of the point of interest. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state or province (if applicable) in which the point of interest is located. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) of the point of interest. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) of the point of interest. | Free text **Recommended text size: max \~20 chars** |
+| AvailabilityTimeWindow - Localized Start Time - Timestamp | Optional | The epoch timestamp when the point of interest is expected to be open/available. | Joda-Time Instant |
+| AvailabilityTimeWindow - Localized Start Time - Timezone | Optional | The timezone in which the point of interest is expected to be open/available. | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| AvailabilityTimeWindow - Localized End Time - Timestamp | Optional | The epoch timestamp until which the point of interest is expected to be open/available. | Joda-Time Instant |
+| AvailabilityTimeWindow - Localized End Time - Timezone | Optional | The timezone in which the point of interest is expected to be open/available. | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the point of interest. **Note:** Provide this field if your app wants to control how this is displayed to the users. Provide the concise string that can be displayed to the user. For example, if the count is 1,000,000, consider using abbreviations like 1M, so that it won't be truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the point of interest. **Note:** Provide this field if you don't want to handle the display abbreviation logic yourself. If both Count and Count Value are present, we will use the Count to display to users | Long |
+| Price - CurrentPrice | Conditionally required | The current price of the tickets/entry pass for the point of interest. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the tickets/entry pass for the point of interest. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Eligible Enums - TYPE_TRAVEL_AND_LOCAL - TYPE_MOVIES_AND_TV_SHOWS (Example - theater) - TYPE_MEDICAL (Example - hospital) - TYPE_EDUCATION (Example - school) - TYPE_SPORTS (Example - stadium) See the [Content Category section](https://developer.android.com/guide/playcore/engage/travel#content-category) for guidance. |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `RestaurantReservationEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | String **Recommended text size: Max 50 chars** |
+| Localized Reservation Start Time - Timestamp | **Required** | The epoch timestamp when the reservation is expected to start. | Joda-Time Instant |
+| Localized Reservation Start Time - Timezone | **Required** | The timezone in which the reservation is expected to start. | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| Location - Country | **Required** | The country in which the restaurant is happening. | Free text **Recommended text size: max \~20 chars** |
+| Location - City | **Required** | The city in which the restaurant is happening. | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | **Required** | The address of the prestaurant that will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Location - Street Address | Optional | The street address (if applicable) of the restaurant. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state or province (if applicable) in which the restaurant is located. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) of the restaurant. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) of the restaurant. | Free text **Recommended text size: max \~20 chars** |
+| Poster images | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Table Size | Optional | The number of people in the reservation group | Integer \> 0 |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `EventReservationEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | String **Recommended text size: Max 50 chars** |
+| Localized Start time - Timestamp | **Required** | The epoch timestamp when the event is expected to start. | Joda-Time Instant |
+| Localized Start time - Timezone | **Required** | The timezone in which the event is expected to start. | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| Event mode | **Required** | A field to indicate whether the event will be virtual, in-person or both. | Enum: VIRTUAL, IN_PERSON, or HYBRID |
+| Location - Country | Conditionally required | The country in which the event is happening. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - City | Conditionally required | The city in which the event is happening. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | Conditionally required | The address or venue name where the event will take place that should be displayed to the user. **Note:** This is required for events which are IN_PERSON or HYBRID | Free text **Recommended text size: max \~20 chars** |
+| Location - Street Address | Optional | The street address (if applicable) of the location at which event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state or province (if applicable) in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) of the location in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) in which the event is being hosted. | Free text **Recommended text size: max \~20 chars** |
+| Poster images | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** Image is highly recommended. If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Localized End time - Timestamp | Optional | The epoch timestamp when the event is expected to end. | Joda-Time Instant |
+| Localized End time - Timezone | Optional | The timezone in which the event is expected to end. | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| Service Provider - Name | Optional | The name of the service provider. **Note:**Either text or image is required for the service provider. | Free text. For example, name of the event organizer/tour |
+| Service Provider - Image | Optional | The logo/image of the service provider. **Note:**Either text or image is required for the service provider. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Badges | Optional | Each badge is either free text (max 15 chars) or small image. |   |
+| Badge - Text | Optional | Title for the badge **Note:** Either text or image is required for the badge | Free text **Recommended text size: max 15 chars** |
+| Badge - Image | Optional | Small image Special UX treatment, for example as badge overlay on the image/video thumbnail. **Note:** Either text or image is required for the badge | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Reservation ID | Optional | The reservation ID for the event reservation. | Free text |
+| Price - CurrentPrice | Conditionally required | The current price of the ticket/pass for the event. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the ticket/pass for the event. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the event. **Note:** Provide this field if your app wants to control how this is displayed to the users. Provide the concise string that can be displayed to the user. For example, if the count is 1,000,000, consider using abbreviations like 1M, so that it won't be truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the event. **Note:** Provide this field if you don't want to handle the display abbreviation logic yourself. If both Count and Count Value are present, we will use the Count to display to users | Long |
+| Content Categories | Optional | Describe the category of the content in the entity. | List of Eligible Enums - TYPE_MOVIES_AND_TV_SHOWS (Example - Cinema) - TYPE_DIGITAL_GAMES (Example - eSports) - TYPE_MUSIC (Example - Concert) - TYPE_TRAVEL_AND_LOCAL (Example - Tour, festival) - TYPE_HEALTH_AND_FITENESS (Example - Yoga class) - TYPE_EDUCATION (Example - Class) - TYPE_SPORTS (Example - Football game) - TYPE_DATING (Example - meetup) See the [Content Category section](https://developer.android.com/guide/playcore/engage/travel#content-category) for guidance. |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `LodgingReservationEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | Free text. For example, "Your Stay from Dec 12th" **Recommended text size: Max 50 chars** |
+| Localized Check-in Time - Timestamp | **Required** | The epoch timestamp that represents the check in time for the reservation. | Joda-Time Instant |
+| Localized Check-in Time - Timezone | **Required** | The timezone in which the check in time exists for the reservation. | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| Localized Check-out Time - Timestamp | **Required** | The epoch timestamp that represents the check out time for the reservation. | Joda-Time Instant |
+| Localized Check-out Time - Timezone | **Required** | The timezone in which the check out time exists for the reservation. | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| Location - Country | **Required** | The country in which the lodging is located. | Free text **Recommended text size: max \~20 chars** |
+| Location - City | **Required** | The city in which the lodging is located. | Free text **Recommended text size: max \~20 chars** |
+| Location - Display Address | **Required** | The address that will be displayed to the user. Provide a succinct address, using abbreviations where possible (for example, "St" for "Street", "Ave" for "Avenue"). This string may be truncated depending on the user's device and settings. Include the city name for clear identification. | Free text **Recommended text size: max \~35 chars** |
+| Location - Street Address | Optional | The street address (if applicable) of the lodging. | Free text **Recommended text size: max \~20 chars** |
+| Location - State | Optional | The state or province (if applicable) in which the lodging is located. | Free text **Recommended text size: max \~20 chars** |
+| Location - Zip code | Optional | The zip code (if applicable) of the lodging. | Free text **Recommended text size: max \~20 chars** |
+| Location - Neighborhood | Optional | The neighborhood (if applicable) of the lodging. | Free text **Recommended text size: max \~20 chars** |
+| Poster images | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 **Note:** If a badge is provided, ensure safe space of 24 dps at both the top and bottom of the image | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Reservation ID | Optional | The reservation ID for the lodging reservation. | Free text |
+| Rating - Max value | Optional | The maximum value of the rating scale. **Must be provided if current value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Current value | Optional | The current value of the rating scale. **Must be provided if maximum value of rating is also provided.** | Number \>= 0.0 |
+| Rating - Count | Optional | The count of the ratings for the lodging. **Note:** Provide this field if your app wants to control how this is displayed to the users. Provide the concise string that can be displayed to the user. For example, if the count is 1,000,000, consider using abbreviations like 1M, so that it won't be truncated on smaller display sizes. | String |
+| Rating - Count Value | Optional | The count of the ratings for the lodging. **Note:** Provide this field if you don't want to handle the display abbreviation logic yourself. If both Count and Count Value are present, we will use the Count to display to users | Long |
+| Price - CurrentPrice | Conditionally required | The current price of the lodging. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the lodging, which is be struck-through in the UI. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `TransportationReservationEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | Free text. For example, "SFO to SAN" **Recommended text size: Max 50 chars** |
+| Transportation Type | **Required** | The mode/type of transportation for the reservation. | Enum: FLIGHT, TRAIN, BUS, or FERRY |
+| Localized Departure Time - Timestamp | **Required** | The epoch timestamp that represents the departure time. | Joda-Time Instant |
+| Localized Departure Time - Timezone | **Required** | The timezone of the departure time. | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| Localized Arrival Time - Timestamp | **Required** | The epoch timestamp that represents the arrival time. | Joda-Time Instant |
+| Localized Arrival Time - Timezone | **Required** | The timezone of the arrival time. | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| Transportation Number | **Required** | The flight number, bus number, train number, or ferry/cruise number. | Free text |
+| Localized Boarding Time - Timestamp | **Required** | The epoch timestamp that represents the boarding time for the reservation (if applicable) | Joda-Time Instant |
+| Localized Boarding Time - Timezone | **Required** | The timezone of the boarding time for the reservation (if applicable) | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| Departure Location - Country | Optional | The country of departure. | Free text **Recommended text size: max \~20 chars** |
+| Departure Location - City | Optional | The city of departure. | Free text **Recommended text size: max \~20 chars** |
+| Departure Location - Display Address | Optional | The location of departure that will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Departure Location - Street Address | Optional | The street address (if applicable) of the departure location. | Free text **Recommended text size: max \~20 chars** |
+| Departure Location - State | Optional | The state or province (if applicable) of the departure location. | Free text **Recommended text size: max \~20 chars** |
+| Departure Location - Zip code | Optional | The zip code (if applicable) of the departure location. | Free text **Recommended text size: max \~20 chars** |
+| Departure Location - Neighborhood | Optional | The neighborhood (if applicable) of the departure location. | Free text **Recommended text size: max \~20 chars** |
+| Arrival Location - Country | Optional | The country of arrival. | Free text **Recommended text size: max \~20 chars** |
+| Arrival Location - City | Optional | The city of arrival. | Free text **Recommended text size: max \~20 chars** |
+| Arrival Location - Display Address | Optional | The location of arrival that will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Arrival Location - Street Address | Optional | The street address (if applicable) of the arrival location. | Free text **Recommended text size: max \~20 chars** |
+| Arrival Location - State | Optional | The state or province (if applicable) of the arrival location. | Free text **Recommended text size: max \~20 chars** |
+| Arrival Location - Zip code | Optional | The zip code (if applicable) of the arrival location. | Free text **Recommended text size: max \~20 chars** |
+| Arrival Location - Neighborhood | Optional | The neighborhood (if applicable) of the arrival location. | Free text **Recommended text size: max \~20 chars** |
+| Service Provider - Name | Optional | The name of the service provider. **Note:**Either text or image is required for the service provider. | Free text. For example, Airline name |
+| Service Provider - Image | Optional | The logo/image of the service provider. **Note:**Either text or image is required for the service provider. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Poster images | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Reservation ID | Optional | The reservation ID for the transportation reservation. | Free text |
+| Price - CurrentPrice | Conditionally required | The current price of the reservation. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the reservation, which is be struck-through in the UI. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### `VehicleRentalReservationEntity`
+
+| Attribute | Requirement | Description | Format |
+|---|---|---|---|
+| Action Uri | **Required** | Deep Link to the entity in the provider app. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) | Uri |
+| Title | **Required** | Title of the entity. | Free text. For example, "Avis Union Square SF" **Recommended text size: Max 50 chars** |
+| Localized Pickup Time - Timestamp | **Required** | The epoch timestamp that represents the pick up time for the reservation. | Joda-Time Instant |
+| Localized Pickup Time - Timezone | **Required** | The timezone of the pick up time for the reservation. | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| Localized Return Time - Timestamp | Optional | The epoch timestamp that represents the check out time for the reservation. | Joda-Time Instant |
+| Localized Return Time - Timezone | Optional | The timezone of the check out time for the reservation. | Joda-Time DateTimeZone See [Timezone Specifications](https://developer.android.com/guide/playcore/engage/travel#tz-specs) for guidance. |
+| Pickup Address - Country | Optional | The country of the pickup location. | Free text **Recommended text size: max \~20 chars** |
+| Pickup Address - City | Optional | The city of the pickup location. | Free text **Recommended text size: max \~20 chars** |
+| Pickup Address - Display Address | Optional | The pickup location that will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Pickup Address - Street Address | Optional | The street address (if applicable) of the pickup location. | Free text **Recommended text size: max \~20 chars** |
+| Pickup Address - State | Optional | The state or province (if applicable) of the pickup location. | Free text **Recommended text size: max \~20 chars** |
+| Pickup Address - Zip code | Optional | The zip code (if applicable) of the pickup location. | Free text **Recommended text size: max \~20 chars** |
+| Pickup Address - Neighborhood | Optional | The neighborhood (if applicable) of the pickup location. | Free text **Recommended text size: max \~20 chars** |
+| Return Address - Country | Optional | The country of return location. | Free text **Recommended text size: max \~20 chars** |
+| Return Address - City | Optional | The city of return location. | Free text **Recommended text size: max \~20 chars** |
+| Return Address - Display Address | Optional | The return location that will be displayed to the user. | Free text **Recommended text size: max \~20 chars** |
+| Return Address - Street Address | Optional | The street address (if applicable) of the return location. | Free text **Recommended text size: max \~20 chars** |
+| Return Address - State | Optional | The state or province (if applicable) of the return location. | Free text **Recommended text size: max \~20 chars** |
+| Return Address - Zip code | Optional | The zip code (if applicable) of the return location. | Free text **Recommended text size: max \~20 chars** |
+| Return Address - Neighborhood | Optional | The neighborhood (if applicable) of the return location. | Free text **Recommended text size: max \~20 chars** |
+| Service Provider - Name | Optional | The name of the service provider. **Note:**Either text or image is required for the service provider. | Free text. For example, "Avis Car Rental" |
+| Service Provider - Image | Optional | The logo/image of the service provider. **Note:**Either text or image is required for the service provider. | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Poster images | Optional | We will show only 1 image when multiple images are provided. Recommended aspect ratio is 16:9 | See [Image Specifications](https://developer.android.com/guide/playcore/engage/travel#image-specs) for guidance. |
+| Description | Optional | A single paragraph of text to describe the entity. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size: 180 chars** |
+| Subtitle list | Optional | Up to 3 subtitles, with each subtitle a single line of text. **Note:** Either description or subtitle list will be displayed to the user, not both. | Free text **Recommended text size for each subtitle: max 50 chars** |
+| Confirmation ID | Optional | The confirmation ID for the vehicle rental reservation. | Free text |
+| Price - CurrentPrice | Conditionally required | The current price of the reservation. **Must be provided if strikethrough price is provided.** | Free text |
+| Price - StrikethroughPrice | Optional | The original price of the reservation, which is be struck-through in the UI. | Free text |
+| Price Callout | Optional | Price callout to feature a promo, event, member discount, if available. | Free text **Recommended text size: under 45 chars (Text that is too long may show ellipses)** |
+| **DisplayTimeWindow (Optional) - Set a time window for a content to be shown on the surface** ||||
+| Start Timestamp | Optional | The epoch timestamp after which the content should be shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+| End Timestamp | Optional | The epoch timestamp after which the content is no longer shown on the surface. If not set, content is eligible to be shown on the surface. | Epoch timestamp in milliseconds |
+
+#### Image specifications
+
+Required specifications for image assets are listed in this table:
+
+| Aspect ratio | Minimum pixels | Recommended pixels |
+|---|---|---|
+| Square (1x1) **Preferred** | 300x300 | 1200x1200 |
+| Landscape (1.91x1) | 600x314 | 1200x628 |
+| Portrait (4x5) | 480x600 | 960x1200 |
+
+The images are required to be hosted on public CDNs so that Google can access
+them.
+
+*File formats*
+
+PNG, JPG, static GIF, WebP
+
+*Maximum file size*
+
+5120 KB
+
+*Additional recommendations*
+
+- **Image safe area:** Put your important content in the center 80% of the image.
+- Use a transparent background so that the image can be properly displayed in Dark and Light theme settings.
+
+#### Timezone specifications
+
+Prefer ID (for example, "America/Los_Angeles") over offset (for example,
+"-07:00").
+
+Sample usage: `DateTimeZone.forID("America/Los_Angeles")`
+
+#### Content Category
+
+The content category allows apps to publish content belonging to multiple
+categories. This maps the content with some of the predefined categories namely:
+
+- `TYPE_EDUCATION`
+- `TYPE_SPORTS`
+- `TYPE_MOVIES_AND_TV_SHOWS`
+- `TYPE_BOOKS`
+- `TYPE_AUDIOBOOKS`
+- `TYPE_MUSIC`
+- `TYPE_DIGITAL_GAMES`
+- `TYPE_TRAVEL_AND_LOCAL`
+- `TYPE_HOME_AND_AUTO`
+- `TYPE_BUSINESS`
+- `TYPE_NEWS`
+- `TYPE_FOOD_AND_DRINK`
+- `TYPE_SHOPPING`
+- `TYPE_HEALTH_AND_FITENESS`
+- `TYPE_MEDICAL`
+- `TYPE_PARENTING`
+- `TYPE_DATING`
+
+The images are required to be hosted on public CDNs so that Google can access
+them.
+
+*Guidelines to use the content categories*
+
+1. Some entities like **ArticleEntity** and **GenericFeaturedEntity** are eligible to use any of the content categories. For other entities like **EventEntity** , **EventReservationEntity** , **PointOfInterestEntity**, only a subset of these categories are eligible. Check the list of categories eligible for an entity type before populating the list.
+2. Use the specific entity type for some content categories over a combination
+   of the Generic entities and the ContentCategory:
+
+   - TYPE_MOVIES_AND_TV_SHOWS - Check out the entities from [Watch integration guide](https://developer.android.com/guide/playcore/engage/watch) before using the generic entities.
+   - TYPE_BOOKS - Check out the [EbookEntity](https://developer.android.com/guide/playcore/engage/read#ebookentity) before using the generic entities.
+   - TYPE_AUDIOBOOKS - Check out [AudiobookEntity](https://developer.android.com/guide/playcore/engage/read#audiobookentity) before using the generic entities.
+   - TYPE_SHOPPING - Check out [ShoppingEntity](https://developer.android.com/guide/playcore/engage/shopping#shoppingEntity) before using the generic entities.
+   - TYPE_FOOD_AND_DRINK - Check out entities from [Food Integration guide](https://developer.android.com/guide/playcore/engage/food) before using the generic entities.
+3. The ContentCategory field is optional and should be left blank if the
+   content doesn't belong to any of the categories mentioned earlier.
+
+4. In case multiple content categories are provided, provide them in the order
+   of relevance to the content with the most relevant content category placed
+   first in the list.
+
+### Step 2: Provide Cluster data
+
+It is recommended to have the content publish job executed in the background
+(for example, using [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager))
+and scheduled on a regular basis or on an event basis (for example, every time
+the user opens the app or when the user just added something to their cart).
+
+`AppEngageTravelClient` is responsible for publishing clusters.
+
+There are following APIs to publish clusters in the client:
+
+- `isServiceAvailable`
+- `publishRecommendationClusters`
+- `publishFeaturedCluster`
+- `publishReservationCluster`
+- `publishContinueSearchCluster`
+- `publishUserAccountManagementRequest`
+- `updatePublishStatus`
+- `deleteRecommendationsClusters`
+- `deleteFeaturedCluster`
+- `deleteReservationCluster`
+- `deleteContinueSearchCluster`
+- `deleteUserManagementCluster`
+- `deleteClusters`
+
+#### `isServiceAvailable`
+
+This API is used to check if the service is available for integration and
+whether the content can be presented on the device.
+
+##### For Engage SDK v1.6.0 and higher (Recommended)
+
+You can check the service availability for every cluster type that you intend to
+publish. The `isServiceAvailable` API accepts a request object,
+`ServiceAvailabilityRequest`, which contains the cluster types for which service
+availability needs to be checked. You can find the `ClusterType` enum values
+required for `ServiceAvailabilityRequest` from the following table.
+
+| Cluster Type | Cluster Type Constant | Integer Value |
+|---|---|---|
+| Unknown | `TYPE_UNKNOWN` | 0 |
+| Recommendation Cluster | `TYPE_RECOMMENDATION` | 1 |
+| Featured Cluster | `TYPE_FEATURED` | 2 |
+| Continuation Cluster | `TYPE_CONTINUATION` | 3 |
+| User Management Cluster | `TYPE_ENGAGEMENT` | 8 |
+| Subscription Cluster | `TYPE_SUBSCRIPTION` | 12 |
+| Continue Search Cluster | `TYPE_CONTINUE_SEARCH` | 13 |
+| Reservation Cluster | `TYPE_RESERVATION` | 14 |
+
+### Kotlin
+
+    val request = ServiceAvailabilityRequest.Builder()
+        .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+        .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+        .build()
+
+    client.isServiceAvailable(request).addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            val availabilityMap = task.result
+            if (availabilityMap[ClusterType.TYPE_CONTINUATION] == true) {
+                // Proceed with publishing continuation content
+            }
+            if (availabilityMap[ClusterType.TYPE_RECOMMENDATION] == true) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    }
+
+### Java
+
+    ServiceAvailabilityRequest request =
+        new ServiceAvailabilityRequest.Builder()
+            .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+            .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+            .build();
+
+    client.isServiceAvailable(request).addOnCompleteListener(task -> {
+        if (task.isSuccessful()) {
+            Map<Integer, Boolean> availabilityMap = task.getResult();
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_CONTINUATION))) {
+                // Proceed with publishing continuation content
+            }
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_RECOMMENDATION))) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    });
+
+###### Conditional Service Availability Feature
+
+Some integrated apps request a special configuration that enables and disables
+the Engage service intermittently in order to reduce their serving cost. This
+intermittent content ingestion strategy, although possible, negatively affects
+the user and the product -- stale content will not be presented and some surfaces
+will not be served at all.
+
+Starting with v1.6.0, the Engage SDK allows checking availability for specific
+cluster types. This provides more flexibility so that if the intermittent
+content strategy was adopted by a given application, some cluster types can
+follow that intermittent strategy while other cluster types are always enabled
+(i.e. continuation clusters).
+
+If the Engage service should not be 'continuously' enabled on all supported
+devices for whatever reason, and is configured for intermittent ingestion for
+any set of devices, all continuation cluster publications (e.g. Reservation
+and Continue Search) will be still enabled by default configuration, and the
+rest of the cluster types will be enabled and disabled intermittently. If
+intermittent ingestion applies to you but this default configuration is not
+suitable for your needs, please contact engage-developers@google.com.
+
+##### For SDK versions prior to v1.6.0 (Deprecated)
+
+### Kotlin
+
+    client.isServiceAvailable.addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            // Handle IPC call success
+            if(task.result) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    }
+
+### Java
+
+    client.isServiceAvailable().addOnCompleteListener(task - > {
+        if (task.isSuccessful()) {
+            // Handle success
+            if(task.getResult()) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    });
+
+> [!NOTE]
+> **Note:** We highly recommend keeping a periodic job running to check if the service becomes available at a later point in time. The availability of the service may change with Android version upgrades, app upgrades, installs, and uninstalls. By ensuring periodic job checks at a certain time interval, data can be published once the service becomes available.
+
+#### `publishRecommendationClusters`
+
+This API is used to publish a list of `RecommendationCluster` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishRecommendationClusters(
+          PublishRecommendationClustersRequest.Builder()
+            .addRecommendationCluster(
+              RecommendationCluster.Builder()
+                .addEntity(entity1)
+                .addEntity(entity2)
+                .setTitle("Top Picks For You")
+                .build()
+            )
+            .build()
+        )
+
+### Java
+
+    client.publishRecommendationClusters(
+                new PublishRecommendationClustersRequest.Builder()
+                    .addRecommendationCluster(
+                        new RecommendationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .setTitle("Top Picks For You")
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `RecommendationCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Recommendation Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishFeaturedCluster`
+
+This API is used to publish a list of `FeaturedCluster` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishFeaturedCluster(
+        PublishFeaturedClusterRequest.Builder()
+          .setFeaturedCluster(
+            FeaturedCluster.Builder()
+              .addEntity(entity1)
+              .addEntity(entity2)
+              .build())
+          .build())
+
+### Java
+
+    client.publishFeaturedCluster(
+                new PublishFeaturedClustersRequest.Builder()
+                    .addFeaturedCluster(
+                        new FeaturedCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `FeaturedCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Featured Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishReservationCluster`
+
+This API is used to publish a `ReservationCluster` object.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishReservationCluster(
+        PublishReservationClusterRequest.Builder()
+          .setReservationCluster(
+            ReservationCluster.Builder()
+              .addLodgingReservationEntity(lodgingReservationEntity)
+              .addVehicleRentalReservationEntity(vehicleRentalReservationEntity)
+              .addTransportationReservationEntity(transportationReservationEntity)
+              .addEventReservationEntity(eventReservationEntity)
+              .addRestaurantReservationEntity(restaurantReservationEntity)
+              .build())
+          .build())
+
+### Java
+
+    client.publishReservationCluster(
+                new PublishReservationClusterRequest.Builder()
+                    .setReservationCluster(
+                        new ReservationCluster.Builder()
+                            .addLodgingReservationEntity(lodgingReservationEntity)
+                            .addVehicleRentalReservationEntity(vehicleRentalReservationEntity)
+                            .addTransportationReservationEntity(transportationReservationEntity)
+                            .addEventReservationEntity(eventReservationEntity)
+                            .addRestaurantReservationEntity(restaurantReservationEntity)
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `ReservationCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Reservation Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishContinueSearchCluster`
+
+This API is used to publish a list of `ContinueSearchCluster` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs replace any existing content. **Don't** call delete and publish APIs subsequently to replace the content, as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishContinueSearchCluster(
+        PublishContinueSearchClusterRequest.Builder()
+          .setContinueSearchCluster(
+            ContinueSearchCluster.Builder()
+              .addPointOfInterestEntity(entity1)
+              .addPointOfInterestEntity(entity2)
+              .build())
+          .build())
+
+### Java
+
+    client.publishContinueSearchCluster(
+                new PublishContinueSearchClusterRequest.Builder()
+                    .setContinueSearchCluster(
+                        new ContinueSearchCluster.Builder()
+                            .addPointOfInterestEntity(entity1)
+                            .addPointOfInterestEntity(entity2)
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `ContinueSearchCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Continue Search Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishUserAccountManagementRequest`
+
+This API is used to publish a Sign In card . The signin action directs users to
+the app's sign in page so that the app can publish content (or provide more
+personalized content)
+
+The following metadata is part of the Sign In Card -
+
+| Attribute | Requirement | Description |
+|---|---|---|
+| Action Uri | Required | Deeplink to Action (i.e. navigates to app sign in page) |
+| Image | Optional - If not provided, Title must be provided | Image Shown on the Card 16x9 aspect ratio images with a resolution of 1264x712 |
+| Title | Optional - If not provided, Image must be provided | Title on the Card |
+| Action Text | Optional | Text Shown on the CTA (i.e. Sign in) |
+| Subtitle | Optional | Optional Subtitle on the Card |
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    var SIGN_IN_CARD_ENTITY =
+          SignInCardEntity.Builder()
+              .addPosterImage(
+                  Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build()
+
+    client.publishUserAccountManagementRequest(
+                PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+### Java
+
+    SignInCardEntity SIGN_IN_CARD_ENTITY =
+          new SignInCardEntity.Builder()
+              .addPosterImage(
+                  new Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build();
+
+    client.publishUserAccountManagementRequest(
+                new PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `UserAccountManagementCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated UserAccountManagementCluster Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `updatePublishStatus`
+
+If for any internal business reason, none of the clusters is published, we
+**strongly recommend** updating the publish status using the
+**updatePublishStatus** API. This is important because :
+
+- Providing the status in all scenarios, even when the content is published (STATUS == PUBLISHED), is critical to populate dashboards that use this explicit status to convey the health and other metrics of your integration.
+- If no content is published but the integration status isn't broken (STATUS == NOT_PUBLISHED), Google can avoid triggering alerts in the app health dashboards. It confirms that content is not published due to an **expected** situation from the provider's standpoint.
+- It helps developers provide insights into when the data is published versus not.
+- Google may use the status codes to nudge the user to do certain actions in the app so they can see the app content or overcome it.
+
+The list of eligible publish status codes are :
+
+    // Content is published
+    AppEngagePublishStatusCode.PUBLISHED,
+
+    // Content is not published as user is not signed in
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN,
+
+    // Content is not published as user is not subscribed
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SUBSCRIPTION,
+
+    // Content is not published as user location is ineligible
+    AppEngagePublishStatusCode.NOT_PUBLISHED_INELIGIBLE_LOCATION,
+
+    // Content is not published as there is no eligible content
+    AppEngagePublishStatusCode.NOT_PUBLISHED_NO_ELIGIBLE_CONTENT,
+
+    // Content is not published as the feature is disabled by the client
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_FEATURE_DISABLED_BY_CLIENT,
+
+    // Content is not published as the feature due to a client error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR,
+
+    // Content is not published as the feature due to a service error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR,
+
+    // Content is not published due to some other reason
+    // Reach out to engage-developers@ before using this enum.
+    AppEngagePublishStatusCode.NOT_PUBLISHED_OTHER
+
+If the content is not published due to a user not logged in, Google would
+recommend publishing the Sign In Card. If for any reason providers are not able
+to publish the Sign In Card then we recommend calling the
+**updatePublishStatus** API with the status code
+**NOT_PUBLISHED_REQUIRES_SIGN_IN**
+
+### Kotlin
+
+    client.updatePublishStatus(
+       PublishStatusRequest.Builder()
+         .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+         .build())
+
+### Java
+
+    client.updatePublishStatus(
+        new PublishStatusRequest.Builder()
+            .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+            .build());
+
+#### `deleteRecommendationClusters`
+
+This API is used to delete the content of Recommendation Clusters.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteRecommendationClusters()
+
+### Java
+
+    client.deleteRecommendationClusters();
+
+When the service receives the request, it removes the existing data from the
+Recommendation Clusters. In case of an error, the entire request is rejected and
+the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteFeaturedCluster`
+
+This API is used to delete the content of Featured Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteFeaturedCluster()
+
+### Java
+
+    client.deleteFeaturedCluster();
+
+When the service receives the request, it removes the existing data from the
+Featured Cluster. In case of an error, the entire request is rejected and the
+existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteReservationCluster`
+
+This API is used to delete the content of Reservation Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteReservationCluster()
+
+### Java
+
+    client.deleteReservationCluster();
+
+When the service receives the request, it removes the existing data from the
+Reservation Cluster. In case of an error, the entire request is rejected and
+the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteUserManagementCluster`
+
+This API is used to delete the content of UserAccountManagement Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteUserManagementCluster()
+
+### Java
+
+    client.deleteUserManagementCluster();
+
+When the service receives the request, it removes the existing data from the
+UserAccountManagement Cluster. In case of an error, the entire request is
+rejected and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteContinueSearchCluster`
+
+This API is used to delete the content of Continue Search Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteContinueSearchCluster()
+
+### Java
+
+    client.deleteContinueSearchCluster();
+
+When the service receives the request, it removes the existing data from the
+Continue Search Cluster. In case of an error, the entire request is
+rejected, and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This API is available from version 1.5.6 onwards.
+
+#### `deleteClusters`
+
+This API is used to delete the content of a given cluster type.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteClusters(
+        DeleteClustersRequest.Builder()
+          .addClusterType(ClusterType.TYPE_RESERVATION)
+          .addClusterType(ClusterType.TYPE_FEATURED)
+          .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+          .addClusterType(ClusterType.TYPE_CONTINUE_SEARCH)
+          .build())
+
+### Java
+
+    client.deleteClusters(
+                new DeleteClustersRequest.Builder()
+                    .addClusterType(ClusterType.TYPE_RESERVATION)
+                    .addClusterType(ClusterType.TYPE_FEATURED)
+                    .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+                    .addClusterType(ClusterType.TYPE_CONTINUE_SEARCH)
+                    .build());
+
+When the service receives the request, it removes the existing data from all
+clusters matching the specified cluster types. Clients can choose to pass one or
+many cluster types. In case of an error, the entire request is rejected and the
+existing state is maintained.
+
+#### Error handling
+
+It is highly recommended to listen to the task result from the publish APIs such
+that a follow-up action can be taken to recover and resubmit an successful task.
+
+### Kotlin
+
+    client.publishRecommendationClusters(
+            PublishRecommendationClustersRequest.Builder()
+              .addRecommendationCluster(..)
+              .build())
+          .addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+              // do something
+            } else {
+              val exception = task.exception
+              if (exception is AppEngageException) {
+                @AppEngageErrorCode val errorCode = exception.errorCode
+                if (errorCode == AppEngageErrorCode.SERVICE_NOT_FOUND) {
+                  // do something
+                }
+              }
+            }
+          }
+
+### Java
+
+    client.publishRecommendationClusters(
+                  new PublishRecommendationClustersRequest.Builder()
+                      .addRecommendationCluster(...)
+                      .build())
+              .addOnCompleteListener(
+                  task -> {
+                    if (task.isSuccessful()) {
+                      // do something
+                    } else {
+                      Exception exception = task.getException();
+                      if (exception instanceof AppEngageException) {
+                        @AppEngageErrorCode
+                        int errorCode = ((AppEngageException) exception).getErrorCode();
+                        if (errorCode == AppEngageErrorCode.SERVICE_NOT_FOUND) {
+                          // do something
+                        }
+                      }
+                    }
+                  });
+
+The error is returned as an `AppEngageException` with the cause included as an
+error code.
+
+| Error code | Error name | Note |
+|---|---|---|
+| `1` | `SERVICE_NOT_FOUND` | The service is not available on the given device. |
+| `2` | `SERVICE_NOT_AVAILABLE` | The service is available on the given device, but it is not available at the time of the call (for example, it is explicitly disabled). |
+| `3` | `SERVICE_CALL_EXECUTION_FAILURE` | The task execution failed due to threading issues. In this case, it can be retried. |
+| `4` | `SERVICE_CALL_PERMISSION_DENIED` | The caller is not allowed to make the service call. |
+| `5` | `SERVICE_CALL_INVALID_ARGUMENT` | The request contains invalid data (for example, more than the allowed number of clusters). |
+| `6` | `SERVICE_CALL_INTERNAL` | There is an error on the service side. |
+| `7` | `SERVICE_CALL_RESOURCE_EXHAUSTED` | The service call is made too frequently. |
+
+### Step 3: Handle broadcast intents
+
+In addition to making publish content API calls through a job, it is also
+required to set up a
+[`BroadcastReceiver`](https://developer.android.com/reference/android/content/BroadcastReceiver) to receive
+the request for a content publish.
+
+The goal of broadcast intents is mainly for app reactivation and forcing data
+sync. Broadcast intents are not designed to be sent very frequently. It is only
+triggered when the Engage Service determines the content might be stale (for
+example, a week old). That way, there is more confidence that the user can have
+a fresh content experience, even if the application has not been executed for a
+long period of time.
+
+The `BroadcastReceiver` must be set up in the following two ways:
+
+- Dynamically register an instance of the `BroadcastReceiver` class using
+  `Context.registerReceiver()`. This enables communication from applications
+  that are still live in memory.
+
+### Kotlin
+
+    class AppEngageBroadcastReceiver : BroadcastReceiver(){
+      // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+      // is received
+      // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is received
+      // Trigger continue search cluster publish when PUBLISH_CONTINUE_SEARCH
+      // broadcast is received
+      // Trigger reservation cluster publish when PUBLISH_RESERVATION broadcast is
+      // received
+    }
+
+    fun registerBroadcastReceivers(context: Context){
+      var  context = context
+      context = context.applicationContext
+
+    // Register Recommendation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Featured Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Continue Search Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(com.google.android.engage.travel.service.Intents.ACTION_PUBLISH_CONTINUE_SEARCH),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Reservation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(com.google.android.engage.travel.service.Intents.ACTION_PUBLISH_RESERVATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+    }
+
+### Java
+
+    class AppEngageBroadcastReceiver extends BroadcastReceiver {
+    // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+    // is received
+
+    // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is received
+
+    // Trigger continue search cluster publish when PUBLISH_CONTINUE_SEARCH
+    // broadcast is received
+
+    // Trigger reservation cluster publish when PUBLISH_RESERVATION broadcast is
+    // received
+    }
+
+    public static void registerBroadcastReceivers(Context context) {
+
+    context = context.getApplicationContext();
+
+    // Register Recommendation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Featured Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Continue Search Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.travel.service.Intents.ACTION_PUBLISH_CONTINUE_SEARCH),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Reservation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.travel.service.Intents.ACTION_PUBLISH_RESERVATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    }
+
+- Statically declare an implementation with the `<receiver>` tag in your
+  `AndroidManifest.xml` file. This allows the application to receive broadcast
+  intents when it is not running, and also allows the application to publish
+  the content.
+
+    <application>
+       <receiver
+          android:name=".AppEngageBroadcastReceiver"
+          android:permission="com.google.android.engage.REQUEST_ENGAGE_DATA"
+          android:exported="true"
+          android:enabled="true">
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_RECOMMENDATION" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_FEATURED" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.travel.PUBLISH_CONTINUE_SEARCH" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.travel.PUBLISH_RESERVATION" />
+          </intent-filter>
+       </receiver>
+    </application>
+
+The following [intents](https://developer.android.com/reference/android/content/Intent) is sent by the
+service:
+
+- `com.google.android.engage.action.PUBLISH_RECOMMENDATION` It is recommended to start a `publishRecommendationClusters` call when receiving this intent.
+- `com.google.android.engage.action.PUBLISH_FEATURED` It is recommended to start a `publishFeaturedCluster` call when receiving this intent.
+- `com.google.android.engage.action.travel.PUBLISH_CONTINUE_SEARCH` It is recommended to start a `publishContinueSearchCluster` call when receiving this intent.
+- `com.google.android.engage.action.travel.PUBLISH_RESERVATION` It is recommended to start a `publishReservationCluster` call when receiving this intent.
+
+## Integration workflow
+
+For a step-by-step guide on verifying your integration after it is complete, see
+[Engage developer integration workflow](https://developer.android.com/guide/playcore/engage/workflow).
+
+## FAQs
+
+See [Engage SDK Frequently Asked Questions](https://developer.android.com/guide/playcore/engage/faq) for
+FAQs.
+
+## Contact
+
+Contact
+[`engage-developers@google.com`](mailto:engage-developers@google.com) if there are
+any questions during the integration process.
+
+## Next steps
+
+After completing this integration, your next steps are as follows:
+
+- Send an email to [`engage-developers@google.com`](mailto:engage-developers@google.com) and attach your integrated APK that is ready for testing by Google.
+- Google performs a verification and reviews internally to make sure the integration works as expected. If changes are needed, Google contacts you with any necessary details.
+- When testing is complete and no changes are needed, Google contacts you to notify you that you can start publishing the updated and integrated APK to the Play Store.
+- After Google has confirmed that your updated APK has been published to the Play Store, your **Recommendation** , **Featured** , **Reservation** , and **Continue Search** clusters may be published and visible to users.

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/tv/continue-watching/index.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/tv/continue-watching/index.md
@@ -1,0 +1,19 @@
+Continue watching leverages the **Continuation cluster** to show unfinished
+videos, and next episodes to be watched from the same TV show, from multiple
+apps in one UI grouping. You can feature your entities in this continuation
+cluster. Follow this guide to learn how to enhance user engagement through the
+continue watching experience using [Engage SDK](https://developer.android.com/guide/playcore/engage).
+
+You manage the continuation cluster by using the client API in a TV app or from
+a REST API:
+
+- [Integrate continue watching on Android TV](https://developer.android.com/guide/playcore/engage/tv/continue-watching/client)
+- [Integrate continue watching using REST API](https://developer.android.com/guide/playcore/engage/tv/continue-watching/rest)
+
+## Sample code
+
+This [sample app](https://github.com/googlesamples/tv-video-discovery-samples) demonstrates how you can integrate with Engage SDK
+to send personalized user data to Google. It shows how to build a common module
+that you can import in both mobile and TV apps. The sample also illustrates
+when to call the publish and delete APIs, as well as how to use Workers to
+make these calls.

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/tv/entitlements.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/tv/entitlements.md
@@ -1,0 +1,353 @@
+This guide contains instructions for developers to share app subscription and
+entitlement data with Google TV using [Engage SDK](https://developer.android.com/guide/playcore/engage). Users can find
+content they are entitled to and enable Google TV to deliver highly relevant
+content recommendations to users, directly within Google TV experiences on TV,
+mobile, and tablet.
+
+## Prerequisites
+
+> [!IMPORTANT]
+> **Important:** [Express interest in developing with Engage](http://g.co/tv/vda).
+
+Onboarding the media actions feed is required before you can use the device
+entitlement API. If you haven't already done so, complete the [media actions
+feed](https://developers.google.com/actions/media?authuser=0) onboarding process.
+
+## Pre-work
+
+Complete the [Pre-work](https://developer.android.com/guide/playcore/engage/tv/getting-started#pre-work) instructions in the Getting Started guide.
+
+1. Publish subscription information on the following events:
+   1. User logs in to your app.
+   2. User switches between profiles (if profiles are supported).
+   3. User purchases a new subscription.
+   4. User upgrades an existing subscription.
+   5. User subscription expires.
+
+## Integration
+
+This section provides the necessary code examples and instructions for
+implementing `SubscriptionEntity` to manage various subscription types.
+
+### Common tier subscription
+
+For users with basic subscriptions to media provider services, for example, a
+service that has one subscription tier that grants access to all the paid
+content, provide these essential details:
+
+1. `SubscriptionType`: Clearly indicate the specific subscription plan the user
+   has.
+
+   - `SUBSCRIPTION_TYPE_ACTIVE`: User has an active paid subscription.
+   - `SUBSCRIPTION_TYPE_ACTIVE_TRIAL`: User has a trial subscription.
+   - `SUBSCRIPTION_TYPE_INACTIVE`: User has an account but no active subscription or trial.
+
+   > [!IMPORTANT]
+   > **Important:** Only users with `SUBSCRIPTION_TYPE_ACTIVE` or `SUBSCRIPTION_TYPE_ACTIVE_TRIAL` are eligible for personalized content recommendations based on their subscription.
+
+2. `ExpirationTimeMillis`: Optional time in milliseconds. Specify when the
+   subscription is set to expire.
+
+3. `ProviderPackageName`: Specify the package name of the app that handles the
+   subscription.
+
+Example for the sample media provider feed.
+
+    "actionAccessibilityRequirement": [
+      {
+        "@type": "ActionAccessSpecification",
+        "category": "subscription",
+        "availabilityStarts": "2022-06-01T07:00:00Z",
+        "availabilityEnds": "2026-05-31T07:00:00Z",
+        "requiresSubscription": {
+        "@type": "MediaSubscription",
+        // Don't match this string,
+        // ID is only used to for reconciliation purpose
+        "@id": "https://www.example.com/971bfc78-d13a-4419",
+        // Don't match this, as name is only used for displaying purpose
+        "name": "Basic common name",
+        "commonTier": true
+      }
+
+The following example creates a `SubscriptionEntity` for a user:
+
+    val subscription = SubscriptionEntity.Builder()
+      setSubscriptionType(
+        SubscriptionType.SUBSCRIPTION_TYPE_ACTIVE
+      )
+      .setProviderPackageName("com.google.android.example")
+      // Optional
+      // December 30, 2025 12:00:00AM in milliseconds since epoch
+      .setExpirationTimeMillis(1767052800000)
+      .build()
+
+### Premium subscription
+
+If app offer multi-tiered premium subscription packages, which includes expanded
+content or features beyond the common tier, represent this by adding one or more
+entitlements to Subscription.
+
+This entitlement has the following fields:
+
+1. `Identifier`: Required identifier string for this entitlement. This must match one of the [entitlement identifiers](https://developers.google.com/actions/media/concepts/access-requirements#entitlement-identifier) (note that this isn't the ID field) provided in the media provider's feed published to Google TV.
+2. `Name`: This is auxiliary information and is used for entitlement matching. While optional, providing a human readable entitlement name enhances understanding of user entitlements for both developers and support teams. For example: Sling Orange.
+3. `ExpirationTimeMillis`: Optionally specify the expiration time in milliseconds for this entitlement, if it differs from the subscription expiration time. By default, the entitlement will expire with the expiry of subscription.
+
+For the following sample media provider feed snippet:
+
+    "actionAccessibilityRequirement": [
+      {
+        "@type": "ActionAccessSpecification",
+        "category": "subscription",
+        "availabilityStarts": "2022-06-01T07:00:00Z",
+        "availabilityEnds": "2026-05-31T07:00:00Z",
+        "requiresSubscription": {
+        "@type": "MediaSubscription",
+        // Don't match this string,
+        // ID is only used to for reconciliation purpose
+        "@id": "https://www.example.com/971bfc78-d13a-4419",
+
+        // Don't match this, as name is only used for displaying purpose
+        "name": "Example entitlement name",
+        "commonTier": false,
+        // match this identifier in your API. This is the crucial
+        // entitlement identifier used for recommendation purpose.
+        "identifier": "example.com:entitlementString1"
+      }
+
+The following example creates a `SubscriptionEntity` for a subscribed user:
+
+    // Subscription with entitlements.
+    // The entitlement expires at the same time as its subscription.
+    val subscription = SubscriptionEntity.Builder()
+      .setSubscriptionType(
+        SubscriptionType.SUBSCRIPTION_TYPE_ACTIVE
+      )
+      .setProviderPackageName("com.google.android.example")
+      // Optional
+      // December 30, 2025 12:00:00AM in milliseconds
+      .setExpirationTimeMillis(1767052800000)
+      .addEntitlement(
+        SubscriptionEntitlement.Builder()
+        // matches with the identifier in media provider feed
+        .setEntitlementId("example.com:entitlementString1")
+        .setDisplayName("entitlement name1")
+        .build()
+      )
+      .build()
+
+    // Subscription with entitlements
+    // The entitement has different expiration time from its subscription
+    val subscription = SubscriptionEntity.Builder()
+      .setSubscriptionType(
+        SubscriptionType.SUBSCRIPTION_TYPE_ACTIVE
+      )
+      .setProviderPackageName("com.google.android.example")
+      // Optional
+      // December 30, 2025 12:00:00AM in milliseconds
+      .setExpirationTimeMillis(1767052800000)
+      .addEntitlement(
+        SubscriptionEntitlement.Builder()
+        .setEntitlementId("example.com:entitlementString1")
+        .setDisplayName("entitlement name1")
+        // You may set the expiration time for entitlement
+        // December 15, 2025 10:00:00 AM in milliseconds
+        .setExpirationTimeMillis(1765792800000)
+        .build())
+      .build()
+
+### Subscription for linked service package
+
+While subscriptions typically belong to the originating app's media provider, a
+subscription can be attributed to a linked service package by specifying the
+linked service package name within the subscription.
+
+Following code sample demonstrate how to create user subscription.
+
+    // Subscription for linked service package
+    val subscription = SubscriptionEntity.Builder()
+      .setSubscriptionType(
+        SubscriptionType.SUBSCRIPTION_TYPE_ACTIVE
+      )
+      .setProviderPackageName("com.google.android.example")
+      // Optional
+      // December 30, 2025 12:00:00AM in milliseconds since epoch
+      .setExpirationTimeMillis(1767052800000)
+      .build()
+
+In addition, if the user has another subscription to a subsidiary service, add
+another subscription and set the linked service package name accordingly.
+
+    // Subscription for linked service package
+    val linkedSubscription = Subscription.Builder()
+      .setSubscriptionType(
+        SubscriptionType.SUBSCRIPTION_TYPE_ACTIVE
+      )
+      .setProviderPackageName("linked service package name")
+      // Optional
+      // December 30, 2025 12:00:00AM in milliseconds since epoch
+      .setExpirationTimeMillis(1767052800000)
+      .addBundledSubscription(
+        BundledSubscription.Builder()
+          .setBundledSubscriptionProviderPackageName(
+            "bundled-subscription-package-name"
+          )
+          .setSubscriptionType(SubscriptionType.SUBSCRIPTION_TYPE_ACTIVE)
+          .setExpirationTimeMillis(111)
+          .addEntitlement(
+            SubscriptionEntitlement.Builder()
+            .setExpirationTimeMillis(111)
+            .setDisplayName("Silver subscription")
+            .setEntitlementId("subscription.tier.platinum")
+            .build()
+          )
+          .build()
+      )
+        .build()
+
+Optionally, add entitlements to a linked service subscription too.
+
+### Provide subscription set
+
+Run the content publish job while the app is in the foreground.
+
+Use the `publishSubscriptionCluster()` method, from the
+`AppEngagePublishClient` class, to publish a `SubscriptionCluster` object.
+
+Make sure to initialize the client and check for service availability as
+described in the [Getting Started guide](https://developer.android.com/guide/playcore/engage/tv/getting-started#common-integration).
+
+    client.publishSubscription(
+      PublishSubscriptionRequest.Builder()
+        .setAccountProfile(accountProfile)
+        .setSubscription(subscription)
+        .build()
+      )
+
+Use `setSubscription()` to verify that user should have only one subscription to
+the service.
+
+Use `addLinkedSubscription()`, or `addLinkedSubscriptions()` which accept a list
+of linked subscriptions, to enable user to have zero or more linked
+subscriptions.
+
+When the service receives the request, a new entry is created and the old entry
+is automatically deleted after 60 days. The system always uses the latest entry.
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+### Keep subscription up-to-date
+
+1. To provide immediate updates upon changes, call
+   `publishSubscriptionCluster` whenever a user's subscription state changes
+   like activation, deactivation, upgrades, downgrades.
+
+2. To provide regular validation for ongoing accuracy, call
+   `publishSubscriptionCluster` at least once per month.
+
+   > [!NOTE]
+   > **Note:** As Google TV automatically deletes historical data beyond 60 days to safeguard user privacy, publishing user subscription data at least once per month verify the validity of data. Unlike `publishContinuationCluster` for continue watching data, don't set `syncAcrossDevices` flag, as subscription information is by default used to provide content across all devices.
+
+3. To delete the Engage data, manually delete a user's data from the
+   Google TV server before the standard 60-day retention period, use the
+   `client.deleteClusters` method. This deletes all existing Engage
+   data for the account profile, or for the entire account depending on the
+   given [`DeleteReason`](https://developer.android.com/reference/com/google/android/engage/service/DeleteReason).
+
+   The following code snippet shows how to remove a user subscription:
+
+       // If the user logs out from your media app, you must make the following call
+       // to remove subscription and other Engage data from the current
+       // google TV device.
+       client.deleteClusters(
+         new DeleteClustersRequest.Builder()
+           .setAccountProfile(accountProfile)
+         .setReason(DeleteReason.DELETE_REASON_USER_LOG_OUT)
+         .build()
+         )
+
+   The following code snippet demonstrates removal of user subscription
+   when user revokes the consent:
+
+       // If the user revokes the consent to share across device, make the call
+       // to remove subscription and other Engage data from all google
+       // TV devices.
+       client.deleteClusters(
+         new DeleteClustersRequest.Builder()
+           .setAccountProfile(accountProfile)
+           .setReason(DeleteReason.DELETE_REASON_LOSS_OF_CONSENT)
+           .build()
+       )
+
+   Following code demonstrates how to remove subscription data on user profile
+   deletion.
+
+       // If the user delete a specific profile, you must make the following call
+       // to remove subscription data and other Engage data.
+       client.deleteClusters(
+         new DeleteClustersRequest.Builder()
+         .setAccountProfile(accountProfile)
+         .setReason(DeleteReason.DELETE_REASON_ACCOUNT_PROFILE_DELETION)
+         .build()
+       )
+
+### Testing
+
+This section provides a step-by-step guide for testing subscription
+implementation. Verify data accuracy and proper functionality before launch.
+
+#### Publish Integration checklist
+
+1. Publishing should happen when the app is in the foreground and user the
+   actively interacting with it.
+
+2. Publish when:
+
+   - User logs in for the first time.
+   - User changes profile (if profiles are supported).
+   - User purchases new subscription.
+   - User upgrades subscription.
+   - User subscription expires.
+3. Check if app is correctly calling `isServiceAvailable()` and
+   `publishClusters()` APIs in logcat, on the publishing events.
+
+4. Verify that data is visible in the verification app. The verification app
+   should display subscription as a separate row. When the publish API is
+   invoked, the data should show up in the verification app.
+
+   > [!IMPORTANT]
+   > **Important:** Verify that the [Engage Service Flag](https://developer.android.com/guide/playcore/engage/workflow#switch-to-prod) is **not** set to production.
+
+5. Go to app and perform each of the following actions:
+
+   - Sign in.
+   - Switch between profiles (if supported).
+   - Purchase a new subscription.
+   - Upgrade an existing subscription.
+   - Expire the subscription.
+
+#### Verify integration
+
+To test your integration, use the [verification app](https://developer.android.com/guide/playcore/engage/tv/getting-started#testing).
+
+1. For each of the events, check if app has invoked the `publishSubscription` API. Verify the published data in the verification app. **Verify that everything is green in verification app**
+2. If all the entity's information is correct, it shows an "All Good" green
+   check in all entities.
+
+   ![Verification App Success Screenshot](https://developer.android.com/static/images/guide/playcore/engage/ett-va-success.png) **Figure 1.** Successful subscription
+3. Problems are also highlighted in verification app
+
+   ![Verification App Error Screenshot](https://developer.android.com/static/images/guide/playcore/engage/ett-va-error.png) **Figure 2.**Subscription unsuccessful
+4. To see the problems in the bundled subscription, use the TV remote to focus
+   on that specific bundled subscription and click to see the problems. You
+   might have to first focus on the row and move to the right to find Bundled
+   Subscription card. The problems are highlighted as red as shown in Fig 3.
+   Also, use the remote to move down to see problems in the entitlements within
+   bundled subscription
+
+   ![Verification App Error Details Screenshot](https://developer.android.com/static/images/guide/playcore/engage/ett-va-error-details.png) **Figure 3.**Subscription Errors
+5. To see the problems in the entitlement, use the TV remote to focus on that
+   specific entitlement and click to see the problems. The problems are
+   highlighted as red.
+
+   ![Verification App Error Screenshot](https://developer.android.com/static/images/guide/playcore/engage/ett-va-details.png) **Figure 4.**Subscription Error Details

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/tv/getting-started.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/tv/getting-started.md
@@ -1,0 +1,173 @@
+<br />
+
+[Engage SDK](https://developer.android.com/guide/playcore/engage) lets you deliver personalized recommendations
+and continuation content directly to users on Google TV.
+
+This guide covers how to get started with Engage SDK integrations for TV. After
+you complete the pre-work on this page, you can integrate one or more
+of the TV features:
+
+- [Publish continue watching data](https://developer.android.com/guide/playcore/engage/tv/continue-watching)
+- [Publish device entitlements](https://developer.android.com/guide/playcore/engage/tv/entitlements)
+- [Publish recommendations](https://developer.android.com/guide/playcore/engage/tv/recommendations)
+
+## Pre-work
+
+Before you begin, complete the following steps:
+
+1. [Express interest in developing with Engage SDK](http://g.co/tv/engage) to enroll in
+   the program, if eligible.
+
+2. Verify that your app targets Android 4.4 (API level 19) or higher for this
+   integration.
+
+3. Add the `com.google.android.engage` library to your app:
+
+   There are separate SDKs to use in the integration: one for mobile apps and
+   one for TV apps.
+
+   ### Mobile
+
+       dependencies {
+         implementation 'com.google.android.engage:engage-core:1.6.0'
+       }
+
+   ### TV
+
+       dependencies {
+         implementation 'com.google.android.engage:engage-tv:1.0.6'
+       }
+
+4. Add permission for `WRITE_EPG_DATA` for TV APK
+
+       <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA" />
+
+5. Verify reliable content publishing by using a background service, such as
+   `androidx.work`, for scheduling.
+
+6. Test your implementation using the verification app as outlined in the
+   [Testing section](https://developer.android.com/guide/playcore/engage/tv/getting-started#testing).
+
+7. In your production app, set the Engage service environment to production in
+   the `AndroidManifest.xml` file.
+
+       <meta-data
+           android:name="com.google.android.engage.service.ENV"
+           android:value="PRODUCTION" />
+
+   > [!IMPORTANT]
+   > **Important:** The Engage service environment declaration is only needed for your release build. For your local testing with the verification app, don't include this element.
+
+## Common integration steps
+
+### Initialize the client
+
+Use `AppEngagePublishClient` to interact with the service. Always check if the
+service is available before publishing.
+
+    val client = AppEngagePublishClient(context)
+
+    client.isServiceAvailable().addOnCompleteListener { task ->
+      if (task.isSuccessful && task.result) {
+        // Service is available, proceed with publishing
+      } else {
+        // Service is not available or call failed
+      }
+    }
+
+### Create an account profile
+
+`AccountProfile` identifies the user. You can specify an account ID, and
+optionally a profile ID and locale.
+
+    val accountProfile = AccountProfile.Builder()
+        .setAccountId("your_users_account_id")
+        .setProfileId("your_users_profile_id") // Optional
+        .setLocale(Locale.US.toLanguageTag())  // Optional, e.g., "en-US"
+        .build()
+
+An `AccountProfile` must be provided with an account ID in order for content to
+be synchronized between devices. See [Cross-device syncing](https://developer.android.com/guide/playcore/engage/tv/continue-watching/client#cross-device_syncing).
+
+## Testing
+
+To test your integration, download the verification app:
+
+[Download verification
+app](https://developer.android.com/guide/playcore/engage/tv/getting-started#lightbox-trigger)
+
+The verification app is an Android app with capabilities to help you test your
+integration. It let you to check data accuracy and proper functionality by
+verifying published data and broadcast intents before launch.
+
+1. Install and open the Engage Verification app.
+2. If the value of `isServiceAvailable` is `false` in the verification app, click the **Toggle** button within the verification app to set it to `true`.
+3. Enter the package name of your app. It automatically shows the published data.
+4. Run your app and perform publishing actions, such as logging in or watching a video.
+5. Verify that the data shows up in the verification app.
+
+## Download
+
+Before downloading, you must agree to the following terms and conditions.
+
+## Terms and Conditions
+
+This is the Android Software Development Kit License Agreement
+
+### 1. Introduction
+
+1.1 The Android Software Development Kit (referred to in the License Agreement as the "SDK" and specifically including the Android system files, packaged APIs, and Google APIs add-ons) is licensed to you subject to the terms of the License Agreement. The License Agreement forms a legally binding contract between you and Google in relation to your use of the SDK. 1.2 "Android" means the Android software stack for devices, as made available under the Android Open Source Project, which is located at the following URL: https://source.android.com , as updated from time to time. 1.3 A "compatible implementation" means any Android device that (i) complies with the Android Compatibility Definition document, which can be found at the Android compatibility website (https://source.android.com/compatibility) and which may be updated from time to time; and (ii) successfully passes the Android Compatibility Test Suite (CTS). 1.4 "Google" means Google LLC, organized under the laws of the State of Delaware, USA, and operating under the laws of the USA with principal place of business at 1600 Amphitheatre Parkway, Mountain View, CA 94043, USA.
+
+### 2. Accepting this License Agreement
+
+2.1 In order to use the SDK, you must first agree to the License Agreement. You may not use the SDK if you do not accept the License Agreement. 2.2 By clicking to accept and/or using this SDK, you hereby agree to the terms of the License Agreement. 2.3 You may not use the SDK and may not accept the License Agreement if you are a person barred from receiving the SDK under the laws of the United States or other countries, including the country in which you are resident or from which you use the SDK. 2.4 If you are agreeing to be bound by the License Agreement on behalf of your employer or other entity, you represent and warrant that you have full legal authority to bind your employer or such entity to the License Agreement. If you do not have the requisite authority, you may not accept the License Agreement or use the SDK on behalf of your employer or other entity.
+
+### 3. SDK License from Google
+
+3.1 Subject to the terms of the License Agreement, Google grants you a limited, worldwide, royalty-free, non-assignable, non-exclusive, and non-sublicensable license to use the SDK solely to develop applications for compatible implementations of Android. 3.2 You may not use this SDK to develop applications for other platforms (including non-compatible implementations of Android) or to develop another SDK. You are of course free to develop applications for other platforms, including non-compatible implementations of Android, provided that this SDK is not used for that purpose. 3.3 You agree that Google or third parties own all legal right, title and interest in and to the SDK, including any Intellectual Property Rights that subsist in the SDK. "Intellectual Property Rights" means any and all rights under patent law, copyright law, trade secret law, trademark law, and any and all other proprietary rights. Google reserves all rights not expressly granted to you. 3.4 You may not use the SDK for any purpose not expressly permitted by the License Agreement. Except to the extent required by applicable third party licenses, you may not copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the SDK or any part of the SDK. 3.5 Use, reproduction and distribution of components of the SDK licensed under an open source software license are governed solely by the terms of that open source software license and not the License Agreement. 3.6 You agree that the form and nature of the SDK that Google provides may change without prior notice to you and that future versions of the SDK may be incompatible with applications developed on previous versions of the SDK. You agree that Google may stop (permanently or temporarily) providing the SDK (or any features within the SDK) to you or to users generally at Google's sole discretion, without prior notice to you. 3.7 Nothing in the License Agreement gives you a right to use any of Google's trade names, trademarks, service marks, logos, domain names, or other distinctive brand features. 3.8 You agree that you will not remove, obscure, or alter any proprietary rights notices (including copyright and trademark notices) that may be affixed to or contained within the SDK.
+
+### 4. Use of the SDK by You
+
+4.1 Google agrees that it obtains no right, title or interest from you (or your licensors) under the License Agreement in or to any software applications that you develop using the SDK, including any intellectual property rights that subsist in those applications. 4.2 You agree to use the SDK and write applications only for purposes that are permitted by (a) the License Agreement and (b) any applicable law, regulation or generally accepted practices or guidelines in the relevant jurisdictions (including any laws regarding the export of data or software to and from the United States or other relevant countries). 4.3 You agree that if you use the SDK to develop applications for general public users, you will protect the privacy and legal rights of those users. If the users provide you with user names, passwords, or other login information or personal information, you must make the users aware that the information will be available to your application, and you must provide legally adequate privacy notice and protection for those users. If your application stores personal or sensitive information provided by users, it must do so securely. If the user provides your application with Google Account information, your application may only use that information to access the user's Google Account when, and for the limited purposes for which, the user has given you permission to do so. 4.4 You agree that you will not engage in any activity with the SDK, including the development or distribution of an application, that interferes with, disrupts, damages, or accesses in an unauthorized manner the servers, networks, or other properties or services of any third party including, but not limited to, Google or any mobile communications carrier. 4.5 You agree that you are solely responsible for (and that Google has no responsibility to you or to any third party for) any data, content, or resources that you create, transmit or display through Android and/or applications for Android, and for the consequences of your actions (including any loss or damage which Google may suffer) by doing so. 4.6 You agree that you are solely responsible for (and that Google has no responsibility to you or to any third party for) any breach of your obligations under the License Agreement, any applicable third party contract or Terms of Service, or any applicable law or regulation, and for the consequences (including any loss or damage which Google or any third party may suffer) of any such breach.
+
+### 5. Your Developer Credentials
+
+5.1 You agree that you are responsible for maintaining the confidentiality of any developer credentials that may be issued to you by Google or which you may choose yourself and that you will be solely responsible for all applications that are developed under your developer credentials.
+
+### 6. Privacy and Information
+
+6.1 In order to continually innovate and improve the SDK, Google may collect certain usage statistics from the software including but not limited to a unique identifier, associated IP address, version number of the software, and information on which tools and/or services in the SDK are being used and how they are being used. Before any of this information is collected, the SDK will notify you and seek your consent. If you withhold consent, the information will not be collected. 6.2 The data collected is examined in the aggregate to improve the SDK and is maintained in accordance with Google's Privacy Policy, which is located at the following URL: https://policies.google.com/privacy 6.3 Anonymized and aggregated sets of the data may be shared with Google partners to improve the SDK.
+
+### 7. Third Party Applications
+
+7.1 If you use the SDK to run applications developed by a third party or that access data, content or resources provided by a third party, you agree that Google is not responsible for those applications, data, content, or resources. You understand that all data, content or resources which you may access through such third party applications are the sole responsibility of the person from which they originated and that Google is not liable for any loss or damage that you may experience as a result of the use or access of any of those third party applications, data, content, or resources. 7.2 You should be aware the data, content, and resources presented to you through such a third party application may be protected by intellectual property rights which are owned by the providers (or by other persons or companies on their behalf). You may not modify, rent, lease, loan, sell, distribute or create derivative works based on these data, content, or resources (either in whole or in part) unless you have been specifically given permission to do so by the relevant owners. 7.3 You acknowledge that your use of such third party applications, data, content, or resources may be subject to separate terms between you and the relevant third party. In that case, the License Agreement does not affect your legal relationship with these third parties.
+
+### 8. Using Android APIs
+
+8.1 Google Data APIs 8.1.1 If you use any API to retrieve data from Google, you acknowledge that the data may be protected by intellectual property rights which are owned by Google or those parties that provide the data (or by other persons or companies on their behalf). Your use of any such API may be subject to additional Terms of Service. You may not modify, rent, lease, loan, sell, distribute or create derivative works based on this data (either in whole or in part) unless allowed by the relevant Terms of Service. 8.1.2 If you use any API to retrieve a user's data from Google, you acknowledge and agree that you will retrieve data only with the user's explicit consent and only when, and for the limited purposes for which, the user has given you permission to do so. If you use the Android Recognition Service API, documented at the following URL: https://developer.android.com/reference/android/speech/RecognitionService, as updated from time to time, you acknowledge that the use of the API is subject to the Data Processing Addendum for Products where Google is a Data Processor, which is located at the following URL: https://privacy.google.com/businesses/gdprprocessorterms/, as updated from time to time. By clicking to accept, you hereby agree to the terms of the Data Processing Addendum for Products where Google is a Data Processor.
+
+### 9. Terminating this License Agreement
+
+9.1 The License Agreement will continue to apply until terminated by either you or Google as set out below. 9.2 If you want to terminate the License Agreement, you may do so by ceasing your use of the SDK and any relevant developer credentials. 9.3 Google may at any time, terminate the License Agreement with you if: (A) you have breached any provision of the License Agreement; or (B) Google is required to do so by law; or (C) the partner with whom Google offered certain parts of SDK (such as APIs) to you has terminated its relationship with Google or ceased to offer certain parts of the SDK to you; or (D) Google decides to no longer provide the SDK or certain parts of the SDK to users in the country in which you are resident or from which you use the service, or the provision of the SDK or certain SDK services to you by Google is, in Google's sole discretion, no longer commercially viable. 9.4 When the License Agreement comes to an end, all of the legal rights, obligations and liabilities that you and Google have benefited from, been subject to (or which have accrued over time whilst the License Agreement has been in force) or which are expressed to continue indefinitely, will be unaffected by this cessation, and the provisions of paragraph 14.7 will continue to apply to such rights, obligations and liabilities indefinitely.
+
+### 10. DISCLAIMER OF WARRANTIES
+
+10.1 YOU EXPRESSLY UNDERSTAND AND AGREE THAT YOUR USE OF THE SDK IS AT YOUR SOLE RISK AND THAT THE SDK IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTY OF ANY KIND FROM GOOGLE. 10.2 YOUR USE OF THE SDK AND ANY MATERIAL DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE SDK IS AT YOUR OWN DISCRETION AND RISK AND YOU ARE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR OTHER DEVICE OR LOSS OF DATA THAT RESULTS FROM SUCH USE. 10.3 GOOGLE FURTHER EXPRESSLY DISCLAIMS ALL WARRANTIES AND CONDITIONS OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES AND CONDITIONS OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+
+### 11. LIMITATION OF LIABILITY
+
+11.1 YOU EXPRESSLY UNDERSTAND AND AGREE THAT GOOGLE, ITS SUBSIDIARIES AND AFFILIATES, AND ITS LICENSORS WILL NOT BE LIABLE TO YOU UNDER ANY THEORY OF LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR EXEMPLARY DAMAGES THAT MAY BE INCURRED BY YOU, INCLUDING ANY LOSS OF DATA, WHETHER OR NOT GOOGLE OR ITS REPRESENTATIVES HAVE BEEN ADVISED OF OR SHOULD HAVE BEEN AWARE OF THE POSSIBILITY OF ANY SUCH LOSSES ARISING.
+
+### 12. Indemnification
+
+12.1 To the maximum extent permitted by law, you agree to defend, indemnify and hold harmless Google, its affiliates and their respective directors, officers, employees and agents from and against any and all claims, actions, suits or proceedings, as well as any and all losses, liabilities, damages, costs and expenses (including reasonable attorneys fees) arising out of or accruing from (a) your use of the SDK, (b) any application you develop on the SDK that infringes any copyright, trademark, trade secret, trade dress, patent or other intellectual property right of any person or defames any person or violates their rights of publicity or privacy, and (c) any non-compliance by you with the License Agreement.
+
+### 13. Changes to the License Agreement
+
+13.1 Google may make changes to the License Agreement as it distributes new versions of the SDK. When these changes are made, Google will make a new version of the License Agreement available on the website where the SDK is made available.
+
+### 14. General Legal Terms
+
+14.1 The License Agreement constitutes the whole legal agreement between you and Google and governs your use of the SDK (excluding any services which Google may provide to you under a separate written agreement), and completely replaces any prior agreements between you and Google in relation to the SDK. 14.2 You agree that if Google does not exercise or enforce any legal right or remedy which is contained in the License Agreement (or which Google has the benefit of under any applicable law), this will not be taken to be a formal waiver of Google's rights and that those rights or remedies will still be available to Google. 14.3 If any court of law, having the jurisdiction to decide on this matter, rules that any provision of the License Agreement is invalid, then that provision will be removed from the License Agreement without affecting the rest of the License Agreement. The remaining provisions of the License Agreement will continue to be valid and enforceable. 14.4 You acknowledge and agree that each member of the group of companies of which Google is the parent will be third party beneficiaries to the License Agreement and that such other companies will be entitled to directly enforce, and rely upon, any provision of the License Agreement that confers a benefit on (or rights in favor of) them. Other than this, no other person or company will be third party beneficiaries to the License Agreement. 14.5 EXPORT RESTRICTIONS. THE SDK IS SUBJECT TO UNITED STATES EXPORT LAWS AND REGULATIONS. YOU MUST COMPLY WITH ALL DOMESTIC AND INTERNATIONAL EXPORT LAWS AND REGULATIONS THAT APPLY TO THE SDK. THESE LAWS INCLUDE RESTRICTIONS ON DESTINATIONS, END USERS AND END USE. 14.6 The rights granted in the License Agreement may not be assigned or transferred by either you or Google without the prior written approval of the other party. Neither you nor Google will be permitted to delegate their responsibilities or obligations under the License Agreement without the prior written approval of the other party. 14.7 The License Agreement, and your relationship with Google under the License Agreement, will be governed by the laws of the State of California without regard to its conflict of laws provisions. You and Google agree to submit to the exclusive jurisdiction of the courts located within the county of Santa Clara, California to resolve any legal matter arising from the License Agreement. Notwithstanding this, you agree that Google will still be allowed to apply for injunctive remedies (or an equivalent type of urgent legal relief) in any jurisdiction. *April 28, 2026* I have read and agree with the above terms and conditions <button class="button button-disabled"> Download </button> [Download](https://dl.google.com/developers/android/channels/verify_app_multiplatform_public_20260701.apk)
+
+*verify_app_multiplatform_public_20260701.apk*

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/tv/recommendations.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/tv/recommendations.md
@@ -1,0 +1,471 @@
+This guide contains instructions for developers to integrate their recommended
+video content, using the [Engage SDK](https://developer.android.com/guide/playcore/engage), to populate recommendations
+experiences across Google surfaces, such as TV, mobile, and tablet.
+
+Recommendation leverages the **Recommendation cluster** to show movies and TV
+shows, from multiple apps in one UI grouping. Each developer partner can
+broadcast a maximum **of 25 entities** in each recommendations cluster and there
+can be a maximum **of 7** recommendation clusters per request.
+
+## Pre-work
+
+> [!IMPORTANT]
+> **Important:** [Express interest in developing with Engage](http://g.co/tv/vda).
+
+Complete the [Pre-work](https://developer.android.com/guide/playcore/engage/tv/getting-started#pre-work) instructions in the Getting Started guide.
+
+1. Execute publishing on a foreground service.
+2. Publish recommendations data at most once daily, triggered by either of
+   - User's first login of the day. (*or*)
+   - When the user starts interacting with the application.
+
+## Integration
+
+`AppEngagePublishClient` publishes the recommendation cluster. Use the
+`publishRecommendationClusters` method to publish a recommendations object.
+
+Make sure to initialize the client and check for service availability as
+described in the [Getting Started guide](https://developer.android.com/guide/playcore/engage/tv/getting-started#common-integration).
+
+    client.publishRecommendationClusters(recommendationRequest)
+
+### Upserting recommendation clusters
+
+Clusters are logical grouping of the entities. The following code examples
+explains how to build the clusters based on your preference and how to create a
+publishing request and upsert all clusters.
+
+The [`RecommendationClusterType`](https://developer.android.com/reference/com/google/android/engage/common/datamodel/RecommendationClusterType) determines how the
+cluster will be displayed.
+
+    // cluster for popular movies
+    val recommendationCluster1 = RecommendationCluster
+      .Builder()
+      .addEntity(movie1)
+      .addEntity(movie2)
+      .addEntity(movie3)
+      .addEntity(movie4)
+      .addEntity(tvShow)
+      // This cluster is meant to be used as an individual provider row
+      .setRecommendationClusterType(TYPE_PROVIDER_ROW)
+      .setTitle("Popular Movies")
+      .build()
+
+    // cluster for live TV programs
+    val recommendationCluster2 = RecommendationCluster
+      .Builder()
+      .addEntity(liveTvProgramEntity1)
+      .addEntity(liveTvProgramEntity2)
+      .addEntity(liveTvProgramEntity3)
+      .addEntity(liveTvProgramEntity4)
+      .addEntity(liveTvProgramEntity5)
+     // This cluster is meant to be used as an individual provider row
+      .setRecommendationClusterType(TYPE_PROVIDER_ROW)
+      .setTitle("Popular Live TV Programs")
+      .build()
+
+    // creating a publishing request
+    val recommendationRequest = PublishRecommendationClustersRequest
+      .Builder()
+      .setSyncAcrossDevices(true)
+      .setAccountProfile(accountProfile)
+      .addRecommendationCluster(recommendationCluster1)
+      .addRecommendationCluster(recommendationCluster2)
+      .build()
+
+When the service receives the request, the following actions occur within one
+transaction:
+
+- Existing `RecommendationsCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated `RecommendationsCluster`. In case of an error, the entire request is rejected and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** Publish APIs are upsert operations, replacing existing content; update entities by republishing the entire cluster. Only publish recommendations for adult accounts. Avoid using delete APIs followed by publish, as the latter inherently replaces content.
+
+### Cross-device sync
+
+`SyncAcrossDevices` flag controls whether a user's recommendations cluster data
+is shared with Google TV and available across their devices such as TV, phone,
+tablets. In order for the recommendation to work, it must be set to true.
+
+### Obtain consent
+
+The media application must provide a clear setting to enable or disable
+cross-device syncing. Explain the benefits to the user and store the user's
+preference once and apply it in `publishRecommendations` Request accordingly. To
+get the most out of cross-device feature, verify app obtains user
+consent and enables `SyncAcrossDevices` to `true`.
+
+### Delete the Engage data
+
+To manually delete a user's data from the Google TV server before the standard
+60-day retention period, use the `client.deleteClusters()` method. Upon
+receiving the request, the service deletes all existing Engage
+data for the account profile, or for the entire account.
+
+The [`DeleteReason`](https://developer.android.com/reference/com/google/android/engage/service/DeleteReason) enum defines the reason for data deletion.
+The following code removes recommendations on logout.
+
+    // If the user logs out from your media app, you must make the following call
+    // to remove recommendations data from the current Google TV device, otherwise,
+    // the recommendations data persists on the current Google TV device until 60
+    // days later.
+    client.deleteClusters(
+      new DeleteClustersRequest.Builder()
+        .setAccountProfile(AccountProfile())
+        .setReason(DeleteReason.DELETE_REASON_USER_LOG_OUT)
+        .build()
+    )
+
+    // If the user revokes the consent to share data with Google TV, you must make
+    // the following call to remove recommendations data from all current Google TV
+    // devices. Otherwise, the recommendations data persists until 60 days later.
+    client.deleteClusters(
+      new DeleteClustersRequest.Builder()
+        .setAccountProfile(AccountProfile())
+        .setReason(DeleteReason.DELETE_REASON_LOSS_OF_CONSENT)
+        .build()
+    )
+
+## Create entities
+
+The SDK has defined different entities to represent each item type. Following
+entities are supported for the Recommendation cluster:
+
+1. [`MediaActionFeedEntity`](https://developer.android.com/reference/com/google/android/engage/video/datamodel/MediaActionFeedEntity)
+2. [`MovieEntity`](https://developer.android.com/reference/com/google/android/engage/video/datamodel/MovieEntity)
+3. [`TvShowEntity`](https://developer.android.com/reference/com/google/android/engage/video/datamodel/TvShowEntity)
+4. [`LiveTvChannelEntity`](https://developer.android.com/reference/com/google/android/engage/video/datamodel/LiveTvChannelEntity)
+5. [`LiveTvProgramEntity`](https://developer.android.com/reference/com/google/android/engage/video/datamodel/LiveTvProgramEntity)
+
+### Provide descriptions
+
+Provide a short description for each entity; this description will be displayed
+when users hover over the entity, providing them with additional details.
+
+### Call to action text
+
+Provide an optional call to action text for each entity. This text will be
+displayed to the user to encourage engagement.
+
+### Tags
+
+Optionally provide a list of tags for each entity. Tags can be used for
+categorization and filtering.
+
+### Platform specific playBack URIs
+
+Create playback URIs for each supported platform: Android TV, Android, or iOS.
+This allows the system to select the appropriate URI for video playback on the
+respective platform.
+
+In the rare case when the playback URIs are identical for all platforms,
+repeat it for every platform.
+
+    // Required. Set this when you want recommended entities to show up on
+    // Google TV
+    val playbackUriTv = PlatformSpecificUri
+      .Builder()
+      .setPlatformType(PlatformType.TYPE_ANDROID_TV)
+      .setActionUri(Uri.parse("https://www.example.com/entity_uri_for_tv"))
+      .build()
+
+    // Optional. Set this when you want recommended entities to show up on
+    // Google TV Android app
+    val playbackUriAndroid = PlatformSpecificUri
+      .Builder()
+      .setPlatformType(PlatformType.TYPE_ANDROID_MOBILE)
+      .setActionUri(Uri.parse("https://www.example.com/entity_uri_for_android"))
+      .build()
+
+    // Optional. Set this when you want recommended entities to show up on
+    // Google TV iOS app
+    val playbackUriIos = PlatformSpecificUri
+      .Builder()
+      .setPlatformType(PlatformType.TYPE_IOS)
+      .setActionUri(Uri.parse("https://www.example.com/entity_uri_for_ios"))
+      .build()
+
+    val platformSpecificPlaybackUris =
+      Arrays.asList(playbackUriTv, playbackUriAndroid, playbackUriIos)
+
+    // Provide appropriate rating for the system.
+    val contentRating = new RatingSystem
+      .Builder()
+      .setAgencyName("MPAA")
+      .setRating("PG-13")
+      .build()
+
+### Poster images
+
+Poster images require a URI and pixel dimensions (height and width). Target
+different form factors by providing multiple poster images, but verify all
+images maintain a 16:9 aspect ratio and a minimum height of 200 pixels for
+correct display of the "Recommendations" entity, especially within Google's
+[Entertainment Space](https://support.google.com/entertainmentspace/answer/10346911). Images with a height less than 200
+pixels may not be shown.
+
+    Image image1 = new Image.Builder()
+      .setImageUri(Uri.parse("http://www.example.com/entity_image1.png");)
+      .setImageHeightInPixel(300)
+      .setImageWidthInPixel(169)
+      .build()
+
+    Image image2 = new Image.Builder()
+      .setImageUri(Uri.parse("http://www.example.com/entity_image2.png");)
+      .setImageHeightInPixel(640)
+      .setImageWidthInPixel(360)
+      .build()
+
+    // And other images for different form factors.
+    val images = Arrays.asList(image1, image2)
+
+### Recommendation reason
+
+Optionally provide a recommendation reason which can be used by Google
+TV to construct reasons as to why to suggest a specific Movie or TV Show to
+the user.
+
+    //Allows us to construct reason: "Because it is top 10 on your Channel"
+    val topOnPartner = RecommendationReasonTopOnPartner
+      .Builder()
+      .setNum(10) //any valid integer value
+      .build()
+
+    //Allows us to construct reason: "Because it is popular on your Channel"
+    val popularOnPartner = RecommendationReasonPopularOnPartner
+      .Builder()
+      .build()
+
+    //Allows us to construct reason: "New to your channel, or Just added"
+    val newOnPartner = RecommendationReasonNewOnPartner
+      .Builder()
+      .build()
+
+    //Allows us to construct reason: "Because you watched Star Wars"
+    val watchedSimilarTitles = RecommendationReasonWatchedSimilarTitles
+      .addSimilarWatchedTitleName("Movie or TV Show Title")
+      .addSimilarWatchedTitleName("Movie or TV Show Title")
+      .Builder()
+      .build()
+
+    //Allows us to construct reason: "Recommended for you by ChannelName"
+    val recommendedForUser = RecommendationReasonRecommendedForUser
+      .Builder()
+      .build()
+
+    val watchAgain = RecommendationReasonWatchAgain
+      .Builder()
+      .build()
+
+    val fromUserWatchList = RecommendationReasonFromUserWatchlist
+      .Builder()
+      .build()
+
+    val userLikedOnPartner = RecommendationReasonUserLikedOnPartner
+      .Builder()
+      .setTitleName("Movie or TV Show Title")
+      .build()
+
+    val generic = RecommendationReasonGeneric.Builder().build()
+
+### Display time window
+
+If an entity should only be available for a limited time, set a custom
+expiration time. Without an explicit expiration time, entities will
+automatically expire and be erased after 60 days. So set an expiration time only
+when the entities need to be expired sooner. Specify multiple such
+availability windows.
+
+    val window1 = DisplayTimeWindow
+      .Builder()
+      .setStartTimeStampMillis(now()+ 1.days.toMillis())
+      .setEndTimeStampMillis(now()+ 30.days.toMillis())
+
+    val window2 = DisplayTimeWindow
+      .Builder()
+      .setEndTimeStampMillis(now()+ 30.days.toMillis())
+
+    val availabilityTimeWindows: List<DisplayTimeWindow> = listof(window1,window2)
+
+### DataFeedElementId
+
+If you have integrated your Media catalogue or Media action feed with Google TV,
+you need not create separate entities for Movie or TV Show and instead you can
+create a [`MediaActionFeedEntity`](https://developer.android.com/reference/com/google/android/engage/video/datamodel/MediaActionFeedEntity) which includes the
+required field DataFeedElementId. This Id must be unique and must match with the
+ID in Media Action Feed as it helps to identify ingested feed content and
+perform media content lookups.
+
+    val id = "dataFeedElementId"
+
+### `MovieEntity`
+
+Here's an example of creating a `MovieEntity` with all the required fields:
+
+    val movieEntity = MovieEntity.Builder()
+      .setName("Movie name")
+      .setDescription("A sentence describing movie.")
+      .addPlatformSpecificPlaybackUri(platformSpecificPlaybackUris)
+      .addPosterImages(images)
+      // Suppose the duration is 2 hours, it is 72000000 in milliseconds
+      .setDurationMills(72000000)
+      .setCallToActionText("Watch Now")
+      .addTag("Action")
+      .build()
+
+You can provide additional data such as genres, content ratings, release date,
+recommendation reason and availability time windows, which may be used by Google
+TV for enhanced displays or filtering purposes.
+
+    val genres = Arrays.asList("Action", "Science fiction");
+    val rating1 = RatingSystem.Builder().setAgencyName("MPAA").setRating("pg-13").build();
+    val contentRatings = Arrays.asList(rating1);
+    //Suppose release date is 11-02-2025
+    val releaseDate  = 1739233800000L
+    val movieEntity = MovieEntity.Builder()
+      ...
+      .addGenres(genres)
+      .setReleaseDateEpochMillis(releaseDate)
+      .addContentRatings(contentRatings)
+      .setRecommendationReason(topOnPartner or watchedSimilarTitles)
+      .addAllAvailabilityTimeWindows(availabilityTimeWindows)
+      .build()
+
+### `TvShowEntity`
+
+Here's an example of creating a `TvShowEntity` with all the required fields:
+
+    val tvShowEntity = TvShowEntity.Builder()
+      .setName("Show title")
+      .setDescription("A sentence describing TV Show.")
+      .addPlatformSpecificPlaybackUri(platformSpecificPlaybackUris)
+      .addPosterImages(images)
+      .setCallToActionText("Watch Now")
+      .addTag("Drama")
+      .build();
+
+Optionally provide additional data such as genres, content ratings,
+recommendation reason, offer price, season count or availability time window,
+which may be used by Google TV for enhanced displays or filtering purposes.
+
+    val genres = Arrays.asList("Action", "Science fiction");
+    val rating1 = RatingSystem.Builder()
+      .setAgencyName("MPAA")
+      .setRating("pg-13")
+      .build();
+    val price = Price.Builder()
+      .setCurrentPrice("$14.99")
+      .setStrikethroughPrice("$16.99")
+      .build();
+    val contentRatings = Arrays.asList(rating1);
+    val seasonCount = 5;
+    val tvShowEntity = TvShowEntity.Builder()
+      ...
+      .addGenres(genres)
+      .addContentRatings(contentRatings)
+      .setRecommendationReason(topOnPartner or watchedSimilarTitles)
+      .addAllAvailabilityTimeWindows(availabilityTimeWindows)
+      .setSeasonCount(seasonCount)
+      .setPrice(price)
+      .build()
+
+### `MediaActionFeedEntity`
+
+Here's an example of creating an `MediaActionFeedEntity` with all the required
+fields:
+
+    val mediaActionFeedEntity = MediaActionFeedEntity.Builder()
+      .setDataFeedElementId(id)
+      .setCallToActionText("Watch Now")
+      .addTag("Action")
+      .build()
+
+Optionally provide additional data such as description, recommendation reason
+and display time window, which may be used by Google TV for enhanced displays or
+filtering purposes.
+
+    val mediaActionFeedEntity = MediaActionFeedEntity.Builder()
+      .setName("Movie name or TV Show name")
+      .setDescription("A sentence describing an entity")
+      .setRecommendationReason(topOnPartner or watchedSimilarTitles)
+      .addPosterImages(images)
+      .build()
+
+### `LiveTvChannelEntity`
+
+This represents a live TV channel. Here's an example of creating a
+`LiveTvChannelEntity` with all the required fields:
+
+    val liveTvChannelEntity = LiveTvChannelEntity.Builder()
+      .setName("Channel Name")
+      // ID of the live TV channel
+      .setEntityId("https://www.example.com/channel/12345")
+      .setDescription("A sentence describing this live TV channel.")
+      // channel playback uri must contain at least PlatformType.TYPE_ANDROID_TV
+      .addPlatformSpecificPlaybackUri(channelPlaybackUris)
+      .addLogoImage(logoImage)
+      .setCallToActionText("Watch Now")
+      .addTag("News")
+      .build()
+
+Optionally provide additional data such as content ratings or
+recommendation reason.
+
+    val rating1 = RatingSystem.Builder()
+      .setAgencyName("MPAA")
+      .setRating("pg-13")
+      .build()
+    val contentRatings = Arrays.asList(rating1)
+
+    val liveTvChannelEntity = LiveTvChannelEntity.Builder()
+      ...
+      .addContentRatings(contentRatings)
+      .setRecommendationReason(topOnPartner)
+      .build()
+
+### `LiveTvProgramEntity`
+
+This represents a live TV program card airing or scheduled to air on
+a live TV channel. Here's an example of creating a `LiveTvProgramEntity`
+with all the required fields:
+
+    val liveTvProgramEntity = LiveTvProgramEntity.Builder()
+      // First set the channel information
+      .setChannelName("Channel Name")
+      .setChannelId("https://www.example.com/channel/12345")
+      // channel playback uri must contain at least PlatformType.TYPE_ANDROID_TV
+      .addPlatformSpecificPlaybackUri(channelPlaybackUris)
+      .setChannelLogoImage(channelLogoImage)
+      // Then set the program or card specific information.
+      .setName("Program Name")
+      .setEntityId("https://www.example.com/schedule/123")
+      .setDescription("Program Description")
+      .addAvailabilityTimeWindow(
+          DisplayTimeWindow.Builder()
+            .setStartTimestampMillis(1756713600000L)// 2025-09-01T07:30:00+0000
+            .setEndTimestampMillis(1756715400000L))// 2025-09-01T08:00:00+0000
+      .addPosterImage(programImage)
+      .setCallToActionText("Watch Now")
+      .addTag("Sports")
+      .build()
+
+Optionally provide additional data such as content ratings, genres, or
+recommendation reason.
+
+    val rating1 = RatingSystem.Builder()
+      .setAgencyName("MPAA")
+      .setRating("pg-13")
+      .build()
+    val contentRatings = Arrays.asList(rating1)
+    val genres = Arrays.asList("Action", "Science fiction")
+
+    val liveTvProgramEntity = LiveTvProgramEntity.Builder()
+      ...
+      .addContentRatings(contentRatings)
+      .addGenres(genres)
+      .setRecommendationReason(topOnPartner)
+      .build()
+
+> [!NOTE]
+> **Note:** If the additional fields are provided directly within the entity, these values will be prioritized. The locale, if provided in the Account Profile, will be used to fetch the remaining entity metadata from Google's database in the language consistent with the request.

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/watch.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/android/guide/playcore/engage/watch.md
@@ -1,0 +1,1064 @@
+> [!IMPORTANT]
+> **Important:** Engage SDK has superseded Media Home, which is now deprecated. If you have an existing Media Home integration, follow the instructions in these guides to migrate your content to Engage SDK, which allows your content to be published to more devices and form factors. Please contact [`engage-developers@google.com`](mailto:engage-developers@google.com) if you have any questions.
+
+Boost app engagement by reaching your users where they are. Integrate Engage
+SDK to deliver Continue Watching content and personalized recommendations
+directly to users across multiple on-device surfaces
+**[Collections](https://android-developers.googleblog.com/2024/07/introducing-collections-powered-by-engage-sdk.html)** ,
+**[Entertainment Space](https://blog.google/products/android/entertainment-space/)** , and the Play Store. The
+integration adds less than 50 KB (compressed) to the average APK and takes
+most apps about a week of developer time. Learn more at our
+**[business site](http://play.google.com/console/about/programs/EngageSDK)**.
+
+This guide contains instructions for developer partners to integrate their video
+content, using the Engage SDK to populate both this new surface area and
+existing Google surfaces.
+
+> [!NOTE]
+> **Note:** Check the [TV integration guide](https://developer.android.com/guide/playcore/engage/tv) to learn more about the Continue Watching experience on Google TV.
+
+## Integration detail
+
+### Terminology
+
+This integration includes the following three cluster types: **Recommendation** ,
+**Continuation** , and **Featured**.
+
+- **Recommendation** clusters show personalized suggestions for content to watch
+  from an individual developer partner.
+
+  Your recommendations take the following structure:
+  - **Recommendation Cluster:** A UI view that contains a group of
+    recommendations from the same developer partner.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/watch-term-1.png) **Figure 1.** Entertainment Space UI showing a Recommendation Cluster from a single partner.
+  - **Entity:** An object representing a single item in a cluster. An entity
+    can be a movie, a TV show, a TV series, live video, and more. See the
+    [Provide entity data](https://developer.android.com/guide/playcore/engage/watch#provide-entity-data) section for a list of
+    supported entity types.
+
+    ![](https://developer.android.com/static/images/guide/playcore/engage/watch-term-2.png) **Figure 2.** Entertainment Space UI showing a single Entity within a single partner's Recommendation Cluster.
+- The **Continuation** cluster shows unfinished videos and relevant newly
+  released episodes from multiple developer partners in one UI grouping. Each
+  developer partner will be allowed to broadcast a maximum of 10 entities in the
+  Continuation cluster. Research has shown that personalized recommendations
+  along with personalized Continuation content creates the best user engagement.
+
+  ![](https://developer.android.com/static/images/guide/playcore/engage/watch-term-3.png) **Figure 3.** Entertainment Space UI showing a Continuation cluster with unfinished recommendations from multiple partners (only one recommendation is currently visible).
+- The **Featured** cluster showcases a selection of entities from multiple
+  developer partners in one UI grouping. There will be a single Featured
+  cluster, which is surfaced near the top of the UI with a priority placement
+  above all Recommendation clusters. Each developer partner will be allowed to
+  broadcast up to 10 entities in the Featured cluster.
+
+  ![](https://developer.android.com/static/images/guide/playcore/engage/watch-term-4.png) **Figure 4.** Entertainment Space UI showing a Featured cluster with recommendations from multiple partners (only one recommendation is currently visible).
+
+### Pre-work
+
+Minimum API level: 19
+
+Add the `com.google.android.engage:engage-core` library to your app:
+
+    dependencies {
+        // Make sure you also include that repository in your project's build.gradle file.
+        implementation 'com.google.android.engage:engage-core:1.6.0'
+    }
+
+For more information, see [Package visibility in Android
+11](https://developer.android.com/about/versions/11/privacy/package-visibility).
+
+### Summary
+
+The design is based on an implementation of a [bound
+service](https://developer.android.com/guide/components/bound-services).
+
+The data a client can publish is subject to the following limits for different
+cluster types:
+
+| Cluster type | Cluster limits | Maximum entity limits in a cluster |
+|---|---|---|
+| Recommendation Cluster(s) | At most 7 | At most 50 |
+| Continuation Cluster | At most 1 | At most 20 |
+| Featured Cluster | At most 1 | At most 20 |
+
+> [!IMPORTANT]
+> **Important:** Engage SDK has superseded Media Home, which is now deprecated. If you have an existing Media Home integration, follow the instructions in [Step
+> 0](https://developer.android.com/guide/playcore/engage/watch#migration) to migrate your content to Engage SDK, which allows your content to be published to more devices and form factors. Contact [`engage-developers@google.com`](mailto:engage-developers@google.com). If you don't have an existing Media Home integration, skip to [Step
+> 1](https://developer.android.com/guide/playcore/engage/watch#provide-entity-data).
+
+### Step 0: Migration from existing Media Home SDK integration
+
+#### Map data models from existing integration
+
+If you are migrating from an existing Media Home integration, the following
+table outlines how to map data models in existing SDKs to the new Engage SDK:
+
+| MediaHomeVideoContract integration equivalent | Engage SDK integration equivalent |
+|---|---|
+| `com.google.android.mediahome.video.PreviewChannel` | ` com.google.android.engage.common.datamodel.RecommendationCluster ` |
+| `com.google.android.mediahome.video.PreviewChannel.Builder` | ` com.google.android.engage.common.datamodel.RecommendationCluster.Builder ` |
+| `com.google.android.mediahome.video.PreviewChannelHelper` | `com.google.android.engage.video.service.AppEngageVideoClient` |
+| `com.google.android.mediahome.video.PreviewProgram` | Divided into separate classes: `EventVideo`, `LiveStreamingVideo`, `Movie`, `TvEpisode`, `TvSeason`, `TvShow`, `VideoClipEntity` |
+| `com.google.android.mediahome.video.PreviewProgram.Builder` | Divided into builders in separate classes: `EventVideo`, `LiveStreamingVideo`, `Movie`, `TvEpisode`, `TvSeason`, `TvShow`, `VideoClipEntity` |
+| `com.google.android.mediahome.video.VideoContract` | No longer needed. |
+| `com.google.android.mediahome.video.WatchNextProgram` | Divided into attributes in separate classes: `EventVideoEntity`, `LiveStreamingVideoEntity`, `MovieEntity`, `TvEpisodeEntity`, `TvSeasonEntity`, `TvShowEntity`, `VideoClipEntity` |
+| `com.google.android.mediahome.video.WatchNextProgram.Builder` | Divided into attributes in separate classes: `EventVideoEntity`, `LiveStreamingVideoEntity`, `MovieEntity`, `TvEpisodeEntity`, `TvSeasonEntity`, `TvShowEntity`, `VideoClipEntity` |
+
+#### Publishing clusters in Media Home SDK vs Engage SDK
+
+With Media Home SDK, clusters and entities were published through separate APIs:
+
+    // 1. Fetch existing channels
+    List<PreviewChannel> channels = PreviewChannelHelper.getAllChannels();
+
+    // 2. If there are no channels, publish new channels
+    long channelId = PreviewChannelHelper.publishChannel(builder.build());
+
+    // 3. If there are existing channels, decide whether to update channel contents
+    PreviewChannelHelper.updatePreviewChannel(channelId, builder.build());
+
+    // 4. Delete all programs in the channel
+    PreviewChannelHelper.deleteAllPreviewProgramsByChannelId(channelId);
+
+    // 5. publish new programs in the channel
+    PreviewChannelHelper.publishPreviewProgram(builder.build());
+
+With Engage SDK, cluster and entity publishing are combined into a single API
+call. All entities that belong to a cluster are published together with that
+cluster:
+
+### Kotlin
+
+    RecommendationCluster.Builder()
+                .addEntity(MOVIE_ENTITY)
+                .addEntity(MOVIE_ENTITY)
+                .addEntity(MOVIE_ENTITY)
+                .setTitle("Top Picks For You")
+                .build()
+
+### Java
+
+    new RecommendationCluster.Builder()
+                            .addEntity(MOVIE_ENTITY)
+                            .addEntity(MOVIE_ENTITY)
+                            .addEntity(MOVIE_ENTITY)
+                            .setTitle("Top Picks For You")
+                            .build();
+
+### Step 1: Provide entity data
+
+The SDK has defined different entities to represent each item type. We support
+the following entities for the Watch category:
+
+1. [`MovieEntity`](https://developer.android.com/guide/playcore/engage/watch#movieentity)
+2. [`TvShowEntity`](https://developer.android.com/guide/playcore/engage/watch#tvshowentity)
+3. [`TvSeasonEntity`](https://developer.android.com/guide/playcore/engage/watch#tvseasonentity)
+4. [`TvEpisodeEntity`](https://developer.android.com/guide/playcore/engage/watch#tvepisodeentity)
+5. [`LiveStreamingVideoEntity`](https://developer.android.com/guide/playcore/engage/watch#livestreamingvideoentity)
+6. [`VideoClipEntity`](https://developer.android.com/guide/playcore/engage/watch#videoclipentity)
+
+The following chart outlines attributes and requirements for each type.
+
+#### `MovieEntity`
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** |   |
+| Poster images | **Required** | At least one image is required, and must be provided with an aspect ratio. (Landscape is preferred but passing both portrait and landscape images for different scenarios is recommended.) See [Image Specifications](https://developer.android.com/guide/playcore/engage/watch#image-specs) for guidance. |
+| Playback uri | **Required** | The deep link to the provider app to start playing the movie. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Info page uri | Optional | The deep link to the provider app to show details about the movie. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Release date | Optional | In epoch milliseconds. |
+| Availability | **Required** | AVAILABLE: The content is available to the user without any further action. FREE_WITH_SUBSCRIPTION: The content is available after the user purchases a subscription. PAID_CONTENT: The content requires user purchase or rental. PURCHASED: The content has been purchased or rented by the user. |
+| Offer price | Optional | Free text |
+| Duration | **Required** | In milliseconds. |
+| Genre | **Required** | Free text |
+| Content ratings | Optional | Free text, follow the industry standard. ([Example](https://www.spectrum.net/support/tv/tv-and-movie-ratings-descriptions)) |
+| Call to action text | Optional | Free text to be displayed as a call to action. |
+| Tags | Optional | List of tags associated with the entity. |
+| Watch next type | Conditionally required | Must be provided when the item is in the Continuation cluster and must be one of the following four types: CONTINUE: The user has already watched more than 1 minute of this content. NEW: The user has watched all available episodes from some episodic content, but a new episode has become available and there is exactly one unwatched episode. This works for TV shows, recorded soccer matches in a series, and so on. NEXT: The user has watched one or more complete episodes from some episodic content, but there remains either more than one episode remaining or exactly one episode remaining where the last episode is not "NEW" and was released before the user started watching the episodic content. WATCHLIST: The user has explicitly elected to add a movie, event, or series to a watchlist to manually curate what they want to watch next. |
+| Last engagement time | Conditionally required | Must be provided when the item is in the Continuation cluster. In epoch milliseconds. |
+| Last playback position time | Conditionally required | Must be provided when the item is in the Continuation cluster and WatchNextType is CONTINUE. In epoch milliseconds. |
+
+#### `TvShowEntity`
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** |   |
+| Poster images | **Required** | At least one image is required, and must be provided with an aspect ratio. (Landscape is preferred but passing both portrait and landscape images for different scenarios is recommended.) See [Image Specifications](https://developer.android.com/guide/playcore/engage/watch#image-specs) for guidance. |
+| Info page uri | **Required** | The deep link to the provider app to show the details of the TV show. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Playback uri | Optional | The deep link to the provider app to start playing the TV show. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| First episode air date | Optional | In epoch milliseconds. |
+| Latest episode air date | Optional | In epoch milliseconds. |
+| Availability | **Required** | AVAILABLE: The content is available to the user without any further action. FREE_WITH_SUBSCRIPTION: The content is available after the user purchases a subscription. PAID_CONTENT: The content requires user purchase or rental. PURCHASED: The content has been purchased or rented by the user. |
+| Offer price | Optional | Free text |
+| Season count | **Required** | Positive integer |
+| Genre | **Required** | Free text |
+| Content ratings | Optional | Free text, follow the industry standard. ([Example](https://www.spectrum.net/support/tv/tv-and-movie-ratings-descriptions)) |
+| Call to action text | Optional | Free text to be displayed as a call to action. |
+| Tags | Optional | List of tags associated with the entity. |
+| Watch next type | Conditionally required | Must be provided when the item is in the Continuation cluster and must be one of the following four types: CONTINUE: The user has already watched more than 1 minute of this content. NEW: The user has watched all available episodes from some episodic content, but a new episode has become available and there is exactly one unwatched episode. This works for TV shows, recorded soccer matches in a series, and so on. NEXT: The user has watched one or more complete episodes from some episodic content, but there remains either more than one episode remaining or exactly one episode remaining where the last episode is not "NEW" and was released before the user started watching the episodic content. WATCHLIST: The user has explicitly elected to add a movie, event, or series to a watchlist to manually curate what they want to watch next. |
+| Last engagement time | Conditionally required | Must be provided when the item is in the Continuation cluster. In epoch milliseconds. |
+| Last playback position time | Conditionally required | Must be provided when the item is in the Continuation cluster and WatchNextType is CONTINUE. In epoch milliseconds. |
+
+#### `TvSeasonEntity`
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** |   |
+| Poster images | **Required** | At least one image is required, and must be provided with an aspect ratio. (Landscape is preferred but passing both portrait and landscape images for different scenarios is recommended.) See [Image Specifications](https://developer.android.com/guide/playcore/engage/watch#image-specs) for guidance. |
+| Info page uri | **Required** | The deep link to the provider app to show the details of the TV show season. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Playback uri | Optional | The deep link to the provider app to start playing the TV show season. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Display Season number | **Optional** **Available in v1.3.1** | String |
+| First episode air date | Optional | In epoch milliseconds. |
+| Latest episode air date | Optional | In epoch milliseconds. |
+| Availability | **Required** | AVAILABLE: The content is available to the user without any further action. FREE_WITH_SUBSCRIPTION: The content is available after the user purchases a subscription. PAID_CONTENT: The content requires user purchase or rental. PURCHASED: The content has been purchased or rented by the user. |
+| Offer price | Optional | Free text |
+| Episode count | **Required** | Positive integer |
+| Genre | **Required** | Free text |
+| Content ratings | Optional | Free text, follow the industry standard. ([Example](https://www.spectrum.net/support/tv/tv-and-movie-ratings-descriptions)) |
+| Call to action text | Optional | Free text to be displayed as a call to action. |
+| Tags | Optional | List of tags associated with the entity. |
+| Watch next type | Conditionally required | Must be provided when the item is in the Continuation cluster and must be one of the following four types: CONTINUE: The user has already watched more than 1 minute of this content. NEW: The user has watched all available episodes from some episodic content, but a new episode has become available and there is exactly one unwatched episode. This works for TV shows, recorded soccer matches in a series, and so on. NEXT: The user has watched one or more complete episodes from some episodic content, but there remains either more than one episode remaining or exactly one episode remaining where the last episode is not "NEW" and was released before the user started watching the episodic content. WATCHLIST: The user has explicitly elected to add a movie, event, or series to a watchlist to manually curate what they want to watch next. |
+| Last engagement time | Conditionally required | Must be provided when the item is in the Continuation cluster. In epoch milliseconds. |
+| Last playback position time | Conditionally required | Must be provided when the item is in the Continuation cluster and WatchNextType is CONTINUE. In epoch milliseconds. |
+
+#### `TvEpisodeEntity`
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** |   |
+| Poster images | **Required** | At least one image is required, and must be provided with an aspect ratio. (Landscape is preferred but passing both portrait and landscape images for different scenarios is recommended.) See [Image Specifications](https://developer.android.com/guide/playcore/engage/watch#image-specs) for guidance. |
+| Playback uri | **Required** | The deep link to the provider app to start playing the episode. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Info page uri | Optional | The deep link to the provider app to show details about the TV show episode. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Display Episode number | **Optional** **Available in v1.3.1** | String |
+| Air date | **Required** | In epoch milliseconds. |
+| Availability | **Required** | AVAILABLE: The content is available to the user without any further action. FREE_WITH_SUBSCRIPTION: The content is available after the user purchases a subscription. PAID_CONTENT: The content requires user purchase or rental. PURCHASED: The content has been purchased or rented by the user. |
+| Offer price | Optional | Free text |
+| Duration | **Required** | Must be a positive value in milliseconds. |
+| Genre | **Required** | Free text |
+| Content ratings | Optional | Free text, follow the industry standard. ([Example](https://www.spectrum.net/support/tv/tv-and-movie-ratings-descriptions)) |
+| Call to action text | Optional | Free text to be displayed as a call to action. |
+| Tags | Optional | List of tags associated with the entity. |
+| Watch next type | Conditionally required | Must be provided when the item is in the Continuation cluster and must be one of the following four types: CONTINUE: The user has already watched more than 1 minute of this content. NEW: The user has watched all available episodes from some episodic content, but a new episode has become available and there is exactly one unwatched episode. This works for TV shows, recorded soccer matches in a series, and so on. NEXT: The user has watched one or more complete episodes from some episodic content, but there remains either more than one episode remaining or exactly one episode remaining where the last episode is not "NEW" and was released before the user started watching the episodic content. WATCHLIST: The user has explicitly elected to add a movie, event, or series to a watchlist to manually curate what they want to watch next. |
+| Last engagement time | Conditionally required | Must be provided when the item is in the Continuation cluster. In epoch milliseconds. |
+| Last playback position time | Conditionally required | Must be provided when the item is in the Continuation cluster and WatchNextType is CONTINUE. In epoch milliseconds. |
+
+#### `LiveStreamingVideoEntity`
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** |   |
+| Poster images | **Required** | At least one image is required, and must be provided with an aspect ratio. (Landscape is preferred but passing both portrait and landscape images for different scenarios is recommended.) See [Image Specifications](https://developer.android.com/guide/playcore/engage/watch#image-specs) for guidance. |
+| Playback uri | **Required** | The deep link to the provider app to start playing the video. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Broadcaster | **Required** | Free text |
+| Start time | Optional | In epoch milliseconds. |
+| End time | Optional | In epoch milliseconds. |
+| View count | Optional | Free text, must be localized. |
+| Call to action text | Optional | Free text to be displayed as a call to action. |
+| Tags | Optional | List of tags associated with the entity. |
+| Watch next type | Conditionally required | Must be provided when the item is in the Continuation cluster and must be one of the following four types: CONTINUE: The user has already watched more than 1 minute of this content. NEW: The user has watched all available episodes from some episodic content, but a new episode has become available and there is exactly one unwatched episode. This works for TV shows, recorded soccer matches in a series, and so on. NEXT: The user has watched one or more complete episodes from some episodic content, but there remains either more than one episode remaining or exactly one episode remaining where the last episode is not "NEW" and was released before the user started watching the episodic content. WATCHLIST: The user has explicitly elected to add a movie, event, or series to a watchlist to manually curate what they want to watch next. |
+| Last engagement time | Conditionally required | Must be provided when the item is in the Continuation cluster. In epoch milliseconds. |
+| Last playback position time | Conditionally required | Must be provided when the item is in the Continuation cluster and WatchNextType is CONTINUE. In epoch milliseconds. |
+
+#### `VideoClipEntity`
+
+The `VideoClipEntity` object represents a video entity coming from social media,
+such as TikTok or YouTube.
+
+| Attribute | Requirement | Notes |
+|---|---|---|
+| Name | **Required** |   |
+| Poster images | **Required** | At least one image is required, and must be provided with an aspect ratio. (Landscape is preferred but passing both portrait and landscape images for different scenarios is recommended.) See [Image Specifications](https://developer.android.com/guide/playcore/engage/watch#image-specs) for guidance. |
+| Playback uri | **Required** | The deep link to the provider app to start playing the video. Note: You can use deep links for attribution. [Refer to this FAQ](https://developer.android.com/guide/playcore/engage/faq#deeplinks-attribution) |
+| Created time | **Required** | In epoch milliseconds. |
+| Duration | **Required** | Must be a positive value in milliseconds. |
+| Creator | **Required** | Free text |
+| Creator image | Optional | Image of the Creator avatar |
+| View count | Optional | Free text, must be localized. |
+| Call to action text | Optional | Free text to be displayed as a call to action. |
+| Tags | Optional | List of tags associated with the entity. |
+| Watch next type | Conditionally required | Must be provided when the item is in the Continuation cluster and must be one of the following four types: CONTINUE: The user has already watched more than 1 minute of this content. NEW: The user has watched all available episodes from some episodic content, but a new episode has become available and there is exactly one unwatched episode. This works for TV shows, recorded soccer matches in a series, and so on. NEXT: The user has watched one or more complete episodes from some episodic content, but there remains either more than one episode remaining or exactly one episode remaining where the last episode is not "NEW" and was released before the user started watching the episodic content. WATCHLIST: The user has explicitly elected to add a movie, event, or series to a watchlist to manually curate what they want to watch next. |
+| Last engagement time | Conditionally required | Must be provided when the item is in the Continuation cluster. In epoch milliseconds. |
+| Last playback position time | Conditionally required | Must be provided when the item is in the Continuation cluster and WatchNextType is CONTINUE. In epoch milliseconds. |
+
+#### Image specifications
+
+The following section lists the required specifications for image assets:
+
+*File formats*
+
+PNG, JPG, static GIF, WebP
+
+*Maximum file size*
+
+5120 KB
+
+*Additional recommendations*
+
+- **Image safe area:** Put your important content in the center 80% of the image.
+
+#### Example
+
+### Kotlin
+
+    var movie = MovieEntity.Builder()
+        .setName("Avengers")
+        .addPosterImage(Image.Builder()
+                              .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                              .setImageHeightInPixel(960)
+                              .setImageWidthInPixel(408)
+                              .build())
+        .setPlayBackUri(Uri.parse("http://tv.com/playback/1"))
+        .setReleaseDateEpochMillis(1633032895L)
+        .setAvailability(ContentAvailability.AVAILABILITY_AVAILABLE)
+        .setDurationMillis(12345678L)
+        .addGenre("action")
+        .addContentRating("R")
+        .setWatchNextType(WatchNextType.TYPE_NEW)
+        .setLastEngagementTimeMillis(1664568895L)
+        .setCallToActionText("Watch Now")
+        .addTag("Action")
+        .build()
+
+### Java
+
+    MovieEntity movie = new MovieEntity.Builder()
+                      .setName("Avengers")
+                      .addPosterImage(
+                          new Image.Builder()
+                              .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                              .setImageHeightInPixel(960)
+                              .setImageWidthInPixel(408)
+                              .build())
+                      .setPlayBackUri(Uri.parse("http://tv.com/playback/1"))
+                      .setReleaseDateEpochMillis(1633032895L)
+                      .setAvailability(ContentAvailability.AVAILABILITY_AVAILABLE)
+                      .setDurationMillis(12345678L)
+                      .addGenre("action")
+                      .addContentRating("R")
+                      .setWatchNextType(WatchNextType.TYPE_NEW)
+                      .setLastEngagementTimeMillis(1664568895L)
+                      .setCallToActionText("Watch Now")
+                      .addTag("Action")
+                      .build();
+
+### Step 2: Provide Cluster data
+
+It's recommended to have the content publish job executed in the background
+(for example, using [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager))
+and scheduled on a regular basis or on an event basis (for example, every time
+the user opens the app or when the user just added something to their cart).
+
+`AppEngagePublishClient` is responsible for publishing clusters. Following
+APIs are available in the client:
+
+- `isServiceAvailable`
+- `publishRecommendationClusters`
+- `publishFeaturedCluster`
+- `publishContinuationCluster`
+- `publishUserAccountManagementRequest`
+- `updatePublishStatus`
+- `deleteRecommendationsClusters`
+- `deleteFeaturedCluster`
+- `deleteContinuationCluster`
+- `deleteUserManagementCluster`
+- `deleteClusters`
+
+#### `isServiceAvailable`
+
+This API is used to check if the service is available for integration and
+whether the content can be presented on the device.
+
+##### For Engage SDK v1.6.0 and higher (Recommended)
+
+You can check the service availability for every cluster type that you intend to
+publish. The `isServiceAvailable` API accepts a request object,
+`ServiceAvailabilityRequest`, which contains the cluster types for which service
+availability needs to be checked. You can find the `ClusterType` enum values
+required for `ServiceAvailabilityRequest` from the following table.
+
+| Cluster Type | Cluster Type Constant | Integer Value |
+|---|---|---|
+| Unknown | `TYPE_UNKNOWN` | 0 |
+| Recommendation Cluster | `TYPE_RECOMMENDATION` | 1 |
+| Featured Cluster | `TYPE_FEATURED` | 2 |
+| Continuation Cluster | `TYPE_CONTINUATION` | 3 |
+| User Management Cluster | `TYPE_ENGAGEMENT` | 8 |
+| Subscription Cluster | `TYPE_SUBSCRIPTION` | 12 |
+
+### Kotlin
+
+    val request = ServiceAvailabilityRequest.Builder()
+        .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+        .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+        .build()
+
+    client.isServiceAvailable(request).addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            val availabilityMap = task.result
+            if (availabilityMap[ClusterType.TYPE_CONTINUATION] == true) {
+                // Proceed with publishing continuation content
+            }
+            if (availabilityMap[ClusterType.TYPE_RECOMMENDATION] == true) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    }
+
+### Java
+
+    ServiceAvailabilityRequest request =
+        new ServiceAvailabilityRequest.Builder()
+            .addIntendedClusterType(ClusterType.TYPE_CONTINUATION)
+            .addIntendedClusterType(ClusterType.TYPE_RECOMMENDATION)
+            .build();
+
+    client.isServiceAvailable(request).addOnCompleteListener(task -> {
+        if (task.isSuccessful()) {
+            Map<Integer, Boolean> availabilityMap = task.getResult();
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_CONTINUATION))) {
+                // Proceed with publishing continuation content
+            }
+            if (Boolean.TRUE.equals(availabilityMap.get(ClusterType.TYPE_RECOMMENDATION))) {
+                // Proceed with publishing recommendation content
+            }
+        } else {
+            // The IPC call itself fails, proceed with error handling logic here,
+            // such as retry.
+        }
+    });
+
+###### Conditional Service Availability Feature
+
+Some integrated apps request a special configuration that enables and disables
+the Engage service intermittently in order to reduce their serving cost. This
+intermittent content ingestion strategy, although possible, negatively affects
+the user and the product -- stale content will not be presented and some surfaces
+will not be served at all.
+
+Starting with v1.6.0, the Engage SDK allows checking availability for specific
+cluster types. This provides more flexibility so that if the intermittent
+content strategy was adopted by a given application, some cluster types can
+follow that intermittent strategy while other cluster types are always enabled
+(i.e. continuation clusters).
+
+If the Engage service should not be 'continuously' enabled on all supported
+devices for whatever reason, and is configured for intermittent ingestion for
+any set of devices, all continuation cluster publications (e.g. Continue
+Watching) will be still enabled by default configuration, and the rest of the
+cluster types will be enabled and disabled intermittently. If intermittent
+ingestion applies to you but this default configuration is not suitable for
+your needs, please contact engage-developers@google.com.
+
+##### For SDK versions prior to v1.6.0 (Deprecated)
+
+### Kotlin
+
+    client.isServiceAvailable.addOnCompleteListener { task ->
+        if (task.isSuccessful) {
+            // Handle IPC call success
+            if(task.result) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    }
+
+### Java
+
+    client.isServiceAvailable().addOnCompleteListener(task - > {
+        if (task.isSuccessful()) {
+            // Handle success
+            if(task.getResult()) {
+              // Service is available on the device, proceed with content publish
+              // calls.
+            } else {
+              // Service is not available, no further action is needed.
+            }
+        } else {
+          // The IPC call itself fails, proceed with error handling logic here,
+          // such as retry.
+        }
+    });
+
+> [!NOTE]
+> **Note:** We highly recommend keeping a periodic job running to check if the service becomes available at a later point in time. The availability of the service may change with Android version upgrades, app upgrades, installs, and uninstalls. By ensuring periodic job checks at a certain time interval, data can be published once the service becomes available.
+
+#### `publishRecommendationClusters`
+
+This API is used to publish a list of `RecommendationCluster` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishRecommendationClusters(
+          PublishRecommendationClustersRequest.Builder()
+            .addRecommendationCluster(
+              RecommendationCluster.Builder()
+                .addEntity(entity1)
+                .addEntity(entity2)
+                .setTitle("Top Picks For You")
+                .build()
+            )
+            .build()
+        )
+
+### Java
+
+    client.publishRecommendationClusters(
+                new PublishRecommendationClustersRequest.Builder()
+                    .addRecommendationCluster(
+                        new RecommendationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .setTitle("Top Picks For You")
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `RecommendationCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Recommendation Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishFeaturedCluster`
+
+This API is used to publish a list of `FeaturedCluster` objects.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishFeaturedCluster(
+        PublishFeaturedClusterRequest.Builder()
+          .setFeaturedCluster(
+            FeaturedCluster.Builder()
+              .addEntity(entity1)
+              .addEntity(entity2)
+              .build())
+          .build())
+
+### Java
+
+    client.publishFeaturedCluster(
+                new PublishFeaturedClustersRequest.Builder()
+                    .addFeaturedCluster(
+                        new FeaturedCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `FeaturedCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Featured Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishContinuationCluster`
+
+This API is used to publish a `ContinuationCluster` object.
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    client.publishContinuationCluster(
+        PublishContinuationClusterRequest.Builder()
+          .setContinuationCluster(
+            ContinuationCluster.Builder()
+              .addEntity(entity1)
+              .addEntity(entity2)
+              .build())
+          .build())
+
+### Java
+
+    client.publishContinuationCluster(
+                new PublishContinuationClusterRequest.Builder()
+                    .setContinuationCluster(
+                        new ContinuationCluster.Builder()
+                            .addEntity(entity1)
+                            .addEntity(entity2)
+                            .build())
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `ContinuationCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated Continuation Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `publishUserAccountManagementRequest`
+
+This API is used to publish a Sign In card . The signin action directs users to
+the app's sign in page so that the app can publish content (or provide more
+personalized content)
+
+The following metadata is part of the Sign In Card -
+
+| Attribute | Requirement | Description |
+|---|---|---|
+| Action Uri | Required | Deeplink to Action (i.e. navigates to app sign in page) |
+| Image | Optional - If not provided, Title must be provided | Image Shown on the Card 16x9 aspect ratio images with a resolution of 1264x712 |
+| Title | Optional - If not provided, Image must be provided | Title on the Card |
+| Action Text | Optional | Text Shown on the CTA (i.e. Sign in) |
+| Subtitle | Optional | Optional Subtitle on the Card |
+
+> [!IMPORTANT]
+> **Important:** The publish APIs are upsert APIs; it replaces the existing content. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently.
+
+### Kotlin
+
+    var SIGN_IN_CARD_ENTITY =
+          SignInCardEntity.Builder()
+              .addPosterImage(
+                  Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build()
+
+    client.publishUserAccountManagementRequest(
+                PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+### Java
+
+    SignInCardEntity SIGN_IN_CARD_ENTITY =
+          new SignInCardEntity.Builder()
+              .addPosterImage(
+                  new Image.Builder()
+                      .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                      .setImageHeightInPixel(500)
+                      .setImageWidthInPixel(500)
+                      .build())
+              .setActionText("Sign In")
+              .setActionUri(Uri.parse("http://xx.com/signin"))
+              .build();
+
+    client.publishUserAccountManagementRequest(
+                new PublishUserAccountManagementRequest.Builder()
+                    .setSignInCardEntity(SIGN_IN_CARD_ENTITY)
+                    .build());
+
+When the service receives the request, the following actions take place within
+one transaction:
+
+- Existing `UserAccountManagementCluster` data from the developer partner is removed.
+- Data from the request is parsed and stored in the updated UserAccountManagementCluster Cluster.
+
+In case of an error, the entire request is rejected and the existing state is
+maintained.
+
+#### `updatePublishStatus`
+
+If for any internal business reason, none of the clusters is published,
+we **strongly recommend** updating the publish status using the
+**updatePublishStatus** API.
+This is important because :
+
+- Providing the status in all scenarios, even when the content is published (STATUS == PUBLISHED), is critical to populate dashboards that use this explicit status to convey the health and other metrics of your integration.
+- If no content is published but the integration status isn't broken (STATUS == NOT_PUBLISHED), Google can avoid triggering alerts in the app health dashboards. It confirms that content is not published due to an **expected** situation from the provider's standpoint.
+- It helps developers provide insights into when the data is published versus not.
+- Google may use the status codes to nudge the user to do certain actions in the app so they can see the app content or overcome it.
+
+The list of eligible publish status codes are :
+
+    // Content is published
+    AppEngagePublishStatusCode.PUBLISHED,
+
+    // Content is not published as user is not signed in
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN,
+
+    // Content is not published as user is not subscribed
+    AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SUBSCRIPTION,
+
+    // Content is not published as user location is ineligible
+    AppEngagePublishStatusCode.NOT_PUBLISHED_INELIGIBLE_LOCATION,
+
+    // Content is not published as there is no eligible content
+    AppEngagePublishStatusCode.NOT_PUBLISHED_NO_ELIGIBLE_CONTENT,
+
+    // Content is not published as the feature is disabled by the client
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_FEATURE_DISABLED_BY_CLIENT,
+
+    // Content is not published as the feature due to a client error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR,
+
+    // Content is not published as the feature due to a service error
+    // Available in v1.3.1
+    AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR,
+
+    // Content is not published due to some other reason
+    // Reach out to engage-developers@ before using this enum.
+    AppEngagePublishStatusCode.NOT_PUBLISHED_OTHER
+
+If the content is not published due to a user not logged in,
+Google would recommend publishing the Sign In Card.
+If for any reason providers are not able to publish the Sign In Card
+then we recommend calling the **updatePublishStatus** API
+with the status code **NOT_PUBLISHED_REQUIRES_SIGN_IN**
+
+### Kotlin
+
+    client.updatePublishStatus(
+       PublishStatusRequest.Builder()
+         .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+         .build())
+
+### Java
+
+    client.updatePublishStatus(
+        new PublishStatusRequest.Builder()
+            .setStatusCode(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+            .build());
+
+#### `deleteRecommendationClusters`
+
+This API is used to delete the content of Recommendation Clusters.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteRecommendationClusters()
+
+### Java
+
+    client.deleteRecommendationClusters();
+
+When the service receives the request, it removes the existing data from the
+Recommendation Clusters. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteFeaturedCluster`
+
+This API is used to delete the content of Featured Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteFeaturedCluster()
+
+### Java
+
+    client.deleteFeaturedCluster();
+
+When the service receives the request, it removes the existing data from the
+Featured Cluster. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteContinuationCluster`
+
+This API is used to delete the content of Continuation Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteContinuationCluster()
+
+### Java
+
+    client.deleteContinuationCluster();
+
+When the service receives the request, it removes the existing data from the
+Continuation Cluster. In case of an error, the entire request is rejected
+and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteUserManagementCluster`
+
+This API is used to delete the content of UserAccountManagement Cluster.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteUserManagementCluster()
+
+### Java
+
+    client.deleteUserManagementCluster();
+
+When the service receives the request, it removes the existing data from the
+UserAccountManagement Cluster. In case of an error, the entire request is
+rejected and the existing state is maintained.
+
+> [!NOTE]
+> **Note:** This api is available from version 1.1.0 onwards.
+
+#### `deleteClusters`
+
+This API is used to delete the content of a given cluster type.
+
+> [!IMPORTANT]
+> **Important:** Delete APIs should only be called when there is no content to publish. **Don't** call delete and publish APIs subsequently to replace the content as the publish APIs do that inherently. Reach out to [`engage-developers@google.com`](mailto:engage-developers@google.com) before using delete APIs.
+
+### Kotlin
+
+    client.deleteClusters(
+        DeleteClustersRequest.Builder()
+          .addClusterType(ClusterType.TYPE_CONTINUATION)
+          .addClusterType(ClusterType.TYPE_FEATURED)
+          .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+          .build())
+
+### Java
+
+    client.deleteClusters(
+                new DeleteClustersRequest.Builder()
+                    .addClusterType(ClusterType.TYPE_CONTINUATION)
+                    .addClusterType(ClusterType.TYPE_FEATURED)
+                    .addClusterType(ClusterType.TYPE_RECOMMENDATION)
+                    .build());
+
+When the service receives the request, it removes the existing data from all
+clusters matching the specified cluster types. Clients can choose to pass one or
+many cluster types. In case of an error, the entire request is rejected and the
+existing state is maintained.
+
+#### Error handling
+
+It is highly recommended to listen to the task result from the publish APIs such
+that a follow-up action can be taken to recover and resubmit an successful task.
+
+### Kotlin
+
+    client.publishRecommendationClusters(
+            PublishRecommendationClustersRequest.Builder()
+              .addRecommendationCluster(..)
+              .build())
+          .addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+              // do something
+            } else {
+              val exception = task.exception
+              if (exception is AppEngageException) {
+                @AppEngageErrorCode val errorCode = exception.errorCode
+                if (errorCode == AppEngageErrorCode.SERVICE_NOT_FOUND) {
+                  // do something
+                }
+              }
+            }
+          }
+
+### Java
+
+    client.publishRecommendationClusters(
+                  new PublishRecommendationClustersRequest.Builder()
+                      .addRecommendationCluster(...)
+                      .build())
+              .addOnCompleteListener(
+                  task -> {
+                    if (task.isSuccessful()) {
+                      // do something
+                    } else {
+                      Exception exception = task.getException();
+                      if (exception instanceof AppEngageException) {
+                        @AppEngageErrorCode
+                        int errorCode = ((AppEngageException) exception).getErrorCode();
+                        if (errorCode == AppEngageErrorCode.SERVICE_NOT_FOUND) {
+                          // do something
+                        }
+                      }
+                    }
+                  });
+
+The error is returned as an `AppEngageException` with the cause included as an
+error code.
+
+| Error code | Error name | Note |
+|---|---|---|
+| `1` | `SERVICE_NOT_FOUND` | The service is not available on the given device. |
+| `2` | `SERVICE_NOT_AVAILABLE` | The service is available on the given device, but it is not available at the time of the call (for example, it is explicitly disabled). |
+| `3` | `SERVICE_CALL_EXECUTION_FAILURE` | The task execution failed due to threading issues. In this case, it can be retried. |
+| `4` | `SERVICE_CALL_PERMISSION_DENIED` | The caller is not allowed to make the service call. |
+| `5` | `SERVICE_CALL_INVALID_ARGUMENT` | The request contains invalid data (for example, more than the allowed number of clusters). |
+| `6` | `SERVICE_CALL_INTERNAL` | There is an error on the service side. |
+| `7` | `SERVICE_CALL_RESOURCE_EXHAUSTED` | The service call is made too frequently. |
+
+### Step 3: Handle broadcast intents
+
+In addition to making publish content API calls through a job, it is also
+required to set up a
+[`BroadcastReceiver`](https://developer.android.com/reference/android/content/BroadcastReceiver) to receive
+the request for a content publish.
+
+The goal of broadcast intents is mainly for app reactivation and forcing data
+sync. Broadcast intents are not designed to be sent very frequently. It is only
+triggered when the Engage Service determines the content might be stale (for
+example, a week old). That way, there is more confidence that the user can have
+a fresh content experience, even if the application has not been executed for a
+long period of time.
+
+The `BroadcastReceiver` must be set up in the following two ways:
+
+- Dynamically register an instance of the `BroadcastReceiver` class using
+  `Context.registerReceiver()`. This enables communication from applications
+  that are still live in memory.
+
+### Kotlin
+
+    class AppEngageBroadcastReceiver : BroadcastReceiver(){
+      // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+      // is received
+      // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is received
+      // Trigger continuation cluster publish when PUBLISH_CONTINUATION broadcast is
+      // received
+    }
+
+    fun registerBroadcastReceivers(context: Context){
+      var  context = context
+      context = context.applicationContext
+
+    // Register Recommendation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_RECOMMENDATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Featured Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_FEATURED),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+
+    // Register Continuation Cluster Publish Intent
+      context.registerReceiver(AppEngageBroadcastReceiver(),
+                               IntentFilter(Intents.ACTION_PUBLISH_CONTINUATION),
+                               com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                               /*scheduler=*/null)
+    }
+
+### Java
+
+    class AppEngageBroadcastReceiver extends BroadcastReceiver {
+    // Trigger recommendation cluster publish when PUBLISH_RECOMMENDATION broadcast
+    // is received
+
+    // Trigger featured cluster publish when PUBLISH_FEATURED broadcast is received
+
+    // Trigger continuation cluster publish when PUBLISH_CONTINUATION broadcast is
+    // received
+    }
+
+    public static void registerBroadcastReceivers(Context context) {
+
+    context = context.getApplicationContext();
+
+    // Register Recommendation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents. ACTION_PUBLISH_RECOMMENDATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Featured Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    // Register Continuation Cluster Publish Intent
+    context.registerReceiver(new AppEngageBroadcastReceiver(),
+                             new IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_CONTINUATION),
+                             com.google.android.engage.service.BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                             /*scheduler=*/null);
+
+    }
+
+- Statically declare an implementation with the `<receiver>` tag in your
+  `AndroidManifest.xml` file. This allows the application to receive broadcast
+  intents when it is not running, and also allows the application to publish
+  the content.
+
+    <application>
+       <receiver
+          android:name=".AppEngageBroadcastReceiver"
+          android:permission="com.google.android.engage.REQUEST_ENGAGE_DATA"
+          android:exported="true"
+          android:enabled="true">
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_RECOMMENDATION" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_FEATURED" />
+          </intent-filter>
+          <intent-filter>
+             <action android:name="com.google.android.engage.action.PUBLISH_CONTINUATION" />
+          </intent-filter>
+       </receiver>
+    </application>
+
+The following [intents](https://developer.android.com/reference/android/content/Intent) is sent by the
+service:
+
+- `com.google.android.engage.action.PUBLISH_RECOMMENDATION` It is recommended to start a `publishRecommendationClusters` call when receiving this intent.
+- `com.google.android.engage.action.PUBLISH_FEATURED` It is recommended to start a `publishFeaturedCluster` call when receiving this intent.
+- `com.google.android.engage.action.PUBLISH_CONTINUATION` It is recommended to start a `publishContinuationCluster` call when receiving this intent.
+
+## Integration workflow
+
+For a step-by-step guide on verifying your integration after it is complete, see
+[Engage developer integration workflow](https://developer.android.com/guide/playcore/engage/workflow).
+
+## FAQs
+
+See [Engage SDK Frequently Asked Questions](https://developer.android.com/guide/playcore/engage/faq) for
+FAQs.
+
+## Contact
+
+Contact
+[`engage-developers@google.com`](mailto:engage-developers@google.com) if there are
+any questions during the integration process.
+
+## Next steps
+
+After completing this integration, your next steps are as follows:
+
+- Send an email to [`engage-developers@google.com`](mailto:engage-developers@google.com) and attach your integrated APK that is ready for testing by Google.
+- Google performs a verification and reviews internally to make sure the integration works as expected. If changes are needed, Google contacts you with any necessary details.
+- When testing is complete and no changes are needed, Google contacts you to notify you that you can start publishing the updated and integrated APK to the Play Store.
+- After Google has confirmed that your updated APK has been published to the Play Store, your **Recommendation** , **Featured** , and **Continuation** clusters may be published and visible to users.

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/clusters.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/clusters.md
@@ -1,0 +1,149 @@
+This file defines the structure of various clusters in the Engage SDK.
+
+    {
+      "clusters": {
+        "FeaturedCluster": {
+          "package": "com.google.android.engage.common.datamodel.FeaturedCluster",
+          "fields": {
+            "entities": {
+              "type": "List<Entity>",
+              "requirement": "Required",
+              "adder": "addEntity(Entity)",
+              "getter": "getEntities()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            }
+          }
+        },
+        "ContinuationCluster": {
+          "package": "com.google.android.engage.common.datamodel.ContinuationCluster",
+          "fields": {
+            "syncAcrossDevices": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setSyncAcrossDevices(boolean)",
+              "getter": "getSyncAcrossDevices()"
+            },
+            "accountProfile": {
+              "type": "AccountProfile",
+              "requirement": "Optional",
+              "setter": "setAccountProfile(AccountProfile)",
+              "getter": "getAccountProfile()"
+            },
+            "entities": {
+              "type": "List<Entity>",
+              "requirement": "Required",
+              "adder": "addEntity(Entity)",
+              "getter": "getEntities()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            }
+          }
+        },
+        "RecommendationCluster": {
+          "package": "com.google.android.engage.common.datamodel.RecommendationCluster",
+          "fields": {
+            "entities": {
+              "type": "List<Entity>",
+              "requirement": "Required",
+              "adder": "addEntity(Entity)",
+              "getter": "getEntities()"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "subtitle": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setSubtitle(String)",
+              "getter": "getSubtitle()"
+            },
+            "actionText": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setActionText(String)",
+              "getter": "getActionText()"
+            },
+            "actionUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setActionUri(Uri)",
+              "getter": "getActionUri()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            },
+            "recommendationClusterType": {
+              "type": "@RecommendationClusterType int",
+              "requirement": "Optional",
+              "setter": "setRecommendationClusterType(@RecommendationClusterType int)",
+              "getter": "getRecommendationClusterType()"
+            }
+          }
+        },
+        "SubscriptionCluster": {
+          "package": "com.google.android.engage.common.datamodel.SubscriptionCluster",
+          "fields": {
+            "accountProfile": {
+              "type": "AccountProfile",
+              "requirement": "Optional",
+              "setter": "setAccountProfile(AccountProfile)",
+              "getter": "getAccountProfile()"
+            },
+            "subscriptionEntities": {
+              "type": "List<SubscriptionEntity>",
+              "requirement": "Required",
+              "adder": "addSubscriptionEntity(SubscriptionEntity)",
+              "getter": "getSubscriptionEntities()"
+            }
+          }
+        },
+        "EngagementCluster": {
+          "package": "com.google.android.engage.common.datamodel.EngagementCluster",
+          "fields": {
+            "signInCardEntity": {
+              "type": "SignInCardEntity",
+              "requirement": "Required",
+              "setter": "setSignInCardEntity(SignInCardEntity)"
+            },
+            "userSettingsCardEntity": {
+              "type": "UserSettingsCardEntity",
+              "requirement": "Required",
+              "setter": "setUserSettingsCardEntity(UserSettingsCardEntity)"
+            }
+          }
+        }
+      }
+    }

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/common.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/common.md
@@ -1,0 +1,519 @@
+This file defines common data models and entities used across the Engage SDK.
+
+    {
+      "entities": {
+        "Image": {
+          "package": "com.google.android.engage.common.datamodel.Image",
+          "fields": {
+            "imageUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setImageUri(Uri)",
+              "getter": "getImageUri()"
+            },
+            "height": {
+              "type": "Integer",
+              "requirement": "Optional"
+            },
+            "width": {
+              "type": "Integer",
+              "requirement": "Optional"
+            },
+            "accessibilityText": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setAccessibilityText(String)",
+              "getter": "getAccessibilityText()"
+            },
+            "theme": {
+              "type": "ImageThemeEnum",
+              "requirement": "Optional"
+            },
+            "cropType": {
+              "type": "ImageCropTypeEnum",
+              "requirement": "Optional"
+            },
+            "imageHeightInPixel": {
+              "requirement": "Required",
+              "setter": "setImageHeightInPixel(int)",
+              "type": "Integer",
+              "getter": "getImageHeightInPixel()"
+            },
+            "imageWidthInPixel": {
+              "requirement": "Required",
+              "setter": "setImageWidthInPixel(int)",
+              "type": "Integer",
+              "getter": "getImageWidthInPixel()"
+            },
+            "imageTheme": {
+              "requirement": "Optional",
+              "setter": "setImageTheme(@ImageTheme int)",
+              "type": "@ImageTheme int",
+              "getter": "getImageTheme()"
+            },
+            "imageCropType": {
+              "requirement": "Optional",
+              "setter": "setImageCropType(@ImageCropType int)",
+              "type": "@ImageCropType int",
+              "getter": "getImageCropType()"
+            }
+          }
+        },
+        "Price": {
+          "package": "com.google.android.engage.common.datamodel.Price",
+          "fields": {
+            "currentPrice": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setCurrentPrice(String)",
+              "getter": "getCurrentPrice()"
+            },
+            "strikethroughPrice": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setStrikethroughPrice(String)",
+              "getter": "getStrikethroughPrice()"
+            }
+          }
+        },
+        "Rating": {
+          "package": "com.google.android.engage.common.datamodel.Rating",
+          "fields": {
+            "ratingValue": {
+              "type": "Float",
+              "requirement": "Required"
+            },
+            "maxValue": {
+              "type": "Double",
+              "requirement": "Required",
+              "setter": "setMaxValue(double)",
+              "getter": "getMaxValue()"
+            },
+            "ratingCount": {
+              "type": "Integer",
+              "requirement": "Optional"
+            },
+            "ratingCountValue": {
+              "type": "String",
+              "requirement": "Optional"
+            },
+            "currentValue": {
+              "requirement": "Required",
+              "setter": "setCurrentValue(double)",
+              "type": "Double",
+              "getter": "getCurrentValue()"
+            },
+            "count": {
+              "requirement": "Optional",
+              "setter": "setCount(String)",
+              "type": "String",
+              "getter": "getCount()"
+            },
+            "countValue": {
+              "requirement": "Optional",
+              "setter": "setCountValue(long)",
+              "type": "Long",
+              "getter": "getCountValue()"
+            }
+          }
+        },
+        "DisplayTimeWindow": {
+          "package": "com.google.android.engage.common.datamodel.DisplayTimeWindow",
+          "fields": {
+            "startTimeMillis": {
+              "type": "Long",
+              "requirement": "Required"
+            },
+            "endTimeMillis": {
+              "type": "Long",
+              "requirement": "Required"
+            },
+            "startTimestampMillis": {
+              "requirement": "Optional",
+              "setter": "setStartTimestampMillis(long)",
+              "type": "Long",
+              "getter": "getStartTimestampMillis()"
+            },
+            "endTimestampMillis": {
+              "requirement": "Optional",
+              "setter": "setEndTimestampMillis(long)",
+              "type": "Long",
+              "getter": "getEndTimestampMillis()"
+            }
+          }
+        },
+        "AccountProfile": {
+          "package": "com.google.android.engage.common.datamodel.AccountProfile",
+          "fields": {
+            "accountId": {
+              "type": "@NonNull String",
+              "requirement": "Required",
+              "setter": "setAccountId(@NonNull String)",
+              "getter": "getAccountId()"
+            },
+            "profileId": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setProfileId(@NonNull String)",
+              "getter": "getProfileId()"
+            },
+            "accountName": {
+              "type": "String",
+              "requirement": "Optional"
+            },
+            "profileImage": {
+              "type": "Image",
+              "requirement": "Optional"
+            },
+            "locale": {
+              "requirement": "Optional",
+              "setter": "setLocale(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getLocale()"
+            }
+          }
+        },
+        "Address": {
+          "package": "com.google.android.engage.common.datamodel.Address",
+          "fields": {
+            "city": {
+              "type": "@NonNull String",
+              "requirement": "Required",
+              "setter": "setCity(@NonNull String)",
+              "getter": "getCity()"
+            },
+            "country": {
+              "type": "@NonNull String",
+              "requirement": "Required",
+              "setter": "setCountry(@NonNull String)",
+              "getter": "getCountry()"
+            },
+            "displayAddress": {
+              "type": "@NonNull String",
+              "requirement": "Required",
+              "setter": "setDisplayAddress(@NonNull String)",
+              "getter": "getDisplayAddress()"
+            },
+            "streetAddress": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setStreetAddress(String)",
+              "getter": "getStreetAddress()"
+            },
+            "state": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setState(String)",
+              "getter": "getState()"
+            },
+            "zipCode": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setZipCode(String)",
+              "getter": "getZipCode()"
+            },
+            "neighborhood": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setNeighborhood(String)",
+              "getter": "getNeighborhood()"
+            }
+          }
+        },
+        "Badge": {
+          "package": "com.google.android.engage.common.datamodel.Badge",
+          "fields": {
+            "text": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setText(String)",
+              "getter": "getText()"
+            },
+            "image": {
+              "type": "Image",
+              "requirement": "Optional",
+              "setter": "setImage(Image)",
+              "getter": "getImage()"
+            }
+          }
+        },
+        "LocalizedTimestamp": {
+          "package": "com.google.android.engage.common.datamodel.LocalizedTimestamp",
+          "fields": {
+            "timestamp": {
+              "type": "Instant",
+              "requirement": "Required",
+              "setter": "setTimestamp(Instant)",
+              "getter": "getTimestamp()"
+            },
+            "timezone": {
+              "type": "DateTimeZone",
+              "requirement": "Required",
+              "setter": "setTimezone(DateTimeZone)",
+              "getter": "getTimezone()"
+            }
+          }
+        },
+        "SignInCardEntity": {
+          "package": "com.google.android.engage.common.datamodel.SignInCardEntity",
+          "fields": {
+            "actionText": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setActionText(String)",
+              "getter": "getActionText()"
+            },
+            "actionUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionUri(Uri)",
+              "getter": "getActionUri()"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "subtitle": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setSubtitle(String)",
+              "getter": "getSubtitle()"
+            },
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            }
+          }
+        },
+        "GenericFeaturedEntity": {
+          "package": "com.google.android.engage.common.datamodel.GenericFeaturedEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "actionUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionUri(Uri)",
+              "getter": "getActionUri()"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "subtitles": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "adderAll": "addSubtitles(List<String>)"
+            },
+            "badges": {
+              "type": "List<Badge>",
+              "requirement": "Optional",
+              "adder": "addBadge(Badge)",
+              "adderAll": "addBadges(List<Badge>)"
+            },
+            "contentCategories": {
+              "type": "List<@EligibleContentCategory int>",
+              "requirement": "Optional",
+              "adder": "addContentCategory(@EligibleContentCategory int)",
+              "adderAll": "addContentCategories(List<Integer>)"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            }
+          }
+        },
+        "SubscriptionEntity": {
+          "package": "com.google.android.engage.common.datamodel.SubscriptionEntity",
+          "fields": {}
+        },
+        "UserSettingsCardEntity": {
+          "package": "com.google.android.engage.common.datamodel.UserSettingsCardEntity",
+          "fields": {
+            "actionText": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setActionText(String)",
+              "getter": "getActionText()"
+            },
+            "actionUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionUri(Uri)",
+              "getter": "getActionUri()"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "subtitle": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setSubtitle(String)",
+              "getter": "getSubtitle()"
+            },
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            }
+          }
+        },
+        "ArticleEntity": {
+          "package": "com.google.android.engage.common.datamodel.ArticleEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "actionUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionUri(Uri)",
+              "getter": "getActionUri()"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "subtitles": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "adderAll": "addSubtitles(List<String>)"
+            },
+            "badges": {
+              "type": "List<Badge>",
+              "requirement": "Optional",
+              "adder": "addBadge(Badge)",
+              "adderAll": "addBadges(List<Badge>)"
+            },
+            "contentCategories": {
+              "type": "List<@EligibleContentCategory int>",
+              "requirement": "Optional",
+              "adder": "addContentCategory(@EligibleContentCategory int)",
+              "adderAll": "addContentCategories(List<Integer>)"
+            },
+            "progressPercentage": {
+              "type": "Integer",
+              "requirement": "Required",
+              "setter": "setProgressPercentage(int)",
+              "getter": "getProgressPercentage()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "lastEngagementTimestampMillis": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setLastEngagementTimestampMillis(long)",
+              "getter": "getLastEngagementTimestampMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "source": {
+              "type": "Badge",
+              "requirement": "Optional",
+              "setter": "setSource(Badge)",
+              "getter": "getSource()"
+            },
+            "lastContentPublishTimestampMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastContentPublishTimestampMillis(Long)",
+              "getter": "getLastContentPublishTimestampMillis()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            }
+          }
+        }
+      },
+      "intents": {
+        "ACTION_PUBLISH_RECOMMENDATION": "com.google.android.engage.action.PUBLISH_RECOMMENDATION",
+        "ACTION_PUBLISH_FEATURED": "com.google.android.engage.action.PUBLISH_FEATURED",
+        "ACTION_PUBLISH_CONTINUATION": "com.google.android.engage.action.PUBLISH_CONTINUATION"
+      },
+      "imports": [
+        "com.google.android.engage.service.AppEngagePublishClient",
+        "com.google.android.engage.service.AppEngageErrorCode",
+        "com.google.android.engage.service.AppEngageException",
+        "com.google.android.engage.service.AppEngagePublishStatusCode"
+      ]
+    }

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/patterns.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/patterns.md
@@ -1,0 +1,484 @@
+## EngageBroadcastReceiver
+
+Setting up the `BroadcastReceiver` correctly requires **both** static and
+dynamic registration. Static registration allows the app to receive broadcasts
+even when it is not running, while dynamic registration is required on newer
+Android versions to safely receive broadcasts when the app is live in memory.
+
+### BroadcastReceiver Implementation
+
+
+```kotlin
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.core.content.ContextCompat
+import com.google.android.engage.service.BroadcastReceiverPermissions
+
+class EngageBroadcastReceiver : BroadcastReceiver() {
+    // IMPORTANT: Only trigger the specific publish job for the received intent action.
+    // DO NOT publish all clusters at once.
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (intent == null || context == null) return
+        when (intent.action) {
+            com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION
+            -> EngagePublisher.publishOneTime(context, Constants.PUBLISH_TYPE_RECOMMENDATIONS)
+            // Note: If app handles other publish actions (e.g. Featured, Continuation), add them here.
+            com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED
+            -> EngagePublisher.publishOneTime(context, Constants.PUBLISH_TYPE_FEATURED)
+
+            /** Note: If vertical has other intents (e.g. FOOD shopping cart, etc.), add them here.
+             * com.google.android.engage.food.service.Intents.ACTION_PUBLISH_FOOD_SHOPPING_CART
+             * -> EngagePublisher.publishOneTime(context, Constants.PUBLISH_TYPE_FOOD_SHOPPING_CARD)
+             * com.google.android.engage.travel.service.Intents.ACTION_PUBLISH_RESERVATION
+             * -> EngagePublisher.publishOneTime(context, Constants.PUBLISH_TYPE_RESERVATION )
+             **/
+        }
+    }
+
+    companion object {
+        /**
+         * Dynamically registers the receiver.
+         * This is required in addition to static registration in AndroidManifest.xml.
+         * Call this method in your Application's onCreate() or your main Activity's onCreate().
+         */
+        fun register(context: Context) {
+            val appContext = context.applicationContext
+            val receiver = EngageBroadcastReceiver()
+
+            // Register Cluster Publish Intents
+            val filter = IntentFilter().apply {
+                addAction(com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION)
+                addAction(com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED)
+                addAction(com.google.android.engage.service.Intents.ACTION_PUBLISH_CONTINUATION)
+            }
+            ContextCompat.registerReceiver(
+                appContext,
+                receiver,
+                filter,
+                BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                null,
+                ContextCompat.RECEIVER_EXPORTED
+            )
+            // Note: Add vertical-specific intents here if applicable (e.g., FOOD shopping cart, etc.)
+        }
+    }
+}
+```
+
+<br />
+
+### Static Registration (AndroidManifest.xml)
+
+Add the `<receiver>` tag inside the `<application>` block in
+`AndroidManifest.xml`
+
+
+```kotlin
+<!--    Add the `<receiver>` tag inside the `<application>` block in `AndroidManifest.xml`:-->
+<receiver
+    android:name="com.example.snippets.engage.EngageBroadcastReceiver"
+    android:permission="com.google.android.engage.REQUEST_ENGAGE_DATA"
+    android:exported="true"
+    android:enabled="true">
+    <!-- Recommended for production TV APKs -->
+    <intent-filter>
+        <action android:name="com.google.android.engage.action.PUBLISH_RECOMMENDATION" />
+        <action android:name="com.google.android.engage.action.PUBLISH_FEATURED" />
+        <action android:name="com.google.android.engage.action.PUBLISH_CONTINUATION" />
+        <!-- Note: Add vertical-specific intents here if applicable (e.g., FOOD shopping cart, etc.) -->
+    </intent-filter>
+</receiver>
+```
+
+<br />
+
+## EngageWorker
+
+
+```kotlin
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.google.android.engage.service.AppEngageErrorCode
+import com.google.android.engage.service.AppEngageException
+import com.google.android.engage.service.AppEngagePublishClient
+import com.google.android.engage.service.AppEngagePublishStatusCode
+import com.google.android.engage.service.PublishStatusRequest
+import com.google.android.gms.tasks.Task
+import kotlinx.coroutines.tasks.await
+
+class EngageWorker(context: Context, workerParams: WorkerParameters) : CoroutineWorker(context, workerParams) {
+    // Replace {AppEngagePublishClient} with the "client" class found in references/schemas/{VERTICAL}.md.
+    // Client class can vary based on app's vertical.
+    // Refer to the references/schemas/{VERTICAL}.md to find the right class.
+    // This is an example of using AppEngagePublishClient.
+    private val client = AppEngagePublishClient(context)
+    private val clusterRequestFactory = ClusterRequestFactory(context)
+
+    override suspend fun doWork(): Result {
+        if (runAttemptCount > Constants.MAX_PUBLISHING_ATTEMPTS) {
+            // If we keep failing, report it as a service error before giving up.
+            updatePublishStatus(AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR)
+            return Result.failure()
+        }
+
+        // Check if engage service is available before publishing.
+        val isAvailable = client.isServiceAvailable.await()
+
+        // If the service is not available, do not attempt to publish and indicate failure.
+        if (!isAvailable) {
+            return Result.failure()
+        }
+
+        val publishType = inputData.getString(Constants.PUBLISH_TYPE_KEY)
+        return when (publishType) {
+            Constants.PUBLISH_TYPE_RECOMMENDATIONS -> publishRecommendations()
+            // Constants.PUBLISH_TYPE_FEATURED -> publishFeatured()
+            Constants.PUBLISH_TYPE_CONTINUATION -> publishContinuation()
+            Constants.PUBLISH_TYPE_USER_ACCOUNT_MANAGEMENT -> publishUserAccountManagement()
+            else -> Result.failure()
+        }
+    }
+
+    // Use similar patterns for other clusters (Featured, Continuation, FoodShoppingList, Reservation etc.)
+    private suspend fun publishRecommendations(): Result {
+        val publishTask: Task<Void> =
+            client.publishRecommendationClusters(
+                clusterRequestFactory.constructRecommendationClustersRequest()
+            )
+        return publishAndProvideResult(publishTask)
+    }
+
+    private suspend fun publishContinuation(): Result {
+        // Empty Continuation Guard: If there is no continuation content,
+        // we must delete the cluster instead of publishing an empty one on the UI.
+        if (getContinuationData().isEmpty()) {
+            val deleteTask = client.deleteContinuationCluster()
+            return publishAndProvideResult(deleteTask)
+        }
+
+        val publishTask: Task<Void> =
+            client.publishContinuationCluster(
+                clusterRequestFactory.constructContinuationClusterRequest()
+            )
+        return publishAndProvideResult(publishTask)
+    }
+
+    private suspend fun publishUserAccountManagement(): Result {
+        val publishTask: Task<Void>
+        if (isAccountSignedIn()) {
+            // If signed in, we delete the sign-in card.
+            publishTask = client.deleteUserManagementCluster()
+            return publishAndProvideResult(publishTask)
+        } else {
+            // If not signed in, we publish the sign-in card.
+            // Note: Even though we are publishing a card, the status code is NOT_PUBLISHED_REQUIRES_SIGN_IN
+            // because the actual content (recommendations/continuation) is not published.
+            publishTask =
+                client.publishUserAccountManagementRequest(
+                    clusterRequestFactory.constructUserAccountManagementClusterRequest()
+                )
+            return try {
+                publishTask.await()
+                updatePublishStatus(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+                Result.success()
+            } catch (publishException: Exception) {
+                handlePublishException(publishException)
+            }
+        }
+    }
+
+    private fun isAccountSignedIn(): Boolean {
+        // Implement your app's sign-in check logic here.
+        // ...
+    }
+
+    private fun getContinuationData(): List<Any> {
+        // Implement your app's data loading logic here.
+        // ...
+    }
+
+    private suspend fun publishAndProvideResult(
+        publishTask: Task<Void>
+    ): Result {
+        return try {
+            // An AppEngageException may occur while publishing, so we may not be able to await the result.
+            publishTask.await()
+            // Update status to PUBLISHED only after successful publication.
+            updatePublishStatus(AppEngagePublishStatusCode.PUBLISHED)
+            Result.success()
+        } catch (publishException: Exception) {
+            handlePublishException(publishException)
+        }
+    }
+
+    private fun handlePublishException(publishException: Exception): Result {
+        val appEngageException = publishException as? AppEngageException
+        if (appEngageException != null) {
+            logPublishing(appEngageException)
+
+            // Map AppEngageException error codes to PublishStatusCodes
+            val errorStatusCode = when (appEngageException.errorCode) {
+                AppEngageErrorCode.SERVICE_CALL_INVALID_ARGUMENT ->
+                    AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR
+
+                AppEngageErrorCode.SERVICE_CALL_PERMISSION_DENIED ->
+                    AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR
+
+                else ->
+                    AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR
+            }
+            updatePublishStatus(errorStatusCode)
+
+            // Some errors are recoverable, such as a threading issue, some are unrecoverable
+            // such as a cluster not containing all necessary fields. If an error is recoverable, we
+            // should attempt to publish again. Setting the result to retry means WorkManager will
+            // attempt to run the worker again, thus attempting to publish again.
+            return if (isErrorRecoverable(appEngageException)) Result.retry() else Result.failure()
+        }
+        return Result.failure()
+    }
+
+    private fun updatePublishStatus(statusCode: Int) {
+        client
+            .updatePublishStatus(PublishStatusRequest.Builder().setStatusCode(statusCode).build())
+            .addOnSuccessListener {
+                Log.i(TAG, "Successfully updated publish status code to $statusCode")
+            }
+            .addOnFailureListener { exception ->
+                Log.e(TAG, "Failed to update publish status code to $statusCode\n${exception.stackTrace}")
+            }
+    }
+
+    private fun logPublishing(publishingException: AppEngageException) {
+        val message = when (publishingException.errorCode) {
+            AppEngageErrorCode.SERVICE_NOT_FOUND -> "Service not found"
+            AppEngageErrorCode.SERVICE_CALL_EXECUTION_FAILURE -> "Execution failure"
+            AppEngageErrorCode.SERVICE_NOT_AVAILABLE -> "Service not available"
+            AppEngageErrorCode.SERVICE_CALL_PERMISSION_DENIED -> "Permission denied"
+            AppEngageErrorCode.SERVICE_CALL_INVALID_ARGUMENT -> "Invalid argument"
+            AppEngageErrorCode.SERVICE_CALL_INTERNAL -> "Internal error"
+            AppEngageErrorCode.SERVICE_CALL_RESOURCE_EXHAUSTED -> "Resource exhausted"
+            else -> "Unknown error"
+        }
+        Log.d(TAG, message)
+    }
+
+    private fun isErrorRecoverable(publishingException: AppEngageException): Boolean {
+        return when (publishingException.errorCode) {
+            // Recoverable Error codes
+            AppEngageErrorCode.SERVICE_CALL_EXECUTION_FAILURE,
+            AppEngageErrorCode.SERVICE_CALL_INTERNAL,
+            AppEngageErrorCode.SERVICE_CALL_RESOURCE_EXHAUSTED -> true
+            // Non recoverable error codes
+            AppEngageErrorCode.SERVICE_NOT_FOUND,
+            AppEngageErrorCode.SERVICE_CALL_INVALID_ARGUMENT,
+            AppEngageErrorCode.SERVICE_CALL_PERMISSION_DENIED,
+            AppEngageErrorCode.SERVICE_NOT_AVAILABLE -> false
+            else -> false
+        }
+    }
+}
+```
+
+<br />
+
+## ClusterRequestFactory
+
+
+```kotlin
+class ClusterRequestFactory(context: Context) {
+
+    // ...
+
+    private val signInCard =
+        com.google.android.engage.common.datamodel.SignInCardEntity.Builder()
+            .addPosterImage(
+                com.google.android.engage.common.datamodel.Image.Builder()
+                    .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                    .setImageHeightInPixel(500)
+                    .setImageWidthInPixel(500)
+                    .build()
+            )
+            .setActionText(signInCardAction)
+            .setActionUri(Uri.parse("https://xyz.com/signin"))
+            .build()
+
+    fun constructRecommendationClustersRequest(): com.google.android.engage.service.PublishRecommendationClustersRequest {
+
+        val items = appDataRepository.getRecommendations()
+        val recommendationCluster = com.google.android.engage.common.datamodel.RecommendationCluster.Builder()
+            .setTitle("Recommended Content") // Required field
+            .setRecommendationClusterType(com.google.android.engage.common.datamodel.RecommendationClusterType.TYPE_TOP_PICKS_FOR_YOU) // Required field
+        for (item in items) {
+            recommendationCluster.addEntity(ItemToEntityConverter.convert(item))
+        }
+        return com.google.android.engage.service.PublishRecommendationClustersRequest.Builder()
+            .addRecommendationCluster(recommendationCluster.build())
+            .setAccountProfile(accountProfile) // Set the account profile on the request for personalization/sync
+            .build()
+    }
+
+    fun constructContinuationClusterRequest(): com.google.android.engage.service.PublishContinuationClusterRequest {
+        val items = appDataRepository.getContinuationData()
+
+        val continuationCluster = com.google.android.engage.common.datamodel.ContinuationCluster.Builder()
+            .setAccountProfile(accountProfile) // Set the account profile on the request for personalization/sync
+
+        for (item in items) {
+            continuationCluster.addEntity(ItemToEntityConverter.convert(item))
+        }
+        return com.google.android.engage.service.PublishContinuationClusterRequest.Builder()
+            .setContinuationCluster(continuationCluster.build())
+            .build()
+    }
+
+    fun constructUserAccountManagementClusterRequest(): com.google.android.engage.service.PublishUserAccountManagementRequest =
+        com.google.android.engage.service.PublishUserAccountManagementRequest.Builder()
+            .setSignInCardEntity(signInCard)
+            .build()
+}
+```
+
+<br />
+
+## EngagePublisher
+
+
+```kotlin
+object EngagePublisher {
+
+    fun publishPeriodically(context: Context, publishType: String) {
+        val workRequest = PeriodicWorkRequestBuilder<EngageWorker>(Constants.REPEAT_INTERVAL, TimeUnit.HOURS)
+            .setInputData(workDataOf(Constants.PUBLISH_TYPE_KEY to publishType))
+            .build()
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork("EngagePeriodic", ExistingPeriodicWorkPolicy.KEEP, workRequest)
+    }
+
+    fun publishOneTime(context: Context, publishType: String) {
+
+        val workRequest = OneTimeWorkRequestBuilder<EngageWorker>()
+            .setInputData(workDataOf(Constants.PUBLISH_TYPE_KEY to publishType))
+            .build()
+        WorkManager.getInstance(context).enqueueUniqueWork("EngageOneTime", ExistingWorkPolicy.REPLACE, workRequest)
+    }
+}
+```
+
+<br />
+
+## Constants
+
+
+```kotlin
+object Constants {
+    // Holds common values like attempt counts, publish types etc.
+    const val REPEAT_INTERVAL = 24L
+    const val MAX_PUBLISHING_ATTEMPTS = 3
+    const val PUBLISH_TYPE_KEY = "PUBLISH_TYPE"
+    const val PUBLISH_TYPE_RECOMMENDATIONS = "RECOMMENDATIONS"
+    const val PUBLISH_TYPE_FEATURED = "FEATURED"
+    const val PUBLISH_TYPE_CONTINUATION = "CONTINUATION"
+    // ...
+    const val PUBLISH_TYPE_USER_ACCOUNT_MANAGEMENT = "USER_ACCOUNT_MANAGEMENT"
+    // const val PUBLISH_TYPE_FOOD_SHOPPING_CARD = "FOOD_SHOPPING_CARD"
+    // const val PUBLISH_TYPE_RESERVATION = "RESERVATION"
+}
+```
+
+<br />
+
+## ItemToEntityConverter
+
+
+```kotlin
+object ItemToEntityConverter {
+    // Converts app's local models to appropriate engage entity models.
+    // Use `{VERTICAL}.md` in the `references/schemas/` directory to identify the correct Engage entities.
+    // This is an example of using EbookEntity model.
+    fun convert(item: AppData): EbookEntity {
+        return EbookEntity.Builder()
+            // Implement required data mapping logic here.
+            .setName(item.title)
+            .addAuthor(item.author)
+            .build()
+    }
+}
+```
+
+<br />
+
+## Dependency Specifications (libs.versions.toml)
+
+This skill specifies all dependencies following in `libs.versions.toml` format.
+Adapt these definitions to other formats (such as standard Groovy `build.gradle`
+or Kotlin DSL `build.gradle.kts` implementation lines) as required by the
+project.
+
+    [versions]
+    engage-core = "1.5.12"
+    engage-tv = "1.0.6"
+    playServicesOssLicenses = "17.5.1"
+    workManager = "2.11.2"
+    coroutines = "1.10.2"
+
+    [libraries]
+    engage-core = { group = "com.google.android.engage", name = "engage-core", version.ref = "engage-core" }
+    engage-tv = { group = "com.google.android.engage", name = "engage-tv", version.ref = "engage-tv" }
+    play-services-oss-licenses = { group = "com.google.android.gms", name = "play-services-oss-licenses", version.ref = "playServicesOssLicenses" }
+    androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workManager" }
+    androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "workManager" }
+    kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+    kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "coroutines" }
+    kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+
+## TV Integrations
+
+The following patterns and configurations are specific to Android TV
+integrations.
+
+### AndroidManifest.xml (TV)
+
+
+```kotlin
+<!-- Mandatory for TV integrations -->
+<uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA" />
+```
+
+<br />
+
+### PlatformSpecificUri Example
+
+
+```kotlin
+val platformSpecificPlaybackUris = listOf(
+    com.google.android.engage.common.datamodel.PlatformSpecificUri.Builder()
+        .setPlatformType(com.google.android.engage.common.datamodel.PlatformType.TYPE_ANDROID_TV)
+        .setActionUri(Uri.parse("https://www.example.com/tv/play/123"))
+        .build(),
+    com.google.android.engage.common.datamodel.PlatformSpecificUri.Builder()
+        .setPlatformType(com.google.android.engage.common.datamodel.PlatformType.TYPE_ANDROID_MOBILE)
+        .setActionUri(Uri.parse("https://www.example.com/mobile/play/123"))
+        .build()
+)
+```
+
+<br />
+
+### AccountProfile Example
+
+
+```kotlin
+val accountProfile: AccountProfile
+    get() = AccountProfile.Builder()
+        .setAccountId("user_123")
+        .setProfileId("profile_456")
+        // AppCompatDelegate.getApplicationLocales().get(0) for Per-App Language Preferences
+        .setLocale(Locale.getDefault().toLanguageTag())
+        .build()
+```
+
+<br />

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/requests.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/requests.md
@@ -1,0 +1,231 @@
+This file defines the request structures for publishing various data models in
+the Engage SDK.
+
+    {
+      "PublishRecommendationClustersRequest": {
+        "package": "com.google.android.engage.service.PublishRecommendationClustersRequest",
+        "fields": {
+          "recommendationClusters": {
+            "type": "List<RecommendationCluster>",
+            "requirement": "Required",
+            "adder": "addRecommendationCluster(RecommendationCluster)",
+            "getter": "getRecommendationClusters()"
+          },
+          "accountProfile": {
+            "type": "@NonNull AccountProfile",
+            "requirement": "Optional",
+            "setter": "setAccountProfile(@NonNull AccountProfile)",
+            "getter": "getAccountProfile()"
+          },
+          "syncAcrossDevices": {
+            "type": "Boolean",
+            "requirement": "Optional",
+            "setter": "setSyncAcrossDevices(boolean)",
+            "getter": "getSyncAcrossDevices()"
+          }
+        }
+      },
+      "PublishFeaturedClusterRequest": {
+        "package": "com.google.android.engage.service.PublishFeaturedClusterRequest",
+        "fields": {
+          "featuredCluster": {
+            "type": "FeaturedCluster",
+            "requirement": "Required",
+            "setter": "setFeaturedCluster(FeaturedCluster)",
+            "getter": "getFeaturedCluster()"
+          }
+        }
+      },
+      "DeleteClustersRequest": {
+        "package": "com.google.android.engage.service.DeleteClustersRequest",
+        "fields": {
+          "clusterTypes": {
+            "type": "List<@ClusterType int>",
+            "requirement": "Optional",
+            "adder": "addClusterType(@ClusterType int)"
+          },
+          "deleteReason": {
+            "type": "@DeleteReason int",
+            "requirement": "Optional",
+            "setter": "setDeleteReason(@DeleteReason int)",
+            "getter": "getDeleteReason()"
+          },
+          "accountProfile": {
+            "requirement": "Optional",
+            "setter": "setAccountProfile(AccountProfile)",
+            "type": "AccountProfile",
+            "getter": "getAccountProfile()"
+          },
+          "syncAcrossDevices": {
+            "requirement": "Optional",
+            "setter": "setSyncAcrossDevices(boolean)",
+            "type": "Boolean",
+            "getter": "getSyncAcrossDevices()"
+          }
+        }
+      },
+      "PublishContinuationClusterRequest": {
+        "package": "com.google.android.engage.service.PublishContinuationClusterRequest",
+        "fields": {
+          "continuationCluster": {
+            "type": "ContinuationCluster",
+            "requirement": "Required",
+            "setter": "setContinuationCluster(ContinuationCluster)",
+            "getter": "getContinuationCluster()"
+          }
+        }
+      },
+      "PublishStatusRequest": {
+        "package": "com.google.android.engage.service.PublishStatusRequest",
+        "fields": {
+          "statusCode": {
+            "type": "@AppEngagePublishStatusCode int",
+            "requirement": "Required",
+            "setter": "setStatusCode(@AppEngagePublishStatusCode int)",
+            "getter": "getStatusCode()"
+          }
+        }
+      },
+      "PublishSubscriptionRequest": {
+        "package": "com.google.android.engage.service.PublishSubscriptionRequest",
+        "fields": {
+          "subscriptionClusters": {
+            "type": "List<SubscriptionCluster>",
+            "requirement": "Required"
+          },
+          "accountProfile": {
+            "type": "AccountProfile",
+            "requirement": "Required",
+            "setter": "setAccountProfile(AccountProfile)",
+            "getter": "getAccountProfile()"
+          },
+          "subscription": {
+            "requirement": "Required",
+            "setter": "setSubscription(SubscriptionEntity)",
+            "type": "SubscriptionEntity",
+            "getter": "getSubscription()"
+          }
+        }
+      },
+      "PublishUserAccountManagementRequest": {
+        "package": "com.google.android.engage.service.PublishUserAccountManagementRequest",
+        "fields": {
+          "actionUri": {
+            "type": "Uri",
+            "requirement": "Required"
+          },
+          "signInCardEntity": {
+            "type": "SignInCardEntity",
+            "requirement": "Required",
+            "setter": "setSignInCardEntity(SignInCardEntity)"
+          },
+          "userSettingsCardEntity": {
+            "requirement": "Required",
+            "setter": "setUserSettingsCardEntity(UserSettingsCardEntity)",
+            "type": "UserSettingsCardEntity"
+          }
+        }
+      },
+      "PublishShoppingCartClusterRequest": {
+        "package": "com.google.android.engage.shopping.service.PublishShoppingCartClusterRequest",
+        "fields": {
+          "shoppingCart": {
+            "requirement": "Required",
+            "setter": "setShoppingCart(ShoppingCart)",
+            "type": "ShoppingCart",
+            "getter": "getShoppingCart()"
+          }
+        }
+      },
+      "PublishShoppingListsRequest": {
+        "package": "com.google.android.engage.shopping.service.PublishShoppingListsRequest",
+        "fields": {
+          "shoppingLists": {
+            "type": "List<ShoppingList>",
+            "requirement": "Optional",
+            "adder": "addShoppingList(ShoppingList)",
+            "getter": "getShoppingLists()",
+            "adderAll": "addShoppingLists(List<ShoppingList>)"
+          }
+        }
+      },
+      "PublishShoppingOrderTrackingClusterRequest": {
+        "package": "com.google.android.engage.shopping.service.PublishShoppingOrderTrackingClusterRequest",
+        "fields": {
+          "shoppingOrderTrackingCluster": {
+            "type": "ShoppingOrderTrackingCluster",
+            "requirement": "Required",
+            "setter": "setShoppingOrderTrackingCluster(ShoppingOrderTrackingCluster)",
+            "getter": "getShoppingOrderTrackingCluster()"
+          }
+        }
+      },
+      "PublishShoppingReorderClusterRequest": {
+        "package": "com.google.android.engage.shopping.service.PublishShoppingReorderClusterRequest",
+        "fields": {
+          "reorderCluster": {
+            "type": "ShoppingReorderCluster",
+            "requirement": "Required",
+            "setter": "setReorderCluster(ShoppingReorderCluster)",
+            "getter": "getReorderCluster()"
+          }
+        }
+      },
+      "PublishFoodShoppingCartsRequest": {
+        "package": "com.google.android.engage.food.service.PublishFoodShoppingCartsRequest",
+        "fields": {
+          "foodShoppingCarts": {
+            "type": "List<FoodShoppingCart>",
+            "requirement": "Optional",
+            "adder": "addFoodShoppingCart(FoodShoppingCart)",
+            "getter": "getFoodShoppingCarts()",
+            "adderAll": "addFoodShoppingCarts(List<FoodShoppingCart>)"
+          }
+        }
+      },
+      "PublishFoodShoppingListsRequest": {
+        "package": "com.google.android.engage.food.service.PublishFoodShoppingListsRequest",
+        "fields": {
+          "foodShoppingLists": {
+            "type": "List<FoodShoppingList>",
+            "requirement": "Optional",
+            "adder": "addFoodShoppingList(FoodShoppingList)",
+            "getter": "getFoodShoppingLists()",
+            "adderAll": "addFoodShoppingLists(List<FoodShoppingList>)"
+          }
+        }
+      },
+      "PublishReorderClusterRequest": {
+        "package": "com.google.android.engage.food.service.PublishReorderClusterRequest",
+        "fields": {
+          "reorderCluster": {
+            "requirement": "Required",
+            "setter": "setReorderCluster(FoodReorderCluster)",
+            "type": "FoodReorderCluster",
+            "getter": "getReorderCluster()"
+          }
+        }
+      },
+      "PublishContinueSearchClusterRequest": {
+        "package": "com.google.android.engage.travel.service.PublishContinueSearchClusterRequest",
+        "fields": {
+          "continueSearchCluster": {
+            "type": "ContinueSearchCluster",
+            "requirement": "Required",
+            "setter": "setContinueSearchCluster(ContinueSearchCluster)",
+            "getter": "getContinueSearchCluster()"
+          }
+        }
+      },
+      "PublishReservationClusterRequest": {
+        "package": "com.google.android.engage.travel.service.PublishReservationClusterRequest",
+        "fields": {
+          "reservationCluster": {
+            "type": "ReservationCluster",
+            "requirement": "Required",
+            "setter": "setReservationCluster(ReservationCluster)",
+            "getter": "getReservationCluster()"
+          }
+        }
+      }
+    }

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/food.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/food.md
@@ -1,0 +1,509 @@
+This file defines the schema for the FOOD vertical in the Engage SDK.
+
+    {
+      "client": "com.google.android.engage.food.service.AppEngageFoodClient",
+      "clusterTypes": [
+        "TYPE_RECOMMENDATION",
+        "TYPE_FEATURED",
+        "TYPE_FOOD_SHOPPING_CART",
+        "TYPE_FOOD_SHOPPING_LIST",
+        "TYPE_FOOD_REORDER"
+      ],
+      "entities": {
+        "ProductEntity": {
+          "package": "com.google.android.engage.food.datamodel.ProductEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "rating": {
+              "type": "Rating",
+              "requirement": "Optional",
+              "setter": "setRating(Rating)",
+              "getter": "getRating()",
+              "requiredFor": [
+                "Required if strikethrough price is provided",
+                "Mutually required with other rating fields"
+              ]
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            },
+            "callout": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setCallout(String)",
+              "getter": "getCallout()"
+            },
+            "calloutFinePrint": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setCalloutFinePrint(String)",
+              "getter": "getCalloutFinePrint()"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()",
+              "requiredFor": [
+                "Required if strikethrough price is provided"
+              ]
+            }
+          }
+        },
+        "StoreEntity": {
+          "package": "com.google.android.engage.food.datamodel.StoreEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "rating": {
+              "type": "Rating",
+              "requirement": "Optional",
+              "setter": "setRating(Rating)",
+              "getter": "getRating()",
+              "requiredFor": [
+                "Mutually required with other rating fields"
+              ]
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "location": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setLocation(String)",
+              "getter": "getLocation()"
+            },
+            "category": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setCategory(String)",
+              "getter": "getCategory()"
+            },
+            "callout": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setCallout(String)",
+              "getter": "getCallout()"
+            },
+            "calloutFinePrint": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setCalloutFinePrint(String)",
+              "getter": "getCalloutFinePrint()"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            }
+          }
+        },
+        "RestaurantReservationEntity": {
+          "package": "com.google.android.engage.food.datamodel.RestaurantReservationEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "actionUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionUri(Uri)",
+              "getter": "getActionUri()"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "subtitles": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "adderAll": "addSubtitles(List<String>)"
+            },
+            "location": {
+              "type": "Address",
+              "requirement": "Required",
+              "setter": "setLocation(Address)",
+              "getter": "getLocation()"
+            },
+            "reservationStartTime": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setReservationStartTime(Long)",
+              "getter": "getReservationStartTime()"
+            },
+            "localizedReservationStartTime": {
+              "type": "LocalizedTimestamp",
+              "requirement": "Required",
+              "setter": "setLocalizedReservationStartTime(LocalizedTimestamp)",
+              "getter": "getLocalizedReservationStartTime()"
+            },
+            "tableSize": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setTableSize(Integer)",
+              "getter": "getTableSize()"
+            },
+            "reservationId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setReservationId(String)",
+              "getter": "getReservationId()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            }
+          }
+        },
+        "RecipeEntity": {
+          "package": "com.google.android.engage.food.datamodel.RecipeEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "rating": {
+              "type": "Rating",
+              "requirement": "Optional",
+              "setter": "setRating(Rating)",
+              "getter": "getRating()",
+              "requiredFor": [
+                "Mutually required with other rating fields"
+              ]
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "author": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setAuthor(String)",
+              "getter": "getAuthor()"
+            },
+            "category": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setCategory(String)",
+              "getter": "getCategory()"
+            },
+            "callout": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setCallout(String)",
+              "getter": "getCallout()"
+            },
+            "cookTime": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setCookTime(String)",
+              "getter": "getCookTime()"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            }
+          }
+        }
+      },
+      "methods": {
+        "isServiceAvailable": null,
+        "publishRecommendationClusters": "PublishRecommendationClustersRequest",
+        "publishFeaturedCluster": "PublishFeaturedClusterRequest",
+        "publishFoodShoppingCarts": "PublishFoodShoppingCartsRequest",
+        "publishReorderCluster": "PublishReorderClusterRequest",
+        "publishFoodShoppingLists": "PublishFoodShoppingListsRequest",
+        "publishUserAccountManagementRequest": "PublishUserAccountManagementRequest",
+        "updatePublishStatus": "PublishStatusRequest",
+        "deleteFoodShoppingCartCluster": "DeleteClustersRequest",
+        "deleteFoodShoppingListCluster": "DeleteClustersRequest",
+        "deleteReorderCluster": "DeleteClustersRequest",
+        "deleteRecommendationsClusters": "DeleteClustersRequest",
+        "deleteFeaturedCluster": "DeleteClustersRequest",
+        "deleteUserManagementCluster": "DeleteClustersRequest"
+      },
+      "clusters": {
+        "FoodReorderCluster": {
+          "package": "com.google.android.engage.food.datamodel.FoodReorderCluster",
+          "fields": {
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "actionText": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setActionText(String)",
+              "getter": "getActionText()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Optional",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "itemLabels": {
+              "type": "List<List<String>>",
+              "requirement": "Optional",
+              "adder": "addItemLabel(String)",
+              "getter": "getItemLabels()",
+              "adderAll": "addItemLabels(List<String>)"
+            },
+            "numberOfItems": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setNumberOfItems(int)",
+              "getter": "getNumberOfItems()"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            }
+          }
+        },
+        "FoodShoppingList": {
+          "package": "com.google.android.engage.food.datamodel.FoodShoppingList",
+          "fields": {
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "actionText": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setActionText(String)",
+              "getter": "getActionText()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Optional",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "itemLabels": {
+              "type": "List<List<String>>",
+              "requirement": "Optional",
+              "adder": "addItemLabel(String)",
+              "getter": "getItemLabels()",
+              "adderAll": "addItemLabels(List<String>)"
+            },
+            "numberOfItems": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setNumberOfItems(int)",
+              "getter": "getNumberOfItems()"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "lastUserInteractionTimestampMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastUserInteractionTimestampMillis(long)",
+              "getter": "getLastUserInteractionTimestampMillis()"
+            }
+          }
+        },
+        "FoodShoppingCart": {
+          "package": "com.google.android.engage.food.datamodel.FoodShoppingCart",
+          "fields": {
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "actionText": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setActionText(String)",
+              "getter": "getActionText()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Optional",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "itemLabels": {
+              "type": "List<List<String>>",
+              "requirement": "Optional",
+              "adder": "addItemLabel(String)",
+              "getter": "getItemLabels()",
+              "adderAll": "addItemLabels(List<String>)"
+            },
+            "numberOfItems": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setNumberOfItems(int)",
+              "getter": "getNumberOfItems()"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            },
+            "lastUserInteractionTimestampMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastUserInteractionTimestampMillis(long)",
+              "getter": "getLastUserInteractionTimestampMillis()"
+            }
+          }
+        }
+      },
+      "intents": {
+        "ACTION_PUBLISH_FOOD_SHOPPING_CART": "com.google.android.engage.action.food.PUBLISH_FOOD_SHOPPING_CART",
+        "ACTION_PUBLISH_FOOD_SHOPPING_LIST": "com.google.android.engage.action.food.PUBLISH_FOOD_SHOPPING_LIST",
+        "ACTION_PUBLISH_REORDER_CLUSTER": "com.google.android.engage.action.food.PUBLISH_REORDER_CLUSTER"
+      }
+    }

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/listen.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/listen.md
@@ -1,0 +1,842 @@
+This file defines the schema for the LISTEN vertical in the Engage SDK.
+
+    {
+      "client": "com.google.android.engage.service.AppEngagePublishClient",
+      "clusterTypes": [
+        "TYPE_RECOMMENDATION",
+        "TYPE_FEATURED",
+        "TYPE_CONTINUATION"
+      ],
+      "entities": {
+        "MusicAlbumEntity": {
+          "package": "com.google.android.engage.audio.datamodel.MusicAlbumEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "songsCount": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setSongsCount(int)",
+              "getter": "getSongsCount()"
+            },
+            "releaseDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setReleaseDateEpochMillis(long)",
+              "getter": "getReleaseDateEpochMillis()"
+            },
+            "durationMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setDurationMillis(long)",
+              "getter": "getDurationMillis()"
+            },
+            "genres": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addGenre(String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "musicLabels": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addMusicLabel(String)",
+              "getter": "getMusicLabels()",
+              "adderAll": "addMusicLabels(List<String>)"
+            },
+            "artists": {
+              "type": "List<String>",
+              "requirement": "Required",
+              "adder": "addArtist(String)",
+              "getter": "getArtists()",
+              "adderAll": "addArtists(List<String>)"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "explicitContent": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setExplicitContent(boolean)",
+              "getter": "isExplicitContent()"
+            },
+            "musicAlbumType": {
+              "type": "@MusicAlbumType int",
+              "requirement": "Optional",
+              "setter": "setMusicAlbumType(@MusicAlbumType int)",
+              "getter": "getMusicAlbumType()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()"
+            },
+            "progressPercentComplete": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setProgressPercentComplete(int)",
+              "getter": "getProgressPercentComplete()"
+            }
+          }
+        },
+        "MusicTrackEntity": {
+          "package": "com.google.android.engage.audio.datamodel.MusicTrackEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "durationMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setDurationMillis(long)",
+              "getter": "getDurationMillis()"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "album": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setAlbum(String)",
+              "getter": "getAlbum()"
+            },
+            "artists": {
+              "type": "List<String>",
+              "requirement": "Required",
+              "adder": "addArtist(String)",
+              "getter": "getArtists()",
+              "adderAll": "addArtists(List<String>)"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "explicitContent": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setExplicitContent(boolean)",
+              "getter": "isExplicitContent()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()"
+            },
+            "progressPercentComplete": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setProgressPercentComplete(int)",
+              "getter": "getProgressPercentComplete()"
+            }
+          }
+        },
+        "PodcastEpisodeEntity": {
+          "package": "com.google.android.engage.audio.datamodel.PodcastEpisodeEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "episodeIndex": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setEpisodeIndex(int)",
+              "getter": "getEpisodeIndex()"
+            },
+            "podcastSeriesTitle": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setPodcastSeriesTitle(String)",
+              "getter": "getPodcastSeriesTitle()"
+            },
+            "productionName": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setProductionName(String)",
+              "getter": "getProductionName()"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "durationMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setDurationMillis(long)",
+              "getter": "getDurationMillis()"
+            },
+            "publishDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setPublishDateEpochMillis(long)",
+              "getter": "getPublishDateEpochMillis()"
+            },
+            "genres": {
+              "type": "List<List<String>>",
+              "requirement": "Optional",
+              "adder": "addGenre(String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "hosts": {
+              "type": "List<List<String>>",
+              "requirement": "Optional",
+              "adder": "addHost(String)",
+              "getter": "getHosts()",
+              "adderAll": "addHosts(List<String>)"
+            },
+            "explicitContent": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setExplicitContent(boolean)",
+              "getter": "isExplicitContent()"
+            },
+            "listenNextType": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setListenNextType(int)",
+              "getter": "getListenNextType()"
+            },
+            "videoPodcast": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setVideoPodcast(boolean)",
+              "getter": "isVideoPodcast()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()"
+            },
+            "progressPercentComplete": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setProgressPercentComplete(int)",
+              "getter": "getProgressPercentComplete()"
+            }
+          }
+        },
+        "MusicVideoEntity": {
+          "package": "com.google.android.engage.audio.datamodel.MusicVideoEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "durationMillis": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setDurationMillis(long)",
+              "getter": "getDurationMillis()"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "viewCount": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setViewCount(String)",
+              "getter": "getViewCount()"
+            },
+            "artists": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addArtist(String)",
+              "getter": "getArtists()",
+              "adderAll": "addArtists(List<String>)"
+            },
+            "contentRatings": {
+              "type": "List<List<String>>",
+              "requirement": "Optional",
+              "adder": "addContentRating(String)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<String>)"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "explicitContent": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setExplicitContent(boolean)",
+              "getter": "isExplicitContent()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()"
+            },
+            "progressPercentComplete": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setProgressPercentComplete(int)",
+              "getter": "getProgressPercentComplete()"
+            }
+          }
+        },
+        "LiveRadioStationEntity": {
+          "package": "com.google.android.engage.audio.datamodel.LiveRadioStationEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()"
+            },
+            "radioFrequencyId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setRadioFrequencyId(String)",
+              "getter": "getRadioFrequencyId()"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "showTitle": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setShowTitle(String)",
+              "getter": "getShowTitle()"
+            },
+            "hosts": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addHost(String)",
+              "getter": "getHosts()",
+              "adderAll": "addHosts(List<String>)"
+            }
+          }
+        },
+        "GenericAudioEntity": {
+          "package": "com.google.android.engage.audio.datamodel.GenericAudioEntity",
+          "fields": {
+            "entityId": {
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "type": "String",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "type": "String",
+              "getter": "getName()"
+            },
+            "posterImages": {
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "type": "List<Image>",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "actionUri": {
+              "requirement": "Required",
+              "setter": "setActionUri(Uri)",
+              "type": "Uri",
+              "getter": "getActionUri()"
+            },
+            "downloadedOnDevice": {
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "type": "Boolean",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "explicitContent": {
+              "requirement": "Required",
+              "setter": "setExplicitContent(boolean)",
+              "type": "Boolean",
+              "getter": "isExplicitContent()"
+            },
+            "progressPercentComplete": {
+              "requirement": "Optional",
+              "setter": "setProgressPercentComplete(int)",
+              "type": "Integer",
+              "getter": "getProgressPercentComplete()"
+            },
+            "lastEngagementTimeMillis": {
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "type": "Long",
+              "getter": "getLastEngagementTimeMillis()"
+            },
+            "listenNextType": {
+              "requirement": "Optional",
+              "setter": "setListenNextType(@ListenNextType int)",
+              "type": "@ListenNextType int",
+              "getter": "getListenNextType()"
+            },
+            "price": {
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "type": "Price",
+              "getter": "getPrice()"
+            },
+            "rating": {
+              "requirement": "Optional",
+              "setter": "setRating(Rating)",
+              "type": "Rating",
+              "getter": "getRating()"
+            },
+            "callout": {
+              "requirement": "Optional",
+              "setter": "setCallout(String)",
+              "type": "String",
+              "getter": "getCallout()"
+            },
+            "calloutFinePrint": {
+              "requirement": "Optional",
+              "setter": "setCalloutFinePrint(String)",
+              "type": "String",
+              "getter": "getCalloutFinePrint()"
+            },
+            "displayTimeWindows": {
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "type": "List<DisplayTimeWindow>",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "type": "List<List<DisplayTimeWindow>>",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            },
+            "isBook": {
+              "requirement": "Optional",
+              "setter": "setIsBook(boolean)",
+              "type": "Boolean",
+              "getter": "isBook()"
+            },
+            "isTalk": {
+              "requirement": "Optional",
+              "setter": "setIsTalk(Boolean)",
+              "type": "Boolean",
+              "getter": "isTalk()"
+            },
+            "isVideoSupported": {
+              "requirement": "Optional",
+              "setter": "setIsVideoSupported(Boolean)",
+              "type": "Boolean",
+              "getter": "isVideoSupported()"
+            },
+            "isArtist": {
+              "requirement": "Optional",
+              "setter": "setIsArtist(Boolean)",
+              "type": "Boolean",
+              "getter": "isArtist()"
+            },
+            "subtitles": {
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "type": "List<String>",
+              "adderAll": "addSubtitles(List<String>)"
+            }
+          }
+        },
+        "PodcastSeriesEntity": {
+          "package": "com.google.android.engage.audio.datamodel.PodcastSeriesEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "episodeCount": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setEpisodeCount(int)",
+              "getter": "getEpisodeCount()"
+            },
+            "productionName": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setProductionName(String)",
+              "getter": "getProductionName()"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "genres": {
+              "type": "List<List<String>>",
+              "requirement": "Optional",
+              "adder": "addGenre(String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "hosts": {
+              "type": "List<List<String>>",
+              "requirement": "Optional",
+              "adder": "addHost(String)",
+              "getter": "getHosts()",
+              "adderAll": "addHosts(List<String>)"
+            },
+            "explicitContent": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setExplicitContent(boolean)",
+              "getter": "isExplicitContent()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()"
+            }
+          }
+        },
+        "MusicArtistEntity": {
+          "package": "com.google.android.engage.audio.datamodel.MusicArtistEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()"
+            }
+          }
+        },
+        "PlaylistEntity": {
+          "package": "com.google.android.engage.audio.datamodel.PlaylistEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "songsCount": {
+              "type": "Integer",
+              "requirement": "Required",
+              "setter": "setSongsCount(int)",
+              "getter": "getSongsCount()"
+            },
+            "durationMillis": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setDurationMillis(long)",
+              "getter": "getDurationMillis()"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "explicitContent": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setExplicitContent(boolean)",
+              "getter": "isExplicitContent()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()"
+            },
+            "progressPercentComplete": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setProgressPercentComplete(int)",
+              "getter": "getProgressPercentComplete()"
+            }
+          }
+        }
+      },
+      "methods": {
+        "isServiceAvailable": null,
+        "publishRecommendationClusters": "PublishRecommendationClustersRequest",
+        "publishFeaturedCluster": "PublishFeaturedClusterRequest",
+        "publishContinuationCluster": "PublishContinuationClusterRequest",
+        "publishSubscription": "PublishSubscriptionRequest",
+        "publishUserAccountManagementRequest": "PublishUserAccountManagementRequest",
+        "updatePublishStatus": "PublishStatusRequest",
+        "deleteRecommendationsClusters": "DeleteClustersRequest",
+        "deleteFeaturedCluster": "DeleteClustersRequest",
+        "deleteContinuationCluster": "DeleteClustersRequest",
+        "deleteSubscription": "DeleteClustersRequest",
+        "deleteUserManagementCluster": "DeleteClustersRequest"
+      },
+      "intents": {}
+    }

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/other.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/other.md
@@ -1,0 +1,220 @@
+This file defines the schema for the OTHER vertical in the Engage SDK.
+
+    {
+      "client": "com.google.android.engage.service.AppEngagePublishClient",
+      "clusterTypes": [
+        "TYPE_RECOMMENDATION",
+        "TYPE_FEATURED"
+      ],
+      "entities": {
+        "ArticleEntity": {
+          "package": "com.google.android.engage.common.datamodel.ArticleEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "subtitleList": {
+              "type": "List<String>",
+              "requirement": "Optional"
+            },
+            "badgeList": {
+              "type": "List<Badge>",
+              "requirement": "Optional"
+            },
+            "contentCategoryList": {
+              "type": "List<Integer>",
+              "requirement": "Optional"
+            },
+            "lastEngagementTime": {
+              "type": "Long",
+              "requirement": "Optional",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "actionUri": {
+              "requirement": "Required",
+              "setter": "setActionUri(Uri)",
+              "type": "Uri",
+              "getter": "getActionUri()"
+            },
+            "subtitles": {
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "type": "List<String>",
+              "adderAll": "addSubtitles(List<String>)"
+            },
+            "badges": {
+              "requirement": "Optional",
+              "adder": "addBadge(Badge)",
+              "type": "List<Badge>",
+              "adderAll": "addBadges(List<Badge>)"
+            },
+            "contentCategories": {
+              "requirement": "Optional",
+              "adder": "addContentCategory(@EligibleContentCategory int)",
+              "type": "List<@EligibleContentCategory int>",
+              "adderAll": "addContentCategories(List<Integer>)"
+            },
+            "progressPercentage": {
+              "requirement": "Required",
+              "setter": "setProgressPercentage(int)",
+              "type": "Integer",
+              "getter": "getProgressPercentage()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "lastEngagementTimestampMillis": {
+              "requirement": "Required",
+              "setter": "setLastEngagementTimestampMillis(long)",
+              "type": "Long",
+              "getter": "getLastEngagementTimestampMillis()"
+            },
+            "source": {
+              "requirement": "Optional",
+              "setter": "setSource(Badge)",
+              "type": "Badge",
+              "getter": "getSource()"
+            },
+            "lastContentPublishTimestampMillis": {
+              "requirement": "Optional",
+              "setter": "setLastContentPublishTimestampMillis(Long)",
+              "type": "Long",
+              "getter": "getLastContentPublishTimestampMillis()"
+            },
+            "allDisplayTimeWindows": {
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "type": "List<List<DisplayTimeWindow>>",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            }
+          }
+        },
+        "GenericFeaturedEntity": {
+          "package": "com.google.android.engage.common.datamodel.GenericFeaturedEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "actionUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionUri(Uri)",
+              "getter": "getActionUri()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "subtitleList": {
+              "type": "List<String>",
+              "requirement": "Optional"
+            },
+            "badgeList": {
+              "type": "List<Badge>",
+              "requirement": "Optional"
+            },
+            "contentCategoryList": {
+              "type": "List<Integer>",
+              "requirement": "Optional"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "subtitles": {
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "type": "List<String>",
+              "adderAll": "addSubtitles(List<String>)"
+            },
+            "badges": {
+              "requirement": "Optional",
+              "adder": "addBadge(Badge)",
+              "type": "List<Badge>",
+              "adderAll": "addBadges(List<Badge>)"
+            },
+            "contentCategories": {
+              "requirement": "Optional",
+              "adder": "addContentCategory(@EligibleContentCategory int)",
+              "type": "List<@EligibleContentCategory int>",
+              "adderAll": "addContentCategories(List<Integer>)"
+            },
+            "allDisplayTimeWindows": {
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "type": "List<List<DisplayTimeWindow>>",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            }
+          }
+        }
+      },
+      "methods": {
+        "isServiceAvailable": null,
+        "publishRecommendationClusters": "PublishRecommendationClustersRequest",
+        "publishFeaturedCluster": "PublishFeaturedClusterRequest",
+        "publishContinuationCluster": "PublishContinuationClusterRequest",
+        "publishSubscription": "PublishSubscriptionRequest",
+        "publishUserAccountManagementRequest": "PublishUserAccountManagementRequest",
+        "updatePublishStatus": "PublishStatusRequest",
+        "deleteRecommendationsClusters": "DeleteClustersRequest",
+        "deleteFeaturedCluster": "DeleteClustersRequest",
+        "deleteContinuationCluster": "DeleteClustersRequest",
+        "deleteSubscription": "DeleteClustersRequest",
+        "deleteUserManagementCluster": "DeleteClustersRequest"
+      },
+      "intents": {}
+    }

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/read.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/read.md
@@ -1,0 +1,412 @@
+This file defines the schema for the READ vertical in the Engage SDK.
+
+    {
+      "client": "com.google.android.engage.service.AppEngagePublishClient",
+      "clusterTypes": [
+        "TYPE_RECOMMENDATION",
+        "TYPE_FEATURED",
+        "TYPE_CONTINUATION"
+      ],
+      "entities": {
+        "EbookEntity": {
+          "package": "com.google.android.engage.books.datamodel.EbookEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "authors": {
+              "type": "List<String>",
+              "requirement": "Required",
+              "adder": "addAuthor(String)",
+              "getter": "getAuthors()",
+              "adderAll": "addAuthors(List<String>)"
+            },
+            "publishDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setPublishDateEpochMillis(long)",
+              "getter": "getPublishDateEpochMillis()"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "pageCount": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setPageCount(int)",
+              "getter": "getPageCount()"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()"
+            },
+            "genres": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addGenre(String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "seriesName": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setSeriesName(String)",
+              "getter": "getSeriesName()"
+            },
+            "seriesUnitIndex": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setSeriesUnitIndex(Integer)",
+              "getter": "getSeriesUnitIndex()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "progressPercentComplete": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setProgressPercentComplete(int)",
+              "getter": "getProgressPercentComplete()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "rating": {
+              "type": "Rating",
+              "requirement": "Optional",
+              "setter": "setRating(Rating)",
+              "getter": "getRating()"
+            },
+            "availability": {
+              "type": "@ContentAvailability int",
+              "requirement": "Optional",
+              "setter": "setAvailability(@ContentAvailability int)",
+              "getter": "getAvailability()"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            },
+            "continueBookType": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setContinueBookType(int)",
+              "getter": "getContinueBookType()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            }
+          }
+        },
+        "BookSeriesEntity": {
+          "package": "com.google.android.engage.books.datamodel.BookSeriesEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "bookCount": {
+              "type": "Integer",
+              "requirement": "Required",
+              "setter": "setBookCount(int)",
+              "getter": "getBookCount()"
+            },
+            "authors": {
+              "type": "List<String>",
+              "requirement": "Required",
+              "adder": "addAuthor(String)",
+              "getter": "getAuthors()",
+              "adderAll": "addAuthors(List<String>)"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "genres": {
+              "type": "List<List<String>>",
+              "requirement": "Optional",
+              "adder": "addGenre(String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "progressPercentComplete": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setProgressPercentComplete(int)",
+              "getter": "getProgressPercentComplete()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "rating": {
+              "type": "Rating",
+              "requirement": "Optional",
+              "setter": "setRating(Rating)",
+              "getter": "getRating()"
+            },
+            "availability": {
+              "type": "@ContentAvailability int",
+              "requirement": "Optional",
+              "setter": "setAvailability(@ContentAvailability int)",
+              "getter": "getAvailability()"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            },
+            "continueBookType": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setContinueBookType(int)",
+              "getter": "getContinueBookType()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            }
+          }
+        },
+        "AudiobookEntity": {
+          "package": "com.google.android.engage.books.datamodel.AudiobookEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "rating": {
+              "type": "Rating",
+              "requirement": "Optional",
+              "setter": "setRating(Rating)",
+              "getter": "getRating()"
+            },
+            "availability": {
+              "type": "@ContentAvailability int",
+              "requirement": "Optional",
+              "setter": "setAvailability(@ContentAvailability int)",
+              "getter": "getAvailability()"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            },
+            "authors": {
+              "type": "List<String>",
+              "requirement": "Required",
+              "adder": "addAuthor(String)",
+              "getter": "getAuthors()",
+              "adderAll": "addAuthors(List<String>)"
+            },
+            "narrators": {
+              "type": "List<String>",
+              "requirement": "Required",
+              "adder": "addNarrator(String)",
+              "getter": "getNarrators()",
+              "adderAll": "addNarrators(List<String>)"
+            },
+            "publishDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setPublishDateEpochMillis(long)",
+              "getter": "getPublishDateEpochMillis()"
+            },
+            "durationMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setDurationMillis(long)",
+              "getter": "getDurationMillis()"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()"
+            },
+            "seriesName": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setSeriesName(String)",
+              "getter": "getSeriesName()"
+            },
+            "seriesUnitIndex": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setSeriesUnitIndex(Integer)",
+              "getter": "getSeriesUnitIndex()"
+            },
+            "genres": {
+              "type": "List<List<String>>",
+              "requirement": "Optional",
+              "adder": "addGenre(String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()"
+            },
+            "progressPercentComplete": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setProgressPercentComplete(int)",
+              "getter": "getProgressPercentComplete()"
+            },
+            "continueBookType": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setContinueBookType(int)",
+              "getter": "getContinueBookType()"
+            }
+          }
+        }
+      },
+      "methods": {
+        "isServiceAvailable": null,
+        "publishRecommendationClusters": "PublishRecommendationClustersRequest",
+        "publishFeaturedCluster": "PublishFeaturedClusterRequest",
+        "publishContinuationCluster": "PublishContinuationClusterRequest",
+        "publishSubscription": "PublishSubscriptionRequest",
+        "publishUserAccountManagementRequest": "PublishUserAccountManagementRequest",
+        "updatePublishStatus": "PublishStatusRequest",
+        "deleteRecommendationsClusters": "DeleteClustersRequest",
+        "deleteFeaturedCluster": "DeleteClustersRequest",
+        "deleteContinuationCluster": "DeleteClustersRequest",
+        "deleteSubscription": "DeleteClustersRequest",
+        "deleteUserManagementCluster": "DeleteClustersRequest"
+      },
+      "intents": {}
+    }

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/shopping.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/shopping.md
@@ -1,0 +1,357 @@
+This file defines the schema for the SHOPPING vertical in the Engage SDK.
+
+    {
+      "client": "com.google.android.engage.shopping.service.AppEngageShoppingClient",
+      "clusterTypes": [
+        "TYPE_RECOMMENDATION",
+        "TYPE_FEATURED",
+        "TYPE_SHOPPING_CART",
+        "TYPE_SHOPPING_LIST",
+        "TYPE_SHOPPING_REORDER",
+        "TYPE_SHOPPING_ORDER_TRACKING"
+      ],
+      "entities": {
+        "ShoppingEntity": {
+          "package": "com.google.android.engage.shopping.datamodel.ShoppingEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "callout": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setCallout(String)",
+              "getter": "getCallout()"
+            },
+            "calloutFinePrint": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setCalloutFinePrint(String)",
+              "getter": "getCalloutFinePrint()"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()",
+              "requiredFor": [
+                "Required if strikethrough price is provided"
+              ]
+            },
+            "rating": {
+              "type": "Rating",
+              "requirement": "Optional",
+              "setter": "setRating(Rating)",
+              "getter": "getRating()",
+              "requiredFor": [
+                "Required if strikethrough price is provided",
+                "Mutually required with other rating fields"
+              ]
+            }
+          }
+        }
+      },
+      "methods": {
+        "isServiceAvailable": null,
+        "publishRecommendationClusters": "PublishRecommendationClustersRequest",
+        "publishFeaturedCluster": "PublishFeaturedClusterRequest",
+        "publishShoppingCart": "PublishShoppingCartClusterRequest",
+        "publishShoppingLists": "PublishShoppingListsRequest",
+        "publishShoppingReorderCluster": "PublishShoppingReorderClusterRequest",
+        "publishShoppingOrderTrackingCluster": "PublishShoppingOrderTrackingClusterRequest",
+        "publishUserAccountManagementRequest": "PublishUserAccountManagementRequest",
+        "updatePublishStatus": "PublishStatusRequest",
+        "deleteShoppingCartCluster": "DeleteClustersRequest",
+        "deleteShoppingListCluster": "DeleteClustersRequest",
+        "deleteReorderCluster": "DeleteClustersRequest",
+        "deleteShoppingOrderTrackingCluster": "DeleteClustersRequest",
+        "deleteRecommendationsClusters": "DeleteClustersRequest",
+        "deleteFeaturedCluster": "DeleteClustersRequest",
+        "deleteUserManagementCluster": "DeleteClustersRequest"
+      },
+      "clusters": {
+        "ShoppingList": {
+          "package": "com.google.android.engage.shopping.datamodel.ShoppingList",
+          "fields": {
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "actionText": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setActionText(String)",
+              "getter": "getActionText()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Optional",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "itemLabels": {
+              "type": "List<List<String>>",
+              "requirement": "Optional",
+              "adder": "addItemLabel(String)",
+              "getter": "getItemLabels()",
+              "adderAll": "addItemLabels(List<String>)"
+            },
+            "numberOfItems": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setNumberOfItems(int)",
+              "getter": "getNumberOfItems()"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "lastUserInteractionTimestampMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastUserInteractionTimestampMillis(long)",
+              "getter": "getLastUserInteractionTimestampMillis()"
+            }
+          }
+        },
+        "ShoppingReorderCluster": {
+          "package": "com.google.android.engage.shopping.datamodel.ShoppingReorderCluster",
+          "fields": {
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "actionText": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setActionText(String)",
+              "getter": "getActionText()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Optional",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "itemLabels": {
+              "type": "List<List<String>>",
+              "requirement": "Optional",
+              "adder": "addItemLabel(String)",
+              "getter": "getItemLabels()",
+              "adderAll": "addItemLabels(List<String>)"
+            },
+            "numberOfItems": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setNumberOfItems(int)",
+              "getter": "getNumberOfItems()"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            }
+          }
+        },
+        "ShoppingCart": {
+          "package": "com.google.android.engage.shopping.datamodel.ShoppingCart",
+          "fields": {
+            "title": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "actionText": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setActionText(String)",
+              "getter": "getActionText()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Optional",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "itemLabels": {
+              "type": "List<List<String>>",
+              "requirement": "Optional",
+              "adder": "addItemLabel(String)",
+              "getter": "getItemLabels()",
+              "adderAll": "addItemLabels(List<String>)"
+            },
+            "numberOfItems": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setNumberOfItems(int)",
+              "getter": "getNumberOfItems()"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            },
+            "lastUserInteractionTimestampMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastUserInteractionTimestampMillis(long)",
+              "getter": "getLastUserInteractionTimestampMillis()"
+            }
+          }
+        },
+        "ShoppingOrderTrackingCluster": {
+          "package": "com.google.android.engage.shopping.datamodel.ShoppingOrderTrackingCluster",
+          "fields": {
+            "title": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Optional",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "status": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setStatus(String)",
+              "getter": "getStatus()"
+            },
+            "orderTime": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setOrderTime(long)",
+              "getter": "getOrderTime()"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "orderReadyTimeWindow": {
+              "type": "OrderReadyTimeWindow",
+              "requirement": "Optional",
+              "setter": "setOrderReadyTimeWindow(OrderReadyTimeWindow)",
+              "getter": "getOrderReadyTimeWindow()"
+            },
+            "numberOfItems": {
+              "type": "Integer",
+              "requirement": "Optional",
+              "setter": "setNumberOfItems(Integer)",
+              "getter": "getNumberOfItems()"
+            },
+            "orderDescription": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setOrderDescription(String)",
+              "getter": "getOrderDescription()"
+            },
+            "subtitles": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "adderAll": "addSubtitles(List<String>)"
+            },
+            "orderValue": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setOrderValue(Price)",
+              "getter": "getOrderValue()"
+            },
+            "shoppingOrderType": {
+              "type": "@ShoppingOrderType int",
+              "requirement": "Required",
+              "setter": "setShoppingOrderType(@ShoppingOrderType int)",
+              "getter": "getShoppingOrderType()"
+            },
+            "trackingId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTrackingId(String)",
+              "getter": "getTrackingId()"
+            }
+          }
+        }
+      },
+      "intents": {
+        "ACTION_PUBLISH_SHOPPING_CART": "com.google.android.engage.action.shopping.PUBLISH_SHOPPING_CART",
+        "ACTION_PUBLISH_SHOPPING_LIST": "com.google.android.engage.action.shopping.PUBLISH_SHOPPING_LIST",
+        "ACTION_PUBLISH_REORDER_CLUSTER": "com.google.android.engage.action.shopping.PUBLISH_REORDER_CLUSTER",
+        "ACTION_PUBLISH_ORDER_TRACKING_CLUSTER": "com.google.android.engage.action.shopping.PUBLISH_ORDER_TRACKING_CLUSTER"
+      }
+    }

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/social.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/social.md
@@ -1,0 +1,228 @@
+This file defines the schema for the SOCIAL vertical in the Engage SDK.
+
+    {
+      "client": "com.google.android.engage.social.service.AppEngageSocialClient",
+      "clusterTypes": [
+        "TYPE_RECOMMENDATION",
+        "TYPE_FEATURED"
+      ],
+      "entities": {
+        "SocialPostEntity": {
+          "package": "com.google.android.engage.social.datamodel.SocialPostEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            },
+            "genericPost": {
+              "type": "GenericPost",
+              "requirement": "Required",
+              "setter": "setGenericPost(GenericPost)",
+              "getter": "getGenericPost()"
+            },
+            "profile": {
+              "type": "Profile",
+              "requirement": "Optional",
+              "setter": "setProfile(Profile)",
+              "getter": "getProfile()"
+            },
+            "interactions": {
+              "type": "List<Interaction>",
+              "requirement": "Optional",
+              "adder": "addInteraction(Interaction)",
+              "getter": "getInteractions()"
+            },
+            "allInteractions": {
+              "type": "List<List<Interaction>>",
+              "requirement": "Optional",
+              "adder": "addAllInteraction(Interaction)",
+              "adderAll": "addAllInteraction(List<Interaction>)"
+            }
+          }
+        },
+        "PortraitMediaEntity": {
+          "package": "com.google.android.engage.social.datamodel.PortraitMediaEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            },
+            "portraitMediaPost": {
+              "type": "PortraitMediaPost",
+              "requirement": "Required",
+              "setter": "setPortraitMediaPost(PortraitMediaPost)",
+              "getter": "getPortraitMediaPost()"
+            },
+            "profile": {
+              "type": "Profile",
+              "requirement": "Optional",
+              "setter": "setProfile(Profile)",
+              "getter": "getProfile()"
+            },
+            "interactions": {
+              "type": "List<List<Interaction>>",
+              "requirement": "Optional",
+              "adder": "addInteractions(Interaction)",
+              "getter": "getInteractions()",
+              "adderAll": "addInteractions(List<Interaction>)"
+            },
+            "recommendationReason": {
+              "type": "@NonNull RecommendationReason",
+              "requirement": "Optional",
+              "setter": "setRecommendationReason(@NonNull RecommendationReason)",
+              "getter": "getRecommendationReason()"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<@NonNull PlatformSpecificUri>",
+              "requirement": "Optional",
+              "adder": "addPlatformSpecificPlaybackUri(@NonNull PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "commentsSummary": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setCommentsSummary(@NonNull String)",
+              "getter": "getCommentsSummary()"
+            },
+            "interaction": {
+              "requirement": "Optional",
+              "setter": "setInteraction(Interaction)",
+              "type": "Interaction",
+              "getter": "getInteraction()"
+            }
+          }
+        },
+        "PersonEntity": {
+          "package": "com.google.android.engage.social.datamodel.PersonEntity",
+          "fields": {
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "profile": {
+              "type": "Profile",
+              "requirement": "Required",
+              "setter": "setProfile(Profile)",
+              "getter": "getProfile()"
+            },
+            "headerImage": {
+              "type": "Image",
+              "requirement": "Optional",
+              "setter": "setHeaderImage(Image)",
+              "getter": "getHeaderImage()"
+            },
+            "popularity": {
+              "type": "Popularity",
+              "requirement": "Optional",
+              "setter": "setPopularity(Popularity)",
+              "getter": "getPopularity()"
+            },
+            "rating": {
+              "type": "Rating",
+              "requirement": "Optional",
+              "setter": "setRating(Rating)",
+              "getter": "getRating()"
+            },
+            "locations": {
+              "type": "Address",
+              "requirement": "Optional"
+            },
+            "badges": {
+              "type": "List<Badge>",
+              "requirement": "Optional",
+              "adder": "addBadge(Badge)",
+              "adderAll": "addBadges(List<Badge>)"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "subtitles": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "adderAll": "addSubtitles(List<String>)"
+            },
+            "contentCategories": {
+              "type": "List<@EligibleContentCategory int>",
+              "requirement": "Optional",
+              "adder": "addContentCategory(@EligibleContentCategory int)",
+              "adderAll": "addContentCategories(List<Integer>)"
+            },
+            "location": {
+              "requirement": "Optional",
+              "setter": "setLocation(Address)",
+              "type": "Address",
+              "getter": "getLocation()"
+            }
+          }
+        }
+      },
+      "methods": {
+        "isServiceAvailable": null,
+        "publishRecommendationClusters": "PublishRecommendationClustersRequest",
+        "publishUserAccountManagementRequest": "PublishUserAccountManagementRequest",
+        "updatePublishStatus": "PublishStatusRequest",
+        "deleteUserManagementCluster": "DeleteClustersRequest",
+        "deleteRecommendationsClusters": "DeleteClustersRequest"
+      },
+      "intents": {}
+    }

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/travel.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/travel.md
@@ -1,0 +1,923 @@
+This file defines the schema for the TRAVEL vertical in the Engage SDK.
+
+    {
+      "client": "com.google.android.engage.travel.service.AppEngageTravelClient",
+      "clusterTypes": [
+        "TYPE_RECOMMENDATION",
+        "TYPE_FEATURED",
+        "TYPE_RESERVATION",
+        "TYPE_CONTINUE_SEARCH"
+      ],
+      "entities": {
+        "EventEntity": {
+          "package": "com.google.android.engage.travel.datamodel.EventEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "title": {
+              "type": "@NonNull String",
+              "requirement": "Required",
+              "setter": "setTitle(@NonNull String)",
+              "getter": "getTitle()"
+            },
+            "startTime": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setStartTime(Long)",
+              "getter": "getStartTime()"
+            },
+            "localizedStartTime": {
+              "type": "LocalizedTimestamp",
+              "requirement": "Required",
+              "setter": "setLocalizedStartTime(LocalizedTimestamp)",
+              "getter": "getLocalizedStartTime()"
+            },
+            "eventMode": {
+              "type": "@EventMode int",
+              "requirement": "Required",
+              "setter": "setEventMode(@EventMode int)",
+              "getter": "getEventMode()"
+            },
+            "locations": {
+              "type": "Address",
+              "requirement": "Required"
+            },
+            "endTime": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setEndTime(Long)",
+              "getter": "getEndTime()"
+            },
+            "localizedEndTime": {
+              "type": "LocalizedTimestamp",
+              "requirement": "Optional",
+              "setter": "setLocalizedEndTime(LocalizedTimestamp)",
+              "getter": "getLocalizedEndTime()"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "subtitles": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "adderAll": "addSubtitles(List<String>)"
+            },
+            "badges": {
+              "type": "List<Badge>",
+              "requirement": "Optional",
+              "adder": "addBadge(Badge)",
+              "adderAll": "addBadges(List<Badge>)"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()",
+              "requiredFor": [
+                "Required if strikethrough price is provided"
+              ]
+            },
+            "priceCallout": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setPriceCallout(String)",
+              "getter": "getPriceCallout()"
+            },
+            "contentCategories": {
+              "type": "List<@EligibleContentCategory int>",
+              "requirement": "Optional",
+              "adder": "addContentCategory(@EligibleContentCategory int)",
+              "adderAll": "addContentCategories(List<Integer>)"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            },
+            "location": {
+              "requirement": "Required",
+              "setter": "setLocation(Address)",
+              "type": "Address",
+              "getter": "getLocation()",
+              "requiredFor": [
+                "Required if strikethrough price is provided"
+              ]
+            }
+          }
+        },
+        "LodgingEntity": {
+          "package": "com.google.android.engage.travel.datamodel.LodgingEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "locations": {
+              "type": "Address",
+              "requirement": "Required"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()",
+              "requiredFor": [
+                "Required if strikethrough price is provided"
+              ]
+            },
+            "priceCallout": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setPriceCallout(String)",
+              "getter": "getPriceCallout()"
+            },
+            "badges": {
+              "type": "List<Badge>",
+              "requirement": "Optional",
+              "adder": "addBadge(Badge)",
+              "adderAll": "addBadges(List<Badge>)"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "subtitles": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "adderAll": "addSubtitles(List<String>)"
+            },
+            "availabilityTimeWindow": {
+              "type": "AvailabilityTimeWindow",
+              "requirement": "Optional",
+              "setter": "setAvailabilityTimeWindow(AvailabilityTimeWindow)",
+              "getter": "getAvailabilityTimeWindow()"
+            },
+            "rating": {
+              "type": "Rating",
+              "requirement": "Optional",
+              "setter": "setRating(Rating)",
+              "getter": "getRating()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            },
+            "location": {
+              "requirement": "Required",
+              "setter": "setLocation(Address)",
+              "type": "Address",
+              "getter": "getLocation()",
+              "requiredFor": [
+                "Required if strikethrough price is provided"
+              ]
+            }
+          }
+        },
+        "PointOfInterestEntity": {
+          "package": "com.google.android.engage.travel.datamodel.PointOfInterestEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "actionLinkUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionLinkUri(Uri)",
+              "getter": "getActionLinkUri()"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "locations": {
+              "type": "Address",
+              "requirement": "Required"
+            },
+            "availabilityTimeWindow": {
+              "type": "AvailabilityTimeWindow",
+              "requirement": "Optional",
+              "setter": "setAvailabilityTimeWindow(AvailabilityTimeWindow)",
+              "getter": "getAvailabilityTimeWindow()"
+            },
+            "badges": {
+              "type": "List<Badge>",
+              "requirement": "Optional",
+              "adder": "addBadge(Badge)",
+              "adderAll": "addBadges(List<Badge>)"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "subtitles": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "adderAll": "addSubtitles(List<String>)"
+            },
+            "rating": {
+              "type": "Rating",
+              "requirement": "Optional",
+              "setter": "setRating(Rating)",
+              "getter": "getRating()"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()",
+              "requiredFor": [
+                "Required if strikethrough price is provided"
+              ]
+            },
+            "priceCallout": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setPriceCallout(String)",
+              "getter": "getPriceCallout()"
+            },
+            "contentCategories": {
+              "type": "List<@EligibleContentCategory int>",
+              "requirement": "Optional",
+              "adder": "addContentCategory(@EligibleContentCategory int)",
+              "adderAll": "addContentCategories(List<Integer>)"
+            },
+            "lastEngagementTime": {
+              "type": "Instant",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTime(Instant)",
+              "getter": "getLastEngagementTime()",
+              "requiredFor": [
+                "ContinueSearchCluster"
+              ]
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            },
+            "location": {
+              "requirement": "Required",
+              "setter": "setLocation(Address)",
+              "type": "Address",
+              "getter": "getLocation()",
+              "requiredFor": [
+                "RecommendationCluster"
+              ]
+            }
+          }
+        },
+        "LodgingReservationEntity": {
+          "package": "com.google.android.engage.travel.datamodel.LodgingReservationEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "actionUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionUri(Uri)",
+              "getter": "getActionUri()"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "subtitles": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "adderAll": "addSubtitles(List<String>)"
+            },
+            "address": {
+              "type": "Address",
+              "requirement": "Required",
+              "setter": "setAddress(Address)",
+              "getter": "getAddress()"
+            },
+            "checkInTime": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setCheckInTime(long)",
+              "getter": "getCheckInTime()"
+            },
+            "localizedCheckInTime": {
+              "type": "LocalizedTimestamp",
+              "requirement": "Required",
+              "setter": "setLocalizedCheckInTime(LocalizedTimestamp)",
+              "getter": "getLocalizedCheckInTime()"
+            },
+            "checkOutTime": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setCheckOutTime(long)",
+              "getter": "getCheckOutTime()"
+            },
+            "localizedCheckOutTime": {
+              "type": "LocalizedTimestamp",
+              "requirement": "Required",
+              "setter": "setLocalizedCheckOutTime(LocalizedTimestamp)",
+              "getter": "getLocalizedCheckOutTime()"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()",
+              "requiredFor": [
+                "Required if strikethrough price is provided"
+              ]
+            },
+            "priceCallout": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setPriceCallout(String)",
+              "getter": "getPriceCallout()"
+            },
+            "rating": {
+              "type": "Rating",
+              "requirement": "Optional",
+              "setter": "setRating(Rating)",
+              "getter": "getRating()",
+              "requiredFor": [
+                "Required if strikethrough price is provided",
+                "Mutually required with other rating fields"
+              ]
+            },
+            "reservationId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setReservationId(String)",
+              "getter": "getReservationId()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            }
+          }
+        },
+        "EventReservationEntity": {
+          "package": "com.google.android.engage.travel.datamodel.EventReservationEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "actionUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionUri(Uri)",
+              "getter": "getActionUri()"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "subtitles": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "adderAll": "addSubtitles(List<String>)"
+            },
+            "startTime": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setStartTime(Long)",
+              "getter": "getStartTime()"
+            },
+            "localizedStartTime": {
+              "type": "LocalizedTimestamp",
+              "requirement": "Required",
+              "setter": "setLocalizedStartTime(LocalizedTimestamp)",
+              "getter": "getLocalizedStartTime()"
+            },
+            "eventMode": {
+              "type": "@EventMode int",
+              "requirement": "Required",
+              "setter": "setEventMode(@EventMode int)",
+              "getter": "getEventMode()"
+            },
+            "location": {
+              "type": "Address",
+              "requirement": "Required",
+              "setter": "setLocation(Address)",
+              "getter": "getLocation()"
+            },
+            "endTime": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setEndTime(Long)",
+              "getter": "getEndTime()"
+            },
+            "localizedEndTime": {
+              "type": "LocalizedTimestamp",
+              "requirement": "Optional",
+              "setter": "setLocalizedEndTime(LocalizedTimestamp)",
+              "getter": "getLocalizedEndTime()"
+            },
+            "serviceProvider": {
+              "type": "ServiceProvider",
+              "requirement": "Optional",
+              "setter": "setServiceProvider(ServiceProvider)",
+              "getter": "getServiceProvider()"
+            },
+            "badges": {
+              "type": "List<Badge>",
+              "requirement": "Optional",
+              "adder": "addBadge(Badge)",
+              "adderAll": "addBadges(List<Badge>)"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()",
+              "requiredFor": [
+                "Required if strikethrough price is provided"
+              ]
+            },
+            "priceCallout": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setPriceCallout(String)",
+              "getter": "getPriceCallout()"
+            },
+            "rating": {
+              "type": "Rating",
+              "requirement": "Optional",
+              "setter": "setRating(Rating)",
+              "getter": "getRating()",
+              "requiredFor": [
+                "Required if strikethrough price is provided"
+              ]
+            },
+            "contentCategories": {
+              "type": "List<@EligibleContentCategory int>",
+              "requirement": "Optional",
+              "adder": "addContentCategory(@EligibleContentCategory int)",
+              "adderAll": "addContentCategories(List<Integer>)"
+            },
+            "reservationId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setReservationId(String)",
+              "getter": "getReservationId()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            }
+          }
+        },
+        "TransportationReservationEntity": {
+          "package": "com.google.android.engage.travel.datamodel.TransportationReservationEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "actionUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionUri(Uri)",
+              "getter": "getActionUri()"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "subtitles": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "adderAll": "addSubtitles(List<String>)"
+            },
+            "departureTime": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setDepartureTime(Long)",
+              "getter": "getDepartureTime()"
+            },
+            "localizedDepartureTime": {
+              "type": "LocalizedTimestamp",
+              "requirement": "Required",
+              "setter": "setLocalizedDepartureTime(LocalizedTimestamp)",
+              "getter": "getLocalizedDepartureTime()"
+            },
+            "arrivalTime": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setArrivalTime(Long)",
+              "getter": "getArrivalTime()"
+            },
+            "localizedArrivalTime": {
+              "type": "LocalizedTimestamp",
+              "requirement": "Required",
+              "setter": "setLocalizedArrivalTime(LocalizedTimestamp)",
+              "getter": "getLocalizedArrivalTime()"
+            },
+            "transportationType": {
+              "type": "@TransportationType int",
+              "requirement": "Required",
+              "setter": "setTransportationType(@TransportationType int)",
+              "getter": "getTransportationType()"
+            },
+            "departureLocation": {
+              "type": "Address",
+              "requirement": "Optional",
+              "setter": "setDepartureLocation(Address)",
+              "getter": "getDepartureLocation()"
+            },
+            "arrivalLocation": {
+              "type": "Address",
+              "requirement": "Optional",
+              "setter": "setArrivalLocation(Address)",
+              "getter": "getArrivalLocation()"
+            },
+            "serviceProvider": {
+              "type": "ServiceProvider",
+              "requirement": "Optional",
+              "setter": "setServiceProvider(ServiceProvider)",
+              "getter": "getServiceProvider()"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()",
+              "requiredFor": [
+                "Required if strikethrough price is provided"
+              ]
+            },
+            "priceCallout": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setPriceCallout(String)",
+              "getter": "getPriceCallout()"
+            },
+            "transportationNumber": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setTransportationNumber(String)",
+              "getter": "getTransportationNumber()"
+            },
+            "boardingTime": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setBoardingTime(Long)",
+              "getter": "getBoardingTime()"
+            },
+            "localizedBoardingTime": {
+              "type": "LocalizedTimestamp",
+              "requirement": "Required",
+              "setter": "setLocalizedBoardingTime(LocalizedTimestamp)",
+              "getter": "getLocalizedBoardingTime()"
+            },
+            "reservationId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setReservationId(String)",
+              "getter": "getReservationId()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            }
+          }
+        },
+        "VehicleRentalReservationEntity": {
+          "package": "com.google.android.engage.travel.datamodel.VehicleRentalReservationEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "actionUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionUri(Uri)",
+              "getter": "getActionUri()"
+            },
+            "title": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setTitle(String)",
+              "getter": "getTitle()"
+            },
+            "description": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDescription(String)",
+              "getter": "getDescription()"
+            },
+            "subtitles": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addSubtitle(String)",
+              "adderAll": "addSubtitles(List<String>)"
+            },
+            "pickupTime": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setPickupTime(Long)",
+              "getter": "getPickupTime()"
+            },
+            "localizedPickupTime": {
+              "type": "LocalizedTimestamp",
+              "requirement": "Required",
+              "setter": "setLocalizedPickupTime(LocalizedTimestamp)",
+              "getter": "getLocalizedPickupTime()"
+            },
+            "returnTime": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setReturnTime(Long)",
+              "getter": "getReturnTime()"
+            },
+            "localizedReturnTime": {
+              "type": "LocalizedTimestamp",
+              "requirement": "Optional",
+              "setter": "setLocalizedReturnTime(LocalizedTimestamp)",
+              "getter": "getLocalizedReturnTime()"
+            },
+            "pickupAddress": {
+              "type": "Address",
+              "requirement": "Optional",
+              "setter": "setPickupAddress(Address)",
+              "getter": "getPickupAddress()"
+            },
+            "returnAddress": {
+              "type": "Address",
+              "requirement": "Optional",
+              "setter": "setReturnAddress(Address)",
+              "getter": "getReturnAddress()"
+            },
+            "serviceProvider": {
+              "type": "ServiceProvider",
+              "requirement": "Optional",
+              "setter": "setServiceProvider(ServiceProvider)",
+              "getter": "getServiceProvider()"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()",
+              "requiredFor": [
+                "Required if strikethrough price is provided"
+              ]
+            },
+            "priceCallout": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setPriceCallout(String)",
+              "getter": "getPriceCallout()"
+            },
+            "confirmationId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setConfirmationId(String)",
+              "getter": "getConfirmationId()"
+            },
+            "displayTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addDisplayTimeWindow(DisplayTimeWindow)",
+              "getter": "getDisplayTimeWindows()"
+            },
+            "allDisplayTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllDisplayTimeWindow(DisplayTimeWindow)",
+              "adderAll": "addAllDisplayTimeWindow(List<DisplayTimeWindow>)"
+            }
+          }
+        }
+      },
+      "methods": {
+        "isServiceAvailable": null,
+        "publishRecommendationClusters": "PublishRecommendationClustersRequest",
+        "publishFeaturedCluster": "PublishFeaturedClusterRequest",
+        "publishUserAccountManagementRequest": "PublishUserAccountManagementRequest",
+        "updatePublishStatus": "PublishStatusRequest",
+        "publishContinueSearchCluster": "PublishContinueSearchClusterRequest",
+        "publishReservationCluster": "PublishReservationClusterRequest",
+        "deleteRecommendationsClusters": "DeleteClustersRequest",
+        "deleteFeaturedCluster": "DeleteClustersRequest",
+        "deleteUserManagementCluster": "DeleteClustersRequest",
+        "deleteContinueSearchCluster": "DeleteClustersRequest",
+        "deleteReservationCluster": "DeleteClustersRequest"
+      },
+      "clusters": {
+        "ContinueSearchCluster": {
+          "package": "com.google.android.engage.travel.datamodel.ContinueSearchCluster",
+          "fields": {
+            "pointOfInterestEntities": {
+              "type": "List<PointOfInterestEntity>",
+              "requirement": "Required",
+              "adder": "addPointOfInterestEntity(PointOfInterestEntity)"
+            }
+          }
+        },
+        "ReservationCluster": {
+          "package": "com.google.android.engage.travel.datamodel.ReservationCluster",
+          "fields": {
+            "lodgingReservationEntities": {
+              "type": "List<LodgingReservationEntity>",
+              "requirement": "Optional",
+              "adder": "addLodgingReservationEntity(LodgingReservationEntity)"
+            },
+            "vehicleRentalReservationEntities": {
+              "type": "List<VehicleRentalReservationEntity>",
+              "requirement": "Optional",
+              "adder": "addVehicleRentalReservationEntity(VehicleRentalReservationEntity)"
+            },
+            "transportationReservationEntities": {
+              "type": "List<TransportationReservationEntity>",
+              "requirement": "Optional",
+              "adder": "addTransportationReservationEntity(TransportationReservationEntity)"
+            },
+            "eventReservationEntities": {
+              "type": "List<EventReservationEntity>",
+              "requirement": "Optional",
+              "adder": "addEventReservationEntity(EventReservationEntity)"
+            },
+            "restaurantReservationEntities": {
+              "type": "List<RestaurantReservationEntity>",
+              "requirement": "Optional",
+              "adder": "addRestaurantReservationEntity(RestaurantReservationEntity)"
+            }
+          }
+        }
+      },
+      "intents": {
+        "ACTION_PUBLISH_CONTINUE_SEARCH_CLUSTER": "com.google.android.engage.action.travel.PUBLISH_CONTINUE_SEARCH",
+        "ACTION_PUBLISH_RESERVATION_CLUSTER": "com.google.android.engage.action.travel.PUBLISH_RESERVATION"
+      }
+    }

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/tv.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/tv.md
@@ -1,0 +1,1226 @@
+This file defines the schema for the TV vertical in the Engage SDK.
+
+    {
+      "client": "com.google.android.engage.service.AppEngagePublishClient",
+      "clusterTypes": [
+        "TYPE_RECOMMENDATION",
+        "TYPE_FEATURED",
+        "TYPE_CONTINUATION",
+        "TYPE_SUBSCRIPTION",
+        "TYPE_ENGAGEMENT"
+      ],
+      "entities": {
+        "MovieEntity": {
+          "package": "com.google.android.engage.video.datamodel.MovieEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "watchNextType": {
+              "type": "@WatchNextType int",
+              "requirement": "Optional",
+              "setter": "setWatchNextType(@WatchNextType int)",
+              "getter": "getWatchNextType()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "lastPlayBackPositionTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastPlayBackPositionTimeMillis(long)",
+              "getter": "getLastPlayBackPositionTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "availabilityTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addAvailabilityTimeWindow(DisplayTimeWindow)",
+              "getter": "getAvailabilityTimeWindows()"
+            },
+            "allAvailabilityTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllAvailabilityTimeWindows(DisplayTimeWindow)",
+              "adderAll": "addAllAvailabilityTimeWindows(List<DisplayTimeWindow>)"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "releaseDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setReleaseDateEpochMillis(long)",
+              "getter": "getReleaseDateEpochMillis()"
+            },
+            "availability": {
+              "type": "@ContentAvailability int",
+              "requirement": "Required",
+              "setter": "setAvailability(@ContentAvailability int)",
+              "getter": "getAvailability()"
+            },
+            "durationMillis": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setDurationMillis(long)",
+              "getter": "getDurationMillis()"
+            },
+            "genres": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addGenre(String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "contentRatings": {
+              "type": "List<String>",
+              "requirement": "Required",
+              "adder": "addContentRating(RatingSystem)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<RatingSystem>)"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<PlatformSpecificUri>",
+              "requirement": "Optional",
+              "adder": "addPlatformSpecificPlaybackUri(PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "recommendationReason": {
+              "type": "@NonNull RecommendationReason",
+              "requirement": "Optional",
+              "setter": "setRecommendationReason(@NonNull RecommendationReason)",
+              "getter": "getRecommendationReason()"
+            },
+            "description": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setDescription(@NonNull String)",
+              "getter": "getDescription()"
+            },
+            "contentRatingsLegacies": {
+              "requirement": "Required",
+              "adder": "addContentRatingsLegacy(String)",
+              "type": "List<List<String>>",
+              "getter": "getContentRatingsLegacy()",
+              "adderAll": "addContentRatingsLegacy(List<String>)"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "TvShowEntity": {
+          "package": "com.google.android.engage.video.datamodel.TvShowEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "watchNextType": {
+              "type": "@WatchNextType int",
+              "requirement": "Optional",
+              "setter": "setWatchNextType(@WatchNextType int)",
+              "getter": "getWatchNextType()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "lastPlayBackPositionTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastPlayBackPositionTimeMillis(long)",
+              "getter": "getLastPlayBackPositionTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "availabilityTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addAvailabilityTimeWindow(DisplayTimeWindow)",
+              "getter": "getAvailabilityTimeWindows()"
+            },
+            "allAvailabilityTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllAvailabilityTimeWindows(DisplayTimeWindow)",
+              "adderAll": "addAllAvailabilityTimeWindows(List<DisplayTimeWindow>)"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "firstEpisodeAirDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setFirstEpisodeAirDateEpochMillis(long)",
+              "getter": "getFirstEpisodeAirDateEpochMillis()"
+            },
+            "latestEpisodeAirDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLatestEpisodeAirDateEpochMillis(long)",
+              "getter": "getLatestEpisodeAirDateEpochMillis()"
+            },
+            "availability": {
+              "type": "@ContentAvailability int",
+              "requirement": "Required",
+              "setter": "setAvailability(@ContentAvailability int)",
+              "getter": "getAvailability()"
+            },
+            "seasonCount": {
+              "type": "Integer",
+              "requirement": "Required",
+              "setter": "setSeasonCount(int)",
+              "getter": "getSeasonCount()"
+            },
+            "genres": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addGenre(String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "contentRatings": {
+              "type": "List<String>",
+              "requirement": "Required",
+              "adder": "addContentRating(RatingSystem)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<RatingSystem>)"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<PlatformSpecificUri>",
+              "requirement": "Required",
+              "adder": "addPlatformSpecificPlaybackUri(PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "recommendationReason": {
+              "type": "@NonNull RecommendationReason",
+              "requirement": "Optional",
+              "setter": "setRecommendationReason(@NonNull RecommendationReason)",
+              "getter": "getRecommendationReason()"
+            },
+            "description": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setDescription(@NonNull String)",
+              "getter": "getDescription()"
+            },
+            "contentRatingsLegacies": {
+              "requirement": "Required",
+              "adder": "addContentRatingsLegacy(String)",
+              "type": "List<List<String>>",
+              "getter": "getContentRatingsLegacy()",
+              "adderAll": "addContentRatingsLegacy(List<String>)"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "TvSeasonEntity": {
+          "package": "com.google.android.engage.video.datamodel.TvSeasonEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "watchNextType": {
+              "type": "@WatchNextType int",
+              "requirement": "Optional",
+              "setter": "setWatchNextType(@WatchNextType int)",
+              "getter": "getWatchNextType()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "lastPlayBackPositionTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastPlayBackPositionTimeMillis(long)",
+              "getter": "getLastPlayBackPositionTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "availabilityTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addAvailabilityTimeWindow(DisplayTimeWindow)",
+              "getter": "getAvailabilityTimeWindows()"
+            },
+            "allAvailabilityTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllAvailabilityTimeWindows(DisplayTimeWindow)",
+              "adderAll": "addAllAvailabilityTimeWindows(List<DisplayTimeWindow>)"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "seasonNumber": {
+              "type": "Integer",
+              "requirement": "Required",
+              "setter": "setSeasonNumber(int)"
+            },
+            "seasonDisplayNumber": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setSeasonDisplayNumber(String)",
+              "getter": "getSeasonDisplayNumber()"
+            },
+            "firstEpisodeAirDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setFirstEpisodeAirDateEpochMillis(long)",
+              "getter": "getFirstEpisodeAirDateEpochMillis()"
+            },
+            "latestEpisodeAirDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLatestEpisodeAirDateEpochMillis(long)",
+              "getter": "getLatestEpisodeAirDateEpochMillis()"
+            },
+            "availability": {
+              "type": "@ContentAvailability int",
+              "requirement": "Required",
+              "setter": "setAvailability(@ContentAvailability int)",
+              "getter": "getAvailability()"
+            },
+            "episodeCount": {
+              "type": "Integer",
+              "requirement": "Required",
+              "setter": "setEpisodeCount(int)",
+              "getter": "getEpisodeCount()"
+            },
+            "genres": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addGenre(String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "contentRatings": {
+              "type": "List<String>",
+              "requirement": "Required",
+              "adder": "addContentRating(RatingSystem)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<RatingSystem>)"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()"
+            },
+            "contentRatingsLegacies": {
+              "requirement": "Required",
+              "adder": "addContentRatingsLegacy(String)",
+              "type": "List<List<String>>",
+              "getter": "getContentRatingsLegacy()",
+              "adderAll": "addContentRatingsLegacy(List<String>)"
+            }
+          }
+        },
+        "TvEpisodeEntity": {
+          "package": "com.google.android.engage.video.datamodel.TvEpisodeEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "watchNextType": {
+              "type": "@WatchNextType int",
+              "requirement": "Optional",
+              "setter": "setWatchNextType(@WatchNextType int)",
+              "getter": "getWatchNextType()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "lastPlayBackPositionTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastPlayBackPositionTimeMillis(long)",
+              "getter": "getLastPlayBackPositionTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "availabilityTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addAvailabilityTimeWindow(DisplayTimeWindow)",
+              "getter": "getAvailabilityTimeWindows()"
+            },
+            "allAvailabilityTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllAvailabilityTimeWindows(DisplayTimeWindow)",
+              "adderAll": "addAllAvailabilityTimeWindows(List<DisplayTimeWindow>)"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "episodeNumber": {
+              "type": "Integer",
+              "requirement": "Required",
+              "setter": "setEpisodeNumber(int)"
+            },
+            "episodeDisplayNumber": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setEpisodeDisplayNumber(String)",
+              "getter": "getEpisodeDisplayNumber()"
+            },
+            "airDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setAirDateEpochMillis(long)",
+              "getter": "getAirDateEpochMillis()"
+            },
+            "availability": {
+              "type": "@ContentAvailability int",
+              "requirement": "Required",
+              "setter": "setAvailability(@ContentAvailability int)",
+              "getter": "getAvailability()"
+            },
+            "genres": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addGenre(String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "contentRatings": {
+              "type": "List<String>",
+              "requirement": "Required",
+              "adder": "addContentRating(RatingSystem)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<RatingSystem>)"
+            },
+            "durationMillis": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setDurationMillis(long)",
+              "getter": "getDurationMillis()"
+            },
+            "seasonNumber": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setSeasonNumber(String)",
+              "getter": "getSeasonNumber()"
+            },
+            "seasonTitle": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setSeasonTitle(String)",
+              "getter": "getSeasonTitle()"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()"
+            },
+            "showTitle": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setShowTitle(String)",
+              "getter": "getShowTitle()"
+            },
+            "isNextEpisodeAvailable": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setIsNextEpisodeAvailable(boolean)",
+              "getter": "getIsNextEpisodeAvailable()"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<PlatformSpecificUri>",
+              "requirement": "Optional",
+              "adder": "addPlatformSpecificPlaybackUri(PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "contentRatingsLegacies": {
+              "requirement": "Required",
+              "adder": "addContentRatingsLegacy(String)",
+              "type": "List<List<String>>",
+              "getter": "getContentRatingsLegacy()",
+              "adderAll": "addContentRatingsLegacy(List<String>)"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "MediaActionFeedEntity": {
+          "package": "com.google.android.engage.video.datamodel.MediaActionFeedEntity",
+          "fields": {
+            "dataFeedElementId": {
+              "type": "@NonNull String",
+              "requirement": "Required",
+              "setter": "setDataFeedElementId(@NonNull String)",
+              "getter": "getDataFeedElementId()"
+            },
+            "name": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setName(@NonNull String)",
+              "getter": "getName()"
+            },
+            "recommendationReason": {
+              "type": "@NonNull RecommendationReason",
+              "requirement": "Optional",
+              "setter": "setRecommendationReason(@NonNull RecommendationReason)",
+              "getter": "getRecommendationReason()"
+            },
+            "description": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setDescription(@NonNull String)",
+              "getter": "getDescription()"
+            },
+            "posterImages": {
+              "type": "List<List<Image>>",
+              "requirement": "Optional",
+              "adder": "addPosterImage(@NonNull Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "LiveTvProgramEntity": {
+          "package": "com.google.android.engage.video.datamodel.LiveTvProgramEntity",
+          "fields": {
+            "channelId": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setChannelId(@NonNull String)",
+              "getter": "getChannelId()"
+            },
+            "channelName": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setChannelName(@NonNull String)",
+              "getter": "getChannelName()"
+            },
+            "channelLogoImage": {
+              "type": "@NonNull Image",
+              "requirement": "Optional",
+              "setter": "setChannelLogoImage(@NonNull Image)",
+              "getter": "getChannelLogoImage()"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<@NonNull PlatformSpecificUri>",
+              "requirement": "Optional",
+              "adder": "addPlatformSpecificPlaybackUri(@NonNull PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "contentRatings": {
+              "type": "List<@NonNull RatingSystem>",
+              "requirement": "Optional",
+              "adder": "addContentRating(@NonNull RatingSystem)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<RatingSystem>)"
+            },
+            "genres": {
+              "type": "List<@NonNull String>",
+              "requirement": "Optional",
+              "adder": "addGenre(@NonNull String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "availabilityTimeWindows": {
+              "type": "List<@NonNull DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addAvailabilityTimeWindow(@NonNull DisplayTimeWindow)",
+              "getter": "getAvailabilityTimeWindows()",
+              "adderAll": "addAvailabilityTimeWindows(List<DisplayTimeWindow>)"
+            },
+            "posterImages": {
+              "type": "List<@NonNull Image>",
+              "requirement": "Optional",
+              "adder": "addPosterImage(@NonNull Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "recommendationReason": {
+              "type": "@NonNull RecommendationReason",
+              "requirement": "Optional",
+              "setter": "setRecommendationReason(@NonNull RecommendationReason)",
+              "getter": "getRecommendationReason()"
+            },
+            "description": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setDescription(@NonNull String)",
+              "getter": "getDescription()"
+            },
+            "entityId": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setEntityId(@NonNull String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setName(@NonNull String)",
+              "getter": "getName()"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "LiveStreamingVideoEntity": {
+          "package": "com.google.android.engage.video.datamodel.LiveStreamingVideoEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "watchNextType": {
+              "type": "@WatchNextType int",
+              "requirement": "Optional",
+              "setter": "setWatchNextType(@WatchNextType int)",
+              "getter": "getWatchNextType()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "lastPlayBackPositionTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastPlayBackPositionTimeMillis(long)",
+              "getter": "getLastPlayBackPositionTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "availabilityTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addAvailabilityTimeWindow(DisplayTimeWindow)",
+              "getter": "getAvailabilityTimeWindows()"
+            },
+            "allAvailabilityTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllAvailabilityTimeWindows(DisplayTimeWindow)",
+              "adderAll": "addAllAvailabilityTimeWindows(List<DisplayTimeWindow>)"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "startTimeEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setStartTimeEpochMillis(long)",
+              "getter": "getStartTimeEpochMillis()"
+            },
+            "endTimeEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setEndTimeEpochMillis(long)",
+              "getter": "getEndTimeEpochMillis()"
+            },
+            "broadcaster": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setBroadcaster(String)",
+              "getter": "getBroadcaster()"
+            },
+            "viewCount": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setViewCount(String)",
+              "getter": "getViewCount()"
+            },
+            "broadcasterIcon": {
+              "type": "Image",
+              "requirement": "Optional",
+              "setter": "setBroadcasterIcon(Image)",
+              "getter": "getBroadcasterIcon()"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<PlatformSpecificUri>",
+              "requirement": "Optional",
+              "adder": "addPlatformSpecificPlaybackUri(PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "description": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setDescription(@NonNull String)",
+              "getter": "getDescription()"
+            },
+            "genres": {
+              "type": "List<@NonNull String>",
+              "requirement": "Optional",
+              "adder": "addGenre(@NonNull String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "contentRatings": {
+              "type": "List<@NonNull RatingSystem>",
+              "requirement": "Optional",
+              "adder": "addContentRating(@NonNull RatingSystem)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<RatingSystem>)"
+            },
+            "recommendationReason": {
+              "type": "@NonNull RecommendationReason",
+              "requirement": "Optional",
+              "setter": "setRecommendationReason(@NonNull RecommendationReason)",
+              "getter": "getRecommendationReason()"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "LiveTvChannelEntity": {
+          "package": "com.google.android.engage.video.datamodel.LiveTvChannelEntity",
+          "fields": {
+            "entityId": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setEntityId(@NonNull String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setName(@NonNull String)",
+              "getter": "getName()"
+            },
+            "description": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setDescription(@NonNull String)",
+              "getter": "getDescription()"
+            },
+            "logoImage": {
+              "type": "@NonNull Image",
+              "requirement": "Optional",
+              "setter": "setLogoImage(@NonNull Image)",
+              "getter": "getLogoImage()"
+            },
+            "contentRatings": {
+              "type": "List<@NonNull RatingSystem>",
+              "requirement": "Optional",
+              "adder": "addContentRating(@NonNull RatingSystem)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<RatingSystem>)"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<@NonNull PlatformSpecificUri>",
+              "requirement": "Optional",
+              "adder": "addPlatformSpecificPlaybackUri(@NonNull PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "recommendationReason": {
+              "type": "@NonNull RecommendationReason",
+              "requirement": "Optional",
+              "setter": "setRecommendationReason(@NonNull RecommendationReason)",
+              "getter": "getRecommendationReason()"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "VideoClipEntity": {
+          "package": "com.google.android.engage.video.datamodel.VideoClipEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "watchNextType": {
+              "type": "@WatchNextType int",
+              "requirement": "Optional",
+              "setter": "setWatchNextType(@WatchNextType int)",
+              "getter": "getWatchNextType()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "lastPlayBackPositionTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastPlayBackPositionTimeMillis(long)",
+              "getter": "getLastPlayBackPositionTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "availabilityTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addAvailabilityTimeWindow(DisplayTimeWindow)",
+              "getter": "getAvailabilityTimeWindows()"
+            },
+            "allAvailabilityTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllAvailabilityTimeWindows(DisplayTimeWindow)",
+              "adderAll": "addAllAvailabilityTimeWindows(List<DisplayTimeWindow>)"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "createdTimeEpochMillis": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setCreatedTimeEpochMillis(long)",
+              "getter": "getCreatedTimeEpochMillis()"
+            },
+            "durationMillis": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setDurationMillis(long)",
+              "getter": "getDurationMillis()"
+            },
+            "creator": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setCreator(String)",
+              "getter": "getCreator()"
+            },
+            "creatorImage": {
+              "type": "Image",
+              "requirement": "Optional",
+              "setter": "setCreatorImage(Image)",
+              "getter": "getCreatorImage()"
+            },
+            "viewCount": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setViewCount(String)",
+              "getter": "getViewCount()"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<PlatformSpecificUri>",
+              "requirement": "Optional",
+              "adder": "addPlatformSpecificPlaybackUri(PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "RatingSystem": {
+          "package": "com.google.android.engage.video.datamodel.RatingSystem",
+          "fields": {
+            "rating": {
+              "type": "@NonNull String",
+              "requirement": "Required",
+              "setter": "setRating(@NonNull String)",
+              "getter": "getRating()"
+            },
+            "agencyName": {
+              "type": "@NonNull String",
+              "requirement": "Required",
+              "setter": "setAgencyName(@NonNull String)",
+              "getter": "getAgencyName()"
+            }
+          }
+        },
+        "PlatformSpecificUri": {
+          "package": "com.google.android.engage.common.datamodel.PlatformSpecificUri",
+          "fields": {
+            "platformType": {
+              "type": "@PlatformType int",
+              "requirement": "Required",
+              "setter": "setPlatformType(@PlatformType int)",
+              "getter": "getPlatformType()"
+            },
+            "actionUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setActionUri(Uri)",
+              "getter": "getActionUri()"
+            }
+          }
+        },
+        "SubscriptionEntitlement": {
+          "package": "com.google.android.engage.common.datamodel.SubscriptionEntitlement",
+          "fields": {
+            "entitlementId": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setEntitlementId(String)",
+              "getter": "getEntitlementId()"
+            },
+            "displayName": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setDisplayName(String)",
+              "getter": "getDisplayName()"
+            },
+            "expirationTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setExpirationTimeMillis(long)",
+              "getter": "getExpirationTimeMillis()"
+            }
+          }
+        },
+        "BundledSubscription": {
+          "package": "com.google.android.engage.common.datamodel.BundledSubscription",
+          "fields": {
+            "bundledSubscriptionProviderPackageName": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setBundledSubscriptionProviderPackageName(String)",
+              "getter": "getBundledSubscriptionProviderPackageName()"
+            },
+            "subscriptionType": {
+              "type": "@SubscriptionType int",
+              "requirement": "Optional",
+              "setter": "setSubscriptionType(@SubscriptionType int)",
+              "getter": "getSubscriptionType()"
+            },
+            "expirationTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setExpirationTimeMillis(long)",
+              "getter": "getExpirationTimeMillis()"
+            },
+            "entitlements": {
+              "type": "List<SubscriptionEntitlement>",
+              "requirement": "Optional",
+              "adder": "addEntitlement(SubscriptionEntitlement)",
+              "getter": "getEntitlements()",
+              "adderAll": "addEntitlements(List<SubscriptionEntitlement>)"
+            }
+          }
+        }
+      },
+      "methods": {
+        "isServiceAvailable": null,
+        "publishRecommendationClusters": "PublishRecommendationClustersRequest",
+        "publishFeaturedCluster": "PublishFeaturedClusterRequest",
+        "publishContinuationCluster": "PublishContinuationClusterRequest",
+        "publishSubscription": "PublishSubscriptionRequest",
+        "publishUserAccountManagementRequest": "PublishUserAccountManagementRequest",
+        "updatePublishStatus": "PublishStatusRequest",
+        "deleteRecommendationsClusters": "DeleteClustersRequest",
+        "deleteFeaturedCluster": "DeleteClustersRequest",
+        "deleteContinuationCluster": "DeleteClustersRequest",
+        "deleteSubscription": "DeleteClustersRequest",
+        "deleteUserManagementCluster": "DeleteClustersRequest"
+      },
+      "intents": {}
+    }

--- a/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/watch.md
+++ b/platforms/android/.agents/skills/engage-sdk-integration/references/schemas/watch.md
@@ -1,0 +1,1137 @@
+This file defines the schema for the WATCH vertical in the Engage SDK.
+
+    {
+      "client": "com.google.android.engage.service.AppEngagePublishClient",
+      "clusterTypes": [
+        "TYPE_RECOMMENDATION",
+        "TYPE_FEATURED",
+        "TYPE_CONTINUATION"
+      ],
+      "entities": {
+        "MovieEntity": {
+          "package": "com.google.android.engage.video.datamodel.MovieEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "watchNextType": {
+              "type": "@WatchNextType int",
+              "requirement": "Optional",
+              "setter": "setWatchNextType(@WatchNextType int)",
+              "getter": "getWatchNextType()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "lastPlayBackPositionTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastPlayBackPositionTimeMillis(long)",
+              "getter": "getLastPlayBackPositionTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "availabilityTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addAvailabilityTimeWindow(DisplayTimeWindow)",
+              "getter": "getAvailabilityTimeWindows()"
+            },
+            "allAvailabilityTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllAvailabilityTimeWindows(DisplayTimeWindow)",
+              "adderAll": "addAllAvailabilityTimeWindows(List<DisplayTimeWindow>)"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "releaseDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setReleaseDateEpochMillis(long)",
+              "getter": "getReleaseDateEpochMillis()"
+            },
+            "availability": {
+              "type": "@ContentAvailability int",
+              "requirement": "Required",
+              "setter": "setAvailability(@ContentAvailability int)",
+              "getter": "getAvailability()"
+            },
+            "durationMillis": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setDurationMillis(long)",
+              "getter": "getDurationMillis()"
+            },
+            "genres": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addGenre(String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "contentRatings": {
+              "type": "List<String>",
+              "requirement": "Required",
+              "adder": "addContentRating(RatingSystem)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<RatingSystem>)"
+            },
+            "contentRatingsLegacies": {
+              "type": "List<List<String>>",
+              "requirement": "Required",
+              "adder": "addContentRatingsLegacy(String)",
+              "getter": "getContentRatingsLegacy()",
+              "adderAll": "addContentRatingsLegacy(List<String>)"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<PlatformSpecificUri>",
+              "requirement": "Optional",
+              "adder": "addPlatformSpecificPlaybackUri(PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "recommendationReason": {
+              "type": "@NonNull RecommendationReason",
+              "requirement": "Optional",
+              "setter": "setRecommendationReason(@NonNull RecommendationReason)",
+              "getter": "getRecommendationReason()"
+            },
+            "description": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setDescription(@NonNull String)",
+              "getter": "getDescription()"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "TvShowEntity": {
+          "package": "com.google.android.engage.video.datamodel.TvShowEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "watchNextType": {
+              "type": "@WatchNextType int",
+              "requirement": "Optional",
+              "setter": "setWatchNextType(@WatchNextType int)",
+              "getter": "getWatchNextType()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "lastPlayBackPositionTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastPlayBackPositionTimeMillis(long)",
+              "getter": "getLastPlayBackPositionTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "availabilityTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addAvailabilityTimeWindow(DisplayTimeWindow)",
+              "getter": "getAvailabilityTimeWindows()"
+            },
+            "allAvailabilityTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllAvailabilityTimeWindows(DisplayTimeWindow)",
+              "adderAll": "addAllAvailabilityTimeWindows(List<DisplayTimeWindow>)"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "firstEpisodeAirDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setFirstEpisodeAirDateEpochMillis(long)",
+              "getter": "getFirstEpisodeAirDateEpochMillis()"
+            },
+            "latestEpisodeAirDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLatestEpisodeAirDateEpochMillis(long)",
+              "getter": "getLatestEpisodeAirDateEpochMillis()"
+            },
+            "availability": {
+              "type": "@ContentAvailability int",
+              "requirement": "Required",
+              "setter": "setAvailability(@ContentAvailability int)",
+              "getter": "getAvailability()"
+            },
+            "seasonCount": {
+              "type": "Integer",
+              "requirement": "Required",
+              "setter": "setSeasonCount(int)",
+              "getter": "getSeasonCount()"
+            },
+            "genres": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addGenre(String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "contentRatings": {
+              "type": "List<String>",
+              "requirement": "Required",
+              "adder": "addContentRating(RatingSystem)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<RatingSystem>)"
+            },
+            "contentRatingsLegacies": {
+              "type": "List<List<String>>",
+              "requirement": "Required",
+              "adder": "addContentRatingsLegacy(String)",
+              "getter": "getContentRatingsLegacy()",
+              "adderAll": "addContentRatingsLegacy(List<String>)"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<PlatformSpecificUri>",
+              "requirement": "Required",
+              "adder": "addPlatformSpecificPlaybackUri(PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "recommendationReason": {
+              "type": "@NonNull RecommendationReason",
+              "requirement": "Optional",
+              "setter": "setRecommendationReason(@NonNull RecommendationReason)",
+              "getter": "getRecommendationReason()"
+            },
+            "description": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setDescription(@NonNull String)",
+              "getter": "getDescription()"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "TvSeasonEntity": {
+          "package": "com.google.android.engage.video.datamodel.TvSeasonEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "watchNextType": {
+              "type": "@WatchNextType int",
+              "requirement": "Optional",
+              "setter": "setWatchNextType(@WatchNextType int)",
+              "getter": "getWatchNextType()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "lastPlayBackPositionTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastPlayBackPositionTimeMillis(long)",
+              "getter": "getLastPlayBackPositionTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "availabilityTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addAvailabilityTimeWindow(DisplayTimeWindow)",
+              "getter": "getAvailabilityTimeWindows()"
+            },
+            "allAvailabilityTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllAvailabilityTimeWindows(DisplayTimeWindow)",
+              "adderAll": "addAllAvailabilityTimeWindows(List<DisplayTimeWindow>)"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "seasonNumber": {
+              "type": "Integer",
+              "requirement": "Required",
+              "setter": "setSeasonNumber(int)"
+            },
+            "seasonDisplayNumber": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setSeasonDisplayNumber(String)",
+              "getter": "getSeasonDisplayNumber()"
+            },
+            "firstEpisodeAirDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setFirstEpisodeAirDateEpochMillis(long)",
+              "getter": "getFirstEpisodeAirDateEpochMillis()"
+            },
+            "latestEpisodeAirDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLatestEpisodeAirDateEpochMillis(long)",
+              "getter": "getLatestEpisodeAirDateEpochMillis()"
+            },
+            "availability": {
+              "type": "@ContentAvailability int",
+              "requirement": "Required",
+              "setter": "setAvailability(@ContentAvailability int)",
+              "getter": "getAvailability()"
+            },
+            "episodeCount": {
+              "type": "Integer",
+              "requirement": "Required",
+              "setter": "setEpisodeCount(int)",
+              "getter": "getEpisodeCount()"
+            },
+            "genres": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addGenre(String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "contentRatings": {
+              "type": "List<String>",
+              "requirement": "Required",
+              "adder": "addContentRating(RatingSystem)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<RatingSystem>)"
+            },
+            "contentRatingsLegacies": {
+              "type": "List<List<String>>",
+              "requirement": "Required",
+              "adder": "addContentRatingsLegacy(String)",
+              "getter": "getContentRatingsLegacy()",
+              "adderAll": "addContentRatingsLegacy(List<String>)"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()"
+            }
+          }
+        },
+        "TvEpisodeEntity": {
+          "package": "com.google.android.engage.video.datamodel.TvEpisodeEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "watchNextType": {
+              "type": "@WatchNextType int",
+              "requirement": "Optional",
+              "setter": "setWatchNextType(@WatchNextType int)",
+              "getter": "getWatchNextType()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "lastPlayBackPositionTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastPlayBackPositionTimeMillis(long)",
+              "getter": "getLastPlayBackPositionTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "availabilityTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addAvailabilityTimeWindow(DisplayTimeWindow)",
+              "getter": "getAvailabilityTimeWindows()"
+            },
+            "allAvailabilityTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllAvailabilityTimeWindows(DisplayTimeWindow)",
+              "adderAll": "addAllAvailabilityTimeWindows(List<DisplayTimeWindow>)"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "infoPageUri": {
+              "type": "Uri",
+              "requirement": "Optional",
+              "setter": "setInfoPageUri(Uri)",
+              "getter": "getInfoPageUri()"
+            },
+            "episodeNumber": {
+              "type": "Integer",
+              "requirement": "Required",
+              "setter": "setEpisodeNumber(int)"
+            },
+            "episodeDisplayNumber": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setEpisodeDisplayNumber(String)",
+              "getter": "getEpisodeDisplayNumber()"
+            },
+            "airDateEpochMillis": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setAirDateEpochMillis(long)",
+              "getter": "getAirDateEpochMillis()"
+            },
+            "availability": {
+              "type": "@ContentAvailability int",
+              "requirement": "Required",
+              "setter": "setAvailability(@ContentAvailability int)",
+              "getter": "getAvailability()"
+            },
+            "genres": {
+              "type": "List<String>",
+              "requirement": "Optional",
+              "adder": "addGenre(String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "contentRatings": {
+              "type": "List<String>",
+              "requirement": "Required",
+              "adder": "addContentRating(RatingSystem)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<RatingSystem>)"
+            },
+            "contentRatingsLegacies": {
+              "type": "List<List<String>>",
+              "requirement": "Required",
+              "adder": "addContentRatingsLegacy(String)",
+              "getter": "getContentRatingsLegacy()",
+              "adderAll": "addContentRatingsLegacy(List<String>)"
+            },
+            "durationMillis": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setDurationMillis(long)",
+              "getter": "getDurationMillis()"
+            },
+            "seasonNumber": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setSeasonNumber(String)",
+              "getter": "getSeasonNumber()"
+            },
+            "seasonTitle": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setSeasonTitle(String)",
+              "getter": "getSeasonTitle()"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "price": {
+              "type": "Price",
+              "requirement": "Optional",
+              "setter": "setPrice(Price)",
+              "getter": "getPrice()"
+            },
+            "showTitle": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setShowTitle(String)",
+              "getter": "getShowTitle()"
+            },
+            "isNextEpisodeAvailable": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setIsNextEpisodeAvailable(boolean)",
+              "getter": "getIsNextEpisodeAvailable()"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<PlatformSpecificUri>",
+              "requirement": "Optional",
+              "adder": "addPlatformSpecificPlaybackUri(PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "MediaActionFeedEntity": {
+          "package": "com.google.android.engage.video.datamodel.MediaActionFeedEntity",
+          "fields": {
+            "dataFeedElementId": {
+              "type": "@NonNull String",
+              "requirement": "Required",
+              "setter": "setDataFeedElementId(@NonNull String)",
+              "getter": "getDataFeedElementId()"
+            },
+            "name": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setName(@NonNull String)",
+              "getter": "getName()"
+            },
+            "recommendationReason": {
+              "type": "@NonNull RecommendationReason",
+              "requirement": "Optional",
+              "setter": "setRecommendationReason(@NonNull RecommendationReason)",
+              "getter": "getRecommendationReason()"
+            },
+            "description": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setDescription(@NonNull String)",
+              "getter": "getDescription()"
+            },
+            "posterImages": {
+              "type": "List<List<Image>>",
+              "requirement": "Optional",
+              "adder": "addPosterImage(@NonNull Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "LiveTvProgramEntity": {
+          "package": "com.google.android.engage.video.datamodel.LiveTvProgramEntity",
+          "fields": {
+            "channelId": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setChannelId(@NonNull String)",
+              "getter": "getChannelId()"
+            },
+            "channelName": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setChannelName(@NonNull String)",
+              "getter": "getChannelName()"
+            },
+            "channelLogoImage": {
+              "type": "@NonNull Image",
+              "requirement": "Optional",
+              "setter": "setChannelLogoImage(@NonNull Image)",
+              "getter": "getChannelLogoImage()"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<@NonNull PlatformSpecificUri>",
+              "requirement": "Optional",
+              "adder": "addPlatformSpecificPlaybackUri(@NonNull PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "contentRatings": {
+              "type": "List<@NonNull RatingSystem>",
+              "requirement": "Optional",
+              "adder": "addContentRating(@NonNull RatingSystem)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<RatingSystem>)"
+            },
+            "genres": {
+              "type": "List<@NonNull String>",
+              "requirement": "Optional",
+              "adder": "addGenre(@NonNull String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "availabilityTimeWindows": {
+              "type": "List<@NonNull DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addAvailabilityTimeWindow(@NonNull DisplayTimeWindow)",
+              "getter": "getAvailabilityTimeWindows()",
+              "adderAll": "addAvailabilityTimeWindows(List<DisplayTimeWindow>)"
+            },
+            "posterImages": {
+              "type": "List<@NonNull Image>",
+              "requirement": "Optional",
+              "adder": "addPosterImage(@NonNull Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "recommendationReason": {
+              "type": "@NonNull RecommendationReason",
+              "requirement": "Optional",
+              "setter": "setRecommendationReason(@NonNull RecommendationReason)",
+              "getter": "getRecommendationReason()"
+            },
+            "description": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setDescription(@NonNull String)",
+              "getter": "getDescription()"
+            },
+            "entityId": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setEntityId(@NonNull String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setName(@NonNull String)",
+              "getter": "getName()"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "LiveStreamingVideoEntity": {
+          "package": "com.google.android.engage.video.datamodel.LiveStreamingVideoEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "watchNextType": {
+              "type": "@WatchNextType int",
+              "requirement": "Optional",
+              "setter": "setWatchNextType(@WatchNextType int)",
+              "getter": "getWatchNextType()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "lastPlayBackPositionTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastPlayBackPositionTimeMillis(long)",
+              "getter": "getLastPlayBackPositionTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "availabilityTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addAvailabilityTimeWindow(DisplayTimeWindow)",
+              "getter": "getAvailabilityTimeWindows()"
+            },
+            "allAvailabilityTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllAvailabilityTimeWindows(DisplayTimeWindow)",
+              "adderAll": "addAllAvailabilityTimeWindows(List<DisplayTimeWindow>)"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "startTimeEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setStartTimeEpochMillis(long)",
+              "getter": "getStartTimeEpochMillis()"
+            },
+            "endTimeEpochMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setEndTimeEpochMillis(long)",
+              "getter": "getEndTimeEpochMillis()"
+            },
+            "broadcaster": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setBroadcaster(String)",
+              "getter": "getBroadcaster()"
+            },
+            "viewCount": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setViewCount(String)",
+              "getter": "getViewCount()"
+            },
+            "broadcasterIcon": {
+              "type": "Image",
+              "requirement": "Optional",
+              "setter": "setBroadcasterIcon(Image)",
+              "getter": "getBroadcasterIcon()"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<PlatformSpecificUri>",
+              "requirement": "Optional",
+              "adder": "addPlatformSpecificPlaybackUri(PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "description": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setDescription(@NonNull String)",
+              "getter": "getDescription()"
+            },
+            "genres": {
+              "type": "List<@NonNull String>",
+              "requirement": "Optional",
+              "adder": "addGenre(@NonNull String)",
+              "getter": "getGenres()",
+              "adderAll": "addGenres(List<String>)"
+            },
+            "contentRatings": {
+              "type": "List<@NonNull RatingSystem>",
+              "requirement": "Optional",
+              "adder": "addContentRating(@NonNull RatingSystem)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<RatingSystem>)"
+            },
+            "recommendationReason": {
+              "type": "@NonNull RecommendationReason",
+              "requirement": "Optional",
+              "setter": "setRecommendationReason(@NonNull RecommendationReason)",
+              "getter": "getRecommendationReason()"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "LiveTvChannelEntity": {
+          "package": "com.google.android.engage.video.datamodel.LiveTvChannelEntity",
+          "fields": {
+            "entityId": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setEntityId(@NonNull String)",
+              "getter": "getEntityId()"
+            },
+            "name": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setName(@NonNull String)",
+              "getter": "getName()"
+            },
+            "description": {
+              "type": "@NonNull String",
+              "requirement": "Optional",
+              "setter": "setDescription(@NonNull String)",
+              "getter": "getDescription()"
+            },
+            "logoImage": {
+              "type": "@NonNull Image",
+              "requirement": "Optional",
+              "setter": "setLogoImage(@NonNull Image)",
+              "getter": "getLogoImage()"
+            },
+            "contentRatings": {
+              "type": "List<@NonNull RatingSystem>",
+              "requirement": "Optional",
+              "adder": "addContentRating(@NonNull RatingSystem)",
+              "getter": "getContentRatings()",
+              "adderAll": "addContentRatings(List<RatingSystem>)"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<@NonNull PlatformSpecificUri>",
+              "requirement": "Optional",
+              "adder": "addPlatformSpecificPlaybackUri(@NonNull PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "recommendationReason": {
+              "type": "@NonNull RecommendationReason",
+              "requirement": "Optional",
+              "setter": "setRecommendationReason(@NonNull RecommendationReason)",
+              "getter": "getRecommendationReason()"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        },
+        "VideoClipEntity": {
+          "package": "com.google.android.engage.video.datamodel.VideoClipEntity",
+          "fields": {
+            "entityId": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setEntityId(String)",
+              "getter": "getEntityId()"
+            },
+            "posterImages": {
+              "type": "List<Image>",
+              "requirement": "Required",
+              "adder": "addPosterImage(Image)",
+              "getter": "getPosterImages()",
+              "adderAll": "addPosterImages(List<Image>)"
+            },
+            "name": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setName(String)",
+              "getter": "getName()"
+            },
+            "lastEngagementTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastEngagementTimeMillis(long)",
+              "getter": "getLastEngagementTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "watchNextType": {
+              "type": "@WatchNextType int",
+              "requirement": "Optional",
+              "setter": "setWatchNextType(@WatchNextType int)",
+              "getter": "getWatchNextType()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "lastPlayBackPositionTimeMillis": {
+              "type": "Long",
+              "requirement": "Optional",
+              "setter": "setLastPlayBackPositionTimeMillis(long)",
+              "getter": "getLastPlayBackPositionTimeMillis()",
+              "requiredFor": [
+                "ContinuationCluster"
+              ]
+            },
+            "availabilityTimeWindows": {
+              "type": "List<DisplayTimeWindow>",
+              "requirement": "Optional",
+              "adder": "addAvailabilityTimeWindow(DisplayTimeWindow)",
+              "getter": "getAvailabilityTimeWindows()"
+            },
+            "allAvailabilityTimeWindows": {
+              "type": "List<List<DisplayTimeWindow>>",
+              "requirement": "Optional",
+              "adder": "addAllAvailabilityTimeWindows(DisplayTimeWindow)",
+              "adderAll": "addAllAvailabilityTimeWindows(List<DisplayTimeWindow>)"
+            },
+            "playBackUri": {
+              "type": "Uri",
+              "requirement": "Required",
+              "setter": "setPlayBackUri(Uri)",
+              "getter": "getPlayBackUri()"
+            },
+            "createdTimeEpochMillis": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setCreatedTimeEpochMillis(long)",
+              "getter": "getCreatedTimeEpochMillis()"
+            },
+            "durationMillis": {
+              "type": "Long",
+              "requirement": "Required",
+              "setter": "setDurationMillis(long)",
+              "getter": "getDurationMillis()"
+            },
+            "creator": {
+              "type": "String",
+              "requirement": "Required",
+              "setter": "setCreator(String)",
+              "getter": "getCreator()"
+            },
+            "creatorImage": {
+              "type": "Image",
+              "requirement": "Optional",
+              "setter": "setCreatorImage(Image)",
+              "getter": "getCreatorImage()"
+            },
+            "viewCount": {
+              "type": "String",
+              "requirement": "Optional",
+              "setter": "setViewCount(String)",
+              "getter": "getViewCount()"
+            },
+            "downloadedOnDevice": {
+              "type": "Boolean",
+              "requirement": "Optional",
+              "setter": "setDownloadedOnDevice(boolean)",
+              "getter": "isDownloadedOnDevice()"
+            },
+            "platformSpecificPlaybackUris": {
+              "type": "List<PlatformSpecificUri>",
+              "requirement": "Optional",
+              "adder": "addPlatformSpecificPlaybackUri(PlatformSpecificUri)",
+              "getter": "getPlatformSpecificPlaybackUris()",
+              "adderAll": "addPlatformSpecificPlaybackUris(List<PlatformSpecificUri>)"
+            },
+            "callToActionText": {
+              "requirement": "Optional",
+              "setter": "setCallToActionText(@NonNull String)",
+              "type": "@NonNull String",
+              "getter": "getCallToActionText()"
+            },
+            "tags": {
+              "requirement": "Optional",
+              "adder": "addTag(@NonNull String)",
+              "type": "List<@NonNull String>",
+              "adderAll": "addTags(List<String>)",
+              "getter": "getTags()"
+            }
+          }
+        }
+      },
+      "methods": {
+        "isServiceAvailable": null,
+        "publishRecommendationClusters": "PublishRecommendationClustersRequest",
+        "publishFeaturedCluster": "PublishFeaturedClusterRequest",
+        "publishContinuationCluster": "PublishContinuationClusterRequest",
+        "publishSubscription": "PublishSubscriptionRequest",
+        "publishUserAccountManagementRequest": "PublishUserAccountManagementRequest",
+        "updatePublishStatus": "PublishStatusRequest",
+        "deleteRecommendationsClusters": "DeleteClustersRequest",
+        "deleteFeaturedCluster": "DeleteClustersRequest",
+        "deleteContinuationCluster": "DeleteClustersRequest",
+        "deleteSubscription": "DeleteClustersRequest",
+        "deleteUserManagementCluster": "DeleteClustersRequest"
+      },
+      "intents": {}
+    }

--- a/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/SKILL.md
+++ b/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: migrate-xml-views-to-jetpack-compose
+description: Provides a structured workflow for migrating an Android XML View to Jetpack
+  Compose. This skill details the step-by-step process, from planning and dependency
+  setup, to theming and layout migration, validation and XML cleanup. Use this skill
+  when you need to migrate an XML View to Jetpack Compose in an Android project. It
+  solves the problem of converting the UI of a legacy XML View into modern, declarative
+  Compose components while maintaining interoperability.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-07-02'
+  keywords:
+  - Jetpack Compose
+  - migration
+  - XML
+  - Views
+  - interoperability
+  - incremental adoption
+  - UI development
+---
+
+This skill guides through the process of migrating an existing Android XML View
+to Jetpack Compose. It performs a stable, safe and visually consistent
+transition by following a structured, 10-step methodology. This skill migrates
+UI (XML to Jetpack Compose) only.
+
+## Objective
+
+To systematically convert a single legacy XML layout into modern, declarative
+Jetpack Compose UI while maintaining pixel-perfect visual parity and functional
+integrity.
+
+## Summary of the 10-step migration process
+
+1. **Identify the optimal XML candidate for migration**
+2. **Analyze the project and layout**
+3. **Create a plan**
+4. **Capture the XML View UI**
+5. **Set up Compose dependencies and compiler**
+6. **Set up Compose theming**
+7. **Migrate the XML layout to Compose**
+8. **Validate the migration**
+9. **Replace usages**
+10. **XML code removal**
+
+## Detailed steps
+
+### Step 1: Identify the optimal XML candidate for migration
+
+If the user has explicitly specified a target XML layout, proceed to Step 2.
+Otherwise, analyze the codebase to identify the best candidate for migration by
+following the logic in [references/identify-optimal-xml-candidate.md](references/identify-optimal-xml-candidate.md).
+
+### Step 2: Analyze the project and layout
+
+Analyze the identified XML View's structure, hierarchy, and implementation
+details.
+Use [references/analysis-of-the-project-and-layout.md](references/analysis-of-the-project-and-layout.md) to
+guide your technical audit of the layout and surrounding project context.
+
+### Step 3: Create a plan
+
+Using the outputs and analysis done in the Step 1 and 2, generate a
+step-by-step plan for the migration. If you support user interaction, present
+to the user and ask for approval before proceeding. If user interaction is not
+supported, proceed to Step 4 following the generated plan.
+
+### Step 4: Capture the XML View UI
+
+**IF** you support user interaction, ask the user to upload a screenshot of the
+XML View UI or provide an absolute path to a file. Use this image as a visual
+reference for the layout migration in Step 7.
+**ELSE IF** you are able to run an Android emulator, locate an existing
+screenshot test for the XML candidate. If none exists, create one using the
+existing project testing framework. If no framework exists,
+use **UI Automator** or **Espresso** to create a screenshot test with minimum
+required setup. Run the test and take a baseline screenshot of the XML UI.
+**ELSE** proceed to Step 5.
+
+### Step 5: Set up Compose dependencies and compiler
+
+Check `build.gradle` or `libs.versions.toml` for Compose dependencies and
+compiler setup. If missing, use
+[Setup Compose Dependencies and Compiler](references/android/develop/ui/compose/setup-compose-dependencies-and-compiler.md).
+Run a sync to ensure dependencies resolve without errors.
+
+### Step 6: Set up Compose theming
+
+If the project already has Compose theming set up, proceed to Step 7. If Compose
+theming is missing, initialize it. For Material-based projects, follow
+[Material 3 migration guidelines](references/android/develop/ui/compose/designsystems/migrate-xml-theme-to-compose.md).
+For custom design systems, apply expert judgment to migrate XML theming and
+match existing styles.
+**Constraints:** Do not migrate the entire theme. Implement only the minimum
+theming required for the specific XML candidate. Maintain original XML themes
+for interoperability. Maintain existing project code conventions, patterns,
+names and values.
+
+### Step 7: Migrate the XML View to Compose
+
+Convert the XML candidate to Jetpack Compose code, referencing
+[references/xml-layout-migration.md](references/xml-layout-migration.md) and the image from Step 4.
+You must include a **Compose Preview** for the newly created composable to
+facilitate visual verification.
+
+### Step 8: Replace usages
+
+Replace the usages of the migrated XML layout to use the new Compose component.
+
+- To add Compose in Views, use [Compose in Views](references/android/develop/ui/compose/migrate/interoperability-apis/compose-in-views.md).
+- To add Views in Compose, use [Views in Compose](references/android/develop/ui/compose/migrate/interoperability-apis/views-in-compose.md).
+
+### Step 9: Validate the migration
+
+Compare the baseline screenshot image from Step 4 with the rendered Compose
+Preview of the new composable. Ignore string content; focus on layout and
+styling. Iterate on the Compose code until visual parity is achieved. Once
+verified, write a Compose UI test for the new composable.
+
+### Step 10: XML code removal
+
+Delete the migrated XML file and its associated legacy tests. **Caution:** Only
+remove code and resources that are not referenced by other parts of the project.

--- a/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/references/analysis-of-the-project-and-layout.md
+++ b/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/references/analysis-of-the-project-and-layout.md
@@ -1,0 +1,42 @@
+## 1. Project health \& build validation
+
+Before performing any analysis, you must confirm the project is in a functional state.
+\* **Integrity check:** Verify the project syncs (Gradle) and builds successfully.
+\* **Error resolution:** If there are pre-existing build errors or sync failures, you must report these immediately and attempt to fix. **Do not proceed** with migration until a stable baseline is established.
+
+## 2. Compose pattern \& consistency analysis
+
+If Jetpack Compose is already present, you must align with the established implementation style.
+\* **Pattern identification:** Scan the codebase for `@Composable` functions. Identify the project's "Best Practices" regarding state hoisting, composable construction and naming conventions, and file organization.
+\* **Theming review:** Determine how `MaterialTheme` or custom theme systems are implemented.
+\* Identify if the project uses a custom design system theme.
+\* Map how attributes, styles, and other theme components are accessed in Compose.
+
+## 3. Design system \& infrastructure audit
+
+Understand the design system classification (e.g. Material 2, Material 3, or custom design system).
+\* **Resource mapping:** Locate central XML definitions:
+\* `colors.xml` (Light/Dark variants)
+\* `dimens.xml`
+\* `styles.xml` / `themes.xml`
+\* **Hybrid analysis:** Determine if the project is **XML-only** , **Compose-only** , or **Hybrid** .
+\* **Reuse constraint:** If a Compose theming layer (e.g., `AppTheme.kt`) already exists, **DO NOT** generate a new one. You must reuse the existing infrastructure and contribute to it by following its existing implementation pattern.
+
+## 4. Candidate layout decomposition
+
+Analyze the specific XML layout targeted for migration. You must extract and document the following requirements for the new composable:
+\* **Inputs:** UI State objects, primitive parameters, and click listeners.
+\* **Styling:** Specific color constants, typography styles, and shape definitions referenced in the XML.
+\* **Resources:** Identifying string resources, drawables, and dimensions.
+\* **Layout logic:** Modifiers required to replicate the XML constraints (padding, alignment, weight).
+
+## 5. Architectural \& non-UI analysis
+
+Understand the environment in which the UI resides to ensure proper integration.
+\* **State management:** Identify the usage of `ViewModel`, `Flow`, or `LiveData`.
+\* **Dependency Injection:** Check for Hilt, Koin, or manual DI to understand how dependencies are provided to the UI layer.
+\* **Testing \& architecture:** Note the architectural pattern (MVI, MVVM, or custom architecture setup.) and existing UI testing frameworks to ensure the migrated code remains testable. Unless the user explicitly requests, **DO NOT** make any changes to any non-UI code that aren't strictly required for the migration of the XML View.
+
+*** ** * ** ***
+
+> **Pro-tip:** Always prioritize the "Existing infrastructure" over "Default templates." If the project has a custom way of handling spacing or colors, composable code, or any other project layer, your generated Compose code must reflect that specific implementation.

--- a/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/references/android/develop/ui/compose/designsystems/migrate-xml-theme-to-compose.md
+++ b/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/references/android/develop/ui/compose/designsystems/migrate-xml-theme-to-compose.md
@@ -1,0 +1,171 @@
+When you introduce Compose in an existing app, you need to migrate your Material
+XML themes to use `MaterialTheme` for Compose components. This means your app's
+theming will have two sources of truth: the View-based theme and the Compose
+theme. Any changes to your styling need to be made in multiple places. Once
+your app is fully migrated to Compose, remove your XML theming.
+
+You can use the [Material Theme Builder](https://m3.material.io/theme-builder)
+tool for migrating colors.
+
+When you start the migration from XML to Compose, migrate the theming to
+Material 3 Compose theming.
+
+## Glossary
+
+| Term | Definition |
+|---|---|
+| `MaterialTheme` | The composable function that provides theming (colors, typography, shapes) to Compose UI components. |
+| `Shapes` | A Compose object used to define custom component shapes for a `MaterialTheme`. |
+| `Typography` | A Compose object used to define custom text styles (font families, sizes, weights) for a `MaterialTheme`. |
+| `ColorScheme` | A Compose object used to define custom color schemes for `MaterialTheme`. |
+| XML Theme | The Android theming system defined in XML files, used by the View system. |
+
+## Limitations
+
+Before migrating, be aware of the following limitations:
+
+- This guide focuses on migrating to Material 3 only. For migrating from alternative design systems, see [Material 2](https://developer.android.com/develop/ui/compose/designsystems/material) or [Custom design systems in Compose](https://developer.android.com/develop/ui/compose/designsystems/custom).
+- The ultimate goal is a complete migration to Compose, which allows for the removal of XML theming. This guide explains how to migrate, but it doesn't explain how to finally remove XML theming.
+
+## Step 1: Evaluate the design system
+
+Identify which design system is used in the XML View project.
+Analyze the migration path and necessary steps to migrate the existing design
+system to Material 3 in Compose.
+
+## Step 2: Identify theme source files
+
+In XML you write `?attr/colorPrimary`. In Compose, you access theme values
+with `MaterialTheme.*`:
+
+Identify and locate all XML resources and files necessary for theming:
+light and dark color schemes and qualifiers, themes, shapes, dimensions,
+typography, styles and other relevant files.
+
+Resources such as strings can be reused as is and don't need to be migrated.
+
+## Step 3: Migrate colors
+
+**Key principle:** XML uses named hex colors.
+Material 3 uses *semantic roles* (e.g., `primary`, `onPrimary`, `surface`).
+Stop naming colors by their hex; name them by their role.
+
+Examples:
+
+| XML color name | Material 3 role |
+|---|---|
+| `colorPrimary` | `primary` |
+| `colorPrimaryDark` / `colorPrimaryVariant` | `primaryContainer` or `secondary` |
+| `colorAccent` | `secondary` or `tertiary` |
+| `colorOnPrimary` | `onPrimary` |
+| `android:colorBackground` | `background` |
+| `colorSurface` | `surface` |
+| `colorOnSurface` | `onSurface` |
+| `colorError` | `error` |
+| `colorOnError` | `onError` |
+| `colorOutline` | `outline` |
+| `colorSurfaceVariant` | `surfaceVariant` |
+| `colorOnSurfaceVariant` | `onSurfaceVariant` |
+
+*** ** * ** ***
+
+Migrate the dark and light color schemes from XML to their equivalents in
+Material 3 Compose.
+
+> [!NOTE]
+> **Note:** Material 3 naming differs from Material 2 color naming.
+
+## Step 4: Migrate custom shapes and typography
+
+- If your app uses custom shapes:
+
+  1. In your Compose code, define a `Shapes` object to replicate your XML shape definitions.
+  2. Provide this `Shapes` object to your `MaterialTheme`.
+
+     For more details, see [shapes](https://developer.android.com/develop/ui/compose/designsystems/material3#shapes).
+- If your app uses custom typography:
+
+  1. In your Compose code, define a `Typography` object in your Compose code to replicate your XML text styles and font definitions.
+  2. Provide this `Typography` object to your `MaterialTheme`.
+
+     For more details, see [typography](https://developer.android.com/develop/ui/compose/designsystems/material3#typography).
+
+| Compose role | XML name |
+|---|---|
+| `displayLarge` | `TextAppearance.Material3.DisplayLarge` |
+| `displayMedium` | `TextAppearance.Material3.DisplayMedium` |
+| `displaySmall` | `TextAppearance.Material3.DisplaySmall` |
+| `headlineLarge` | `TextAppearance.Material3.HeadlineLarge` |
+| `headlineMedium` | `TextAppearance.Material3.HeadlineMedium` |
+| `headlineSmall` | `TextAppearance.Material3.HeadlineSmall` |
+| `titleLarge` | `TextAppearance.Material3.TitleLarge` |
+| `titleMedium` | `TextAppearance.Material3.TitleMedium` |
+| `titleSmall` | `TextAppearance.Material3.TitleSmall` |
+| `bodyLarge` | `TextAppearance.Material3.BodyLarge` |
+| `bodyMedium` | `TextAppearance.Material3.BodyMedium` |
+| `bodySmall` | `TextAppearance.Material3.BodySmall` |
+| `labelLarge` | `TextAppearance.Material3.LabelLarge` |
+| `labelMedium` | `TextAppearance.Material3.LabelMedium` |
+| `labelSmall` | `TextAppearance.Material3.LabelSmall` |
+
+## Step 5: Migrate styles (styles.xml)
+
+XML styles (styles.xml) system defines styles and appearance of:
+
+1. Widgets, components, themes for windows and dialogs
+2. Typography
+3. Themes and overlays
+4. Shapes
+
+XML Views and components combine multiple attributes to create a style.
+They set their styles from styles.xml in two different ways:
+
+1. Setting "style="@style/..." directly and explicitly in the XML View
+2. Setting the style indirectly and implicitly for a component as part of a larger Theme (theme.xml)
+
+Styles have no **direct** equivalent in Compose - instead styles are passed as:
+parameters or modifiers to composables, using the
+[new, experimental Styles API](https://developer.android.com/develop/ui/compose/styles) defined in the AppTheme, or by creating
+layered, reusable composable variations with the defined style.
+
+Provide separate @Composable functions named according to the style and the
+base component, to signify the difference in styling and use cases for those
+components.
+
+- **Pattern:** If an XML element uses a custom style (e.g., `style="@style/MyPrimaryButton"`), don't try to replicate the style inline. Instead, suggest creating a specific composable.
+- **Example:**
+  - *XML:* `<Button style="@style/MyPrimaryButton" ... />`
+  - *Compose:* `MyPrimaryButton(onClick = { ... })`
+- **Common Attribute Groups:** If a style sets common modifiers (like padding + height), extract them into a readable extension property or a shared Modifier variable.
+
+### Common examples
+
+| XML | Compose |
+|---|---|
+| `Theme.Material3.*` | `MaterialTheme(colorScheme, typography, shapes) { }` |
+| `TextAppearance.Material3.BodyMedium` | `TextStyle(...)` defined in `Typography(bodyMedium = ...)` |
+| `ShapeAppearance.*.SmallComponent` | `Shapes(small = RoundedCornerShape(X.dp))` |
+| `Widget.Material3.Button` | `Button(colors = ButtonDefaults.buttonColors(...))` |
+| `Widget.Material3.CardView` | `Card(shape=..., elevation=..., colors=...)` |
+| `Widget.*.TextInputLayout.OutlinedBox` | `OutlinedTextField(colors = OutlinedTextFieldDefaults.colors(...))` |
+| `Widget.*.Chip.Filter` | `FilterChip(colors = FilterChipDefaults.filterChipColors(...))` |
+| `Widget.*.Toolbar.Primary` | `TopAppBar(colors = TopAppBarDefaults.topAppBarColors(...))` |
+| `Widget.*.FloatingActionButton` | `FloatingActionButton(containerColor = ...)` |
+| `backgroundTint` | `containerColor` in `ComponentDefaults.ComponentColors()` |
+| `android:textColor` | `contentColor` in `ComponentDefaults.ComponentColors()` |
+| `cornerRadius` | `shape = RoundedCornerShape(X.dp)` |
+| `android:elevation` | `elevation = ComponentDefaults.elevation(defaultElevation = X.dp)` |
+| `android:padding` | `contentPadding = PaddingValues(...)` or `Modifier.padding()` |
+| `android:minHeight` | `Modifier.heightIn(min = X.dp)` |
+| `strokeColor` + `strokeWidth` | `border = BorderStroke(width, color)` |
+| `android:textSize` | `fontSize = X.sp` in `TextStyle` |
+
+## Step 6: Validate the theme migration
+
+Always use the existing theme values from the original XML theme as the source
+of truth for the new Material Theme in Compose.
+Never invent new theme values during migration, to maintain brand consistency
+and avoid visual regressions.
+
+Verify all new Compose theme values match the existing XML values.
+Don't hardcode any migrated values.

--- a/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/references/android/develop/ui/compose/migrate/interoperability-apis/compose-in-views.md
+++ b/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/references/android/develop/ui/compose/migrate/interoperability-apis/compose-in-views.md
@@ -1,0 +1,299 @@
+> [!NOTE]
+> **Note:** Interoperability is supported for hybrid apps that use Compose and Views. For apps that are only in Compose, use the recommended Compose-only architecture with a single Activity and latest navigation libraries, like Navigation 3.
+
+You can add Compose-based UI into an existing app that uses a View-based design.
+
+To create a new, entirely Compose-based screen, have your
+activity call the `setContent()` method, and pass whatever composable functions
+you like.
+
+
+```kotlin
+class ExampleActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent { // In here, we can call composables!
+            MaterialTheme {
+                Greeting(name = "compose")
+            }
+        }
+    }
+}
+
+@Composable
+fun Greeting(name: String) {
+    Text(text = "Hello $name!")
+}
+```
+
+<br />
+
+This code looks just like what you'd find in a Compose-only app.
+
+> [!CAUTION]
+> **Caution:** To use the `ComponentActivity.setContent`
+> method, add the `androidx.activity:activity-compose:$latestVersion`
+> dependency to your `build.gradle` file.
+>
+> See the [Activity releases page](https://developer.android.com/jetpack/androidx/releases/activity)
+> to find out the latest version.
+
+## `ViewCompositionStrategy` for `ComposeView`
+
+[`ViewCompositionStrategy`](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/ViewCompositionStrategy)
+defines when the Composition should be disposed. The default,
+[`ViewCompositionStrategy.Default`](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/ViewCompositionStrategy#Default()),
+disposes the Composition when the underlying
+[`ComposeView`](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/ComposeView)
+detaches from the window, unless it is part of a pooling container such as a
+`RecyclerView`. In a single-Activity Compose-only app, this default behavior is
+what you would want, however, if you are incrementally adding Compose in your
+codebase, this behavior may cause state loss in some scenarios.
+
+To change the `ViewCompositionStrategy`, call the [`setViewCompositionStrategy()`](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/AbstractComposeView#setViewCompositionStrategy(androidx.compose.ui.platform.ViewCompositionStrategy))
+method and provide a different strategy.
+
+The table below summarizes the different scenarios you can use
+`ViewCompositionStrategy` in:
+
+| `ViewCompositionStrategy` | Description and Interop Scenario |
+|---|---|
+| [`DisposeOnDetachedFromWindow`](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/ViewCompositionStrategy.DisposeOnDetachedFromWindow) | The Composition will be disposed when the underlying `ComposeView` is detached from the window. Has since been superseded by `DisposeOnDetachedFromWindowOrReleasedFromPool`. Interop scenario: \* `ComposeView` whether it's the sole element in the View hierarchy, or in the context of a mixed View/Compose screen (not in Fragment). |
+| [`DisposeOnDetachedFromWindowOrReleasedFromPool`](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool) (**Default**) | Similar to `DisposeOnDetachedFromWindow`, when the Composition is not in a pooling container, such as a `RecyclerView`. If it is in a pooling container, it will dispose when either the pooling container itself detaches from the window, or when the item is being discarded (i.e. when the pool is full). Interop scenario: \* `ComposeView` whether it's the sole element in the View hierarchy, or in the context of a mixed View/Compose screen (not in Fragment). \* `ComposeView` as an item in a pooling container such as `RecyclerView`. |
+| [`DisposeOnLifecycleDestroyed`](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/ViewCompositionStrategy.DisposeOnLifecycleDestroyed) | The Composition will be disposed when the provided [`Lifecycle`](https://developer.android.com/reference/androidx/lifecycle/Lifecycle) is destroyed. Interop scenario \* `ComposeView` in a Fragment's View. |
+| [`DisposeOnViewTreeLifecycleDestroyed`](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed) | The Composition will be disposed when the `Lifecycle` owned by the `LifecycleOwner` returned by `ViewTreeLifecycleOwner.get` of the next window the View is attached to is destroyed. Interop scenario: \* `ComposeView` in a Fragment's View. \* `ComposeView` in a View wherein the Lifecycle is not known yet. |
+
+## `ComposeView` in Fragments (Transitionary Step)
+
+> [!NOTE]
+> **Note:** For hybrid apps with Views and Compose, that use Fragments, use `ComposeView` to wrap composables content and add to a Fragment during migration. For Compose-only apps, do not use Fragments and instead use the recommended Compose-only architecture with a single Activity and latest navigation libraries, like Navigation 3.
+
+If you want to incorporate Compose UI content in a fragment or an existing View
+layout, use [`ComposeView`](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/ComposeView)
+and call its
+[`setContent()`](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/ComposeView#setContent(kotlin.Function0))
+method. `ComposeView` is an Android [`View`](https://developer.android.com/reference/android/view/View).
+
+You can put the `ComposeView` in your XML layout just like any other `View`:
+
+```xml
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+  <TextView
+      android:id="@+id/text"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content" />
+
+  <androidx.compose.ui.platform.ComposeView
+      android:id="@+id/compose_view"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent" />
+</LinearLayout>
+```
+
+In the Kotlin source code, inflate the layout from the [layout
+resource](https://developer.android.com/guide/topics/resources/layout-resource) defined in XML. Then get the
+`ComposeView` using the XML ID, set a Composition strategy that works best for
+the host `View`, and call `setContent()` to use Compose.
+
+
+```kotlin
+class ExampleFragmentXml : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val view = inflater.inflate(R.layout.fragment_example, container, false)
+        val composeView = view.findViewById<ComposeView>(R.id.compose_view)
+        composeView.apply {
+            // Dispose of the Composition when the view's LifecycleOwner
+            // is destroyed
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                // In Compose world
+                MaterialTheme {
+                    Text("Hello Compose!")
+                }
+            }
+        }
+        return view
+    }
+}
+```
+
+<br />
+
+Alternatively, you can also use view binding to obtain references to the
+`ComposeView` by referencing the generated binding class for your XML layout file:
+
+
+```kotlin
+class ExampleFragment : Fragment() {
+
+    private var _binding: FragmentExampleBinding? = null
+
+    // This property is only valid between onCreateView and onDestroyView.
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentExampleBinding.inflate(inflater, container, false)
+        val view = binding.root
+        binding.composeView.apply {
+            // Dispose of the Composition when the view's LifecycleOwner
+            // is destroyed
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                // In Compose world
+                MaterialTheme {
+                    Text("Hello Compose!")
+                }
+            }
+        }
+        return view
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}
+```
+
+<br />
+
+![Two slightly different text elements, one above the other](https://developer.android.com/static/develop/ui/compose/images/interop-hellos.png)
+
+**Figure 1.** This shows the output of the code that adds Compose elements in a
+View UI hierarchy. The "Hello Android!" text is displayed by a
+`TextView` widget. The "Hello Compose!" text is displayed by a
+Compose text element.
+
+You can also include a `ComposeView` directly in a fragment if your full screen
+is built with Compose, which lets you avoid using an XML layout file entirely.
+
+
+```kotlin
+class ExampleFragmentNoXml : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            // Dispose of the Composition when the view's LifecycleOwner
+            // is destroyed
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                MaterialTheme {
+                    // In Compose world
+                    Text("Hello Compose!")
+                }
+            }
+        }
+    }
+}
+```
+
+<br />
+
+## Multiple `ComposeView` instances in the same layout
+
+If there are multiple `ComposeView` elements in the same layout, each one must
+have a unique ID for `savedInstanceState` to work.
+
+
+```kotlin
+class ExampleFragmentMultipleComposeView : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View = LinearLayout(requireContext()).apply {
+        addView(
+            ComposeView(requireContext()).apply {
+                setViewCompositionStrategy(
+                    ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+                )
+                id = R.id.compose_view_x
+                // ...
+            }
+        )
+        addView(TextView(requireContext()))
+        addView(
+            ComposeView(requireContext()).apply {
+                setViewCompositionStrategy(
+                    ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+                )
+                id = R.id.compose_view_y
+                // ...
+            }
+        )
+    }
+}
+```
+
+<br />
+
+The `ComposeView` IDs are defined in the `res/values/ids.xml` file:
+
+```xml
+<resources>
+  <item name="compose_view_x" type="id" />
+  <item name="compose_view_y" type="id" />
+</resources>
+```
+
+## Preview composables in Layout Editor
+
+You can also preview composables within the Layout Editor for your XML layout
+containing a `ComposeView`. Doing so lets you see how your composables look
+within a mixed Views and Compose layout.
+
+Say you want to display the following composable in the Layout Editor. Note
+that composables annotated with `@Preview` are good candidates to preview in the
+Layout Editor.
+
+
+```kotlin
+@Preview
+@Composable
+fun GreetingPreview() {
+    Greeting(name = "Android")
+}
+```
+
+<br />
+
+To display this composable, use the `tools:composableName` tools attribute and
+set its value to the fully qualified name of the composable to preview in the
+layout.
+
+```xml
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+  <androidx.compose.ui.platform.ComposeView
+      android:id="@+id/my_compose_view"
+      tools:composableName="com.example.compose.snippets.interop.InteroperabilityAPIsSnippetsKt.GreetingPreview"
+      android:layout_height="match_parent"
+      android:layout_width="match_parent"/>
+
+</LinearLayout>
+```
+
+![Composable displayed within layout editor](https://developer.android.com/static/develop/ui/compose/images/layout-editor-composable-preview.png)

--- a/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/references/android/develop/ui/compose/migrate/interoperability-apis/views-in-compose.md
+++ b/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/references/android/develop/ui/compose/migrate/interoperability-apis/views-in-compose.md
@@ -1,0 +1,286 @@
+You can include an Android View hierarchy in a Compose UI. This approach is
+particularly useful if you want to use UI elements that are not yet available in
+Compose, like
+[`AdView`](https://developers.google.com/android/reference/com/google/android/gms/ads/AdView).
+This approach also lets you reuse custom views you may have designed.
+
+> [!NOTE]
+> **Note:** Use `AndroidView` as a wrapper only for missing SDK components without Compose support. Rewrite your custom Views in Compose wherever possible, starting the migration with the simplest custom Views and scaling to more complex ones.
+
+<br />
+
+To include a view element or hierarchy, use the [`AndroidView`](https://developer.android.com/reference/kotlin/androidx/compose/ui/viewinterop/AndroidView.composable#AndroidView(kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1))
+composable. `AndroidView` is passed a lambda that returns a
+[`View`](https://developer.android.com/reference/android/view/View). `AndroidView` also provides an `update`
+callback that is called when the view is inflated. The `AndroidView` recomposes
+whenever a `State` read within the callback changes. `AndroidView`, like many
+other built-in composables, takes a `Modifier` parameter that can be used, for
+example, to set its position in the parent composable.
+
+
+```kotlin
+@Composable
+fun CustomView() {
+    var selectedItem by remember { mutableIntStateOf(0) }
+
+    // Adds view to Compose
+    AndroidView(
+        modifier = Modifier.fillMaxSize(), // Occupy the max size in the Compose UI tree
+        factory = { context ->
+            // Creates view
+            MyView(context).apply {
+                // Sets up listeners for View -> Compose communication
+                setOnClickListener {
+                    selectedItem = 1
+                }
+            }
+        },
+        update = { view ->
+            // View's been inflated or state read in this block has been updated
+            // Add logic here if necessary
+
+            // As selectedItem is read here, AndroidView will recompose
+            // whenever the state changes
+            // Example of Compose -> View communication
+            view.selectedItem = selectedItem
+        }
+    )
+}
+
+@Composable
+fun ContentExample() {
+    Column(Modifier.fillMaxSize()) {
+        Text("Look at this CustomView!")
+        CustomView()
+    }
+}
+```
+
+<br />
+
+> [!NOTE]
+> **Note:** Prefer to construct a View in the `AndroidView` `factory` lambda instead of using `remember` to hold a View reference outside of `AndroidView`.
+
+## `AndroidView` with view binding
+
+To embed an XML layout, use the
+[`AndroidViewBinding`](https://developer.android.com/reference/kotlin/androidx/compose/ui/viewinterop/package-summary#AndroidViewBinding(kotlin.Function3,%20androidx.compose.ui.Modifier,%20kotlin.Function1))
+API, which is provided by the `androidx.compose.ui:ui-viewbinding` library. To
+do this, your project must enable [view binding](https://developer.android.com/topic/libraries/view-binding#setup).
+
+> [!NOTE]
+> **Note:** For Compose-only apps, don't use `AndroidViewBinding` to inflate full screen-level XML layouts, and instead use it only for smaller, legacy XML layouts during the incremental migration process.
+
+
+```kotlin
+@Composable
+fun AndroidViewBindingExample() {
+    AndroidViewBinding(ExampleLayoutBinding::inflate) {
+        exampleView.setBackgroundColor(Color.GRAY)
+    }
+}
+```
+
+<br />
+
+## `AndroidView` in Lazy lists
+
+If you are using an `AndroidView` in a Lazy list (`LazyColumn`, `LazyRow`,
+`Pager`, etc.), consider using the [`AndroidView`](https://developer.android.com/reference/kotlin/androidx/compose/ui/viewinterop/package-summary#AndroidView(kotlin.Function1,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1))
+overload introduced in version 1.4.0-rc01. This overload allows Compose to reuse
+the underlying `View` instance when the containing composition is reused as is
+the case for Lazy lists.
+
+This overload of `AndroidView` adds 2 additional parameters:
+
+- `onReset` - A callback invoked to signal that the `View` is about to be reused. This must be non-null to enable View reuse.
+- `onRelease` (optional) - A callback invoked to signal that the `View` has exited the composition and will not be reused again.
+
+
+```kotlin
+@Composable
+fun AndroidViewInLazyList() {
+    LazyColumn {
+        items(100) { index ->
+            AndroidView(
+                modifier = Modifier.fillMaxSize(), // Occupy the max size in the Compose UI tree
+                factory = { context ->
+                    MyView(context)
+                },
+                update = { view ->
+                    view.selectedItem = index
+                },
+                onReset = { view ->
+                    view.clear()
+                }
+            )
+        }
+    }
+}
+```
+
+<br />
+
+## Fragments in Compose (Transitionary Step)
+
+Use the `AndroidFragment` composable to add a `Fragment` in Compose.
+`AndroidFragment` has fragment-specific handling such as removing the
+fragment when the composable leaves the composition.
+
+> [!NOTE]
+> **Note:** Wrap existing Fragments in Compose only during incremental migration. For Compose-only apps, do not use Fragments and instead use the recommended Compose-only architecture with a single Activity and latest navigation libraries, like Navigation 3.
+
+To include a fragment, use the [`AndroidFragment`](https://developer.android.com/reference/kotlin/androidx/fragment/compose/package-summary#AndroidFragment)
+composable. You pass a `Fragment` class to `AndroidFragment`, which then adds
+an instance of that class directly into the composition. `AndroidFragment` also
+provides a `fragmentState` object to create the `AndroidFragment` with a given
+state, `arguments` to pass into the new fragment, and an `onUpdate` callback
+that provides the fragment from the composition. Like many
+other built-in composables, `AndroidFragment` accepts a `Modifier` parameter
+that you can use, for
+example, to set its position in the parent composable.
+
+Call `AndroidFragment` in Compose as follows:
+
+
+```kotlin
+@Composable
+fun FragmentInComposeExample() {
+    AndroidFragment<MyFragment>()
+}
+```
+
+<br />
+
+## Calling the Android framework from Compose
+
+Compose operates within the Android framework classes. For example, it's hosted
+on Android View classes, like `Activity` or `Fragment`, and might use Android
+framework classes like the `Context`, system resources,
+`Service`, or `BroadcastReceiver`.
+
+To learn more about system resources, see [Resources in Compose](https://developer.android.com/develop/ui/compose/resources).
+
+### Composition Locals
+
+[`CompositionLocal`](https://developer.android.com/reference/kotlin/androidx/compose/runtime/CompositionLocal)
+classes allow passing data implicitly through composable functions. They're
+usually provided with a value in a certain node of the UI tree. That value can
+be used by its composable descendants without declaring the `CompositionLocal`
+as a parameter in the composable function.
+
+`CompositionLocal` is used to propagate values for Android framework types in
+Compose such as `Context`, `Configuration` or the `View` in which the Compose
+code is hosted with the corresponding
+[`LocalContext`](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/package-summary#LocalContext()),
+[`LocalConfiguration`](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/package-summary#LocalConfiguration()),
+or
+[`LocalView`](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/package-summary#LocalView()).
+Note that `CompositionLocal` classes are prefixed with `Local` for better
+discoverability with auto-complete in the IDE.
+
+Access the current value of a `CompositionLocal` by using its `current`
+property. For example, the code below shows a toast message by providing
+`LocalContext.current` into the `Toast.makeToast` method.
+
+
+```kotlin
+@Composable
+fun ToastGreetingButton(greeting: String) {
+    val context = LocalContext.current
+    Button(onClick = {
+        Toast.makeText(context, greeting, Toast.LENGTH_SHORT).show()
+    }) {
+        Text("Greet")
+    }
+}
+```
+
+<br />
+
+### Broadcast receivers
+
+To showcase `CompositionLocal` and [side
+effects](https://developer.android.com/develop/ui/compose/side-effects), if a
+[`BroadcastReceiver`](https://developer.android.com/guide/components/broadcasts) needs to be registered from
+a composable function, use of `LocalContext` to use the current context, and
+`rememberUpdatedState` and `DisposableEffect` side effects.
+
+
+```kotlin
+@Composable
+fun SystemBroadcastReceiver(
+    systemAction: String,
+    onSystemEvent: (intent: Intent?) -> Unit
+) {
+    // Grab the current context in this part of the UI tree
+    val context = LocalContext.current
+
+    // Safely use the latest onSystemEvent lambda passed to the function
+    val currentOnSystemEvent by rememberUpdatedState(onSystemEvent)
+
+    // If either context or systemAction changes, unregister and register again
+    DisposableEffect(context, systemAction) {
+        val intentFilter = IntentFilter(systemAction)
+        val broadcast = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                currentOnSystemEvent(intent)
+            }
+        }
+
+        context.registerReceiver(broadcast, intentFilter)
+
+        // When the effect leaves the Composition, remove the callback
+        onDispose {
+            context.unregisterReceiver(broadcast)
+        }
+    }
+}
+
+@Composable
+fun HomeScreen() {
+
+    SystemBroadcastReceiver(Intent.ACTION_BATTERY_CHANGED) { batteryStatus ->
+        val isCharging = /* Get from batteryStatus ... */ true
+        /* Do something if the device is charging */
+    }
+
+    /* Rest of the HomeScreen */
+}
+```
+
+<br />
+
+## Other interactions
+
+If there isn't a utility defined for the interaction you need, the best practice
+is to follow the general Compose guideline,
+*data flows down, events flow up* (discussed at more length in [Thinking
+in Compose](https://developer.android.com/develop/ui/compose/mental-model)). For example, this composable
+launches a different activity:
+
+
+```kotlin
+class OtherInteractionsActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // get data from savedInstanceState
+        setContent {
+            MaterialTheme {
+                ExampleComposable(data, onButtonClick = {
+                    startActivity(Intent(this, MyActivity::class.java))
+                })
+            }
+        }
+    }
+}
+
+@Composable
+fun ExampleComposable(data: DataExample, onButtonClick: () -> Unit) {
+    Button(onClick = onButtonClick) {
+        Text(data.title)
+    }
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/references/android/develop/ui/compose/setup-compose-dependencies-and-compiler.md
+++ b/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/references/android/develop/ui/compose/setup-compose-dependencies-and-compiler.md
@@ -1,0 +1,197 @@
+For Gradle, use the Compose Compiler Gradle plugin to set up and configure
+Compose.
+
+> [!NOTE]
+> **Note:** The Compose Compiler Gradle Plugin is only available from Kotlin 2.0+. For migration instructions, see ["Jetpack Compose compiler moving to the Kotlin
+> repository"](https://android-developers.googleblog.com/2024/04/jetpack-compose-compiler-moving-to-kotlin-repository.html).
+
+### Set up with Gradle version catalogs
+
+Set up the Compose Compiler Gradle plugin:
+
+1. In the `libs.versions.toml` file, remove any reference to the Compose Compiler.
+2. In the `versions` and `plugins` sections, add the new dependency:
+
+       [versions]
+       kotlin = "2.3.21"
+
+       [plugins]
+       org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+
+       // Add this line
+       compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+
+3. In the project's root `build.gradle.kts` file, add the following to the
+   `plugins` section.
+
+       plugins {
+       // Existing plugins
+       alias(libs.plugins.compose.compiler) apply false
+       }
+
+4. In each module that uses Compose, apply the plugin:
+
+       plugins {
+       // Existing plugins
+       alias(libs.plugins.compose.compiler)
+       }
+
+The project should now build and compile if it was using the default set up. If
+it had configured custom options on the Compose compiler, follow the next
+section.
+
+### Set up the Compose Compiler without Gradle version catalogs
+
+Add the plugin to `build.gradle.kts` files associated with modules where Compose
+is used:
+
+    plugins {
+        id("org.jetbrains.kotlin.plugin.compose") version "2.3.21" // this version matches your Kotlin version
+    }
+
+Add the classpath to your top-level project `build.gradle.kts` file:
+
+    buildscript {
+        dependencies {
+            classpath("org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:2.3.21")
+        }
+    }
+
+### Configuration options with the Compose Compiler Gradle Plugin
+
+To configure the Compose compiler using the Gradle plugin, add the
+`composeCompiler` block to the module's `build.gradle.kts` file at the top
+level:
+
+    android { ... }
+
+    composeCompiler {
+        reportsDestination = layout.buildDirectory.dir("compose_compiler")
+        stabilityConfigurationFile = rootProject.layout.projectDirectory.file("stability_config.conf")
+    }
+
+For the full list of available options, see the [documentation](https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compiler.html#compose-compiler-options-dsl).
+
+## Set up Compose dependencies
+
+Always use the latest Compose BOM version: `2026.06.00`.
+
+Set the `compose` flag to `true` inside the Android [`BuildFeatures`](https://developer.android.com/reference/tools/gradle-api/7.0/com/android/build/api/dsl/BuildFeatures) to
+enable [Compose functionality](https://developer.android.com/develop/ui/compose/tooling) in Android Studio.
+
+Add the following definition to your app's `build.gradle` file:
+
+### Groovy
+
+    android {
+        buildFeatures {
+            compose true
+        }
+    }
+
+### Kotlin
+
+    android {
+        buildFeatures {
+            compose = true
+        }
+    }
+
+Add the Compose BOM and the subset of Compose library dependencies:
+
+### Groovy
+
+    dependencies {
+
+        def composeBom = platform('androidx.compose:compose-bom:2026.06.00')
+        implementation composeBom
+        androidTestImplementation composeBom
+
+        // Choose one of the following:
+        // Material Design 3
+        implementation 'androidx.compose.material3:material3'
+        // or skip Material Design and build directly on top of foundational components
+        implementation 'androidx.compose.foundation:foundation'
+        // or only import the main APIs for the underlying toolkit systems,
+        // such as input and measurement/layout
+        implementation 'androidx.compose.ui:ui'
+
+        // Android Studio Preview support
+        implementation 'androidx.compose.ui:ui-tooling-preview'
+        debugImplementation 'androidx.compose.ui:ui-tooling'
+
+        // UI Tests
+        androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+        debugImplementation 'androidx.compose.ui:ui-test-manifest'
+
+        // Optional - Add window size utils
+        implementation 'androidx.compose.material3.adaptive:adaptive'
+
+        // Optional - Integration with activities
+        implementation 'androidx.activity:activity-compose:1.13.0'
+        // Optional - Integration with ViewModels
+        implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0'
+        // Optional - Integration with LiveData
+        implementation 'androidx.compose.runtime:runtime-livedata'
+        // Optional - Integration with RxJava
+        implementation 'androidx.compose.runtime:runtime-rxjava2'
+
+    }
+
+### Kotlin
+
+    dependencies {
+
+        val composeBom = platform("androidx.compose:compose-bom:2026.06.00")
+        implementation(composeBom)
+        androidTestImplementation(composeBom)
+
+        // Choose one of the following:
+        // Material Design 3
+        implementation("androidx.compose.material3:material3")
+        // or skip Material Design and build directly on top of foundational components
+        implementation("androidx.compose.foundation:foundation")
+        // or only import the main APIs for the underlying toolkit systems,
+        // such as input and measurement/layout
+        implementation("androidx.compose.ui:ui")
+
+        // Android Studio Preview support
+        implementation("androidx.compose.ui:ui-tooling-preview")
+        debugImplementation("androidx.compose.ui:ui-tooling")
+
+        // UI Tests
+        androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+        debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+        // Optional - Add window size utils
+        implementation("androidx.compose.material3.adaptive:adaptive")
+
+        // Optional - Integration with activities
+        implementation("androidx.activity:activity-compose:1.13.0")
+        // Optional - Integration with ViewModels
+        implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")
+        // Optional - Integration with LiveData
+        implementation("androidx.compose.runtime:runtime-livedata")
+        // Optional - Integration with RxJava
+        implementation("androidx.compose.runtime:runtime-rxjava2")
+
+    }
+
+> [!NOTE]
+> **Note:** Jetpack Compose is shipped using a Bill of Materials (BOM), to keep the versions of all library groups in sync. Read more about it in the [Bill of
+> Materials page](https://developer.android.com/develop/ui/compose/bom/bom).
+
+## `compileSdk` and Android Gradle Plugin compatibility
+
+Compose library releases continually adopt the latest `compileSdk` versions to
+provide access to the latest Android features. Newer `compileSdk` versions
+require newer versions of Android Gradle Plugin, so adopting new Compose
+releases also requires projects to adopt new versions of the Android Gradle
+Plugin. We recommend keeping your project's `compileSdk` up to date with the
+latest released versions. `compileSdk` is unrelated from `targetSdk`.
+
+For example, starting with Compose 1.12.0, projects are required to use
+`compileSdk 37` and Android Gradle Plugin (AGP) 9.
+
+To check which version of AGP is supported for different API levels, see the
+[Android Gradle plugin API level support](https://developer.android.com/build/releases/about-agp#api-level-support) documentation.

--- a/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/references/identify-optimal-xml-candidate.md
+++ b/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/references/identify-optimal-xml-candidate.md
@@ -1,0 +1,31 @@
+### 1. Analysis scope
+
+**Action:** Use find files and examine all XML layout files within the project (typically located in `res`directories). For each file, parse the view hierarchy and metadata.
+
+### 2. Selection criteria
+
+Prioritize layouts that meet the following criteria:
+
+- **Hierarchy depth:** Target **leaf nodes** or components at the bottom of the UI tree.
+- **Complexity:** Select layouts with the **smallest number of nested children** and minimal logic.
+- **State management:** Prioritize **stateless** components or those with the fewest UI state variables.
+- **Dependency footprint:** Identify layouts with **zero to minimal external UI dependencies**.
+- **Isolation:** Focus on **self-contained** components that do not rely heavily on parent context or complex data binding.
+
+### 3. Risk assessment
+
+Evaluate the migration risk based on:
+\* **Reusability:** Find layouts with **minimum reuse** across the project to limit regression impact.
+\* **Accessibility:** Ensure the layout has an **easily accessible entry point** (e.g., used in a simple Activity, Fragment, or as a standalone include).
+
+*** ** * ** ***
+
+## Output requirements
+
+Provide a ranked list of the top 3-5 candidates. For each candidate, include:
+1. **File path:** (e.g., `res/layout/item_user_profile.xml`)
+2. **Rationale:** Why this is a good candidate based on the provided criteria.
+3. **Complexity score:** A rating from 1-5 (1 being simplest).
+4. **Dependency count:** List of custom/external views found within.
+
+**Action:** If you support user interaction, ask the user to choose which XML to proceed with. Else proceed with the best option, based on the previous criteria.

--- a/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/references/xml-layout-migration.md
+++ b/platforms/android/.agents/skills/migrate-xml-views-to-jetpack-compose/references/xml-layout-migration.md
@@ -1,0 +1,86 @@
+## 1. Structural analysis \& mapping
+
+**Identify the precise mapping** between XML elements and Compose equivalents.
+You must determine:
+
+- The exact `@Composable` functions (e.g., `ConstraintLayout`, `Column`, `LazyColumn`) that replace the XML tag hierarchy.
+- The specific parameters and `Modifier` extensions required to replicate XML attributes (e.g., `layout_width`, `padding`, `elevation`).
+- The appropriate state management strategy for interactive elements.
+
+## 2. Migration execution
+
+**Convert the XML layout code to Jetpack Compose**, ensuring the visual
+hierarchy and layout logic are preserved while leveraging Compose's declarative
+nature.
+
+## 3. Theming \& design system integrity
+
+**Do not use hard-coded values.** Follow these rules for styling:
+
+- **Token Alignment:** Cross-reference XML dimensions, colors, and style attributes with the existing Compose `Theme` (e.g., `MaterialTheme.colorScheme` or custom design system tokens).
+- **Reuse over Creation:** If matching values exist in the current Compose theme, reuse them. If a value is missing but required for the design, define it within the theme structure rather than hard-coding it in the Composable.
+- **Project Consistency:** You **MUST** strictly adhere to existing code conventions, naming standards, and implementation patterns found in the project. **Prioritize** project-specific reusable components over generic Material defaults.
+
+## 4. Component layering \& reusability
+
+Evaluate if the XML layout serves as a foundation-level design system component
+(reused across the app with a distinct role). If it is:
+
+- **Create a reusable composable:** Do not just inline the code. Define a new standalone `@Composable`.
+- **Parameterization:** Expose specific parameters for variable data (text, colors, styles) and use `Modifier` for layout-specific customizations.
+- **Feature parity \& restriction:** Ensure the new composable enforces the same UI constraints as the original XML component, preventing unauthorized style overrides while maintaining the intended flexibility.
+
+Example before migration:
+
+    <style
+        name="Widget.Rounded.Button"
+        parent="Widget.Button.Borderless">
+        <item name="android:fontFamily">sans-serif-medium</item>
+        <item name="android:minWidth">@dimen/min_width</item>
+        <item name="android:paddingStart">@dimen/padding_2</item>
+        <item name="android:paddingEnd">@dimen/padding_2</item>
+        <item name="cornerRadius">8dp</item>
+    </style>
+
+Example after migration:
+
+
+```kotlin
+@Composable
+fun RoundedBorderlessButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
+    TextButton(
+        onClick, modifier
+            .defaultMinSize(minWidth = dimensionResource(R.dimen.min_width))
+            .padding(
+                start = dimensionResource(R.dimen.padding_2),
+                end = dimensionResource(R.dimen.padding_2)
+            ), enabled, shape = RoundedCornerShape(8.dp),
+        colors = ButtonDefaults.textButtonColors(
+            contentColor = MaterialTheme.colorScheme.primary
+        )
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium.copy(
+                fontFamily = FontFamily.SansSerif,
+                fontWeight = FontWeight.Medium
+            )
+        )
+    }
+}
+```
+
+<br />
+
+*** ** * ** ***
+
+## 5. Output requirements
+
+- Provide the full Kotlin file content.
+- Include necessary imports.
+- Add documentation comments (`/** ... */`) explaining the mapping logic for complex transformations.

--- a/platforms/android/.agents/skills/navigation-3/SKILL.md
+++ b/platforms/android/.agents/skills/navigation-3/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: navigation-3
+description: Learn how to install and migrate to Jetpack Navigation 3, and how to
+  implement features and patterns such as deep links, multiple backstacks, scenes
+  (dialogs, bottom sheets, list-detail, two-pane, supporting pane), conditional navigation
+  (such as logged-in navigation versus anonymous), returning results from flows, integration
+  with Hilt, ViewModel, Kotlin, and view interoperability.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-07-09'
+  keywords:
+  - recipe
+  - Android
+  - Navigation 2
+  - Navigation 3
+  - migration
+  - Compose
+  - guide
+  - dependencies
+  - NavKey
+  - NavHost
+  - NavDisplay
+  - BottomSheet
+  - list-detail
+  - scenes
+  - two-pane
+  - supporting pane
+  - multiple backstacks
+  - dialog
+  - Hilt
+  - ViewModel
+  - View interop.
+---
+
+*** ** * ** ***
+
+## Migration guide
+
+- *[Navigation 2 to Navigation 3 migration guide](references/android/guide/navigation/navigation-3/migration-guide.md)*: Step-by-step guide to migrate an Android application from Navigation 2 to Navigation 3, covering dependency updates, route changes, state management, and UI component replacements.
+
+### Requirements
+
+- *[Guide: Migrate to type-safe navigation in Compose](references/android/guide/navigation/type-safe-destinations.md)* : Step-by-step guide to migrating an Android application from string-based navigation to **Type-Safe Navigation** in Jetpack Compose using Jetpack Navigation 2.
+
+## Developer documentation
+
+- *[Navigation 3](references/android/guide/navigation/navigation-3/index.md)*. Search documentation for more information on basics, saving and managing navigation state, modularizing navigation code, creating custom layouts using Scenes, animating between destinations, or applying logic or wrappers to destinations.
+
+## Recipes
+
+Code examples showcasing common patterns.
+
+### Basic API usage
+
+- *[Basic](references/android/guide/navigation/navigation-3/recipes/basic.md)*: Shows most basic API usage.
+- *[Saveable back stack](references/android/guide/navigation/navigation-3/recipes/basicsaveable.md)*: Shows basic API usage with a persistent back stack.
+- *[Entry provider DSL](references/android/guide/navigation/navigation-3/recipes/basicdsl.md)*: Shows basic API usage using the entryProvider DSL.
+
+### Common UI
+
+- *[Common UI](references/android/guide/navigation/navigation-3/recipes/common-ui.md)*: Demonstrates how to implement a common navigation UI pattern with a bottom navigation bar and multiple back stacks, where each tab in the navigation bar has its own navigation history.
+
+### Deep links
+
+- *[Basic](https://developer.android.com/guide/navigation/navigation-3/recipes/deeplinks-basic)*: Shows how to parse a deep link URL from an Android Intent into a navigation key.
+- *[Advanced](references/android/guide/navigation/navigation-3/recipes/deeplinks-advanced.md)*: Shows how to handle deep links with a synthetic back stack and correct "Up" navigation behavior.
+
+### Scenes
+
+#### Use built-in Scenes
+
+- *[Dialog](references/android/guide/navigation/navigation-3/recipes/dialog.md)*: Shows how to create a Dialog.
+
+#### Create custom Scenes
+
+- *[BottomSheet](references/android/guide/navigation/navigation-3/recipes/bottomsheet.md)*: Shows how to create a BottomSheet destination.
+- *[List-Detail Scene](references/android/guide/navigation/navigation-3/recipes/scenes-listdetail.md)*: Demonstrates how to implement adaptive list-detail layouts using the Navigation 3 Scenes API.
+- *[Two pane Scene](references/android/guide/navigation/navigation-3/recipes/scenes-twopane.md)*: Demonstrates how to implement adaptive two-pane layouts using the Navigation 3 Scenes API.
+
+### Material Adaptive
+
+- *[Material List-Detail](references/android/guide/navigation/navigation-3/recipes/material-listdetail.md)*: Demonstrates how to implement an adaptive list-detail layout using Material 3 Adaptive.
+- *[Material Supporting Pane](references/android/guide/navigation/navigation-3/recipes/material-supportingpane.md)*: Demonstrates how to implement an adaptive supporting pane layout using Material 3 Adaptive.
+
+### Animations
+
+- *[Animations](references/android/guide/navigation/navigation-3/recipes/animations.md)*: Shows how to override the default animations for all destinations and a single destination.
+
+### Common back stack behavior
+
+- *[Multiple back stacks](references/android/guide/navigation/navigation-3/recipes/multiple-backstacks.md)*: Shows how to create multiple top level routes, each with its own back stack. Top level routes are displayed in a navigation bar allowing users to switch between them. State is retained for each top level route, and the navigation state persists config changes and process death.
+
+### Conditional navigation
+
+- *[Conditional navigation](references/android/guide/navigation/navigation-3/recipes/conditional.md)*: Switch to a different navigation flow when a condition is met. For example, for authentication or first-time user onboarding.
+
+### Architecture
+
+- *[Modularized navigation code (Hilt)](references/android/guide/navigation/navigation-3/recipes/modular-hilt.md)*: Demonstrates how to decouple navigation code into separate modules using Hilt or Dagger for DI.
+- *[Modularized navigation code (Koin)](references/android/guide/navigation/navigation-3/recipes/modular-koin.md)*: Demonstrates how to decouple navigation code into separate modules using Koin for DI.
+
+### Working with ViewModel
+
+#### Passing navigation arguments
+
+- *[Basic ViewModel](references/android/guide/navigation/navigation-3/recipes/passingarguments.md)* : Navigation arguments are passed to a `ViewModel` constructed using `viewModel()`
+
+### Returning results
+
+- *[Returning Results as Events](references/android/guide/navigation/navigation-3/recipes/results-event.md)* : Returning results as events to content in another `NavEntry`
+- *[Returning Results as State](references/android/guide/navigation/navigation-3/recipes/results-state.md)* : Returning results as state stored in a `CompositionLocal`

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/index.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/index.md
@@ -1,0 +1,38 @@
+Navigation 3 is a new navigation library designed to work with Compose. With
+Navigation 3, you have full control over your back stack, and navigating to and
+from destinations is as simple as adding and removing items from a list. It
+creates a flexible app navigation system by providing:
+
+- Conventions for modeling a back stack, where each entry on the back stack represents content that the user has navigated to
+- A UI that automatically updates with back stack changes (including animations)
+- A scope for items in the back stack, allowing state to be retained while an item is in the back stack
+- An adaptive layout system that allows multiple destinations to be displayed at the same time, and allowing seamless switching between those layouts
+- A mechanism for content to communicate with its parent layout (metadata)
+
+At a high level, you implement Navigation 3 in the following ways:
+
+1. Define the content that users can navigate to in your app, each with a unique key, and add a function to resolve that key to the content. See [Resolve keys
+   to content](https://developer.android.com/guide/navigation/navigation-3/basics#resolve-keys).
+2. Create a back stack that keys are pushed onto and removed as users navigate your app. See [Create a back stack](https://developer.android.com/guide/navigation/navigation-3/basics#create-back).
+3. Use a [`NavDisplay`](https://developer.android.com/reference/kotlin/androidx/navigation3/ui/NavDisplay.composable) to display your app's back stack. Whenever the back stack changes, it updates the UI to display relevant content. See [Display
+   the back stack](https://developer.android.com/guide/navigation/navigation-3/basics#display-back).
+4. Modify `NavDisplay`'s [scene strategies](https://developer.android.com/guide/navigation/navigation-3/custom-layouts) as needed to support adaptive layouts and different platforms.
+
+You can see the [full source code](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:navigation3/) for Navigation 3 on AOSP.
+
+## Improvements upon Jetpack Navigation
+
+Navigation 3 improves upon the original Jetpack Navigation API in the following
+ways:
+
+- Provides a simpler integration with Compose
+- Offers you full control of the back stack
+- Makes it possible to create layouts that can read more than one destination from the back stack at the same time, allowing them to adapt to changes in window size and other inputs.
+
+Read more about Navigation 3's principles and API design choices in [this blog
+post](https://android-developers.googleblog.com/2025/05/announcing-jetpack-navigation-3-for-compose.html).
+
+## Code samples
+
+The [recipes repository](https://github.com/android/nav3-recipes) contains examples of how to use the
+Navigation 3 building blocks to solve common navigation challenges.

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/migration-guide.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/migration-guide.md
@@ -1,0 +1,498 @@
+To migrate your app from [Navigation 2](https://developer.android.com/guide/navigation) to Navigation 3, follow these steps:
+
+1. Add the Navigation 3 dependencies.
+2. Update your navigation routes to implement the `NavKey` interface.
+3. Create classes to hold and modify your navigation state.
+4. Replace `NavController` with these classes.
+5. Move your destinations from `NavHost`'s `NavGraph` into an `entryProvider`.
+6. Replace `NavHost` with `NavDisplay`.
+7. Remove Navigation 2 dependencies.
+
+> [!IMPORTANT]
+> **Important:** We released an agent skill to help you install and migrate to Jetpack Navigation 3. Try out the skill from the [Android skills repository](https://github.com/android/skills).
+
+<br />
+
+
+## AI Prompt
+
+### Migrate from Navigation 2 to Navigation 3
+
+This prompt will use this guide to migrate to navigation 3.
+
+    Migrate from Navigation 2 to Navigation 3 using the official
+    migration guide.
+
+### Using AI prompts
+
+AI prompts are intended to be used within Gemini in Android Studio.
+
+Learn more about Gemini in Studio here: [https://developer.android.com/studio/gemini/overview](https://developer.android.com/studio/gemini/overview)
+<button class="devsite-dialog-close">Close</button> <button class="button icon-button android-ai-prompt-help-button" data-modal-dialog-id="ai-prompt_help_modal__migrate-from-navigation-2-to-navigation-3"> </button> <button class="button google-feedback" data-p="5207477" data-b="llm-prompts" data-context="migrate-from-navigation-2-to-navigation-3"> Share your thoughts </button>
+
+<br />
+
+If you run into problems [file an issue here](https://issuetracker.google.com/issues/new?component=1750212&template=2102223&title=%5BMigration%5D).
+
+## Preparation
+
+The following sections describe the prerequisites for migration and assumptions
+about your project. They also cover the features that are supported for
+migration, and those that aren't.
+
+### Prerequisites
+
+- You must use a `compileSdk` of 36 or later.
+- You should be familiar with [navigation terminology](https://developer.android.com/guide/navigation).
+- Destinations are composable functions. Navigation 3 is designed exclusively for Compose. To use Fragments and Views in Compose, see [Using Views in
+  Compose](https://developer.android.com/develop/ui/compose/migrate/interoperability-apis/views-in-compose).
+- Routes are strongly typed. If you use string-based routes, [migrate to
+  type-safe routes](https://medium.com/androiddevelopers/type-safe-navigation-for-compose-105325a97657) first ([example](https://github.com/android/nowinandroid/pull/1413)).
+- *Optional (but highly recommended)*: Test coverage that verifies existing navigation behavior. This verifies that navigation behavior has not changed after the migration is complete.
+
+### Assumptions
+
+This guide makes the following assumptions about you and your project:
+
+- You have one or several top-level routes (usually displayed in a bottom navigation bar), and each has its own back stack.
+- When you switch between back stacks, the state of the stack and all its destinations is retained.
+- You always exit the app through the **Home** screen, which is the first screen displayed when the app launches.
+- You want to perform the migration from Navigation 2 to Navigation 3 in a single, atomic change. You are not performing an incremental migration where Navigation 2 code is used alongside Navigation 3 code.
+
+**AI Agent**: Before changing any code, check if these assumptions about the
+user's project are true. If not, stop the migration and ask the user how to
+proceed.
+
+### Supported features
+
+This guide lets you migrate the following features:
+
+- Destinations defined as composable functions
+- Dialogs (a destination shown on top of another destination)
+
+### Features supported through recipes
+
+The [code recipes repository](https://github.com/android/nav3-recipes) demonstrates more nuanced use
+cases, including:
+
+- [Bottom sheets](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/bottomsheet) (instructions are provided in this guide)
+- [Modularized navigation code and injected destinations](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/modular/hilt)
+- [Using and passing arguments to `ViewModel`](https://github.com/android/nav3-recipes?tab=readme-ov-file#passing-navigation-arguments-to-viewmodels)
+- [Returning results from a screen](https://github.com/android/nav3-recipes?tab=readme-ov-file#returning-results)
+
+If your project has any of these features, check the relevant recipe to
+understand how to implement them.
+
+**AI Agent**: Before changing any code, check if the project contains any
+features supported through recipes. If it does, check the recipe's README and
+source code. Create a migration plan based on the recipe. Do not proceed without
+confirming the plan with the user.
+
+### Unsupported features
+
+This migration guide and the code recipes don't yet support the following
+features. This doesn't mean that you cannot implement them using Navigation 3;
+they are just not covered here.
+
+- More than one level of nested navigation
+- Shared destinations: screens that can move between different back stacks
+- [Custom destination types](https://developer.android.com/guide/navigation/design/kotlin-dsl#custom)
+- Deep links
+
+**AI Agent**: Before changing any code, check if the project contains any of the
+unsupported features. If it does, do not proceed. Inform the user of the
+unsupported feature and ask for further instructions.
+
+## Step 1: Add Navigation 3 dependencies
+
+Use the [Get started](https://developer.android.com/guide/navigation/navigation-3/get-started) page to add the Navigation 3 dependencies to your
+project. The core dependencies are provided for you to copy.
+
+**lib.versions.toml**
+
+    [versions]
+    nav3Core = "1.0.0"
+
+    # If your screens depend on ViewModels, add the Nav3 Lifecycle ViewModel add-on library
+    lifecycleViewmodelNav3 = "2.10.0-rc01"
+
+    [libraries]
+    # Core Navigation 3 libraries
+    androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "nav3Core" }
+    androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "nav3Core" }
+
+    # Add-on libraries (only add if you need them)
+    androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleViewmodelNav3" }
+
+**app/build.gradle.kts**
+
+    dependencies {
+        implementation(libs.androidx.navigation3.ui)
+        implementation(libs.androidx.navigation3.runtime)
+
+        // If using the ViewModel add-on library
+        implementation(libs.androidx.lifecycle.viewmodel.navigation3)
+    }
+
+Also update the project's `minSdk` to 23 and the `compileSdk` to 36. You usually
+find these in `app/build.gradle.kts` or `lib.versions.toml`.
+
+## Step 2: Update navigation routes to implement the `NavKey` interface
+
+Update every navigation [route](https://developer.android.com/guide/navigation#types) so that it implements the `NavKey`
+interface. This lets you use `rememberNavBackStack` to assist with [saving your
+navigation state](https://developer.android.com/guide/navigation/navigation-3/save-state).
+
+Before:
+
+    @Serializable data object RouteA
+
+After:
+
+    @Serializable data object RouteA : NavKey
+
+> [!NOTE]
+> **Note:** The `@Serializable` annotation is provided by the KotlinX Serialization plugin. You can add this by following [these project setup steps](https://developer.android.com/guide/navigation/navigation-3/get-started#project-setup).
+
+## Step 3: Create classes to hold and modify your navigation state
+
+### Step 3.1: Create a navigation state holder
+
+Copy the following code into a file named `NavigationState.kt`. Add your package
+name to match your project structure.
+
+    // package com.example.project
+
+    import androidx.compose.runtime.Composable
+    import androidx.compose.runtime.MutableState
+    import androidx.compose.runtime.getValue
+    import androidx.compose.runtime.mutableStateOf
+    import androidx.compose.runtime.remember
+    import androidx.compose.runtime.saveable.rememberSerializable
+    import androidx.compose.runtime.setValue
+    import androidx.compose.runtime.snapshots.SnapshotStateList
+    import androidx.compose.runtime.toMutableStateList
+    import androidx.navigation3.runtime.NavBackStack
+    import androidx.navigation3.runtime.NavEntry
+    import androidx.navigation3.runtime.NavKey
+    import androidx.navigation3.runtime.rememberDecoratedNavEntries
+    import androidx.navigation3.runtime.rememberNavBackStack
+    import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+    import androidx.navigation3.runtime.serialization.NavKeySerializer
+    import androidx.savedstate.compose.serialization.serializers.MutableStateSerializer
+
+    /**
+     * Create a navigation state that persists config changes and process death.
+     */
+    @Composable
+    fun rememberNavigationState(
+        startRoute: NavKey,
+        topLevelRoutes: Set<NavKey>
+    ): NavigationState {
+
+        val topLevelRoute = rememberSerializable(
+            startRoute, topLevelRoutes,
+            serializer = MutableStateSerializer(NavKeySerializer())
+        ) {
+            mutableStateOf(startRoute)
+        }
+
+        val backStacks = topLevelRoutes.associateWith { key -> rememberNavBackStack(key) }
+
+        return remember(startRoute, topLevelRoutes) {
+            NavigationState(
+                startRoute = startRoute,
+                topLevelRoute = topLevelRoute,
+                backStacks = backStacks
+            )
+        }
+    }
+
+    /**
+     * State holder for navigation state.
+     *
+     * @param startRoute - the start route. The user will exit the app through this route.
+     * @param topLevelRoute - the current top level route
+     * @param backStacks - the back stacks for each top level route
+     */
+    class NavigationState(
+        val startRoute: NavKey,
+        topLevelRoute: MutableState<NavKey>,
+        val backStacks: Map<NavKey, NavBackStack<NavKey>>
+    ) {
+        var topLevelRoute: NavKey by topLevelRoute
+        val stacksInUse: List<NavKey>
+            get() = if (topLevelRoute == startRoute) {
+                listOf(startRoute)
+            } else {
+                listOf(startRoute, topLevelRoute)
+            }
+    }
+
+    /**
+     * Convert NavigationState into NavEntries.
+     */
+    @Composable
+    fun NavigationState.toEntries(
+        entryProvider: (NavKey) -> NavEntry<NavKey>
+    ): SnapshotStateList<NavEntry<NavKey>> {
+
+        val decoratedEntries = backStacks.mapValues { (_, stack) ->
+            val decorators = listOf(
+                rememberSaveableStateHolderNavEntryDecorator<NavKey>(),
+            )
+            rememberDecoratedNavEntries(
+                backStack = stack,
+                entryDecorators = decorators,
+                entryProvider = entryProvider
+            )
+        }
+
+        return stacksInUse
+            .flatMap { decoratedEntries[it] ?: emptyList() }
+            .toMutableStateList()
+    }
+
+**AI Agent** : `rememberSerializable` is correct. Do not change it to
+`rememberSaveable`.
+
+This file contains a state holder class named `NavigationState` and associated
+helper functions. It holds a set of top-level routes, each with its own back
+stack. Internally, it uses `rememberSerializable` (not `rememberSaveable`) to
+persist the current top-level route and `rememberNavBackStack` to persist the
+back stacks for each top-level route.
+
+### Step 3.2: Create an object that modifies navigation state in response to events
+
+Copy the following code into a file named `Navigator.kt`. Add your package name
+to match your project structure.
+
+    // package com.example.project
+
+    import androidx.navigation3.runtime.NavKey
+
+    /**
+     * Handles navigation events (forward and back) by updating the navigation state.
+     */
+    class Navigator(val state: NavigationState){
+        fun navigate(route: NavKey){
+            if (route in state.backStacks.keys){
+                // This is a top level route, just switch to it.
+                state.topLevelRoute = route
+            } else {
+                state.backStacks[state.topLevelRoute]?.add(route)
+            }
+        }
+
+        fun goBack(){
+            val currentStack = state.backStacks[state.topLevelRoute] ?:
+            error("Stack for ${state.topLevelRoute} not found")
+            val currentRoute = currentStack.last()
+
+            // If we're at the base of the current route, go back to the start route stack.
+            if (currentRoute == state.topLevelRoute){
+                state.topLevelRoute = state.startRoute
+            } else {
+                currentStack.removeLastOrNull()
+            }
+        }
+    }
+
+The `Navigator` class provides two navigation event methods:
+
+- `navigate` to a specific route.
+- `goBack` from the current route.
+
+Both methods modify the `NavigationState`.
+
+> [!IMPORTANT]
+> **Architecture principles:** These classes follow the principles of [Unidirectional Data Flow](https://developer.android.com/topic/architecture):
+>
+> - The `Navigator` handles navigation events and uses them to update `NavigationState`.
+> - The UI (provided by `NavDisplay`) observes `NavigationState` and reacts to any changes in that state by updating its UI.
+
+### Step 3.3: Create the `NavigationState` and `Navigator`
+
+Create instances of `NavigationState` and `Navigator` with the same scope as
+your `NavController`.
+
+    val navigationState = rememberNavigationState(
+        startRoute = <Insert your starting route>,
+        topLevelRoutes = <Insert your set of top level routes>
+    )
+
+    val navigator = remember { Navigator(navigationState) }
+
+## Step 4: Replace `NavController`
+
+Replace `NavController` navigation event methods with `Navigator` equivalents.
+
+| **`NavController` field or method** | **`Navigator` equivalent** |
+|---|---|
+| `navigate()` | `navigate()` |
+| `popBackStack()` | `goBack()` |
+
+Replace `NavController` fields with `NavigationState` fields.
+
+| **`NavController` field or method** | **`NavigationState` equivalent** |
+|---|---|
+| `currentBackStack` | `backStacks[topLevelRoute]` |
+| `currentBackStackEntry` `currentBackStackEntryAsState()` `currentBackStackEntryFlow` `currentDestination` | `backStacks[topLevelRoute].last()` |
+| Get the top level route: Traverse up the hierarchy from the current back stack entry to find it. | `topLevelRoute` |
+
+Use `NavigationState.topLevelRoute` to determine the item that is currently
+selected in a navigation bar.
+
+Before:
+
+    val isSelected = navController.currentBackStackEntryAsState().value?.destination.isRouteInHierarchy(key::class)
+
+    fun NavDestination?.isRouteInHierarchy(route: KClass<*>) =
+        this?.hierarchy?.any {
+            it.hasRoute(route)
+        } ?: false
+
+After:
+
+    val isSelected = key == navigationState.topLevelRoute
+
+Verify that you have removed all references to `NavController`, including
+any imports.
+
+## Step 5: Move your destinations from `NavHost`'s `NavGraph` into an `entryProvider`
+
+In Navigation 2, you [define your destinations](https://developer.android.com/guide/navigation/design#compose)
+using the [NavGraphBuilder DSL](https://developer.android.com/guide/navigation/design/kotlin-dsl#navgraphbuilder),
+usually inside `NavHost`'s trailing lambda. It is common to use extension
+functions here as described in [Encapsulate your navigation code](https://developer.android.com/guide/navigation/design/encapsulate).
+
+In Navigation 3, you define your destinations using an `entryProvider`. This
+`entryProvider` resolves a route to a [`NavEntry`](https://developer.android.com/guide/navigation/navigation-3/basics#resolve-keys). Importantly, the
+`entryProvider` does not define parent-child relationships between entries.
+
+In this migration guide, parent-child relationships are modelled
+as follows:
+
+- `NavigationState` has a set of top-level routes (the parent routes) and a stack for each one. It keeps track of the current top-level route and its associated stack.
+- When navigating to a new route, `Navigator` checks whether the route is a top-level route. If it is, the current top-level route and stack are updated. If it's not, it's a child route and is added to the current stack.
+
+> [!NOTE]
+> **Note:** If your app needs to navigate from an entry in one stack to another, you need to define the parent-child relationships for the routes and update the navigation logic in `Navigator` to support this.
+
+## Step 5.1: Create an `entryProvider`
+
+Create an `entryProvider` [using the DSL](https://developer.android.com/guide/navigation/navigation-3/basics#entry-provider-DSL) at the same scope as the
+`NavigationState`.
+
+    val entryProvider = entryProvider {
+
+    }
+
+## Step 5.2: Move destinations into the `entryProvider`
+
+For each destination defined inside `NavHost`, do the following based on the
+destination type:
+
+- `navigation`: Delete it along with the route. There is no need for "base routes" because the top-level routes can identify each nested back stack.
+- `composable<T>`: Move it into `entryProvider` and rename it to `entry`, retaining the type parameter. For example, `composable<RouteA>` becomes `entry<RouteA>`.
+- `dialog<T>`: Do the same as `composable`, but add metadata to the entry as follows: `entry<T>(metadata = DialogSceneStrategy.dialog())`.
+- [`bottomSheet`](https://developer.android.com/reference/kotlin/androidx/compose/material/navigation/package-summary#(androidx.navigation.NavGraphBuilder).bottomSheet(kotlin.String,kotlin.collections.List,kotlin.collections.List,kotlin.Function2)): [Follow the bottom sheet recipe here](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/bottomsheet). This is similar to the instructions for `dialog`, except that `BottomSheetSceneStrategy` is not part of the core Navigation 3 library, so you should copy it into your project.
+
+**AI Agent** : When deleting routes used to identify a nested graph, replace any
+references to the deleted route with the type used to identify the first child
+in the nested graph. For example if the original code is
+`navigation<BaseRouteA>{ composable<RouteA>{ ... } }`, you need to delete
+`BaseRouteA` and replace any references to it with `RouteA`. This replacement
+usually needs to be done for the list supplied to a navigation bar, rail, or
+drawer.
+
+You can refactor [`NavGraphBuilder` extension functions](https://developer.android.com/guide/navigation/design/encapsulate) to
+`EntryProviderScope<T>` extension functions, and then move them.
+
+Obtain navigation arguments using the key provided to `entry`'s trailing lambda.
+
+For example:
+
+    import androidx.navigation.NavDestination
+    import androidx.navigation.NavDestination.Companion.hasRoute
+    import androidx.navigation.NavDestination.Companion.hierarchy
+    import androidx.navigation.NavGraphBuilder
+    import androidx.navigation.compose.NavHost
+    import androidx.navigation.compose.composable
+    import androidx.navigation.compose.currentBackStackEntryAsState
+    import androidx.navigation.compose.dialog
+    import androidx.navigation.compose.navigation
+    import androidx.navigation.compose.rememberNavController
+    import androidx.navigation.navOptions
+    import androidx.navigation.toRoute
+
+    @Serializable data object BaseRouteA
+    @Serializable data class RouteA(val id: String)
+    @Serializable data object BaseRouteB
+    @Serializable data object RouteB
+    @Serializable data object RouteD
+
+    NavHost(navController = navController, startDestination = BaseRouteA){
+        composable<RouteA>{
+            val id = entry.toRoute<RouteA>().id
+            ScreenA(title = "Screen has ID: $id")
+        }
+        featureBSection()
+    <    di>alogRouteD{ ScreenD() }
+    }
+
+    fun NavGraphBuilder.featureBSection() {
+        <navigation>BaseRouteB(startDestination = RouteB) {
+            <compos>ableRouteB { ScreenB() }
+        }
+    }
+
+becomes:
+
+    import androidx.navigation3.runtime.EntryProviderScope
+    import androidx.navigation3.runtime.NavKey
+    import androidx.navigation3.runtime.entryProvider
+    import androidx.navigation3.scene.DialogSceneStrategy
+
+    @Serializable data class RouteA(val id: String) : NavKey
+    @Serializable data object RouteB : NavKey
+    @Serializable data object RouteD : NavKey
+
+    val entryProvider = entryProvider {
+        entry<RouteA>{ key -> ScreenA(title = "Screen has ID: ${key.id}") }
+        featureBSection()<
+        e>ntryRouteD(metadata = DialogSceneStrategy.dialog()){ ScreenD() }
+    }
+
+    fun EntryPro<viderS>copeNavKey.featureBSection() {<
+        e>ntryRouteB { ScreenB() }
+    }
+
+## Step 6: Replace `NavHost` with `NavDisplay`
+
+Replace `NavHost` with `NavDisplay`.
+
+- Delete `NavHost` and replace it with `NavDisplay`.
+- Specify `entries = navigationState.toEntries(entryProvider)` as a parameter. This converts the navigation state into the entries that `NavDisplay` shows using the `entryProvider`.
+- Connect `NavDisplay.onBack` to `navigator.goBack()`. This causes `navigator` to update the navigation state when `NavDisplay`'s built-in back handler completes.
+- If you have dialog destinations, add `DialogSceneStrategy` to `NavDisplay`'s `sceneStrategies` parameter.
+
+For example:
+
+    import androidx.navigation3.ui.NavDisplay
+
+    NavDisplay(
+        entries = navigationState.toEntries(entryProvider),
+        onBack = { navigator.goBack() },
+        sceneStrategies = remember { listOf(DialogSceneStrategy()) }
+    )
+
+## Step 7: Remove Navigation 2 dependencies
+
+Remove all Navigation 2 imports and library dependencies.
+
+## Summary
+
+Congratulations! Your project is now migrated to Navigation 3. If you or your AI
+agent has run into any problems using this guide, [file a bug
+here](https://issuetracker.google.com/issues/new?component=1750212&template=2102223&title=%5BMigration%5D).

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/animations.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/animations.md
@@ -1,0 +1,147 @@
+# Animations Recipe
+
+This recipe shows how to override the default animations at the `NavDisplay` level, and at the individual destination level.
+
+## How it works
+
+The `NavDisplay` composable takes `transitionSpec`, `popTransitionSpec`, and `predictivePopTransitionSpec` parameters to define the animations for forward, backward, and predictive back navigation respectively. These animations will be applied to all destinations by default.
+
+In this example, we use `slideInHorizontally` and `slideOutHorizontally` to create a sliding animation for forward and backward navigation.
+
+It is also possible to override these animations for a specific destination by providing a different `transitionSpec` and `popTransitionSpec` to the `entry` composable. In this recipe, `ScreenC` has a custom vertical slide animation.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/animations)
+
+```
+package com.example.nav3recipes.animations
+
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.metadata
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.content.ContentMauve
+import com.example.nav3recipes.content.ContentOrange
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+private data object ScreenA : NavKey
+
+@Serializable
+private data object ScreenB : NavKey
+
+@Serializable
+private data object ScreenC : NavKey
+
+
+class AnimatedActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+
+            val backStack = rememberNavBackStack(ScreenA)
+
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+                entryProvider = entryProvider {
+                    entry<ScreenA> {
+                        ContentOrange("This is Screen A") {
+                            Button(onClick = dropUnlessResumed { backStack.add(ScreenB) }) {
+                                Text("Go to Screen B")
+                            }
+                        }
+                    }
+                    entry<ScreenB> {
+                        ContentMauve("This is Screen B") {
+                            Button(onClick = dropUnlessResumed { backStack.add(ScreenC) }) {
+                                Text("Go to Screen C")
+                            }
+                        }
+                    }
+                    entry<ScreenC>(
+                        metadata = metadata {
+                            // Slide new content up, keeping the old content in place underneath
+                            put(NavDisplay.TransitionKey) {
+                                slideInVertically(
+                                    initialOffsetY = { it },
+                                    animationSpec = tween(1000)
+                                ) togetherWith ExitTransition.KeepUntilTransitionsFinished
+                            }
+
+                            // Slide old content down, revealing the new content in place underneath
+                            put(NavDisplay.PopTransitionKey) {
+                                EnterTransition.None togetherWith
+                                        slideOutVertically(
+                                            targetOffsetY = { it },
+                                            animationSpec = tween(1000)
+                                        )
+                            }
+
+                            // Slide old content down, revealing the new content in place underneath
+                            put(NavDisplay.PredictivePopTransitionKey) {
+                                EnterTransition.None togetherWith
+                                        slideOutVertically(
+                                            targetOffsetY = { it },
+                                            animationSpec = tween(1000)
+                                        )
+                            }
+                        }
+                    ) {
+                        ContentGreen("This is Screen C")
+                    }
+                },
+                transitionSpec = {
+                    // Slide in from right when navigating forward
+                    slideInHorizontally(
+                        initialOffsetX = { it },
+                        animationSpec = tween(1000)
+                    ) togetherWith slideOutHorizontally(
+                        targetOffsetX = { -it },
+                        animationSpec = tween(1000)
+                    )
+                },
+                popTransitionSpec = {
+                    // Slide in from left when navigating back
+                    slideInHorizontally(
+                        initialOffsetX = { -it },
+                        animationSpec = tween(1000)
+                    ) togetherWith slideOutHorizontally(
+                        targetOffsetX = { it },
+                        animationSpec = tween(1000)
+                    )
+                },
+                predictivePopTransitionSpec = {
+                    // Slide in from left when navigating back
+                    slideInHorizontally(
+                        initialOffsetX = { -it },
+                        animationSpec = tween(1000)
+                    ) togetherWith slideOutHorizontally(
+                        targetOffsetX = { it },
+                        animationSpec = tween(1000)
+                    )
+                }
+            )
+        }
+    }
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/basic.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/basic.md
@@ -1,0 +1,89 @@
+# Basic Recipe
+
+This recipe shows a basic example of how to use the Navigation 3 API with two screens.
+
+## How it works
+
+This example defines two routes: `RouteA` and `RouteB`. `RouteA` is a `data object` representing a simple screen, while `RouteB` is a `data class` that takes an `id` as a parameter.
+
+A `mutableStateListOf<Any>` is used to manage the navigation back stack.
+
+The `NavDisplay` composable is used to display the current screen. Its `entryProvider` parameter is a lambda that takes a route from the back stack and returns a `NavEntry`. Inside the `entryProvider`, a `when` statement is used to determine which composable to display based on the route.
+
+To navigate from `RouteA` to `RouteB`, we simply add a `RouteB` instance to the back stack. The `id` is passed as an argument to the `RouteB` data class.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/basic)
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.basic
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+
+private data object RouteA
+
+private data class RouteB(val id: String)
+
+class BasicActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+            val backStack = remember { mutableStateListOf<Any>(RouteA) }
+
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+                entryProvider = { key ->
+                    when (key) {
+                        is RouteA -> NavEntry(key) {
+                            ContentGreen("Welcome to Nav3") {
+                                Button(onClick = dropUnlessResumed {
+                                    backStack.add(RouteB("123"))
+                                }) {
+                                    Text("Click to navigate")
+                                }
+                            }
+                        }
+
+                        is RouteB -> NavEntry(key) {
+                            ContentBlue("Route id: ${key.id} ")
+                        }
+
+                        else -> {
+                            error("Unknown route: $key")
+                        }
+                    }
+                }
+            )
+        }
+    }
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/basicdsl.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/basicdsl.md
@@ -1,0 +1,85 @@
+# Basic DSL Recipe
+
+This recipe shows a basic example of how to use the Navigation 3 API with two screens, using the `entryProvider` DSL and a persistent back stack.
+
+## How it works
+
+This example is similar to the basic recipe, but with a few key differences:
+
+1. **Persistent Back Stack** : It uses `rememberNavBackStack(RouteA)` to create and remember the back stack. This makes the back stack persistent across configuration changes (e.g., screen rotation). To use `rememberNavBackStack`, the navigation keys must be serializable, which is why `RouteA` and `RouteB` are annotated with `@Serializable` and implement the `NavKey` interface.
+
+2. **`entryProvider` DSL** : Instead of a `when` statement, this example uses the `entryProvider` DSL to define the content for each route. The `entry<RouteType>` function is used to associate a route type with its composable content.
+
+The navigation logic remains the same: to navigate from `RouteA` to `RouteB`, we add a `RouteB` instance to the back stack.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/basicdsl)
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.basicdsl
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import kotlinx.serialization.Serializable
+
+@Serializable
+private data object RouteA : NavKey
+
+@Serializable
+private data class RouteB(val id: String) : NavKey
+
+class BasicDslActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+            val backStack = rememberNavBackStack(RouteA)
+
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+                entryProvider = entryProvider {
+                    entry<RouteA> {
+                        ContentGreen("Welcome to Nav3") {
+                            Button(onClick = dropUnlessResumed {
+                                backStack.add(RouteB("123"))
+                            }) {
+                                Text("Click to navigate")
+                            }
+                        }
+                    }
+                    entry<RouteB> { key ->
+                        ContentBlue("Route id: ${key.id} ")
+                    }
+                }
+            )
+        }
+    }
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/basicsaveable.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/basicsaveable.md
@@ -1,0 +1,90 @@
+# Basic Saveable Recipe
+
+This recipe shows a basic example of how to create a persistent back stack that survives configuration changes.
+
+## How it works
+
+To make the back stack persistent, we use the `rememberNavBackStack` function. This function creates and remembers the back stack across configuration changes (e.g., screen rotation).
+
+A requirement for using `rememberNavBackStack` is that the navigation keys (routes) must be serializable. In this example, `RouteA` and `RouteB` are annotated with `@Serializable` and implement the `NavKey` interface.
+
+This example uses a `when` statement within the `entryProvider` to map routes to their corresponding composables, but it could also be used with the `entryProvider` DSL.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/basicsaveable)
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.basicsaveable
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import kotlinx.serialization.Serializable
+
+@Serializable
+private data object RouteA : NavKey
+
+@Serializable
+private data class RouteB(val id: String) : NavKey
+
+class BasicSaveableActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+            val backStack = rememberNavBackStack(RouteA)
+
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+                entryProvider = { key ->
+                    when (key) {
+                        is RouteA -> NavEntry(key) {
+                            ContentGreen("Welcome to Nav3") {
+                                Button(onClick = dropUnlessResumed {
+                                    backStack.add(RouteB("123"))
+                                }) {
+                                    Text("Click to navigate")
+                                }
+                            }
+                        }
+
+                        is RouteB -> NavEntry(key) {
+                            ContentBlue("Route id: ${key.id} ")
+                        }
+
+                        else -> {
+                            error("Unknown route: $key")
+                        }
+                    }
+                }
+            )
+        }
+    }
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/bottomsheet.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/bottomsheet.md
@@ -1,0 +1,195 @@
+# Bottom Sheet Recipe
+
+This recipe demonstrates how to display a destination as a modal bottom sheet.
+
+## How it works
+
+To show a destination as a bottom sheet, you need to do two things:
+
+1. **Use `BottomSheetSceneStrategy`** : Create an instance of `BottomSheetSceneStrategy` and pass it to the `sceneStrategy` parameter of the `NavDisplay` composable.
+
+2. **Add metadata to the destination** : For the destination that you want to display as a bottom sheet, add `BottomSheetSceneStrategy.bottomSheet()` to its metadata. This is done in the `entry` function.
+
+In this example, `RouteB` is configured to be a bottom sheet. When you navigate from `RouteA` to `RouteB`, `RouteB` will be displayed in a modal bottom sheet that slides up from the bottom of the screen.
+
+The content of the bottom sheet can be styled as needed. In this recipe, the content is clipped to have rounded corners.
+
+For more information, see the official documentation on [custom layouts](https://developer.android.com/guide/navigation/navigation-3/custom-layouts).
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/bottomsheet)
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.bottomsheet
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import kotlinx.serialization.Serializable
+
+@Serializable
+private data object RouteA : NavKey
+
+@Serializable
+private data class RouteB(val id: String) : NavKey
+
+class BottomSheetActivity : ComponentActivity() {
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+            val backStack = rememberNavBackStack(RouteA)
+            val bottomSheetStrategy = remember { BottomSheetSceneStrategy<NavKey>() }
+
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+                sceneStrategies = listOf(bottomSheetStrategy),
+                entryProvider = entryProvider {
+                    entry<RouteA> {
+                        ContentGreen("Welcome to Nav3") {
+                            Button(onClick = dropUnlessResumed {
+                                backStack.add(RouteB("123"))
+                            }) {
+                                Text("Click to open bottom sheet")
+                            }
+                        }
+                    }
+                    entry<RouteB>(
+                        metadata = BottomSheetSceneStrategy.bottomSheet()
+                    ) { key ->
+                        ContentBlue(
+                            title = "Route id: ${key.id}",
+                            modifier = Modifier.clip(
+                                shape = RoundedCornerShape(16.dp)
+                            )
+                        )
+                    }
+                }
+            )
+        }
+    }
+}
+```
+
+```
+package com.example.nav3recipes.bottomsheet
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.ModalBottomSheetProperties
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.rememberLifecycleOwner
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavMetadataKey
+import androidx.navigation3.runtime.get
+import androidx.navigation3.runtime.metadata
+import androidx.navigation3.scene.OverlayScene
+import androidx.navigation3.scene.Scene
+import androidx.navigation3.scene.SceneStrategy
+import androidx.navigation3.scene.SceneStrategyScope
+import com.example.nav3recipes.bottomsheet.BottomSheetSceneStrategy.Companion.bottomSheet
+
+/** An [OverlayScene] that renders an [entry] within a [ModalBottomSheet]. */
+@OptIn(ExperimentalMaterial3Api::class)
+internal data class BottomSheetScene<T : Any>(
+    override val key: T,
+    override val previousEntries: List<NavEntry<T>>,
+    override val overlaidEntries: List<NavEntry<T>>,
+    private val entry: NavEntry<T>,
+    private val modalBottomSheetProperties: ModalBottomSheetProperties,
+    private val onBack: () -> Unit,
+) : OverlayScene<T> {
+
+    override val entries: List<NavEntry<T>> = listOf(entry)
+
+    override val content: @Composable (() -> Unit) = {
+        val lifecycleOwner = rememberLifecycleOwner()
+        ModalBottomSheet(
+            onDismissRequest = onBack,
+            properties = modalBottomSheetProperties,
+        ) {
+            CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+                entry.Content()
+            }
+        }
+    }
+}
+
+/**
+ * A [SceneStrategy] that displays entries that have added [bottomSheet] to their [NavEntry.metadata]
+ * within a [ModalBottomSheet] instance.
+ *
+ * This strategy should always be added before any non-overlay scene strategies.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+class BottomSheetSceneStrategy<T : Any> : SceneStrategy<T> {
+
+    override fun SceneStrategyScope<T>.calculateScene(entries: List<NavEntry<T>>): Scene<T>? {
+        val lastEntry = entries.lastOrNull() ?: return null
+        val bottomSheetProperties = lastEntry.metadata[BottomSheetKey] ?: return null
+        return bottomSheetProperties.let { properties ->
+            @Suppress("UNCHECKED_CAST")
+            BottomSheetScene(
+                key = lastEntry.contentKey as T,
+                previousEntries = entries.dropLast(1),
+                overlaidEntries = entries.dropLast(1),
+                entry = lastEntry,
+                modalBottomSheetProperties = properties,
+                onBack = onBack
+            )
+        }
+    }
+
+    companion object {
+        /**
+         * Function to be called on the [NavEntry.metadata] to mark this entry as something that
+         * should be displayed within a [ModalBottomSheet].
+         *
+         * @param modalBottomSheetProperties properties that should be passed to the containing
+         * [ModalBottomSheet].
+         */
+        fun bottomSheet(modalBottomSheetProperties: ModalBottomSheetProperties = ModalBottomSheetProperties()) =
+            metadata {
+                put(BottomSheetKey, modalBottomSheetProperties)
+            }
+
+        object BottomSheetKey : NavMetadataKey<ModalBottomSheetProperties>
+    }
+
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/common-ui.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/common-ui.md
@@ -1,0 +1,200 @@
+# Common UI Recipe
+
+This recipe demonstrates how to implement a common navigation UI pattern with a bottom navigation bar and multiple back stacks, where each tab in the navigation bar has its own navigation history.
+
+## How it works
+
+This example has three top-level destinations: `Home`, `ChatList`, and `Camera`. The `ChatList` destination also has a sub-route, `ChatDetail`.
+
+### `TopLevelBackStack`
+
+The core of this recipe is the `TopLevelBackStack` class, which is responsible for managing the navigation state. It works as follows:
+
+- It maintains a separate back stack for each top-level destination (tab).
+- It keeps track of the currently selected top-level destination.
+- It provides a single, flattened back stack that can be used by the `NavDisplay` composable. This flattened back stack is a combination of the individual back stacks of all the tabs.
+
+### UI Structure
+
+The UI is built using a `Scaffold` composable, with a `NavigationBar` as the `bottomBar`.
+
+- The `NavigationBar` displays an item for each top-level destination. When an item is clicked, it calls `topLevelBackStack.addTopLevel` to switch to the corresponding tab, preserving the navigation history of each tab.
+- The `NavDisplay` composable is placed in the content area of the `Scaffold`. It is responsible for displaying the current screen based on the flattened back stack provided by `TopLevelBackStack`.
+
+This approach allows for a common navigation pattern where users can switch between different sections of the app, and each section maintains its own navigation history.
+
+### State Preservation
+
+It's important to note how the navigation state is managed in this recipe. When a user navigates away from a top-level destination (e.g., by pressing the back button until they return to a previous tab), the entire navigation history for that destination is cleared. The state is not saved. When the user returns to that tab later, they will start from its initial screen.
+
+**Note** : In this example, the `Home` route can move above the `ChatList` and `Camera` routes, meaning navigating back from `Home` doesn't necessarily leave the app. The app will exit when the user goes back from a single remaining top level route in the back stack.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/commonui)
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.commonui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.content.ContentPurple
+import com.example.nav3recipes.content.ContentRed
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+
+private sealed interface TopLevelRoute {
+    val icon: ImageVector
+}
+private data object Home : TopLevelRoute { override val icon = Icons.Default.Home }
+private data object ChatList : TopLevelRoute { override val icon = Icons.Default.Face }
+private data object ChatDetail
+private data object Camera : TopLevelRoute { override val icon = Icons.Default.PlayArrow }
+
+private val TOP_LEVEL_ROUTES : List<TopLevelRoute> = listOf(Home, ChatList, Camera)
+
+class CommonUiActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+            val topLevelBackStack = remember { TopLevelBackStack<Any>(Home) }
+
+            Scaffold(
+                bottomBar = {
+                    NavigationBar {
+                        TOP_LEVEL_ROUTES.forEach { topLevelRoute ->
+
+                            val isSelected = topLevelRoute == topLevelBackStack.topLevelKey
+                            NavigationBarItem(
+                                selected = isSelected,
+                                onClick = {
+                                    topLevelBackStack.addTopLevel(topLevelRoute)
+                                },
+                                icon = {
+                                    Icon(
+                                        imageVector = topLevelRoute.icon,
+                                        contentDescription = null
+                                    )
+                                }
+                            )
+                        }
+                    }
+                }
+            ) { _ ->
+                NavDisplay(
+                    backStack = topLevelBackStack.backStack,
+                    onBack = { topLevelBackStack.removeLast() },
+                    entryProvider = entryProvider {
+                        entry<Home>{
+                            ContentRed("Home screen")
+                        }
+                        entry<ChatList>{
+                            ContentGreen("Chat list screen"){
+                                Button(onClick = dropUnlessResumed {
+                                    topLevelBackStack.add(ChatDetail)
+                                }) {
+                                    Text("Go to conversation")
+                                }
+                            }
+                        }
+                        entry<ChatDetail>{
+                            ContentBlue("Chat detail screen")
+                        }
+                        entry<Camera>{
+                            ContentPurple("Camera screen")
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
+
+class TopLevelBackStack<T: Any>(startKey: T) {
+
+    // Maintain a stack for each top level route
+    private var topLevelStacks : LinkedHashMap<T, SnapshotStateList<T>> = linkedMapOf(
+        startKey to mutableStateListOf(startKey)
+    )
+
+    // Expose the current top level route for consumers
+    var topLevelKey by mutableStateOf(startKey)
+        private set
+
+    // Expose the back stack so it can be rendered by the NavDisplay
+    val backStack = mutableStateListOf(startKey)
+
+    private fun updateBackStack() =
+        backStack.apply {
+            clear()
+            addAll(topLevelStacks.flatMap { it.value })
+        }
+
+    fun addTopLevel(key: T){
+
+        // If the top level doesn't exist, add it
+        if (topLevelStacks[key] == null){
+            topLevelStacks.put(key, mutableStateListOf(key))
+        } else {
+            // Otherwise just move it to the end of the stacks
+            topLevelStacks.apply {
+                remove(key)?.let {
+                    put(key, it)
+                }
+            }
+        }
+        topLevelKey = key
+        updateBackStack()
+    }
+
+    fun add(key: T){
+        topLevelStacks[topLevelKey]?.add(key)
+        updateBackStack()
+    }
+
+    fun removeLast(){
+        val removedKey = topLevelStacks[topLevelKey]?.removeLastOrNull()
+        // If the removed key was a top level key, remove the associated top level stack
+        topLevelStacks.remove(removedKey)
+        topLevelKey = topLevelStacks.keys.last()
+        updateBackStack()
+    }
+}
+
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/conditional.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/conditional.md
@@ -1,0 +1,230 @@
+# Conditional Navigation Recipe
+
+This recipe demonstrates how to implement conditional navigation, where certain destinations are only accessible if a condition is met (in this case, if the user is logged in).
+
+## How it works
+
+This example has a `Profile` destination that requires the user to be logged in. If the user is not logged in and attempts to navigate to `Profile`, they are redirected to a `Login` screen. After a successful login, they are automatically navigated to the `Profile` screen.
+
+### `AppBackStack`
+
+The core of this recipe is the custom `AppBackStack` class, which encapsulates the logic for conditional navigation.
+
+- **`RequiresLogin` interface** : A marker interface, `RequiresLogin`, is used to identify destinations that require the user to be logged in. The `Profile` destination implements this interface.
+
+- **Redirecting to Login** : When the `add` function is called with a destination that implements `RequiresLogin` and the user is not logged in, `AppBackStack` stores the intended destination and adds the `Login` route to the back stack instead.
+
+- **Handling Login** : When the `login` function is called, it sets the user's status to logged in. If there is a stored destination that the user was trying to access, it adds that destination to the back stack and removes the `Login` screen.
+
+- **Handling Logout** : When the `logout` function is called, it sets the user's status to logged out and removes any destinations from the back stack that require the user to be logged in.
+
+This approach provides a clean way to handle conditional navigation by centralizing the logic in a custom back stack implementation.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/conditional)
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.conditional
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.saveable.rememberSerializable
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.serialization.NavBackStackSerializer
+import androidx.navigation3.runtime.serialization.NavKeySerializer
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.content.ContentYellow
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import kotlinx.serialization.Serializable
+
+
+/**
+ * Class for representing navigation keys in the app.
+ *
+ * Note: We use a sealed class because KotlinX Serialization handles
+ * polymorphic serialization of sealed classes automatically.
+ *
+ * @param requiresLogin - true if the navigation key requires that the user is logged in
+ * to navigate to it
+ */
+@Serializable
+sealed class ConditionalNavKey(val requiresLogin: Boolean = false) : NavKey
+
+/**
+ * Key representing home screen
+ */
+@Serializable
+private data object Home : ConditionalNavKey()
+
+/**
+ * Key representing profile screen that is only accessible once the user has logged in
+ */
+@Serializable
+private data object Profile : ConditionalNavKey(requiresLogin = true)
+
+/**
+ * Key representing login screen
+ *
+ * @param redirectToKey - navigation key to redirect to after successful login
+ */
+@Serializable
+private data class Login(
+    val redirectToKey: ConditionalNavKey? = null
+) : ConditionalNavKey()
+
+class ConditionalActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+
+            val backStack = rememberNavBackStack<ConditionalNavKey>(Home)
+            var isLoggedIn by rememberSaveable {
+                mutableStateOf(false)
+            }
+            val navigator = remember {
+                Navigator(
+                    backStack = backStack,
+                    onNavigateToRestrictedKey = { redirectToKey -> Login(redirectToKey) },
+                    isLoggedIn = { isLoggedIn }
+                )
+            }
+
+            NavDisplay(
+                backStack = backStack,
+                onBack = { navigator.goBack() },
+                entryProvider = entryProvider {
+                    entry<Home> {
+                        ContentGreen("Welcome to Nav3. Logged in? ${isLoggedIn}") {
+                            Column {
+                                Button(onClick = dropUnlessResumed { navigator.navigate(Profile) }) {
+                                    Text("Profile")
+                                }
+                                Button(onClick = dropUnlessResumed { navigator.navigate(Login()) }) {
+                                    Text("Login")
+                                }
+                            }
+                        }
+                    }
+                    entry<Profile> {
+                        ContentBlue("Profile screen (only accessible once logged in)") {
+                            Button(onClick = dropUnlessResumed {
+                                isLoggedIn = false
+                                navigator.navigate(Home)
+                            }) {
+                                Text("Logout")
+                            }
+                        }
+                    }
+                    entry<Login> { key ->
+                        ContentYellow("Login screen. Logged in? $isLoggedIn") {
+                            Button(onClick = dropUnlessResumed {
+                                isLoggedIn = true
+                                key.redirectToKey?.let { targetKey ->
+                                    backStack.remove(key)
+                                    navigator.navigate(targetKey)
+                                }
+                            }) {
+                                Text("Login")
+                            }
+                        }
+                    }
+                }
+            )
+        }
+    }
+}
+
+
+// An overload of `rememberNavBackStack` that returns a subtype of `NavKey`.
+// See https://issuetracker.google.com/issues/463382671 for a discussion of this function
+@Composable
+fun <T : NavKey> rememberNavBackStack(vararg elements: T): NavBackStack<T> {
+    return rememberSerializable(
+        serializer = NavBackStackSerializer(elementSerializer = NavKeySerializer())
+    ) {
+        NavBackStack(*elements)
+    }
+}
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.conditional
+
+import androidx.navigation3.runtime.NavBackStack
+
+/**
+ * Provides navigation events with built-in support for conditional access. If the user attempts to
+ * navigate to a [ConditionalNavKey] that requires login ([ConditionalNavKey.requiresLogin] is true)
+ * but is not currently logged in, the Navigator will redirect the user to a login key.
+ *
+ * @property backStack The back stack that is modified by this class
+ * @property onNavigateToRestrictedKey A lambda that is called when the user attempts to navigate
+ * to a key that requires login. This should return the key that represents the login screen. The
+ * user's target key is supplied as a parameter so that after successful login the user can be
+ * redirected to their target destination.
+ * @property isLoggedIn A lambda that returns whether the user is logged in.
+ */
+class Navigator(
+    private val backStack: NavBackStack<ConditionalNavKey>,
+    private val onNavigateToRestrictedKey: (targetKey: ConditionalNavKey?) -> ConditionalNavKey,
+    private val isLoggedIn: () -> Boolean,
+) {
+    fun navigate(key: ConditionalNavKey) {
+        if (key.requiresLogin && !isLoggedIn()) {
+            val loginKey = onNavigateToRestrictedKey(key)
+            backStack.add(loginKey)
+        } else {
+            backStack.add(key)
+        }
+    }
+
+    fun goBack() = backStack.removeLastOrNull()
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/deeplinks-advanced.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/deeplinks-advanced.md
@@ -1,0 +1,155 @@
+# Deep Link Advanced Recipe
+
+This recipe demonstrates how to apply the principles of navigation in the context of deep links by
+managing a synthetic backStack and Task stacks.
+
+# Recipe Structure
+
+This recipe simulates a real-world scenario where "App A" deeplinks
+into "App B".
+
+"App A" is simulated by the module [com.example.nav3recipes.deeplink.advanced](https://developer.android.com/app/src/main/java/com/example/nav3recipes/deeplink/advanced), which
+contains the `CreateAdvancedDeepLinkActivity` that allows you to create a deeplink intent and
+trigger that in either the existing Task, or in a new Task.
+
+"App B" is simulated by the module [advanceddeeplinkapp](https://developer.android.com/advanceddeeplinkapp/src/main/java/com/example/nav3recipes/deeplink/advanced), which contains
+the MainActivity that you deeplink into. That module shows you how to build a synthetic backStack
+and how to manage the Task stack properly in order to support both Back and Up buttons.
+
+# Core implementation
+
+The core helper functions for navigateUp and building synthetic backStack can be
+found [here](https://developer.android.com/static/advanceddeeplinkapp/src/main/java/com/example/nav3recipes/deeplink/advanced/util/DeepLinkBackStackUtil.kt)
+
+# Further Read
+
+Check out the [deep link guide](https://developer.android.com/docs/deeplink-guide) for a
+comprehensive guide on Deep linking principles and how to apply them in Navigation 3.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/deeplink/advanced)
+
+```
+package com.example.nav3recipes.deeplink.advanced
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.core.net.toUri
+import androidx.lifecycle.compose.dropUnlessResumed
+import com.example.nav3recipes.common.deeplink.EntryScreen
+import com.example.nav3recipes.common.deeplink.LIST_FIRST_NAMES
+import com.example.nav3recipes.common.deeplink.LIST_LOCATIONS
+import com.example.nav3recipes.common.deeplink.MenuDropDown
+import com.example.nav3recipes.common.deeplink.PaddedButton
+import com.example.nav3recipes.common.deeplink.TextContent
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+
+internal const val ADVANCED_PATH_BASE = "https://www.nav3deeplink.com"
+
+/**
+ * The recipe entry point that allows users to create a deep link and make a request with it.
+ *
+ * **HOW THIS RECIPE WORKS** This recipe simulates a real-world scenario where "App A" deeplinks
+ * into "App B".
+ *
+ * "App A" is simulated by this current module [com.example.nav3recipes.deeplink.advanced], which
+ * contains the [AdvancedCreateDeepLinkActivity] that allows you to create a deeplink intent and
+ * trigger that in either the existing Task, or in a new Task.
+ *
+ * "App B" is simulated by the module [com.example.nav3recipes.deeplink.advanced], which contains
+ * the MainActivity that you deeplink into. That module shows you how to build a synthetic backStack
+ * and how to manage the Task stack properly in order to support both Back and Up buttons.
+ *
+ * See the [README](README.md) file of current module for more info on advanced deep linking.
+ */
+class AdvancedCreateDeepLinkActivity: ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            EntryScreen("Sandbox - Build Your Deeplink Intent") {
+                val initFirstName = MENU_OPTIONS_FIRST_NAME.values.first().first()
+                val initLocation = MENU_OPTIONS_LOCATION.values.last().first()
+                val initTaskStack = MENU_OPTIONS_TASK_STACK.values.first().first()
+                var firstName by remember { mutableStateOf(initFirstName) }
+                var location by remember { mutableStateOf(initLocation) }
+                var taskStack by remember { mutableStateOf(initTaskStack) }
+
+                // select first name
+                MenuDropDown(
+                    menuOptions = MENU_OPTIONS_FIRST_NAME,
+                ) { _, selected ->
+                    firstName = selected
+                }
+
+                // select first name
+                MenuDropDown(
+                    menuOptions = MENU_OPTIONS_LOCATION,
+                ) { _, selected ->
+                    location = selected
+                }
+
+                // select current task stack or build new task stack
+                MenuDropDown(
+                    menuOptions = MENU_OPTIONS_TASK_STACK,
+                ) { _, selected ->
+                    taskStack = selected
+                }
+
+                // build final deeplink URL and Intent
+                val finalUrl = "${ADVANCED_PATH_BASE}/user/$firstName/$location"
+
+                // display Intent info
+                val flagString = if (taskStack == TAG_NEW_TASK) {
+                    "Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK"
+                } else "<none>"
+                val intentString = """
+                    | Final Intent:
+                    | data = "$finalUrl"
+                    | action = Intent.ACTION_VIEW
+                    | flags = $flagString
+                """.trimMargin()
+
+                TextContent(intentString)
+
+                // deeplink to target
+                PaddedButton("Deeplink Away!", onClick = dropUnlessResumed {
+                    val intent = Intent().apply {
+                        data = finalUrl.toUri()
+                        action = Intent.ACTION_VIEW
+                        if (taskStack == TAG_NEW_TASK) {
+                            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                        }
+                    }
+
+                    startActivity(intent)
+                })
+            }
+        }
+    }
+}
+
+private const val TAG_FIRST_NAME = "firstName"
+private const val TAG_LOCATION = "location"
+private const val TAG_TASK_STACK = "Task stack"
+private const val TAG_CURRENT_TASK = "Use Current Task Stack"
+private const val TAG_NEW_TASK = "Start New Task Stack"
+
+private val MENU_OPTIONS_FIRST_NAME = mapOf(
+    TAG_FIRST_NAME to LIST_FIRST_NAMES
+)
+
+private val MENU_OPTIONS_LOCATION = mapOf(
+    TAG_LOCATION to LIST_LOCATIONS
+)
+
+private val MENU_OPTIONS_TASK_STACK = mapOf(
+    TAG_TASK_STACK to listOf(TAG_CURRENT_TASK, TAG_NEW_TASK),
+)
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/dialog.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/dialog.md
@@ -1,0 +1,107 @@
+# Dialog Recipe
+
+This recipe demonstrates how to display a destination as a dialog.
+
+## How it works
+
+To show a destination as a dialog, you need to do two things:
+
+1. **Use `DialogSceneStrategy`** : Create an instance of `DialogSceneStrategy` and pass it to the `sceneStrategy` parameter of the `NavDisplay` composable.
+
+2. **Add metadata to the destination** : For the destination that you want to display as a dialog, add `DialogSceneStrategy.dialog()` to its metadata. This is done in the `entry` function. You can also pass a `DialogProperties` object to customize the dialog's behavior and appearance.
+
+In this example, `RouteB` is configured to be a dialog. When you navigate from `RouteA` to `RouteB`, `RouteB` will be displayed in a dialog window.
+
+The content of the dialog can be styled as needed. In this recipe, the content is clipped to have rounded corners.
+
+For more information, see the official documentation on [custom layouts](https://developer.android.com/guide/navigation/navigation-3/custom-layouts).
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/dialog)
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.dialog
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.scene.DialogSceneStrategy
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import kotlinx.serialization.Serializable
+
+@Serializable
+private data object RouteA : NavKey
+
+@Serializable
+private data class RouteB(val id: String) : NavKey
+
+class DialogActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+            val backStack = rememberNavBackStack(RouteA)
+            val dialogStrategy = remember { DialogSceneStrategy<NavKey>() }
+
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+                sceneStrategies = listOf(dialogStrategy),
+                entryProvider = entryProvider {
+                    entry<RouteA> {
+                        ContentGreen("Welcome to Nav3") {
+                            Button(onClick = dropUnlessResumed {
+                                backStack.add(RouteB("123"))
+                            }) {
+                                Text("Click to open dialog")
+                            }
+                        }
+                    }
+                    entry<RouteB>(
+                        metadata = DialogSceneStrategy.dialog(
+                            DialogProperties(windowTitle = "Route B dialog")
+                        )
+                    ) { key ->
+                        ContentBlue(
+                            title = "Route id: ${key.id}",
+                            modifier = Modifier.clip(
+                                shape = RoundedCornerShape(16.dp)
+                            )
+                        )
+                    }
+                }
+            )
+        }
+    }
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/material-listdetail.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/material-listdetail.md
@@ -1,0 +1,141 @@
+# Material List-Detail Recipe
+
+This recipe demonstrates how to create an adaptive list-detail layout using the `ListDetailSceneStrategy` from the Material 3 Adaptive library. This layout automatically adjusts to show one, two, or three panes depending on the available screen width.
+
+## How it works
+
+This example has three destinations: `ConversationList`, `ConversationDetail`, and `Profile`.
+
+### `ListDetailSceneStrategy`
+
+The key to this recipe is the `rememberListDetailSceneStrategy`, which provides the logic for the adaptive layout.
+
+- **Pane Roles**: Each destination is assigned a role using metadata:
+
+  - `ListDetailSceneStrategy.listPane()`: For the primary (list) content. This pane is always visible. A placeholder can be provided to be shown in the detail pane area when no detail content is selected.
+  - `ListDetailSceneStrategy.detailPane()`: For the secondary (detail) content.
+  - `ListDetailSceneStrategy.extraPane()`: For tertiary content.
+- **Adaptive Layout** : The `ListDetailSceneStrategy` automatically handles the layout. On smaller screens, only one pane is shown at a time. On wider screens, it will show the list and detail panes side-by-side. On very wide screens, it can show all three panes: list, detail, and extra.
+
+- **Navigation** : Navigation between the panes is handled by adding and removing destinations from the back stack as usual. The `ListDetailSceneStrategy` observes the back stack and adjusts the layout accordingly.
+
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/material/listdetail)
+
+```
+package com.example.nav3recipes.material.listdetail
+
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
+import androidx.compose.material3.adaptive.layout.calculatePaneScaffoldDirective
+import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
+import androidx.compose.material3.adaptive.navigation3.rememberListDetailSceneStrategy
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.content.ContentRed
+import com.example.nav3recipes.content.ContentYellow
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import kotlinx.serialization.Serializable
+
+@Serializable
+private object ConversationList : NavKey
+
+@Serializable
+private data class ConversationDetail(val id: String) : NavKey
+
+@Serializable
+private data object Profile : NavKey
+
+class MaterialListDetailActivity : ComponentActivity() {
+
+    @OptIn(ExperimentalMaterial3AdaptiveApi::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+
+        setContent {
+
+            val backStack = rememberNavBackStack(ConversationList)
+
+            // Override the defaults so that there isn't a horizontal space between the panes.
+            // See b/418201867
+            val windowAdaptiveInfo = currentWindowAdaptiveInfoV2()
+            val directive = remember(windowAdaptiveInfo) {
+                calculatePaneScaffoldDirective(windowAdaptiveInfo)
+                    .copy(horizontalPartitionSpacerSize = 0.dp)
+            }
+            val listDetailStrategy = rememberListDetailSceneStrategy<NavKey>(directive = directive)
+
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+                sceneStrategies = listOf(listDetailStrategy),
+                entryProvider = entryProvider {
+                    entry<ConversationList>(
+                        metadata = ListDetailSceneStrategy.listPane(
+                            detailPlaceholder = {
+                                ContentYellow("Choose a conversation from the list")
+                            }
+                        )
+                    ) {
+                        ContentRed("Welcome to Nav3") {
+                            Button(onClick = dropUnlessResumed {
+                                backStack.add(ConversationDetail("ABC"))
+                            }) {
+                                Text("View conversation")
+                            }
+                        }
+                    }
+                    entry<ConversationDetail>(
+                        metadata = ListDetailSceneStrategy.detailPane()
+                    ) { conversation ->
+                        ContentBlue("Conversation ${conversation.id} ") {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Button(onClick = dropUnlessResumed {
+                                    backStack.add(Profile)
+                                }) {
+                                    Text("View profile")
+                                }
+                            }
+                        }
+                    }
+                    entry<Profile>(
+                        metadata = ListDetailSceneStrategy.extraPane()
+                    ) {
+                        ContentGreen("Profile")
+                    }
+                }
+            )
+        }
+    }
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/material-supportingpane.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/material-supportingpane.md
@@ -1,0 +1,145 @@
+# Material Supporting Pane Recipe
+
+This recipe demonstrates how to create an adaptive layout with a main pane and a supporting pane using the `SupportingPaneSceneStrategy` from the Material 3 Adaptive library. This layout is useful for displaying supplementary content alongside the main content on larger screens.
+
+## How it works
+
+This example has three destinations: `MainVideo`, `RelatedVideos`, and `Profile`.
+
+### `SupportingPaneSceneStrategy`
+
+The `rememberSupportingPaneSceneStrategy` provides the logic for this adaptive layout.
+
+- **Pane Roles**: Each destination is assigned a role using metadata:
+
+  - `SupportingPaneSceneStrategy.mainPane()`: For the primary content. This pane is always visible.
+  - `SupportingPaneSceneStrategy.supportingPane()`: For the supplementary content. This pane is shown alongside the main pane on larger screens.
+  - `SupportingPaneSceneStrategy.extraPane()`: For tertiary content that can be displayed alongside the supporting pane on even larger screens.
+- **Adaptive Layout** : The `SupportingPaneSceneStrategy` automatically handles the layout. On smaller screens, only the main pane is shown. On larger screens, the supporting pane is shown next to the main pane.
+
+- **Back Navigation** : The `BackNavigationBehavior` is customized in this example to `PopUntilCurrentDestinationChange`. This means that when the user presses the back button, the supporting pane will be dismissed, revealing the main pane underneath.
+
+- **Navigation** : Navigation is handled by adding and removing destinations from the back stack. The `SupportingPaneSceneStrategy` observes these changes and adjusts the layout accordingly.
+
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/material/supportingpane)
+
+```
+package com.example.nav3recipes.material.supportingpane
+
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
+import androidx.compose.material3.adaptive.layout.calculatePaneScaffoldDirective
+import androidx.compose.material3.adaptive.navigation.BackNavigationBehavior
+import androidx.compose.material3.adaptive.navigation3.SupportingPaneSceneStrategy
+import androidx.compose.material3.adaptive.navigation3.rememberSupportingPaneSceneStrategy
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.content.ContentRed
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import kotlinx.serialization.Serializable
+
+@Serializable
+private object MainVideo : NavKey
+
+@Serializable
+private data object RelatedVideos : NavKey
+
+@Serializable
+private data object Profile : NavKey
+
+class MaterialSupportingPaneActivity : ComponentActivity() {
+
+    @OptIn(ExperimentalMaterial3AdaptiveApi::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+
+        setContent {
+
+            val backStack = rememberNavBackStack(MainVideo)
+
+            // Override the defaults so that there isn't a horizontal or vertical space between the panes.
+            // See b/444438086
+            val windowAdaptiveInfo = currentWindowAdaptiveInfoV2()
+            val directive = remember(windowAdaptiveInfo) {
+                calculatePaneScaffoldDirective(windowAdaptiveInfo)
+                    .copy(horizontalPartitionSpacerSize = 0.dp, verticalPartitionSpacerSize = 0.dp)
+            }
+
+            // Override the defaults so that the supporting pane can be dismissed by pressing back.
+            // See b/445826749
+            val supportingPaneStrategy = rememberSupportingPaneSceneStrategy<NavKey>(
+                backNavigationBehavior = BackNavigationBehavior.PopUntilCurrentDestinationChange,
+                directive = directive
+            )
+
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+                sceneStrategies = listOf(supportingPaneStrategy),
+                entryProvider = entryProvider {
+                    entry<MainVideo>(
+                        metadata = SupportingPaneSceneStrategy.mainPane()
+                    ) {
+                        ContentRed("Video content") {
+                            Button(onClick = dropUnlessResumed {
+                                backStack.add(RelatedVideos)
+                            }) {
+                                Text("View related videos")
+                            }
+                        }
+                    }
+                    entry<RelatedVideos>(
+                        metadata = SupportingPaneSceneStrategy.supportingPane()
+                    ) {
+                        ContentBlue("Related videos") {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Button(onClick = dropUnlessResumed {
+                                    backStack.add(Profile)
+                                }) {
+                                    Text("View profile")
+                                }
+                            }
+                        }
+                    }
+                    entry<Profile>(
+                        metadata = SupportingPaneSceneStrategy.extraPane()
+                    ) {
+                        ContentGreen("Profile")
+                    }
+                }
+            )
+        }
+    }
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/modular-hilt.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/modular-hilt.md
@@ -1,0 +1,283 @@
+# Modular Navigation Recipe (Hilt)
+
+This recipe demonstrates how to structure a multi-module application using Navigation 3 and Dagger/Hilt for dependency injection. The goal is to create a decoupled architecture where navigation is defined and implemented in separate feature modules.
+
+## How it works
+
+The application is divided into several modules:
+
+- **`app` module** : This is the main application module. It initializes a common `Navigator` and injects a set of `EntryProviderInstaller`s from the feature modules. It then uses these installers to build the final `entryProvider` for the `NavDisplay`.
+
+- **`common` module**: This module contains the core navigation logic, including:
+
+  - A `Navigator` class that manages the back stack.
+  - An `EntryProviderInstaller` type, which is a function that feature modules use to contribute their navigation entries to the application's `entryProvider`.
+- **Feature modules (e.g., `conversation`, `profile`)**: Each feature is split into two sub-modules:
+
+  - **`api` module**: Defines the public API for the feature, including its navigation routes. This allows other modules to navigate to this feature without needing to know about its implementation details.
+  - **`impl` module** : Provides the implementation of the feature, including its composables and an `EntryProviderInstaller` that maps the feature's routes to its composables. This installer is then provided to the `app` module using Dagger/Hilt.
+
+This modular approach allows for a clean separation of concerns, making the codebase more scalable and maintainable. Each feature is responsible for its own navigation logic, and the `app` module only combines these pieces together.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/modular/hilt)
+
+```
+package com.example.nav3recipes.modular.hilt
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityRetainedComponent
+import dagger.multibindings.IntoSet
+
+// API
+object Profile
+
+// IMPLEMENTATION
+@Module
+@InstallIn(ActivityRetainedComponent::class)
+object ProfileModule {
+
+    @IntoSet
+    @Provides
+    fun provideEntryProviderInstaller() : EntryProviderInstaller = {
+        entry<Profile>{
+            ProfileScreen()
+        }
+    }
+}
+
+@Composable
+private fun ProfileScreen() {
+    val profileColor = MaterialTheme.colorScheme.surfaceVariant
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(profileColor)
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "Profile Screen",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+```
+
+```
+package com.example.nav3recipes.modular.hilt
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class HiltModularActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var navigator: Navigator
+
+    @Inject
+    lateinit var entryProviderScopes: Set<@JvmSuppressWildcards EntryProviderInstaller>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setEdgeToEdgeConfig()
+        setContent {
+            Scaffold { paddingValues ->
+                NavDisplay(
+                    backStack = navigator.backStack,
+                    modifier = Modifier.padding(paddingValues),
+                    onBack = { navigator.goBack() },
+                    entryProvider = entryProvider {
+                        entryProviderScopes.forEach { builder -> this.builder() }
+                    }
+                )
+            }
+        }
+    }
+}
+```
+
+```
+package com.example.nav3recipes.modular.hilt
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
+import com.example.nav3recipes.ui.theme.colors
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityRetainedComponent
+import dagger.multibindings.IntoSet
+
+// API
+object ConversationList
+data class ConversationDetail(val id: Int) {
+    val color: Color
+        get() = colors[id % colors.size]
+}
+
+// IMPL
+@Module
+@InstallIn(ActivityRetainedComponent::class)
+object ConversationModule {
+
+    @IntoSet
+    @Provides
+    fun provideEntryProviderInstaller(navigator: Navigator): EntryProviderInstaller =
+        {
+            entry<ConversationList> {
+                ConversationListScreen(
+                    onConversationClicked = { conversationDetail ->
+                        navigator.goTo(conversationDetail)
+                    }
+                )
+            }
+            entry<ConversationDetail> { key ->
+                ConversationDetailScreen(key) { navigator.goTo(Profile) }
+            }
+        }
+}
+
+@Composable
+private fun ConversationListScreen(
+    onConversationClicked: (ConversationDetail) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        items(10) { index ->
+            val conversationId = index + 1
+            val conversationDetail = ConversationDetail(conversationId)
+            val backgroundColor = conversationDetail.color
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = dropUnlessResumed {
+                        onConversationClicked(conversationDetail)
+                    }),
+                headlineContent = {
+                    Text(
+                        text = "Conversation $conversationId",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                },
+                colors = ListItemDefaults.colors(
+                    containerColor = backgroundColor // Set container color directly
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConversationDetailScreen(
+    conversationDetail: ConversationDetail,
+    onProfileClicked: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(conversationDetail.color)
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "Conversation Detail Screen: ${conversationDetail.id}",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = dropUnlessResumed(block = onProfileClicked)) {
+            Text("View Profile")
+        }
+    }
+}
+```
+
+```
+package com.example.nav3recipes.modular.hilt
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.navigation3.runtime.EntryProviderScope
+import dagger.hilt.android.scopes.ActivityRetainedScoped
+
+
+typealias EntryProviderInstaller = EntryProviderScope<Any>.() -> Unit
+
+@ActivityRetainedScoped
+class Navigator(startDestination: Any) {
+    val backStack : SnapshotStateList<Any> = mutableStateListOf(startDestination)
+
+    fun goTo(destination: Any){
+        backStack.add(destination)
+    }
+
+    fun goBack(){
+        backStack.removeLastOrNull()
+    }
+}
+```
+
+```
+package com.example.nav3recipes.modular.hilt
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityRetainedComponent
+import dagger.hilt.android.scopes.ActivityRetainedScoped
+
+@Module
+@InstallIn(ActivityRetainedComponent::class)
+object AppModule {
+
+    @Provides
+    @ActivityRetainedScoped
+    fun provideNavigator() : Navigator = Navigator(startDestination = ConversationList)
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/modular-koin.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/modular-koin.md
@@ -1,0 +1,287 @@
+# Modular Navigation Recipe (Koin)
+
+This recipe demonstrates how to structure a multi-module application using Navigation 3 and Koin for dependency injection. The goal is to create a decoupled architecture where navigation is defined and implemented in separate feature modules. It relies on the [`koin-compose-navigation3`](https://insert-koin.io/docs/reference/koin-compose/navigation3) artifact.
+
+## How it works
+
+The application is divided into several Android modules:
+
+- **`app` module** : This is the main application module. It `includes()` the feature modules and initializes a common `Navigator`.
+
+- **`common` module** : This module contains the core navigation logic used by both the application module and the feature modules. Namely, it defines a `Navigator` class that manages the back stack.
+
+- **Feature modules (e.g., `conversation`, `profile`)**: Each feature is split into two sub-modules:
+
+  - **`api` module**: Defines the public API for the feature, including its navigation routes. This allows other modules to navigate to this feature without needing to know about its implementation details.
+  - **`impl` module** : Provides the implementation of the feature, including its composables and Koin `Module`. The Koin module uses the [`navigation`](https://insert-koin.io/docs/reference/koin-compose/navigation3/#declaring-navigation-entries) DSL to define the entry provider installers for the feature module.
+
+This modular approach allows for a clean separation of concerns, making the codebase more scalable and maintainable. Each feature is responsible for its own navigation logic, and the `app` module only combines these pieces together.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/modular/koin)
+
+```
+package com.example.nav3recipes.modular.koin
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.koin.androidx.scope.dsl.activityRetainedScope
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.dsl.module
+import org.koin.dsl.navigation3.navigation
+
+// API
+object Profile
+
+// IMPL
+@OptIn(KoinExperimentalAPI::class)
+val profileModule = module {
+    activityRetainedScope {
+        navigation<Profile> { ProfileScreen() }
+    }
+}
+
+@Composable
+private fun ProfileScreen() {
+    val profileColor = MaterialTheme.colorScheme.surfaceVariant
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(profileColor)
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "Profile Screen",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+```
+
+```
+package com.example.nav3recipes.modular.koin
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
+import com.example.nav3recipes.ui.theme.colors
+import org.koin.androidx.scope.dsl.activityRetainedScope
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.dsl.module
+import org.koin.dsl.navigation3.navigation
+
+// API
+object ConversationList
+data class ConversationDetail(val id: Int) {
+    val color: Color
+        get() = colors[id % colors.size]
+}
+
+// IMPL
+@OptIn(KoinExperimentalAPI::class)
+val conversationModule = module {
+    activityRetainedScope {
+        navigation<ConversationList> {
+            ConversationListScreen(
+                onConversationClicked = { conversationDetail ->
+                    get<Navigator>().goTo(conversationDetail)
+                }
+            )
+        }
+
+        navigation<ConversationDetail> { key ->
+            ConversationDetailScreen(key) {
+                get<Navigator>().goTo(Profile)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConversationListScreen(
+    onConversationClicked: (ConversationDetail) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        items(10) { index ->
+            val conversationId = index + 1
+            val conversationDetail = ConversationDetail(conversationId)
+            val backgroundColor = conversationDetail.color
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = dropUnlessResumed {
+                        onConversationClicked(conversationDetail)
+                    }),
+                headlineContent = {
+                    Text(
+                        text = "Conversation $conversationId",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                },
+                colors = ListItemDefaults.colors(
+                    containerColor = backgroundColor // Set container color directly
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConversationDetailScreen(
+    conversationDetail: ConversationDetail,
+    onProfileClicked: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(conversationDetail.color)
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "Conversation Detail Screen: ${conversationDetail.id}",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = dropUnlessResumed(block = onProfileClicked)) {
+            Text("View Profile")
+        }
+    }
+}
+```
+
+```
+package com.example.nav3recipes.modular.koin
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
+
+class Navigator(startDestination: Any) {
+    val backStack : SnapshotStateList<Any> = mutableStateListOf(startDestination)
+
+    fun goTo(destination: Any){
+        backStack.add(destination)
+    }
+
+    fun goBack(){
+        backStack.removeLastOrNull()
+    }
+}
+```
+
+```
+package com.example.nav3recipes.modular.koin
+
+import org.koin.androidx.scope.dsl.activityRetainedScope
+import org.koin.dsl.module
+
+val appModule = module {
+    includes(profileModule,conversationModule)
+
+    activityRetainedScope {
+        scoped {
+            Navigator(startDestination = ConversationList)
+        }
+    }
+}
+```
+
+```
+package com.example.nav3recipes.modular.koin
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Modifier
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import org.koin.android.ext.android.inject
+import org.koin.android.scope.AndroidScopeComponent
+import org.koin.androidx.compose.navigation3.getEntryProvider
+import org.koin.androidx.scope.activityRetainedScope
+import org.koin.core.Koin
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.core.component.KoinComponent
+import org.koin.core.scope.Scope
+import org.koin.dsl.koinApplication
+
+/**
+ * This recipe demonstrates how to use a modular approach with Navigation 3,
+ * where different parts of the application are defined in separate modules and injected
+ * into the main app using Koin.
+ * 
+ * Features (Conversation and Profile) are split into two modules: 
+ * - api: defines the public facing routes for this feature
+ * - impl: defines the entryProviders for this feature, these are injected into the app's main activity
+ * The common module defines:
+ * - a common navigator class that exposes a back stack and methods to modify that back stack
+ * - a type that should be used by feature modules to inject entryProviders into the app's main activity
+ * The app module creates the navigator by supplying a start destination and provides this navigator
+ * to the rest of the app module (i.e. MainActivity) and the feature modules.
+ */
+@OptIn(KoinExperimentalAPI::class)
+class KoinModularActivity : ComponentActivity(), AndroidScopeComponent, KoinComponent {
+    // Local Koin Context Instance
+    companion object {
+        private val localKoin = koinApplication {
+            modules(appModule)
+        }.koin
+    }
+    // Override default Koin context to use the local one
+    override fun getKoin(): Koin = localKoin
+    override val scope : Scope by activityRetainedScope()
+    val navigator: Navigator by inject()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setEdgeToEdgeConfig()
+        setContent {
+            Scaffold { paddingValues ->
+                NavDisplay(
+                    backStack = navigator.backStack,
+                    modifier = Modifier.padding(paddingValues),
+                    onBack = { navigator.goBack() },
+                    entryProvider = getEntryProvider()
+                )
+            }
+        }
+    }
+
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/multiple-backstacks.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/multiple-backstacks.md
@@ -1,0 +1,436 @@
+# Multiple back stacks recipe
+
+This recipe demonstrates how to create multiple back stacks.
+
+The app has three top level routes: `RouteA`, `RouteB` and `RouteC`. These routes have sub routes `RouteA1`, `RouteB1` and `RouteC1` respectively. The content for the sub routes is a counter that can be used to verify state retention through configuration changes and process death.
+
+The app's navigation state is held in the `NavigationState` class. The state itself is created using `rememberNavigationState`.
+
+Navigation events are handled by the `Navigator`. It updates the navigation state.
+
+The navigation state is converted into `NavEntry`s with `NavigationState.toDecoratedEntries`. These entries are then displayed by `NavDisplay`.
+
+Key behaviors:
+
+- This app follows the "exit through home" pattern where the user always exits through the starting back stack. This means that `RouteA`'s entries are *always* in the list of entries.
+- Navigating to a top level route that is not the starting route *replaces* the other entries. For example, navigating A-\>B-\>C would result in entries for A+C, B's entries are removed.
+
+Important implementation details:
+
+- Each top level route has its own `SaveableStateHolderNavEntryDecorator`. This is the object responsible for managing the state for the entries in its back stack.
+
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/multiplestacks)
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.multiplestacks
+
+import androidx.navigation3.runtime.NavKey
+
+/**
+ * Handles navigation events (forward and back) by updating the navigation state.
+ */
+class Navigator(val state: NavigationState){
+    fun navigate(route: NavKey){
+        if (route in state.backStacks.keys){
+            // This is a top level route, just switch to it
+            state.topLevelRoute = route
+        } else {
+            state.backStacks[state.topLevelRoute]?.add(route)
+        }
+    }
+
+    fun goBack(){
+        val currentStack = state.backStacks[state.topLevelRoute] ?:
+        error("Stack for ${state.topLevelRoute} not found")
+        val currentRoute = currentStack.last()
+
+        // If we're at the base of the current route, go back to the start route stack.
+        if (currentRoute == state.topLevelRoute){
+            state.topLevelRoute = state.startRoute
+        } else {
+            currentStack.removeLastOrNull()
+        }
+    }
+}
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.multiplestacks
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSerializable
+import androidx.compose.runtime.setValue
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.rememberDecoratedNavEntries
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.runtime.serialization.NavKeySerializer
+import androidx.savedstate.compose.serialization.serializers.MutableStateSerializer
+
+/**
+ * Create a navigation state that persists config changes and process death.
+ *
+ * @param startRoute - The top level route to start on. This should also be in `topLevelRoutes`.
+ * @param topLevelRoutes - The top level routes in the app.
+ */
+@Composable
+fun rememberNavigationState(
+    startRoute: NavKey,
+    topLevelRoutes: Set<NavKey>
+): NavigationState {
+
+    val topLevelRoute = rememberSerializable(
+        startRoute, topLevelRoutes,
+        serializer = MutableStateSerializer(NavKeySerializer())
+    ) {
+        mutableStateOf(startRoute)
+    }
+
+    // Create a back stack for each top level route.
+    val backStacks = topLevelRoutes.associateWith { key -> rememberNavBackStack(key) }
+
+    return remember(startRoute, topLevelRoutes) {
+        NavigationState(
+            startRoute = startRoute,
+            topLevelRoute = topLevelRoute,
+            backStacks = backStacks
+        )
+    }
+}
+
+/**
+ * State holder for navigation state. This class does not modify its own state. It is designed
+ * to be modified using the `Navigator` class.
+ *
+ * @param startRoute - the start route. The user will exit the app through this route.
+ * @param topLevelRoute - the state object that backs the top level route.
+ * @param backStacks - the back stacks for each top level route.
+ */
+class NavigationState(
+    val startRoute: NavKey,
+    topLevelRoute: MutableState<NavKey>,
+    val backStacks: Map<NavKey, NavBackStack<NavKey>>
+) {
+
+    /**
+     * The top level route.
+     */
+    var topLevelRoute: NavKey by topLevelRoute
+
+    /**
+     * Convert the navigation state into `NavEntry`s that have been decorated with a
+     * `SaveableStateHolder`.
+     *
+     * @param entryProvider - the entry provider used to convert the keys in the
+     * back stacks to `NavEntry`s.
+     */
+    @Composable
+    fun toDecoratedEntries(
+        entryProvider: (NavKey) -> NavEntry<NavKey>
+    ): List<NavEntry<NavKey>> {
+
+        // For each back stack, create a `SaveableStateHolder` decorator and use it to decorate
+        // the entries from that stack. When backStacks changes, `rememberDecoratedNavEntries` will
+        // be recomposed and a new list of decorated entries is returned.
+        val decoratedEntries = backStacks.mapValues { (_, stack) ->
+            val decorators = listOf(
+                rememberSaveableStateHolderNavEntryDecorator<NavKey>(),
+            )
+            rememberDecoratedNavEntries(
+                backStack = stack,
+                entryDecorators = decorators,
+                entryProvider = entryProvider
+            )
+        }
+
+        // Only return the entries for the stacks that are currently in use.
+        return getTopLevelRoutesInUse()
+            .flatMap { decoratedEntries[it] ?: emptyList() }
+    }
+
+    /**
+     * Get the top level routes that are currently in use. The start route is always the first route
+     * in the list. This means the user will always exit the app through the starting route
+     * ("exit through home" pattern). The list will contain a maximum of one other route. This is a
+     * design decision. In your app, you may wish to allow more than two top level routes to be
+     * active.
+     *
+     * Note that even if a top level route is not in use its state is still retained.
+     *
+     * @return the current top level routes that are in use.
+     */
+    private fun getTopLevelRoutesInUse() : List<NavKey> =
+		if (topLevelRoute == startRoute) {
+            listOf(startRoute)
+        } else {
+            listOf(startRoute, topLevelRoute)
+        }
+}
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.multiplestacks
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Camera
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data object RouteA : NavKey
+
+@Serializable
+data object RouteA1 : NavKey
+
+@Serializable
+data object RouteB : NavKey
+
+@Serializable
+data object RouteB1 : NavKey
+
+@Serializable
+data object RouteC : NavKey
+
+@Serializable
+data object RouteC1 : NavKey
+
+private val TOP_LEVEL_ROUTES = mapOf<NavKey, NavBarItem>(
+    RouteA to NavBarItem(icon = Icons.Default.Home, description = "Route A"),
+    RouteB to NavBarItem(icon = Icons.Default.Face, description = "Route B"),
+    RouteC to NavBarItem(icon = Icons.Default.Camera, description = "Route C"),
+)
+
+data class NavBarItem(
+    val icon: ImageVector,
+    val description: String
+)
+
+class MultipleStacksActivity : ComponentActivity() {
+    @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+            val navigationState = rememberNavigationState(
+                startRoute = RouteA,
+                topLevelRoutes = TOP_LEVEL_ROUTES.keys
+            )
+
+            val navigator = remember { Navigator(navigationState) }
+
+            val entryProvider = entryProvider {
+                featureASection(onSubRouteClick = { navigator.navigate(RouteA1) })
+                featureBSection(onSubRouteClick = { navigator.navigate(RouteB1) })
+                featureCSection(onSubRouteClick = { navigator.navigate(RouteC1) })
+            }
+
+            Scaffold(bottomBar = {
+                NavigationBar {
+                    TOP_LEVEL_ROUTES.forEach { (key, value) ->
+                        val isSelected = key == navigationState.topLevelRoute
+                        NavigationBarItem(
+                            selected = isSelected,
+                            onClick = { navigator.navigate(key) },
+                            icon = {
+                                Icon(
+                                    imageVector = value.icon,
+                                    contentDescription = value.description
+                                )
+                            },
+                            label = { Text(value.description) }
+                        )
+                    }
+                }
+            }) {
+                NavDisplay(
+                    entries = navigationState.toDecoratedEntries(entryProvider),
+                    onBack = { navigator.goBack() }
+                )
+            }
+        }
+    }
+}
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.multiplestacks
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.content.ContentMauve
+import com.example.nav3recipes.content.ContentOrange
+import com.example.nav3recipes.content.ContentPink
+import com.example.nav3recipes.content.ContentPurple
+import com.example.nav3recipes.content.ContentRed
+
+fun EntryProviderScope<NavKey>.featureASection(
+    onSubRouteClick: () -> Unit,
+) {
+    entry<RouteA> {
+        ContentRed("Route A") {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Button(onClick = dropUnlessResumed(block = onSubRouteClick)) {
+                    Text("Go to A1")
+                }
+            }
+        }
+    }
+    entry<RouteA1> {
+        ContentPink("Route A1") {
+            var count by rememberSaveable {
+                mutableIntStateOf(0)
+            }
+
+            Button(onClick = { count++ }) {
+                Text("Value: $count")
+            }
+        }
+    }
+}
+
+fun EntryProviderScope<NavKey>.featureBSection(
+    onSubRouteClick: () -> Unit,
+) {
+    entry<RouteB> {
+        ContentGreen("Route B") {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Button(onClick = dropUnlessResumed(block = onSubRouteClick)) {
+                    Text("Go to B1")
+                }
+            }
+        }
+    }
+    entry<RouteB1> {
+        ContentPurple("Route B1") {
+            var count by rememberSaveable {
+                mutableIntStateOf(0)
+            }
+            Button(onClick = { count++ }) {
+                Text("Value: $count")
+            }
+        }
+    }
+}
+
+fun EntryProviderScope<NavKey>.featureCSection(
+    onSubRouteClick: () -> Unit,
+) {
+    entry<RouteC> {
+        ContentMauve("Route C") {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Button(onClick = dropUnlessResumed(block = onSubRouteClick)) {
+                    Text("Go to C1")
+                }
+            }
+        }
+    }
+    entry<RouteC1> {
+        ContentOrange("Route C1") {
+            var count by rememberSaveable {
+                mutableIntStateOf(0)
+            }
+
+            Button(onClick = { count++ }) {
+                Text("Value: $count")
+            }
+        }
+    }
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/passingarguments.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/passingarguments.md
@@ -1,0 +1,371 @@
+# Passing Arguments to ViewModels (Hilt)
+
+This recipe demonstrates how to pass navigation arguments (keys) to a `ViewModel` using Hilt for dependency injection.
+
+## How it works
+
+This example uses Dagger/Hilt's assisted injection feature:
+
+1. The `ViewModel` is annotated with `@HiltViewModel` and its constructor uses `@AssistedInject` to receive the navigation key (which is annotated with `@Assisted`).
+2. An `@AssistedFactory` interface is defined to create the `ViewModel`.
+3. The `hiltViewModel` composable function is used to obtain the `ViewModel` instance. A `creationCallback` is provided to pass the navigation key to the factory, making it available to the `ViewModel`.
+
+**Note** : The `rememberViewModelStoreNavEntryDecorator` is added to the `NavDisplay`'s `entryDecorators`. This ensures that `ViewModel`s are correctly scoped to their corresponding `NavEntry`, so that a new `ViewModel` instance is created for each unique navigation key.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/hilt)
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.passingarguments.viewmodels.hilt
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.passingarguments.viewmodels.basic.RouteB
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.lifecycle.HiltViewModel
+
+data object RouteA
+data class RouteB(val id: String)
+
+@AndroidEntryPoint
+class HiltViewModelsActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+            val backStack = remember { mutableStateListOf<Any>(RouteA) }
+
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+
+                // In order to add the `ViewModelStoreNavEntryDecorator` (see comment below for why)
+                // we also need to add the default `NavEntryDecorator`s as well. These provide
+                // extra information to the entry's content to enable it to display correctly
+                // and save its state.
+                entryDecorators = listOf(
+                    rememberSaveableStateHolderNavEntryDecorator(),
+                    rememberViewModelStoreNavEntryDecorator()
+                ),
+                entryProvider = entryProvider {
+                    entry<RouteA> {
+                        ContentGreen("Welcome to Nav3") {
+                            LazyColumn {
+                                items(10) { i ->
+                                    Button(onClick = dropUnlessResumed {
+                                        backStack.add(RouteB("$i"))
+                                    }) {
+                                        Text("$i")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    entry<RouteB> { key ->
+                        val viewModel = hiltViewModel<RouteBViewModel, RouteBViewModel.Factory>(
+                            // Note: We need a new ViewModel for every new RouteB instance. Usually
+                            // we would need to supply a `key` String that is unique to the
+                            // instance, however, the ViewModelStoreNavEntryDecorator (supplied
+                            // above) does this for us, using `NavEntry.contentKey` to uniquely
+                            // identify the viewModel.
+                            //
+                            // tl;dr: Make sure you use rememberViewModelStoreNavEntryDecorator()
+                            // if you want a new ViewModel for each new navigation key instance.
+                            creationCallback = { factory ->
+                                factory.create(key)
+                            }
+                        )
+                        ScreenB(viewModel = viewModel)
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun ScreenB(viewModel: RouteBViewModel) {
+    ContentBlue("Route id: ${viewModel.navKey.id} ")
+}
+
+@HiltViewModel(assistedFactory = RouteBViewModel.Factory::class)
+class RouteBViewModel @AssistedInject constructor(
+    @Assisted val navKey: RouteB
+) : ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(navKey: RouteB): RouteBViewModel
+    }
+}
+```
+
+# Passing Arguments to ViewModels (Basic)
+
+This recipe demonstrates how to pass navigation arguments (keys) to a `ViewModel` using a custom `ViewModelProvider.Factory`.
+
+## How it works
+
+1. A custom `ViewModelProvider.Factory` is created that takes the navigation key as a constructor parameter.
+2. Inside the `entry` composable, `viewModel(factory = ...)` is used to create the `ViewModel` instance, passing the current navigation key to the factory. This makes the navigation key available to the `ViewModel`.
+
+**Note** : The `rememberViewModelStoreNavEntryDecorator` is added to the `NavDisplay`'s `entryDecorators`. This ensures that `ViewModel`s are correctly scoped to their corresponding `NavEntry`, so that a new `ViewModel` instance is created for each unique navigation key.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/basic)
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.passingarguments.viewmodels.basic
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+
+data object RouteA
+
+data class RouteB(val id: String)
+
+class BasicViewModelsActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+            val backStack = remember { mutableStateListOf<Any>(RouteA) }
+
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+                // In order to add the `ViewModelStoreNavEntryDecorator` (see comment below for why)
+                // we also need to add the default `NavEntryDecorator`s as well. These provide
+                // extra information to the entry's content to enable it to display correctly
+                // and save its state.
+                entryDecorators = listOf(
+                    rememberSaveableStateHolderNavEntryDecorator(),
+                    rememberViewModelStoreNavEntryDecorator()
+                ),
+                entryProvider = entryProvider {
+                    entry<RouteA> {
+                        ContentGreen("Welcome to Nav3") {
+                            LazyColumn {
+                                items(10) { i ->
+                                    Button(onClick = dropUnlessResumed {
+                                        backStack.add(RouteB("$i"))
+                                    }) {
+                                        Text("$i")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    entry<RouteB> { key ->
+                        // Note: We need a new ViewModel for every new RouteB instance. Usually
+                        // we would need to supply a `key` String that is unique to the
+                        // instance, however, the ViewModelStoreNavEntryDecorator (supplied
+                        // above) does this for us, using `NavEntry.contentKey` to uniquely
+                        // identify the viewModel.
+                        //
+                        // tl;dr: Make sure you use rememberViewModelStoreNavEntryDecorator()
+                        // if you want a new ViewModel for each new navigation key instance.
+                        ScreenB(viewModel = viewModel(factory = RouteBViewModel.Factory(key)))
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun ScreenB(viewModel: RouteBViewModel = viewModel()) {
+    ContentBlue("Route id: ${viewModel.key.id} ")
+}
+
+class RouteBViewModel(
+    val key: RouteB
+) : ViewModel() {
+    class Factory(
+        private val key: RouteB,
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return RouteBViewModel(key) as T
+        }
+    }
+}
+```
+
+# Passing Arguments to ViewModels (Koin)
+
+This recipe demonstrates how to pass navigation arguments (keys) to a `ViewModel` using Koin for dependency injection.
+
+## How it works
+
+1. A Koin module is defined that provides the `ViewModel`.
+2. The `koinViewModel` composable function is used to get the `ViewModel` instance.
+3. The navigation key is passed to the `ViewModel`'s constructor using `parametersOf(key)`. This makes the navigation key available to the `ViewModel`.
+
+**Note** : The `rememberViewModelStoreNavEntryDecorator` is added to the `NavDisplay`'s `entryDecorators`. This ensures that `ViewModel`s are correctly scoped to their corresponding `NavEntry`, so that a new `ViewModel` instance is created for each unique navigation key.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/koin)
+
+```
+package com.example.nav3recipes.passingarguments.viewmodels.koin
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import org.koin.compose.KoinApplication
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.core.parameter.parametersOf
+import org.koin.dsl.koinConfiguration
+import org.koin.dsl.module
+
+data object RouteA
+data class RouteB(val id: String)
+
+class KoinViewModelsActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+            val backStack = remember { mutableStateListOf<Any>(RouteA) }
+
+            // Koin Compose Entry point
+            KoinApplication(
+                configuration = koinConfiguration {
+                    modules(appModule)
+                }
+            ) {
+                NavDisplay(
+                    backStack = backStack,
+                    onBack = { backStack.removeLastOrNull() },
+
+                    // In order to add the `ViewModelStoreNavEntryDecorator` (see comment below for why)
+                    // we also need to add the default `NavEntryDecorator`s as well. These provide
+                    // extra information to the entry's content to enable it to display correctly
+                    // and save its state.
+                    entryDecorators = listOf(
+                        rememberSaveableStateHolderNavEntryDecorator(),
+                        rememberViewModelStoreNavEntryDecorator()
+                    ),
+                    entryProvider = entryProvider {
+                        entry<RouteA> {
+                            ContentGreen("Welcome to Nav3") {
+                                LazyColumn {
+                                    items(10) { i ->
+                                        Button(onClick = dropUnlessResumed {
+                                            backStack.add(RouteB("$i"))
+                                        }) {
+                                            Text("$i")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        entry<RouteB> { key ->
+                            val viewModel = koinViewModel<RouteBViewModel> {
+                                parametersOf(key)
+                            }
+                            ScreenB(viewModel = viewModel)
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+// Local Koin Module
+private val appModule = module {
+    viewModelOf(::RouteBViewModel)
+}
+
+@Composable
+fun ScreenB(viewModel: RouteBViewModel) {
+    ContentBlue("Route id: ${viewModel.navKey.id} ")
+}
+
+class RouteBViewModel(val navKey: RouteB) : ViewModel()
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/results-event.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/results-event.md
@@ -1,0 +1,273 @@
+# Returning a Result (Event-Based)
+
+This recipe demonstrates how to return a result from one screen to a previous screen using an event-based approach.
+
+## How it works
+
+This example uses a `ResultEventBus` to facilitate communication between the screens.
+
+1. **ResultEventBusNavEntryDecorator** : A `NavEntryDecorator` that provides a `ResultEventBus` via `LocalResultEventBus`.
+2. **`ResultEventBus`** : A `ResultEventBus` is created and made available to the composables via `LocalResultEventBus`. This EventBus sends and receives the results.
+3. **Sending the result** : The screen that produces the result calls `resultBus.sendResult(person)` to send the data back as a one-time event.
+4. **Receiving the result** : The screen that needs the result uses a `ResultEffect` composable to listen for results of a specific type. When a result is received, the effect's lambda is triggered.
+
+This approach is useful for results that are transient and should be handled as one-time events.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/results/event)
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.results.common
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+
+class HomeViewModel : ViewModel() {
+    var person by mutableStateOf<Person?>(null)
+}
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.results.common
+
+import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object Home : NavKey
+
+@Serializable
+class PersonDetailsForm : NavKey
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.results.common
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Person(val name: String, val favoriteColor: String)
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.results.common
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+
+@Composable
+fun HomeScreen(
+    person: Person?,
+    onNext: () -> Unit
+) {
+    ContentBlue("Hello ${person?.name ?: "unknown person"}") {
+
+        if (person != null) {
+            Text("Your favorite color is ${person.favoriteColor}")
+        }
+
+        Spacer(Modifier.height(16.dp))
+        Button(onClick = dropUnlessResumed(block = onNext)) {
+            Text("Tell us about yourself")
+        }
+    }
+}
+
+@Composable
+fun PersonDetailsScreen(
+    onSubmit: (Person) -> Unit
+) {
+    ContentGreen("About you") {
+
+        val nameTextState = rememberTextFieldState()
+        OutlinedTextField(
+            state = nameTextState,
+            label = { Text("Please enter your name") }
+        )
+
+        val favoriteColorTextState = rememberTextFieldState()
+        OutlinedTextField(
+            state = favoriteColorTextState,
+            label = { Text("Please enter your favorite color") }
+        )
+
+        Button(
+            onClick = dropUnlessResumed {
+                val person = Person(
+                    name = nameTextState.text.toString(),
+                    favoriteColor = favoriteColorTextState.text.toString()
+                )
+                onSubmit(person)
+            },
+            enabled = nameTextState.text.isNotBlank() &&
+                    favoriteColorTextState.text.isNotBlank()
+        ) {
+            Text("Submit")
+        }
+    }
+}
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.results.event
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.runtime.result.LocalResultEventBus
+import androidx.navigation3.runtime.result.ResultEffect
+import androidx.navigation3.runtime.result.rememberResultEventBusNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.results.common.Home
+import com.example.nav3recipes.results.common.HomeScreen
+import com.example.nav3recipes.results.common.HomeViewModel
+import com.example.nav3recipes.results.common.Person
+import com.example.nav3recipes.results.common.PersonDetailsForm
+import com.example.nav3recipes.results.common.PersonDetailsScreen
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+
+class ResultEventActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            Scaffold { paddingValues ->
+
+                val backStack = rememberNavBackStack(Home)
+
+                NavDisplay(
+                    backStack = backStack,
+                    modifier = Modifier.padding(paddingValues),
+                    onBack = { backStack.removeLastOrNull() },
+                    entryDecorators = listOf(
+                        rememberSaveableStateHolderNavEntryDecorator(),
+                        rememberResultEventBusNavEntryDecorator()
+                    ),
+                    entryProvider = entryProvider {
+                        entry<Home> {
+                            val viewModel = viewModel<HomeViewModel>(key = Home.toString())
+                            ResultEffect<Person> { person ->
+                                viewModel.person = person
+                            }
+
+                            val person = viewModel.person
+                            HomeScreen(
+                                person = person,
+                                onNext = { backStack.add(PersonDetailsForm()) }
+                            )
+                        }
+                        entry<PersonDetailsForm> {
+                            val resultBus = LocalResultEventBus.current
+                            PersonDetailsScreen(
+                                onSubmit = { person ->
+                                    resultBus.sendResult<Person>(result = person)
+                                    backStack.removeLastOrNull()
+                                }
+                            )
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/results-state.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/results-state.md
@@ -1,0 +1,266 @@
+# Returning a Result (State-Based)
+
+This recipe demonstrates how to return a result from one screen to a previous screen using a state-based approach.
+
+## How it works
+
+This example uses a `ResultEventBus` to manage the result as state.
+
+1. **ResultEventBusNavEntryDecorator** : A `NavEntryDecorator` that provides a `ResultEventBus` via `LocalResultEventBus`.
+2. **`ResultEventBus`** : A `ResultEventBus` is created and made available to the composables via `LocalResultEventBus`. This EventBus sends and receives the results.
+3. **Setting the result** : The screen that produces the result calls `resultBus.sendResult(person)` to send the data back.
+4. **Observing the result** : The screen that needs the result calls `resultBus.conflateAsState<Person?>()` to get a `State` object representing the result. The UI then observes this state and recomposes whenever the result changes.
+
+This approach is suitable when only the latest result is required. The result state does not survive configuration change or process death.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/results/state)
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.results.common
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+
+class HomeViewModel : ViewModel() {
+    var person by mutableStateOf<Person?>(null)
+}
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.results.common
+
+import androidx.navigation3.runtime.NavKey
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object Home : NavKey
+
+@Serializable
+class PersonDetailsForm : NavKey
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.results.common
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Person(val name: String, val favoriteColor: String)
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.results.common
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+
+@Composable
+fun HomeScreen(
+    person: Person?,
+    onNext: () -> Unit
+) {
+    ContentBlue("Hello ${person?.name ?: "unknown person"}") {
+
+        if (person != null) {
+            Text("Your favorite color is ${person.favoriteColor}")
+        }
+
+        Spacer(Modifier.height(16.dp))
+        Button(onClick = dropUnlessResumed(block = onNext)) {
+            Text("Tell us about yourself")
+        }
+    }
+}
+
+@Composable
+fun PersonDetailsScreen(
+    onSubmit: (Person) -> Unit
+) {
+    ContentGreen("About you") {
+
+        val nameTextState = rememberTextFieldState()
+        OutlinedTextField(
+            state = nameTextState,
+            label = { Text("Please enter your name") }
+        )
+
+        val favoriteColorTextState = rememberTextFieldState()
+        OutlinedTextField(
+            state = favoriteColorTextState,
+            label = { Text("Please enter your favorite color") }
+        )
+
+        Button(
+            onClick = dropUnlessResumed {
+                val person = Person(
+                    name = nameTextState.text.toString(),
+                    favoriteColor = favoriteColorTextState.text.toString()
+                )
+                onSubmit(person)
+            },
+            enabled = nameTextState.text.isNotBlank() &&
+                    favoriteColorTextState.text.isNotBlank()
+        ) {
+            Text("Submit")
+        }
+    }
+}
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.results.state
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.runtime.result.LocalResultEventBus
+import androidx.navigation3.runtime.result.rememberResultEventBusNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.results.common.Home
+import com.example.nav3recipes.results.common.HomeScreen
+import com.example.nav3recipes.results.common.Person
+import com.example.nav3recipes.results.common.PersonDetailsForm
+import com.example.nav3recipes.results.common.PersonDetailsScreen
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+
+class ResultStateActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            Scaffold { paddingValues ->
+                val backStack = rememberNavBackStack(Home)
+                NavDisplay(
+                    backStack = backStack,
+                    modifier = Modifier.padding(paddingValues),
+                    onBack = { backStack.removeLastOrNull() },
+                    entryDecorators = listOf(
+                        rememberSaveableStateHolderNavEntryDecorator(),
+                        rememberResultEventBusNavEntryDecorator()
+                    ),
+                    entryProvider = entryProvider {
+                        entry<Home> {
+                            val resultState = LocalResultEventBus
+                                .current
+                                .conflateAsState<Person?>(null)
+                            val person = resultState.value
+                            HomeScreen(
+                                person = person,
+                                onNext = { backStack.add(PersonDetailsForm()) }
+                            )
+                        }
+                        entry<PersonDetailsForm> {
+                            val resultBus = LocalResultEventBus.current
+                            PersonDetailsScreen(
+                                onSubmit = { person ->
+                                    resultBus.sendResult(result = person)
+                                    backStack.removeLastOrNull()
+                                }
+                            )
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/scenes-listdetail.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/scenes-listdetail.md
@@ -1,0 +1,435 @@
+# List-Detail Scene Recipe
+
+This example shows how to create a list-detail layout using the Scenes API.
+
+A `ListDetailSceneStrategy` will return a `ListDetailScene` if:
+
+- the window width is over 600dp
+- A `Detail` entry is the last item in the back stack
+- A `List` entry is in the back stack
+
+The `ListDetailScene` provides a `CompositionLocal` named `LocalBackButtonVisibility` that can be used by the detail `NavEntry` to control whether it displays a back button. This is useful when the detail entry usually displays a back button but should not display it when being displayed in a `ListDetailScene`. See <https://github.com/android/nav3-recipes/issues/151> for more details on this use case.
+
+See `ListDetailScene.kt` for more implementation details.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/scenes/listdetail)
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.scenes.listdetail
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavMetadataKey
+import androidx.navigation3.runtime.contains
+import androidx.navigation3.runtime.metadata
+import androidx.navigation3.scene.Scene
+import androidx.navigation3.scene.SceneStrategy
+import androidx.navigation3.scene.SceneStrategyScope
+import androidx.window.core.layout.WindowSizeClass
+import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_MEDIUM_LOWER_BOUND
+
+/**
+ * A [Scene] that displays a list and a detail [NavEntry] side-by-side in a 40/60 split.
+ *
+ */
+data class ListDetailScene<T : Any>(
+    override val key: Any,
+    override val previousEntries: List<NavEntry<T>>,
+    val listEntry: NavEntry<T>,
+    val detailEntry: NavEntry<T>,
+) : Scene<T> {
+    override val entries: List<NavEntry<T>> = listOf(listEntry, detailEntry)
+    override val content: @Composable (() -> Unit) = {
+        Row(modifier = Modifier.fillMaxSize()) {
+            Column(modifier = Modifier.weight(0.4f)) {
+                listEntry.Content()
+            }
+
+            // Let the detail entry know not to display a back button.
+            CompositionLocalProvider(LocalBackButtonVisibility provides false) {
+                Column(modifier = Modifier.weight(0.6f)) {
+                    AnimatedContent(
+                        targetState = detailEntry,
+                        contentKey = { entry -> entry.contentKey },
+                        transitionSpec = {
+                            slideInHorizontally(
+                                initialOffsetX = { it }
+                            ) togetherWith
+                                    slideOutHorizontally(targetOffsetX = { -it })
+                        }
+                    ) { entry ->
+                        entry.Content()
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Helper function to add metadata to a [NavEntry] indicating it can be displayed
+         * in the list pane of a [ListDetailScene].
+         */
+        fun listPane() = metadata {
+            put(ListKey, true)
+        }
+
+        /**
+         * Helper function to add metadata to a [NavEntry] indicating it can be displayed
+         * in the detail pane of a the [ListDetailScene].
+         */
+        fun detailPane() = metadata {
+            put(DetailKey, true)
+        }
+    }
+
+    object ListKey : NavMetadataKey<Boolean>
+    object DetailKey : NavMetadataKey<Boolean>
+}
+
+/**
+ * This `CompositionLocal` can be used by a detail `NavEntry` to decide whether to display
+ * a back button. Default is `true`. It is set to `false` for a detail `NavEntry` when being
+ * displayed in a `ListDetailScene`.
+ */
+val LocalBackButtonVisibility = compositionLocalOf { true }
+
+@Composable
+fun <T : Any> rememberListDetailSceneStrategy(): ListDetailSceneStrategy<T> {
+    val windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass
+
+    return remember(windowSizeClass) {
+        ListDetailSceneStrategy(windowSizeClass)
+    }
+}
+
+
+/**
+ * A [SceneStrategy] that returns a [ListDetailScene] if:
+ *
+ * - the window width is over 600dp
+ * - A `Detail` entry is the last item in the back stack
+ * - A `List` entry is in the back stack
+ *
+ * Notably, when the detail entry changes the scene's key does not change. This allows the scene,
+ * rather than the NavDisplay, to handle animations when the detail entry changes.
+ */
+class ListDetailSceneStrategy<T : Any>(val windowSizeClass: WindowSizeClass) : SceneStrategy<T> {
+
+    override fun SceneStrategyScope<T>.calculateScene(entries: List<NavEntry<T>>): Scene<T>? {
+
+        if (!windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_MEDIUM_LOWER_BOUND)) {
+            return null
+        }
+
+        val detailEntry =
+            entries.lastOrNull()?.takeIf { it.metadata.contains(ListDetailScene.DetailKey) }
+                ?: return null
+        val listEntry =
+            entries.findLast { it.metadata.contains(ListDetailScene.ListKey) } ?: return null
+
+        // We use the list's contentKey to uniquely identify the scene.
+        // This allows the detail panes to be animated in and out by the scene, rather than
+        // having NavDisplay animate the whole scene out when the selected detail item changes.
+        val sceneKey = listEntry.contentKey
+
+        return ListDetailScene(
+            key = sceneKey,
+            previousEntries = entries.dropLast(1),
+            listEntry = listEntry,
+            detailEntry = detailEntry
+        )
+    }
+}
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.scenes.listdetail
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import kotlinx.serialization.Serializable
+
+/**
+ * This example shows how to create a list-detail layout using the Scenes API.
+ *
+ * A `ListDetailScene` will render content in two panes if:
+ *
+ * - the window width is over 600dp
+ * - A `Detail` entry is the last item in the back stack
+ * - A `List` entry is in the back stack
+ *
+ * @see `ListDetailScene`
+ */
+@Serializable
+data object ConversationList : NavKey
+
+@Serializable
+data class ConversationDetail(
+    val id: Int,
+    val colorId: Int
+) : NavKey
+
+@Serializable
+data object Profile : NavKey
+
+class ListDetailActivity : ComponentActivity() {
+
+    @OptIn(ExperimentalSharedTransitionApi::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+
+        setContent {
+
+            Scaffold { paddingValues ->
+
+                val backStack = rememberNavBackStack(ConversationList)
+                val listDetailStrategy = rememberListDetailSceneStrategy<NavKey>()
+
+                SharedTransitionLayout {
+                    NavDisplay(
+                        backStack = backStack,
+                        onBack = { backStack.removeLastOrNull() },
+                        sceneStrategies = listOf(listDetailStrategy),
+                        sharedTransitionScope = this,
+                        modifier = Modifier.padding(paddingValues),
+                        entryProvider = entryProvider {
+                            entry<ConversationList>(
+                                metadata = ListDetailScene.listPane()
+                            ) {
+                                ConversationListScreen(
+                                    onConversationClicked = { detailRoute ->
+                                        backStack.addDetail(detailRoute)
+                                    }
+                                )
+                            }
+                            entry<ConversationDetail>(
+                                metadata = ListDetailScene.detailPane()
+                            ) { conversationDetail ->
+                                ConversationDetailScreen(
+                                    conversationDetail = conversationDetail,
+                                    onBack = { backStack.removeLastOrNull() },
+                                    onProfileClicked = { backStack.add(Profile) }
+                                )
+                            }
+                            entry<Profile> {
+                                ProfileScreen()
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun NavBackStack<NavKey>.addDetail(detailRoute: ConversationDetail) {
+
+    // Remove any existing detail routes before adding this detail route.
+    // In certain scenarios, such as when multiple detail panes can be shown at once, it may
+    // be desirable to keep existing detail routes on the back stack.
+    removeIf { it is ConversationDetail }
+    add(detailRoute)
+}
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.scenes.listdetail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
+import com.example.nav3recipes.ui.theme.colors
+
+@Composable
+fun ConversationListScreen(
+    onConversationClicked: (ConversationDetail) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        items(10) { index ->
+            val conversationId = index + 1
+            val conversationDetail = ConversationDetail(
+                id = conversationId,
+                colorId = conversationId % colors.size
+            )
+            val backgroundColor = colors[conversationDetail.colorId]
+            ListItem(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = dropUnlessResumed {
+                        onConversationClicked(conversationDetail)
+                    }),
+                headlineContent = {
+                    Text(
+                        text = "Conversation $conversationId",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                },
+                colors = ListItemDefaults.colors(
+                    containerColor = backgroundColor // Set container color directly
+                )
+            )
+        }
+    }
+}
+
+@Composable
+fun ConversationDetailScreen(
+    conversationDetail: ConversationDetail,
+    onBack: () -> Unit,
+    onProfileClicked: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colors[conversationDetail.colorId])
+            .padding(16.dp)
+    ) {
+        if (LocalBackButtonVisibility.current) {
+            IconButton(
+                onClick = onBack,
+                modifier = Modifier.align(Alignment.TopStart)
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back"
+                )
+            }
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "Conversation Detail Screen: ${conversationDetail.id}",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = dropUnlessResumed(block = onProfileClicked)) {
+                Text("View Profile")
+            }
+        }
+    }
+}
+
+@Composable
+fun ProfileScreen() {
+    val profileColor = MaterialTheme.colorScheme.surfaceVariant
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(profileColor)
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "Profile Screen",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/scenes-twopane.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/navigation-3/recipes/scenes-twopane.md
@@ -1,0 +1,244 @@
+# Two-Pane Scene Recipe
+
+This example shows how to create a two pane layout using the Scenes API.
+
+A `TwoPaneSceneStrategy` will return a `TwoPaneScene` if:
+
+- the window width is over 600dp
+- the last two nav entries on the back stack have indicated that they support being displayed in a `TwoPaneScene` in their metadata.
+
+See `TwoPaneScene.kt` for more implementation details.
+[![](https://developer.android.com/static/images/picto-icons/code.svg) Explore View the full recipe on GitHub.](https://github.com/android/nav3-recipes/tree/main/app/src/main/java/com/example/nav3recipes/scenes/twopane)
+
+```
+package com.example.nav3recipes.scenes.twopane
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavMetadataKey
+import androidx.navigation3.runtime.contains
+import androidx.navigation3.runtime.metadata
+import androidx.navigation3.scene.Scene
+import androidx.navigation3.scene.SceneStrategy
+import androidx.navigation3.scene.SceneStrategyScope
+import androidx.window.core.layout.WindowSizeClass
+import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_MEDIUM_LOWER_BOUND
+
+// --- TwoPaneScene ---
+/**
+ * A custom [Scene] that displays two [NavEntry]s side-by-side in a 50/50 split.
+ */
+data class TwoPaneScene<T : Any>(
+    override val key: Any,
+    override val previousEntries: List<NavEntry<T>>,
+    val firstEntry: NavEntry<T>,
+    val secondEntry: NavEntry<T>
+) : Scene<T> {
+    override val entries: List<NavEntry<T>> = listOf(firstEntry, secondEntry)
+    override val content: @Composable (() -> Unit) = {
+        Row(modifier = Modifier.fillMaxSize()) {
+            Column(modifier = Modifier.weight(0.5f)) {
+                firstEntry.Content()
+            }
+            Column(modifier = Modifier.weight(0.5f)) {
+                secondEntry.Content()
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Helper function to add metadata to a [NavEntry] indicating it can be displayed
+         * in a two-pane layout.
+         */
+        fun twoPane() = metadata {
+            put(TwoPaneKey, true)
+        }
+    }
+
+    object TwoPaneKey : NavMetadataKey<Boolean>
+}
+
+@Composable
+fun <T : Any> rememberTwoPaneSceneStrategy(): TwoPaneSceneStrategy<T> {
+    val windowSizeClass = currentWindowAdaptiveInfoV2().windowSizeClass
+
+    return remember(windowSizeClass) {
+        TwoPaneSceneStrategy(windowSizeClass)
+    }
+}
+
+
+// --- TwoPaneSceneStrategy ---
+/**
+ * A [SceneStrategy] that activates a [TwoPaneScene] if the window is wide enough
+ * and the top two back stack entries declare support for two-pane display.
+ */
+class TwoPaneSceneStrategy<T : Any>(val windowSizeClass: WindowSizeClass) : SceneStrategy<T> {
+
+    override fun SceneStrategyScope<T>.calculateScene(entries: List<NavEntry<T>>): Scene<T>? {
+
+        // Condition 1: Only return a Scene if the window is sufficiently wide to render two panes.
+        // We use isWidthAtLeastBreakpoint with WIDTH_DP_MEDIUM_LOWER_BOUND (600dp).
+        if (!windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_MEDIUM_LOWER_BOUND)) {
+            return null
+        }
+
+        val lastTwoEntries = entries.takeLast(2)
+
+        // Condition 2: Only return a Scene if there are two entries, and both have declared
+        // they can be displayed in a two pane scene.
+        return if (lastTwoEntries.size == 2
+            && lastTwoEntries.all { it.metadata.contains(TwoPaneScene.TwoPaneKey) }
+        ) {
+            val firstEntry = lastTwoEntries.first()
+            val secondEntry = lastTwoEntries.last()
+
+            // The scene key must uniquely represent the state of the scene.
+            // A Pair of the first and second entry keys ensures uniqueness.
+            val sceneKey = Pair(firstEntry.contentKey, secondEntry.contentKey)
+
+            TwoPaneScene(
+                key = sceneKey,
+                // Where we go back to is a UX decision. In this case, we only remove the top
+                // entry from the back stack, despite displaying two entries in this scene.
+                // This is because in this app we only ever add one entry to the
+                // back stack at a time. It would therefore be confusing to the user to add one
+                // when navigating forward, but remove two when navigating back.
+                previousEntries = entries.dropLast(1),
+                firstEntry = firstEntry,
+                secondEntry = secondEntry
+            )
+
+        } else {
+            null
+        }
+    }
+
+
+}
+```
+
+```
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.scenes.twopane
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentBase
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.content.ContentRed
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import com.example.nav3recipes.ui.theme.colors
+import kotlinx.serialization.Serializable
+
+@Serializable
+private object Home : NavKey
+
+@Serializable
+private data class Product(val id: Int) : NavKey
+
+@Serializable
+private data object Profile : NavKey
+
+class TwoPaneActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            val backStack = rememberNavBackStack(Home)
+            val twoPaneStrategy = rememberTwoPaneSceneStrategy<NavKey>()
+
+            SharedTransitionLayout {
+                NavDisplay(
+                    backStack = backStack,
+                    onBack = { backStack.removeLastOrNull() },
+                    sceneStrategies = listOf(twoPaneStrategy),
+                    sharedTransitionScope = this,
+                    entryProvider = entryProvider {
+                        entry<Home>(
+                            metadata = TwoPaneScene.twoPane()
+                        ) {
+                            ContentRed("Welcome to Nav3") {
+                                Button(onClick = { backStack.addProductRoute(1) }) {
+                                    Text("View the first product")
+                                }
+                            }
+                        }
+                        entry<Product>(
+                            metadata = TwoPaneScene.twoPane()
+                        ) { product ->
+                            ContentBase(
+                                "Product ${product.id} ",
+                                Modifier.background(colors[product.id % colors.size])
+                            ) {
+                                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                    Button(onClick = dropUnlessResumed {
+                                        backStack.addProductRoute(product.id + 1)
+                                    }) {
+                                        Text("View the next product")
+                                    }
+                                    Button(onClick = dropUnlessResumed {
+                                        backStack.add(Profile)
+                                    }) {
+                                        Text("View profile")
+                                    }
+                                }
+                            }
+                        }
+                        entry<Profile> {
+                            ContentGreen("Profile (single pane only)")
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+private fun NavBackStack<NavKey>.addProductRoute(productId: Int) {
+    val productRoute =
+        Product(productId)
+    // Avoid adding the same product route to the back stack twice.
+    if (!contains(productRoute)) {
+        add(productRoute)
+    }
+}
+```

--- a/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/type-safe-destinations.md
+++ b/platforms/android/.agents/skills/navigation-3/references/android/guide/navigation/type-safe-destinations.md
@@ -1,0 +1,129 @@
+This guide outlines the process of replacing string-based routes with
+serializable Kotlin types to achieve compile-time safety and eliminate runtime
+crashes caused by typos or incorrect argument types.
+
+## Prerequisites
+
+Before starting the migration, verify that your project meets the following
+requirements:
+
+1. **Navigation version**: Update to Jetpack Navigation 2.8.0 or higher
+2. **Kotlin serialization plugin**:
+3. Add the plugin to `libs.versions.toml`:
+
+    [libraries]
+    kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+
+    [plugins]
+    kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+
+- Add the dependencies to your top-level `build.gradle.kts` and module-level `build.gradle.kts`.
+
+## Step 1: Define Your Destinations
+
+Replace your constant route strings with `@Serializable` objects and classes.
+
+- **For screens without arguments** : Use a `data object`
+- **For screens with arguments** : Use a `data class`
+
+**Before (string based):**
+
+    const val ROUTE_HOME = "home"
+    const val ROUTE_PROFILE = "profile/{userId}"
+
+**After (type safe):**
+
+    import kotlinx.serialization.Serializable
+
+    @Serializable
+    object Home
+
+    @Serializable
+    data class Profile(val userId: String)
+
+## Step 2: Update the NavHost Configuration
+
+Update your `NavHost` to use the new generic types in the `composable` and
+`dialog` function.
+
+**Before:**
+
+    NavHost(navController, startDestination = "home") {
+        composable("home") { HomeScreen(...) }
+        composable("profile/{userId}") { backStackEntry ->
+            val userId = backStackEntry.arguments?.getString("userId")
+            ProfileScreen(userId)
+        }
+    }
+
+**After:**
+
+    NavHost(navController, startDestination = Home) {
+        composable<Home> {
+            HomeScreen(...)
+        }
+        composable<Profile> { backStackEntry ->
+            // The library automatically handles argument extraction
+            val profile: Profile = backStackEntry.toRoute()
+            ProfileScreen(profile.userId)
+        }
+    }
+
+## Step 3: Implement Type-Safe Navigation Calls
+
+Replace string-interpolated navigation calls with class instances.
+
+**Before:**
+
+    navController.navigate("profile/user123")
+
+**After:**
+
+    navController.navigate(Profile(userId = "user123"))
+
+## Step 4: Accessing Arguments in ViewModels
+
+If you use a `ViewModel`, you can now extract the route object directly from the
+`SavedStateHandle`.
+
+**Implementation:**
+
+    class ProfileViewModel(
+        savedStateHandle: SavedStateHandle
+    ) : ViewModel() {
+        // Automatically parses arguments into the Profile class
+        private val profile = savedStateHandle.toRoute<Profile>()
+        val userId = profile.userId
+    }
+
+## Step 5: (Advanced) Handling Custom Types
+
+If you need to pass complex data classes (not just primitives), you must define
+a custom `NavType`.
+
+1. **Create the Custom Type** : \`\`\`kotlin val SearchFilterType = object : NavType(isNullableAllowed = false) { override fun get(bundle: Bundle, key: String): SearchFilter? = Json.decodeFromString(bundle.getString(key) ?: return null)
+
+    override fun parseValue(value: String): SearchFilter =
+        Json.decodeFromString(Uri.decode(value))
+
+    override fun put(bundle: Bundle, key: String, value: SearchFilter) {
+        bundle.putString(key, Json.encodeToString(value))
+    }
+
+}
+
+
+
+    2. **Register it in the Graph**:
+    ```kotlin
+    composable<Search>(
+        typeMap = mapOf(typeOf<SearchFilter>() to SearchFilterType)
+    ) { ... }
+
+## Best practices and tips
+
+- **Sealed Hierarchies**: For large apps, group your routes using a sealed interface or class to keep the navigation structure organized
+- **Object Instances** : For routes without parameters, always use `object` instead of `class` to avoid unnecessary allocations
+- **Nullable Types** : The new API supports nullable types (for example, `data
+  class Search(val query: String?)`) and provides default values automatically
+- **Testing** : Use `navController.currentBackStackEntry?.hasRoute<T>()` to check the current destination in a type-safe manner during UI tests

--- a/platforms/android/.agents/skills/perfetto-sql/SKILL.md
+++ b/platforms/android/.agents/skills/perfetto-sql/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: perfetto-sql
+description: Translates natural language data intents into syntactically valid Perfetto
+  SQL queries and executes them against a local trace file. Use this skill to extract
+  slice, thread, or memory data from Android Perfetto traces using trace_processor.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-05-14'
+  keywords:
+  - Android
+  - Perfetto SQL
+  - Query Guidelines
+  - Performance Profiling
+  - Trace Analysis
+  - SQL Best Practices
+  - SPAN_JOIN
+  - Idempotency
+---
+
+## Guidelines and Hints
+
+- **Idempotency:** Ensure queries are idempotent to prevent "already exists" errors during multiple executions.
+  - For Perfetto objects, always use `CREATE OR REPLACE`: `CREATE OR REPLACE
+    PERFETTO TABLE`, `CREATE OR REPLACE PERFETTO VIEW`, `CREATE OR REPLACE
+    PERFETTO FUNCTION`, `CREATE OR REPLACE PERFETTO MACRO`.
+  - For SQLite Virtual Tables (such as `SPAN_JOIN`), `CREATE OR REPLACE` is not supported. Explicitly drop them first: `DROP TABLE IF EXISTS
+    my_table; CREATE VIRTUAL TABLE my_table USING SPAN_JOIN(...);`
+  - For standard SQLite indexes, prepend `DROP INDEX IF EXISTS index_name;`.
+- `SPAN_JOIN` will crash if intervals **within the same input table** overlap. Always use the `PARTITIONED {column}` (for example, `PARTITIONED upid`) clause to isolate intervals.
+- Intermediate tables fed into a `SPAN_JOIN` must be materialized using `CREATE PERFETTO TABLE`, not `CREATE VIEW`.
+- **Trace Boundaries (`dur = -1`):** Slices or thread states that don't finish before the trace ends are recorded with `dur = -1`. When calculating a bounding box (for example, `ts + dur`) or summing durations (`SUM(dur)`), handle incomplete durations using: `IIF(dur = -1, trace_end() - ts, dur)`.
+- **Robust State Transitions:** Avoid manual timestamp arithmetic (for example, `ts + dur = next.ts`) to join adjacent events. Rely on standard library modules (for example, `sched.runnable`, `linux.perf.counters`, `intervals.overlap`) which safely handle trace gaps and preemptions.
+- **Unique Identifiers:** When writing SQL queries in Perfetto, you must join tables using `utid` (unique thread ID) or `upid` (unique process ID) instead of the regular `tid` or `pid`. **Why it's useful** : The operating system recycles `TIDs` and `PIDs`, while `UTIDs` and `UPIDs` remain unique for the lifetime of the trace, which prevents incorrect joins.
+- **Safe Argument Extraction:** Use `EXTRACT_ARG(arg_set_id, 'key')` to extract dictionary or JSON-like properties from slices or tracks. Don't attempt string parsing.
+- **String Matching (Always use GLOB):** Use `GLOB` instead of `LIKE`. `LIKE` causes performance bottlenecks and treats underscores (`_`) as wildcards, leading to bugs.
+  - **Exact matches:** Use `=`.
+  - **Substring matches:** Use `GLOB` with `*` (for example, `name GLOB
+    '*RenderThread*'`).
+  - **Case-insensitive matches:** Use `LOWER(name) GLOB` and make sure the search string is fully lowercase (for example, `LOWER(name) GLOB
+    '*renderthread*'`). Use this when dealing with inconsistent trace capitalization (for example, `WakeLock` versus `wakelock`).
+- **Calculating Time Overlaps:** To calculate the overlap duration between two
+  time intervals `[start1, end1]` and `[start2, end2]`:
+
+  > **Precedence Rule:** Always prefer using `SPAN_JOIN` or standard library
+  > functions (for example, `intervals.overlap`) to calculate overlaps
+  > **between two different sets of intervals** . Avoid manual arithmetic if a
+  > standard library feature or `SPAN_JOIN` can achieve the same result. Use
+  > the following logic if no built-in alternative exists.
+  1. **Condition:** The intervals overlap if `start1 < end2` and `start2 <
+     end1`.
+  2. **Duration:** The overlap duration is calculated as `MIN(end1, end2) -
+     MAX(start1, start2)`
+
+     > **Important:** Incomplete Perfetto slices have a duration of -1
+     > (`dur = -1`). Always calculate the effective end time using `ts +
+     > IIF(dur = -1, trace_end() - ts, dur)` before applying this logic.
+- Query `android_thread_slices_for_all_startups` for app startup requests.
+
+- Join `counter_track` with `counter` to get values of counter with a specific
+  name.
+
+- When querying for a CPU frequency counter, include the `linux.cpu.frequency`
+  module and use the `cpu_frequency_counters` table.
+
+- When looking for events around a specific timestamp, start with 100ms as the
+  window size.
+
+- Always prefix column names with table or view alias, that is:
+  `{alias}.{column_name}`.
+
+- To calculate the total time spent in slices matching a specific name pattern
+  (for example, `*{name_pattern}*`), you must sum their durations. **Why it's
+  useful** : This helps quantify the total impact of a specific function or
+  feature on performance across multiple calls. Here is an example query (note
+  the safe handling of incomplete slices): `sql SELECT count(*) as
+  total_count, sum(IIF(slice.dur = -1, trace_end() - slice.ts, slice.dur)) /
+  1000000.0 as total_dur_ms FROM slice WHERE slice.name GLOB
+  '*{name_pattern}*';`
+
+## Resources
+
+- **Documentation:** The Perfetto Standard Library documentation is in [`perfetto-stdlib.md`](references/perfetto-stdlib.md). Use this file as a reference to discover available modules, find schemas (columns and types) for specific tables or views, or determine the `INCLUDE PERFETTO MODULE` statements required before drafting SQL query.
+- **Execution Tool:** Queries are executed using the official `trace_processor` wrapper script downloaded directly from Perfetto. Output is returned in pure CSV format.
+
+## Execution Protocol
+
+You must follow these steps sequentially, mirroring a multi-agent pipeline:
+
+### Step 0: Tool Setup
+
+**Fetch the Wrapper:** You must use the top level of the current project workspace (`./trace_processor`).
+
+> **CRITICAL GUARDRAIL:** NEVER use filesystem search tools (`find`, `find_by_name`, `grep`, `dir /s`, `Get-ChildItem`) across the home directory or workspace to locate `trace_processor` — unconstrained searches across entire workspaces will stop responding or time out.
+
+Perform a direct file check at the top level of your workspace (e.g., `ls trace_processor`). If missing, download `https://get.perfetto.dev/trace_processor` directly into the root workspace (`curl -LO`), make it executable on macOS/Linux (`chmod +x`), and ensure `trace_processor` is added to `.gitignore`. Execute queries directly via `./trace_processor` (on Windows, explicitly invoke `python trace_processor`).
+
+> **Important:** The file served at this URL is a `~10KB` Python wrapper script. Don't assume the download failed because it is human-readable text. This is the intended behavior. This script handles lazy-loading the precompiled binary automatically on its first run. Use it directly.
+
+### Step 1: Dissection and Schema Research
+
+1. Identify the core question, required data points, and filtering conditions.
+2. **Precedence Rule:** If the user's request contains a SQL query, use it **without modification** and skip to Step 2 for validation.
+3. **Mandatory Schema and Module Search:** For every table or view you plan to use, you MUST find its schema in [`perfetto-stdlib.md`](references/perfetto-stdlib.md). **Don't read the entire documentation file** --- it consumes the context window. Follow this precise workflow:
+   - **Discovery and Search:** Use available search tools (`grep`, `read_file` or file search) with line limits to discover relevant views, tables or modules based on your problem domain and high-level intents (for example, 'CPU time', 'running time', 'overlap', 'jank').
+     - **Why:** Searching solely for exact table names misses comprehensive, pre-computed views built for these analyses.
+     - **Note:** You must verify if a Standard Library module already provides the needed abstraction before drafting manual arithmetic or custom functions.
+   - **Targeted Bounded Reads:** Once you identify the relevant modules, efficiently read the tables and views within that module section.
+   - **Extract:** Extract only the schema, columns, and the exact `INCLUDE
+     PERFETTO MODULE` statements for the required object from the documentation.
+   - **Verify:** Review the columns, types, and descriptions to ensure the table matches your needs.
+4. Print the research results before drafting the query:
+5. *Tables/Views:* `Schema for {name}:` listing columns and types.
+
+### Step 2: Draft and Validate Loop (Max 3 Iterations)
+
+Draft the SQL query in SQLite syntax using **only** the schemas retrieved in
+Step 1. After drafting, you must validate against this checklist:
+
+- \[ \] **SQLite Syntax:** Does the query parse successfully without syntax errors?
+- \[ \] **Idempotency:** Are all object creations safe to re-run? (Did you use `CREATE OR REPLACE PERFETTO` and `DROP TABLE IF EXISTS` for virtual tables?)
+- \[ \] **Existence:** Were all tables found in the documentation?
+- \[ \] **Intent Check:** Is there a pre-existing standard library table or view that will fulfill this intent before instead of writing manual arithmetic?
+- \[ \] **Column Accuracy:** Do columns match the retrieved schemas?
+- \[ \] **Alias Check:** Are ALL column names prefixed with their table or view alias (for example, `alias.column_name`)?
+- \[ \] **Module Check:** Are `INCLUDE PERFETTO MODULE` statements included for all non-prelude modules? **You must use the exact module names provided in
+  the documentation.**
+- \[ \] **Span Join Check:** If using `SPAN_JOIN`, are tables safely `PARTITIONED` to prevent overlapping interval crashes? Are intermediate tables materialized with `CREATE PERFETTO TABLE`?
+- \[ \] **No LIKE Constraint:** Did you map string matches using `GLOB` or `=` instead of prohibited `LIKE`?
+- \[ \] **Execution Check:** You MUST run queries using the standalone
+  `./trace_processor` wrapper with the `--query-string` flag:
+  `./trace_processor --query-string "QUERY" {trace_file}`.
+
+  **Execution Rules:**
+  - **File Usage** : If you must create a SQL file to execute queries (for example, due to query length or escaping issues), you must create them in the `/tmp/` directory.
+  - **State:** The execution is purely ephemeral. Database state does not persist across turns. You **cannot** share state (like views or tables) across queries in different turns. Every query must be standalone and fully self-contained.
+  - **Failure Resilience:** Debug and fix SQL syntax and logic errors when query fails.Don't simplify the analytical intent to pass validation. For example, if requested to calculate an overlap or intersection, you must fix the intersection math. Don't substitute with disjoint queries (for example, returning independent total durations) as a workaround.
+
+### Step 3: Final Output
+
+1. Explicitly return and state the final validated SQL and explain the results to the user.
+2. Before finishing your response, delete all temporary SQL files you created in `/tmp/` directory.

--- a/platforms/android/.agents/skills/perfetto-sql/references/perfetto-stdlib.md
+++ b/platforms/android/.agents/skills/perfetto-sql/references/perfetto-stdlib.md
@@ -1,0 +1,6670 @@
+*This page documents the PerfettoSQL standard library.*
+
+## Introduction
+
+The PerfettoSQL standard library is a repository of tables, views, functions
+and macros, contributed by domain experts, which make querying traces easier
+Its design is heavily inspired by standard libraries in languages like Python,
+C++ and Java.
+
+Some of the purposes of the standard library include:
+1) Acting as a way of sharing and commonly written queries without needing
+to copy/paste large amounts of SQL.
+2) Raising the abstraction level when exposing data in the trace. Many
+modules in the standard library convert low-level trace concepts
+e.g. slices, tracks and into concepts developers may be more familar with
+e.g. for Android developers: app startups, binder transactions etc.
+
+Standard library modules can be included as follows
+
+    -- Include all tables/views/functions from the android.startup.startups
+    -- module in the standard library.
+    INCLUDE PERFETTO MODULE android.startup.startups;
+
+    -- Use the android_startups table defined in the android.startup.startups
+    -- module.
+    SELECT *
+    FROM android_startups;
+
+Prelude is a special module is automatically included. It contains key helper
+tables, views and functions which are universally useful.
+
+More information on importing modules is available in the
+[syntax documentation](https://perfetto.dev/docs/analysis/perfetto-sql-syntax#including-perfettosql-modules)
+for the `INCLUDE PERFETTO MODULE` statement.
+
+## Package: prelude
+
+#### Views/Tables
+
+<br />
+
+**trace_metrics**. Lists all metrics built-into trace processor.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | The name of the metric. |
+
+<br />
+
+<br />
+
+<br />
+
+**track**. Tracks are a fundamental concept in trace processor and represent a "timeline" for events of the same type and with the same context
+
+<br />
+
+VIEW
+Tracks are a fundamental concept in trace processor and represent a
+"timeline" for events of the same type and with the same context. See
+https://perfetto.dev/docs/analysis/trace-processor#tracks for a more
+detailed explanation, with examples.
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this track. Identical to \|track_id\|, prefer using \|track_id\| instead. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| name | STRING | Name of the track; can be null for some types of tracks (e.g. thread tracks). |
+| parent_id | UINT | The track which is the "parent" of this track. Only non-null for tracks created using Perfetto's track_event API. |
+| source_arg_set_id | UINT | Args for this track which store information about "source" of this track in the trace. For example: whether this track orginated from atrace, Chrome tracepoints etc. Alias of `args.arg_set_id`. |
+| machine_id | UINT | Machine identifier, non-null for tracks on a remote machine. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu**. Contains information about the CPUs on the device this trace was taken on.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this CPU. Identical to \|ucpu\|, prefer using \|ucpu\| instead. |
+| ucpu | UINT | Unique identifier for this CPU. Isn't equal to \|cpu\| for remote machines and is equal to \|cpu\| for the host machine. |
+| cpu | UINT | The 0-based CPU core identifier. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| cluster_id | UINT | The cluster id is shared by CPUs in the same cluster. |
+| processor | STRING | A string describing this core. |
+| machine_id | UINT | Machine identifier, non-null for CPUs on a remote machine. |
+| capacity | UINT | Capacity of a CPU of a device, a metric which indicates the relative performance of a CPU on a device For details see: https://www.kernel.org/doc/Documentation/devicetree/bindings/arm/cpu-capacity.txt |
+| arg_set_id | UINT | Extra key/value pairs associated with this cpu. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_available_frequencies**. Contains the frequency values that the CPUs on the device are capable of running at.
+
+<br />
+
+VIEW
+Contains the frequency values that the CPUs on the device are capable of
+running at.
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this cpu frequency. |
+| cpu | UINT | The CPU for this frequency, meaningful only in single machine traces. For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| freq | UINT | CPU frequency in KHz. |
+| ucpu | UINT | The CPU that the slice executed on (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+
+<br />
+
+<br />
+
+<br />
+
+**sched_slice**. This table holds slices with kernel thread scheduling information
+
+<br />
+
+VIEW
+This table holds slices with kernel thread scheduling information. These
+slices are collected when the Linux "ftrace" data source is used with the
+"sched/switch" and "sched/wakeup\*" events enabled.
+
+The rows in this table will always have a matching row in the \|thread_state\|
+table with \|thread_state.state\| = 'Running'
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this scheduling slice. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| ts | LONG | The timestamp at the start of the slice (in nanoseconds). |
+| dur | LONG | The duration of the slice (in nanoseconds). |
+| cpu | UINT | The CPU that the slice executed on (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| utid | UINT | The thread's unique id in the trace. |
+| end_state | STRING | A string representing the scheduling state of the kernel thread at the end of the slice. The individual characters in the string mean the following: R (runnable), S (awaiting a wakeup), D (in an uninterruptible sleep), T (suspended), t (being traced), X (exiting), P (parked), W (waking), I (idle), N (not contributing to the load average), K (wakeable on fatal signals) and Z (zombie, awaiting cleanup). |
+| priority | INT | The kernel priority that the thread ran at. |
+| ucpu | UINT | The unique CPU identifier that the slice executed on. |
+
+<br />
+
+<br />
+
+<br />
+
+**sched** . Shorter alias for table `sched_slice`.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Alias for `sched_slice.id`. |
+| type | STRING | Alias for `sched_slice.type`. |
+| ts | LONG | Alias for `sched_slice.ts`. |
+| dur | LONG | Alias for `sched_slice.dur`. |
+| cpu | UINT | Alias for `sched_slice.cpu`. |
+| utid | UINT | Alias for `sched_slice.utid`. |
+| end_state | STRING | Alias for `sched_slice.end_state`. |
+| priority | INT | Alias for `sched_slice.priority`. |
+| ucpu | UINT | Alias for `sched_slice.ucpu`. |
+| ts_end | UINT | Legacy column, should no longer be used. |
+
+<br />
+
+<br />
+
+<br />
+
+**thread_state**. This table contains the scheduling state of every thread on the system during the trace. The rows in this table which have \|state\| = 'Running', will have a corresponding row in the \|sched_slice\| table.
+
+<br />
+
+VIEW
+This table contains the scheduling state of every thread on the system during
+the trace.
+
+The rows in this table which have \|state\| = 'Running', will have a
+corresponding row in the \|sched_slice\| table.
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this thread state. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| ts | LONG | The timestamp at the start of the slice (in nanoseconds). |
+| dur | LONG | The duration of the slice (in nanoseconds). |
+| cpu | UINT | The CPU that the thread executed on (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| utid | UINT | The thread's unique id in the trace. |
+| state | STRING | The scheduling state of the thread. Can be "Running" or any of the states described in \|sched_slice.end_state\|. |
+| io_wait | UINT | Indicates whether this thread was blocked on IO. |
+| blocked_function | STRING | The function in the kernel this thread was blocked on. |
+| waker_utid | UINT | The unique thread id of the thread which caused a wakeup of this thread. |
+| waker_id | UINT | The unique thread state id which caused a wakeup of this thread. |
+| irq_context | UINT | Whether the wakeup was from interrupt context or process context. |
+| ucpu | UINT | The unique CPU identifier that the thread executed on. |
+
+<br />
+
+<br />
+
+<br />
+
+**raw**. Contains 'raw' events from the trace for some types of events
+
+<br />
+
+VIEW
+Contains 'raw' events from the trace for some types of events. This table
+only exists for debugging purposes and should not be relied on in production
+usecases (i.e. metrics, standard library etc.)
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this raw event. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| ts | LONG | The timestamp of this event. |
+| name | STRING | The name of the event. For ftrace events, this will be the ftrace event name. |
+| cpu | UINT | The CPU this event was emitted on (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| utid | UINT | The thread this event was emitted on. |
+| arg_set_id | UINT | The set of key/value pairs associated with this event. |
+| common_flags | UINT | Ftrace event flags for this event. Currently only emitted for sched_waking events. |
+| ucpu | UINT | The unique CPU identifier that this event was emitted on. |
+
+<br />
+
+<br />
+
+<br />
+
+**ftrace_event**. Contains all the ftrace events in the trace
+
+<br />
+
+VIEW
+Contains all the ftrace events in the trace. This table exists only for
+debugging purposes and should not be relied on in production usecases (i.e.
+metrics, standard library etc). Note also that this table might be empty if
+raw ftrace parsing has been disabled.
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this ftrace event. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| ts | LONG | The timestamp of this event. |
+| name | STRING | The ftrace event name. |
+| cpu | UINT | The CPU this event was emitted on (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| utid | UINT | The thread this event was emitted on. |
+| arg_set_id | UINT | The set of key/value pairs associated with this event. |
+| common_flags | UINT | Ftrace event flags for this event. Currently only emitted for sched_waking events. |
+| ucpu | UINT | The unique CPU identifier that this event was emitted on. |
+
+<br />
+
+<br />
+
+<br />
+
+**experimental_sched_upid**. The sched_slice table with the upid column.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this scheduling slice. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| ts | LONG | The timestamp at the start of the slice (in nanoseconds). |
+| dur | LONG | The duration of the slice (in nanoseconds). |
+| cpu | UINT | The CPU that the slice executed on (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| utid | UINT | The thread's unique id in the trace. |
+| end_state | STRING | A string representing the scheduling state of the kernel thread at the end of the slice. The individual characters in the string mean the following: R (runnable), S (awaiting a wakeup), D (in an uninterruptible sleep), T (suspended), t (being traced), X (exiting), P (parked), W (waking), I (idle), N (not contributing to the load average), K (wakeable on fatal signals) and Z (zombie, awaiting cleanup). |
+| priority | INT | The kernel priority that the thread ran at. |
+| ucpu | UINT | The unique CPU identifier that the slice executed on. |
+| upid | UINT | The process's unique id in the trace. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_track**. Tracks which are associated to a single CPU.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this cpu track. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| name | STRING | Name of the track. |
+| parent_id | UINT | The track which is the "parent" of this track. Only non-null for tracks created using Perfetto's track_event API. |
+| source_arg_set_id | UINT | Args for this track which store information about "source" of this track in the trace. For example: whether this track orginated from atrace, Chrome tracepoints etc. |
+| machine_id | UINT | Machine identifier, non-null for tracks on a remote machine. |
+| cpu | UINT | The CPU that the track is associated with (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| ucpu | UINT | The unique CPU identifier that this track is associated with. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_counter_track**. Tracks containing counter-like events associated to a CPU.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this cpu counter track. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| name | STRING | Name of the track. |
+| parent_id | UINT | The track which is the "parent" of this track. Only non-null for tracks created using Perfetto's track_event API. |
+| source_arg_set_id | UINT | Args for this track which store information about "source" of this track in the trace. For example: whether this track orginated from atrace, Chrome tracepoints etc. |
+| machine_id | UINT | Machine identifier, non-null for tracks on a remote machine. |
+| unit | STRING | The units of the counter. This column is rarely filled. |
+| description | STRING | The description for this track. For debugging purposes only. |
+| cpu | UINT | The CPU that the track is associated with (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| ucpu | UINT | The unique CPU identifier that this track is associated with. |
+
+<br />
+
+<br />
+
+<br />
+
+**counters** . Alias of the `counter` table.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Alias of `counter.id`. |
+| type | STRING | Alias of `counter.type`. |
+| ts | LONG | Alias of `counter.ts`. |
+| track_id | INT | Alias of `counter.track_id`. |
+| value | DOUBLE | Alias of `counter.value`. |
+| arg_set_id | INT | Alias of `counter.arg_set_id`. |
+| name | STRING | Legacy column, should no longer be used. |
+| unit | STRING | Legacy column, should no longer be used. |
+| description | STRING | Legacy column, should no longer be used. |
+
+<br />
+
+<br />
+
+<br />
+
+**slice**. Contains slices from userspace which explains what threads were doing during the trace.
+
+<br />
+
+VIEW
+Contains slices from userspace which explains what threads were doing
+during the trace.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the slice. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| ts | LONG | The timestamp at the start of the slice (in nanoseconds). |
+| dur | LONG | The duration of the slice (in nanoseconds). |
+| track_id | INT | The id of the track this slice is located on. |
+| category | STRING | The "category" of the slice. If this slice originated with track_event, this column contains the category emitted. Otherwise, it is likely to be null (with limited exceptions). |
+| name | STRING | The name of the slice. The name describes what was happening during the slice. |
+| depth | INT | The depth of the slice in the current stack of slices. |
+| stack_id | LONG | A unique identifier obtained from the names of all slices in this stack. This is rarely useful and kept around only for legacy reasons. |
+| parent_stack_id | LONG | The stack_id for the parent of this slice. Rarely useful. |
+| parent_id | INT | The id of the parent (i.e. immediate ancestor) slice for this slice. |
+| arg_set_id | INT | The id of the argument set associated with this slice. |
+| thread_ts | LONG | The thread timestamp at the start of the slice. This column will only be populated if thread timestamp collection is enabled with track_event. |
+| thread_dur | LONG | The thread time used by this slice. This column will only be populated if thread timestamp collection is enabled with track_event. |
+| thread_instruction_count | LONG | The value of the CPU instruction counter at the start of the slice. This column will only be populated if thread instruction collection is enabled with track_event. |
+| thread_instruction_delta | LONG | The change in value of the CPU instruction counter between the start and end of the slice. This column will only be populated if thread instruction collection is enabled with track_event. |
+| cat | STRING | Alias of `category`. |
+| slice_id | LONG | Alias of `id`. |
+
+<br />
+
+<br />
+
+<br />
+
+**instant**. Contains instant events from userspace which indicates what happened at a single moment in time.
+
+<br />
+
+VIEW
+Contains instant events from userspace which indicates what happened at a
+single moment in time.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | LONG | The timestamp of the instant (in nanoseconds). |
+| track_id | INT | The id of the track this instant is located on. |
+| name | STRING | The name of the instant. The name describes what happened during the instant. |
+| arg_set_id | INT | The id of the argument set associated with this instant. |
+
+<br />
+
+<br />
+
+<br />
+
+**slices** . Alternative alias of table `slice`.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Alias of `slice.id`. |
+| type | STRING | Alias of `slice.type`. |
+| ts | LONG | Alias of `slice.ts`. |
+| dur | LONG | Alias of `slice.dur`. |
+| track_id | INT | Alias of `slice.track_id`. |
+| category | STRING | Alias of `slice.category`. |
+| name | STRING | Alias of `slice.name`. |
+| depth | INT | Alias of `slice.depth`. |
+| stack_id | LONG | Alias of `slice.stack_id`. |
+| parent_stack_id | LONG | Alias of `slice.parent_stack_id`. |
+| parent_id | INT | Alias of `slice.parent_id`. |
+| arg_set_id | INT | Alias of `slice.arg_set_id`. |
+| thread_ts | LONG | Alias of `slice.thread_ts`. |
+| thread_dur | LONG | Alias of `slice.thread_dur`. |
+| thread_instruction_count | LONG | Alias of `slice.thread_instruction_count`. |
+| thread_instruction_delta | LONG | Alias of `slice.thread_instruction_delta`. |
+| cat | LONG | Alias of `slice.cat`. |
+| slice_id | LONG | Alias of `slice.slice_id`. |
+
+<br />
+
+<br />
+
+<br />
+
+**thread**. Contains information of threads seen during the trace.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the thread. Prefer using `utid` instead. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| utid | INT | Unique thread id. This is != the OS tid. This is a monotonic number associated to each thread. The OS thread id (tid) cannot be used as primary key because tids and pids are recycled by most kernels. |
+| tid | INT | The OS id for this thread. Note: this is *not* unique over the lifetime of the trace so cannot be used as a primary key. Use \|utid\| instead. |
+| name | STRING | The name of the thread. Can be populated from many sources (e.g. ftrace, /proc scraping, track event etc). |
+| start_ts | LONG | The start timestamp of this thread (if known). Is null in most cases unless a thread creation event is enabled (e.g. task_newtask ftrace event on Linux/Android). |
+| end_ts | LONG | The end timestamp of this thread (if known). Is null in most cases unless a thread destruction event is enabled (e.g. sched_process_free ftrace event on Linux/Android). |
+| upid | LONG | The process hosting this thread. |
+| is_main_thread | BOOL | Boolean indicating if this thread is the main thread in the process. |
+| machine_id | INT | Machine identifier, non-null for threads on a remote machine. |
+
+<br />
+
+<br />
+
+<br />
+
+**process**. Contains information of processes seen during the trace.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the process. Prefer using `upid` instead. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| upid | LONG | Unique process id. This is != the OS pid. This is a monotonic number associated to each process. The OS process id (pid) cannot be used as primary key because tids and pids are recycled by most kernels. |
+| pid | LONG | The OS id for this process. Note: this is *not* unique over the lifetime of the trace so cannot be used as a primary key. Use \|upid\| instead. |
+| name | STRING | The name of the process. Can be populated from many sources (e.g. ftrace, /proc scraping, track event etc). |
+| start_ts | LONG | The start timestamp of this process (if known). Is null in most cases unless a process creation event is enabled (e.g. task_newtask ftrace event on Linux/Android). |
+| end_ts | LONG | The end timestamp of this process (if known). Is null in most cases unless a process destruction event is enabled (e.g. sched_process_free ftrace event on Linux/Android). |
+| parent_upid | INT | The upid of the process which caused this process to be spawned. |
+| uid | INT | The Unix user id of the process. |
+| android_appid | INT | Android appid of this process. |
+| cmdline | STRING | /proc/cmdline for this process. |
+| arg_set_id | INT | Extra args for this process. |
+| machine_id | INT | Machine identifier, non-null for processes on a remote machine. |
+
+<br />
+
+<br />
+
+<br />
+
+**args**. Arbitrary key-value pairs which allow adding metadata to other, strongly typed tables. Note: for a given row, only one of \|int_value\|, \|string_value\|, \|real_value\| will be non-null.
+
+<br />
+
+VIEW
+Arbitrary key-value pairs which allow adding metadata to other, strongly
+typed tables.
+Note: for a given row, only one of \|int_value\|, \|string_value\|, \|real_value\|
+will be non-null.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the arg. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| arg_set_id | INT | The id for a single set of arguments. |
+| flat_key | STRING | The "flat key" of the arg: this is the key without any array indexes. |
+| key | STRING | The key for the arg. |
+| int_value | LONG | The integer value of the arg. |
+| string_value | STRING | The string value of the arg. |
+| real_value | DOUBLE | The double value of the arg. |
+| value_type | STRING | The type of the value of the arg. Will be one of 'int', 'uint', 'string', 'real', 'pointer', 'bool' or 'json'. |
+| display_value | STRING | The human-readable formatted value of the arg. |
+
+<br />
+
+<br />
+
+<br />
+
+**perf_session**. Contains the Linux perf sessions in the trace.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the perf session. Prefer using `perf_session_id` instead. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| perf_session_id | INT | The id of the perf session. |
+| cmdline | STRING | Command line used to collect the data. |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**slice_is_ancestor** -\> BOOL. Given two slice ids, returns whether the first is an ancestor of the second.
+
+<br />
+
+<br />
+
+<br />
+
+Returns BOOL: Whether `ancestor_id` slice is an ancestor of `descendant_id`.
+
+| Argument | Type | Description |
+|---|---|---|
+| ancestor_id | LONG | Id of the potential ancestor slice. |
+| descendant_id | LONG | Id of the potential descendant slice. |
+
+<br />
+
+<br />
+
+<br />
+
+**trace_start** -\> LONG. Fetch start of the trace.
+
+<br />
+
+<br />
+
+<br />
+
+Returns LONG: Start of the trace in nanoseconds.
+
+<br />
+
+<br />
+
+<br />
+
+**trace_end** -\> LONG. Fetch end of the trace.
+
+<br />
+
+<br />
+
+<br />
+
+Returns LONG: End of the trace in nanoseconds.
+
+<br />
+
+<br />
+
+<br />
+
+**trace_dur** -\> LONG. Fetch duration of the trace.
+
+<br />
+
+<br />
+
+<br />
+
+Returns LONG: Duration of the trace in nanoseconds.
+
+<br />
+
+<br />
+
+#### Macros
+
+<br />
+
+**cast_int** . Casts \|value\| to INT.
+
+<br />
+
+<br />
+
+<br />
+
+Returns: Expr,
+
+| Argument | Type | Description |
+|---|---|---|
+| value | Expr | Query or subquery that will be cast. |
+
+<br />
+
+<br />
+
+<br />
+
+**cast_double** . Casts \|value\| to DOUBLE.
+
+<br />
+
+<br />
+
+<br />
+
+Returns: Expr,
+
+| Argument | Type | Description |
+|---|---|---|
+| value | Expr | Query or subquery that will be cast. |
+
+<br />
+
+<br />
+
+<br />
+
+**cast_string** . Casts \|value\| to STRING.
+
+<br />
+
+<br />
+
+<br />
+
+Returns: Expr,
+
+| Argument | Type | Description |
+|---|---|---|
+| value | Expr | Query or subquery that will be cast. |
+
+<br />
+
+<br />
+
+## Package: v8
+
+### v8.jit
+
+#### Views/Tables
+
+<br />
+
+**v8_isolate**. A V8 Isolate instance
+
+<br />
+
+VIEW
+A V8 Isolate instance. A V8 Isolate represents an isolated instance of the V8
+engine.
+
+| Column | Type | Description |
+|---|---|---|
+| v8_isolate_id | UINT | Unique V8 isolate id. |
+| upid | UINT | Process the isolate was created in. |
+| internal_isolate_id | UINT | Internal id used by the v8 engine. Unique in a process. |
+| embedded_blob_code_start_address | LONG | Absolute start address of the embedded code blob. |
+| embedded_blob_code_size | LONG | Size in bytes of the embedded code blob. |
+| code_range_base_address | LONG | Base address of the code range if the isolate defines one. |
+| code_range_size | LONG | Size of a code range if the isolate defines one. |
+| shared_code_range | LONG | Whether the code range for this Isolate is shared with others in the same process. There is at max one such shared code range per process. |
+| embedded_blob_code_copy_start_address | LONG | Used when short builtin calls are enabled, where embedded builtins are copied into the CodeRange so calls can be nearer. |
+
+<br />
+
+<br />
+
+<br />
+
+**v8_js_script**. Represents a script that was compiled to generate code
+
+<br />
+
+VIEW
+Represents a script that was compiled to generate code. Some V8 code is
+generated out of scripts and will reference a V8Script other types of code
+will not (e.g. builtins).
+
+| Column | Type | Description |
+|---|---|---|
+| v8_js_script_id | UINT | Unique V8 JS script id. |
+| v8_isolate_id | UINT | V8 isolate this script belongs to (joinable with `v8_isolate.v8_isolate_id`). |
+| internal_script_id | UINT | Script id used by the V8 engine. |
+| script_type | STRING | Script type. |
+| name | STRING | Script name. |
+| source | STRING | Actual contents of the script. |
+
+<br />
+
+<br />
+
+<br />
+
+**v8_wasm_script**. Represents one WASM script.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| v8_wasm_script_id | UINT | Unique V8 WASM script id. |
+| v8_isolate_id | UINT | V8 Isolate this script belongs to (joinable with `v8_isolate.v8_isolate_id`). |
+| internal_script_id | UINT | Script id used by the V8 engine. |
+| url | STRING | URL of the source. |
+| source | STRING | Actual contents of the script. |
+
+<br />
+
+<br />
+
+<br />
+
+**v8_js_function**. Represents a v8 Javascript function.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| v8_js_function_id | UINT | Unique V8 JS function id. |
+| name | STRING | Function name. |
+| v8_js_script_id | UINT | Script where the function is defined (joinable with `v8_js_script.v8_js_script_id`). |
+| is_toplevel | BOOL | Whether this function represents the top level script. |
+| kind | STRING | Function kind (e.g. regular function or constructor). |
+| line | UINT | Line in script where function is defined. Starts at 1. |
+| col | UINT | Column in script where function is defined. Starts at 1. |
+
+<br />
+
+<br />
+
+## Package: wattson
+
+### wattson.system_state
+
+#### Views/Tables
+
+<br />
+
+**wattson_system_states**. The final system state for the CPU subsystem, which has all the information needed by Wattson to estimate energy for the CPU subsystem.
+
+<br />
+
+TABLE
+The final system state for the CPU subsystem, which has all the information
+needed by Wattson to estimate energy for the CPU subsystem.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | LONG | Starting timestamp of the current counter where system state is constant. |
+| dur | INT | Duration of the current counter where system state is constant. |
+| l3_hit_count | INT | Number of L3 hits the current system state. |
+| l3_miss_count | INT | Number of L3 misses in the current system state. |
+| freq_0 | INT | Frequency of CPU0. |
+| idle_0 | INT | Idle state of CPU0. |
+| freq_1 | INT | Frequency of CPU1. |
+| idle_1 | INT | Idle state of CPU1. |
+| freq_2 | INT | Frequency of CPU2. |
+| idle_2 | INT | Idle state of CPU2. |
+| freq_3 | INT | Frequency of CPU3. |
+| idle_3 | INT | Idle state of CPU3. |
+| freq_4 | INT | Frequency of CPU4. |
+| idle_4 | INT | Idle state of CPU4. |
+| freq_5 | INT | Frequency of CPU5. |
+| idle_5 | INT | Idle state of CPU5. |
+| freq_6 | INT | Frequency of CPU6. |
+| idle_6 | INT | Idle state of CPU6. |
+| freq_7 | INT | Frequency of CPU7. |
+| idle_7 | INT | Idle state of CPU7. |
+| suspended | BOOL | Flag indicating if current system state is suspended. |
+
+<br />
+
+<br />
+
+## Package: stacks
+
+### stacks.cpu_profiling
+
+#### Views/Tables
+
+<br />
+
+**cpu_profiling_samples**. Table containing all the timestamped samples of CPU profiling which occurred during the trace. Currently, this table is backed by the following data sources: \* Linux perf \* macOS instruments \* Chrome CPU profiling \* Legacy V8 CPU profiling \* Profiling data in Gecko traces
+
+<br />
+
+TABLE
+Table containing all the timestamped samples of CPU profiling which occurred
+during the trace.
+
+Currently, this table is backed by the following data sources:
+\* Linux perf
+\* macOS instruments
+\* Chrome CPU profiling
+\* Legacy V8 CPU profiling
+\* Profiling data in Gecko traces
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the sample. |
+| ts | INT | The timestamp of the sample. |
+| utid | INT | The utid of the thread of the sample, if available. |
+| tid | INT | The tid of the sample, if available. |
+| thread_name | STRING | The thread name of thread of the sample, if available. |
+| ucpu | INT | The ucpu of the sample, if available. |
+| cpu | INT | The cpu of the sample, if available. |
+| callsite_id | INT | The callsite id of the sample. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_profiling_summary_tree** . Table summarising the callstacks captured during any CPU profiling which occurred during the trace. Specifically, this table returns a tree containing all the callstacks seen during the trace with `self_count` equal to the number of samples with that frame as the leaf and `cumulative_count` equal to the number of samples with the frame anywhere in the tree. The data sources supported are the same as the `cpu_profiling_samples` table.
+
+<br />
+
+TABLE
+Table summarising the callstacks captured during any CPU profiling which
+occurred during the trace.
+
+Specifically, this table returns a tree containing all the callstacks seen
+during the trace with `self_count` equal to the number of samples with that
+frame as the leaf and `cumulative_count` equal to the number of samples with
+the frame anywhere in the tree.
+
+The data sources supported are the same as the `cpu_profiling_samples` table.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the callstack; by callstack we mean a unique set of frames up to the root frame. |
+| parent_id | INT | The id of the parent callstack for this callstack. NULL if this is root. |
+| name | STRING | The function name of the frame for this callstack. |
+| mapping_name | STRING | The name of the mapping containing the frame. This can be a native binary, library, JAR or APK. |
+| source_file | STRING | The name of the file containing the function. |
+| line_number | INT | The line number in the file the function is located at. |
+| self_count | INT | The number of samples with this function as the leaf frame. |
+| cumulative_count | INT | The number of samples with this function appearing anywhere on the callstack. |
+
+<br />
+
+<br />
+
+## Package: pkvm
+
+### pkvm.hypervisor
+
+#### Views/Tables
+
+<br />
+
+**pkvm_hypervisor_events**. Events when CPU entered hypervisor.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| slice_id | INT | Id of the corresponding slice in slices table. |
+| cpu | INT | CPU that entered hypervisor. |
+| ts | INT | Timestamp when CPU entered hypervisor (in nanoseconds). |
+| dur | INT | How much time CPU spent in hypervisor (in nanoseconds). |
+| reason | STRING | Reason for entering hypervisor (e.g. host_hcall, host_mem_abort), or NULL if unknown. |
+
+<br />
+
+<br />
+
+## Package: slices
+
+### slices.cpu_time
+
+#### Views/Tables
+
+<br />
+
+**thread_slice_cpu_time**. Time each thread slice spent running on CPU. Requires scheduling data to be available in the trace.
+
+<br />
+
+TABLE
+Time each thread slice spent running on CPU.
+Requires scheduling data to be available in the trace.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Id of a slice. Alias of `slice.id`. |
+| name | STRING | Name of the slice. |
+| utid | INT | Id of the thread the slice is running on. Alias of `thread.id`. |
+| thread_name | STRING | Name of the thread. |
+| upid | INT | Id of the process the slice is running on. Alias of `process.id`. |
+| process_name | STRING | Name of the process. |
+| cpu_time | INT | Duration of the time the slice was running. |
+
+<br />
+
+<br />
+
+<br />
+
+**thread_slice_cpu_cycles**. CPU cycles per each slice.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Id of a slice. Alias of `slice.id`. |
+| name | STRING | Name of the slice. |
+| utid | INT | Id of the thread the slice is running on. Alias of `thread.id`. |
+| thread_name | STRING | Name of the thread. |
+| upid | INT | Id of the process the slice is running on. Alias of `process.id`. |
+| process_name | STRING | Name of the process. |
+| millicycles | INT | Sum of CPU millicycles. Null if frequency couldn't be fetched for any period during the runtime of the slice. |
+| megacycles | INT | Sum of CPU megacycles. Null if frequency couldn't be fetched for any period during the runtime of the slice. |
+
+<br />
+
+<br />
+
+### slices.with_context
+
+#### Views/Tables
+
+<br />
+
+**thread_slice**. All thread slices with data about thread, thread track and process. Where possible, use available view functions which filter this view.
+
+<br />
+
+VIEW
+All thread slices with data about thread, thread track and process.
+Where possible, use available view functions which filter this view.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Alias for `slice.id`. |
+| type | STRING | Alias for `slice.type`. |
+| ts | INT | Alias for `slice.ts`. |
+| dur | INT | Alias for `slice.dur`. |
+| category | STRING | Alias for `slice.category`. |
+| name | STRING | Alias for `slice.name`. |
+| track_id | INT | Alias for `slice.track_id`. |
+| track_name | STRING | Alias for `thread_track.name`. |
+| thread_name | STRING | Alias for `thread.name`. |
+| utid | INT | Alias for `thread.utid`. |
+| tid | INT | Alias for `thread.tid`. |
+| is_main_thread | BOOL | Alias for `thread.is_main_thread`. |
+| process_name | STRING | Alias for `process.name`. |
+| upid | INT | Alias for `process.upid`. |
+| pid | INT | Alias for `process.pid`. |
+| depth | INT | Alias for `slice.depth`. |
+| parent_id | INT | Alias for `slice.parent_id`. |
+| arg_set_id | INT | Alias for `slice.arg_set_id`. |
+| thread_ts | INT | Alias for `slice.thread_ts`. |
+| thread_dur | INT | Alias for `slice.thread_dur`. |
+
+<br />
+
+<br />
+
+<br />
+
+**process_slice**. All process slices with data about process track and process. Where possible, use available view functions which filter this view.
+
+<br />
+
+VIEW
+All process slices with data about process track and process.
+Where possible, use available view functions which filter this view.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Alias for `slice.id`. |
+| type | STRING | Alias for `slice.type`. |
+| ts | INT | Alias for `slice.ts`. |
+| dur | INT | Alias for `slice.dur`. |
+| category | STRING | Alias for `slice.category`. |
+| name | STRING | Alias for `slice.name`. |
+| track_id | INT | Alias for `slice.track_id`. |
+| track_name | STRING | Alias for `process_track.name`. |
+| process_name | STRING | Alias for `process.name`. |
+| upid | INT | Alias for `process.upid`. |
+| pid | INT | Alias for `process.pid`. |
+| depth | INT | Alias for `slice.depth`. |
+| parent_id | INT | Alias for `slice.parent_id`. |
+| arg_set_id | INT | Alias for `slice.arg_set_id`. |
+| thread_ts | INT | Alias for `slice.thread_ts`. |
+| thread_dur | INT | Alias for `slice.thread_dur`. |
+
+<br />
+
+<br />
+
+## Package: sched
+
+### sched.runnable
+
+#### Views/Tables
+
+<br />
+
+**sched_previous_runnable_on_thread**. Previous runnable slice on the same thread. For each "Running" thread state finds: - previous "Runnable" (or runnable preempted) state. - previous uninterrupted "Runnable" state with a valid waker thread.
+
+<br />
+
+TABLE
+Previous runnable slice on the same thread.
+For each "Running" thread state finds:
+- previous "Runnable" (or runnable preempted) state.
+- previous uninterrupted "Runnable" state with a valid waker thread.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | `thread_state.id` id. |
+| prev_runnable_id | INT | Previous runnable `thread_state.id`. |
+| prev_wakeup_runnable_id | INT | Previous runnable `thread_state.id` with valid waker thread. |
+
+<br />
+
+<br />
+
+### sched.states
+
+#### Functions
+
+<br />
+
+**sched_state_to_human_readable_string** -\> STRING. Translates a single-letter scheduling state to a human-readable string.
+
+<br />
+
+<br />
+
+<br />
+
+Returns STRING: Humanly readable string representing the scheduling state of the kernel thread. The individual characters in the string mean the following: R (runnable), S (awaiting a wakeup), D (in an uninterruptible sleep), T (suspended), t (being traced), X (exiting), P (parked), W (waking), I (idle), N (not contributing to the load average), K (wakeable on fatal signals) and Z (zombie, awaiting cleanup).
+
+| Argument | Type | Description |
+|---|---|---|
+| short_name | STRING | An individual character string representing the scheduling state of the kernel thread at the end of the slice. |
+
+<br />
+
+<br />
+
+<br />
+
+**sched_state_io_to_human_readable_string** -\> STRING. Translates a single-letter scheduling state and IO wait information to a human-readable string.
+
+<br />
+
+<br />
+
+<br />
+
+Translates a single-letter scheduling state and IO wait information to
+a human-readable string.
+Returns STRING: A human readable string with information about the scheduling state and IO wait.
+
+| Argument | Type | Description |
+|---|---|---|
+| sched_state | STRING | An individual character string representing the scheduling state of the kernel thread at the end of the slice. |
+| io_wait | BOOL | A (posssibly NULL) boolean indicating, if the device was in uninterruptible sleep, if it was an IO sleep. |
+
+<br />
+
+<br />
+
+### sched.thread_level_parallelism
+
+#### Views/Tables
+
+<br />
+
+**sched_runnable_thread_count**. The count of runnable threads over time.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp when the runnable thread count changed to the current value. |
+| runnable_thread_count | INT | Number of runnable threads, covering the range from this timestamp to the next row's timestamp. |
+
+<br />
+
+<br />
+
+<br />
+
+**sched_active_cpu_count**. The count of active CPUs over time.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp when the number of active CPU changed. |
+| active_cpu_count | INT | Number of active CPUs, covering the range from this timestamp to the next row's timestamp. |
+
+<br />
+
+<br />
+
+### sched.time_in_state
+
+#### Views/Tables
+
+<br />
+
+**sched_time_in_state_for_thread**. The time a thread spent in each scheduling state during it's lifetime.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| utid | INT | Utid of the thread. |
+| total_runtime | INT | Total runtime of thread. |
+| state | STRING | One of the scheduling states of kernel thread. |
+| time_in_state | INT | Total time spent in the scheduling state. |
+| percentage_in_state | INT | Percentage of time thread spent in scheduling state in \[0-100\] range. |
+
+<br />
+
+<br />
+
+<br />
+
+**sched_percentage_of_time_in_state**. Summary of time spent by thread in each scheduling state, in percentage (\[0, 100\] ranges)
+
+<br />
+
+TABLE
+Summary of time spent by thread in each scheduling state, in percentage (\[0, 100\]
+ranges). Sum of all states might be smaller than 100, as those values
+are rounded down.
+
+| Column | Type | Description |
+|---|---|---|
+| utid | INT | Utid of the thread. |
+| running | INT | Percentage of time thread spent in running ('Running') state in \[0, 100\] range. |
+| runnable | INT | Percentage of time thread spent in runnable ('R') state in \[0, 100\] range. |
+| runnable_preempted | INT | Percentage of time thread spent in preempted runnable ('R+') state in \[0, 100\] range. |
+| sleeping | INT | Percentage of time thread spent in sleeping ('S') state in \[0, 100\] range. |
+| uninterruptible_sleep | INT | Percentage of time thread spent in uninterruptible sleep ('D') state in \[0, 100\] range. |
+| other | INT | Percentage of time thread spent in other ('T', 't', 'X', 'Z', 'x', 'I', 'K', 'W', 'P', 'N') states in \[0, 100\] range. |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**sched_time_in_state_for_thread_in_interval** . Time the thread spent each state in a given interval.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| ts | INT | The start of the interval. |
+| dur | INT | The duration of the interval. |
+| utid | INT | The utid of the thread. |
+
+| Column | Type | Description |
+|---|---|---|
+| state | INT | Thread state (from the `thread_state` table). Use `sched_state_to_human_readable_string` function to get full name. |
+| io_wait | BOOL | A (posssibly NULL) boolean indicating, if the device was in uninterruptible sleep, if it was an IO sleep. |
+| blocked_function | INT | Some states can specify the blocked function. Usually NULL. |
+| dur | INT | Total time spent with this state, cpu and blocked function. |
+
+<br />
+
+<br />
+
+<br />
+
+**sched_time_in_state_and_cpu_for_thread_in_interval** . Time the thread spent each state and cpu in a given interval.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| ts | INT | The start of the interval. |
+| dur | INT | The duration of the interval. |
+| utid | INT | The utid of the thread. |
+
+| Column | Type | Description |
+|---|---|---|
+| state | INT | Thread state (from the `thread_state` table). Use `sched_state_to_human_readable_string` function to get full name. |
+| io_wait | BOOL | A (posssibly NULL) boolean indicating, if the device was in uninterruptible sleep, if it was an IO sleep. |
+| cpu | INT | Id of the CPU. |
+| blocked_function | INT | Some states can specify the blocked function. Usually NULL. |
+| dur | INT | Total time spent with this state, cpu and blocked function. |
+
+<br />
+
+<br />
+
+<br />
+
+**sched_time_in_state_for_cpu_in_interval** . Time spent by CPU in each scheduling state in a provided interval.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| cpu | INT | CPU id. |
+| ts | INT | Interval start. |
+| dur | INT | Interval duration. |
+
+| Column | Type | Description |
+|---|---|---|
+| end_state | STRING | End state. From `sched.end_state`. |
+| dur | INT | Duration in state. |
+
+<br />
+
+<br />
+
+## Package: intervals
+
+### intervals.overlap
+
+#### Macros
+
+<br />
+
+**intervals_overlap_count** . Compute the distribution of the overlap of the given intervals over time. Each interval is a (ts, dur) pair and the overlap represented as a (ts, value) counter, with the value corresponding to the number of intervals that overlap the given timestamp and interval until the next timestamp.
+
+<br />
+
+<br />
+
+<br />
+
+Compute the distribution of the overlap of the given intervals over time.
+
+Each interval is a (ts, dur) pair and the overlap represented as a (ts, value)
+counter, with the value corresponding to the number of intervals that overlap
+the given timestamp and interval until the next timestamp.
+Returns: TableOrSubquery, The returned table has the schema (ts INT64, value UINT32). \|ts\| is the timestamp when the number of open segments changed. \|value\| is the number of open segments.
+
+| Argument | Type | Description |
+|---|---|---|
+| segments | TableOrSubquery | Table or subquery containing interval data. |
+| ts_column | ColumnName | Column containing interval starts (usually `ts`). |
+| dur_column | ColumnName | Column containing interval durations (usually `dur`). |
+
+<br />
+
+<br />
+
+## Package: time
+
+### time.conversion
+
+#### Functions
+
+<br />
+
+**time_from_ns** -\> INT. Returns the provided nanosecond duration, which is the default representation of time durations in trace processor
+
+<br />
+
+<br />
+
+<br />
+
+Returns the provided nanosecond duration, which is the default
+representation of time durations in trace processor. Provided for
+consistency with other functions.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_from_us** -\> INT. Converts a duration in microseconds to nanoseconds, which is the default representation of time durations in trace processor.
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in microseconds to nanoseconds, which is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| micros | INT | Time duration in microseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_from_ms** -\> INT. Converts a duration in millseconds to nanoseconds, which is the default representation of time durations in trace processor.
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in millseconds to nanoseconds, which is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| millis | INT | Time duration in milliseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_from_s** -\> INT. Converts a duration in seconds to nanoseconds, which is the default representation of time durations in trace processor.
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in seconds to nanoseconds, which is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| seconds | INT | Time duration in seconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_from_min** -\> INT. Converts a duration in minutes to nanoseconds, which is the default representation of time durations in trace processor.
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in minutes to nanoseconds, which is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| minutes | INT | Time duration in minutes. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_from_hours** -\> INT. Converts a duration in hours to nanoseconds, which is the default representation of time durations in trace processor.
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in hours to nanoseconds, which is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| hours | INT | Time duration in hours. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_from_days** -\> INT. Converts a duration in days to nanoseconds, which is the default representation of time durations in trace processor.
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in days to nanoseconds, which is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| days | INT | Time duration in days. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_to_ns** -\> INT. Returns the provided nanosecond duration, which is the default representation of time durations in trace processor
+
+<br />
+
+<br />
+
+<br />
+
+Returns the provided nanosecond duration, which is the default
+representation of time durations in trace processor. Provided for
+consistency with other functions.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_to_us** -\> INT. Converts a duration in nanoseconds to microseconds
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in nanoseconds to microseconds. Nanoseconds is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in microseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_to_ms** -\> INT. Converts a duration in nanoseconds to millseconds
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in nanoseconds to millseconds. Nanoseconds is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in milliseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_to_s** -\> INT. Converts a duration in nanoseconds to seconds
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in nanoseconds to seconds. Nanoseconds is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in seconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_to_min** -\> INT. Converts a duration in nanoseconds to minutes
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in nanoseconds to minutes. Nanoseconds is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in minutes.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_to_hours** -\> INT. Converts a duration in nanoseconds to hours
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in nanoseconds to hours. Nanoseconds is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in hours.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_to_days** -\> INT. Converts a duration in nanoseconds to days
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in nanoseconds to days. Nanoseconds is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in days.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+## Package: linux
+
+### linux.cpu.frequency
+
+#### Views/Tables
+
+<br />
+
+**cpu_frequency_counters**. Counter information for each frequency change for each CPU
+
+<br />
+
+TABLE
+Counter information for each frequency change for each CPU. Finds each time
+region where a CPU frequency is constant.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Counter id. |
+| track_id | INT | Joinable with 'counter_track.id'. |
+| ts | LONG | Starting timestamp of the counter |
+| dur | INT | Duration in which counter is constant and frequency doesn't change. |
+| freq | INT | Frequency in kHz of the CPU that corresponds to this counter. NULL if not found or undefined. |
+| ucpu | INT | Unique CPU id. |
+| cpu | INT | CPU that corresponds to this counter. |
+
+<br />
+
+<br />
+
+### linux.cpu.idle
+
+#### Views/Tables
+
+<br />
+
+**cpu_idle_counters**. Counter information for each idle state change for each CPU
+
+<br />
+
+TABLE
+Counter information for each idle state change for each CPU. Finds each time
+region where a CPU idle state is constant.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Counter id. |
+| track_id | INT | Joinable with 'counter_track.id'. |
+| ts | LONG | Starting timestamp of the counter. |
+| dur | INT | Duration in which the counter is contant and idle state doesn't change. |
+| idle | INT | Idle state of the CPU that corresponds to this counter. An idle state of -1 is defined to be active state for the CPU, and the larger the integer, the deeper the idle state of the CPU. NULL if not found or undefined. |
+| cpu | INT | CPU that corresponds to this counter. |
+
+<br />
+
+<br />
+
+### linux.cpu.idle_stats
+
+#### Views/Tables
+
+<br />
+
+**cpu_idle_stats**. Aggregates cpu idle statistics per core.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| cpu | INT | CPU core number. |
+| state | INT | CPU idle state (C-states). |
+| count | INT | The count of entering idle state. |
+| dur | INT | Total CPU core idle state duration in nanoseconds. |
+| avg_dur | INT | Average CPU core idle state duration in nanoseconds. |
+| idle_percent | FLOAT | Idle state percentage of non suspend time (C-states + P-states). |
+
+<br />
+
+<br />
+
+### linux.cpu.idle_time_in_state
+
+#### Views/Tables
+
+<br />
+
+**cpu_idle_time_in_state_counters**. Counter information for sysfs cpuidle states. Tracks the percentage of time spent in each state between two timestamps, by dividing the incremental time spent in one state, by time all CPUS spent in any state.
+
+<br />
+
+TABLE
+Counter information for sysfs cpuidle states.
+Tracks the percentage of time spent in each state between two timestamps, by
+dividing the incremental time spent in one state, by time all CPUS spent in
+any state.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | LONG | Timestamp. |
+| state_name | STRING | State name. |
+| idle_percentage | DOUBLE | Percentage of time all CPUS spent in this state. |
+| total_residency | DOUBLE | Incremental time spent in this state (residency), in microseconds. |
+| time_slice | INT | Time all CPUS spent in any state, in microseconds. |
+
+<br />
+
+<br />
+
+### linux.cpu.utilization.process
+
+#### Views/Tables
+
+<br />
+
+**cpu_cycles_per_process**. Aggregated CPU statistics for each process.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| upid | INT | Unique process id |
+| millicycles | INT | Sum of CPU millicycles |
+| megacycles | INT | Sum of CPU megacycles |
+| runtime | INT | Total runtime duration |
+| min_freq | INT | Minimum CPU frequency in kHz |
+| max_freq | INT | Maximum CPU frequency in kHz |
+| avg_freq | INT | Average CPU frequency in kHz |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**cpu_process_utilization_per_period** . Returns a table of process utilization per given period. Utilization is calculated as sum of average utilization of each CPU in each period, which is defined as a multiply of \|interval\|
+
+<br />
+
+<br />
+
+<br />
+
+Returns a table of process utilization per given period.
+Utilization is calculated as sum of average utilization of each CPU in each
+period, which is defined as a multiply of \|interval\|. For this reason
+first and last period might have lower then real utilization.
+Argument \| Type \| Description
+--- \| --- \| ---
+interval \| INT \| Length of the period on which utilization should be averaged.
+upid \| INT \| Upid of the process.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp of start of a second. |
+| utilization | DOUBLE | Sum of average utilization over period. Note: as the data is normalized, the values will be in the \[0, 1\] range. |
+| unnormalized_utilization | DOUBLE | Sum of average utilization over all CPUs over period. Note: as the data is unnormalized, the values will be in the \[0, cpu_count\] range. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_process_utilization_per_second** . Returns a table of process utilization per second. Utilization is calculated as sum of average utilization of each CPU in each period, which is defined as a multiply of \|interval\|
+
+<br />
+
+<br />
+
+<br />
+
+Returns a table of process utilization per second.
+Utilization is calculated as sum of average utilization of each CPU in each
+period, which is defined as a multiply of \|interval\|. For this reason
+first and last period might have lower then real utilization.
+Argument \| Type \| Description
+--- \| --- \| ---
+upid \| INT \| Upid of the process.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp of start of a second. |
+| utilization | DOUBLE | Sum of average utilization over period. Note: as the data is normalized, the values will be in the \[0, 1\] range. |
+| unnormalized_utilization | DOUBLE | Sum of average utilization over all CPUs over period. Note: as the data is unnormalized, the values will be in the \[0, cpu_count\] range. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_cycles_per_process_in_interval** . Aggregated CPU statistics for each process in a provided interval.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| ts | INT | Start of the interval. |
+| dur | INT | Duration of the interval. |
+
+| Column | Type | Description |
+|---|---|---|
+| upid | INT | Unique process id. Joinable with `process.id`. |
+| millicycles | INT | Sum of CPU millicycles |
+| megacycles | INT | Sum of CPU megacycles |
+| runtime | INT | Total runtime duration |
+| min_freq | INT | Minimum CPU frequency in kHz |
+| max_freq | INT | Maximum CPU frequency in kHz |
+| avg_freq | INT | Average CPU frequency in kHz |
+
+<br />
+
+<br />
+
+### linux.cpu.utilization.slice
+
+#### Views/Tables
+
+<br />
+
+**cpu_cycles_per_thread_slice**. CPU cycles per each slice.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Id of a slice. Alias of `slice.id`. |
+| name | STRING | Name of the slice. |
+| utid | INT | Id of the thread the slice is running on. Alias of `thread.id`. |
+| thread_name | STRING | Name of the thread. |
+| upid | INT | Id of the process the slice is running on. Alias of `process.id`. |
+| process_name | STRING | Name of the process. |
+| millicycles | INT | Sum of CPU millicycles. Null if frequency couldn't be fetched for any period during the runtime of the slice. |
+| megacycles | INT | Sum of CPU megacycles. Null if frequency couldn't be fetched for any period during the runtime of the slice. |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**cpu_cycles_per_thread_slice_in_interval** . CPU cycles per each slice in interval.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| ts | INT | Start of the interval. |
+| dur | INT | Duration of the interval. |
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Id of a slice. Alias of `slice.id`. |
+| name | STRING | Name of the slice. |
+| utid | INT | Id of the thread the slice is running on. Alias of `thread.id`. |
+| thread_name | STRING | Name of the thread. |
+| upid | INT | Id of the process the slice is running on. Alias of `process.id`. |
+| process_name | STRING | Name of the process. |
+| millicycles | INT | Sum of CPU millicycles. Null if frequency couldn't be fetched for any period during the runtime of the slice. |
+| megacycles | INT | Sum of CPU megacycles. Null if frequency couldn't be fetched for any period during the runtime of the slice. |
+
+<br />
+
+<br />
+
+### linux.cpu.utilization.system
+
+#### Views/Tables
+
+<br />
+
+**cpu_utilization_per_second**. Table with system utilization per second. Utilization is calculated by sum of average utilization of each CPU every second
+
+<br />
+
+TABLE
+Table with system utilization per second.
+Utilization is calculated by sum of average utilization of each CPU every
+second. For this reason first and last second might have lower then real
+utilization.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp of start of a second. |
+| utilization | DOUBLE | Sum of average utilization over period. Note: as the data is normalized, the values will be in the \[0, 1\] range. |
+| unnormalized_utilization | DOUBLE | Sum of average utilization over all CPUs over period. Note: as the data is unnormalized, the values will be in the \[0, cpu_count\] range. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_cycles**. Aggregated CPU statistics for whole trace
+
+<br />
+
+TABLE
+Aggregated CPU statistics for whole trace. Results in only one row.
+
+| Column | Type | Description |
+|---|---|---|
+| millicycles | INT | Sum of CPU millicycles. |
+| megacycles | INT | Sum of CPU megacycles. |
+| runtime | INT | Total runtime of all threads running on all CPUs. |
+| min_freq | INT | Minimum CPU frequency in kHz. |
+| max_freq | INT | Maximum CPU frequency in kHz. |
+| avg_freq | INT | Average CPU frequency in kHz. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_cycles_per_cpu**. Aggregated CPU statistics for each CPU.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| ucpu | INT | Unique CPU id. Joinable with `cpu.id`. |
+| cpu | INT | The number of the CPU. Might not be the same as ucpu in multi machine cases. |
+| millicycles | INT | Sum of CPU millicycles. |
+| megacycles | INT | Sum of CPU megacycles. |
+| runtime | INT | Total runtime of all threads running on CPU. |
+| min_freq | INT | Minimum CPU frequency in kHz. |
+| max_freq | INT | Maximum CPU frequency in kHz. |
+| avg_freq | INT | Average CPU frequency in kHz. |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**cpu_utilization_per_period** . Returns a table of system utilization per given period. Utilization is calculated as sum of average utilization of each CPU in each period, which is defined as a multiply of \|interval\|
+
+<br />
+
+<br />
+
+<br />
+
+Returns a table of system utilization per given period.
+Utilization is calculated as sum of average utilization of each CPU in each
+period, which is defined as a multiply of \|interval\|. For this reason
+first and last period might have lower then real utilization.
+Argument \| Type \| Description
+--- \| --- \| ---
+interval \| INT \| Length of the period on which utilization should be averaged.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp of start of a second. |
+| utilization | DOUBLE | Sum of average utilization over period. Note: as the data is normalized, the values will be in the \[0, 1\] range. |
+| unnormalized_utilization | DOUBLE | Sum of average utilization over all CPUs over period. Note: as the data is unnormalized, the values will be in the \[0, cpu_count\] range. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_cycles_in_interval** . Aggregated CPU statistics in a provided interval
+
+<br />
+
+<br />
+
+<br />
+
+Aggregated CPU statistics in a provided interval. Results in one row.
+Argument \| Type \| Description
+--- \| --- \| ---
+ts \| INT \| Start of the interval.
+dur \| INT \| Duration of the interval.
+
+| Column | Type | Description |
+|---|---|---|
+| millicycles | INT | Sum of CPU millicycles. |
+| megacycles | INT | Sum of CPU megacycles. |
+| runtime | INT | Total runtime of all threads running on all CPUs. |
+| min_freq | INT | Minimum CPU frequency in kHz. |
+| max_freq | INT | Maximum CPU frequency in kHz. |
+| avg_freq | INT | Average CPU frequency in kHz. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_cycles_per_cpu_in_interval** . Aggregated CPU statistics for each CPU in a provided interval.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| ts | INT | Start of the interval. |
+| dur | INT | Duration of the interval. |
+
+| Column | Type | Description |
+|---|---|---|
+| ucpu | INT | Unique CPU id. Joinable with `cpu.id`. |
+| cpu | INT | CPU number. |
+| millicycles | INT | Sum of CPU millicycles. |
+| megacycles | INT | Sum of CPU megacycles. |
+| runtime | INT | Total runtime of all threads running on CPU. |
+| min_freq | INT | Minimum CPU frequency in kHz. |
+| max_freq | INT | Maximum CPU frequency in kHz. |
+| avg_freq | INT | Average CPU frequency in kHz. |
+
+<br />
+
+<br />
+
+### linux.cpu.utilization.thread
+
+#### Views/Tables
+
+<br />
+
+**cpu_cycles_per_thread**. Aggregated CPU statistics for each thread.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| utid | INT | Unique thread id |
+| millicycles | INT | Sum of CPU millicycles |
+| megacycles | INT | Sum of CPU megacycles |
+| runtime | INT | Total runtime duration |
+| min_freq | INT | Minimum CPU frequency in kHz |
+| max_freq | INT | Maximum CPU frequency in kHz |
+| avg_freq | INT | Average CPU frequency in kHz |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**cpu_thread_utilization_per_period** . Returns a table of thread utilization per given period. Utilization is calculated as sum of average utilization of each CPU in each period, which is defined as a multiply of \|interval\|
+
+<br />
+
+<br />
+
+<br />
+
+Returns a table of thread utilization per given period.
+Utilization is calculated as sum of average utilization of each CPU in each
+period, which is defined as a multiply of \|interval\|. For this reason
+first and last period might have lower then real utilization.
+Argument \| Type \| Description
+--- \| --- \| ---
+interval \| INT \| Length of the period on which utilization should be averaged.
+utid \| INT \| Utid of the thread.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp of start of a second. |
+| utilization | DOUBLE | Sum of average utilization over period. Note: as the data is normalized, the values will be in the \[0, 1\] range. |
+| unnormalized_utilization | DOUBLE | Sum of average utilization over all CPUs over period. Note: as the data is unnormalized, the values will be in the \[0, cpu_count\] range. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_thread_utilization_per_second** . Returns a table of thread utilization per second. Utilization is calculated as sum of average utilization of each CPU in each period, which is defined as a multiply of \|interval\|
+
+<br />
+
+<br />
+
+<br />
+
+Returns a table of thread utilization per second.
+Utilization is calculated as sum of average utilization of each CPU in each
+period, which is defined as a multiply of \|interval\|. For this reason
+first and last period might have lower then real utilization.
+Argument \| Type \| Description
+--- \| --- \| ---
+utid \| INT \| Utid of the thread.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp of start of a second. |
+| utilization | DOUBLE | Sum of average utilization over period. Note: as the data is normalized, the values will be in the \[0, 1\] range. |
+| unnormalized_utilization | DOUBLE | Sum of average utilization over all CPUs over period. Note: as the data is unnormalized, the values will be in the \[0, cpu_count\] range. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_cycles_per_thread_in_interval** . Aggregated CPU statistics for each thread in a provided interval.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| ts | INT | Start of the interval. |
+| dur | INT | Duration of the interval. |
+
+| Column | Type | Description |
+|---|---|---|
+| utid | INT | Unique thread id. Joinable with `thread.id`. |
+| millicycles | INT | Sum of CPU millicycles |
+| megacycles | INT | Sum of CPU megacycles |
+| runtime | INT | Total runtime duration |
+| min_freq | INT | Minimum CPU frequency in kHz |
+| max_freq | INT | Maximum CPU frequency in kHz |
+| avg_freq | INT | Average CPU frequency in kHz |
+
+<br />
+
+<br />
+
+### linux.devfreq
+
+#### Views/Tables
+
+<br />
+
+**linux_devfreq_dsu_counter**. ARM DSU device frequency counters
+
+<br />
+
+TABLE
+ARM DSU device frequency counters. This table will only be populated on
+traces collected with "devfreq/devfreq_frequency" ftrace event enabled,
+and from ARM devices with the DSU (DynamIQ Shared Unit) hardware.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Unique identifier for this counter. |
+| ts | LONG | Starting timestamp of the counter. |
+| dur | INT | Duration in which counter is constant and frequency doesn't chamge. |
+| dsu_freq | INT | Frequency in kHz of the device that corresponds to the counter. |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**linux_get_devfreq_counters** . Gets devfreq frequency counter based on device queried
+
+<br />
+
+<br />
+
+<br />
+
+Gets devfreq frequency counter based on device queried. These counters will
+only be available if the "devfreq/devfreq_frequency" ftrace event is enabled.
+Argument \| Type \| Description
+--- \| --- \| ---
+device_name \| STRING \| Devfreq name to query for.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Unique identifier for this counter. |
+| ts | LONG | Starting timestamp of the counter. |
+| dur | INT | Duration in which counter is constant and frequency doesn't chamge. |
+| freq | INT | Frequency in kHz of the device that corresponds to the counter. |
+
+<br />
+
+<br />
+
+### linux.memory.high_watermark
+
+#### Views/Tables
+
+<br />
+
+**memory_rss_high_watermark_per_process**. For each process fetches the memory high watermark until or during timestamp.
+
+<br />
+
+VIEW
+For each process fetches the memory high watermark until or during
+timestamp.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp |
+| dur | INT | Duration |
+| upid | INT | Upid of the process |
+| pid | INT | Pid of the process |
+| process_name | STRING | Name of the process |
+| rss_high_watermark | INT | Maximum `rss` value until now |
+
+<br />
+
+<br />
+
+### linux.memory.process
+
+#### Views/Tables
+
+<br />
+
+**memory_rss_and_swap_per_process**. Memory metrics timeline for each process.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp |
+| dur | INT | Duration |
+| upid | INT | Upid of the process |
+| pid | INT | Pid of the process |
+| process_name | STRING | Name of the process |
+| anon_rss | INT | Anon RSS counter value |
+| file_rss | INT | File RSS counter value |
+| shmem_rss | INT | Shared memory RSS counter value |
+| rss | INT | Total RSS value. Sum of `anon_rss`, `file_rss` and `shmem_rss`. Returns value even if one of the values is NULL. |
+| swap | INT | Swap counter value |
+| anon_rss_and_swap | INT | Sum or `anon_rss` and `swap`. Returns value even if one of the values is NULL. |
+| rss_and_swap | INT | Sum or `rss` and `swap`. Returns value even if one of the values is NULL. |
+
+<br />
+
+<br />
+
+### linux.perf.samples
+
+#### Views/Tables
+
+<br />
+
+**linux_perf_samples_summary_tree** . Table summarising the callstacks captured during all perf samples in the trace. Specifically, this table returns a tree containing all the callstacks seen during the trace with `self_count` equal to the number of samples with that frame as the leaf and `cumulative_count` equal to the number of samples with the frame anywhere in the tree.
+
+<br />
+
+TABLE
+Table summarising the callstacks captured during all
+perf samples in the trace.
+
+Specifically, this table returns a tree containing all
+the callstacks seen during the trace with `self_count`
+equal to the number of samples with that frame as the
+leaf and `cumulative_count` equal to the number of
+samples with the frame anywhere in the tree.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the callstack. A callstack in this context is a unique set of frames up to the root. |
+| parent_id | INT | The id of the parent callstack for this callstack. |
+| name | STRING | The function name of the frame for this callstack. |
+| mapping_name | STRING | The name of the mapping containing the frame. This can be a native binary, library, JAR or APK. |
+| source_file | STRING | The name of the file containing the function. |
+| line_number | INT | The line number in the file the function is located at. |
+| self_count | INT | The number of samples with this function as the leaf frame. |
+| cumulative_count | INT | The number of samples with this function appearing anywhere on the callstack. |
+
+<br />
+
+<br />
+
+### linux.perf.spe
+
+#### Views/Tables
+
+<br />
+
+**linux_perf_spe_record**. Contains ARM Statistical Profiling Extension records
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| ts | LONG | Timestap when the operation was sampled |
+| utid | INT | Thread the operation executed in |
+| exception_level | STRING | Exception level the instruction was executed in |
+| instruction_frame_id | INT | Instruction virtual address |
+| operation | STRING | Type of operation sampled |
+| data_virtual_address | LONG | The virtual address accessed by the operation (0 if no memory access was performed) |
+| data_physical_address | LONG | The physical address accessed by the operation (0 if no memory access was performed) |
+| total_latency | INT | Cycle count from the operation being dispatched for issue to the operation being complete. |
+| issue_latency | INT | Cycle count from the operation being dispatched for issue to the operation being issued for execution. |
+| translation_latency | INT | Cycle count from a virtual address being passed to the MMU for translation to the result of the translation being available. |
+| data_source | STRING | Where the data returned for a load operation was sourced |
+| exception_gen | BOOL | Operation generated an exception |
+| retired | BOOL | Operation architecturally retired |
+| l1d_access | BOOL | Operation caused a level 1 data cache access |
+| l1d_refill | BOOL | Operation caused a level 1 data cache refill |
+| tlb_access | BOOL | Operation caused a TLB access |
+| tlb_refill | BOOL | Operation caused a TLB refill involving at least one translation table walk |
+| not_taken | BOOL | Conditional instruction failed its condition code check |
+| mispred | BOOL | Whether a branch caused a correction to the predicted program flow |
+| llc_access | BOOL | Operation caused a last level data or unified cache access |
+| llc_refill | BOOL | Whether the operation could not be completed by the last level data cache (or any above) |
+| remote_access | BOOL | Operation caused an access to another socket in a multi-socket system |
+| alignment | BOOL | Operation that incurred additional latency due to the alignment of the address and the size of the data being accessed |
+| tme_transaction | BOOL | Whether the operation executed in transactional state |
+| sve_partial_pred | BOOL | SVE or SME operation with at least one false element in the governing predicate(s) |
+| sve_empty_pred | BOOL | SVE or SME operation with no true element in the governing predicate(s) |
+| l2d_access | BOOL | Whether a load operation caused a cache access to at least the level 2 data or unified cache |
+| l2d_hit | BOOL | Whether a load operation accessed and missed the level 2 data or unified cache. Not set for accesses that are satisfied from refilling data of a previous miss |
+| cache_data_modified | BOOL | Whether a load operation accessed modified data in a cache |
+| recenty_fetched | BOOL | Wheter a load operation hit a recently fetched line in a cache |
+| data_snooped | BOOL | Whether a load operation snooped data from a cache outside the cache hierarchy of this core |
+
+<br />
+
+<br />
+
+### linux.threads
+
+#### Views/Tables
+
+<br />
+
+**linux_kernel_threads**. All kernel threads of the trace
+
+<br />
+
+TABLE
+All kernel threads of the trace. As kernel threads are processes, provides
+also process data.
+
+| Column | Type | Description |
+|---|---|---|
+| upid | INT | Upid of kernel thread. Alias of \|process.upid\|. |
+| utid | INT | Utid of kernel thread. Alias of \|thread.utid\|. |
+| pid | INT | Pid of kernel thread. Alias of \|process.pid\|. |
+| tid | INT | Tid of kernel thread. Alias of \|process.pid\|. |
+| process_name | STRING | Name of kernel process. Alias of \|process.name\|. |
+| thread_name | STRING | Name of kernel thread. Alias of \|thread.name\|. |
+| machine_id | INT | Machine id of kernel thread. If NULL then it's a single machine trace. Alias of \|process.machine_id\|. |
+
+<br />
+
+<br />
+
+## Package: android
+
+### android.anrs
+
+#### Views/Tables
+
+<br />
+
+**android_anrs**. List of all ANRs that occurred in the trace (one row per ANR).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| process_name | STRING | Name of the process that triggered the ANR. |
+| pid | INT | PID of the process that triggered the ANR. |
+| upid | INT | UPID of the process that triggered the ANR. |
+| error_id | STRING | UUID of the ANR (generated on the platform). |
+| ts | INT | Timestamp of the ANR. |
+| subject | STRING | Subject line of the ANR. |
+
+<br />
+
+<br />
+
+### android.app_process_starts
+
+#### Views/Tables
+
+<br />
+
+**android_app_process_starts**. All app cold starts with information about their cold start reason: broadcast, service, activity or provider.
+
+<br />
+
+TABLE
+All app cold starts with information about their cold start reason:
+broadcast, service, activity or provider.
+
+| Column | Type | Description |
+|---|---|---|
+| start_id | INT | Slice id of the bindApplication slice in the app. Uniquely identifies a process start. |
+| id | INT | Slice id of intent received in the app. |
+| track_id | INT | Track id of the intent received in the app. |
+| process_name | STRING | Name of the process receiving the intent. |
+| pid | INT | Pid of the process receiving the intent. |
+| upid | INT | Upid of the process receiving the intent. |
+| intent | STRING | Intent action or component responsible for the cold start. |
+| reason | STRING | Process start reason: activity, broadcast, service or provider. |
+| proc_start_ts | INT | Timestamp the process start was dispatched from system_server. |
+| proc_start_dur | INT | Duration to dispatch the process start from system_server. |
+| bind_app_ts | INT | Timestamp the bindApplication started in the app. |
+| bind_app_dur | INT | Duration to complete bindApplication in the app. |
+| intent_ts | INT | Timestamp the Intent was received in the app. |
+| intent_dur | INT | Duration to handle intent in the app. |
+| total_dur | INT | Total duration from proc_start dispatched to intent completed. |
+
+<br />
+
+<br />
+
+### android.auto.multiuser
+
+#### Views/Tables
+
+<br />
+
+**android_auto_multiuser_timing**. Time elapsed between the latest user start and the specific end event like package startup(ex carlauncher) or previous user stop.
+
+<br />
+
+TABLE
+Time elapsed between the latest user start
+and the specific end event
+like package startup(ex carlauncher) or previous user stop.
+
+| Column | Type | Description |
+|---|---|---|
+| event_start_user_id | STRING | Id of the started android user |
+| event_start_time | INT | Start event time |
+| event_end_time | INT | End event time |
+| event_end_name | STRING | End event name |
+| event_start_name | STRING | Start event name |
+| duration | LONG | User switch duration from start event to end event |
+
+<br />
+
+<br />
+
+<br />
+
+**android_auto_multiuser_timing_with_previous_user_resource_usage** . This table extends `android_auto_multiuser_timing` table with previous user resource usage.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| event_start_user_id | STRING | Start user id |
+| event_start_time | INT | Start event time |
+| event_end_time | INT | End event time |
+| event_end_name | STRING | End event name |
+| event_start_name | STRING | Start event name |
+| duration | LONG | User switch duration from start event to end event |
+| user_id | INT | User id |
+| total_cpu_time | LONG | Total CPU time for a user |
+| total_memory_usage_kb | LONG | Total memory user for a user |
+
+<br />
+
+<br />
+
+### android.battery
+
+#### Views/Tables
+
+<br />
+
+**android_battery_charge**. Battery charge at timestamp.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp. |
+| current_avg_ua | DOUBLE | Current average micro ampers. |
+| capacity_percent | DOUBLE | Current capacity percentage. |
+| charge_uah | DOUBLE | Current charge in micro ampers. |
+| current_ua | DOUBLE | Current micro ampers. |
+
+<br />
+
+<br />
+
+### android.battery_stats
+
+#### Views/Tables
+
+<br />
+
+**android_battery_stats_state**. View of human readable battery stats counter-based states
+
+<br />
+
+VIEW
+View of human readable battery stats counter-based states. These are recorded
+by BatteryStats as a bitmap where each 'category' has a unique value at any
+given time.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp in nanoseconds. |
+| dur | INT | The duration the state was active, may be negative for incomplete slices. |
+| safe_dur | INT | The same as `dur`, but extends to trace end for incomplete slices. |
+| track_name | STRING | The name of the counter track. |
+| value | INT | The counter value as a number. |
+| value_name | STRING | The counter value as a human-readable string. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_battery_stats_event_slices**. View of slices derived from battery_stats events
+
+<br />
+
+VIEW
+View of slices derived from battery_stats events. Battery stats records all
+events as instants, however some may indicate whether something started or
+stopped with a '+' or '-' prefix. Events such as jobs, top apps, foreground
+apps or long wakes include these details and allow drawing slices between
+instant events found in a trace.
+
+For example, we may see an event like the following on 'battery_stats.top':
+
+     -top=10215:"com.google.android.apps.nexuslauncher"
+
+This view will find the associated start ('+top') with the matching suffix
+(everything after the '=') to construct a slice. It computes the timestamp
+and duration from the events and extract the details as follows:
+
+     track_name='battery_stats.top'
+     str_value='com.google.android.apps.nexuslauncher'
+     int_value=10215
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp in nanoseconds. |
+| dur | INT | The duration the state was active, may be negative for incomplete slices. |
+| safe_dur | INT | The same as `dur`, but extends to trace end for incomplete slices. |
+| track_name | STRING | The name of the counter track. |
+| str_value | STRING | String value. |
+| int_value | INT | Int value. |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**android_battery_stats_counter_to_string** -\> STRING. Converts a battery_stats counter value to human readable string.
+
+<br />
+
+<br />
+
+<br />
+
+Returns STRING: The human-readable name for the counter value.
+
+| Argument | Type | Description |
+|---|---|---|
+| track | STRING | The counter track name (e.g. 'battery_stats.audio'). |
+| value | FLOAT | The counter value. |
+
+<br />
+
+<br />
+
+### android.binder
+
+#### Views/Tables
+
+<br />
+
+**android_binder_metrics_by_process**. Count Binder transactions per process.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| process_name | STRING | Name of the process that started the binder transaction. |
+| pid | INT | PID of the process that started the binder transaction. |
+| slice_name | STRING | Name of the slice with binder transaction. |
+| event_count | INT | Number of binder transactions in process in slice. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_sync_binder_thread_state_by_txn**. Aggregated thread_states on the client and server side per binder txn This builds on the data from \|_sync_binder_metrics_by_txn\| and for each end (client and server) of the transaction, it returns the aggregated sum of all the thread state durations. The \|thread_state_type\| column represents whether a given 'aggregated thread_state' row is on the client or server side
+
+<br />
+
+VIEW
+Aggregated thread_states on the client and server side per binder txn
+This builds on the data from \|_sync_binder_metrics_by_txn\| and
+for each end (client and server) of the transaction, it returns
+the aggregated sum of all the thread state durations.
+The \|thread_state_type\| column represents whether a given 'aggregated thread_state'
+row is on the client or server side. 'binder_txn' is client side and 'binder_reply'
+is server side.
+
+| Column | Type | Description |
+|---|---|---|
+| binder_txn_id | INT | slice id of the binder txn |
+| client_ts | INT | Client timestamp |
+| client_tid | INT | Client tid |
+| binder_reply_id | INT | slice id of the binder reply |
+| server_ts | INT | Server timestamp |
+| server_tid | INT | Server tid |
+| thread_state_type | STRING | whether thread state is on the txn or reply side |
+| thread_state | STRING | a thread_state that occurred in the txn |
+| thread_state_dur | INT | aggregated dur of the \|thread_state\| in the txn |
+| thread_state_count | INT | aggregated count of the \|thread_state\| in the txn |
+
+<br />
+
+<br />
+
+<br />
+
+**android_sync_binder_blocked_functions_by_txn**. Aggregated blocked_functions on the client and server side per binder txn This builds on the data from \|_sync_binder_metrics_by_txn\| and for each end (client and server) of the transaction, it returns the aggregated sum of all the kernel blocked function durations. The \|thread_state_type\| column represents whether a given 'aggregated blocked_function' row is on the client or server side
+
+<br />
+
+VIEW
+Aggregated blocked_functions on the client and server side per binder txn
+This builds on the data from \|_sync_binder_metrics_by_txn\| and
+for each end (client and server) of the transaction, it returns
+the aggregated sum of all the kernel blocked function durations.
+The \|thread_state_type\| column represents whether a given 'aggregated blocked_function'
+row is on the client or server side. 'binder_txn' is client side and 'binder_reply'
+is server side.
+
+| Column | Type | Description |
+|---|---|---|
+| binder_txn_id | INT | slice id of the binder txn |
+| client_ts | INT | Client ts |
+| client_tid | INT | Client tid |
+| binder_reply_id | INT | slice id of the binder reply |
+| server_ts | INT | Server ts |
+| server_tid | INT | Server tid |
+| thread_state_type | STRING | whether thread state is on the txn or reply side |
+| blocked_function | STRING | blocked kernel function in a thread state |
+| blocked_function_dur | INT | aggregated dur of the \|blocked_function\| in the txn |
+| blocked_function_count | INT | aggregated count of the \|blocked_function\| in the txn |
+
+<br />
+
+<br />
+
+<br />
+
+**android_binder_txns**. Breakdown binder transactions per txn. It returns data about the client and server ends of every binder transaction async.
+
+<br />
+
+TABLE
+Breakdown binder transactions per txn.
+It returns data about the client and server ends of every binder transaction async.
+
+| Column | Type | Description |
+|---|---|---|
+| aidl_name | STRING | name of the binder interface if existing. |
+| aidl_ts | INT | Timestamp the binder interface name was emitted. Proxy to 'ts' and 'dur' for async txns. |
+| aidl_dur | INT | Duration of the binder interface name. Proxy to 'ts' and 'dur' for async txns. |
+| binder_txn_id | INT | slice id of the binder txn. |
+| client_process | STRING | name of the client process. |
+| client_thread | STRING | name of the client thread. |
+| client_upid | INT | Upid of the client process. |
+| client_utid | INT | Utid of the client thread. |
+| client_tid | INT | Tid of the client thread. |
+| client_pid | INT | Pid of the client thread. |
+| is_main_thread | BOOL | Whether the txn was initiated from the main thread of the client process. |
+| client_ts | INT | timestamp of the client txn. |
+| client_dur | INT | wall clock dur of the client txn. |
+| binder_reply_id | INT | slice id of the binder reply. |
+| server_process | STRING | name of the server process. |
+| server_thread | STRING | name of the server thread. |
+| server_upid | INT | Upid of the server process. |
+| server_utid | INT | Utid of the server thread. |
+| server_tid | INT | Tid of the server thread. |
+| server_pid | INT | Pid of the server thread. |
+| server_ts | INT | timestamp of the server txn. |
+| server_dur | INT | wall clock dur of the server txn. |
+| client_oom_score | INT | oom score of the client process at the start of the txn. |
+| server_oom_score | INT | oom score of the server process at the start of the reply. |
+| is_sync | BOOL | whether the txn is synchronous or async (oneway). |
+| client_monotonic_dur | INT | monotonic clock dur of the client txn. |
+| server_monotonic_dur | INT | monotonic clock dur of the server txn. |
+| client_package_version_code | INT | Client package version_code. |
+| server_package_version_code | INT | Server package version_code. |
+| is_client_package_debuggable | INT | Whether client package is debuggable. |
+| is_server_package_debuggable | INT | Whether server package is debuggable. |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**android_binder_outgoing_graph** . Returns a DAG of all outgoing binder txns from a process. The roots of the graph are the threads making the txns and the graph flows from: thread -\> server_process -\> AIDL interface -\> AIDL method. The weights of each node represent the wall execution time in the server_process.
+
+<br />
+
+<br />
+
+<br />
+
+Returns a DAG of all outgoing binder txns from a process.
+The roots of the graph are the threads making the txns and the graph flows from:
+thread -\> server_process -\> AIDL interface -\> AIDL method.
+The weights of each node represent the wall execution time in the server_process.
+Argument \| Type \| Description
+--- \| --- \| ---
+upid \| INT \| Upid of process to generate an outgoing graph for.
+
+| Column | Type | Description |
+|---|---|---|
+| pprof | BYTES | Pprof of outgoing binder txns. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_binder_incoming_graph** . Returns a DAG of all incoming binder txns from a process. The roots of the graph are the clients making the txns and the graph flows from: client_process -\> AIDL interface -\> AIDL method. The weights of each node represent the wall execution time in the server_process.
+
+<br />
+
+<br />
+
+<br />
+
+Returns a DAG of all incoming binder txns from a process.
+The roots of the graph are the clients making the txns and the graph flows from:
+client_process -\> AIDL interface -\> AIDL method.
+The weights of each node represent the wall execution time in the server_process.
+Argument \| Type \| Description
+--- \| --- \| ---
+upid \| INT \| Upid of process to generate an incoming graph for.
+
+| Column | Type | Description |
+|---|---|---|
+| pprof | BYTES | Pprof of incoming binder txns. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_binder_graph** . Returns a graph of all binder txns in a trace. The nodes are client_process and server_process. The weights of each node represent the wall execution time in the server_process.
+
+<br />
+
+<br />
+
+<br />
+
+Returns a graph of all binder txns in a trace.
+The nodes are client_process and server_process.
+The weights of each node represent the wall execution time in the server_process.
+Argument \| Type \| Description
+--- \| --- \| ---
+min_client_oom_score \| INT \| Matches txns from client_processes greater than or equal to the OOM score.
+max_client_oom_score \| INT \| Matches txns from client_processes less than or equal to the OOM score.
+min_server_oom_score \| INT \| Matches txns to server_processes greater than or equal to the OOM score.
+max_server_oom_score \| INT \| Matches txns to server_processes less than or equal to the OOM score.
+
+| Column | Type | Description |
+|---|---|---|
+| pprof | BYTES | Pprof of binder txns. |
+
+<br />
+
+<br />
+
+### android.binder_breakdown
+
+#### Views/Tables
+
+<br />
+
+**android_binder_server_breakdown**. Server side binder breakdowns per transactions per txn.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| binder_txn_id | INT | Client side id of the binder txn. Alias of `slice.id`. |
+| binder_reply_id | INT | Server side id of the binder txn. Alias of `slice.id`. |
+| ts | INT | Timestamp of an exclusive interval during the binder reply with a single reason. |
+| dur | INT | Duration of an exclusive interval during the binder reply with a single reason. |
+| reason | STRING | Cause of delay during an exclusive interval of the binder reply. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_binder_client_breakdown**. Client side binder breakdowns per transactions per txn.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| binder_txn_id | INT | Client side id of the binder txn. Alias of `slice.id`. |
+| binder_reply_id | INT | Server side id of the binder txn. Alias of `slice.id`. |
+| ts | INT | Timestamp of an exclusive interval during the binder txn with a single latency reason. |
+| dur | INT | Duration of an exclusive interval during the binder txn with a single latency reason. |
+| reason | STRING | Cause of delay during an exclusive interval of the binder txn. |
+
+<br />
+
+<br />
+
+### android.cpu.cluster_type
+
+#### Views/Tables
+
+<br />
+
+**android_cpu_cluster_mapping**. Stores the mapping of a cpu to its cluster type - e.g
+
+<br />
+
+TABLE
+Stores the mapping of a cpu to its cluster type - e.g. little, medium, big.
+This cluster type is determined by initially using cpu_capacity from sysfs
+and grouping clusters with identical capacities, ordered by size.
+In the case that capacities are not present, max frequency is used instead.
+If nothing is avaiable, NULL is returned.
+
+| Column | Type | Description |
+|---|---|---|
+| ucpu | INT | Alias of `cpu.ucpu`. |
+| cpu | INT | Alias of `cpu.cpu`. |
+| cluster_type | STRING | The cluster type of the CPU. |
+
+<br />
+
+<br />
+
+### android.device
+
+#### Views/Tables
+
+<br />
+
+**android_device_name**. Extract name of the device based on metadata from the trace.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | Device name. |
+
+<br />
+
+<br />
+
+### android.dvfs
+
+#### Views/Tables
+
+<br />
+
+**android_dvfs_counters**. Dvfs counter with duration.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | Counter name. |
+| ts | INT | Timestamp when counter value changed. |
+| value | DOUBLE | Counter value. |
+| dur | INT | Counter duration. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_dvfs_counter_stats**. Aggregates dvfs counter slice for statistic.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | Counter name on which all the other values are aggregated on. |
+| max | DOUBLE | Max of all counter values for the counter name. |
+| min | DOUBLE | Min of all counter values for the counter name. |
+| dur | INT | Duration between the first and last counter value for the counter name. |
+| wgt_avg | FLOAT | Weighted avergate of all the counter values for the counter name. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_dvfs_counter_residency**. Aggregates dvfs counter slice for residency
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | Counter name. |
+| value | DOUBLE | Counter value. |
+| dur | INT | Counter duration. |
+| pct | DOUBLE | Counter duration as a percentage of total duration. |
+
+<br />
+
+<br />
+
+### android.frames.jank_type
+
+#### Functions
+
+<br />
+
+**android_is_sf_jank_type** -\> BOOL. Categorizes whether the jank was caused by Surface Flinger
+
+<br />
+
+<br />
+
+<br />
+
+Returns BOOL: True when the jank type represents sf jank
+
+| Argument | Type | Description |
+|---|---|---|
+| jank_type | STRING | the jank type from args.display_value with key = "Jank type" |
+
+<br />
+
+<br />
+
+<br />
+
+**android_is_app_jank_type** -\> BOOL. Categorizes whether the jank was caused by the app
+
+<br />
+
+<br />
+
+<br />
+
+Returns BOOL: True when the jank type represents app jank
+
+| Argument | Type | Description |
+|---|---|---|
+| jank_type | STRING | the jank type from args.display_value with key = "Jank type" |
+
+<br />
+
+<br />
+
+### android.frames.per_frame_metrics
+
+#### Views/Tables
+
+<br />
+
+**android_frames_overrun**. The amount by which each frame missed of hit its deadline
+
+<br />
+
+TABLE
+The amount by which each frame missed of hit its deadline. Negative if the
+deadline was not missed. Frames are considered janky if `overrun` is
+positive.
+Calculated as the difference between the end of the
+`expected_frame_timeline_slice` and `actual_frame_timeline_slice` for the
+frame.
+Availability: from S (API 31).
+For Googlers: more details in go/android-performance-metrics-glossary.
+
+| Column | Type | Description |
+|---|---|---|
+| frame_id | INT | Frame id. |
+| overrun | INT | Difference between `expected` and `actual` frame ends. Negative if frame didn't miss deadline. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_frames_ui_time**. How much time did the frame's Choreographer callbacks take.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| frame_id | INT | Frame id |
+| ui_time | INT | UI time duration |
+
+<br />
+
+<br />
+
+<br />
+
+**android_app_vsync_delay_per_frame**. App Vsync delay for a frame
+
+<br />
+
+TABLE
+App Vsync delay for a frame. The time between the VSYNC-app signal and the
+start of Choreographer work.
+Calculated as time difference between the actual frame start (from
+`actual_frame_timeline_slice`) and start of the `Choreographer#doFrame`
+slice.
+For Googlers: more details in go/android-performance-metrics-glossary.
+
+| Column | Type | Description |
+|---|---|---|
+| frame_id | INT | Frame id |
+| app_vsync_delay | INT | App VSYNC delay. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_cpu_time_per_frame** . How much time did the frame take across the UI Thread + RenderThread. Calculated as sum of `app VSYNC delay` `Choreographer#doFrame` slice duration and summed durations of all `DrawFrame` slices associated with this frame. Availability: from N (API 24). For Googlers: more details in go/android-performance-metrics-glossary.
+
+<br />
+
+TABLE
+How much time did the frame take across the UI Thread + RenderThread.
+Calculated as sum of `app VSYNC delay` `Choreographer#doFrame` slice
+duration and summed durations of all `DrawFrame` slices associated with this
+frame.
+Availability: from N (API 24).
+For Googlers: more details in go/android-performance-metrics-glossary.
+
+| Column | Type | Description |
+|---|---|---|
+| frame_id | INT | Frame id |
+| app_vsync_delay | INT | Difference between actual timeline of the frame and `Choreographer#doFrame`. See `android_app_vsync_delay_per_frame` table for more details. |
+| do_frame_dur | INT | Duration of `Choreographer#doFrame` slice. |
+| draw_frame_dur | INT | Duration of `DrawFrame` slice. Summed duration of all `DrawFrame` slices, if more than one. See `android_frames_draw_frame` for more details. |
+| cpu_time | INT | CPU time across the UI Thread + RenderThread. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_frame_stats**. Aggregated stats of the frame. For Googlers: more details in go/android-performance-metrics-glossary.
+
+<br />
+
+TABLE
+Aggregated stats of the frame.
+
+For Googlers: more details in go/android-performance-metrics-glossary.
+
+| Column | Type | Description |
+|---|---|---|
+| frame_id | INT | Frame id. |
+| overrun | INT | The amount by which each frame missed of hit its deadline. See `android_frames_overrun` for details. |
+| cpu_time | INT | How much time did the frame take across the UI Thread + RenderThread. |
+| ui_time | INT | How much time did the frame's Choreographer callbacks take. |
+| was_jank | BOOL | Was frame janky. |
+| was_slow_frame | BOOL | CPU time of the frame took over 20ms. |
+| was_big_jank | BOOL | CPU time of the frame took over 50ms. |
+| was_huge_jank | BOOL | CPU time of the frame took over 200ms. |
+
+<br />
+
+<br />
+
+### android.frames.timeline
+
+#### Views/Tables
+
+<br />
+
+**android_frames_choreographer_do_frame** . All of the `Choreographer#doFrame` slices with their frame id.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | `slice.id` |
+| frame_id | INT | Frame id |
+| ui_thread_utid | INT | Utid of the UI thread |
+| upid | INT | Upid of application process |
+| ts | INT | Timestamp of the slice. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_frames_draw_frame** . All of the `DrawFrame` slices with their frame id and render thread. There might be multiple DrawFrames slices for a single vsync (frame id). This happens when we are drawing multiple layers (e.g
+
+<br />
+
+TABLE
+All of the `DrawFrame` slices with their frame id and render thread.
+There might be multiple DrawFrames slices for a single vsync (frame id).
+This happens when we are drawing multiple layers (e.g. status bar and
+notifications).
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | `slice.id` |
+| frame_id | INT | Frame id |
+| render_thread_utid | INT | Utid of the render thread |
+| upid | INT | Upid of application process |
+
+<br />
+
+<br />
+
+<br />
+
+**android_frames**. All slices related to one frame
+
+<br />
+
+TABLE
+All slices related to one frame. Aggregates `Choreographer#doFrame`,
+`DrawFrame`, `actual_frame_timeline_slice` and
+`expected_frame_timeline_slice` slices.
+See https://perfetto.dev/docs/data-sources/frametimeline for details.
+
+| Column | Type | Description |
+|---|---|---|
+| frame_id | INT | Frame id. |
+| ts | INT | Timestamp of the frame. Start of the frame as defined by the start of "Choreographer#doFrame" slice and the same as the start of the frame in \`actual_frame_timeline_slice if present. |
+| dur | INT | Duration of the frame, as defined by the duration of the corresponding `actual_frame_timeline_slice` or, if not present the time between the `ts` and the end of the final `DrawFrame`. |
+| do_frame_id | INT | `slice.id` of "Choreographer#doFrame" slice. |
+| draw_frame_id | INT | `slice.id` of "DrawFrame" slice. |
+| actual_frame_timeline_id | INT | `slice.id` from `actual_frame_timeline_slice` |
+| expected_frame_timeline_id | INT | `slice.id` from `expected_frame_timeline_slice` |
+| render_thread_utid | INT | `utid` of the render thread. |
+| ui_thread_utid | INT | `utid` of the UI thread. |
+| actual_frame_timeline_count | INT | Count of slices in `actual_frame_timeline_slice` related to this frame. |
+| expected_frame_timeline_count | INT | Count of slices in `expected_frame_timeline_slice` related to this frame. |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**android_first_frame_after** . Returns first frame after the provided timestamp
+
+<br />
+
+<br />
+
+<br />
+
+Returns first frame after the provided timestamp. The returning table has at
+most one row.
+Argument \| Type \| Description
+--- \| --- \| ---
+ts \| INT \| Timestamp.
+
+| Column | Type | Description |
+|---|---|---|
+| frame_id | INT | Frame id. |
+| ts | INT | Start of the frame, the timestamp of the "Choreographer#doFrame" slice. |
+| dur | INT | Duration of the frame. |
+| do_frame_id | INT | `slice.id` of "Choreographer#doFrame" slice. |
+| draw_frame_id | INT | `slice.id` of "DrawFrame" slice. |
+| actual_frame_timeline_id | INT | `slice.id` from `actual_frame_timeline_slice` |
+| expected_frame_timeline_id | INT | `slice.id` from `expected_frame_timeline_slice` |
+| render_thread_utid | INT | `utid` of the render thread. |
+| ui_thread_utid | INT | `utid` of the UI thread. |
+
+<br />
+
+<br />
+
+### android.freezer
+
+#### Views/Tables
+
+<br />
+
+**android_freezer_events**. All frozen processes and their frozen duration.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| upid | INT | Upid of frozen process |
+| pid | INT | Pid of frozen process |
+| ts | INT | Timestamp process was frozen. |
+| dur | INT | Duration process was frozen for. |
+| unfreeze_reason_int | INT | Unfreeze reason Integer. |
+| unfreeze_reason_str | STRING | Unfreeze reason String. |
+
+<br />
+
+<br />
+
+### android.garbage_collection
+
+#### Views/Tables
+
+<br />
+
+**android_garbage_collection_events**. All Garbage collection events with a breakdown of the time spent and heap reclaimed.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| tid | INT | Tid of thread running garbage collection. |
+| pid | INT | Pid of process running garbage collection. |
+| utid | INT | Utid of thread running garbage collection. |
+| upid | INT | Upid of process running garbage collection. |
+| thread_name | STRING | Name of thread running garbage collection. |
+| process_name | STRING | Name of process running garbage collection. |
+| gc_type | STRING | Type of garbage collection. |
+| is_mark_compact | INT | Whether gargage collection is mark compact or copying. |
+| reclaimed_mb | DOUBLE | MB reclaimed after garbage collection. |
+| min_heap_mb | DOUBLE | Minimum heap size in MB during garbage collection. |
+| max_heap_mb | DOUBLE | Maximum heap size in MB during garbage collection. |
+| gc_id | INT | Garbage collection id. |
+| gc_ts | INT | Garbage collection timestamp. |
+| gc_dur | INT | Garbage collection wall duration. |
+| gc_running_dur | INT | Garbage collection duration spent executing on CPU. |
+| gc_runnable_dur | INT | Garbage collection duration spent waiting for CPU. |
+| gc_unint_io_dur | INT | Garbage collection duration spent waiting in the Linux kernel on IO. |
+| gc_unint_non_io_dur | INT | Garbage collection duration spent waiting in the Linux kernel without IO. |
+| gc_int_dur | INT | Garbage collection duration spent waiting in interruptible sleep. |
+
+<br />
+
+<br />
+
+### android.gpu.frequency
+
+#### Views/Tables
+
+<br />
+
+**android_gpu_frequency**. GPU frequency counter per GPU.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp |
+| dur | INT | Duration |
+| gpu_id | INT | GPU id. Joinable with `gpu_counter_track.gpu_id`. |
+| gpu_freq | INT | GPU frequency |
+
+<br />
+
+<br />
+
+### android.gpu.memory
+
+#### Views/Tables
+
+<br />
+
+**android_gpu_memory_per_process**. Counter for GPU memory per process with duration.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp |
+| dur | INT | Duration |
+| upid | INT | Upid of the process |
+| gpu_memory | INT | GPU memory |
+
+<br />
+
+<br />
+
+### android.input
+
+#### Views/Tables
+
+<br />
+
+**android_input_events**. All input events with round trip latency breakdown
+
+<br />
+
+TABLE
+All input events with round trip latency breakdown. Input delivery is socket based and every
+input event sent from the OS needs to be ACK'ed by the app. This gives us 4 subevents to measure
+latencies between:
+1. Input dispatch event sent from OS.
+2. Input dispatch event received in app.
+3. Input ACK event sent from app.
+4. Input ACk event received in OS.
+
+| Column | Type | Description |
+|---|---|---|
+| dispatch_latency_dur | INT | Duration from input dispatch to input received. |
+| handling_latency_dur | INT | Duration from input received to input ACK sent. |
+| ack_latency_dur | INT | Duration from input ACK sent to input ACK recieved. |
+| total_latency_dur | INT | Duration from input dispatch to input event ACK received. |
+| end_to_end_latency_dur | INT | Duration from input read to frame present time. Null if an input event has no associated frame event. |
+| tid | INT | Tid of thread receiving the input event. |
+| thread_name | STRING | Name of thread receiving the input event. |
+| pid | INT | Pid of process receiving the input event. |
+| process_name | STRING | Name of process receiving the input event. |
+| event_type | STRING | Input event type. See InputTransport.h: InputMessage#Type |
+| event_action | STRING | Input event action. |
+| event_seq | STRING | Input event sequence number, monotonically increasing for an event channel and pid. |
+| event_channel | STRING | Input event channel name. |
+| input_event_id | STRING | Unique identifier for the input event. |
+| read_time | INT | Timestamp input event was read by InputReader. |
+| dispatch_track_id | INT | Thread track id of input event dispatching thread. |
+| dispatch_ts | INT | Timestamp input event was dispatched. |
+| dispatch_dur | INT | Duration of input event dispatch. |
+| receive_track_id | INT | Thread track id of input event receiving thread. |
+| receive_ts | INT | Timestamp input event was received. |
+| receive_dur | INT | Duration of input event receipt. |
+| frame_id | INT | Vsync Id associated with the input. Null if an input event has no associated frame event. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_key_events**. Key events processed by the Android framework (from android.input.inputevent data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | ID of the trace entry |
+| event_id | INT | The randomly-generated ID associated with each input event processed by Android Framework, used to track the event through the input pipeline |
+| ts | INT | The timestamp of when the input event was processed by the system |
+| arg_set_id | INT | Details of the input event parsed from the proto message |
+
+<br />
+
+<br />
+
+<br />
+
+**android_motion_events**. Motion events processed by the Android framework (from android.input.inputevent data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | ID of the trace entry |
+| event_id | INT | The randomly-generated ID associated with each input event processed by Android Framework, used to track the event through the input pipeline |
+| ts | INT | The timestamp of when the input event was processed by the system |
+| arg_set_id | INT | Details of the input event parsed from the proto message |
+
+<br />
+
+<br />
+
+<br />
+
+**android_input_event_dispatch**. Input event dispatching information in Android (from android.input.inputevent data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | ID of the trace entry |
+| event_id | INT | Event ID of the input event that was dispatched |
+| arg_set_id | INT | Extra args parsed from the proto message |
+| vsync_id | INT | Vsync ID that identifies the state of the windows during which the dispatch decision was made |
+| window_id | INT | Window ID of the window receiving the event |
+
+<br />
+
+<br />
+
+### android.job_scheduler
+
+#### Views/Tables
+
+<br />
+
+**android_job_scheduler_events**. All scheduled jobs and their latencies.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| job_id | INT | Id of the scheduled job assigned by the app developer. |
+| uid | INT | Uid of the process running the scheduled job. |
+| package_name | STRING | Package name of the process running the scheduled job. |
+| job_service_name | STRING | Service component name of the scheduled job. |
+| track_id | INT | Thread track id of the job scheduler event slice. |
+| id | INT | Slice id of the job scheduler event slice. |
+| ts | INT | Timestamp the job was scheduled. |
+| dur | INT | Duration of the scheduled job. |
+
+<br />
+
+<br />
+
+### android.memory.dmabuf
+
+#### Views/Tables
+
+<br />
+
+**android_dmabuf_allocs**. Track dmabuf allocations, re-attributing gralloc allocations to their source (if binder transactions to gralloc are recorded).
+
+<br />
+
+TABLE
+Track dmabuf allocations, re-attributing gralloc allocations to their source
+(if binder transactions to gralloc are recorded).
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | timestamp of the allocation |
+| buf_size | INT | allocation size (will be negative for release) |
+| inode | INT | dmabuf inode |
+| utid | INT | utid of thread responsible for the allocation if a dmabuf is allocated by gralloc we follow the binder transaction to the requesting thread (requires binder tracing) |
+| tid | INT | tid of thread responsible for the allocation |
+| thread_name | STRING | thread name |
+| upid | INT | upid of process responsible for the allocation (matches utid) |
+| pid | INT | pid of process responsible for the allocation |
+| process_name | STRING | process name |
+
+<br />
+
+<br />
+
+### android.memory.heap_graph.dominator_tree
+
+#### Views/Tables
+
+<br />
+
+**heap_graph_dominator_tree**. All reachable heap graph objects, their immediate dominators and summary of their dominated sets. The heap graph dominator tree is calculated by stdlib graphs.dominator_tree. Each reachable object is a node in the dominator tree, their immediate dominator is their parent node in the tree, and their dominated set is all their descendants in the tree
+
+<br />
+
+TABLE
+All reachable heap graph objects, their immediate dominators and summary of
+their dominated sets.
+The heap graph dominator tree is calculated by stdlib graphs.dominator_tree.
+Each reachable object is a node in the dominator tree, their immediate
+dominator is their parent node in the tree, and their dominated set is all
+their descendants in the tree. All size information come from the
+heap_graph_object prelude table.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Heap graph object id. |
+| idom_id | INT | Immediate dominator object id of the object. If the immediate dominator is the "super-root" (i.e. the object is a root or is dominated by multiple roots) then `idom_id` will be NULL. |
+| dominated_obj_count | INT | Count of all objects dominated by this object, self inclusive. |
+| dominated_size_bytes | INT | Total self_size of all objects dominated by this object, self inclusive. |
+| dominated_native_size_bytes | INT | Total native_size of all objects dominated by this object, self inclusive. |
+| depth | INT | Depth of the object in the dominator tree. Depth of root objects are 1. |
+
+<br />
+
+<br />
+
+### android.memory.heap_graph.heap_graph_class_aggregation
+
+#### Views/Tables
+
+<br />
+
+**android_heap_graph_class_aggregation**. Class-level breakdown of the java heap. Per type name aggregates the object stats and the dominator tree stats.
+
+<br />
+
+TABLE
+Class-level breakdown of the java heap.
+Per type name aggregates the object stats and the dominator tree stats.
+
+| Column | Type | Description |
+|---|---|---|
+| upid | INT | Process upid |
+| graph_sample_ts | INT | Heap dump timestamp |
+| type_id | INT | Class type id |
+| type_name | STRING | Class name (deobfuscated if available) |
+| is_libcore_or_array | BOOL | Is type an instance of a libcore object (java.\*) or array |
+| obj_count | INT | Count of class instances |
+| size_bytes | INT | Size of class instances |
+| native_size_bytes | INT | Native size of class instances |
+| reachable_obj_count | INT | Count of reachable class instances |
+| reachable_size_bytes | INT | Size of reachable class instances |
+| reachable_native_size_bytes | INT | Native size of reachable class instances |
+| dominated_obj_count | INT | Count of all objects dominated by instances of this class Only applies to reachable objects |
+| dominated_size_bytes | INT | Size of all objects dominated by instances of this class Only applies to reachable objects |
+| dominated_native_size_bytes | INT | Native size of all objects dominated by instances of this class Only applies to reachable objects |
+
+<br />
+
+<br />
+
+### android.memory.process
+
+#### Views/Tables
+
+<br />
+
+**memory_oom_score_with_rss_and_swap_per_process**. Process memory and it's OOM adjuster scores
+
+<br />
+
+TABLE
+Process memory and it's OOM adjuster scores. Detects transitions, each new
+interval means that either the memory or OOM adjuster score of the process changed.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp the oom_adj score or memory of the process changed |
+| dur | INT | Duration until the next oom_adj score or memory change of the process. |
+| score | INT | oom adjuster score of the process. |
+| bucket | STRING | oom adjuster bucket of the process. |
+| upid | INT | Upid of the process having an oom_adj update. |
+| process_name | STRING | Name of the process having an oom_adj update. |
+| pid | INT | Pid of the process having an oom_adj update. |
+| oom_adj_id | INT | Slice of the latest oom_adj update in the system_server. Alias of `slice.id`. |
+| oom_adj_ts | INT | Timestamp of the latest oom_adj update in the system_server. |
+| oom_adj_dur | INT | Duration of the latest oom_adj update in the system_server. |
+| oom_adj_track_id | INT | Track of the latest oom_adj update in the system_server. Alias of `track.id`. |
+| oom_adj_thread_name | STRING | Thread name of the latest oom_adj update in the system_server. |
+| oom_adj_reason | STRING | Reason for the latest oom_adj update in the system_server. |
+| oom_adj_trigger | STRING | Trigger for the latest oom_adj update in the system_server. |
+| anon_rss | INT | Anon RSS counter value |
+| file_rss | INT | File RSS counter value |
+| shmem_rss | INT | Shared memory RSS counter value |
+| rss | INT | Total RSS value. Sum of `anon_rss`, `file_rss` and `shmem_rss`. Returns value even if one of the values is NULL. |
+| swap | INT | Swap counter value |
+| anon_rss_and_swap | INT | Sum or `anon_rss` and `swap`. Returns value even if one of the values is NULL. |
+| rss_and_swap | INT | Sum or `rss` and `swap`. Returns value even if one of the values is NULL. |
+
+<br />
+
+<br />
+
+### android.monitor_contention
+
+#### Views/Tables
+
+<br />
+
+**android_monitor_contention**. Contains parsed monitor contention slices.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| blocking_method | STRING | Name of the method holding the lock. |
+| blocked_method | STRING | Blocked_method without arguments and return types. |
+| short_blocking_method | STRING | Blocking_method without arguments and return types. |
+| short_blocked_method | STRING | Blocked_method without arguments and return types. |
+| blocking_src | STRING | File location of blocking_method in form <filename:linenumber>. |
+| blocked_src | STRING | File location of blocked_method in form <filename:linenumber>. |
+| waiter_count | INT | Zero indexed number of threads trying to acquire the lock. |
+| blocked_utid | INT | Utid of thread holding the lock. |
+| blocked_thread_name | STRING | Thread name of thread holding the lock. |
+| blocking_utid | INT | Utid of thread holding the lock. |
+| blocking_thread_name | STRING | Thread name of thread holding the lock. |
+| blocking_tid | INT | Tid of thread holding the lock. |
+| upid | INT | Upid of process experiencing lock contention. |
+| process_name | STRING | Process name of process experiencing lock contention. |
+| id | INT | Slice id of lock contention. |
+| ts | INT | Timestamp of lock contention start. |
+| dur | INT | Wall clock duration of lock contention. |
+| monotonic_dur | INT | Monotonic clock duration of lock contention. |
+| track_id | INT | Thread track id of blocked thread. |
+| is_blocked_thread_main | INT | Whether the blocked thread is the main thread. |
+| blocked_thread_tid | INT | Tid of the blocked thread |
+| is_blocking_thread_main | INT | Whether the blocking thread is the main thread. |
+| blocking_thread_tid | INT | Tid of thread holding the lock. |
+| binder_reply_id | INT | Slice id of binder reply slice if lock contention was part of a binder txn. |
+| binder_reply_ts | INT | Timestamp of binder reply slice if lock contention was part of a binder txn. |
+| binder_reply_tid | INT | Tid of binder reply slice if lock contention was part of a binder txn. |
+| pid | INT | Pid of process experiencing lock contention. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_monitor_contention_chain**. Contains parsed monitor contention slices with the parent-child relationships.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| parent_id | INT | Id of monitor contention slice blocking this contention. |
+| blocking_method | STRING | Name of the method holding the lock. |
+| blocked_method | STRING | Blocked_method without arguments and return types. |
+| short_blocking_method | STRING | Blocking_method without arguments and return types. |
+| short_blocked_method | STRING | Blocked_method without arguments and return types. |
+| blocking_src | STRING | File location of blocking_method in form <filename:linenumber>. |
+| blocked_src | STRING | File location of blocked_method in form <filename:linenumber>. |
+| waiter_count | INT | Zero indexed number of threads trying to acquire the lock. |
+| blocked_utid | INT | Utid of thread holding the lock. |
+| blocked_thread_name | STRING | Thread name of thread holding the lock. |
+| blocking_utid | INT | Utid of thread holding the lock. |
+| blocking_thread_name | STRING | Thread name of thread holding the lock. |
+| blocking_tid | INT | Tid of thread holding the lock. |
+| upid | INT | Upid of process experiencing lock contention. |
+| process_name | STRING | Process name of process experiencing lock contention. |
+| id | INT | Slice id of lock contention. |
+| ts | INT | Timestamp of lock contention start. |
+| dur | INT | Wall clock duration of lock contention. |
+| monotonic_dur | INT | Monotonic clock duration of lock contention. |
+| track_id | INT | Thread track id of blocked thread. |
+| is_blocked_thread_main | INT | Whether the blocked thread is the main thread. |
+| blocked_thread_tid | INT | Tid of the blocked thread |
+| is_blocking_thread_main | INT | Whether the blocking thread is the main thread. |
+| blocking_thread_tid | INT | Tid of thread holding the lock. |
+| binder_reply_id | INT | Slice id of binder reply slice if lock contention was part of a binder txn. |
+| binder_reply_ts | INT | Timestamp of binder reply slice if lock contention was part of a binder txn. |
+| binder_reply_tid | INT | Tid of binder reply slice if lock contention was part of a binder txn. |
+| pid | INT | Pid of process experiencing lock contention. |
+| child_id | INT | Id of monitor contention slice blocked by this contention. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_monitor_contention_chain_thread_state**. Note that we only span join the duration where the lock was actually held and contended. This can be less than the duration the lock was 'waited on' when a different waiter acquired the lock earlier than the first waiter.
+
+<br />
+
+TABLE
+Note that we only span join the duration where the lock was actually held and contended.
+This can be less than the duration the lock was 'waited on' when a different waiter acquired the
+lock earlier than the first waiter.
+
+| Column | Type | Description |
+|---|---|---|
+| parent_id | None | Id of slice blocking the blocking_thread. |
+| blocking_method | None | Name of the method holding the lock. |
+| blocked_methhod | None | Name of the method trying to acquire the lock. |
+| short_blocking_method | None | Blocking_method without arguments and return types. |
+| short_blocked_method | None | Blocked_method without arguments and return types. |
+| blocking_src | None | File location of blocking_method in form <filename:linenumber>. |
+| blocked_src | None | File location of blocked_method in form <filename:linenumber>. |
+| waiter_count | None | Zero indexed number of threads trying to acquire the lock. |
+| blocking_utid | None | Utid of the blocking \|thread_state\|. |
+| blocking_thread_name | None | Thread name of thread holding the lock. |
+| upid | None | Upid of process experiencing lock contention. |
+| process_name | None | Process name of process experiencing lock contention. |
+| id | None | Slice id of lock contention. |
+| ts | None | Timestamp of the blocking \|thread_state\|. |
+| dur | None | Wall clock duration of lock contention. |
+| monotonic_dur | None | Monotonic clock duration of lock contention. |
+| track_id | None | Thread track id of blocked thread. |
+| is_blocked_main_thread | None | Whether the blocked thread is the main thread. |
+| is_blocking_main_thread | None | Whether the blocking thread is the main thread. |
+| binder_reply_id | None | Slice id of binder reply slice if lock contention was part of a binder txn. |
+| binder_reply_ts | None | Timestamp of binder reply slice if lock contention was part of a binder txn. |
+| binder_reply_tid | None | Tid of binder reply slice if lock contention was part of a binder txn. |
+| state | None | Thread state of the blocking thread. |
+| blocked_function | None | Blocked kernel function of the blocking thread. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_monitor_contention_chain_thread_state_by_txn**. Aggregated thread_states on the 'blocking thread', the thread holding the lock. This builds on the data from \|android_monitor_contention_chain\| and for each contention slice, it returns the aggregated sum of all the thread states on the blocking thread. Note that this data is only available for the first waiter on a lock.
+
+<br />
+
+VIEW
+Aggregated thread_states on the 'blocking thread', the thread holding the lock.
+This builds on the data from \|android_monitor_contention_chain\| and
+for each contention slice, it returns the aggregated sum of all the thread states on the
+blocking thread.
+
+Note that this data is only available for the first waiter on a lock.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Slice id of the monitor contention. |
+| thread_state | STRING | A \|thread_state\| that occurred in the blocking thread during the contention. |
+| thread_state_dur | INT | Total time the blocking thread spent in the \|thread_state\| during contention. |
+| thread_state_count | INT | Count of all times the blocking thread entered \|thread_state\| during the contention. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_monitor_contention_chain_blocked_functions_by_txn**. Aggregated blocked_functions on the 'blocking thread', the thread holding the lock. This builds on the data from \|android_monitor_contention_chain\| and for each contention, it returns the aggregated sum of all the kernel blocked function durations on the blocking thread. Note that this data is only available for the first waiter on a lock.
+
+<br />
+
+VIEW
+Aggregated blocked_functions on the 'blocking thread', the thread holding the lock.
+This builds on the data from \|android_monitor_contention_chain\| and
+for each contention, it returns the aggregated sum of all the kernel
+blocked function durations on the blocking thread.
+
+Note that this data is only available for the first waiter on a lock.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Slice id of the monitor contention. |
+| blocked_function | STRING | Blocked kernel function in a thread state in the blocking thread during the contention. |
+| blocked_function_dur | INT | Total time the blocking thread spent in the \|blocked_function\| during the contention. |
+| blocked_function_count | INT | Count of all times the blocking thread executed the \|blocked_function\| during the contention. |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**android_extract_android_monitor_contention_blocking_thread** -\> STRING. Extracts the blocking thread from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Returns STRING: Blocking thread
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_blocking_tid** -\> INT. Extracts the blocking thread tid from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Returns INT: Blocking thread tid
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_blocking_method** -\> STRING. Extracts the blocking method from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Returns STRING: Blocking thread
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_short_blocking_method** -\> STRING. Extracts a shortened form of the blocking method name from a slice name. The shortened form discards the parameter and return types.
+
+<br />
+
+<br />
+
+<br />
+
+Extracts a shortened form of the blocking method name from a slice name.
+The shortened form discards the parameter and return
+types.
+Returns STRING: Blocking thread
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_blocked_method** -\> STRING. Extracts the monitor contention blocked method from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Returns STRING: Blocking thread
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_short_blocked_method** -\> STRING. Extracts a shortened form of the monitor contention blocked method name from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Extracts a shortened form of the monitor contention blocked method name
+from a slice name. The shortened form discards the parameter and return
+types.
+Returns STRING: Blocking thread
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_waiter_count** -\> INT. Extracts the number of waiters on the monitor from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Returns INT: Count of waiters on the lock
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_blocking_src** -\> STRING. Extracts the monitor contention blocking source location from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Returns STRING: Blocking thread
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_blocked_src** -\> STRING. Extracts the monitor contention blocked source location from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Returns STRING: Blocking thread
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**android_monitor_contention_graph** . Returns a DAG of all Java lock contentions in a process. Each node in the graph is a pair. Each edge connects from a node waiting on a lock to a node holding a lock. The weights of each node represent the cumulative wall time the node blocked other nodes connected to it.
+
+<br />
+
+<br />
+
+<br />
+
+Returns a DAG of all Java lock contentions in a process.
+Each node in the graph is a pair. Each edge connects from a node waiting on a lock to a node holding a lock. The weights of each node represent the cumulative wall time the node blocked other nodes connected to it. Argument \| Type \| Description --- \| --- \| --- upid \| INT \| Upid of process to generate a lock graph for.
+
+| Column | Type | Description |
+|---|---|---|
+| pprof | BYTES | Pprof of lock graph. |
+
+<br />
+
+<br />
+
+### android.network_packets
+
+#### Views/Tables
+
+<br />
+
+**android_network_packets**. Android network packet events (from android.network_packets data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp in nanoseconds. |
+| dur | INT | Duration (non-zero only in aggregate events) |
+| track_name | STRING | The track name (interface and direction) |
+| package_name | STRING | Traffic package source (or uid=$X if not found) |
+| iface | STRING | Traffic interface name (linux interface name) |
+| direction | STRING | Traffic direction ('Transmitted' or 'Received') |
+| packet_count | INT | Number of packets in this event |
+| packet_length | INT | Number of bytes in this event (wire size) |
+| packet_transport | STRING | Transport used for traffic in this event |
+| packet_tcp_flags | INT | TCP flags used by tcp frames in this event |
+| socket_tag | STRING | The Android traffic tag of the network socket |
+| socket_uid | INT | The Linux user id of the network socket |
+| local_port | INT | The local port number (for udp or tcp only) |
+| remote_port | INT | The remote port number (for udp or tcp only) |
+| packet_icmp_type | INT | 1-byte ICMP type identifier. |
+| packet_icmp_code | INT | 1-byte ICMP code identifier. |
+| packet_tcp_flags_int | INT | Packet's tcp flags bitmask (e.g. FIN=0x1, SYN=0x2). |
+| socket_tag_int | INT | Packet's socket tag as an integer. |
+
+<br />
+
+<br />
+
+### android.oom_adjuster
+
+#### Views/Tables
+
+<br />
+
+**android_oom_adj_intervals**. All oom adj state intervals across all processes along with the reason for the state update.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp the oom_adj score of the process changed |
+| dur | INT | Duration until the next oom_adj score change of the process. |
+| score | INT | oom_adj score of the process. |
+| bucket | STRING | oom_adj bucket of the process. |
+| upid | INT | Upid of the process having an oom_adj update. |
+| process_name | STRING | Name of the process having an oom_adj update. |
+| oom_adj_id | INT | Slice id of the latest oom_adj update in the system_server. |
+| oom_adj_ts | INT | Timestamp of the latest oom_adj update in the system_server. |
+| oom_adj_dur | INT | Duration of the latest oom_adj update in the system_server. |
+| oom_adj_track_id | INT | Track id of the latest oom_adj update in the system_server |
+| oom_adj_thread_name | STRING | Thread name of the latest oom_adj update in the system_server. |
+| oom_adj_reason | STRING | Reason for the latest oom_adj update in the system_server. |
+| oom_adj_trigger | STRING | Trigger for the latest oom_adj update in the system_server. |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**android_oom_adj_score_to_bucket_name** -\> STRING. Converts an oom_adj score Integer to String sample name. One of: cached, background, job, foreground_service, bfgs, foreground and system.
+
+<br />
+
+<br />
+
+<br />
+
+Converts an oom_adj score Integer to String sample name.
+One of: cached, background, job, foreground_service, bfgs, foreground and
+system.
+Returns STRING: Returns the sample bucket based on the oom score.
+
+| Argument | Type | Description |
+|---|---|---|
+| oom_score | INT | `oom_score` value |
+
+<br />
+
+<br />
+
+<br />
+
+**android_oom_adj_score_to_detailed_bucket_name** -\> STRING. Converts an oom_adj score Integer to String bucket name. Deprecated: use `android_oom_adj_score_to_bucket_name` instead.
+
+<br />
+
+<br />
+
+<br />
+
+Converts an oom_adj score Integer to String bucket name.
+Deprecated: use `android_oom_adj_score_to_bucket_name` instead.
+Returns STRING: Returns the oom_adj bucket.
+
+| Argument | Type | Description |
+|---|---|---|
+| value | INT | oom_adj score. |
+| android_appid | INT | android_app id of the process. |
+
+<br />
+
+<br />
+
+### android.power_rails
+
+#### Views/Tables
+
+<br />
+
+**android_power_rails_counters**. Android power rails counters data. For details see: https://perfetto.dev/docs/data-sources/battery-counters#odpm NOTE: Requires dedicated hardware - table is only populated on Pixels.
+
+<br />
+
+TABLE
+Android power rails counters data.
+For details see: https://perfetto.dev/docs/data-sources/battery-counters#odpm
+NOTE: Requires dedicated hardware - table is only populated on Pixels.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | `counter.id` |
+| ts | INT | Timestamp of the energy measurement. |
+| dur | INT | Time until the next energy measurement. |
+| power_rail_name | STRING | Power rail name. Alias of `counter_track.name`. |
+| raw_power_rail_name | STRING | Raw power rail name. |
+| energy_since_boot | DOUBLE | Energy accumulated by this rail since boot in microwatt-seconds (uWs) (AKA micro-joules). Alias of `counter.value`. |
+| energy_since_boot_at_end | DOUBLE | Energy accumulated by this rail at next energy measurement in microwatt-seconds (uWs) (AKA micro-joules). Alias of `counter.value` of the next meaningful (with value change) counter value. |
+| average_power | DOUBLE | Average power in mW (milliwatts) over between ts and the next energy measurement. |
+| energy_delta | DOUBLE | The change of energy accumulated by this rails since the last measurement in microwatt-seconds (uWs) (AKA micro-joules). |
+| track_id | INT | Power rail track id. Alias of `counter_track.id`. |
+| value | DOUBLE | DEPRECATED. Use `energy_since_boot` instead. |
+
+<br />
+
+<br />
+
+### android.process_metadata
+
+#### Views/Tables
+
+<br />
+
+**android_process_metadata**. Data about packages running on the process.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| upid | INT | Process upid. |
+| pid | INT | Process pid. |
+| process_name | STRING | Process name. |
+| uid | INT | Android app UID. |
+| shared_uid | BOOL | Whether the UID is shared by multiple packages. |
+| package_name | STRING | Name of the packages running in this process. |
+| version_code | INT | Package version code. |
+| debuggable | INT | Whether package is debuggable. |
+
+<br />
+
+<br />
+
+### android.screenshots
+
+#### Views/Tables
+
+<br />
+
+**android_screenshots**. Screenshot slices, used in perfetto UI.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Slice id. |
+| ts | INT | Slice timestamp. |
+| dur | INT | Slice duration, should be typically 0 since screeenshot slices are of instant type. |
+| name | STRING | Slice name. |
+
+<br />
+
+<br />
+
+### android.services
+
+#### Views/Tables
+
+<br />
+
+**android_service_bindings**. All service bindings from client app to server app.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| client_oom_score | INT | OOM score of client process making the binding. |
+| client_process | STRING | Name of client process making the binding. |
+| client_thread | STRING | Name of client thread making the binding. |
+| client_pid | INT | Pid of client process making the binding. |
+| client_tid | INT | Tid of client process making the binding. |
+| client_upid | INT | Upid of client process making the binding. |
+| client_utid | INT | Utid of client thread making the binding. |
+| client_ts | INT | Timestamp the client process made the request. |
+| client_dur | INT | Duration of the client binding request. |
+| server_oom_score | INT | OOM score of server process getting bound to. |
+| server_process | STRING | Name of server process getting bound to |
+| server_thread | STRING | Name of server thread getting bound to. |
+| server_pid | INT | Pid of server process getting bound to. |
+| server_tid | INT | Tid of server process getting bound to. |
+| server_upid | INT | Upid of server process getting bound to. |
+| server_utid | INT | Utid of server process getting bound to. |
+| server_ts | INT | Timestamp the server process got bound to. |
+| server_dur | INT | Duration of the server process handling the binding. |
+| token | STRING | Unique binder identifier for the Service binding. |
+| act | STRING | Intent action name for the service binding. |
+| cmp | STRING | Intent component name for the service binding. |
+| flg | STRING | Intent flag for the service binding. |
+| bind_seq | INT | Monotonically increasing id for the service binding. |
+
+<br />
+
+<br />
+
+### android.slices
+
+#### Functions
+
+<br />
+
+**android_standardize_slice_name** -\> STRING. Some slice names have params in them
+
+<br />
+
+<br />
+
+<br />
+
+Some slice names have params in them. This functions removes them to make it
+possible to aggregate by name.
+Some examples are:
+- Lock/monitor contention slices. The name includes where the lock
+contention is in the code. That part is removed.
+- DrawFrames/ooFrame. The name also includes the frame number.
+- Apk/oat/dex loading: The name of the apk is removed
+Returns STRING: Simplified name.
+
+| Argument | Type | Description |
+|---|---|---|
+| name | STRING | The raw slice name. |
+
+<br />
+
+<br />
+
+### android.startup.startups
+
+#### Views/Tables
+
+<br />
+
+**android_startups**. All activity startups in the trace by startup id. Populated by different scripts depending on the platform version/contents.
+
+<br />
+
+TABLE
+All activity startups in the trace by startup id.
+Populated by different scripts depending on the platform version/contents.
+
+| Column | Type | Description |
+|---|---|---|
+| startup_id | INT | Startup id. |
+| ts | INT | Timestamp of startup start. |
+| ts_end | INT | Timestamp of startup end. |
+| dur | INT | Startup duration. |
+| package | STRING | Package name. |
+| startup_type | STRING | Startup type. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_startup_processes**. Maps a startup to the set of processes that handled the activity start. The vast majority of cases should be a single process
+
+<br />
+
+TABLE
+Maps a startup to the set of processes that handled the activity start.
+
+The vast majority of cases should be a single process. However it is
+possible that the process dies during the activity startup and is respawned.
+
+| Column | Type | Description |
+|---|---|---|
+| startup_id | INT | Startup id. |
+| upid | INT | Upid of process on which activity started. |
+| startup_type | STRING | Type of the startup. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_startup_threads**. Maps a startup to the set of threads on processes that handled the activity start.
+
+<br />
+
+VIEW
+Maps a startup to the set of threads on processes that handled the
+activity start.
+
+| Column | Type | Description |
+|---|---|---|
+| startup_id | INT | Startup id. |
+| ts | INT | Timestamp of start. |
+| dur | INT | Duration of startup. |
+| upid | INT | Upid of process involved in startup. |
+| utid | INT | Utid of the thread. |
+| thread_name | STRING | Name of the thread. |
+| is_main_thread | BOOL | Thread is a main thread. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_thread_slices_for_all_startups**. All the slices for all startups in trace. Generally, this view should not be used
+
+<br />
+
+VIEW
+All the slices for all startups in trace.
+
+Generally, this view should not be used. Instead, use one of the view functions related
+to the startup slices which are created from this table.
+
+| Column | Type | Description |
+|---|---|---|
+| startup_ts | INT | Timestamp of startup. |
+| startup_ts_end | INT | Timestamp of startup end. |
+| startup_id | INT | Startup id. |
+| utid | INT | UTID of thread with slice. |
+| thread_name | STRING | Name of thread. |
+| is_main_thread | BOOL | Whether it is main thread. |
+| arg_set_id | INT | Arg set id. |
+| slice_id | INT | Slice id. |
+| slice_name | STRING | Name of slice. |
+| slice_ts | INT | Timestamp of slice start. |
+| slice_dur | INT | Slice duration. |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**android_sum_dur_for_startup_and_slice** -\> INT. Returns duration of startup for slice name. Sums duration of all slices of startup with provided name.
+
+<br />
+
+<br />
+
+<br />
+
+Returns duration of startup for slice name.
+
+Sums duration of all slices of startup with provided name.
+Returns INT: Sum of duration.
+
+| Argument | Type | Description |
+|---|---|---|
+| startup_id | LONG | Startup id. |
+| slice_name | STRING | Slice name. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_sum_dur_on_main_thread_for_startup_and_slice** -\> INT. Returns duration of startup for slice name on main thread. Sums duration of all slices of startup with provided name only on main thread.
+
+<br />
+
+<br />
+
+<br />
+
+Returns duration of startup for slice name on main thread.
+
+Sums duration of all slices of startup with provided name only on main thread.
+Returns INT: Sum of duration.
+
+| Argument | Type | Description |
+|---|---|---|
+| startup_id | LONG | Startup id. |
+| slice_name | STRING | Slice name. |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**android_slices_for_startup_and_slice_name** . Given a startup id and GLOB for a slice name, returns matching slices with data.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| startup_id | INT | Startup id. |
+| slice_name | STRING | Glob of the slice. |
+
+| Column | Type | Description |
+|---|---|---|
+| slice_id | INT | Id of the slice. |
+| slice_name | STRING | Name of the slice. |
+| slice_ts | INT | Timestamp of start of the slice. |
+| slice_dur | INT | Duration of the slice. |
+| thread_name | STRING | Name of the thread with the slice. |
+| arg_set_id | INT | Arg set id. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_binder_transaction_slices_for_startup** . Returns binder transaction slices for a given startup id with duration over threshold.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| startup_id | INT | Startup id. |
+| threshold | DOUBLE | Only return slices with duration over threshold. |
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Slice id. |
+| slice_dur | INT | Slice duration. |
+| thread_name | STRING | Name of the thread with slice. |
+| process | STRING | Name of the process with slice. |
+| arg_set_id | INT | Arg set id. |
+| is_main_thread | BOOL | Whether is main thread. |
+
+<br />
+
+<br />
+
+### android.startup.time_to_display
+
+#### Views/Tables
+
+<br />
+
+**android_startup_time_to_display**. Startup metric defintions, which focus on the observable time range: TTID - Time To Initial Display \* https://developer.android.com/topic/performance/vitals/launch-time#time-initial \* end of first RenderThread.DrawFrame - bindApplication TTFD - Time To Full Display \* https://developer.android.com/topic/performance/vitals/launch-time#retrieve-TTFD \* end of next RT.DrawFrame, after reportFullyDrawn called - bindApplication Googlers: see go/android-performance-metrics-glossary for details.
+
+<br />
+
+TABLE
+Startup metric defintions, which focus on the observable time range:
+TTID - Time To Initial Display
+\* https://developer.android.com/topic/performance/vitals/launch-time#time-initial
+\* end of first RenderThread.DrawFrame - bindApplication
+TTFD - Time To Full Display
+\* https://developer.android.com/topic/performance/vitals/launch-time#retrieve-TTFD
+\* end of next RT.DrawFrame, after reportFullyDrawn called - bindApplication
+Googlers: see go/android-performance-metrics-glossary for details.
+
+| Column | Type | Description |
+|---|---|---|
+| startup_id | INT | Startup id. |
+| time_to_initial_display | INT | Time to initial display (TTID) |
+| time_to_full_display | INT | Time to full display (TTFD) |
+| ttid_frame_id | INT | `android_frames.frame_id` of frame for initial display |
+| ttfd_frame_id | INT | `android_frames.frame_id` of frame for full display |
+| upid | INT | `process.upid` of the startup |
+
+<br />
+
+<br />
+
+### android.statsd
+
+#### Views/Tables
+
+<br />
+
+**android_statsd_atoms**. Statsd atoms. A subset of the slice table containing statsd atom instant events.
+
+<br />
+
+VIEW
+Statsd atoms.
+
+A subset of the slice table containing statsd atom instant events.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Unique identifier for this slice. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| ts | INT | The timestamp at the start of the slice (in nanoseconds). |
+| dur | INT | The duration of the slice (in nanoseconds). |
+| arg_set_id | INT | The id of the argument set associated with this slice. |
+| thread_instruction_count | INT | The value of the CPU instruction counter at the start of the slice. This column will only be populated if thread instruction collection is enabled with track_event. |
+| thread_instruction_delta | INT | The change in value of the CPU instruction counter between the start and end of the slice. This column will only be populated if thread instruction collection is enabled with track_event. |
+| track_id | INT | The id of the track this slice is located on. |
+| category | STRING | The "category" of the slice. If this slice originated with track_event, this column contains the category emitted. Otherwise, it is likely to be null (with limited exceptions). |
+| name | STRING | The name of the slice. The name describes what was happening during the slice. |
+| depth | INT | The depth of the slice in the current stack of slices. |
+| stack_id | INT | A unique identifier obtained from the names of all slices in this stack. This is rarely useful and kept around only for legacy reasons. |
+| parent_stack_id | INT | The stack_id for the parent of this slice. Rarely useful. |
+| parent_id | INT | The id of the parent (i.e. immediate ancestor) slice for this slice. |
+| thread_ts | INT | The thread timestamp at the start of the slice. This column will only be populated if thread timestamp collection is enabled with track_event. |
+| thread_dur | INT | The thread time used by this slice. This column will only be populated if thread timestamp collection is enabled with track_event. |
+
+<br />
+
+<br />
+
+### android.suspend
+
+#### Views/Tables
+
+<br />
+
+**android_suspend_state**. Table of suspended and awake slices. Selects either the minimal or full ftrace source depending on what's available, marks suspended periods, and complements them to give awake periods.
+
+<br />
+
+TABLE
+Table of suspended and awake slices.
+
+Selects either the minimal or full ftrace source depending on what's
+available, marks suspended periods, and complements them to give awake
+periods.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp |
+| dur | INT | Duration |
+| power_state | STRING | 'awake' or 'suspended' |
+
+<br />
+
+<br />
+
+### android.winscope.inputmethod
+
+#### Views/Tables
+
+<br />
+
+**android_inputmethod_clients**. Android inputmethod clients state dumps (from android.inputmethod data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Dump id |
+| ts | INT | Timestamp when the dump was triggered |
+| arg_set_id | INT | Extra args parsed from the proto message |
+
+<br />
+
+<br />
+
+<br />
+
+**android_inputmethod_manager_service**. Android inputmethod manager service state dumps (from android.inputmethod data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Dump id |
+| ts | INT | Timestamp when the dump was triggered |
+| arg_set_id | INT | Extra args parsed from the proto message |
+
+<br />
+
+<br />
+
+<br />
+
+**android_inputmethod_service**. Android inputmethod service state dumps (from android.inputmethod data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Dump id |
+| ts | INT | Timestamp when the dump was triggered |
+| arg_set_id | INT | Extra args parsed from the proto message |
+
+<br />
+
+<br />
+
+### android.winscope.viewcapture
+
+#### Views/Tables
+
+<br />
+
+**android_viewcapture**. Android viewcapture (from android.viewcapture data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Snapshot id |
+| ts | INT | Timestamp when the snapshot was triggered |
+| arg_set_id | INT | Extra args parsed from the proto message |
+
+<br />
+
+<br />
+
+### android.winscope.windowmanager
+
+#### Views/Tables
+
+<br />
+
+**android_windowmanager**. Android WindowManager (from android.windowmanager data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Snapshot id |
+| ts | INT | Timestamp when the snapshot was triggered |
+| arg_set_id | INT | Extra args parsed from the proto message |
+
+<br />
+
+<br />
+
+## Package: chrome
+
+### chrome.chrome_scrolls
+
+#### Views/Tables
+
+<br />
+
+**chrome_scrolls**. Defines slices for all of the individual scrolls in a trace based on the LatencyInfo-based scroll definition. NOTE: this view of top level scrolls is based on the LatencyInfo definition of a scroll, which differs subtly from the definition based on EventLatencies. TODO(b/278684408): add support for tracking scrolls across multiple Chrome/ WebView instances
+
+<br />
+
+TABLE
+Defines slices for all of the individual scrolls in a trace based on the
+LatencyInfo-based scroll definition.
+
+NOTE: this view of top level scrolls is based on the LatencyInfo definition
+of a scroll, which differs subtly from the definition based on
+EventLatencies.
+TODO(b/278684408): add support for tracking scrolls across multiple Chrome/
+WebView instances. Currently gesture_scroll_id unique within an instance, but
+is not unique across multiple instances. Switching to an EventLatency based
+definition of scrolls should resolve this.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The unique identifier of the scroll. |
+| ts | INT | The start timestamp of the scroll. |
+| dur | INT | The duration of the scroll. |
+| gesture_scroll_begin_ts | INT | The earliest timestamp of the EventLatency slice of the GESTURE_SCROLL_BEGIN type for the corresponding scroll id. |
+| gesture_scroll_end_ts | INT | The earliest timestamp of the EventLatency slice of the GESTURE_SCROLL_END type / the latest timestamp of the EventLatency slice of the GESTURE_SCROLL_UPDATE type for the corresponding scroll id. |
+
+<br />
+
+<br />
+
+### chrome.cpu_powerups
+
+#### Views/Tables
+
+<br />
+
+**chrome_cpu_power_slice**. The CPU power transitions in the trace. Power states are encoded as non-negative integers, with zero representing full-power operation and positive values representing increasingly deep sleep states. On ARM systems, power state 1 represents the WFI (Wait For Interrupt) sleep state that the CPU enters while idle.
+
+<br />
+
+VIEW
+The CPU power transitions in the trace.
+Power states are encoded as non-negative integers, with zero representing
+full-power operation and positive values representing increasingly deep
+sleep states.
+
+On ARM systems, power state 1 represents the WFI (Wait For Interrupt) sleep
+state that the CPU enters while idle.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | The timestamp at the start of the slice. |
+| dur | INT | The duration of the slice. |
+| cpu | INT | The CPU on which the transition occurred |
+| power_state | INT | The power state that the CPU was in at time 'ts' for duration 'dur'. |
+| previous_power_state | INT | The power state that the CPU was previously in. |
+| powerup_id | INT | A unique ID for the CPU power-up. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_cpu_power_first_sched_slice_after_powerup**. The Linux scheduler slices that executed immediately after a CPU power up.
+
+<br />
+
+TABLE
+The Linux scheduler slices that executed immediately after a
+CPU power up.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | The timestamp at the start of the slice. |
+| dur | INT | The duration of the slice. |
+| cpu | INT | The cpu on which the slice executed. |
+| sched_id | INT | Id for the sched_slice table. |
+| utid | INT | Unique id for the thread that ran within the slice. |
+| previous_power_state | INT | The CPU's power state before this slice. |
+| powerup_id | INT | A unique ID for the CPU power-up. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_cpu_power_post_powerup_slice**. A table holding the slices that executed within the scheduler slice that ran on a CPU immediately after power-up.
+
+<br />
+
+TABLE
+A table holding the slices that executed within the scheduler
+slice that ran on a CPU immediately after power-up.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | None | Timestamp of the resulting slice |
+| dur | None | Duration of the slice. |
+| cpu | None | The CPU the sched slice ran on. |
+| utid | None | Unique thread id for the slice. |
+| sched_id | None | 'id' field from the sched_slice table. |
+| type | None | From the sched_slice table, always 'sched_slice'. |
+| end_state | None | The ending state for the sched_slice |
+| priority | None | The kernel thread priority |
+| slice_id | None | Id of the top-level slice for this (sched) slice. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_cpu_power_first_toplevel_slice_after_powerup**. The first top-level slice that ran after a CPU power-up.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| slice_id | INT | ID of the slice in the slice table. |
+| previous_power_state | INT | The power state of the CPU prior to power-up. |
+
+<br />
+
+<br />
+
+### chrome.event_latency
+
+#### Views/Tables
+
+<br />
+
+**chrome_event_latencies**. All EventLatency slices.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Slice Id for the EventLatency scroll event. |
+| name | STRING | Slice name. |
+| ts | INT | The start timestamp of the scroll. |
+| dur | INT | The duration of the scroll. |
+| scroll_update_id | INT | The id of the scroll update event. |
+| is_presented | BOOL | Whether this input event was presented. |
+| event_type | STRING | EventLatency event type. |
+| track_id | INT | Perfetto track this slice is found on. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_gesture_scroll_events**. All scroll-related events (frames) including gesture scroll updates, begins and ends with respective scroll ids and start/end timestamps, regardless of being presented
+
+<br />
+
+TABLE
+All scroll-related events (frames) including gesture scroll updates, begins
+and ends with respective scroll ids and start/end timestamps, regardless of
+being presented. This includes pinches that were presented. See b/315761896
+for context on pinches.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Slice Id for the EventLatency scroll event. |
+| name | STRING | Slice name. |
+| ts | INT | The start timestamp of the scroll. |
+| dur | INT | The duration of the scroll. |
+| scroll_update_id | INT | The id of the scroll update event. |
+| scroll_id | INT | The id of the scroll. |
+| is_presented | BOOL | Whether this input event was presented. |
+| presentation_timestamp | INT | Frame presentation timestamp aka the timestamp of the SwapEndToPresentationCompositorFrame substage. TODO(b/341047059): temporarily use LatchToSwapEnd as a workaround if SwapEndToPresentationCompositorFrame is missing due to b/247542163. |
+| event_type | STRING | EventLatency event type. |
+| track_id | INT | Perfetto track this slice is found on. |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**chrome_get_most_recent_scroll_begin_id** -\> INT. Extracts scroll id for the EventLatency slice at `ts`.
+
+<br />
+
+<br />
+
+<br />
+
+Returns INT: The event_latency_id of the EventLatency slice with the type GESTURE_SCROLL_BEGIN that is the closest to `ts`.
+
+| Argument | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp of the EventLatency slice to get the scroll id for. |
+
+<br />
+
+<br />
+
+### chrome.event_latency_description
+
+#### Views/Tables
+
+<br />
+
+**chrome_event_latency_stage_descriptions**. Source of truth of the descriptions of EventLatency stages.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | The name of the EventLatency stage. |
+| description | STRING | A description of the EventLatency stage. |
+
+<br />
+
+<br />
+
+### chrome.histograms
+
+#### Views/Tables
+
+<br />
+
+**chrome_histograms**. A helper view on top of the histogram events emitted by Chrome. Requires "disabled-by-default-histogram_samples" Chrome category.
+
+<br />
+
+TABLE
+A helper view on top of the histogram events emitted by Chrome.
+Requires "disabled-by-default-histogram_samples" Chrome category.
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | The name of the histogram. |
+| value | INT | The value of the histogram sample. |
+| ts | INT | Alias of \|slice.ts\|. |
+| thread_name | STRING | Thread name. |
+| utid | INT | Utid of the thread. |
+| tid | INT | Tid of the thread. |
+| process_name | STRING | Process name. |
+| upid | INT | Upid of the process. |
+| pid | INT | Pid of the process. |
+
+<br />
+
+<br />
+
+### chrome.interactions
+
+#### Views/Tables
+
+<br />
+
+**chrome_interactions**. All critical user interaction events, including type and table with associated metrics.
+
+<br />
+
+TABLE
+All critical user interaction events, including type and table with
+associated metrics.
+
+| Column | Type | Description |
+|---|---|---|
+| scoped_id | INT | Identifier of the interaction; this is not guaranteed to be unique to the table - rather, it is unique within an individual interaction type. Combine with type to get a unique identifier in this table. |
+| type | STRING | Type of this interaction, which together with scoped_id uniquely identifies this interaction. Also corresponds to a SQL table name containing more details specific to this type of interaction. |
+| name | STRING | Interaction name - e.g. 'PageLoad', 'Tap', etc. Interactions will have unique metrics stored in other tables. |
+| ts | INT | Timestamp of the CUI event. |
+| dur | INT | Duration of the CUI event. |
+
+<br />
+
+<br />
+
+### chrome.metadata
+
+#### Functions
+
+<br />
+
+**chrome_hardware_class** -\> STRING. Returns hardware class of the device, often use to find device brand and model.
+
+<br />
+
+<br />
+
+<br />
+
+Returns hardware class of the device, often use to find device brand
+and model.
+Returns STRING: Hardware class name.
+
+<br />
+
+<br />
+
+### chrome.page_loads
+
+#### Views/Tables
+
+<br />
+
+**chrome_page_loads**. Chrome page loads, including associated high-level metrics and properties.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | ID of the navigation and Chrome browser process; this combination is unique to every individual navigation. |
+| navigation_id | INT | ID of the navigation associated with the page load (i.e. the cross-document navigation in primary main frame which created this page's main document). Also note that navigation_id is specific to a given Chrome browser process, and not globally unique. |
+| navigation_start_ts | INT | Timestamp of the start of navigation. |
+| fcp | INT | Duration between the navigation start and the first contentful paint event (web.dev/fcp). |
+| fcp_ts | INT | Timestamp of the first contentful paint. |
+| lcp | INT | Duration between the navigation start and the largest contentful paint event (web.dev/lcp). |
+| lcp_ts | INT | Timestamp of the largest contentful paint. |
+| dom_content_loaded_event_ts | INT | Timestamp of the DomContentLoaded event: https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event |
+| load_event_ts | INT | Timestamp of the window load event: https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event |
+| mark_fully_loaded_ts | INT | Timestamp of the page self-reporting as fully loaded through the performance.mark('mark_fully_loaded') API. |
+| mark_fully_visible_ts | INT | Timestamp of the page self-reporting as fully visible through the performance.mark('mark_fully_visible') API. |
+| mark_interactive_ts | INT | Timestamp of the page self-reporting as fully interactive through the performance.mark('mark_interactive') API. |
+| url | STRING | URL at the page load event. |
+| browser_upid | INT | The unique process id (upid) of the browser process where the page load occurred. |
+
+<br />
+
+<br />
+
+### chrome.scroll_interactions
+
+#### Views/Tables
+
+<br />
+
+**chrome_scroll_interactions**. Top level scroll events, with metrics.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Unique id for an individual scroll. |
+| name | STRING | Name of the scroll event. |
+| ts | INT | Start timestamp of the scroll. |
+| dur | INT | Duration of the scroll. |
+| frame_count | INT | The total number of frames in the scroll. |
+| vsync_count | INT | The total number of vsyncs in the scroll. |
+| missed_vsync_max | INT | The maximum number of vsyncs missed during any and all janks. |
+| missed_vsync_sum | INT | The total number of vsyncs missed during any and all janks. |
+| delayed_frame_count | INT | The number of delayed frames. |
+| predictor_janky_frame_count | INT | The number of frames that are deemed janky to the human eye after Chrome has applied its scroll prediction algorithm. |
+| renderer_upid | INT | The process id this event occurred on. |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.predictor_error
+
+#### Views/Tables
+
+<br />
+
+**chrome_predictor_error**. The scrolling offsets and predictor jank values for the actual (applied) scroll events.
+
+<br />
+
+TABLE
+The scrolling offsets and predictor jank values for the actual (applied)
+scroll events.
+
+| Column | Type | Description |
+|---|---|---|
+| scroll_id | INT | An ID that ties all EventLatencies in a particular scroll. (implementation note: This is the EventLatency TraceId of the GestureScrollbegin). |
+| event_latency_slice_id | INT | An ID for this particular EventLatency regardless of it being presented or not. |
+| scroll_update_id | INT | An ID that ties this \|event_latency_id\| with the Trace Id (another event_latency_id) that it was presented with. |
+| present_ts | INT | Presentation timestamp. |
+| delta_y | DOUBLE | The delta in raw coordinates between this presented EventLatency and the previous presented frame. |
+| relative_offset_y | DOUBLE | The pixel offset of this presented EventLatency compared to the initial one. |
+| prev_delta | DOUBLE | The delta in raw coordinates of the previous scroll update event. |
+| next_delta | DOUBLE | The delta in raw coordinates of the subsequent scroll update event. |
+| predictor_jank | DOUBLE | The jank value based on the discrepancy between scroll predictor coordinates and the actual deltas between scroll update events. |
+| delta_threshold | DOUBLE | The threshold used to determine if jank occurred. |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.scroll_jank_cause_map
+
+#### Views/Tables
+
+<br />
+
+**chrome_scroll_jank_cause_descriptions**. Source of truth of the descriptions of EventLatency-based scroll jank causes.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| event_latency_stage | STRING | The name of the EventLatency stage. |
+| cause_process | STRING | The process where the cause of scroll jank occurred. |
+| cause_thread | STRING | The thread where the cause of scroll jank occurred. |
+| cause_description | STRING | A description of the cause of scroll jank. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_scroll_jank_causes_with_event_latencies**. Combined description of scroll jank cause and associated event latency stage.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | The name of the EventLatency stage. |
+| description | STRING | Description of the EventLatency stage. |
+| cause_process | STRING | The process name that may cause scroll jank. |
+| cause_thread | STRING | The thread name that may cause scroll jank. The thread will be on the cause_process. |
+| cause_description | STRING | Description of the cause of scroll jank on this process and thread. |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.scroll_jank_cause_utils
+
+#### Table Functions
+
+<br />
+
+**chrome_select_scroll_jank_cause_thread** . Function to retrieve the thread id of the thread on a particular process if there are any slices during a particular EventLatency slice duration; this upid/thread combination refers to a cause of Scroll Jank.
+
+<br />
+
+<br />
+
+<br />
+
+Function to retrieve the thread id of the thread on a particular process if
+there are any slices during a particular EventLatency slice duration; this
+upid/thread combination refers to a cause of Scroll Jank.
+Argument \| Type \| Description
+--- \| --- \| ---
+event_latency_id \| INT \| The slice id of an EventLatency slice.
+process_type \| STRING \| The process type that the thread is on: one of 'Browser', 'Renderer' or 'GPU'.
+thread_name \| STRING \| The name of the thread.
+
+| Column | Type | Description |
+|---|---|---|
+| utid | INT | The utid associated with |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.scroll_jank_intervals
+
+#### Views/Tables
+
+<br />
+
+**chrome_janky_event_latencies_v3**. Selects EventLatency slices that correspond with janks in a scroll
+
+<br />
+
+TABLE
+Selects EventLatency slices that correspond with janks in a scroll. This is
+based on the V3 version of scroll jank metrics.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The slice id. |
+| ts | INT | The start timestamp of the slice. |
+| dur | INT | The duration of the slice. |
+| track_id | INT | The track_id for the slice. |
+| name | STRING | The name of the slice (EventLatency). |
+| cause_of_jank | STRING | The stage of EventLatency that the caused the jank. |
+| sub_cause_of_jank | STRING | The stage of cause_of_jank that caused the jank. |
+| delayed_frame_count | INT | How many vsyncs this frame missed its deadline by. |
+| frame_jank_ts | INT | The start timestamp where frame presentation was delayed. |
+| frame_jank_dur | INT | The duration in ms of the delay in frame presentation. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_janky_frame_presentation_intervals**. Frame presentation interval is the delta between when the frame was supposed to be presented and when it was actually presented.
+
+<br />
+
+VIEW
+Frame presentation interval is the delta between when the frame was supposed
+to be presented and when it was actually presented.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Unique id. |
+| ts | INT | The start timestamp of the slice. |
+| dur | INT | The duration of the slice. |
+| delayed_frame_count | INT | How many vsyncs this frame missed its deadline by. |
+| cause_of_jank | STRING | The stage of EventLatency that the caused the jank. |
+| sub_cause_of_jank | STRING | The stage of cause_of_jank that caused the jank. |
+| event_latency_id | INT | The id of the associated event latency in the slice table. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_scroll_stats**. Scroll jank frame presentation stats for individual scrolls.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| scroll_id | INT | Id of the individual scroll. |
+| frame_count | INT | The number of frames in the scroll. |
+| missed_vsyncs | INT | The number of missed vsyncs in the scroll. |
+| presented_frame_count | INT | The number presented frames in the scroll. |
+| janky_frame_count | INT | The number of janky frames in the scroll. |
+| janky_frame_percent | FLOAT | The % of frames that janked in the scroll. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_scroll_jank_intervals_v3**. Defines slices for all of janky scrolling intervals in a trace.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The unique identifier of the janky interval. |
+| ts | INT | The start timestamp of the janky interval. |
+| dur | INT | The duration of the janky interval. |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.scroll_jank_v3
+
+#### Views/Tables
+
+<br />
+
+**chrome_gesture_scroll_updates**. Grabs all gesture updates with respective scroll ids and start/end timestamps, regardless of being presented.
+
+<br />
+
+TABLE
+Grabs all gesture updates with respective scroll ids and start/end
+timestamps, regardless of being presented.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | The start timestamp of the scroll. |
+| dur | INT | The duration of the scroll. |
+| id | INT | Slice id for the scroll. |
+| scroll_update_id | INT | The id of the scroll update event. |
+| scroll_id | INT | The id of the scroll. |
+| is_presented | BOOL | Whether this input event was presented. |
+| presentation_timestamp | INT | Frame presentation timestamp aka the timestamp of the SwapEndToPresentationCompositorFrame substage. |
+| event_type | STRING | EventLatency event type. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_presented_gesture_scrolls**. Scroll updates, corresponding to all input events that were converted to a presented scroll update.
+
+<br />
+
+TABLE
+Scroll updates, corresponding to all input events that were converted to a
+presented scroll update.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Minimum slice id for input presented in this frame, the non-presented input. |
+| ts | INT | The start timestamp for producing the frame. |
+| dur | INT | The duration between producing and presenting the frame. |
+| last_presented_input_ts | INT | The timestamp of the last input that arrived and got presented in the frame. |
+| scroll_update_id | INT | The id of the scroll update event, a unique identifier to the gesture. |
+| scroll_id | INT | The id of the ongoing scroll. |
+| presentation_timestamp | INT | Frame presentation timestamp. |
+| event_type | STRING | EventLatency event type. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_scroll_updates_with_deltas**. Associate every trace_id with it's perceived delta_y on the screen after prediction.
+
+<br />
+
+TABLE
+Associate every trace_id with it's perceived delta_y on the screen after
+prediction.
+
+| Column | Type | Description |
+|---|---|---|
+| scroll_update_id | INT | The id of the scroll update event. |
+| delta_y | DOUBLE | The perceived delta_y on the screen post prediction. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_full_frame_view**. Obtain the subset of input events that were fully presented.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | ID of the frame. |
+| ts | INT | Start timestamp of the frame. |
+| last_presented_input_ts | INT | The timestamp of the last presented input. |
+| scroll_id | INT | ID of the associated scroll. |
+| scroll_update_id | INT | ID of the associated scroll update. |
+| event_latency_id | INT | ID of the associated EventLatency. |
+| dur | INT | Duration of the associated EventLatency. |
+| presentation_timestamp | INT | Frame presentation timestamp. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_full_frame_delta_view**. Join deltas with EventLatency data.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | ID of the frame. |
+| ts | INT | Start timestamp of the frame. |
+| scroll_id | INT | ID of the associated scroll. |
+| scroll_update_id | INT | ID of the associated scroll update. |
+| last_presented_input_ts | INT | The timestamp of the last presented input. |
+| delta_y | DOUBLE | The perceived delta_y on the screen post prediction. |
+| event_latency_id | INT | ID of the associated EventLatency. |
+| dur | INT | Duration of the associated EventLatency. |
+| presentation_timestamp | INT | Frame presentation timestamp. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_merged_frame_view**. Group all gestures presented at the same timestamp together in a single row.
+
+<br />
+
+TABLE
+Group all gestures presented at the same timestamp together in
+a single row.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | ID of the frame. |
+| max_start_ts | INT | The timestamp of the last presented input. |
+| min_start_ts | INT | The earliest frame start timestamp. |
+| scroll_id | INT | ID of the associated scroll. |
+| scroll_update_id | INT | ID of the associated scroll update. |
+| encapsulated_scroll_ids | STRING | All scroll updates associated with the frame presentation timestamp. |
+| total_delta | DOUBLE | Sum of all perceived delta_y values at the frame presentation timestamp. |
+| segregated_delta_y | STRING | Lists all of the perceived delta_y values at the frame presentation timestamp. |
+| event_latency_id | INT | ID of the associated EventLatency. |
+| dur | INT | Maximum duration of the associated EventLatency. |
+| presentation_timestamp | INT | Frame presentation timestamp. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_frame_info_with_delay**. View contains all chrome presented frames during gesture updates while calculating delay since last presented which usually should equal to \|VSYNC_INTERVAL\| if no jank is present.
+
+<br />
+
+TABLE
+View contains all chrome presented frames during gesture updates
+while calculating delay since last presented which usually should
+equal to \|VSYNC_INTERVAL\| if no jank is present.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | gesture scroll slice id. |
+| max_start_ts | INT | OS timestamp of the last touch move arrival within a frame. |
+| min_start_ts | INT | OS timestamp of the first touch move arrival within a frame. |
+| scroll_id | INT | The scroll which the touch belongs to. |
+| scroll_update_id | INT | ID of the associated scroll update. |
+| encapsulated_scroll_ids | STRING | Trace ids of all frames presented in at this vsync. |
+| total_delta | DOUBLE | Summation of all delta_y of all gesture scrolls in this frame. |
+| segregated_delta_y | STRING | All delta y of all gesture scrolls comma separated, summing those gives \|total_delta\|. |
+| event_latency_id | INT | Event latency id of the presented frame. |
+| dur | INT | Duration of the EventLatency. |
+| presentation_timestamp | INT | Timestamp at which the frame was shown on the screen. |
+| delay_since_last_frame | DOUBLE | Time elapsed since the previous frame was presented, usually equals \|VSYNC\| if no frame drops happened. |
+| delay_since_last_input | DOUBLE | Difference in OS timestamps of inputs in the current and the previous frame. |
+| prev_event_latency_id | INT | The event latency id that will be used as a reference to determine the jank cause. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_vsyncs**. Calculate \|VSYNC_INTERVAL\| as the lowest vsync seen in the trace or the minimum delay between frames larger than zero. TODO(\~M130): Remove the lowest vsync since we should always have vsync_interval_ms.
+
+<br />
+
+TABLE
+Calculate \|VSYNC_INTERVAL\| as the lowest vsync seen in the trace or the
+minimum delay between frames larger than zero.
+
+TODO(\~M130): Remove the lowest vsync since we should always have vsync_interval_ms.
+
+| Column | Type | Description |
+|---|---|---|
+| vsync_interval | DOUBLE | The lowest delay between frames larger than zero. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_janky_frames_no_cause**. Filter the frame view only to frames that had missed vsyncs.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| delay_since_last_frame | DOUBLE | Time elapsed since the previous frame was presented, will be more than \|VSYNC\| in this view. |
+| event_latency_id | INT | Event latency id of the presented frame. |
+| vsync_interval | DOUBLE | Vsync interval at the time of recording the trace. |
+| hardware_class | STRING | Device brand and model. |
+| scroll_id | INT | The scroll corresponding to this frame. |
+| prev_event_latency_id | INT | The event latency id that will be used as a reference to determine the jank cause. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_janky_frames_no_subcause**. Janky frame information including the jank cause.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| delay_since_last_frame | DOUBLE | Time elapsed since the previous frame was presented, will be more than \|VSYNC\| in this view. |
+| event_latency_id | INT | Event latency id of the presented frame. |
+| vsync_interval | DOUBLE | Vsync interval at the time of recording the trace. |
+| hardware_class | STRING | Device brand and model. |
+| scroll_id | INT | The scroll corresponding to this frame. |
+| prev_event_latency_id | INT | The event latency id that will be used as a reference to determine the jank cause. |
+| cause_id | INT | Id of the slice corresponding to the offending stage. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_janky_frames**. Finds all causes of jank for all janky frames, and a cause of sub jank if the cause of jank was GPU related.
+
+<br />
+
+TABLE
+Finds all causes of jank for all janky frames, and a cause of sub jank
+if the cause of jank was GPU related.
+
+| Column | Type | Description |
+|---|---|---|
+| cause_of_jank | STRING | The reason the Vsync was missed. |
+| sub_cause_of_jank | STRING | Further breakdown if the root cause was GPU related. |
+| delay_since_last_frame | DOUBLE | Time elapsed since the previous frame was presented, will be more than \|VSYNC\| in this view. |
+| event_latency_id | INT | Event latency id of the presented frame. |
+| vsync_interval | DOUBLE | Vsync interval at the time of recording the trace. |
+| hardware_class | STRING | Device brand and model. |
+| scroll_id | INT | The scroll corresponding to this frame. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_unique_frame_presentation_ts**. Counting all unique frame presentation timestamps.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| presentation_timestamp | INT | The unique frame presentation timestamp. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_janky_frames_percentage**. Dividing missed frames over total frames to get janky frame percentage. This represents the v3 scroll jank metrics. Reflects Event.Jank.DelayedFramesPercentage UMA metric.
+
+<br />
+
+TABLE
+Dividing missed frames over total frames to get janky frame percentage.
+This represents the v3 scroll jank metrics.
+Reflects Event.Jank.DelayedFramesPercentage UMA metric.
+
+| Column | Type | Description |
+|---|---|---|
+| delayed_frame_percentage | FLOAT | The percent of missed frames relative to total frames - aka the percent of janky frames. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_frames_per_scroll**. Number of frames and janky frames per scroll.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| scroll_id | INT | The ID of the scroll. |
+| num_frames | INT | The number of frames in the scroll. |
+| num_janky_frames | INT | The number of delayed/janky frames. |
+| scroll_jank_percentage | DOUBLE | The percentage of janky frames relative to total frames. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_causes_per_scroll**. Scroll jank causes per scroll.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| scroll_id | INT | The ID of the scroll. |
+| max_delay_since_last_frame | DOUBLE | The maximum time a frame was delayed after the presentation of the previous frame. |
+| vsync_interval | DOUBLE | The expected vsync interval. |
+| scroll_jank_causes | BYTES | A proto amalgamation of each scroll jank cause including cause name, sub cause and the duration of the delay since the previous frame was presented. |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.scroll_jank_v3_cause
+
+#### Functions
+
+<br />
+
+**chrome_get_v3_jank_cause_id** -\> LONG. Given two slice Ids A and B, find the maximum difference between the durations of it's direct children with matching names for example if slice A has children named (X, Y, Z) with durations of (10, 10, 5) and slice B has children named (X, Y) with durations of (9, 9), the function will return the slice id of the slice named Z that is A's child, as no matching slice named Z was found under B, making 5 - 0 = 5 the maximum delta between both slice's direct children
+
+<br />
+
+<br />
+
+<br />
+
+Given two slice Ids A and B, find the maximum difference
+between the durations of it's direct children with matching names
+for example if slice A has children named (X, Y, Z) with durations of (10, 10, 5)
+and slice B has children named (X, Y) with durations of (9, 9), the function will return
+the slice id of the slice named Z that is A's child, as no matching slice named Z was found
+under B, making 5 - 0 = 5 the maximum delta between both slice's direct children
+Returns LONG: The slice id of the breakdown that has the maximum duration delta.
+
+| Argument | Type | Description |
+|---|---|---|
+| janky_slice_id | LONG | The slice id of the parent slice that we want to cause among it's children. |
+| prev_slice_id | LONG | The slice id of the parent slice that's the reference in comparison to \|janky_slice_id\|. |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.scroll_offsets
+
+#### Views/Tables
+
+<br />
+
+**chrome_scroll_input_offsets**. The raw coordinates and pixel offsets for all input events which were part of a scroll.
+
+<br />
+
+TABLE
+The raw coordinates and pixel offsets for all input events which were part of
+a scroll.
+
+| Column | Type | Description |
+|---|---|---|
+| scroll_id | INT | An ID that ties all EventLatencies in a particular scroll. (implementation note: This is the EventLatency TraceId of the GestureScrollbegin). |
+| event_latency_slice_id | INT | An ID for this particular EventLatency regardless of it being presented or not. |
+| scroll_update_id | INT | An ID that ties this \|event_latency_id\| with the Trace Id (another event_latency_id) that it was presented with. |
+| ts | INT | Timestamp the of the scroll input event. |
+| delta_y | DOUBLE | The delta in raw coordinates between this scroll update event and the previous. |
+| relative_offset_y | DOUBLE | The pixel offset of this scroll update event compared to the initial one. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_presented_scroll_offsets**. The scrolling offsets for the actual (applied) scroll events
+
+<br />
+
+TABLE
+The scrolling offsets for the actual (applied) scroll events. These are not
+necessarily inclusive of all user scroll events, rather those scroll events
+that are actually processed.
+
+| Column | Type | Description |
+|---|---|---|
+| scroll_id | INT | An ID that ties all EventLatencies in a particular scroll. (implementation note: This is the EventLatency TraceId of the GestureScrollbegin). |
+| event_latency_slice_id | INT | An ID for this particular EventLatency regardless of it being presented or not. |
+| scroll_update_id | INT | An ID that ties this \|event_latency_id\| with the Trace Id (another event_latency_id) that it was presented with. |
+| ts | INT | Presentation timestamp. |
+| delta_y | DOUBLE | The delta in raw coordinates between this scroll update event and the previous. |
+| relative_offset_y | DOUBLE | The pixel offset of this scroll update event compared to the initial one. |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.utils
+
+#### Table Functions
+
+<br />
+
+**chrome_select_long_task_slices** . Extract mojo information for the long-task-tracking scenario for specific names
+
+<br />
+
+<br />
+
+<br />
+
+Extract mojo information for the long-task-tracking scenario for specific
+names. For example, LongTaskTracker slices may have associated IPC
+metadata, or InterestingTask slices for input may have associated IPC to
+determine whether the task is fling/etc.
+Argument \| Type \| Description
+--- \| --- \| ---
+name \| STRING \| The name of slice.
+
+| Column | Type | Description |
+|---|---|---|
+| interface_name | STRING | Name of the interface of the IPC call. |
+| ipc_hash | INT | Hash of the IPC call. |
+| message_type | STRING | Message type (e.g. reply). |
+| id | INT | The slice id. |
+
+<br />
+
+<br />
+
+### chrome.speedometer
+
+#### Views/Tables
+
+<br />
+
+**chrome_speedometer_measure**. Augmented slices for Speedometer measurements. These are the intervals of time Speedometer uses to compute the final score. There are two intervals that are measured for every test: sync and async
+
+<br />
+
+TABLE
+Augmented slices for Speedometer measurements.
+These are the intervals of time Speedometer uses to compute the final score.
+There are two intervals that are measured for every test: sync and async
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Start timestamp of the measure slice |
+| dur | INT | Duration of the measure slice |
+| name | STRING | Full measure name |
+| iteration | INT | Speedometer iteration the slice belongs to. |
+| suite_name | STRING | Suite name |
+| test_name | STRING | Test name |
+| measure_type | STRING | Type of the measure (sync or async) |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_speedometer_iteration**. Slice that covers one Speedometer iteration. Depending on the Speedometer version these slices might need to be estimated as older versions of Speedometer to not emit marks for this interval
+
+<br />
+
+TABLE
+Slice that covers one Speedometer iteration.
+Depending on the Speedometer version these slices might need to be estimated
+as older versions of Speedometer to not emit marks for this interval. The
+metrics associated are the same ones Speedometer would output, but note we
+use ns precision (Speedometer uses \~100us) so the actual values might differ
+a bit.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Start timestamp of the iteration |
+| dur | INT | Duration of the iteration |
+| name | STRING | Iteration name |
+| iteration | INT | Iteration number |
+| geomean | DOUBLE | Geometric mean of the suite durations for this iteration. |
+| score | DOUBLE | Speedometer score for this iteration (The total score for a run in the average of all iteration scores). |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**chrome_speedometer_score** -\> DOUBLE. Returns the Speedometer score for all iterations in the trace
+
+<br />
+
+<br />
+
+<br />
+
+Returns DOUBLE: Speedometer score
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_speedometer_renderer_main_utid** -\> INT. Returns the utid for the main thread that ran Speedometer 3
+
+<br />
+
+<br />
+
+<br />
+
+Returns INT: Renderer main utid
+
+<br />
+
+<br />
+
+### chrome.speedometer_2_1
+
+#### Views/Tables
+
+<br />
+
+**chrome_speedometer_2_1_measure**. Augmented slices for Speedometer measurements. These are the intervals of time Speedometer uses to compute the final score. There are two intervals that are measured for every test: sync and async sync is the time between the start and sync-end marks, async is the time between the sync-end and async-end marks.
+
+<br />
+
+TABLE
+Augmented slices for Speedometer measurements.
+These are the intervals of time Speedometer uses to compute the final score.
+There are two intervals that are measured for every test: sync and async
+sync is the time between the start and sync-end marks, async is the time
+between the sync-end and async-end marks.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Start timestamp of the measure slice |
+| dur | INT | Duration of the measure slice |
+| name | STRING | Full measure name |
+| iteration | INT | Speedometer iteration the slice belongs to. |
+| suite_name | STRING | Suite name |
+| test_name | STRING | Test name |
+| measure_type | STRING | Type of the measure (sync or async) |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_speedometer_2_1_iteration**. Slice that covers one Speedometer iteration. This slice is actually estimated as a default Speedometer run will not emit marks to cover this interval
+
+<br />
+
+TABLE
+Slice that covers one Speedometer iteration.
+This slice is actually estimated as a default Speedometer run will not emit
+marks to cover this interval. The metrics associated are the same ones
+Speedometer would output, but note we use ns precision (Speedometer uses
+\~100us) so the actual values might differ a bit. Also note Speedometer
+returns the values in ms these here and in ns.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Start timestamp of the iteration |
+| dur | INT | Duration of the iteration |
+| name | STRING | Iteration name |
+| iteration | INT | Iteration number |
+| geomean | DOUBLE | Geometric mean of the suite durations for this iteration. |
+| score | DOUBLE | Speedometer score for this iteration (The total score for a run in the average of all iteration scores). |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**chrome_speedometer_2_1_score** -\> DOUBLE. Returns the Speedometer 2.1 score for all iterations in the trace
+
+<br />
+
+<br />
+
+<br />
+
+Returns DOUBLE: Speedometer 2.1 score
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_speedometer_2_1_renderer_main_utid** -\> INT. Returns the utid for the main thread that ran Speedometer 2.1
+
+<br />
+
+<br />
+
+<br />
+
+Returns INT: Renderer main utid
+
+<br />
+
+<br />
+
+### chrome.speedometer_3
+
+#### Views/Tables
+
+<br />
+
+**chrome_speedometer_3_measure**. Augmented slices for Speedometer measurements. These are the intervals of time Speedometer uses to compute the final score. There are two intervals that are measured for every test: sync and async.
+
+<br />
+
+TABLE
+Augmented slices for Speedometer measurements.
+These are the intervals of time Speedometer uses to compute the final score.
+There are two intervals that are measured for every test: sync and async.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Start timestamp of the measure slice |
+| dur | INT | Duration of the measure slice |
+| name | STRING | Full measure name |
+| iteration | INT | Speedometer iteration the slice belongs to. |
+| suite_name | STRING | Suite name |
+| test_name | STRING | Test name |
+| measure_type | STRING | Type of the measure (sync or async) |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_speedometer_3_iteration**. Slice that covers one Speedometer iteration. The metrics associated are the same ones Speedometer would output, but note we use ns precision (Speedometer uses \~100us) so the actual values might differ a bit.
+
+<br />
+
+TABLE
+Slice that covers one Speedometer iteration.
+The metrics associated are the same ones
+Speedometer would output, but note we use ns precision (Speedometer uses
+\~100us) so the actual values might differ a bit.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Start timestamp of the iteration |
+| dur | INT | Duration of the iteration |
+| name | STRING | Iteration name |
+| iteration | INT | Iteration number |
+| geomean | DOUBLE | Geometric mean of the suite durations for this iteration. |
+| score | DOUBLE | Speedometer score for this iteration (The total score for a run in the average of all iteration scores). |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**chrome_speedometer_3_score** -\> DOUBLE. Returns the Speedometer 3 score for all iterations in the trace
+
+<br />
+
+<br />
+
+<br />
+
+Returns DOUBLE: Speedometer 3 score
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_speedometer_3_renderer_main_utid** -\> INT. Returns the utid for the main thread that ran Speedometer 3
+
+<br />
+
+<br />
+
+<br />
+
+Returns INT: Renderer main utid
+
+<br />
+
+<br />
+
+### chrome.startups
+
+#### Views/Tables
+
+<br />
+
+**chrome_startups**. Chrome startups, including launch cause.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Unique ID |
+| activity_id | INT | Chrome Activity event id of the launch. |
+| name | STRING | Name of the launch start event. |
+| startup_begin_ts | INT | Timestamp that the startup occurred. |
+| first_visible_content_ts | INT | Timestamp to the first visible content. |
+| launch_cause | STRING | Launch cause. See Startup.LaunchCauseType in chrome_track_event.proto. |
+| browser_upid | INT | Process ID of the Browser where the startup occurred. |
+
+<br />
+
+<br />
+
+### chrome.tasks
+
+#### Views/Tables
+
+<br />
+
+**chrome_java_views**. A list of slices corresponding to operations on interesting (non-generic) Chrome Java views
+
+<br />
+
+VIEW
+A list of slices corresponding to operations on interesting (non-generic)
+Chrome Java views. The view is considered interested if it's not a system
+(ContentFrameLayout) or generic library (CompositorViewHolder) views.
+
+TODO(altimin): Add "columns_from slice" annotation.
+TODO(altimin): convert this to EXTEND_TABLE when it becomes available.
+
+| Column | Type | Description |
+|---|---|---|
+| filtered_name | STRING | Name of the view. |
+| is_software_screenshot | BOOL | Whether this slice is a part of non-accelerated capture toolbar screenshot. |
+| is_hardware_screenshot | BOOL | Whether this slice is a part of accelerated capture toolbar screenshot. |
+| slice_id | INT | Slice id. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_scheduler_tasks**. A list of tasks executed by Chrome scheduler.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Slice id. |
+| type | STRING | Type. |
+| name | STRING | Name of the task. |
+| ts | INT | Timestamp. |
+| dur | INT | Duration. |
+| utid | INT | Utid of the thread this task run on. |
+| thread_name | STRING | Name of the thread this task run on. |
+| upid | INT | Upid of the process of this task. |
+| process_name | STRING | Name of the process of this task. |
+| track_id | INT | Same as slice.track_id. |
+| category | STRING | Same as slice.category. |
+| depth | INT | Same as slice.depth. |
+| parent_id | INT | Same as slice.parent_id. |
+| arg_set_id | INT | Same as slice.arg_set_id. |
+| thread_ts | INT | Same as slice.thread_ts. |
+| thread_dur | INT | Same as slice.thread_dur. |
+| posted_from | STRING | Source location where the PostTask was called. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_tasks**. A list of "Chrome tasks": top-level execution units (e.g
+
+<br />
+
+VIEW
+A list of "Chrome tasks": top-level execution units (e.g. scheduler tasks /
+IPCs / system callbacks) run by Chrome. For a given thread, the slices
+corresponding to these tasks will not intersect.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Id for the given task, also the id of the slice this task corresponds to. |
+| name | STRING | Name for the given task. |
+| task_type | STRING | Type of the task (e.g. "scheduler"). |
+| thread_name | STRING | Thread name. |
+| utid | INT | Utid. |
+| process_name | STRING | Process name. |
+| upid | INT | Upid. |
+| ts | INT | Alias of \|slice.ts\|. |
+| dur | INT | Alias of \|slice.dur\|. |
+| track_id | INT | Alias of \|slice.track_id\|. |
+| category | STRING | Alias of \|slice.category\|. |
+| arg_set_id | INT | Alias of \|slice.arg_set_id\|. |
+| thread_ts | INT | Alias of \|slice.thread_ts\|. |
+| thread_dur | INT | Alias of \|slice.thread_dur\|. |
+| full_name | STRING | STRING Legacy alias for \|name\|. |
+
+<br />
+
+<br />
+
+### chrome.vsync_intervals
+
+#### Views/Tables
+
+<br />
+
+**chrome_vsync_intervals**. A simple table that checks the time between VSync (this can be used to determine if we're refreshing at 90 FPS or 60 FPS). Note: In traces without the "Java" category there will be no VSync TraceEvents and this table will be empty.
+
+<br />
+
+TABLE
+A simple table that checks the time between VSync (this can be used to
+determine if we're refreshing at 90 FPS or 60 FPS).
+
+> [!NOTE]
+> **Note:** In traces without the "Java" category there will be no VSync TraceEvents and this table will be empty.
+
+| Column | Type | Description |
+|---|---|---|
+| slice_id | INT | Slice id of the vsync slice. |
+| ts | INT | Timestamp of the vsync slice. |
+| dur | INT | Duration of the vsync slice. |
+| track_id | INT | Track id of the vsync slice. |
+| time_to_next_vsync | INT | Duration until next vsync arrives. |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**chrome_calculate_avg_vsync_interval** -\> FLOAT. Function: compute the average Vysnc interval of the gesture (hopefully this would be either 60 FPS for the whole gesture or 90 FPS but that isnt always the case) on the given time segment. If the trace doesnt contain the VSync TraceEvent we just fall back on assuming its 60 FPS (this is the 1.6e+7 in the COALESCE which corresponds to 16 ms or 60 FPS).
+
+<br />
+
+<br />
+
+<br />
+
+Function: compute the average Vysnc interval of the
+gesture (hopefully this would be either 60 FPS for the whole gesture or 90
+FPS but that isnt always the case) on the given time segment.
+If the trace doesnt contain the VSync TraceEvent we just fall back on
+assuming its 60 FPS (this is the 1.6e+7 in the COALESCE which
+corresponds to 16 ms or 60 FPS).
+Returns FLOAT: The average vsync interval on this time segment or 1.6e+7, if trace doesn't contain the VSync TraceEvent.
+
+| Argument | Type | Description |
+|---|---|---|
+| begin_ts | LONG | Interval start time. |
+| end_ts | LONG | Interval end time. |
+
+<br />
+
+<br />
+
+### chrome.web_content_interactions
+
+#### Views/Tables
+
+<br />
+
+**chrome_web_content_interactions**. Chrome web content interactions (InteractionToFirstPaint), including associated high-level metrics and properties. Multiple events may occur for the same interaction; each row in this table represents the primary (longest) event for the interaction. Web content interactions are discrete, as opposed to sustained (e.g. scrolling); and only occur with the web content itself, as opposed to other parts of Chrome (e.g
+
+<br />
+
+TABLE
+Chrome web content interactions (InteractionToFirstPaint), including
+associated high-level metrics and properties.
+
+Multiple events may occur for the same interaction; each row in this table
+represents the primary (longest) event for the interaction.
+
+Web content interactions are discrete, as opposed to sustained (e.g.
+scrolling); and only occur with the web content itself, as opposed to other
+parts of Chrome (e.g. omnibox). Interaction events include taps, clicks,
+keyboard input (typing), and drags.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Unique id for this interaction. |
+| ts | INT | Start timestamp of the event. Because multiple events may occur for the same interaction, this is the start timestamp of the longest event. |
+| dur | INT | Duration of the event. Because multiple events may occur for the same interaction, this is the duration of the longest event. |
+| interaction_type | STRING | The interaction type. |
+| total_duration_ms | INT | The total duration of all events that occurred for the same interaction. |
+| renderer_upid | INT | The process id this event occurred on. |
+
+<br />
+
+<br />
+
+## Package: counters
+
+### counters.intervals
+
+#### Macros
+
+<br />
+
+**counter_leading_intervals** . For a given counter timeline (e.g
+
+<br />
+
+<br />
+
+<br />
+
+For a given counter timeline (e.g. a single counter track), returns
+intervals of time where the counter has the same value.
+
+Intervals are computed in a "forward-looking" way. That is, if a counter
+changes value at some timestamp, it's assumed it *just* reached that
+value and it should continue to have that value until the next
+value change. The final value is assumed to hold until the very end of
+the trace.
+
+For example, suppose we have the following data:
+`ts=0, value=10, track_id=1
+ts=0, value=10, track_id=2
+ts=10, value=10, track_id=1
+ts=10, value=20, track_id=2
+ts=20, value=30, track_id=1
+[end of trace at ts = 40]`
+
+Then this macro will generate the following intervals:
+`ts=0, dur=20, value=10, track_id=1
+ts=20, dur=10, value=30, track_id=1
+ts=0, dur=10, value=10, track_id=2
+ts=10, dur=30, value=20, track_id=2`
+Returns: TableOrSubquery, Table with the schema (id UINT32, ts UINT64, dur UINT64, track_id UINT64, value DOUBLE, next_value DOUBLE, delta_value DOUBLE).
+
+| Argument | Type | Description |
+|---|---|---|
+| counter_table | TableOrSubquery | A table/view/subquery corresponding to a "counter-like" table. This table must have the columns "id" and "ts" and "track_id" and "value" corresponding to an id, timestamp, counter track_id and associated counter value. |
+
+<br />
+
+<br />
+
+## Package: graphs
+
+### graphs.dominator_tree
+
+#### Macros
+
+<br />
+
+**graph_dominator_tree** . Given a table containing a directed flow-graph and an entry node, computes the "dominator tree" for the graph
+
+<br />
+
+<br />
+
+<br />
+
+Given a table containing a directed flow-graph and an entry node, computes
+the "dominator tree" for the graph. See \[1\] for an explanation of what a
+dominator tree is.
+
+\[1\] https://en.wikipedia.org/wiki/Dominator_(graph_theory)
+
+Example usage on traces containing heap graphs:
+\`\`\`
+CREATE PERFETTO VIEW dominator_compatible_heap_graph AS
+-- Extract the edges from the heap graph which correspond to references
+-- between objects.
+SELECT
+owner_id AS source_node_id,
+owned_id as dest_node_id
+FROM heap_graph_reference
+JOIN heap_graph_object owner on heap_graph_reference.owner_id = owner.id
+WHERE owned_id IS NOT NULL AND owner.reachable
+UNION ALL
+-- Since a Java heap graph is a "forest" structure, we need to add a dummy
+-- "root" node which connects all the roots of the forest into a single
+-- connected component.
+SELECT
+(SELECT max(id) + 1 FROM heap_graph_object) as source_node_id,
+id
+FROM heap_graph_object
+WHERE root_type IS NOT NULL;
+
+SELECT \*
+FROM graph_dominator_tree!(
+dominator_compatible_heap_graph,
+(SELECT max(id) + 1 FROM heap_graph_object)
+);
+\`\`\`
+Returns: TableOrSubquery, The returned table has the schema (node_id UINT32, dominator_node_id UINT32). \|node_id\| is the id of the node from the input graph and \|dominator_node_id\| is the id of the node in the input flow-graph which is the "dominator" of \|node_id\|.
+
+| Argument | Type | Description |
+|---|---|---|
+| graph_table | TableOrSubquery | A table/view/subquery corresponding to a directed flow-graph on which the dominator tree should be computed. This table must have the columns "source_node_id" and "dest_node_id" corresponding to the two nodes on either end of the edges in the graph. Note: the columns must contain uint32 similar to ids in trace processor tables (i.e. the values should be relatively dense and close to zero). The implementation makes assumptions on this for performance reasons and, if this criteria is not, can lead to enormous amounts of memory being allocated. Note: this means that the graph *must* be a single fully connected component with \|root_node_id\| (see below) being the "entry node" for this component. Specifically, all nodes *must* be reachable by following paths from the root node. Failing to adhere to this property will result in undefined behaviour. If working with a "forest"-like structure, a dummy node should be added which links all the roots of the forest together into a single component; an example of this can be found in the heap graph example query above. |
+| root_node_id | Expr | The entry node to \|graph_table\| which will be the root of the dominator tree. |
+
+<br />
+
+<br />
+
+### graphs.partition
+
+#### Macros
+
+<br />
+
+**tree_structural_partition_by_group** . Partitions a tree into a forest of trees based on a given grouping key in a structure-preserving way. Specifically, for each tree in the output forest, all the nodes in that tree have the same ancestors and descendants as in the original tree *iff* that ancestor/descendent belonged to the same group. Example: Input id \| parent_id \| group_key ---\|---\|--- 1 \| NULL \| 1 2 \| 1 \| 1 3 \| NULL \| 2 4 \| NULL \| 2 5 \| 2 \| 1 6 \| NULL \| 3 7 \| 4 \| 2 8 \| 4 \| 1 Or as a graph: `1 (1) / 2 (1) / \ 3 (2) 4 (2) / \ 5 (1) 8 (1) / \ 6 (3) 7 (2)` Possible output (order of rows is implementation-defined) id \| parent_id \| group_key ---\|---\|--- 1 \| NULL \| 1 2 \| 1 \| 1 3 \| NULL \| 2 4 \| NULL \| 2 5 \| 2 \| 1 6 \| NULL \| 3 7 \| 4 \| 2 8 \| 2 \| 1 Or as a forest: `1 (1) 3 (2) 4 (2) 6 (3) | | 2 (1) 7 (2) / \ 5 (1) 8 (1)`
+
+<br />
+
+<br />
+
+<br />
+
+Partitions a tree into a forest of trees based on a given grouping key
+in a structure-preserving way.
+
+Specifically, for each tree in the output forest, all the nodes in that tree
+have the same ancestors and descendants as in the original tree *iff* that
+ancestor/descendent belonged to the same group.
+
+Example:
+Input
+
+| id | parent_id | group_key |
+|---|---|---|
+| 1 | NULL | 1 |
+| 2 | 1 | 1 |
+| 3 | NULL | 2 |
+| 4 | NULL | 2 |
+| 5 | 2 | 1 |
+| 6 | NULL | 3 |
+| 7 | 4 | 2 |
+| 8 | 4 | 1 |
+
+Or as a graph:
+`1 (1)
+/
+2 (1)
+/ \
+3 (2) 4 (2)
+/ \
+5 (1) 8 (1)
+/ \
+6 (3) 7 (2)`
+Possible output (order of rows is implementation-defined)
+
+| id | parent_id | group_key |
+|---|---|---|
+| 1 | NULL | 1 |
+| 2 | 1 | 1 |
+| 3 | NULL | 2 |
+| 4 | NULL | 2 |
+| 5 | 2 | 1 |
+| 6 | NULL | 3 |
+| 7 | 4 | 2 |
+| 8 | 2 | 1 |
+
+Or as a forest:
+`1 (1) 3 (2) 4 (2) 6 (3)
+| |
+2 (1) 7 (2)
+/ \
+5 (1) 8 (1)`
+Returns: TableOrSubquery, The returned table has the schema (id UINT32, parent_id UINT32, group_key UINT32).
+
+| Argument | Type | Description |
+|---|---|---|
+| tree_table | TableOrSubquery | A table/view/subquery corresponding to a tree which should be partitioned. This table must have the columns "id", "parent_id" and "group_key". Note: the columns must contain uint32 similar to ids in trace processor tables (i.e. the values should be relatively dense and close to zero). The implementation makes assumptions on this for performance reasons and, if this criteria is not, can lead to enormous amounts of memory being allocated. |
+
+<br />
+
+<br />
+
+### graphs.search
+
+#### Macros
+
+<br />
+
+**graph_reachable_dfs** . Computes the "reachable" set of nodes in a directed graph from a given set of starting nodes by performing a depth-first search on the graph
+
+<br />
+
+<br />
+
+<br />
+
+Computes the "reachable" set of nodes in a directed graph from a given set
+of starting nodes by performing a depth-first search on the graph. The
+returned nodes are structured as a tree with parent-child relationships
+corresponding to the order in which nodes were encountered by the DFS.
+
+While this macro can be used directly by end users (hence being public),
+it is primarily intended as a lower-level building block upon which higher
+level functions/macros in the standard library can be built.
+
+Example usage on traces containing heap graphs:
+`-- Compute the reachable nodes from the first heap root.
+SELECT *
+FROM graph_reachable_dfs!(
+(
+SELECT
+owner_id AS source_node_id,
+owned_id as dest_node_id
+FROM heap_graph_reference
+WHERE owned_id IS NOT NULL
+),
+(SELECT id FROM heap_graph_object WHERE root_type IS NOT NULL)
+);`
+Returns: TableOrSubquery, The returned table has the schema (node_id UINT32, parent_node_id UINT32). \|node_id\| is the id of the node from the input graph and \|parent_node_id\| is the id of the node which was the first encountered predecessor in a DFS search of the graph.
+
+| Argument | Type | Description |
+|---|---|---|
+| graph_table | TableOrSubquery | A table/view/subquery corresponding to a directed graph on which the reachability search should be performed. This table must have the columns "source_node_id" and "dest_node_id" corresponding to the two nodes on either end of the edges in the graph. Note: the columns must contain uint32 similar to ids in trace processor tables (i.e. the values should be relatively dense and close to zero). The implementation makes assumptions on this for performance reasons and, if this criteria is not, can lead to enormous amounts of memory being allocated. |
+| start_nodes | TableOrSubquery | A table/view/subquery corresponding to the list of start nodes for the BFS. This table must have a single column "node_id". |
+
+<br />
+
+<br />
+
+<br />
+
+**graph_reachable_bfs** . Computes the "reachable" set of nodes in a directed graph from a given starting node by performing a breadth-first search on the graph
+
+<br />
+
+<br />
+
+<br />
+
+Computes the "reachable" set of nodes in a directed graph from a given
+starting node by performing a breadth-first search on the graph. The returned
+nodes are structured as a tree with parent-child relationships corresponding
+to the order in which nodes were encountered by the BFS.
+
+While this macro can be used directly by end users (hence being public),
+it is primarily intended as a lower-level building block upon which higher
+level functions/macros in the standard library can be built.
+
+Example usage on traces containing heap graphs:
+`-- Compute the reachable nodes from all heap roots.
+SELECT *
+FROM graph_reachable_bfs!(
+(
+SELECT
+owner_id AS source_node_id,
+owned_id as dest_node_id
+FROM heap_graph_reference
+WHERE owned_id IS NOT NULL
+),
+(SELECT id FROM heap_graph_object WHERE root_type IS NOT NULL)
+);`
+Returns: TableOrSubquery, The returned table has the schema (node_id UINT32, parent_node_id UINT32). \|node_id\| is the id of the node from the input graph and \|parent_node_id\| is the id of the node which was the first encountered predecessor in a BFS search of the graph.
+
+| Argument | Type | Description |
+|---|---|---|
+| graph_table | TableOrSubquery | A table/view/subquery corresponding to a directed graph on which the reachability search should be performed. This table must have the columns "source_node_id" and "dest_node_id" corresponding to the two nodes on either end of the edges in the graph. Note: the columns must contain uint32 similar to ids in trace processor tables (i.e. the values should be relatively dense and close to zero). The implementation makes assumptions on this for performance reasons and, if this criteria is not, can lead to enormous amounts of memory being allocated. |
+| start_nodes | TableOrSubquery | A table/view/subquery corresponding to the list of start nodes for the BFS. This table must have a single column "node_id". |
+
+<br />
+
+<br />
+
+<br />
+
+**graph_next_sibling** . Computes the next sibling node in a directed graph
+
+<br />
+
+<br />
+
+<br />
+
+Computes the next sibling node in a directed graph. The next node under a parent node
+is determined by on the \|sort_key\|, which should be unique for every node under a parent.
+The order of the next sibling is undefined if the \|sort_key\| is not unique.
+
+Example usage:
+`-- Compute the next sibling:
+SELECT *
+FROM graph_next_sibling!(
+(
+SELECT
+id AS node_id,
+parent_id AS node_parent_id,
+ts AS sort_key
+FROM slice
+)
+);`
+Returns: TableOrSubquery, The returned table has the schema (node_id UINT32, next_node_id UINT32). \|node_id\| is the id of the node from the input graph and \|next_node_id\| is the id of the node which is its next sibling.
+
+| Argument | Type | Description |
+|---|---|---|
+| graph_table | TableOrSubquery | A table/view/subquery corresponding to a directed graph for which to find the next sibling. This table must have the columns "node_id", "node_parent_id" and "sort_key". |
+
+<br />
+
+<br />
+
+<br />
+
+**graph_reachable_weight_bounded_dfs** . Computes the "reachable" set of nodes in a directed graph from a set of starting (root) nodes by performing a depth-first search from each root node on the graph. The search is bounded by the sum of edge weights on the path and the root node specifies the max weight (inclusive) allowed before stopping the search. The returned nodes are structured as a tree with parent-child relationships corresponding to the order in which nodes were encountered by the DFS
+
+<br />
+
+<br />
+
+<br />
+
+Computes the "reachable" set of nodes in a directed graph from a set of
+starting (root) nodes by performing a depth-first search from each root node on the graph.
+The search is bounded by the sum of edge weights on the path and the root node specifies the
+max weight (inclusive) allowed before stopping the search.
+The returned nodes are structured as a tree with parent-child relationships corresponding
+to the order in which nodes were encountered by the DFS. Each row also has the root node from
+which where the edge was encountered.
+
+While this macro can be used directly by end users (hence being public),
+it is primarily intended as a lower-level building block upon which higher
+level functions/macros in the standard library can be built.
+
+Example usage on traces with sched info:
+\`\`\`
+-- Compute the reachable nodes from a sched wakeup chain
+INCLUDE PERFETTO MODULE sched.thread_executing_spans;
+
+SELECT \*
+FROM
+graph_reachable_dfs_bounded
+!(
+(
+SELECT
+id AS source_node_id,
+COALESCE(parent_id, id) AS dest_node_id,
+id - COALESCE(parent_id, id) AS edge_weight
+FROM _wakeup_chain
+),
+(
+SELECT
+id AS root_node_id,
+id - COALESCE(prev_id, id) AS root_target_weight
+FROM _wakeup_chain
+));
+\`\`\`
+Returns: TableOrSubquery, The returned table has the schema (root_node_id, node_id UINT32, parent_node_id UINT32). \|root_node_id\| is the id of the starting node under which this edge was encountered. \|node_id\| is the id of the node from the input graph and \|parent_node_id\| is the id of the node which was the first encountered predecessor in a DFS search of the graph.
+
+| Argument | Type | Description |
+|---|---|---|
+| graph_table | TableOrSubquery | A table/view/subquery corresponding to a directed graph on which the reachability search should be performed. This table must have the columns "source_node_id" and "dest_node_id" corresponding to the two nodes on either end of the edges in the graph and an "edge_weight" corresponding to the weight of the edge between the node. Note: the columns must contain uint32 similar to ids in trace processor tables (i.e. the values should be relatively dense and close to zero). The implementation makes assumptions on this for performance reasons and, if this criteria is not, can lead to enormous amounts of memory being allocated. |
+| root_table | TableOrSubquery | A table/view/subquery corresponding to start nodes to \|graph_table\| which will be the roots of the reachability trees. This table must have the columns "root_node_id" and "root_target_weight" corresponding to the starting node id and the max weight allowed on the tree. Note: the columns must contain uint32 similar to ids in trace processor tables (i.e. the values should be relatively dense and close to zero). The implementation makes assumptions on this for performance reasons and, if this criteria is not, can lead to enormous amounts of memory being allocated. |
+| is_target_weight_floor | Expr | Whether the target_weight is a floor weight or ceiling weight. If it's floor, the search stops right after we exceed the target weight, and we include the node that pushed just passed the target. If ceiling, the search stops right before the target weight and the node that would have pushed us passed the target is not included. |
+
+<br />
+
+<br />
+
+## Package: export
+
+### export.to_firefox_profile
+
+#### Functions
+
+<br />
+
+**export_to_firefox_profile** -\> STRING. Dumps all trace data as a Firefox profile json string See `Profile` in https://github.com/firefox-devtools/profiler/blob/main/src/types/profile.js Also https://firefox-source-docs.mozilla.org/tools/profiler/code-overview.html You would probably want to download the generated json and then open at https://https://profiler.firefox.com You can easily do this from the UI via the following SQL `SELECT CAST(export_to_firefox_profile() AS BLOB) AS profile;` The result will have a link for you to download this json as a file.
+
+<br />
+
+<br />
+
+<br />
+
+Dumps all trace data as a Firefox profile json string
+See `Profile` in
+https://github.com/firefox-devtools/profiler/blob/main/src/types/profile.js
+Also
+https://firefox-source-docs.mozilla.org/tools/profiler/code-overview.html
+
+You would probably want to download the generated json and then open at
+https://https://profiler.firefox.com
+You can easily do this from the UI via the following SQL
+`SELECT CAST(export_to_firefox_profile() AS BLOB) AS profile;`
+The result will have a link for you to download this json as a file.
+Returns STRING: Json profile
+
+<br />
+
+<br />

--- a/platforms/android/.agents/skills/perfetto-trace-analysis/SKILL.md
+++ b/platforms/android/.agents/skills/perfetto-trace-analysis/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: perfetto-trace-analysis
+description: Analyzes Perfetto traces to find the root cause of latency, memory, or
+  jank issues in Android apps. Use when the user provides a Perfetto trace file and
+  asks any question, ongoing investigation, or open-ended request to analyze its contents.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-05-14'
+  keywords:
+  - Perfetto
+  - trace analysis
+  - Android performance
+  - debugging
+  - profiling
+  - jank
+  - bottleneck
+  - SQL
+---
+
+## Resources
+
+- **Domain Hints:** Reference files for specific performance areas: [`CPU`](references/hints_cpu.md), [`Graphics`](references/hints_graphics.md), [`I/O`](references/hints_io.md), [`IPC`](references/hints_ipc.md), [`Memory`](references/hints_memory.md), [`Power`](references/hints_power.md). These files each contain multiple expert-vetted, powerful trace analysis techniques to steer and aid in the analysis.
+- **Perfetto SQL Reference:** Reference guidelines for translating intents into valid queries are located in [the SQL reference](references/sql.md). You must read this reference and follow its Execution Protocol for all SQL generation.
+
+## Setup Phase (Mandatory)
+
+1. **Initialize Scratchpad (Chain of Evidence):**
+   - Maintain your working memory in a local scratchpad file located in the exact same directory as the target trace file.
+   - Name the file using the trace's filename appended with `_analysis.md` (e.g., `[trace_filename]_analysis.md`). Before creating it, check if a file with that name already exists by listing the directory's contents---to avoid biasing your investigation, DO NOT read the file's contents to check for its existence. If it does, append an incrementing version number (e.g., `_v2.md`, `_v3.md`) until you find an available filename. You MUST hardcode this exact filename in all subsequent tool calls.
+   - Use this scratchpad STRICTLY to log verified facts: timestamps, slice names, thread IDs (utid/tid), and thread states.
+   - DO NOT write preliminary hypotheses or premature conclusions in the scratchpad. It is a strict Chain of Evidence.
+2. **Review Domain Hints:** Read the Domain Hints in each file to get a high-level overview of what techniques are possible. Make sure to use this baseline knowledge when researching and retrieving hints during the ongoing investigation.
+3. **Review SQL Reference:** Read the SQL reference in [`references/sql.md`](references/sql.md) and follow its Execution Protocol for all SQL generation. Do not guess schemas.
+4. **Target Resolution:** If the user's request is broad (e.g., "why is the app slow?") and doesn't specify a package name:
+   - Execute a query to identify the active application: `sql INCLUDE
+     PERFETTO MODULE android.startup.startups; SELECT package FROM
+     android_startups;`
+   - If multiple packages are returned, ask the user to choose one. Save the chosen `package_name` to your scratchpad.
+
+## Investigation Protocol
+
+Follow this iterative loop until you have isolated the definitive root cause(s):
+
+### 1. Formulate Hypothesis
+
+- **Prioritization:** Form hypotheses using information from: user prompt \> "Domain Hints" ([`CPU`](references/hints_cpu.md), [`Graphics`](references/hints_graphics.md), [`I/O`](references/hints_io.md), [`IPC`](references/hints_ipc.md), [`Memory`](references/hints_memory.md), [`Power`](references/hints_power.md)) \> general knowledge. Be sure to leverage these "Domain Hints" as they are expert-vetted analysis techniques.
+- **Source Attribution:** Explicitly mention the source of your hypothesis (e.g., "Based on hints_io.md...").
+- **Focus Constraint:** Focus on the primary bottleneck. Avoid investigating deep into binder transactions unless the user explicitly asks for it or there is no other obvious bottleneck.
+- **State Reasoning:** Briefly state your reasoning based on previous findings *before* generating a new query.
+
+### 2. Plan and Collect Data
+
+- **Metrics First:** Start with a high-level view using trace metrics before diving into custom SQL (e.g., `./trace_processor --run-metrics
+  android_startup`).
+- **Broad to Narrow:** Begin with broad queries using minimal filters. Favor fuzzy matching (e.g., `GLOB '*abc*'`) over exact matching.
+- **Overlapping Time:** When filtering by time, you MUST check for events that overlap with the target time range (e.g., `start1 < end2 AND start2 < end1`) to ensure you don't miss slices that span across the boundaries.
+
+### 3. Analyze and Drill Down (Depth-First)
+
+- **Evidentiary Rigor:** Do not draw conclusions without explicit data.
+- **Wall Time vs. CPU Time:** Do not assume a long-running slice is actively computing. You MUST query the `thread_state` table for the exact timestamp window of suspicious slices to verify if the thread was `Running`, `Runnable` (waiting for CPU), or `Sleeping`/`Uninterruptible Sleep` (blocked).
+- **Follow Dependencies:** If a thread is blocked/waiting, you MUST find what it is waiting *for* (Binder, Lock, I/O, etc.). Cross process boundaries if necessary. You cannot conclude an investigation on a waiting thread without identifying the blocker.
+
+### 4. Exhaustive Investigation (Do Not Give Up Early)
+
+- **Multiple Bottlenecks:** Complex performance issues rarely have a single cause. Do NOT stop your investigation after finding the first anomaly. Even if you find a major bottleneck (e.g., emulator graphics lag), you MUST continue searching for other independent system-wide issues (e.g., lock contention, I/O stalls). To find other bottlenecks, search through the content of the "Domain Hints" files ([`CPU`](references/hints_cpu.md), [`Graphics`](references/hints_graphics.md), [`I/O`](references/hints_io.md), [`IPC`](references/hints_ipc.md), [`Memory`](references/hints_memory.md), [`Power`](references/hints_power.md)) to retrieve and leverage expert-vetted, powerful trace analysis techniques. Investigate each relevant hint with depth.
+- **Global Verification:** Periodically perform a system-wide query for the longest running slices (`ORDER BY slice.dur DESC`) and most frequent D-states to ensure your local investigation hasn't missed a massive, unrelated system stall.
+- **Persist Through Dead Ends:** If a hypothesis is disproven or a query returns empty, do not conclude. Pivot your focus, broaden your search constraints (fuzzy matching, wider time windows), and continue the mission.
+
+## Final Report
+
+Only when you have followed the entire chain of dependencies to the root
+cause(s) AND confirmed through exhaustive search that no other major bottlenecks
+exist: 1. Summarize your findings detailing the verified chain of evidence. 2.
+Conclude with: "This concludes the trace analysis. You can review the full chain
+of evidence in \[scratchpad_filename\]. Let me know if you would like me to drill
+down into any of these specific threads, or if you'd like help drafting a bug
+report."

--- a/platforms/android/.agents/skills/perfetto-trace-analysis/references/hints_cpu.md
+++ b/platforms/android/.agents/skills/perfetto-trace-analysis/references/hints_cpu.md
@@ -1,0 +1,16 @@
+- When debugging a long slice: Examine its thread states to understand what the thread was doing (running, sleeping, blocked on I/O).
+- When debugging a long slice for latency issues: Check if its duration is caused by one or more long-running child slices. Apply recursively.
+- When a thread is woken up but there's a delay before it runs, check the "IRQ" track for the corresponding CPU to see if an interrupt is the cause.
+- Check if kernel threads associated with hardware are running with real-time priority; if not, they can be preempted.
+- When analysis of the primary application package does not reveal the root cause, expand to all threads and processes. Search for other runnable threads on the same CPU or high-priority kernel threads.
+- When investigating app startup, use an SQL query to aggregate the reasons for uninterruptible sleep on the main thread.
+- Check the "cpu_frequency" counter for the CPU cores that ran the main process. Missing frequency data or stuck frequencies indicate a kernel-level bug in the governor.
+- Query raw "ftrace" events for logs related to the governor thread (e.g., "su_gov").
+- To find concurrency issues, search for critical threads (e.g., 'RenderThread') in a blocked state (thread_state.state = 'D') and join with scheduling data to find the waker.
+- Compare time spent in userspace functions vs kernel (slices with \[k\] prefix).
+- To detect a 'catch-up storm', look for threads with long gaps in thread_state/cpu_slice activity immediately followed by a high-density burst.
+- Quantify scheduler contention by calculating scheduling latency (measure duration of preceding 'Runnable' state using preceding_sched_slice_for_thread). Search for maximums and high percentiles (p95/p99).
+- If a task exhibits high scheduling latency, check if other CPUs were idle (running swapper or idle thread).
+- Check the cpu_id for key threads; if consistently scheduled on slower cores, it signals a potential performance gain by allowing them on big cores.
+- For a struggling thread, analyze 'Runnable' vs 'Running' state time. A large 'Runnable' time indicates CPU contention.
+- If a slice's wall duration increases but the percentage of 'Running' time is unchanged, it strongly suggests a lower CPU frequency. Check sched_switch to focus on the correct cores.

--- a/platforms/android/.agents/skills/perfetto-trace-analysis/references/hints_graphics.md
+++ b/platforms/android/.agents/skills/perfetto-trace-analysis/references/hints_graphics.md
@@ -1,0 +1,11 @@
+- When investigating UI jank, check for long-running slices on the main thread; if a slice like "ConstraintLayout.onMeasure" is taking a long time (e.g., \>8ms), it is a likely cause of the jank.
+- When a bitmap_write_to_parcel slice takes milliseconds instead of microseconds, investigate its children slices to see how time is spent. Long durations often point to suboptimal kernel operations like memory mapping (mmap) or unnecessary data zeroing.
+- For a high-level overview of graphics memory usage, track the 'gpu_mem_total' counter for a specific process (upid).
+- To find the largest graphics allocations, query the android_graphics_allocs table and sort by size_bytes in descending order. Compare its 'width' and 'height' against the device's display resolution.
+- To detect the "double memory cost" of an image existing on both CPU and GPU, look for a large buffer in android_graphics_allocs and a simultaneous CPU memory allocation of a similar size (rss_anon_bytes or heap_graph).
+- To find potentially costly intermediate render targets, look for large buffers in android_graphics_allocs where 'usage_bits' lack a 'COMPOSER_OVERLAY' flag.
+- To check if an allocation is actually presented on screen, correlate 'buffer_id' with SurfaceFlinger events.
+- To see if high graphics memory is causing performance issues, check the frame duration in 'actual_frame_timeline_frame'. Durations over vsync (e.g., 16.6ms) correlating with 'gpu_mem_total' spikes suggest memory pressure jank.
+- Within the main thread of a janky graphics application, look for frequent or long-running 'texture_upload' slices.
+- Analyze the duration of 'eglSwapBuffersWithDamageKHR' or similar buffer-swapping slices in the graphics rendering thread. Consistently long durations suggest a large "damage area" being redrawn every frame.
+- To identify UI jank, compare the 'actual_frame_timeline' against the 'expected_frame_timeline' on the main process; a significant deviation indicates missed frames.

--- a/platforms/android/.agents/skills/perfetto-trace-analysis/references/hints_io.md
+++ b/platforms/android/.agents/skills/perfetto-trace-analysis/references/hints_io.md
@@ -1,0 +1,12 @@
+- When debugging a long, uninterruptible sleep state related to I/O: Check for overlapping slices with "verity" in their name (dm-verity).
+- When a thread is stuck in an uninterruptible sleep with no blocked_function, look for other threads that might be holding the memory lock (e.g., "jit-thread-pool", memory mapping ops).
+- When analyzing a long uninterruptible sleep, check the "blocked_function" in the thread state details (from sched_blocked_reason ftrace event).
+- A lot of time spent in "do_page_fault" during app startup is a strong indicator of I/O contention.
+- For file integrity mechanisms like DM-Verity, search for events like dm_verity_fec_prefetch.
+- To find the specific kernel dependency of a stalled app thread, locate the thread in state 'D', then look for kworker or kernel threads that become runnable immediately after.
+- For app stalls caused by I/O, analyze the scheduling latency of the relevant kworker threads handling the request.
+- To find inefficient file I/O, query the syscall table for a high frequency of small, sequential read() or pread() syscalls on a single fd.
+- If a thread spends significant time in 'Uninterruptible Sleep', check if 'blocked_function' is 'page_cache_readahead'. Correlate waking timestamps with 'filemap_add_to_page_cache' ftrace events.
+- Aggregate counts of 'filemap_add_to_page_cache' grouping by 'inode' to find the specific file causing I/O pressure.
+- Inspect 'nr_sector' in 'block_rq_issue' ftrace events to understand file read-ahead size.
+- If an I/O issue disappears on subsequent launches, it's a 'cold start' problem (populating page cache).

--- a/platforms/android/.agents/skills/perfetto-trace-analysis/references/hints_ipc.md
+++ b/platforms/android/.agents/skills/perfetto-trace-analysis/references/hints_ipc.md
@@ -1,0 +1,10 @@
+- Look for multiple outbound binder transactions from the same process (system_server) that carry similar data to different destinations in a short time frame. This "binder storm" indicates a lack of multiplexing.
+- To trace data across processes, correlate slices using flow events by linking a slice's ID to flow.source_slice_id or flow.dest_slice_id.
+- To detect binder spam, query the binder_transaction table and group by thread ID (tid), service_name, and method_name to find high numbers of identical calls.
+- When high binder concurrency is found, identify the bottleneck server process by grouping transactions by server_upid.
+- To analyze the latency of a slow binder transaction, calculate the time spent outside the server by subtracting server_dur from the total dur in the binder_transaction table.
+- When a thread is suspected of binder spam, correlate its tid with the cpu_slice table to check for high CPU consumption.
+- To find the code responsible for binder spam, get the utid of the problematic thread and use it to query stack_profile_callsite.
+- To find the callers of a problematic function, filter stack_profile_callsite for frames mapping to it, then trace upwards using parent_id.
+- A long-running slice on one thread causally linked to a slice on another thread (e.g., binder from system_server to SystemUI) indicates a scheduling dependency bottleneck.
+- To find asynchronous operations that might cause UI jank, look for a binder transaction from a controlling process that returns quickly, followed by a long-running slice in the receiving process.

--- a/platforms/android/.agents/skills/perfetto-trace-analysis/references/hints_memory.md
+++ b/platforms/android/.agents/skills/perfetto-trace-analysis/references/hints_memory.md
@@ -1,0 +1,15 @@
+- To investigate low memory kills, look for the "lmk_kill_occurred" ftrace event; a high count indicates severe memory pressure.
+- When you see a burst of "lmk_kill_occurred" events, query for processes with high CPU wall_duration in the "sched_slice" table during the same time window. Runaway processes consuming CPU exacerbate memory pressure.
+- To understand a process's memory impact, inspect its "anon_rss" (Anonymous Resident Set Size) from memory counters like "mem.info".
+- Check system-wide memory stats for a high or rapidly increasing "swap_used" value.
+- To confirm memory thrashing, look for high CPU usage by the "kswapd" kernel thread.
+- To find the direct trigger for LMKD, look for "memory_pressure" trace events from Pressure Stall Information (PSI).
+- To detect 'lost' memory for processes using hardware accelerators (like a TPU), query the counter table for RssFile values. If it drops significantly while hardware is active, check for kswapd0 scheduling slices.
+- When analyzing memory shared with hardware, query the dma_heap_stat and dmabuf_total_size counters (or ion_total_size for older devices) for a more accurate picture than RSS.
+- Be aware that RssFile can over-report memory if the same physical page is mapped multiple times.
+- When investigating OOMs, establish a baseline by querying process memory counters (e.g., mem.rss) and compare the median and 95th percentile against its history.
+- If bitmaps are a major memory consumer, check for outliers in bitmap count by querying android.graphics.Bitmap instances across traces.
+- To find what is holding onto an object (like a bitmap), trace its retainer path back to a GC root by querying heap_graph_reference. Pay close attention to custom application classes.
+- Query the android_bitmaps table to check the width and height properties of bitmaps.
+- Check for the presence of software bitmaps, which consume memory on both the app heap and in graphics memory.
+- When analyzing bitmaps, look for duplicates by checking for multiple android.graphics.Bitmap objects with identical properties.

--- a/platforms/android/.agents/skills/perfetto-trace-analysis/references/hints_power.md
+++ b/platforms/android/.agents/skills/perfetto-trace-analysis/references/hints_power.md
@@ -1,0 +1,7 @@
+- When investigating overall battery drain, start by querying the power_rails track and summing the energy consumed (power_ma \* duration) for each rail name.
+- To check if a device is sleeping correctly during screen-off periods, query the suspend_state track; a lack of time in "suspended" state indicates a wakefulness problem.
+- To find the root cause of the device failing to suspend, query the kernel_wakelock track and aggregate the total duration for each wake lock name.
+- If a top kernel wake lock name contains "bt_" or "bcm" (e.g., bt_host_wake), cross-reference its timing with events in the bluetooth_scan_results track.
+- If the modem rail in power_rails shows high consumption, query the network_packets table and aggregate traffic volume by uid to identify the app.
+- When analyzing network traffic from a shared uid, use the socket_tag associated with network packets for granular attribution.
+- Convert impact into a common energy unit like milliwatt-hours (mWh) to compare the severity of different issues.

--- a/platforms/android/.agents/skills/perfetto-trace-analysis/references/perfetto-stdlib.md
+++ b/platforms/android/.agents/skills/perfetto-trace-analysis/references/perfetto-stdlib.md
@@ -1,0 +1,6670 @@
+*This page documents the PerfettoSQL standard library.*
+
+## Introduction
+
+The PerfettoSQL standard library is a repository of tables, views, functions
+and macros, contributed by domain experts, which make querying traces easier
+Its design is heavily inspired by standard libraries in languages like Python,
+C++ and Java.
+
+Some of the purposes of the standard library include:
+1) Acting as a way of sharing and commonly written queries without needing
+to copy/paste large amounts of SQL.
+2) Raising the abstraction level when exposing data in the trace. Many
+modules in the standard library convert low-level trace concepts
+e.g. slices, tracks and into concepts developers may be more familar with
+e.g. for Android developers: app startups, binder transactions etc.
+
+Standard library modules can be included as follows
+
+    -- Include all tables/views/functions from the android.startup.startups
+    -- module in the standard library.
+    INCLUDE PERFETTO MODULE android.startup.startups;
+
+    -- Use the android_startups table defined in the android.startup.startups
+    -- module.
+    SELECT *
+    FROM android_startups;
+
+Prelude is a special module is automatically included. It contains key helper
+tables, views and functions which are universally useful.
+
+More information on importing modules is available in the
+[syntax documentation](https://perfetto.dev/docs/analysis/perfetto-sql-syntax#including-perfettosql-modules)
+for the `INCLUDE PERFETTO MODULE` statement.
+
+## Package: prelude
+
+#### Views/Tables
+
+<br />
+
+**trace_metrics**. Lists all metrics built-into trace processor.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | The name of the metric. |
+
+<br />
+
+<br />
+
+<br />
+
+**track**. Tracks are a fundamental concept in trace processor and represent a "timeline" for events of the same type and with the same context
+
+<br />
+
+VIEW
+Tracks are a fundamental concept in trace processor and represent a
+"timeline" for events of the same type and with the same context. See
+https://perfetto.dev/docs/analysis/trace-processor#tracks for a more
+detailed explanation, with examples.
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this track. Identical to \|track_id\|, prefer using \|track_id\| instead. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| name | STRING | Name of the track; can be null for some types of tracks (e.g. thread tracks). |
+| parent_id | UINT | The track which is the "parent" of this track. Only non-null for tracks created using Perfetto's track_event API. |
+| source_arg_set_id | UINT | Args for this track which store information about "source" of this track in the trace. For example: whether this track orginated from atrace, Chrome tracepoints etc. Alias of `args.arg_set_id`. |
+| machine_id | UINT | Machine identifier, non-null for tracks on a remote machine. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu**. Contains information about the CPUs on the device this trace was taken on.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this CPU. Identical to \|ucpu\|, prefer using \|ucpu\| instead. |
+| ucpu | UINT | Unique identifier for this CPU. Isn't equal to \|cpu\| for remote machines and is equal to \|cpu\| for the host machine. |
+| cpu | UINT | The 0-based CPU core identifier. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| cluster_id | UINT | The cluster id is shared by CPUs in the same cluster. |
+| processor | STRING | A string describing this core. |
+| machine_id | UINT | Machine identifier, non-null for CPUs on a remote machine. |
+| capacity | UINT | Capacity of a CPU of a device, a metric which indicates the relative performance of a CPU on a device For details see: https://www.kernel.org/doc/Documentation/devicetree/bindings/arm/cpu-capacity.txt |
+| arg_set_id | UINT | Extra key/value pairs associated with this cpu. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_available_frequencies**. Contains the frequency values that the CPUs on the device are capable of running at.
+
+<br />
+
+VIEW
+Contains the frequency values that the CPUs on the device are capable of
+running at.
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this cpu frequency. |
+| cpu | UINT | The CPU for this frequency, meaningful only in single machine traces. For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| freq | UINT | CPU frequency in KHz. |
+| ucpu | UINT | The CPU that the slice executed on (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+
+<br />
+
+<br />
+
+<br />
+
+**sched_slice**. This table holds slices with kernel thread scheduling information
+
+<br />
+
+VIEW
+This table holds slices with kernel thread scheduling information. These
+slices are collected when the Linux "ftrace" data source is used with the
+"sched/switch" and "sched/wakeup\*" events enabled.
+
+The rows in this table will always have a matching row in the \|thread_state\|
+table with \|thread_state.state\| = 'Running'
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this scheduling slice. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| ts | LONG | The timestamp at the start of the slice (in nanoseconds). |
+| dur | LONG | The duration of the slice (in nanoseconds). |
+| cpu | UINT | The CPU that the slice executed on (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| utid | UINT | The thread's unique id in the trace. |
+| end_state | STRING | A string representing the scheduling state of the kernel thread at the end of the slice. The individual characters in the string mean the following: R (runnable), S (awaiting a wakeup), D (in an uninterruptible sleep), T (suspended), t (being traced), X (exiting), P (parked), W (waking), I (idle), N (not contributing to the load average), K (wakeable on fatal signals) and Z (zombie, awaiting cleanup). |
+| priority | INT | The kernel priority that the thread ran at. |
+| ucpu | UINT | The unique CPU identifier that the slice executed on. |
+
+<br />
+
+<br />
+
+<br />
+
+**sched** . Shorter alias for table `sched_slice`.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Alias for `sched_slice.id`. |
+| type | STRING | Alias for `sched_slice.type`. |
+| ts | LONG | Alias for `sched_slice.ts`. |
+| dur | LONG | Alias for `sched_slice.dur`. |
+| cpu | UINT | Alias for `sched_slice.cpu`. |
+| utid | UINT | Alias for `sched_slice.utid`. |
+| end_state | STRING | Alias for `sched_slice.end_state`. |
+| priority | INT | Alias for `sched_slice.priority`. |
+| ucpu | UINT | Alias for `sched_slice.ucpu`. |
+| ts_end | UINT | Legacy column, should no longer be used. |
+
+<br />
+
+<br />
+
+<br />
+
+**thread_state**. This table contains the scheduling state of every thread on the system during the trace. The rows in this table which have \|state\| = 'Running', will have a corresponding row in the \|sched_slice\| table.
+
+<br />
+
+VIEW
+This table contains the scheduling state of every thread on the system during
+the trace.
+
+The rows in this table which have \|state\| = 'Running', will have a
+corresponding row in the \|sched_slice\| table.
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this thread state. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| ts | LONG | The timestamp at the start of the slice (in nanoseconds). |
+| dur | LONG | The duration of the slice (in nanoseconds). |
+| cpu | UINT | The CPU that the thread executed on (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| utid | UINT | The thread's unique id in the trace. |
+| state | STRING | The scheduling state of the thread. Can be "Running" or any of the states described in \|sched_slice.end_state\|. |
+| io_wait | UINT | Indicates whether this thread was blocked on IO. |
+| blocked_function | STRING | The function in the kernel this thread was blocked on. |
+| waker_utid | UINT | The unique thread id of the thread which caused a wakeup of this thread. |
+| waker_id | UINT | The unique thread state id which caused a wakeup of this thread. |
+| irq_context | UINT | Whether the wakeup was from interrupt context or process context. |
+| ucpu | UINT | The unique CPU identifier that the thread executed on. |
+
+<br />
+
+<br />
+
+<br />
+
+**raw**. Contains 'raw' events from the trace for some types of events
+
+<br />
+
+VIEW
+Contains 'raw' events from the trace for some types of events. This table
+only exists for debugging purposes and should not be relied on in production
+usecases (i.e. metrics, standard library etc.)
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this raw event. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| ts | LONG | The timestamp of this event. |
+| name | STRING | The name of the event. For ftrace events, this will be the ftrace event name. |
+| cpu | UINT | The CPU this event was emitted on (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| utid | UINT | The thread this event was emitted on. |
+| arg_set_id | UINT | The set of key/value pairs associated with this event. |
+| common_flags | UINT | Ftrace event flags for this event. Currently only emitted for sched_waking events. |
+| ucpu | UINT | The unique CPU identifier that this event was emitted on. |
+
+<br />
+
+<br />
+
+<br />
+
+**ftrace_event**. Contains all the ftrace events in the trace
+
+<br />
+
+VIEW
+Contains all the ftrace events in the trace. This table exists only for
+debugging purposes and should not be relied on in production usecases (i.e.
+metrics, standard library etc). Note also that this table might be empty if
+raw ftrace parsing has been disabled.
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this ftrace event. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| ts | LONG | The timestamp of this event. |
+| name | STRING | The ftrace event name. |
+| cpu | UINT | The CPU this event was emitted on (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| utid | UINT | The thread this event was emitted on. |
+| arg_set_id | UINT | The set of key/value pairs associated with this event. |
+| common_flags | UINT | Ftrace event flags for this event. Currently only emitted for sched_waking events. |
+| ucpu | UINT | The unique CPU identifier that this event was emitted on. |
+
+<br />
+
+<br />
+
+<br />
+
+**experimental_sched_upid**. The sched_slice table with the upid column.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this scheduling slice. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| ts | LONG | The timestamp at the start of the slice (in nanoseconds). |
+| dur | LONG | The duration of the slice (in nanoseconds). |
+| cpu | UINT | The CPU that the slice executed on (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| utid | UINT | The thread's unique id in the trace. |
+| end_state | STRING | A string representing the scheduling state of the kernel thread at the end of the slice. The individual characters in the string mean the following: R (runnable), S (awaiting a wakeup), D (in an uninterruptible sleep), T (suspended), t (being traced), X (exiting), P (parked), W (waking), I (idle), N (not contributing to the load average), K (wakeable on fatal signals) and Z (zombie, awaiting cleanup). |
+| priority | INT | The kernel priority that the thread ran at. |
+| ucpu | UINT | The unique CPU identifier that the slice executed on. |
+| upid | UINT | The process's unique id in the trace. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_track**. Tracks which are associated to a single CPU.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this cpu track. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| name | STRING | Name of the track. |
+| parent_id | UINT | The track which is the "parent" of this track. Only non-null for tracks created using Perfetto's track_event API. |
+| source_arg_set_id | UINT | Args for this track which store information about "source" of this track in the trace. For example: whether this track orginated from atrace, Chrome tracepoints etc. |
+| machine_id | UINT | Machine identifier, non-null for tracks on a remote machine. |
+| cpu | UINT | The CPU that the track is associated with (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| ucpu | UINT | The unique CPU identifier that this track is associated with. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_counter_track**. Tracks containing counter-like events associated to a CPU.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Unique identifier for this cpu counter track. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| name | STRING | Name of the track. |
+| parent_id | UINT | The track which is the "parent" of this track. Only non-null for tracks created using Perfetto's track_event API. |
+| source_arg_set_id | UINT | Args for this track which store information about "source" of this track in the trace. For example: whether this track orginated from atrace, Chrome tracepoints etc. |
+| machine_id | UINT | Machine identifier, non-null for tracks on a remote machine. |
+| unit | STRING | The units of the counter. This column is rarely filled. |
+| description | STRING | The description for this track. For debugging purposes only. |
+| cpu | UINT | The CPU that the track is associated with (meaningful only in single machine traces). For multi-machine, join with the `cpu` table on `ucpu` to get the CPU identifier of each machine. |
+| ucpu | UINT | The unique CPU identifier that this track is associated with. |
+
+<br />
+
+<br />
+
+<br />
+
+**counters** . Alias of the `counter` table.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Alias of `counter.id`. |
+| type | STRING | Alias of `counter.type`. |
+| ts | LONG | Alias of `counter.ts`. |
+| track_id | INT | Alias of `counter.track_id`. |
+| value | DOUBLE | Alias of `counter.value`. |
+| arg_set_id | INT | Alias of `counter.arg_set_id`. |
+| name | STRING | Legacy column, should no longer be used. |
+| unit | STRING | Legacy column, should no longer be used. |
+| description | STRING | Legacy column, should no longer be used. |
+
+<br />
+
+<br />
+
+<br />
+
+**slice**. Contains slices from userspace which explains what threads were doing during the trace.
+
+<br />
+
+VIEW
+Contains slices from userspace which explains what threads were doing
+during the trace.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the slice. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| ts | LONG | The timestamp at the start of the slice (in nanoseconds). |
+| dur | LONG | The duration of the slice (in nanoseconds). |
+| track_id | INT | The id of the track this slice is located on. |
+| category | STRING | The "category" of the slice. If this slice originated with track_event, this column contains the category emitted. Otherwise, it is likely to be null (with limited exceptions). |
+| name | STRING | The name of the slice. The name describes what was happening during the slice. |
+| depth | INT | The depth of the slice in the current stack of slices. |
+| stack_id | LONG | A unique identifier obtained from the names of all slices in this stack. This is rarely useful and kept around only for legacy reasons. |
+| parent_stack_id | LONG | The stack_id for the parent of this slice. Rarely useful. |
+| parent_id | INT | The id of the parent (i.e. immediate ancestor) slice for this slice. |
+| arg_set_id | INT | The id of the argument set associated with this slice. |
+| thread_ts | LONG | The thread timestamp at the start of the slice. This column will only be populated if thread timestamp collection is enabled with track_event. |
+| thread_dur | LONG | The thread time used by this slice. This column will only be populated if thread timestamp collection is enabled with track_event. |
+| thread_instruction_count | LONG | The value of the CPU instruction counter at the start of the slice. This column will only be populated if thread instruction collection is enabled with track_event. |
+| thread_instruction_delta | LONG | The change in value of the CPU instruction counter between the start and end of the slice. This column will only be populated if thread instruction collection is enabled with track_event. |
+| cat | STRING | Alias of `category`. |
+| slice_id | LONG | Alias of `id`. |
+
+<br />
+
+<br />
+
+<br />
+
+**instant**. Contains instant events from userspace which indicates what happened at a single moment in time.
+
+<br />
+
+VIEW
+Contains instant events from userspace which indicates what happened at a
+single moment in time.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | LONG | The timestamp of the instant (in nanoseconds). |
+| track_id | INT | The id of the track this instant is located on. |
+| name | STRING | The name of the instant. The name describes what happened during the instant. |
+| arg_set_id | INT | The id of the argument set associated with this instant. |
+
+<br />
+
+<br />
+
+<br />
+
+**slices** . Alternative alias of table `slice`.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | UINT | Alias of `slice.id`. |
+| type | STRING | Alias of `slice.type`. |
+| ts | LONG | Alias of `slice.ts`. |
+| dur | LONG | Alias of `slice.dur`. |
+| track_id | INT | Alias of `slice.track_id`. |
+| category | STRING | Alias of `slice.category`. |
+| name | STRING | Alias of `slice.name`. |
+| depth | INT | Alias of `slice.depth`. |
+| stack_id | LONG | Alias of `slice.stack_id`. |
+| parent_stack_id | LONG | Alias of `slice.parent_stack_id`. |
+| parent_id | INT | Alias of `slice.parent_id`. |
+| arg_set_id | INT | Alias of `slice.arg_set_id`. |
+| thread_ts | LONG | Alias of `slice.thread_ts`. |
+| thread_dur | LONG | Alias of `slice.thread_dur`. |
+| thread_instruction_count | LONG | Alias of `slice.thread_instruction_count`. |
+| thread_instruction_delta | LONG | Alias of `slice.thread_instruction_delta`. |
+| cat | LONG | Alias of `slice.cat`. |
+| slice_id | LONG | Alias of `slice.slice_id`. |
+
+<br />
+
+<br />
+
+<br />
+
+**thread**. Contains information of threads seen during the trace.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the thread. Prefer using `utid` instead. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| utid | INT | Unique thread id. This is != the OS tid. This is a monotonic number associated to each thread. The OS thread id (tid) cannot be used as primary key because tids and pids are recycled by most kernels. |
+| tid | INT | The OS id for this thread. Note: this is *not* unique over the lifetime of the trace so cannot be used as a primary key. Use \|utid\| instead. |
+| name | STRING | The name of the thread. Can be populated from many sources (e.g. ftrace, /proc scraping, track event etc). |
+| start_ts | LONG | The start timestamp of this thread (if known). Is null in most cases unless a thread creation event is enabled (e.g. task_newtask ftrace event on Linux/Android). |
+| end_ts | LONG | The end timestamp of this thread (if known). Is null in most cases unless a thread destruction event is enabled (e.g. sched_process_free ftrace event on Linux/Android). |
+| upid | LONG | The process hosting this thread. |
+| is_main_thread | BOOL | Boolean indicating if this thread is the main thread in the process. |
+| machine_id | INT | Machine identifier, non-null for threads on a remote machine. |
+
+<br />
+
+<br />
+
+<br />
+
+**process**. Contains information of processes seen during the trace.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the process. Prefer using `upid` instead. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| upid | LONG | Unique process id. This is != the OS pid. This is a monotonic number associated to each process. The OS process id (pid) cannot be used as primary key because tids and pids are recycled by most kernels. |
+| pid | LONG | The OS id for this process. Note: this is *not* unique over the lifetime of the trace so cannot be used as a primary key. Use \|upid\| instead. |
+| name | STRING | The name of the process. Can be populated from many sources (e.g. ftrace, /proc scraping, track event etc). |
+| start_ts | LONG | The start timestamp of this process (if known). Is null in most cases unless a process creation event is enabled (e.g. task_newtask ftrace event on Linux/Android). |
+| end_ts | LONG | The end timestamp of this process (if known). Is null in most cases unless a process destruction event is enabled (e.g. sched_process_free ftrace event on Linux/Android). |
+| parent_upid | INT | The upid of the process which caused this process to be spawned. |
+| uid | INT | The Unix user id of the process. |
+| android_appid | INT | Android appid of this process. |
+| cmdline | STRING | /proc/cmdline for this process. |
+| arg_set_id | INT | Extra args for this process. |
+| machine_id | INT | Machine identifier, non-null for processes on a remote machine. |
+
+<br />
+
+<br />
+
+<br />
+
+**args**. Arbitrary key-value pairs which allow adding metadata to other, strongly typed tables. Note: for a given row, only one of \|int_value\|, \|string_value\|, \|real_value\| will be non-null.
+
+<br />
+
+VIEW
+Arbitrary key-value pairs which allow adding metadata to other, strongly
+typed tables.
+Note: for a given row, only one of \|int_value\|, \|string_value\|, \|real_value\|
+will be non-null.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the arg. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| arg_set_id | INT | The id for a single set of arguments. |
+| flat_key | STRING | The "flat key" of the arg: this is the key without any array indexes. |
+| key | STRING | The key for the arg. |
+| int_value | LONG | The integer value of the arg. |
+| string_value | STRING | The string value of the arg. |
+| real_value | DOUBLE | The double value of the arg. |
+| value_type | STRING | The type of the value of the arg. Will be one of 'int', 'uint', 'string', 'real', 'pointer', 'bool' or 'json'. |
+| display_value | STRING | The human-readable formatted value of the arg. |
+
+<br />
+
+<br />
+
+<br />
+
+**perf_session**. Contains the Linux perf sessions in the trace.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the perf session. Prefer using `perf_session_id` instead. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| perf_session_id | INT | The id of the perf session. |
+| cmdline | STRING | Command line used to collect the data. |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**slice_is_ancestor** -\> BOOL. Given two slice ids, returns whether the first is an ancestor of the second.
+
+<br />
+
+<br />
+
+<br />
+
+Returns BOOL: Whether `ancestor_id` slice is an ancestor of `descendant_id`.
+
+| Argument | Type | Description |
+|---|---|---|
+| ancestor_id | LONG | Id of the potential ancestor slice. |
+| descendant_id | LONG | Id of the potential descendant slice. |
+
+<br />
+
+<br />
+
+<br />
+
+**trace_start** -\> LONG. Fetch start of the trace.
+
+<br />
+
+<br />
+
+<br />
+
+Returns LONG: Start of the trace in nanoseconds.
+
+<br />
+
+<br />
+
+<br />
+
+**trace_end** -\> LONG. Fetch end of the trace.
+
+<br />
+
+<br />
+
+<br />
+
+Returns LONG: End of the trace in nanoseconds.
+
+<br />
+
+<br />
+
+<br />
+
+**trace_dur** -\> LONG. Fetch duration of the trace.
+
+<br />
+
+<br />
+
+<br />
+
+Returns LONG: Duration of the trace in nanoseconds.
+
+<br />
+
+<br />
+
+#### Macros
+
+<br />
+
+**cast_int** . Casts \|value\| to INT.
+
+<br />
+
+<br />
+
+<br />
+
+Returns: Expr,
+
+| Argument | Type | Description |
+|---|---|---|
+| value | Expr | Query or subquery that will be cast. |
+
+<br />
+
+<br />
+
+<br />
+
+**cast_double** . Casts \|value\| to DOUBLE.
+
+<br />
+
+<br />
+
+<br />
+
+Returns: Expr,
+
+| Argument | Type | Description |
+|---|---|---|
+| value | Expr | Query or subquery that will be cast. |
+
+<br />
+
+<br />
+
+<br />
+
+**cast_string** . Casts \|value\| to STRING.
+
+<br />
+
+<br />
+
+<br />
+
+Returns: Expr,
+
+| Argument | Type | Description |
+|---|---|---|
+| value | Expr | Query or subquery that will be cast. |
+
+<br />
+
+<br />
+
+## Package: v8
+
+### v8.jit
+
+#### Views/Tables
+
+<br />
+
+**v8_isolate**. A V8 Isolate instance
+
+<br />
+
+VIEW
+A V8 Isolate instance. A V8 Isolate represents an isolated instance of the V8
+engine.
+
+| Column | Type | Description |
+|---|---|---|
+| v8_isolate_id | UINT | Unique V8 isolate id. |
+| upid | UINT | Process the isolate was created in. |
+| internal_isolate_id | UINT | Internal id used by the v8 engine. Unique in a process. |
+| embedded_blob_code_start_address | LONG | Absolute start address of the embedded code blob. |
+| embedded_blob_code_size | LONG | Size in bytes of the embedded code blob. |
+| code_range_base_address | LONG | Base address of the code range if the isolate defines one. |
+| code_range_size | LONG | Size of a code range if the isolate defines one. |
+| shared_code_range | LONG | Whether the code range for this Isolate is shared with others in the same process. There is at max one such shared code range per process. |
+| embedded_blob_code_copy_start_address | LONG | Used when short builtin calls are enabled, where embedded builtins are copied into the CodeRange so calls can be nearer. |
+
+<br />
+
+<br />
+
+<br />
+
+**v8_js_script**. Represents a script that was compiled to generate code
+
+<br />
+
+VIEW
+Represents a script that was compiled to generate code. Some V8 code is
+generated out of scripts and will reference a V8Script other types of code
+will not (e.g. builtins).
+
+| Column | Type | Description |
+|---|---|---|
+| v8_js_script_id | UINT | Unique V8 JS script id. |
+| v8_isolate_id | UINT | V8 isolate this script belongs to (joinable with `v8_isolate.v8_isolate_id`). |
+| internal_script_id | UINT | Script id used by the V8 engine. |
+| script_type | STRING | Script type. |
+| name | STRING | Script name. |
+| source | STRING | Actual contents of the script. |
+
+<br />
+
+<br />
+
+<br />
+
+**v8_wasm_script**. Represents one WASM script.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| v8_wasm_script_id | UINT | Unique V8 WASM script id. |
+| v8_isolate_id | UINT | V8 Isolate this script belongs to (joinable with `v8_isolate.v8_isolate_id`). |
+| internal_script_id | UINT | Script id used by the V8 engine. |
+| url | STRING | URL of the source. |
+| source | STRING | Actual contents of the script. |
+
+<br />
+
+<br />
+
+<br />
+
+**v8_js_function**. Represents a v8 Javascript function.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| v8_js_function_id | UINT | Unique V8 JS function id. |
+| name | STRING | Function name. |
+| v8_js_script_id | UINT | Script where the function is defined (joinable with `v8_js_script.v8_js_script_id`). |
+| is_toplevel | BOOL | Whether this function represents the top level script. |
+| kind | STRING | Function kind (e.g. regular function or constructor). |
+| line | UINT | Line in script where function is defined. Starts at 1. |
+| col | UINT | Column in script where function is defined. Starts at 1. |
+
+<br />
+
+<br />
+
+## Package: wattson
+
+### wattson.system_state
+
+#### Views/Tables
+
+<br />
+
+**wattson_system_states**. The final system state for the CPU subsystem, which has all the information needed by Wattson to estimate energy for the CPU subsystem.
+
+<br />
+
+TABLE
+The final system state for the CPU subsystem, which has all the information
+needed by Wattson to estimate energy for the CPU subsystem.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | LONG | Starting timestamp of the current counter where system state is constant. |
+| dur | INT | Duration of the current counter where system state is constant. |
+| l3_hit_count | INT | Number of L3 hits the current system state. |
+| l3_miss_count | INT | Number of L3 misses in the current system state. |
+| freq_0 | INT | Frequency of CPU0. |
+| idle_0 | INT | Idle state of CPU0. |
+| freq_1 | INT | Frequency of CPU1. |
+| idle_1 | INT | Idle state of CPU1. |
+| freq_2 | INT | Frequency of CPU2. |
+| idle_2 | INT | Idle state of CPU2. |
+| freq_3 | INT | Frequency of CPU3. |
+| idle_3 | INT | Idle state of CPU3. |
+| freq_4 | INT | Frequency of CPU4. |
+| idle_4 | INT | Idle state of CPU4. |
+| freq_5 | INT | Frequency of CPU5. |
+| idle_5 | INT | Idle state of CPU5. |
+| freq_6 | INT | Frequency of CPU6. |
+| idle_6 | INT | Idle state of CPU6. |
+| freq_7 | INT | Frequency of CPU7. |
+| idle_7 | INT | Idle state of CPU7. |
+| suspended | BOOL | Flag indicating if current system state is suspended. |
+
+<br />
+
+<br />
+
+## Package: stacks
+
+### stacks.cpu_profiling
+
+#### Views/Tables
+
+<br />
+
+**cpu_profiling_samples**. Table containing all the timestamped samples of CPU profiling which occurred during the trace. Currently, this table is backed by the following data sources: \* Linux perf \* macOS instruments \* Chrome CPU profiling \* Legacy V8 CPU profiling \* Profiling data in Gecko traces
+
+<br />
+
+TABLE
+Table containing all the timestamped samples of CPU profiling which occurred
+during the trace.
+
+Currently, this table is backed by the following data sources:
+\* Linux perf
+\* macOS instruments
+\* Chrome CPU profiling
+\* Legacy V8 CPU profiling
+\* Profiling data in Gecko traces
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the sample. |
+| ts | INT | The timestamp of the sample. |
+| utid | INT | The utid of the thread of the sample, if available. |
+| tid | INT | The tid of the sample, if available. |
+| thread_name | STRING | The thread name of thread of the sample, if available. |
+| ucpu | INT | The ucpu of the sample, if available. |
+| cpu | INT | The cpu of the sample, if available. |
+| callsite_id | INT | The callsite id of the sample. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_profiling_summary_tree** . Table summarising the callstacks captured during any CPU profiling which occurred during the trace. Specifically, this table returns a tree containing all the callstacks seen during the trace with `self_count` equal to the number of samples with that frame as the leaf and `cumulative_count` equal to the number of samples with the frame anywhere in the tree. The data sources supported are the same as the `cpu_profiling_samples` table.
+
+<br />
+
+TABLE
+Table summarising the callstacks captured during any CPU profiling which
+occurred during the trace.
+
+Specifically, this table returns a tree containing all the callstacks seen
+during the trace with `self_count` equal to the number of samples with that
+frame as the leaf and `cumulative_count` equal to the number of samples with
+the frame anywhere in the tree.
+
+The data sources supported are the same as the `cpu_profiling_samples` table.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the callstack; by callstack we mean a unique set of frames up to the root frame. |
+| parent_id | INT | The id of the parent callstack for this callstack. NULL if this is root. |
+| name | STRING | The function name of the frame for this callstack. |
+| mapping_name | STRING | The name of the mapping containing the frame. This can be a native binary, library, JAR or APK. |
+| source_file | STRING | The name of the file containing the function. |
+| line_number | INT | The line number in the file the function is located at. |
+| self_count | INT | The number of samples with this function as the leaf frame. |
+| cumulative_count | INT | The number of samples with this function appearing anywhere on the callstack. |
+
+<br />
+
+<br />
+
+## Package: pkvm
+
+### pkvm.hypervisor
+
+#### Views/Tables
+
+<br />
+
+**pkvm_hypervisor_events**. Events when CPU entered hypervisor.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| slice_id | INT | Id of the corresponding slice in slices table. |
+| cpu | INT | CPU that entered hypervisor. |
+| ts | INT | Timestamp when CPU entered hypervisor (in nanoseconds). |
+| dur | INT | How much time CPU spent in hypervisor (in nanoseconds). |
+| reason | STRING | Reason for entering hypervisor (e.g. host_hcall, host_mem_abort), or NULL if unknown. |
+
+<br />
+
+<br />
+
+## Package: slices
+
+### slices.cpu_time
+
+#### Views/Tables
+
+<br />
+
+**thread_slice_cpu_time**. Time each thread slice spent running on CPU. Requires scheduling data to be available in the trace.
+
+<br />
+
+TABLE
+Time each thread slice spent running on CPU.
+Requires scheduling data to be available in the trace.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Id of a slice. Alias of `slice.id`. |
+| name | STRING | Name of the slice. |
+| utid | INT | Id of the thread the slice is running on. Alias of `thread.id`. |
+| thread_name | STRING | Name of the thread. |
+| upid | INT | Id of the process the slice is running on. Alias of `process.id`. |
+| process_name | STRING | Name of the process. |
+| cpu_time | INT | Duration of the time the slice was running. |
+
+<br />
+
+<br />
+
+<br />
+
+**thread_slice_cpu_cycles**. CPU cycles per each slice.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Id of a slice. Alias of `slice.id`. |
+| name | STRING | Name of the slice. |
+| utid | INT | Id of the thread the slice is running on. Alias of `thread.id`. |
+| thread_name | STRING | Name of the thread. |
+| upid | INT | Id of the process the slice is running on. Alias of `process.id`. |
+| process_name | STRING | Name of the process. |
+| millicycles | INT | Sum of CPU millicycles. Null if frequency couldn't be fetched for any period during the runtime of the slice. |
+| megacycles | INT | Sum of CPU megacycles. Null if frequency couldn't be fetched for any period during the runtime of the slice. |
+
+<br />
+
+<br />
+
+### slices.with_context
+
+#### Views/Tables
+
+<br />
+
+**thread_slice**. All thread slices with data about thread, thread track and process. Where possible, use available view functions which filter this view.
+
+<br />
+
+VIEW
+All thread slices with data about thread, thread track and process.
+Where possible, use available view functions which filter this view.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Alias for `slice.id`. |
+| type | STRING | Alias for `slice.type`. |
+| ts | INT | Alias for `slice.ts`. |
+| dur | INT | Alias for `slice.dur`. |
+| category | STRING | Alias for `slice.category`. |
+| name | STRING | Alias for `slice.name`. |
+| track_id | INT | Alias for `slice.track_id`. |
+| track_name | STRING | Alias for `thread_track.name`. |
+| thread_name | STRING | Alias for `thread.name`. |
+| utid | INT | Alias for `thread.utid`. |
+| tid | INT | Alias for `thread.tid`. |
+| is_main_thread | BOOL | Alias for `thread.is_main_thread`. |
+| process_name | STRING | Alias for `process.name`. |
+| upid | INT | Alias for `process.upid`. |
+| pid | INT | Alias for `process.pid`. |
+| depth | INT | Alias for `slice.depth`. |
+| parent_id | INT | Alias for `slice.parent_id`. |
+| arg_set_id | INT | Alias for `slice.arg_set_id`. |
+| thread_ts | INT | Alias for `slice.thread_ts`. |
+| thread_dur | INT | Alias for `slice.thread_dur`. |
+
+<br />
+
+<br />
+
+<br />
+
+**process_slice**. All process slices with data about process track and process. Where possible, use available view functions which filter this view.
+
+<br />
+
+VIEW
+All process slices with data about process track and process.
+Where possible, use available view functions which filter this view.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Alias for `slice.id`. |
+| type | STRING | Alias for `slice.type`. |
+| ts | INT | Alias for `slice.ts`. |
+| dur | INT | Alias for `slice.dur`. |
+| category | STRING | Alias for `slice.category`. |
+| name | STRING | Alias for `slice.name`. |
+| track_id | INT | Alias for `slice.track_id`. |
+| track_name | STRING | Alias for `process_track.name`. |
+| process_name | STRING | Alias for `process.name`. |
+| upid | INT | Alias for `process.upid`. |
+| pid | INT | Alias for `process.pid`. |
+| depth | INT | Alias for `slice.depth`. |
+| parent_id | INT | Alias for `slice.parent_id`. |
+| arg_set_id | INT | Alias for `slice.arg_set_id`. |
+| thread_ts | INT | Alias for `slice.thread_ts`. |
+| thread_dur | INT | Alias for `slice.thread_dur`. |
+
+<br />
+
+<br />
+
+## Package: sched
+
+### sched.runnable
+
+#### Views/Tables
+
+<br />
+
+**sched_previous_runnable_on_thread**. Previous runnable slice on the same thread. For each "Running" thread state finds: - previous "Runnable" (or runnable preempted) state. - previous uninterrupted "Runnable" state with a valid waker thread.
+
+<br />
+
+TABLE
+Previous runnable slice on the same thread.
+For each "Running" thread state finds:
+- previous "Runnable" (or runnable preempted) state.
+- previous uninterrupted "Runnable" state with a valid waker thread.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | `thread_state.id` id. |
+| prev_runnable_id | INT | Previous runnable `thread_state.id`. |
+| prev_wakeup_runnable_id | INT | Previous runnable `thread_state.id` with valid waker thread. |
+
+<br />
+
+<br />
+
+### sched.states
+
+#### Functions
+
+<br />
+
+**sched_state_to_human_readable_string** -\> STRING. Translates a single-letter scheduling state to a human-readable string.
+
+<br />
+
+<br />
+
+<br />
+
+Returns STRING: Humanly readable string representing the scheduling state of the kernel thread. The individual characters in the string mean the following: R (runnable), S (awaiting a wakeup), D (in an uninterruptible sleep), T (suspended), t (being traced), X (exiting), P (parked), W (waking), I (idle), N (not contributing to the load average), K (wakeable on fatal signals) and Z (zombie, awaiting cleanup).
+
+| Argument | Type | Description |
+|---|---|---|
+| short_name | STRING | An individual character string representing the scheduling state of the kernel thread at the end of the slice. |
+
+<br />
+
+<br />
+
+<br />
+
+**sched_state_io_to_human_readable_string** -\> STRING. Translates a single-letter scheduling state and IO wait information to a human-readable string.
+
+<br />
+
+<br />
+
+<br />
+
+Translates a single-letter scheduling state and IO wait information to
+a human-readable string.
+Returns STRING: A human readable string with information about the scheduling state and IO wait.
+
+| Argument | Type | Description |
+|---|---|---|
+| sched_state | STRING | An individual character string representing the scheduling state of the kernel thread at the end of the slice. |
+| io_wait | BOOL | A (posssibly NULL) boolean indicating, if the device was in uninterruptible sleep, if it was an IO sleep. |
+
+<br />
+
+<br />
+
+### sched.thread_level_parallelism
+
+#### Views/Tables
+
+<br />
+
+**sched_runnable_thread_count**. The count of runnable threads over time.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp when the runnable thread count changed to the current value. |
+| runnable_thread_count | INT | Number of runnable threads, covering the range from this timestamp to the next row's timestamp. |
+
+<br />
+
+<br />
+
+<br />
+
+**sched_active_cpu_count**. The count of active CPUs over time.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp when the number of active CPU changed. |
+| active_cpu_count | INT | Number of active CPUs, covering the range from this timestamp to the next row's timestamp. |
+
+<br />
+
+<br />
+
+### sched.time_in_state
+
+#### Views/Tables
+
+<br />
+
+**sched_time_in_state_for_thread**. The time a thread spent in each scheduling state during it's lifetime.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| utid | INT | Utid of the thread. |
+| total_runtime | INT | Total runtime of thread. |
+| state | STRING | One of the scheduling states of kernel thread. |
+| time_in_state | INT | Total time spent in the scheduling state. |
+| percentage_in_state | INT | Percentage of time thread spent in scheduling state in \[0-100\] range. |
+
+<br />
+
+<br />
+
+<br />
+
+**sched_percentage_of_time_in_state**. Summary of time spent by thread in each scheduling state, in percentage (\[0, 100\] ranges)
+
+<br />
+
+TABLE
+Summary of time spent by thread in each scheduling state, in percentage (\[0, 100\]
+ranges). Sum of all states might be smaller than 100, as those values
+are rounded down.
+
+| Column | Type | Description |
+|---|---|---|
+| utid | INT | Utid of the thread. |
+| running | INT | Percentage of time thread spent in running ('Running') state in \[0, 100\] range. |
+| runnable | INT | Percentage of time thread spent in runnable ('R') state in \[0, 100\] range. |
+| runnable_preempted | INT | Percentage of time thread spent in preempted runnable ('R+') state in \[0, 100\] range. |
+| sleeping | INT | Percentage of time thread spent in sleeping ('S') state in \[0, 100\] range. |
+| uninterruptible_sleep | INT | Percentage of time thread spent in uninterruptible sleep ('D') state in \[0, 100\] range. |
+| other | INT | Percentage of time thread spent in other ('T', 't', 'X', 'Z', 'x', 'I', 'K', 'W', 'P', 'N') states in \[0, 100\] range. |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**sched_time_in_state_for_thread_in_interval** . Time the thread spent each state in a given interval.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| ts | INT | The start of the interval. |
+| dur | INT | The duration of the interval. |
+| utid | INT | The utid of the thread. |
+
+| Column | Type | Description |
+|---|---|---|
+| state | INT | Thread state (from the `thread_state` table). Use `sched_state_to_human_readable_string` function to get full name. |
+| io_wait | BOOL | A (posssibly NULL) boolean indicating, if the device was in uninterruptible sleep, if it was an IO sleep. |
+| blocked_function | INT | Some states can specify the blocked function. Usually NULL. |
+| dur | INT | Total time spent with this state, cpu and blocked function. |
+
+<br />
+
+<br />
+
+<br />
+
+**sched_time_in_state_and_cpu_for_thread_in_interval** . Time the thread spent each state and cpu in a given interval.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| ts | INT | The start of the interval. |
+| dur | INT | The duration of the interval. |
+| utid | INT | The utid of the thread. |
+
+| Column | Type | Description |
+|---|---|---|
+| state | INT | Thread state (from the `thread_state` table). Use `sched_state_to_human_readable_string` function to get full name. |
+| io_wait | BOOL | A (posssibly NULL) boolean indicating, if the device was in uninterruptible sleep, if it was an IO sleep. |
+| cpu | INT | Id of the CPU. |
+| blocked_function | INT | Some states can specify the blocked function. Usually NULL. |
+| dur | INT | Total time spent with this state, cpu and blocked function. |
+
+<br />
+
+<br />
+
+<br />
+
+**sched_time_in_state_for_cpu_in_interval** . Time spent by CPU in each scheduling state in a provided interval.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| cpu | INT | CPU id. |
+| ts | INT | Interval start. |
+| dur | INT | Interval duration. |
+
+| Column | Type | Description |
+|---|---|---|
+| end_state | STRING | End state. From `sched.end_state`. |
+| dur | INT | Duration in state. |
+
+<br />
+
+<br />
+
+## Package: intervals
+
+### intervals.overlap
+
+#### Macros
+
+<br />
+
+**intervals_overlap_count** . Compute the distribution of the overlap of the given intervals over time. Each interval is a (ts, dur) pair and the overlap represented as a (ts, value) counter, with the value corresponding to the number of intervals that overlap the given timestamp and interval until the next timestamp.
+
+<br />
+
+<br />
+
+<br />
+
+Compute the distribution of the overlap of the given intervals over time.
+
+Each interval is a (ts, dur) pair and the overlap represented as a (ts, value)
+counter, with the value corresponding to the number of intervals that overlap
+the given timestamp and interval until the next timestamp.
+Returns: TableOrSubquery, The returned table has the schema (ts INT64, value UINT32). \|ts\| is the timestamp when the number of open segments changed. \|value\| is the number of open segments.
+
+| Argument | Type | Description |
+|---|---|---|
+| segments | TableOrSubquery | Table or subquery containing interval data. |
+| ts_column | ColumnName | Column containing interval starts (usually `ts`). |
+| dur_column | ColumnName | Column containing interval durations (usually `dur`). |
+
+<br />
+
+<br />
+
+## Package: time
+
+### time.conversion
+
+#### Functions
+
+<br />
+
+**time_from_ns** -\> INT. Returns the provided nanosecond duration, which is the default representation of time durations in trace processor
+
+<br />
+
+<br />
+
+<br />
+
+Returns the provided nanosecond duration, which is the default
+representation of time durations in trace processor. Provided for
+consistency with other functions.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_from_us** -\> INT. Converts a duration in microseconds to nanoseconds, which is the default representation of time durations in trace processor.
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in microseconds to nanoseconds, which is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| micros | INT | Time duration in microseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_from_ms** -\> INT. Converts a duration in millseconds to nanoseconds, which is the default representation of time durations in trace processor.
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in millseconds to nanoseconds, which is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| millis | INT | Time duration in milliseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_from_s** -\> INT. Converts a duration in seconds to nanoseconds, which is the default representation of time durations in trace processor.
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in seconds to nanoseconds, which is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| seconds | INT | Time duration in seconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_from_min** -\> INT. Converts a duration in minutes to nanoseconds, which is the default representation of time durations in trace processor.
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in minutes to nanoseconds, which is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| minutes | INT | Time duration in minutes. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_from_hours** -\> INT. Converts a duration in hours to nanoseconds, which is the default representation of time durations in trace processor.
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in hours to nanoseconds, which is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| hours | INT | Time duration in hours. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_from_days** -\> INT. Converts a duration in days to nanoseconds, which is the default representation of time durations in trace processor.
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in days to nanoseconds, which is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| days | INT | Time duration in days. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_to_ns** -\> INT. Returns the provided nanosecond duration, which is the default representation of time durations in trace processor
+
+<br />
+
+<br />
+
+<br />
+
+Returns the provided nanosecond duration, which is the default
+representation of time durations in trace processor. Provided for
+consistency with other functions.
+Returns INT: Time duration in nanoseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_to_us** -\> INT. Converts a duration in nanoseconds to microseconds
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in nanoseconds to microseconds. Nanoseconds is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in microseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_to_ms** -\> INT. Converts a duration in nanoseconds to millseconds
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in nanoseconds to millseconds. Nanoseconds is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in milliseconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_to_s** -\> INT. Converts a duration in nanoseconds to seconds
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in nanoseconds to seconds. Nanoseconds is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in seconds.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_to_min** -\> INT. Converts a duration in nanoseconds to minutes
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in nanoseconds to minutes. Nanoseconds is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in minutes.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_to_hours** -\> INT. Converts a duration in nanoseconds to hours
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in nanoseconds to hours. Nanoseconds is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in hours.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+<br />
+
+**time_to_days** -\> INT. Converts a duration in nanoseconds to days
+
+<br />
+
+<br />
+
+<br />
+
+Converts a duration in nanoseconds to days. Nanoseconds is the default
+representation of time durations in trace processor.
+Returns INT: Time duration in days.
+
+| Argument | Type | Description |
+|---|---|---|
+| nanos | INT | Time duration in nanoseconds. |
+
+<br />
+
+<br />
+
+## Package: linux
+
+### linux.cpu.frequency
+
+#### Views/Tables
+
+<br />
+
+**cpu_frequency_counters**. Counter information for each frequency change for each CPU
+
+<br />
+
+TABLE
+Counter information for each frequency change for each CPU. Finds each time
+region where a CPU frequency is constant.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Counter id. |
+| track_id | INT | Joinable with 'counter_track.id'. |
+| ts | LONG | Starting timestamp of the counter |
+| dur | INT | Duration in which counter is constant and frequency doesn't change. |
+| freq | INT | Frequency in kHz of the CPU that corresponds to this counter. NULL if not found or undefined. |
+| ucpu | INT | Unique CPU id. |
+| cpu | INT | CPU that corresponds to this counter. |
+
+<br />
+
+<br />
+
+### linux.cpu.idle
+
+#### Views/Tables
+
+<br />
+
+**cpu_idle_counters**. Counter information for each idle state change for each CPU
+
+<br />
+
+TABLE
+Counter information for each idle state change for each CPU. Finds each time
+region where a CPU idle state is constant.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Counter id. |
+| track_id | INT | Joinable with 'counter_track.id'. |
+| ts | LONG | Starting timestamp of the counter. |
+| dur | INT | Duration in which the counter is contant and idle state doesn't change. |
+| idle | INT | Idle state of the CPU that corresponds to this counter. An idle state of -1 is defined to be active state for the CPU, and the larger the integer, the deeper the idle state of the CPU. NULL if not found or undefined. |
+| cpu | INT | CPU that corresponds to this counter. |
+
+<br />
+
+<br />
+
+### linux.cpu.idle_stats
+
+#### Views/Tables
+
+<br />
+
+**cpu_idle_stats**. Aggregates cpu idle statistics per core.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| cpu | INT | CPU core number. |
+| state | INT | CPU idle state (C-states). |
+| count | INT | The count of entering idle state. |
+| dur | INT | Total CPU core idle state duration in nanoseconds. |
+| avg_dur | INT | Average CPU core idle state duration in nanoseconds. |
+| idle_percent | FLOAT | Idle state percentage of non suspend time (C-states + P-states). |
+
+<br />
+
+<br />
+
+### linux.cpu.idle_time_in_state
+
+#### Views/Tables
+
+<br />
+
+**cpu_idle_time_in_state_counters**. Counter information for sysfs cpuidle states. Tracks the percentage of time spent in each state between two timestamps, by dividing the incremental time spent in one state, by time all CPUS spent in any state.
+
+<br />
+
+TABLE
+Counter information for sysfs cpuidle states.
+Tracks the percentage of time spent in each state between two timestamps, by
+dividing the incremental time spent in one state, by time all CPUS spent in
+any state.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | LONG | Timestamp. |
+| state_name | STRING | State name. |
+| idle_percentage | DOUBLE | Percentage of time all CPUS spent in this state. |
+| total_residency | DOUBLE | Incremental time spent in this state (residency), in microseconds. |
+| time_slice | INT | Time all CPUS spent in any state, in microseconds. |
+
+<br />
+
+<br />
+
+### linux.cpu.utilization.process
+
+#### Views/Tables
+
+<br />
+
+**cpu_cycles_per_process**. Aggregated CPU statistics for each process.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| upid | INT | Unique process id |
+| millicycles | INT | Sum of CPU millicycles |
+| megacycles | INT | Sum of CPU megacycles |
+| runtime | INT | Total runtime duration |
+| min_freq | INT | Minimum CPU frequency in kHz |
+| max_freq | INT | Maximum CPU frequency in kHz |
+| avg_freq | INT | Average CPU frequency in kHz |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**cpu_process_utilization_per_period** . Returns a table of process utilization per given period. Utilization is calculated as sum of average utilization of each CPU in each period, which is defined as a multiply of \|interval\|
+
+<br />
+
+<br />
+
+<br />
+
+Returns a table of process utilization per given period.
+Utilization is calculated as sum of average utilization of each CPU in each
+period, which is defined as a multiply of \|interval\|. For this reason
+first and last period might have lower then real utilization.
+Argument \| Type \| Description
+--- \| --- \| ---
+interval \| INT \| Length of the period on which utilization should be averaged.
+upid \| INT \| Upid of the process.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp of start of a second. |
+| utilization | DOUBLE | Sum of average utilization over period. Note: as the data is normalized, the values will be in the \[0, 1\] range. |
+| unnormalized_utilization | DOUBLE | Sum of average utilization over all CPUs over period. Note: as the data is unnormalized, the values will be in the \[0, cpu_count\] range. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_process_utilization_per_second** . Returns a table of process utilization per second. Utilization is calculated as sum of average utilization of each CPU in each period, which is defined as a multiply of \|interval\|
+
+<br />
+
+<br />
+
+<br />
+
+Returns a table of process utilization per second.
+Utilization is calculated as sum of average utilization of each CPU in each
+period, which is defined as a multiply of \|interval\|. For this reason
+first and last period might have lower then real utilization.
+Argument \| Type \| Description
+--- \| --- \| ---
+upid \| INT \| Upid of the process.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp of start of a second. |
+| utilization | DOUBLE | Sum of average utilization over period. Note: as the data is normalized, the values will be in the \[0, 1\] range. |
+| unnormalized_utilization | DOUBLE | Sum of average utilization over all CPUs over period. Note: as the data is unnormalized, the values will be in the \[0, cpu_count\] range. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_cycles_per_process_in_interval** . Aggregated CPU statistics for each process in a provided interval.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| ts | INT | Start of the interval. |
+| dur | INT | Duration of the interval. |
+
+| Column | Type | Description |
+|---|---|---|
+| upid | INT | Unique process id. Joinable with `process.id`. |
+| millicycles | INT | Sum of CPU millicycles |
+| megacycles | INT | Sum of CPU megacycles |
+| runtime | INT | Total runtime duration |
+| min_freq | INT | Minimum CPU frequency in kHz |
+| max_freq | INT | Maximum CPU frequency in kHz |
+| avg_freq | INT | Average CPU frequency in kHz |
+
+<br />
+
+<br />
+
+### linux.cpu.utilization.slice
+
+#### Views/Tables
+
+<br />
+
+**cpu_cycles_per_thread_slice**. CPU cycles per each slice.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Id of a slice. Alias of `slice.id`. |
+| name | STRING | Name of the slice. |
+| utid | INT | Id of the thread the slice is running on. Alias of `thread.id`. |
+| thread_name | STRING | Name of the thread. |
+| upid | INT | Id of the process the slice is running on. Alias of `process.id`. |
+| process_name | STRING | Name of the process. |
+| millicycles | INT | Sum of CPU millicycles. Null if frequency couldn't be fetched for any period during the runtime of the slice. |
+| megacycles | INT | Sum of CPU megacycles. Null if frequency couldn't be fetched for any period during the runtime of the slice. |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**cpu_cycles_per_thread_slice_in_interval** . CPU cycles per each slice in interval.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| ts | INT | Start of the interval. |
+| dur | INT | Duration of the interval. |
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Id of a slice. Alias of `slice.id`. |
+| name | STRING | Name of the slice. |
+| utid | INT | Id of the thread the slice is running on. Alias of `thread.id`. |
+| thread_name | STRING | Name of the thread. |
+| upid | INT | Id of the process the slice is running on. Alias of `process.id`. |
+| process_name | STRING | Name of the process. |
+| millicycles | INT | Sum of CPU millicycles. Null if frequency couldn't be fetched for any period during the runtime of the slice. |
+| megacycles | INT | Sum of CPU megacycles. Null if frequency couldn't be fetched for any period during the runtime of the slice. |
+
+<br />
+
+<br />
+
+### linux.cpu.utilization.system
+
+#### Views/Tables
+
+<br />
+
+**cpu_utilization_per_second**. Table with system utilization per second. Utilization is calculated by sum of average utilization of each CPU every second
+
+<br />
+
+TABLE
+Table with system utilization per second.
+Utilization is calculated by sum of average utilization of each CPU every
+second. For this reason first and last second might have lower then real
+utilization.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp of start of a second. |
+| utilization | DOUBLE | Sum of average utilization over period. Note: as the data is normalized, the values will be in the \[0, 1\] range. |
+| unnormalized_utilization | DOUBLE | Sum of average utilization over all CPUs over period. Note: as the data is unnormalized, the values will be in the \[0, cpu_count\] range. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_cycles**. Aggregated CPU statistics for whole trace
+
+<br />
+
+TABLE
+Aggregated CPU statistics for whole trace. Results in only one row.
+
+| Column | Type | Description |
+|---|---|---|
+| millicycles | INT | Sum of CPU millicycles. |
+| megacycles | INT | Sum of CPU megacycles. |
+| runtime | INT | Total runtime of all threads running on all CPUs. |
+| min_freq | INT | Minimum CPU frequency in kHz. |
+| max_freq | INT | Maximum CPU frequency in kHz. |
+| avg_freq | INT | Average CPU frequency in kHz. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_cycles_per_cpu**. Aggregated CPU statistics for each CPU.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| ucpu | INT | Unique CPU id. Joinable with `cpu.id`. |
+| cpu | INT | The number of the CPU. Might not be the same as ucpu in multi machine cases. |
+| millicycles | INT | Sum of CPU millicycles. |
+| megacycles | INT | Sum of CPU megacycles. |
+| runtime | INT | Total runtime of all threads running on CPU. |
+| min_freq | INT | Minimum CPU frequency in kHz. |
+| max_freq | INT | Maximum CPU frequency in kHz. |
+| avg_freq | INT | Average CPU frequency in kHz. |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**cpu_utilization_per_period** . Returns a table of system utilization per given period. Utilization is calculated as sum of average utilization of each CPU in each period, which is defined as a multiply of \|interval\|
+
+<br />
+
+<br />
+
+<br />
+
+Returns a table of system utilization per given period.
+Utilization is calculated as sum of average utilization of each CPU in each
+period, which is defined as a multiply of \|interval\|. For this reason
+first and last period might have lower then real utilization.
+Argument \| Type \| Description
+--- \| --- \| ---
+interval \| INT \| Length of the period on which utilization should be averaged.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp of start of a second. |
+| utilization | DOUBLE | Sum of average utilization over period. Note: as the data is normalized, the values will be in the \[0, 1\] range. |
+| unnormalized_utilization | DOUBLE | Sum of average utilization over all CPUs over period. Note: as the data is unnormalized, the values will be in the \[0, cpu_count\] range. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_cycles_in_interval** . Aggregated CPU statistics in a provided interval
+
+<br />
+
+<br />
+
+<br />
+
+Aggregated CPU statistics in a provided interval. Results in one row.
+Argument \| Type \| Description
+--- \| --- \| ---
+ts \| INT \| Start of the interval.
+dur \| INT \| Duration of the interval.
+
+| Column | Type | Description |
+|---|---|---|
+| millicycles | INT | Sum of CPU millicycles. |
+| megacycles | INT | Sum of CPU megacycles. |
+| runtime | INT | Total runtime of all threads running on all CPUs. |
+| min_freq | INT | Minimum CPU frequency in kHz. |
+| max_freq | INT | Maximum CPU frequency in kHz. |
+| avg_freq | INT | Average CPU frequency in kHz. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_cycles_per_cpu_in_interval** . Aggregated CPU statistics for each CPU in a provided interval.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| ts | INT | Start of the interval. |
+| dur | INT | Duration of the interval. |
+
+| Column | Type | Description |
+|---|---|---|
+| ucpu | INT | Unique CPU id. Joinable with `cpu.id`. |
+| cpu | INT | CPU number. |
+| millicycles | INT | Sum of CPU millicycles. |
+| megacycles | INT | Sum of CPU megacycles. |
+| runtime | INT | Total runtime of all threads running on CPU. |
+| min_freq | INT | Minimum CPU frequency in kHz. |
+| max_freq | INT | Maximum CPU frequency in kHz. |
+| avg_freq | INT | Average CPU frequency in kHz. |
+
+<br />
+
+<br />
+
+### linux.cpu.utilization.thread
+
+#### Views/Tables
+
+<br />
+
+**cpu_cycles_per_thread**. Aggregated CPU statistics for each thread.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| utid | INT | Unique thread id |
+| millicycles | INT | Sum of CPU millicycles |
+| megacycles | INT | Sum of CPU megacycles |
+| runtime | INT | Total runtime duration |
+| min_freq | INT | Minimum CPU frequency in kHz |
+| max_freq | INT | Maximum CPU frequency in kHz |
+| avg_freq | INT | Average CPU frequency in kHz |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**cpu_thread_utilization_per_period** . Returns a table of thread utilization per given period. Utilization is calculated as sum of average utilization of each CPU in each period, which is defined as a multiply of \|interval\|
+
+<br />
+
+<br />
+
+<br />
+
+Returns a table of thread utilization per given period.
+Utilization is calculated as sum of average utilization of each CPU in each
+period, which is defined as a multiply of \|interval\|. For this reason
+first and last period might have lower then real utilization.
+Argument \| Type \| Description
+--- \| --- \| ---
+interval \| INT \| Length of the period on which utilization should be averaged.
+utid \| INT \| Utid of the thread.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp of start of a second. |
+| utilization | DOUBLE | Sum of average utilization over period. Note: as the data is normalized, the values will be in the \[0, 1\] range. |
+| unnormalized_utilization | DOUBLE | Sum of average utilization over all CPUs over period. Note: as the data is unnormalized, the values will be in the \[0, cpu_count\] range. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_thread_utilization_per_second** . Returns a table of thread utilization per second. Utilization is calculated as sum of average utilization of each CPU in each period, which is defined as a multiply of \|interval\|
+
+<br />
+
+<br />
+
+<br />
+
+Returns a table of thread utilization per second.
+Utilization is calculated as sum of average utilization of each CPU in each
+period, which is defined as a multiply of \|interval\|. For this reason
+first and last period might have lower then real utilization.
+Argument \| Type \| Description
+--- \| --- \| ---
+utid \| INT \| Utid of the thread.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp of start of a second. |
+| utilization | DOUBLE | Sum of average utilization over period. Note: as the data is normalized, the values will be in the \[0, 1\] range. |
+| unnormalized_utilization | DOUBLE | Sum of average utilization over all CPUs over period. Note: as the data is unnormalized, the values will be in the \[0, cpu_count\] range. |
+
+<br />
+
+<br />
+
+<br />
+
+**cpu_cycles_per_thread_in_interval** . Aggregated CPU statistics for each thread in a provided interval.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| ts | INT | Start of the interval. |
+| dur | INT | Duration of the interval. |
+
+| Column | Type | Description |
+|---|---|---|
+| utid | INT | Unique thread id. Joinable with `thread.id`. |
+| millicycles | INT | Sum of CPU millicycles |
+| megacycles | INT | Sum of CPU megacycles |
+| runtime | INT | Total runtime duration |
+| min_freq | INT | Minimum CPU frequency in kHz |
+| max_freq | INT | Maximum CPU frequency in kHz |
+| avg_freq | INT | Average CPU frequency in kHz |
+
+<br />
+
+<br />
+
+### linux.devfreq
+
+#### Views/Tables
+
+<br />
+
+**linux_devfreq_dsu_counter**. ARM DSU device frequency counters
+
+<br />
+
+TABLE
+ARM DSU device frequency counters. This table will only be populated on
+traces collected with "devfreq/devfreq_frequency" ftrace event enabled,
+and from ARM devices with the DSU (DynamIQ Shared Unit) hardware.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Unique identifier for this counter. |
+| ts | LONG | Starting timestamp of the counter. |
+| dur | INT | Duration in which counter is constant and frequency doesn't chamge. |
+| dsu_freq | INT | Frequency in kHz of the device that corresponds to the counter. |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**linux_get_devfreq_counters** . Gets devfreq frequency counter based on device queried
+
+<br />
+
+<br />
+
+<br />
+
+Gets devfreq frequency counter based on device queried. These counters will
+only be available if the "devfreq/devfreq_frequency" ftrace event is enabled.
+Argument \| Type \| Description
+--- \| --- \| ---
+device_name \| STRING \| Devfreq name to query for.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Unique identifier for this counter. |
+| ts | LONG | Starting timestamp of the counter. |
+| dur | INT | Duration in which counter is constant and frequency doesn't chamge. |
+| freq | INT | Frequency in kHz of the device that corresponds to the counter. |
+
+<br />
+
+<br />
+
+### linux.memory.high_watermark
+
+#### Views/Tables
+
+<br />
+
+**memory_rss_high_watermark_per_process**. For each process fetches the memory high watermark until or during timestamp.
+
+<br />
+
+VIEW
+For each process fetches the memory high watermark until or during
+timestamp.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp |
+| dur | INT | Duration |
+| upid | INT | Upid of the process |
+| pid | INT | Pid of the process |
+| process_name | STRING | Name of the process |
+| rss_high_watermark | INT | Maximum `rss` value until now |
+
+<br />
+
+<br />
+
+### linux.memory.process
+
+#### Views/Tables
+
+<br />
+
+**memory_rss_and_swap_per_process**. Memory metrics timeline for each process.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp |
+| dur | INT | Duration |
+| upid | INT | Upid of the process |
+| pid | INT | Pid of the process |
+| process_name | STRING | Name of the process |
+| anon_rss | INT | Anon RSS counter value |
+| file_rss | INT | File RSS counter value |
+| shmem_rss | INT | Shared memory RSS counter value |
+| rss | INT | Total RSS value. Sum of `anon_rss`, `file_rss` and `shmem_rss`. Returns value even if one of the values is NULL. |
+| swap | INT | Swap counter value |
+| anon_rss_and_swap | INT | Sum or `anon_rss` and `swap`. Returns value even if one of the values is NULL. |
+| rss_and_swap | INT | Sum or `rss` and `swap`. Returns value even if one of the values is NULL. |
+
+<br />
+
+<br />
+
+### linux.perf.samples
+
+#### Views/Tables
+
+<br />
+
+**linux_perf_samples_summary_tree** . Table summarising the callstacks captured during all perf samples in the trace. Specifically, this table returns a tree containing all the callstacks seen during the trace with `self_count` equal to the number of samples with that frame as the leaf and `cumulative_count` equal to the number of samples with the frame anywhere in the tree.
+
+<br />
+
+TABLE
+Table summarising the callstacks captured during all
+perf samples in the trace.
+
+Specifically, this table returns a tree containing all
+the callstacks seen during the trace with `self_count`
+equal to the number of samples with that frame as the
+leaf and `cumulative_count` equal to the number of
+samples with the frame anywhere in the tree.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The id of the callstack. A callstack in this context is a unique set of frames up to the root. |
+| parent_id | INT | The id of the parent callstack for this callstack. |
+| name | STRING | The function name of the frame for this callstack. |
+| mapping_name | STRING | The name of the mapping containing the frame. This can be a native binary, library, JAR or APK. |
+| source_file | STRING | The name of the file containing the function. |
+| line_number | INT | The line number in the file the function is located at. |
+| self_count | INT | The number of samples with this function as the leaf frame. |
+| cumulative_count | INT | The number of samples with this function appearing anywhere on the callstack. |
+
+<br />
+
+<br />
+
+### linux.perf.spe
+
+#### Views/Tables
+
+<br />
+
+**linux_perf_spe_record**. Contains ARM Statistical Profiling Extension records
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| ts | LONG | Timestap when the operation was sampled |
+| utid | INT | Thread the operation executed in |
+| exception_level | STRING | Exception level the instruction was executed in |
+| instruction_frame_id | INT | Instruction virtual address |
+| operation | STRING | Type of operation sampled |
+| data_virtual_address | LONG | The virtual address accessed by the operation (0 if no memory access was performed) |
+| data_physical_address | LONG | The physical address accessed by the operation (0 if no memory access was performed) |
+| total_latency | INT | Cycle count from the operation being dispatched for issue to the operation being complete. |
+| issue_latency | INT | Cycle count from the operation being dispatched for issue to the operation being issued for execution. |
+| translation_latency | INT | Cycle count from a virtual address being passed to the MMU for translation to the result of the translation being available. |
+| data_source | STRING | Where the data returned for a load operation was sourced |
+| exception_gen | BOOL | Operation generated an exception |
+| retired | BOOL | Operation architecturally retired |
+| l1d_access | BOOL | Operation caused a level 1 data cache access |
+| l1d_refill | BOOL | Operation caused a level 1 data cache refill |
+| tlb_access | BOOL | Operation caused a TLB access |
+| tlb_refill | BOOL | Operation caused a TLB refill involving at least one translation table walk |
+| not_taken | BOOL | Conditional instruction failed its condition code check |
+| mispred | BOOL | Whether a branch caused a correction to the predicted program flow |
+| llc_access | BOOL | Operation caused a last level data or unified cache access |
+| llc_refill | BOOL | Whether the operation could not be completed by the last level data cache (or any above) |
+| remote_access | BOOL | Operation caused an access to another socket in a multi-socket system |
+| alignment | BOOL | Operation that incurred additional latency due to the alignment of the address and the size of the data being accessed |
+| tme_transaction | BOOL | Whether the operation executed in transactional state |
+| sve_partial_pred | BOOL | SVE or SME operation with at least one false element in the governing predicate(s) |
+| sve_empty_pred | BOOL | SVE or SME operation with no true element in the governing predicate(s) |
+| l2d_access | BOOL | Whether a load operation caused a cache access to at least the level 2 data or unified cache |
+| l2d_hit | BOOL | Whether a load operation accessed and missed the level 2 data or unified cache. Not set for accesses that are satisfied from refilling data of a previous miss |
+| cache_data_modified | BOOL | Whether a load operation accessed modified data in a cache |
+| recenty_fetched | BOOL | Wheter a load operation hit a recently fetched line in a cache |
+| data_snooped | BOOL | Whether a load operation snooped data from a cache outside the cache hierarchy of this core |
+
+<br />
+
+<br />
+
+### linux.threads
+
+#### Views/Tables
+
+<br />
+
+**linux_kernel_threads**. All kernel threads of the trace
+
+<br />
+
+TABLE
+All kernel threads of the trace. As kernel threads are processes, provides
+also process data.
+
+| Column | Type | Description |
+|---|---|---|
+| upid | INT | Upid of kernel thread. Alias of \|process.upid\|. |
+| utid | INT | Utid of kernel thread. Alias of \|thread.utid\|. |
+| pid | INT | Pid of kernel thread. Alias of \|process.pid\|. |
+| tid | INT | Tid of kernel thread. Alias of \|process.pid\|. |
+| process_name | STRING | Name of kernel process. Alias of \|process.name\|. |
+| thread_name | STRING | Name of kernel thread. Alias of \|thread.name\|. |
+| machine_id | INT | Machine id of kernel thread. If NULL then it's a single machine trace. Alias of \|process.machine_id\|. |
+
+<br />
+
+<br />
+
+## Package: android
+
+### android.anrs
+
+#### Views/Tables
+
+<br />
+
+**android_anrs**. List of all ANRs that occurred in the trace (one row per ANR).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| process_name | STRING | Name of the process that triggered the ANR. |
+| pid | INT | PID of the process that triggered the ANR. |
+| upid | INT | UPID of the process that triggered the ANR. |
+| error_id | STRING | UUID of the ANR (generated on the platform). |
+| ts | INT | Timestamp of the ANR. |
+| subject | STRING | Subject line of the ANR. |
+
+<br />
+
+<br />
+
+### android.app_process_starts
+
+#### Views/Tables
+
+<br />
+
+**android_app_process_starts**. All app cold starts with information about their cold start reason: broadcast, service, activity or provider.
+
+<br />
+
+TABLE
+All app cold starts with information about their cold start reason:
+broadcast, service, activity or provider.
+
+| Column | Type | Description |
+|---|---|---|
+| start_id | INT | Slice id of the bindApplication slice in the app. Uniquely identifies a process start. |
+| id | INT | Slice id of intent received in the app. |
+| track_id | INT | Track id of the intent received in the app. |
+| process_name | STRING | Name of the process receiving the intent. |
+| pid | INT | Pid of the process receiving the intent. |
+| upid | INT | Upid of the process receiving the intent. |
+| intent | STRING | Intent action or component responsible for the cold start. |
+| reason | STRING | Process start reason: activity, broadcast, service or provider. |
+| proc_start_ts | INT | Timestamp the process start was dispatched from system_server. |
+| proc_start_dur | INT | Duration to dispatch the process start from system_server. |
+| bind_app_ts | INT | Timestamp the bindApplication started in the app. |
+| bind_app_dur | INT | Duration to complete bindApplication in the app. |
+| intent_ts | INT | Timestamp the Intent was received in the app. |
+| intent_dur | INT | Duration to handle intent in the app. |
+| total_dur | INT | Total duration from proc_start dispatched to intent completed. |
+
+<br />
+
+<br />
+
+### android.auto.multiuser
+
+#### Views/Tables
+
+<br />
+
+**android_auto_multiuser_timing**. Time elapsed between the latest user start and the specific end event like package startup(ex carlauncher) or previous user stop.
+
+<br />
+
+TABLE
+Time elapsed between the latest user start
+and the specific end event
+like package startup(ex carlauncher) or previous user stop.
+
+| Column | Type | Description |
+|---|---|---|
+| event_start_user_id | STRING | Id of the started android user |
+| event_start_time | INT | Start event time |
+| event_end_time | INT | End event time |
+| event_end_name | STRING | End event name |
+| event_start_name | STRING | Start event name |
+| duration | LONG | User switch duration from start event to end event |
+
+<br />
+
+<br />
+
+<br />
+
+**android_auto_multiuser_timing_with_previous_user_resource_usage** . This table extends `android_auto_multiuser_timing` table with previous user resource usage.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| event_start_user_id | STRING | Start user id |
+| event_start_time | INT | Start event time |
+| event_end_time | INT | End event time |
+| event_end_name | STRING | End event name |
+| event_start_name | STRING | Start event name |
+| duration | LONG | User switch duration from start event to end event |
+| user_id | INT | User id |
+| total_cpu_time | LONG | Total CPU time for a user |
+| total_memory_usage_kb | LONG | Total memory user for a user |
+
+<br />
+
+<br />
+
+### android.battery
+
+#### Views/Tables
+
+<br />
+
+**android_battery_charge**. Battery charge at timestamp.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp. |
+| current_avg_ua | DOUBLE | Current average micro ampers. |
+| capacity_percent | DOUBLE | Current capacity percentage. |
+| charge_uah | DOUBLE | Current charge in micro ampers. |
+| current_ua | DOUBLE | Current micro ampers. |
+
+<br />
+
+<br />
+
+### android.battery_stats
+
+#### Views/Tables
+
+<br />
+
+**android_battery_stats_state**. View of human readable battery stats counter-based states
+
+<br />
+
+VIEW
+View of human readable battery stats counter-based states. These are recorded
+by BatteryStats as a bitmap where each 'category' has a unique value at any
+given time.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp in nanoseconds. |
+| dur | INT | The duration the state was active, may be negative for incomplete slices. |
+| safe_dur | INT | The same as `dur`, but extends to trace end for incomplete slices. |
+| track_name | STRING | The name of the counter track. |
+| value | INT | The counter value as a number. |
+| value_name | STRING | The counter value as a human-readable string. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_battery_stats_event_slices**. View of slices derived from battery_stats events
+
+<br />
+
+VIEW
+View of slices derived from battery_stats events. Battery stats records all
+events as instants, however some may indicate whether something started or
+stopped with a '+' or '-' prefix. Events such as jobs, top apps, foreground
+apps or long wakes include these details and allow drawing slices between
+instant events found in a trace.
+
+For example, we may see an event like the following on 'battery_stats.top':
+
+     -top=10215:"com.google.android.apps.nexuslauncher"
+
+This view will find the associated start ('+top') with the matching suffix
+(everything after the '=') to construct a slice. It computes the timestamp
+and duration from the events and extract the details as follows:
+
+     track_name='battery_stats.top'
+     str_value='com.google.android.apps.nexuslauncher'
+     int_value=10215
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp in nanoseconds. |
+| dur | INT | The duration the state was active, may be negative for incomplete slices. |
+| safe_dur | INT | The same as `dur`, but extends to trace end for incomplete slices. |
+| track_name | STRING | The name of the counter track. |
+| str_value | STRING | String value. |
+| int_value | INT | Int value. |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**android_battery_stats_counter_to_string** -\> STRING. Converts a battery_stats counter value to human readable string.
+
+<br />
+
+<br />
+
+<br />
+
+Returns STRING: The human-readable name for the counter value.
+
+| Argument | Type | Description |
+|---|---|---|
+| track | STRING | The counter track name (e.g. 'battery_stats.audio'). |
+| value | FLOAT | The counter value. |
+
+<br />
+
+<br />
+
+### android.binder
+
+#### Views/Tables
+
+<br />
+
+**android_binder_metrics_by_process**. Count Binder transactions per process.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| process_name | STRING | Name of the process that started the binder transaction. |
+| pid | INT | PID of the process that started the binder transaction. |
+| slice_name | STRING | Name of the slice with binder transaction. |
+| event_count | INT | Number of binder transactions in process in slice. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_sync_binder_thread_state_by_txn**. Aggregated thread_states on the client and server side per binder txn This builds on the data from \|_sync_binder_metrics_by_txn\| and for each end (client and server) of the transaction, it returns the aggregated sum of all the thread state durations. The \|thread_state_type\| column represents whether a given 'aggregated thread_state' row is on the client or server side
+
+<br />
+
+VIEW
+Aggregated thread_states on the client and server side per binder txn
+This builds on the data from \|_sync_binder_metrics_by_txn\| and
+for each end (client and server) of the transaction, it returns
+the aggregated sum of all the thread state durations.
+The \|thread_state_type\| column represents whether a given 'aggregated thread_state'
+row is on the client or server side. 'binder_txn' is client side and 'binder_reply'
+is server side.
+
+| Column | Type | Description |
+|---|---|---|
+| binder_txn_id | INT | slice id of the binder txn |
+| client_ts | INT | Client timestamp |
+| client_tid | INT | Client tid |
+| binder_reply_id | INT | slice id of the binder reply |
+| server_ts | INT | Server timestamp |
+| server_tid | INT | Server tid |
+| thread_state_type | STRING | whether thread state is on the txn or reply side |
+| thread_state | STRING | a thread_state that occurred in the txn |
+| thread_state_dur | INT | aggregated dur of the \|thread_state\| in the txn |
+| thread_state_count | INT | aggregated count of the \|thread_state\| in the txn |
+
+<br />
+
+<br />
+
+<br />
+
+**android_sync_binder_blocked_functions_by_txn**. Aggregated blocked_functions on the client and server side per binder txn This builds on the data from \|_sync_binder_metrics_by_txn\| and for each end (client and server) of the transaction, it returns the aggregated sum of all the kernel blocked function durations. The \|thread_state_type\| column represents whether a given 'aggregated blocked_function' row is on the client or server side
+
+<br />
+
+VIEW
+Aggregated blocked_functions on the client and server side per binder txn
+This builds on the data from \|_sync_binder_metrics_by_txn\| and
+for each end (client and server) of the transaction, it returns
+the aggregated sum of all the kernel blocked function durations.
+The \|thread_state_type\| column represents whether a given 'aggregated blocked_function'
+row is on the client or server side. 'binder_txn' is client side and 'binder_reply'
+is server side.
+
+| Column | Type | Description |
+|---|---|---|
+| binder_txn_id | INT | slice id of the binder txn |
+| client_ts | INT | Client ts |
+| client_tid | INT | Client tid |
+| binder_reply_id | INT | slice id of the binder reply |
+| server_ts | INT | Server ts |
+| server_tid | INT | Server tid |
+| thread_state_type | STRING | whether thread state is on the txn or reply side |
+| blocked_function | STRING | blocked kernel function in a thread state |
+| blocked_function_dur | INT | aggregated dur of the \|blocked_function\| in the txn |
+| blocked_function_count | INT | aggregated count of the \|blocked_function\| in the txn |
+
+<br />
+
+<br />
+
+<br />
+
+**android_binder_txns**. Breakdown binder transactions per txn. It returns data about the client and server ends of every binder transaction async.
+
+<br />
+
+TABLE
+Breakdown binder transactions per txn.
+It returns data about the client and server ends of every binder transaction async.
+
+| Column | Type | Description |
+|---|---|---|
+| aidl_name | STRING | name of the binder interface if existing. |
+| aidl_ts | INT | Timestamp the binder interface name was emitted. Proxy to 'ts' and 'dur' for async txns. |
+| aidl_dur | INT | Duration of the binder interface name. Proxy to 'ts' and 'dur' for async txns. |
+| binder_txn_id | INT | slice id of the binder txn. |
+| client_process | STRING | name of the client process. |
+| client_thread | STRING | name of the client thread. |
+| client_upid | INT | Upid of the client process. |
+| client_utid | INT | Utid of the client thread. |
+| client_tid | INT | Tid of the client thread. |
+| client_pid | INT | Pid of the client thread. |
+| is_main_thread | BOOL | Whether the txn was initiated from the main thread of the client process. |
+| client_ts | INT | timestamp of the client txn. |
+| client_dur | INT | wall clock dur of the client txn. |
+| binder_reply_id | INT | slice id of the binder reply. |
+| server_process | STRING | name of the server process. |
+| server_thread | STRING | name of the server thread. |
+| server_upid | INT | Upid of the server process. |
+| server_utid | INT | Utid of the server thread. |
+| server_tid | INT | Tid of the server thread. |
+| server_pid | INT | Pid of the server thread. |
+| server_ts | INT | timestamp of the server txn. |
+| server_dur | INT | wall clock dur of the server txn. |
+| client_oom_score | INT | oom score of the client process at the start of the txn. |
+| server_oom_score | INT | oom score of the server process at the start of the reply. |
+| is_sync | BOOL | whether the txn is synchronous or async (oneway). |
+| client_monotonic_dur | INT | monotonic clock dur of the client txn. |
+| server_monotonic_dur | INT | monotonic clock dur of the server txn. |
+| client_package_version_code | INT | Client package version_code. |
+| server_package_version_code | INT | Server package version_code. |
+| is_client_package_debuggable | INT | Whether client package is debuggable. |
+| is_server_package_debuggable | INT | Whether server package is debuggable. |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**android_binder_outgoing_graph** . Returns a DAG of all outgoing binder txns from a process. The roots of the graph are the threads making the txns and the graph flows from: thread -\> server_process -\> AIDL interface -\> AIDL method. The weights of each node represent the wall execution time in the server_process.
+
+<br />
+
+<br />
+
+<br />
+
+Returns a DAG of all outgoing binder txns from a process.
+The roots of the graph are the threads making the txns and the graph flows from:
+thread -\> server_process -\> AIDL interface -\> AIDL method.
+The weights of each node represent the wall execution time in the server_process.
+Argument \| Type \| Description
+--- \| --- \| ---
+upid \| INT \| Upid of process to generate an outgoing graph for.
+
+| Column | Type | Description |
+|---|---|---|
+| pprof | BYTES | Pprof of outgoing binder txns. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_binder_incoming_graph** . Returns a DAG of all incoming binder txns from a process. The roots of the graph are the clients making the txns and the graph flows from: client_process -\> AIDL interface -\> AIDL method. The weights of each node represent the wall execution time in the server_process.
+
+<br />
+
+<br />
+
+<br />
+
+Returns a DAG of all incoming binder txns from a process.
+The roots of the graph are the clients making the txns and the graph flows from:
+client_process -\> AIDL interface -\> AIDL method.
+The weights of each node represent the wall execution time in the server_process.
+Argument \| Type \| Description
+--- \| --- \| ---
+upid \| INT \| Upid of process to generate an incoming graph for.
+
+| Column | Type | Description |
+|---|---|---|
+| pprof | BYTES | Pprof of incoming binder txns. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_binder_graph** . Returns a graph of all binder txns in a trace. The nodes are client_process and server_process. The weights of each node represent the wall execution time in the server_process.
+
+<br />
+
+<br />
+
+<br />
+
+Returns a graph of all binder txns in a trace.
+The nodes are client_process and server_process.
+The weights of each node represent the wall execution time in the server_process.
+Argument \| Type \| Description
+--- \| --- \| ---
+min_client_oom_score \| INT \| Matches txns from client_processes greater than or equal to the OOM score.
+max_client_oom_score \| INT \| Matches txns from client_processes less than or equal to the OOM score.
+min_server_oom_score \| INT \| Matches txns to server_processes greater than or equal to the OOM score.
+max_server_oom_score \| INT \| Matches txns to server_processes less than or equal to the OOM score.
+
+| Column | Type | Description |
+|---|---|---|
+| pprof | BYTES | Pprof of binder txns. |
+
+<br />
+
+<br />
+
+### android.binder_breakdown
+
+#### Views/Tables
+
+<br />
+
+**android_binder_server_breakdown**. Server side binder breakdowns per transactions per txn.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| binder_txn_id | INT | Client side id of the binder txn. Alias of `slice.id`. |
+| binder_reply_id | INT | Server side id of the binder txn. Alias of `slice.id`. |
+| ts | INT | Timestamp of an exclusive interval during the binder reply with a single reason. |
+| dur | INT | Duration of an exclusive interval during the binder reply with a single reason. |
+| reason | STRING | Cause of delay during an exclusive interval of the binder reply. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_binder_client_breakdown**. Client side binder breakdowns per transactions per txn.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| binder_txn_id | INT | Client side id of the binder txn. Alias of `slice.id`. |
+| binder_reply_id | INT | Server side id of the binder txn. Alias of `slice.id`. |
+| ts | INT | Timestamp of an exclusive interval during the binder txn with a single latency reason. |
+| dur | INT | Duration of an exclusive interval during the binder txn with a single latency reason. |
+| reason | STRING | Cause of delay during an exclusive interval of the binder txn. |
+
+<br />
+
+<br />
+
+### android.cpu.cluster_type
+
+#### Views/Tables
+
+<br />
+
+**android_cpu_cluster_mapping**. Stores the mapping of a cpu to its cluster type - e.g
+
+<br />
+
+TABLE
+Stores the mapping of a cpu to its cluster type - e.g. little, medium, big.
+This cluster type is determined by initially using cpu_capacity from sysfs
+and grouping clusters with identical capacities, ordered by size.
+In the case that capacities are not present, max frequency is used instead.
+If nothing is avaiable, NULL is returned.
+
+| Column | Type | Description |
+|---|---|---|
+| ucpu | INT | Alias of `cpu.ucpu`. |
+| cpu | INT | Alias of `cpu.cpu`. |
+| cluster_type | STRING | The cluster type of the CPU. |
+
+<br />
+
+<br />
+
+### android.device
+
+#### Views/Tables
+
+<br />
+
+**android_device_name**. Extract name of the device based on metadata from the trace.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | Device name. |
+
+<br />
+
+<br />
+
+### android.dvfs
+
+#### Views/Tables
+
+<br />
+
+**android_dvfs_counters**. Dvfs counter with duration.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | Counter name. |
+| ts | INT | Timestamp when counter value changed. |
+| value | DOUBLE | Counter value. |
+| dur | INT | Counter duration. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_dvfs_counter_stats**. Aggregates dvfs counter slice for statistic.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | Counter name on which all the other values are aggregated on. |
+| max | DOUBLE | Max of all counter values for the counter name. |
+| min | DOUBLE | Min of all counter values for the counter name. |
+| dur | INT | Duration between the first and last counter value for the counter name. |
+| wgt_avg | FLOAT | Weighted avergate of all the counter values for the counter name. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_dvfs_counter_residency**. Aggregates dvfs counter slice for residency
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | Counter name. |
+| value | DOUBLE | Counter value. |
+| dur | INT | Counter duration. |
+| pct | DOUBLE | Counter duration as a percentage of total duration. |
+
+<br />
+
+<br />
+
+### android.frames.jank_type
+
+#### Functions
+
+<br />
+
+**android_is_sf_jank_type** -\> BOOL. Categorizes whether the jank was caused by Surface Flinger
+
+<br />
+
+<br />
+
+<br />
+
+Returns BOOL: True when the jank type represents sf jank
+
+| Argument | Type | Description |
+|---|---|---|
+| jank_type | STRING | the jank type from args.display_value with key = "Jank type" |
+
+<br />
+
+<br />
+
+<br />
+
+**android_is_app_jank_type** -\> BOOL. Categorizes whether the jank was caused by the app
+
+<br />
+
+<br />
+
+<br />
+
+Returns BOOL: True when the jank type represents app jank
+
+| Argument | Type | Description |
+|---|---|---|
+| jank_type | STRING | the jank type from args.display_value with key = "Jank type" |
+
+<br />
+
+<br />
+
+### android.frames.per_frame_metrics
+
+#### Views/Tables
+
+<br />
+
+**android_frames_overrun**. The amount by which each frame missed of hit its deadline
+
+<br />
+
+TABLE
+The amount by which each frame missed of hit its deadline. Negative if the
+deadline was not missed. Frames are considered janky if `overrun` is
+positive.
+Calculated as the difference between the end of the
+`expected_frame_timeline_slice` and `actual_frame_timeline_slice` for the
+frame.
+Availability: from S (API 31).
+For Googlers: more details in go/android-performance-metrics-glossary.
+
+| Column | Type | Description |
+|---|---|---|
+| frame_id | INT | Frame id. |
+| overrun | INT | Difference between `expected` and `actual` frame ends. Negative if frame didn't miss deadline. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_frames_ui_time**. How much time did the frame's Choreographer callbacks take.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| frame_id | INT | Frame id |
+| ui_time | INT | UI time duration |
+
+<br />
+
+<br />
+
+<br />
+
+**android_app_vsync_delay_per_frame**. App Vsync delay for a frame
+
+<br />
+
+TABLE
+App Vsync delay for a frame. The time between the VSYNC-app signal and the
+start of Choreographer work.
+Calculated as time difference between the actual frame start (from
+`actual_frame_timeline_slice`) and start of the `Choreographer#doFrame`
+slice.
+For Googlers: more details in go/android-performance-metrics-glossary.
+
+| Column | Type | Description |
+|---|---|---|
+| frame_id | INT | Frame id |
+| app_vsync_delay | INT | App VSYNC delay. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_cpu_time_per_frame** . How much time did the frame take across the UI Thread + RenderThread. Calculated as sum of `app VSYNC delay` `Choreographer#doFrame` slice duration and summed durations of all `DrawFrame` slices associated with this frame. Availability: from N (API 24). For Googlers: more details in go/android-performance-metrics-glossary.
+
+<br />
+
+TABLE
+How much time did the frame take across the UI Thread + RenderThread.
+Calculated as sum of `app VSYNC delay` `Choreographer#doFrame` slice
+duration and summed durations of all `DrawFrame` slices associated with this
+frame.
+Availability: from N (API 24).
+For Googlers: more details in go/android-performance-metrics-glossary.
+
+| Column | Type | Description |
+|---|---|---|
+| frame_id | INT | Frame id |
+| app_vsync_delay | INT | Difference between actual timeline of the frame and `Choreographer#doFrame`. See `android_app_vsync_delay_per_frame` table for more details. |
+| do_frame_dur | INT | Duration of `Choreographer#doFrame` slice. |
+| draw_frame_dur | INT | Duration of `DrawFrame` slice. Summed duration of all `DrawFrame` slices, if more than one. See `android_frames_draw_frame` for more details. |
+| cpu_time | INT | CPU time across the UI Thread + RenderThread. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_frame_stats**. Aggregated stats of the frame. For Googlers: more details in go/android-performance-metrics-glossary.
+
+<br />
+
+TABLE
+Aggregated stats of the frame.
+
+For Googlers: more details in go/android-performance-metrics-glossary.
+
+| Column | Type | Description |
+|---|---|---|
+| frame_id | INT | Frame id. |
+| overrun | INT | The amount by which each frame missed of hit its deadline. See `android_frames_overrun` for details. |
+| cpu_time | INT | How much time did the frame take across the UI Thread + RenderThread. |
+| ui_time | INT | How much time did the frame's Choreographer callbacks take. |
+| was_jank | BOOL | Was frame janky. |
+| was_slow_frame | BOOL | CPU time of the frame took over 20ms. |
+| was_big_jank | BOOL | CPU time of the frame took over 50ms. |
+| was_huge_jank | BOOL | CPU time of the frame took over 200ms. |
+
+<br />
+
+<br />
+
+### android.frames.timeline
+
+#### Views/Tables
+
+<br />
+
+**android_frames_choreographer_do_frame** . All of the `Choreographer#doFrame` slices with their frame id.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | `slice.id` |
+| frame_id | INT | Frame id |
+| ui_thread_utid | INT | Utid of the UI thread |
+| upid | INT | Upid of application process |
+| ts | INT | Timestamp of the slice. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_frames_draw_frame** . All of the `DrawFrame` slices with their frame id and render thread. There might be multiple DrawFrames slices for a single vsync (frame id). This happens when we are drawing multiple layers (e.g
+
+<br />
+
+TABLE
+All of the `DrawFrame` slices with their frame id and render thread.
+There might be multiple DrawFrames slices for a single vsync (frame id).
+This happens when we are drawing multiple layers (e.g. status bar and
+notifications).
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | `slice.id` |
+| frame_id | INT | Frame id |
+| render_thread_utid | INT | Utid of the render thread |
+| upid | INT | Upid of application process |
+
+<br />
+
+<br />
+
+<br />
+
+**android_frames**. All slices related to one frame
+
+<br />
+
+TABLE
+All slices related to one frame. Aggregates `Choreographer#doFrame`,
+`DrawFrame`, `actual_frame_timeline_slice` and
+`expected_frame_timeline_slice` slices.
+See https://perfetto.dev/docs/data-sources/frametimeline for details.
+
+| Column | Type | Description |
+|---|---|---|
+| frame_id | INT | Frame id. |
+| ts | INT | Timestamp of the frame. Start of the frame as defined by the start of "Choreographer#doFrame" slice and the same as the start of the frame in \`actual_frame_timeline_slice if present. |
+| dur | INT | Duration of the frame, as defined by the duration of the corresponding `actual_frame_timeline_slice` or, if not present the time between the `ts` and the end of the final `DrawFrame`. |
+| do_frame_id | INT | `slice.id` of "Choreographer#doFrame" slice. |
+| draw_frame_id | INT | `slice.id` of "DrawFrame" slice. |
+| actual_frame_timeline_id | INT | `slice.id` from `actual_frame_timeline_slice` |
+| expected_frame_timeline_id | INT | `slice.id` from `expected_frame_timeline_slice` |
+| render_thread_utid | INT | `utid` of the render thread. |
+| ui_thread_utid | INT | `utid` of the UI thread. |
+| actual_frame_timeline_count | INT | Count of slices in `actual_frame_timeline_slice` related to this frame. |
+| expected_frame_timeline_count | INT | Count of slices in `expected_frame_timeline_slice` related to this frame. |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**android_first_frame_after** . Returns first frame after the provided timestamp
+
+<br />
+
+<br />
+
+<br />
+
+Returns first frame after the provided timestamp. The returning table has at
+most one row.
+Argument \| Type \| Description
+--- \| --- \| ---
+ts \| INT \| Timestamp.
+
+| Column | Type | Description |
+|---|---|---|
+| frame_id | INT | Frame id. |
+| ts | INT | Start of the frame, the timestamp of the "Choreographer#doFrame" slice. |
+| dur | INT | Duration of the frame. |
+| do_frame_id | INT | `slice.id` of "Choreographer#doFrame" slice. |
+| draw_frame_id | INT | `slice.id` of "DrawFrame" slice. |
+| actual_frame_timeline_id | INT | `slice.id` from `actual_frame_timeline_slice` |
+| expected_frame_timeline_id | INT | `slice.id` from `expected_frame_timeline_slice` |
+| render_thread_utid | INT | `utid` of the render thread. |
+| ui_thread_utid | INT | `utid` of the UI thread. |
+
+<br />
+
+<br />
+
+### android.freezer
+
+#### Views/Tables
+
+<br />
+
+**android_freezer_events**. All frozen processes and their frozen duration.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| upid | INT | Upid of frozen process |
+| pid | INT | Pid of frozen process |
+| ts | INT | Timestamp process was frozen. |
+| dur | INT | Duration process was frozen for. |
+| unfreeze_reason_int | INT | Unfreeze reason Integer. |
+| unfreeze_reason_str | STRING | Unfreeze reason String. |
+
+<br />
+
+<br />
+
+### android.garbage_collection
+
+#### Views/Tables
+
+<br />
+
+**android_garbage_collection_events**. All Garbage collection events with a breakdown of the time spent and heap reclaimed.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| tid | INT | Tid of thread running garbage collection. |
+| pid | INT | Pid of process running garbage collection. |
+| utid | INT | Utid of thread running garbage collection. |
+| upid | INT | Upid of process running garbage collection. |
+| thread_name | STRING | Name of thread running garbage collection. |
+| process_name | STRING | Name of process running garbage collection. |
+| gc_type | STRING | Type of garbage collection. |
+| is_mark_compact | INT | Whether gargage collection is mark compact or copying. |
+| reclaimed_mb | DOUBLE | MB reclaimed after garbage collection. |
+| min_heap_mb | DOUBLE | Minimum heap size in MB during garbage collection. |
+| max_heap_mb | DOUBLE | Maximum heap size in MB during garbage collection. |
+| gc_id | INT | Garbage collection id. |
+| gc_ts | INT | Garbage collection timestamp. |
+| gc_dur | INT | Garbage collection wall duration. |
+| gc_running_dur | INT | Garbage collection duration spent executing on CPU. |
+| gc_runnable_dur | INT | Garbage collection duration spent waiting for CPU. |
+| gc_unint_io_dur | INT | Garbage collection duration spent waiting in the Linux kernel on IO. |
+| gc_unint_non_io_dur | INT | Garbage collection duration spent waiting in the Linux kernel without IO. |
+| gc_int_dur | INT | Garbage collection duration spent waiting in interruptible sleep. |
+
+<br />
+
+<br />
+
+### android.gpu.frequency
+
+#### Views/Tables
+
+<br />
+
+**android_gpu_frequency**. GPU frequency counter per GPU.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp |
+| dur | INT | Duration |
+| gpu_id | INT | GPU id. Joinable with `gpu_counter_track.gpu_id`. |
+| gpu_freq | INT | GPU frequency |
+
+<br />
+
+<br />
+
+### android.gpu.memory
+
+#### Views/Tables
+
+<br />
+
+**android_gpu_memory_per_process**. Counter for GPU memory per process with duration.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp |
+| dur | INT | Duration |
+| upid | INT | Upid of the process |
+| gpu_memory | INT | GPU memory |
+
+<br />
+
+<br />
+
+### android.input
+
+#### Views/Tables
+
+<br />
+
+**android_input_events**. All input events with round trip latency breakdown
+
+<br />
+
+TABLE
+All input events with round trip latency breakdown. Input delivery is socket based and every
+input event sent from the OS needs to be ACK'ed by the app. This gives us 4 subevents to measure
+latencies between:
+1. Input dispatch event sent from OS.
+2. Input dispatch event received in app.
+3. Input ACK event sent from app.
+4. Input ACk event received in OS.
+
+| Column | Type | Description |
+|---|---|---|
+| dispatch_latency_dur | INT | Duration from input dispatch to input received. |
+| handling_latency_dur | INT | Duration from input received to input ACK sent. |
+| ack_latency_dur | INT | Duration from input ACK sent to input ACK recieved. |
+| total_latency_dur | INT | Duration from input dispatch to input event ACK received. |
+| end_to_end_latency_dur | INT | Duration from input read to frame present time. Null if an input event has no associated frame event. |
+| tid | INT | Tid of thread receiving the input event. |
+| thread_name | STRING | Name of thread receiving the input event. |
+| pid | INT | Pid of process receiving the input event. |
+| process_name | STRING | Name of process receiving the input event. |
+| event_type | STRING | Input event type. See InputTransport.h: InputMessage#Type |
+| event_action | STRING | Input event action. |
+| event_seq | STRING | Input event sequence number, monotonically increasing for an event channel and pid. |
+| event_channel | STRING | Input event channel name. |
+| input_event_id | STRING | Unique identifier for the input event. |
+| read_time | INT | Timestamp input event was read by InputReader. |
+| dispatch_track_id | INT | Thread track id of input event dispatching thread. |
+| dispatch_ts | INT | Timestamp input event was dispatched. |
+| dispatch_dur | INT | Duration of input event dispatch. |
+| receive_track_id | INT | Thread track id of input event receiving thread. |
+| receive_ts | INT | Timestamp input event was received. |
+| receive_dur | INT | Duration of input event receipt. |
+| frame_id | INT | Vsync Id associated with the input. Null if an input event has no associated frame event. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_key_events**. Key events processed by the Android framework (from android.input.inputevent data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | ID of the trace entry |
+| event_id | INT | The randomly-generated ID associated with each input event processed by Android Framework, used to track the event through the input pipeline |
+| ts | INT | The timestamp of when the input event was processed by the system |
+| arg_set_id | INT | Details of the input event parsed from the proto message |
+
+<br />
+
+<br />
+
+<br />
+
+**android_motion_events**. Motion events processed by the Android framework (from android.input.inputevent data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | ID of the trace entry |
+| event_id | INT | The randomly-generated ID associated with each input event processed by Android Framework, used to track the event through the input pipeline |
+| ts | INT | The timestamp of when the input event was processed by the system |
+| arg_set_id | INT | Details of the input event parsed from the proto message |
+
+<br />
+
+<br />
+
+<br />
+
+**android_input_event_dispatch**. Input event dispatching information in Android (from android.input.inputevent data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | ID of the trace entry |
+| event_id | INT | Event ID of the input event that was dispatched |
+| arg_set_id | INT | Extra args parsed from the proto message |
+| vsync_id | INT | Vsync ID that identifies the state of the windows during which the dispatch decision was made |
+| window_id | INT | Window ID of the window receiving the event |
+
+<br />
+
+<br />
+
+### android.job_scheduler
+
+#### Views/Tables
+
+<br />
+
+**android_job_scheduler_events**. All scheduled jobs and their latencies.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| job_id | INT | Id of the scheduled job assigned by the app developer. |
+| uid | INT | Uid of the process running the scheduled job. |
+| package_name | STRING | Package name of the process running the scheduled job. |
+| job_service_name | STRING | Service component name of the scheduled job. |
+| track_id | INT | Thread track id of the job scheduler event slice. |
+| id | INT | Slice id of the job scheduler event slice. |
+| ts | INT | Timestamp the job was scheduled. |
+| dur | INT | Duration of the scheduled job. |
+
+<br />
+
+<br />
+
+### android.memory.dmabuf
+
+#### Views/Tables
+
+<br />
+
+**android_dmabuf_allocs**. Track dmabuf allocations, re-attributing gralloc allocations to their source (if binder transactions to gralloc are recorded).
+
+<br />
+
+TABLE
+Track dmabuf allocations, re-attributing gralloc allocations to their source
+(if binder transactions to gralloc are recorded).
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | timestamp of the allocation |
+| buf_size | INT | allocation size (will be negative for release) |
+| inode | INT | dmabuf inode |
+| utid | INT | utid of thread responsible for the allocation if a dmabuf is allocated by gralloc we follow the binder transaction to the requesting thread (requires binder tracing) |
+| tid | INT | tid of thread responsible for the allocation |
+| thread_name | STRING | thread name |
+| upid | INT | upid of process responsible for the allocation (matches utid) |
+| pid | INT | pid of process responsible for the allocation |
+| process_name | STRING | process name |
+
+<br />
+
+<br />
+
+### android.memory.heap_graph.dominator_tree
+
+#### Views/Tables
+
+<br />
+
+**heap_graph_dominator_tree**. All reachable heap graph objects, their immediate dominators and summary of their dominated sets. The heap graph dominator tree is calculated by stdlib graphs.dominator_tree. Each reachable object is a node in the dominator tree, their immediate dominator is their parent node in the tree, and their dominated set is all their descendants in the tree
+
+<br />
+
+TABLE
+All reachable heap graph objects, their immediate dominators and summary of
+their dominated sets.
+The heap graph dominator tree is calculated by stdlib graphs.dominator_tree.
+Each reachable object is a node in the dominator tree, their immediate
+dominator is their parent node in the tree, and their dominated set is all
+their descendants in the tree. All size information come from the
+heap_graph_object prelude table.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Heap graph object id. |
+| idom_id | INT | Immediate dominator object id of the object. If the immediate dominator is the "super-root" (i.e. the object is a root or is dominated by multiple roots) then `idom_id` will be NULL. |
+| dominated_obj_count | INT | Count of all objects dominated by this object, self inclusive. |
+| dominated_size_bytes | INT | Total self_size of all objects dominated by this object, self inclusive. |
+| dominated_native_size_bytes | INT | Total native_size of all objects dominated by this object, self inclusive. |
+| depth | INT | Depth of the object in the dominator tree. Depth of root objects are 1. |
+
+<br />
+
+<br />
+
+### android.memory.heap_graph.heap_graph_class_aggregation
+
+#### Views/Tables
+
+<br />
+
+**android_heap_graph_class_aggregation**. Class-level breakdown of the java heap. Per type name aggregates the object stats and the dominator tree stats.
+
+<br />
+
+TABLE
+Class-level breakdown of the java heap.
+Per type name aggregates the object stats and the dominator tree stats.
+
+| Column | Type | Description |
+|---|---|---|
+| upid | INT | Process upid |
+| graph_sample_ts | INT | Heap dump timestamp |
+| type_id | INT | Class type id |
+| type_name | STRING | Class name (deobfuscated if available) |
+| is_libcore_or_array | BOOL | Is type an instance of a libcore object (java.\*) or array |
+| obj_count | INT | Count of class instances |
+| size_bytes | INT | Size of class instances |
+| native_size_bytes | INT | Native size of class instances |
+| reachable_obj_count | INT | Count of reachable class instances |
+| reachable_size_bytes | INT | Size of reachable class instances |
+| reachable_native_size_bytes | INT | Native size of reachable class instances |
+| dominated_obj_count | INT | Count of all objects dominated by instances of this class Only applies to reachable objects |
+| dominated_size_bytes | INT | Size of all objects dominated by instances of this class Only applies to reachable objects |
+| dominated_native_size_bytes | INT | Native size of all objects dominated by instances of this class Only applies to reachable objects |
+
+<br />
+
+<br />
+
+### android.memory.process
+
+#### Views/Tables
+
+<br />
+
+**memory_oom_score_with_rss_and_swap_per_process**. Process memory and it's OOM adjuster scores
+
+<br />
+
+TABLE
+Process memory and it's OOM adjuster scores. Detects transitions, each new
+interval means that either the memory or OOM adjuster score of the process changed.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp the oom_adj score or memory of the process changed |
+| dur | INT | Duration until the next oom_adj score or memory change of the process. |
+| score | INT | oom adjuster score of the process. |
+| bucket | STRING | oom adjuster bucket of the process. |
+| upid | INT | Upid of the process having an oom_adj update. |
+| process_name | STRING | Name of the process having an oom_adj update. |
+| pid | INT | Pid of the process having an oom_adj update. |
+| oom_adj_id | INT | Slice of the latest oom_adj update in the system_server. Alias of `slice.id`. |
+| oom_adj_ts | INT | Timestamp of the latest oom_adj update in the system_server. |
+| oom_adj_dur | INT | Duration of the latest oom_adj update in the system_server. |
+| oom_adj_track_id | INT | Track of the latest oom_adj update in the system_server. Alias of `track.id`. |
+| oom_adj_thread_name | STRING | Thread name of the latest oom_adj update in the system_server. |
+| oom_adj_reason | STRING | Reason for the latest oom_adj update in the system_server. |
+| oom_adj_trigger | STRING | Trigger for the latest oom_adj update in the system_server. |
+| anon_rss | INT | Anon RSS counter value |
+| file_rss | INT | File RSS counter value |
+| shmem_rss | INT | Shared memory RSS counter value |
+| rss | INT | Total RSS value. Sum of `anon_rss`, `file_rss` and `shmem_rss`. Returns value even if one of the values is NULL. |
+| swap | INT | Swap counter value |
+| anon_rss_and_swap | INT | Sum or `anon_rss` and `swap`. Returns value even if one of the values is NULL. |
+| rss_and_swap | INT | Sum or `rss` and `swap`. Returns value even if one of the values is NULL. |
+
+<br />
+
+<br />
+
+### android.monitor_contention
+
+#### Views/Tables
+
+<br />
+
+**android_monitor_contention**. Contains parsed monitor contention slices.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| blocking_method | STRING | Name of the method holding the lock. |
+| blocked_method | STRING | Blocked_method without arguments and return types. |
+| short_blocking_method | STRING | Blocking_method without arguments and return types. |
+| short_blocked_method | STRING | Blocked_method without arguments and return types. |
+| blocking_src | STRING | File location of blocking_method in form <filename:linenumber>. |
+| blocked_src | STRING | File location of blocked_method in form <filename:linenumber>. |
+| waiter_count | INT | Zero indexed number of threads trying to acquire the lock. |
+| blocked_utid | INT | Utid of thread holding the lock. |
+| blocked_thread_name | STRING | Thread name of thread holding the lock. |
+| blocking_utid | INT | Utid of thread holding the lock. |
+| blocking_thread_name | STRING | Thread name of thread holding the lock. |
+| blocking_tid | INT | Tid of thread holding the lock. |
+| upid | INT | Upid of process experiencing lock contention. |
+| process_name | STRING | Process name of process experiencing lock contention. |
+| id | INT | Slice id of lock contention. |
+| ts | INT | Timestamp of lock contention start. |
+| dur | INT | Wall clock duration of lock contention. |
+| monotonic_dur | INT | Monotonic clock duration of lock contention. |
+| track_id | INT | Thread track id of blocked thread. |
+| is_blocked_thread_main | INT | Whether the blocked thread is the main thread. |
+| blocked_thread_tid | INT | Tid of the blocked thread |
+| is_blocking_thread_main | INT | Whether the blocking thread is the main thread. |
+| blocking_thread_tid | INT | Tid of thread holding the lock. |
+| binder_reply_id | INT | Slice id of binder reply slice if lock contention was part of a binder txn. |
+| binder_reply_ts | INT | Timestamp of binder reply slice if lock contention was part of a binder txn. |
+| binder_reply_tid | INT | Tid of binder reply slice if lock contention was part of a binder txn. |
+| pid | INT | Pid of process experiencing lock contention. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_monitor_contention_chain**. Contains parsed monitor contention slices with the parent-child relationships.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| parent_id | INT | Id of monitor contention slice blocking this contention. |
+| blocking_method | STRING | Name of the method holding the lock. |
+| blocked_method | STRING | Blocked_method without arguments and return types. |
+| short_blocking_method | STRING | Blocking_method without arguments and return types. |
+| short_blocked_method | STRING | Blocked_method without arguments and return types. |
+| blocking_src | STRING | File location of blocking_method in form <filename:linenumber>. |
+| blocked_src | STRING | File location of blocked_method in form <filename:linenumber>. |
+| waiter_count | INT | Zero indexed number of threads trying to acquire the lock. |
+| blocked_utid | INT | Utid of thread holding the lock. |
+| blocked_thread_name | STRING | Thread name of thread holding the lock. |
+| blocking_utid | INT | Utid of thread holding the lock. |
+| blocking_thread_name | STRING | Thread name of thread holding the lock. |
+| blocking_tid | INT | Tid of thread holding the lock. |
+| upid | INT | Upid of process experiencing lock contention. |
+| process_name | STRING | Process name of process experiencing lock contention. |
+| id | INT | Slice id of lock contention. |
+| ts | INT | Timestamp of lock contention start. |
+| dur | INT | Wall clock duration of lock contention. |
+| monotonic_dur | INT | Monotonic clock duration of lock contention. |
+| track_id | INT | Thread track id of blocked thread. |
+| is_blocked_thread_main | INT | Whether the blocked thread is the main thread. |
+| blocked_thread_tid | INT | Tid of the blocked thread |
+| is_blocking_thread_main | INT | Whether the blocking thread is the main thread. |
+| blocking_thread_tid | INT | Tid of thread holding the lock. |
+| binder_reply_id | INT | Slice id of binder reply slice if lock contention was part of a binder txn. |
+| binder_reply_ts | INT | Timestamp of binder reply slice if lock contention was part of a binder txn. |
+| binder_reply_tid | INT | Tid of binder reply slice if lock contention was part of a binder txn. |
+| pid | INT | Pid of process experiencing lock contention. |
+| child_id | INT | Id of monitor contention slice blocked by this contention. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_monitor_contention_chain_thread_state**. Note that we only span join the duration where the lock was actually held and contended. This can be less than the duration the lock was 'waited on' when a different waiter acquired the lock earlier than the first waiter.
+
+<br />
+
+TABLE
+Note that we only span join the duration where the lock was actually held and contended.
+This can be less than the duration the lock was 'waited on' when a different waiter acquired the
+lock earlier than the first waiter.
+
+| Column | Type | Description |
+|---|---|---|
+| parent_id | None | Id of slice blocking the blocking_thread. |
+| blocking_method | None | Name of the method holding the lock. |
+| blocked_methhod | None | Name of the method trying to acquire the lock. |
+| short_blocking_method | None | Blocking_method without arguments and return types. |
+| short_blocked_method | None | Blocked_method without arguments and return types. |
+| blocking_src | None | File location of blocking_method in form <filename:linenumber>. |
+| blocked_src | None | File location of blocked_method in form <filename:linenumber>. |
+| waiter_count | None | Zero indexed number of threads trying to acquire the lock. |
+| blocking_utid | None | Utid of the blocking \|thread_state\|. |
+| blocking_thread_name | None | Thread name of thread holding the lock. |
+| upid | None | Upid of process experiencing lock contention. |
+| process_name | None | Process name of process experiencing lock contention. |
+| id | None | Slice id of lock contention. |
+| ts | None | Timestamp of the blocking \|thread_state\|. |
+| dur | None | Wall clock duration of lock contention. |
+| monotonic_dur | None | Monotonic clock duration of lock contention. |
+| track_id | None | Thread track id of blocked thread. |
+| is_blocked_main_thread | None | Whether the blocked thread is the main thread. |
+| is_blocking_main_thread | None | Whether the blocking thread is the main thread. |
+| binder_reply_id | None | Slice id of binder reply slice if lock contention was part of a binder txn. |
+| binder_reply_ts | None | Timestamp of binder reply slice if lock contention was part of a binder txn. |
+| binder_reply_tid | None | Tid of binder reply slice if lock contention was part of a binder txn. |
+| state | None | Thread state of the blocking thread. |
+| blocked_function | None | Blocked kernel function of the blocking thread. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_monitor_contention_chain_thread_state_by_txn**. Aggregated thread_states on the 'blocking thread', the thread holding the lock. This builds on the data from \|android_monitor_contention_chain\| and for each contention slice, it returns the aggregated sum of all the thread states on the blocking thread. Note that this data is only available for the first waiter on a lock.
+
+<br />
+
+VIEW
+Aggregated thread_states on the 'blocking thread', the thread holding the lock.
+This builds on the data from \|android_monitor_contention_chain\| and
+for each contention slice, it returns the aggregated sum of all the thread states on the
+blocking thread.
+
+Note that this data is only available for the first waiter on a lock.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Slice id of the monitor contention. |
+| thread_state | STRING | A \|thread_state\| that occurred in the blocking thread during the contention. |
+| thread_state_dur | INT | Total time the blocking thread spent in the \|thread_state\| during contention. |
+| thread_state_count | INT | Count of all times the blocking thread entered \|thread_state\| during the contention. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_monitor_contention_chain_blocked_functions_by_txn**. Aggregated blocked_functions on the 'blocking thread', the thread holding the lock. This builds on the data from \|android_monitor_contention_chain\| and for each contention, it returns the aggregated sum of all the kernel blocked function durations on the blocking thread. Note that this data is only available for the first waiter on a lock.
+
+<br />
+
+VIEW
+Aggregated blocked_functions on the 'blocking thread', the thread holding the lock.
+This builds on the data from \|android_monitor_contention_chain\| and
+for each contention, it returns the aggregated sum of all the kernel
+blocked function durations on the blocking thread.
+
+Note that this data is only available for the first waiter on a lock.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Slice id of the monitor contention. |
+| blocked_function | STRING | Blocked kernel function in a thread state in the blocking thread during the contention. |
+| blocked_function_dur | INT | Total time the blocking thread spent in the \|blocked_function\| during the contention. |
+| blocked_function_count | INT | Count of all times the blocking thread executed the \|blocked_function\| during the contention. |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**android_extract_android_monitor_contention_blocking_thread** -\> STRING. Extracts the blocking thread from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Returns STRING: Blocking thread
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_blocking_tid** -\> INT. Extracts the blocking thread tid from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Returns INT: Blocking thread tid
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_blocking_method** -\> STRING. Extracts the blocking method from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Returns STRING: Blocking thread
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_short_blocking_method** -\> STRING. Extracts a shortened form of the blocking method name from a slice name. The shortened form discards the parameter and return types.
+
+<br />
+
+<br />
+
+<br />
+
+Extracts a shortened form of the blocking method name from a slice name.
+The shortened form discards the parameter and return
+types.
+Returns STRING: Blocking thread
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_blocked_method** -\> STRING. Extracts the monitor contention blocked method from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Returns STRING: Blocking thread
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_short_blocked_method** -\> STRING. Extracts a shortened form of the monitor contention blocked method name from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Extracts a shortened form of the monitor contention blocked method name
+from a slice name. The shortened form discards the parameter and return
+types.
+Returns STRING: Blocking thread
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_waiter_count** -\> INT. Extracts the number of waiters on the monitor from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Returns INT: Count of waiters on the lock
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_blocking_src** -\> STRING. Extracts the monitor contention blocking source location from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Returns STRING: Blocking thread
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+<br />
+
+**android_extract_android_monitor_contention_blocked_src** -\> STRING. Extracts the monitor contention blocked source location from a slice name
+
+<br />
+
+<br />
+
+<br />
+
+Returns STRING: Blocking thread
+
+| Argument | Type | Description |
+|---|---|---|
+| slice_name | STRING | Name of slice |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**android_monitor_contention_graph** . Returns a DAG of all Java lock contentions in a process. Each node in the graph is a pair. Each edge connects from a node waiting on a lock to a node holding a lock. The weights of each node represent the cumulative wall time the node blocked other nodes connected to it.
+
+<br />
+
+<br />
+
+<br />
+
+Returns a DAG of all Java lock contentions in a process.
+Each node in the graph is a pair. Each edge connects from a node waiting on a lock to a node holding a lock. The weights of each node represent the cumulative wall time the node blocked other nodes connected to it. Argument \| Type \| Description --- \| --- \| --- upid \| INT \| Upid of process to generate a lock graph for.
+
+| Column | Type | Description |
+|---|---|---|
+| pprof | BYTES | Pprof of lock graph. |
+
+<br />
+
+<br />
+
+### android.network_packets
+
+#### Views/Tables
+
+<br />
+
+**android_network_packets**. Android network packet events (from android.network_packets data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp in nanoseconds. |
+| dur | INT | Duration (non-zero only in aggregate events) |
+| track_name | STRING | The track name (interface and direction) |
+| package_name | STRING | Traffic package source (or uid=$X if not found) |
+| iface | STRING | Traffic interface name (linux interface name) |
+| direction | STRING | Traffic direction ('Transmitted' or 'Received') |
+| packet_count | INT | Number of packets in this event |
+| packet_length | INT | Number of bytes in this event (wire size) |
+| packet_transport | STRING | Transport used for traffic in this event |
+| packet_tcp_flags | INT | TCP flags used by tcp frames in this event |
+| socket_tag | STRING | The Android traffic tag of the network socket |
+| socket_uid | INT | The Linux user id of the network socket |
+| local_port | INT | The local port number (for udp or tcp only) |
+| remote_port | INT | The remote port number (for udp or tcp only) |
+| packet_icmp_type | INT | 1-byte ICMP type identifier. |
+| packet_icmp_code | INT | 1-byte ICMP code identifier. |
+| packet_tcp_flags_int | INT | Packet's tcp flags bitmask (e.g. FIN=0x1, SYN=0x2). |
+| socket_tag_int | INT | Packet's socket tag as an integer. |
+
+<br />
+
+<br />
+
+### android.oom_adjuster
+
+#### Views/Tables
+
+<br />
+
+**android_oom_adj_intervals**. All oom adj state intervals across all processes along with the reason for the state update.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp the oom_adj score of the process changed |
+| dur | INT | Duration until the next oom_adj score change of the process. |
+| score | INT | oom_adj score of the process. |
+| bucket | STRING | oom_adj bucket of the process. |
+| upid | INT | Upid of the process having an oom_adj update. |
+| process_name | STRING | Name of the process having an oom_adj update. |
+| oom_adj_id | INT | Slice id of the latest oom_adj update in the system_server. |
+| oom_adj_ts | INT | Timestamp of the latest oom_adj update in the system_server. |
+| oom_adj_dur | INT | Duration of the latest oom_adj update in the system_server. |
+| oom_adj_track_id | INT | Track id of the latest oom_adj update in the system_server |
+| oom_adj_thread_name | STRING | Thread name of the latest oom_adj update in the system_server. |
+| oom_adj_reason | STRING | Reason for the latest oom_adj update in the system_server. |
+| oom_adj_trigger | STRING | Trigger for the latest oom_adj update in the system_server. |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**android_oom_adj_score_to_bucket_name** -\> STRING. Converts an oom_adj score Integer to String sample name. One of: cached, background, job, foreground_service, bfgs, foreground and system.
+
+<br />
+
+<br />
+
+<br />
+
+Converts an oom_adj score Integer to String sample name.
+One of: cached, background, job, foreground_service, bfgs, foreground and
+system.
+Returns STRING: Returns the sample bucket based on the oom score.
+
+| Argument | Type | Description |
+|---|---|---|
+| oom_score | INT | `oom_score` value |
+
+<br />
+
+<br />
+
+<br />
+
+**android_oom_adj_score_to_detailed_bucket_name** -\> STRING. Converts an oom_adj score Integer to String bucket name. Deprecated: use `android_oom_adj_score_to_bucket_name` instead.
+
+<br />
+
+<br />
+
+<br />
+
+Converts an oom_adj score Integer to String bucket name.
+Deprecated: use `android_oom_adj_score_to_bucket_name` instead.
+Returns STRING: Returns the oom_adj bucket.
+
+| Argument | Type | Description |
+|---|---|---|
+| value | INT | oom_adj score. |
+| android_appid | INT | android_app id of the process. |
+
+<br />
+
+<br />
+
+### android.power_rails
+
+#### Views/Tables
+
+<br />
+
+**android_power_rails_counters**. Android power rails counters data. For details see: https://perfetto.dev/docs/data-sources/battery-counters#odpm NOTE: Requires dedicated hardware - table is only populated on Pixels.
+
+<br />
+
+TABLE
+Android power rails counters data.
+For details see: https://perfetto.dev/docs/data-sources/battery-counters#odpm
+NOTE: Requires dedicated hardware - table is only populated on Pixels.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | `counter.id` |
+| ts | INT | Timestamp of the energy measurement. |
+| dur | INT | Time until the next energy measurement. |
+| power_rail_name | STRING | Power rail name. Alias of `counter_track.name`. |
+| raw_power_rail_name | STRING | Raw power rail name. |
+| energy_since_boot | DOUBLE | Energy accumulated by this rail since boot in microwatt-seconds (uWs) (AKA micro-joules). Alias of `counter.value`. |
+| energy_since_boot_at_end | DOUBLE | Energy accumulated by this rail at next energy measurement in microwatt-seconds (uWs) (AKA micro-joules). Alias of `counter.value` of the next meaningful (with value change) counter value. |
+| average_power | DOUBLE | Average power in mW (milliwatts) over between ts and the next energy measurement. |
+| energy_delta | DOUBLE | The change of energy accumulated by this rails since the last measurement in microwatt-seconds (uWs) (AKA micro-joules). |
+| track_id | INT | Power rail track id. Alias of `counter_track.id`. |
+| value | DOUBLE | DEPRECATED. Use `energy_since_boot` instead. |
+
+<br />
+
+<br />
+
+### android.process_metadata
+
+#### Views/Tables
+
+<br />
+
+**android_process_metadata**. Data about packages running on the process.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| upid | INT | Process upid. |
+| pid | INT | Process pid. |
+| process_name | STRING | Process name. |
+| uid | INT | Android app UID. |
+| shared_uid | BOOL | Whether the UID is shared by multiple packages. |
+| package_name | STRING | Name of the packages running in this process. |
+| version_code | INT | Package version code. |
+| debuggable | INT | Whether package is debuggable. |
+
+<br />
+
+<br />
+
+### android.screenshots
+
+#### Views/Tables
+
+<br />
+
+**android_screenshots**. Screenshot slices, used in perfetto UI.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Slice id. |
+| ts | INT | Slice timestamp. |
+| dur | INT | Slice duration, should be typically 0 since screeenshot slices are of instant type. |
+| name | STRING | Slice name. |
+
+<br />
+
+<br />
+
+### android.services
+
+#### Views/Tables
+
+<br />
+
+**android_service_bindings**. All service bindings from client app to server app.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| client_oom_score | INT | OOM score of client process making the binding. |
+| client_process | STRING | Name of client process making the binding. |
+| client_thread | STRING | Name of client thread making the binding. |
+| client_pid | INT | Pid of client process making the binding. |
+| client_tid | INT | Tid of client process making the binding. |
+| client_upid | INT | Upid of client process making the binding. |
+| client_utid | INT | Utid of client thread making the binding. |
+| client_ts | INT | Timestamp the client process made the request. |
+| client_dur | INT | Duration of the client binding request. |
+| server_oom_score | INT | OOM score of server process getting bound to. |
+| server_process | STRING | Name of server process getting bound to |
+| server_thread | STRING | Name of server thread getting bound to. |
+| server_pid | INT | Pid of server process getting bound to. |
+| server_tid | INT | Tid of server process getting bound to. |
+| server_upid | INT | Upid of server process getting bound to. |
+| server_utid | INT | Utid of server process getting bound to. |
+| server_ts | INT | Timestamp the server process got bound to. |
+| server_dur | INT | Duration of the server process handling the binding. |
+| token | STRING | Unique binder identifier for the Service binding. |
+| act | STRING | Intent action name for the service binding. |
+| cmp | STRING | Intent component name for the service binding. |
+| flg | STRING | Intent flag for the service binding. |
+| bind_seq | INT | Monotonically increasing id for the service binding. |
+
+<br />
+
+<br />
+
+### android.slices
+
+#### Functions
+
+<br />
+
+**android_standardize_slice_name** -\> STRING. Some slice names have params in them
+
+<br />
+
+<br />
+
+<br />
+
+Some slice names have params in them. This functions removes them to make it
+possible to aggregate by name.
+Some examples are:
+- Lock/monitor contention slices. The name includes where the lock
+contention is in the code. That part is removed.
+- DrawFrames/ooFrame. The name also includes the frame number.
+- Apk/oat/dex loading: The name of the apk is removed
+Returns STRING: Simplified name.
+
+| Argument | Type | Description |
+|---|---|---|
+| name | STRING | The raw slice name. |
+
+<br />
+
+<br />
+
+### android.startup.startups
+
+#### Views/Tables
+
+<br />
+
+**android_startups**. All activity startups in the trace by startup id. Populated by different scripts depending on the platform version/contents.
+
+<br />
+
+TABLE
+All activity startups in the trace by startup id.
+Populated by different scripts depending on the platform version/contents.
+
+| Column | Type | Description |
+|---|---|---|
+| startup_id | INT | Startup id. |
+| ts | INT | Timestamp of startup start. |
+| ts_end | INT | Timestamp of startup end. |
+| dur | INT | Startup duration. |
+| package | STRING | Package name. |
+| startup_type | STRING | Startup type. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_startup_processes**. Maps a startup to the set of processes that handled the activity start. The vast majority of cases should be a single process
+
+<br />
+
+TABLE
+Maps a startup to the set of processes that handled the activity start.
+
+The vast majority of cases should be a single process. However it is
+possible that the process dies during the activity startup and is respawned.
+
+| Column | Type | Description |
+|---|---|---|
+| startup_id | INT | Startup id. |
+| upid | INT | Upid of process on which activity started. |
+| startup_type | STRING | Type of the startup. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_startup_threads**. Maps a startup to the set of threads on processes that handled the activity start.
+
+<br />
+
+VIEW
+Maps a startup to the set of threads on processes that handled the
+activity start.
+
+| Column | Type | Description |
+|---|---|---|
+| startup_id | INT | Startup id. |
+| ts | INT | Timestamp of start. |
+| dur | INT | Duration of startup. |
+| upid | INT | Upid of process involved in startup. |
+| utid | INT | Utid of the thread. |
+| thread_name | STRING | Name of the thread. |
+| is_main_thread | BOOL | Thread is a main thread. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_thread_slices_for_all_startups**. All the slices for all startups in trace. Generally, this view should not be used
+
+<br />
+
+VIEW
+All the slices for all startups in trace.
+
+Generally, this view should not be used. Instead, use one of the view functions related
+to the startup slices which are created from this table.
+
+| Column | Type | Description |
+|---|---|---|
+| startup_ts | INT | Timestamp of startup. |
+| startup_ts_end | INT | Timestamp of startup end. |
+| startup_id | INT | Startup id. |
+| utid | INT | UTID of thread with slice. |
+| thread_name | STRING | Name of thread. |
+| is_main_thread | BOOL | Whether it is main thread. |
+| arg_set_id | INT | Arg set id. |
+| slice_id | INT | Slice id. |
+| slice_name | STRING | Name of slice. |
+| slice_ts | INT | Timestamp of slice start. |
+| slice_dur | INT | Slice duration. |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**android_sum_dur_for_startup_and_slice** -\> INT. Returns duration of startup for slice name. Sums duration of all slices of startup with provided name.
+
+<br />
+
+<br />
+
+<br />
+
+Returns duration of startup for slice name.
+
+Sums duration of all slices of startup with provided name.
+Returns INT: Sum of duration.
+
+| Argument | Type | Description |
+|---|---|---|
+| startup_id | LONG | Startup id. |
+| slice_name | STRING | Slice name. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_sum_dur_on_main_thread_for_startup_and_slice** -\> INT. Returns duration of startup for slice name on main thread. Sums duration of all slices of startup with provided name only on main thread.
+
+<br />
+
+<br />
+
+<br />
+
+Returns duration of startup for slice name on main thread.
+
+Sums duration of all slices of startup with provided name only on main thread.
+Returns INT: Sum of duration.
+
+| Argument | Type | Description |
+|---|---|---|
+| startup_id | LONG | Startup id. |
+| slice_name | STRING | Slice name. |
+
+<br />
+
+<br />
+
+#### Table Functions
+
+<br />
+
+**android_slices_for_startup_and_slice_name** . Given a startup id and GLOB for a slice name, returns matching slices with data.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| startup_id | INT | Startup id. |
+| slice_name | STRING | Glob of the slice. |
+
+| Column | Type | Description |
+|---|---|---|
+| slice_id | INT | Id of the slice. |
+| slice_name | STRING | Name of the slice. |
+| slice_ts | INT | Timestamp of start of the slice. |
+| slice_dur | INT | Duration of the slice. |
+| thread_name | STRING | Name of the thread with the slice. |
+| arg_set_id | INT | Arg set id. |
+
+<br />
+
+<br />
+
+<br />
+
+**android_binder_transaction_slices_for_startup** . Returns binder transaction slices for a given startup id with duration over threshold.
+
+<br />
+
+<br />
+
+<br />
+
+| Argument | Type | Description |
+|---|---|---|
+| startup_id | INT | Startup id. |
+| threshold | DOUBLE | Only return slices with duration over threshold. |
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Slice id. |
+| slice_dur | INT | Slice duration. |
+| thread_name | STRING | Name of the thread with slice. |
+| process | STRING | Name of the process with slice. |
+| arg_set_id | INT | Arg set id. |
+| is_main_thread | BOOL | Whether is main thread. |
+
+<br />
+
+<br />
+
+### android.startup.time_to_display
+
+#### Views/Tables
+
+<br />
+
+**android_startup_time_to_display**. Startup metric defintions, which focus on the observable time range: TTID - Time To Initial Display \* https://developer.android.com/topic/performance/vitals/launch-time#time-initial \* end of first RenderThread.DrawFrame - bindApplication TTFD - Time To Full Display \* https://developer.android.com/topic/performance/vitals/launch-time#retrieve-TTFD \* end of next RT.DrawFrame, after reportFullyDrawn called - bindApplication Googlers: see go/android-performance-metrics-glossary for details.
+
+<br />
+
+TABLE
+Startup metric defintions, which focus on the observable time range:
+TTID - Time To Initial Display
+\* https://developer.android.com/topic/performance/vitals/launch-time#time-initial
+\* end of first RenderThread.DrawFrame - bindApplication
+TTFD - Time To Full Display
+\* https://developer.android.com/topic/performance/vitals/launch-time#retrieve-TTFD
+\* end of next RT.DrawFrame, after reportFullyDrawn called - bindApplication
+Googlers: see go/android-performance-metrics-glossary for details.
+
+| Column | Type | Description |
+|---|---|---|
+| startup_id | INT | Startup id. |
+| time_to_initial_display | INT | Time to initial display (TTID) |
+| time_to_full_display | INT | Time to full display (TTFD) |
+| ttid_frame_id | INT | `android_frames.frame_id` of frame for initial display |
+| ttfd_frame_id | INT | `android_frames.frame_id` of frame for full display |
+| upid | INT | `process.upid` of the startup |
+
+<br />
+
+<br />
+
+### android.statsd
+
+#### Views/Tables
+
+<br />
+
+**android_statsd_atoms**. Statsd atoms. A subset of the slice table containing statsd atom instant events.
+
+<br />
+
+VIEW
+Statsd atoms.
+
+A subset of the slice table containing statsd atom instant events.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Unique identifier for this slice. |
+| type | STRING | The name of the "most-specific" child table containing this row. |
+| ts | INT | The timestamp at the start of the slice (in nanoseconds). |
+| dur | INT | The duration of the slice (in nanoseconds). |
+| arg_set_id | INT | The id of the argument set associated with this slice. |
+| thread_instruction_count | INT | The value of the CPU instruction counter at the start of the slice. This column will only be populated if thread instruction collection is enabled with track_event. |
+| thread_instruction_delta | INT | The change in value of the CPU instruction counter between the start and end of the slice. This column will only be populated if thread instruction collection is enabled with track_event. |
+| track_id | INT | The id of the track this slice is located on. |
+| category | STRING | The "category" of the slice. If this slice originated with track_event, this column contains the category emitted. Otherwise, it is likely to be null (with limited exceptions). |
+| name | STRING | The name of the slice. The name describes what was happening during the slice. |
+| depth | INT | The depth of the slice in the current stack of slices. |
+| stack_id | INT | A unique identifier obtained from the names of all slices in this stack. This is rarely useful and kept around only for legacy reasons. |
+| parent_stack_id | INT | The stack_id for the parent of this slice. Rarely useful. |
+| parent_id | INT | The id of the parent (i.e. immediate ancestor) slice for this slice. |
+| thread_ts | INT | The thread timestamp at the start of the slice. This column will only be populated if thread timestamp collection is enabled with track_event. |
+| thread_dur | INT | The thread time used by this slice. This column will only be populated if thread timestamp collection is enabled with track_event. |
+
+<br />
+
+<br />
+
+### android.suspend
+
+#### Views/Tables
+
+<br />
+
+**android_suspend_state**. Table of suspended and awake slices. Selects either the minimal or full ftrace source depending on what's available, marks suspended periods, and complements them to give awake periods.
+
+<br />
+
+TABLE
+Table of suspended and awake slices.
+
+Selects either the minimal or full ftrace source depending on what's
+available, marks suspended periods, and complements them to give awake
+periods.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp |
+| dur | INT | Duration |
+| power_state | STRING | 'awake' or 'suspended' |
+
+<br />
+
+<br />
+
+### android.winscope.inputmethod
+
+#### Views/Tables
+
+<br />
+
+**android_inputmethod_clients**. Android inputmethod clients state dumps (from android.inputmethod data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Dump id |
+| ts | INT | Timestamp when the dump was triggered |
+| arg_set_id | INT | Extra args parsed from the proto message |
+
+<br />
+
+<br />
+
+<br />
+
+**android_inputmethod_manager_service**. Android inputmethod manager service state dumps (from android.inputmethod data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Dump id |
+| ts | INT | Timestamp when the dump was triggered |
+| arg_set_id | INT | Extra args parsed from the proto message |
+
+<br />
+
+<br />
+
+<br />
+
+**android_inputmethod_service**. Android inputmethod service state dumps (from android.inputmethod data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Dump id |
+| ts | INT | Timestamp when the dump was triggered |
+| arg_set_id | INT | Extra args parsed from the proto message |
+
+<br />
+
+<br />
+
+### android.winscope.viewcapture
+
+#### Views/Tables
+
+<br />
+
+**android_viewcapture**. Android viewcapture (from android.viewcapture data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Snapshot id |
+| ts | INT | Timestamp when the snapshot was triggered |
+| arg_set_id | INT | Extra args parsed from the proto message |
+
+<br />
+
+<br />
+
+### android.winscope.windowmanager
+
+#### Views/Tables
+
+<br />
+
+**android_windowmanager**. Android WindowManager (from android.windowmanager data source).
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Snapshot id |
+| ts | INT | Timestamp when the snapshot was triggered |
+| arg_set_id | INT | Extra args parsed from the proto message |
+
+<br />
+
+<br />
+
+## Package: chrome
+
+### chrome.chrome_scrolls
+
+#### Views/Tables
+
+<br />
+
+**chrome_scrolls**. Defines slices for all of the individual scrolls in a trace based on the LatencyInfo-based scroll definition. NOTE: this view of top level scrolls is based on the LatencyInfo definition of a scroll, which differs subtly from the definition based on EventLatencies. TODO(b/278684408): add support for tracking scrolls across multiple Chrome/ WebView instances
+
+<br />
+
+TABLE
+Defines slices for all of the individual scrolls in a trace based on the
+LatencyInfo-based scroll definition.
+
+NOTE: this view of top level scrolls is based on the LatencyInfo definition
+of a scroll, which differs subtly from the definition based on
+EventLatencies.
+TODO(b/278684408): add support for tracking scrolls across multiple Chrome/
+WebView instances. Currently gesture_scroll_id unique within an instance, but
+is not unique across multiple instances. Switching to an EventLatency based
+definition of scrolls should resolve this.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The unique identifier of the scroll. |
+| ts | INT | The start timestamp of the scroll. |
+| dur | INT | The duration of the scroll. |
+| gesture_scroll_begin_ts | INT | The earliest timestamp of the EventLatency slice of the GESTURE_SCROLL_BEGIN type for the corresponding scroll id. |
+| gesture_scroll_end_ts | INT | The earliest timestamp of the EventLatency slice of the GESTURE_SCROLL_END type / the latest timestamp of the EventLatency slice of the GESTURE_SCROLL_UPDATE type for the corresponding scroll id. |
+
+<br />
+
+<br />
+
+### chrome.cpu_powerups
+
+#### Views/Tables
+
+<br />
+
+**chrome_cpu_power_slice**. The CPU power transitions in the trace. Power states are encoded as non-negative integers, with zero representing full-power operation and positive values representing increasingly deep sleep states. On ARM systems, power state 1 represents the WFI (Wait For Interrupt) sleep state that the CPU enters while idle.
+
+<br />
+
+VIEW
+The CPU power transitions in the trace.
+Power states are encoded as non-negative integers, with zero representing
+full-power operation and positive values representing increasingly deep
+sleep states.
+
+On ARM systems, power state 1 represents the WFI (Wait For Interrupt) sleep
+state that the CPU enters while idle.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | The timestamp at the start of the slice. |
+| dur | INT | The duration of the slice. |
+| cpu | INT | The CPU on which the transition occurred |
+| power_state | INT | The power state that the CPU was in at time 'ts' for duration 'dur'. |
+| previous_power_state | INT | The power state that the CPU was previously in. |
+| powerup_id | INT | A unique ID for the CPU power-up. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_cpu_power_first_sched_slice_after_powerup**. The Linux scheduler slices that executed immediately after a CPU power up.
+
+<br />
+
+TABLE
+The Linux scheduler slices that executed immediately after a
+CPU power up.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | The timestamp at the start of the slice. |
+| dur | INT | The duration of the slice. |
+| cpu | INT | The cpu on which the slice executed. |
+| sched_id | INT | Id for the sched_slice table. |
+| utid | INT | Unique id for the thread that ran within the slice. |
+| previous_power_state | INT | The CPU's power state before this slice. |
+| powerup_id | INT | A unique ID for the CPU power-up. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_cpu_power_post_powerup_slice**. A table holding the slices that executed within the scheduler slice that ran on a CPU immediately after power-up.
+
+<br />
+
+TABLE
+A table holding the slices that executed within the scheduler
+slice that ran on a CPU immediately after power-up.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | None | Timestamp of the resulting slice |
+| dur | None | Duration of the slice. |
+| cpu | None | The CPU the sched slice ran on. |
+| utid | None | Unique thread id for the slice. |
+| sched_id | None | 'id' field from the sched_slice table. |
+| type | None | From the sched_slice table, always 'sched_slice'. |
+| end_state | None | The ending state for the sched_slice |
+| priority | None | The kernel thread priority |
+| slice_id | None | Id of the top-level slice for this (sched) slice. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_cpu_power_first_toplevel_slice_after_powerup**. The first top-level slice that ran after a CPU power-up.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| slice_id | INT | ID of the slice in the slice table. |
+| previous_power_state | INT | The power state of the CPU prior to power-up. |
+
+<br />
+
+<br />
+
+### chrome.event_latency
+
+#### Views/Tables
+
+<br />
+
+**chrome_event_latencies**. All EventLatency slices.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Slice Id for the EventLatency scroll event. |
+| name | STRING | Slice name. |
+| ts | INT | The start timestamp of the scroll. |
+| dur | INT | The duration of the scroll. |
+| scroll_update_id | INT | The id of the scroll update event. |
+| is_presented | BOOL | Whether this input event was presented. |
+| event_type | STRING | EventLatency event type. |
+| track_id | INT | Perfetto track this slice is found on. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_gesture_scroll_events**. All scroll-related events (frames) including gesture scroll updates, begins and ends with respective scroll ids and start/end timestamps, regardless of being presented
+
+<br />
+
+TABLE
+All scroll-related events (frames) including gesture scroll updates, begins
+and ends with respective scroll ids and start/end timestamps, regardless of
+being presented. This includes pinches that were presented. See b/315761896
+for context on pinches.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Slice Id for the EventLatency scroll event. |
+| name | STRING | Slice name. |
+| ts | INT | The start timestamp of the scroll. |
+| dur | INT | The duration of the scroll. |
+| scroll_update_id | INT | The id of the scroll update event. |
+| scroll_id | INT | The id of the scroll. |
+| is_presented | BOOL | Whether this input event was presented. |
+| presentation_timestamp | INT | Frame presentation timestamp aka the timestamp of the SwapEndToPresentationCompositorFrame substage. TODO(b/341047059): temporarily use LatchToSwapEnd as a workaround if SwapEndToPresentationCompositorFrame is missing due to b/247542163. |
+| event_type | STRING | EventLatency event type. |
+| track_id | INT | Perfetto track this slice is found on. |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**chrome_get_most_recent_scroll_begin_id** -\> INT. Extracts scroll id for the EventLatency slice at `ts`.
+
+<br />
+
+<br />
+
+<br />
+
+Returns INT: The event_latency_id of the EventLatency slice with the type GESTURE_SCROLL_BEGIN that is the closest to `ts`.
+
+| Argument | Type | Description |
+|---|---|---|
+| ts | INT | Timestamp of the EventLatency slice to get the scroll id for. |
+
+<br />
+
+<br />
+
+### chrome.event_latency_description
+
+#### Views/Tables
+
+<br />
+
+**chrome_event_latency_stage_descriptions**. Source of truth of the descriptions of EventLatency stages.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | The name of the EventLatency stage. |
+| description | STRING | A description of the EventLatency stage. |
+
+<br />
+
+<br />
+
+### chrome.histograms
+
+#### Views/Tables
+
+<br />
+
+**chrome_histograms**. A helper view on top of the histogram events emitted by Chrome. Requires "disabled-by-default-histogram_samples" Chrome category.
+
+<br />
+
+TABLE
+A helper view on top of the histogram events emitted by Chrome.
+Requires "disabled-by-default-histogram_samples" Chrome category.
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | The name of the histogram. |
+| value | INT | The value of the histogram sample. |
+| ts | INT | Alias of \|slice.ts\|. |
+| thread_name | STRING | Thread name. |
+| utid | INT | Utid of the thread. |
+| tid | INT | Tid of the thread. |
+| process_name | STRING | Process name. |
+| upid | INT | Upid of the process. |
+| pid | INT | Pid of the process. |
+
+<br />
+
+<br />
+
+### chrome.interactions
+
+#### Views/Tables
+
+<br />
+
+**chrome_interactions**. All critical user interaction events, including type and table with associated metrics.
+
+<br />
+
+TABLE
+All critical user interaction events, including type and table with
+associated metrics.
+
+| Column | Type | Description |
+|---|---|---|
+| scoped_id | INT | Identifier of the interaction; this is not guaranteed to be unique to the table - rather, it is unique within an individual interaction type. Combine with type to get a unique identifier in this table. |
+| type | STRING | Type of this interaction, which together with scoped_id uniquely identifies this interaction. Also corresponds to a SQL table name containing more details specific to this type of interaction. |
+| name | STRING | Interaction name - e.g. 'PageLoad', 'Tap', etc. Interactions will have unique metrics stored in other tables. |
+| ts | INT | Timestamp of the CUI event. |
+| dur | INT | Duration of the CUI event. |
+
+<br />
+
+<br />
+
+### chrome.metadata
+
+#### Functions
+
+<br />
+
+**chrome_hardware_class** -\> STRING. Returns hardware class of the device, often use to find device brand and model.
+
+<br />
+
+<br />
+
+<br />
+
+Returns hardware class of the device, often use to find device brand
+and model.
+Returns STRING: Hardware class name.
+
+<br />
+
+<br />
+
+### chrome.page_loads
+
+#### Views/Tables
+
+<br />
+
+**chrome_page_loads**. Chrome page loads, including associated high-level metrics and properties.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | ID of the navigation and Chrome browser process; this combination is unique to every individual navigation. |
+| navigation_id | INT | ID of the navigation associated with the page load (i.e. the cross-document navigation in primary main frame which created this page's main document). Also note that navigation_id is specific to a given Chrome browser process, and not globally unique. |
+| navigation_start_ts | INT | Timestamp of the start of navigation. |
+| fcp | INT | Duration between the navigation start and the first contentful paint event (web.dev/fcp). |
+| fcp_ts | INT | Timestamp of the first contentful paint. |
+| lcp | INT | Duration between the navigation start and the largest contentful paint event (web.dev/lcp). |
+| lcp_ts | INT | Timestamp of the largest contentful paint. |
+| dom_content_loaded_event_ts | INT | Timestamp of the DomContentLoaded event: https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event |
+| load_event_ts | INT | Timestamp of the window load event: https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event |
+| mark_fully_loaded_ts | INT | Timestamp of the page self-reporting as fully loaded through the performance.mark('mark_fully_loaded') API. |
+| mark_fully_visible_ts | INT | Timestamp of the page self-reporting as fully visible through the performance.mark('mark_fully_visible') API. |
+| mark_interactive_ts | INT | Timestamp of the page self-reporting as fully interactive through the performance.mark('mark_interactive') API. |
+| url | STRING | URL at the page load event. |
+| browser_upid | INT | The unique process id (upid) of the browser process where the page load occurred. |
+
+<br />
+
+<br />
+
+### chrome.scroll_interactions
+
+#### Views/Tables
+
+<br />
+
+**chrome_scroll_interactions**. Top level scroll events, with metrics.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Unique id for an individual scroll. |
+| name | STRING | Name of the scroll event. |
+| ts | INT | Start timestamp of the scroll. |
+| dur | INT | Duration of the scroll. |
+| frame_count | INT | The total number of frames in the scroll. |
+| vsync_count | INT | The total number of vsyncs in the scroll. |
+| missed_vsync_max | INT | The maximum number of vsyncs missed during any and all janks. |
+| missed_vsync_sum | INT | The total number of vsyncs missed during any and all janks. |
+| delayed_frame_count | INT | The number of delayed frames. |
+| predictor_janky_frame_count | INT | The number of frames that are deemed janky to the human eye after Chrome has applied its scroll prediction algorithm. |
+| renderer_upid | INT | The process id this event occurred on. |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.predictor_error
+
+#### Views/Tables
+
+<br />
+
+**chrome_predictor_error**. The scrolling offsets and predictor jank values for the actual (applied) scroll events.
+
+<br />
+
+TABLE
+The scrolling offsets and predictor jank values for the actual (applied)
+scroll events.
+
+| Column | Type | Description |
+|---|---|---|
+| scroll_id | INT | An ID that ties all EventLatencies in a particular scroll. (implementation note: This is the EventLatency TraceId of the GestureScrollbegin). |
+| event_latency_slice_id | INT | An ID for this particular EventLatency regardless of it being presented or not. |
+| scroll_update_id | INT | An ID that ties this \|event_latency_id\| with the Trace Id (another event_latency_id) that it was presented with. |
+| present_ts | INT | Presentation timestamp. |
+| delta_y | DOUBLE | The delta in raw coordinates between this presented EventLatency and the previous presented frame. |
+| relative_offset_y | DOUBLE | The pixel offset of this presented EventLatency compared to the initial one. |
+| prev_delta | DOUBLE | The delta in raw coordinates of the previous scroll update event. |
+| next_delta | DOUBLE | The delta in raw coordinates of the subsequent scroll update event. |
+| predictor_jank | DOUBLE | The jank value based on the discrepancy between scroll predictor coordinates and the actual deltas between scroll update events. |
+| delta_threshold | DOUBLE | The threshold used to determine if jank occurred. |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.scroll_jank_cause_map
+
+#### Views/Tables
+
+<br />
+
+**chrome_scroll_jank_cause_descriptions**. Source of truth of the descriptions of EventLatency-based scroll jank causes.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| event_latency_stage | STRING | The name of the EventLatency stage. |
+| cause_process | STRING | The process where the cause of scroll jank occurred. |
+| cause_thread | STRING | The thread where the cause of scroll jank occurred. |
+| cause_description | STRING | A description of the cause of scroll jank. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_scroll_jank_causes_with_event_latencies**. Combined description of scroll jank cause and associated event latency stage.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| name | STRING | The name of the EventLatency stage. |
+| description | STRING | Description of the EventLatency stage. |
+| cause_process | STRING | The process name that may cause scroll jank. |
+| cause_thread | STRING | The thread name that may cause scroll jank. The thread will be on the cause_process. |
+| cause_description | STRING | Description of the cause of scroll jank on this process and thread. |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.scroll_jank_cause_utils
+
+#### Table Functions
+
+<br />
+
+**chrome_select_scroll_jank_cause_thread** . Function to retrieve the thread id of the thread on a particular process if there are any slices during a particular EventLatency slice duration; this upid/thread combination refers to a cause of Scroll Jank.
+
+<br />
+
+<br />
+
+<br />
+
+Function to retrieve the thread id of the thread on a particular process if
+there are any slices during a particular EventLatency slice duration; this
+upid/thread combination refers to a cause of Scroll Jank.
+Argument \| Type \| Description
+--- \| --- \| ---
+event_latency_id \| INT \| The slice id of an EventLatency slice.
+process_type \| STRING \| The process type that the thread is on: one of 'Browser', 'Renderer' or 'GPU'.
+thread_name \| STRING \| The name of the thread.
+
+| Column | Type | Description |
+|---|---|---|
+| utid | INT | The utid associated with |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.scroll_jank_intervals
+
+#### Views/Tables
+
+<br />
+
+**chrome_janky_event_latencies_v3**. Selects EventLatency slices that correspond with janks in a scroll
+
+<br />
+
+TABLE
+Selects EventLatency slices that correspond with janks in a scroll. This is
+based on the V3 version of scroll jank metrics.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The slice id. |
+| ts | INT | The start timestamp of the slice. |
+| dur | INT | The duration of the slice. |
+| track_id | INT | The track_id for the slice. |
+| name | STRING | The name of the slice (EventLatency). |
+| cause_of_jank | STRING | The stage of EventLatency that the caused the jank. |
+| sub_cause_of_jank | STRING | The stage of cause_of_jank that caused the jank. |
+| delayed_frame_count | INT | How many vsyncs this frame missed its deadline by. |
+| frame_jank_ts | INT | The start timestamp where frame presentation was delayed. |
+| frame_jank_dur | INT | The duration in ms of the delay in frame presentation. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_janky_frame_presentation_intervals**. Frame presentation interval is the delta between when the frame was supposed to be presented and when it was actually presented.
+
+<br />
+
+VIEW
+Frame presentation interval is the delta between when the frame was supposed
+to be presented and when it was actually presented.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Unique id. |
+| ts | INT | The start timestamp of the slice. |
+| dur | INT | The duration of the slice. |
+| delayed_frame_count | INT | How many vsyncs this frame missed its deadline by. |
+| cause_of_jank | STRING | The stage of EventLatency that the caused the jank. |
+| sub_cause_of_jank | STRING | The stage of cause_of_jank that caused the jank. |
+| event_latency_id | INT | The id of the associated event latency in the slice table. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_scroll_stats**. Scroll jank frame presentation stats for individual scrolls.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| scroll_id | INT | Id of the individual scroll. |
+| frame_count | INT | The number of frames in the scroll. |
+| missed_vsyncs | INT | The number of missed vsyncs in the scroll. |
+| presented_frame_count | INT | The number presented frames in the scroll. |
+| janky_frame_count | INT | The number of janky frames in the scroll. |
+| janky_frame_percent | FLOAT | The % of frames that janked in the scroll. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_scroll_jank_intervals_v3**. Defines slices for all of janky scrolling intervals in a trace.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | The unique identifier of the janky interval. |
+| ts | INT | The start timestamp of the janky interval. |
+| dur | INT | The duration of the janky interval. |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.scroll_jank_v3
+
+#### Views/Tables
+
+<br />
+
+**chrome_gesture_scroll_updates**. Grabs all gesture updates with respective scroll ids and start/end timestamps, regardless of being presented.
+
+<br />
+
+TABLE
+Grabs all gesture updates with respective scroll ids and start/end
+timestamps, regardless of being presented.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | The start timestamp of the scroll. |
+| dur | INT | The duration of the scroll. |
+| id | INT | Slice id for the scroll. |
+| scroll_update_id | INT | The id of the scroll update event. |
+| scroll_id | INT | The id of the scroll. |
+| is_presented | BOOL | Whether this input event was presented. |
+| presentation_timestamp | INT | Frame presentation timestamp aka the timestamp of the SwapEndToPresentationCompositorFrame substage. |
+| event_type | STRING | EventLatency event type. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_presented_gesture_scrolls**. Scroll updates, corresponding to all input events that were converted to a presented scroll update.
+
+<br />
+
+TABLE
+Scroll updates, corresponding to all input events that were converted to a
+presented scroll update.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Minimum slice id for input presented in this frame, the non-presented input. |
+| ts | INT | The start timestamp for producing the frame. |
+| dur | INT | The duration between producing and presenting the frame. |
+| last_presented_input_ts | INT | The timestamp of the last input that arrived and got presented in the frame. |
+| scroll_update_id | INT | The id of the scroll update event, a unique identifier to the gesture. |
+| scroll_id | INT | The id of the ongoing scroll. |
+| presentation_timestamp | INT | Frame presentation timestamp. |
+| event_type | STRING | EventLatency event type. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_scroll_updates_with_deltas**. Associate every trace_id with it's perceived delta_y on the screen after prediction.
+
+<br />
+
+TABLE
+Associate every trace_id with it's perceived delta_y on the screen after
+prediction.
+
+| Column | Type | Description |
+|---|---|---|
+| scroll_update_id | INT | The id of the scroll update event. |
+| delta_y | DOUBLE | The perceived delta_y on the screen post prediction. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_full_frame_view**. Obtain the subset of input events that were fully presented.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | ID of the frame. |
+| ts | INT | Start timestamp of the frame. |
+| last_presented_input_ts | INT | The timestamp of the last presented input. |
+| scroll_id | INT | ID of the associated scroll. |
+| scroll_update_id | INT | ID of the associated scroll update. |
+| event_latency_id | INT | ID of the associated EventLatency. |
+| dur | INT | Duration of the associated EventLatency. |
+| presentation_timestamp | INT | Frame presentation timestamp. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_full_frame_delta_view**. Join deltas with EventLatency data.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | ID of the frame. |
+| ts | INT | Start timestamp of the frame. |
+| scroll_id | INT | ID of the associated scroll. |
+| scroll_update_id | INT | ID of the associated scroll update. |
+| last_presented_input_ts | INT | The timestamp of the last presented input. |
+| delta_y | DOUBLE | The perceived delta_y on the screen post prediction. |
+| event_latency_id | INT | ID of the associated EventLatency. |
+| dur | INT | Duration of the associated EventLatency. |
+| presentation_timestamp | INT | Frame presentation timestamp. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_merged_frame_view**. Group all gestures presented at the same timestamp together in a single row.
+
+<br />
+
+TABLE
+Group all gestures presented at the same timestamp together in
+a single row.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | ID of the frame. |
+| max_start_ts | INT | The timestamp of the last presented input. |
+| min_start_ts | INT | The earliest frame start timestamp. |
+| scroll_id | INT | ID of the associated scroll. |
+| scroll_update_id | INT | ID of the associated scroll update. |
+| encapsulated_scroll_ids | STRING | All scroll updates associated with the frame presentation timestamp. |
+| total_delta | DOUBLE | Sum of all perceived delta_y values at the frame presentation timestamp. |
+| segregated_delta_y | STRING | Lists all of the perceived delta_y values at the frame presentation timestamp. |
+| event_latency_id | INT | ID of the associated EventLatency. |
+| dur | INT | Maximum duration of the associated EventLatency. |
+| presentation_timestamp | INT | Frame presentation timestamp. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_frame_info_with_delay**. View contains all chrome presented frames during gesture updates while calculating delay since last presented which usually should equal to \|VSYNC_INTERVAL\| if no jank is present.
+
+<br />
+
+TABLE
+View contains all chrome presented frames during gesture updates
+while calculating delay since last presented which usually should
+equal to \|VSYNC_INTERVAL\| if no jank is present.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | gesture scroll slice id. |
+| max_start_ts | INT | OS timestamp of the last touch move arrival within a frame. |
+| min_start_ts | INT | OS timestamp of the first touch move arrival within a frame. |
+| scroll_id | INT | The scroll which the touch belongs to. |
+| scroll_update_id | INT | ID of the associated scroll update. |
+| encapsulated_scroll_ids | STRING | Trace ids of all frames presented in at this vsync. |
+| total_delta | DOUBLE | Summation of all delta_y of all gesture scrolls in this frame. |
+| segregated_delta_y | STRING | All delta y of all gesture scrolls comma separated, summing those gives \|total_delta\|. |
+| event_latency_id | INT | Event latency id of the presented frame. |
+| dur | INT | Duration of the EventLatency. |
+| presentation_timestamp | INT | Timestamp at which the frame was shown on the screen. |
+| delay_since_last_frame | DOUBLE | Time elapsed since the previous frame was presented, usually equals \|VSYNC\| if no frame drops happened. |
+| delay_since_last_input | DOUBLE | Difference in OS timestamps of inputs in the current and the previous frame. |
+| prev_event_latency_id | INT | The event latency id that will be used as a reference to determine the jank cause. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_vsyncs**. Calculate \|VSYNC_INTERVAL\| as the lowest vsync seen in the trace or the minimum delay between frames larger than zero. TODO(\~M130): Remove the lowest vsync since we should always have vsync_interval_ms.
+
+<br />
+
+TABLE
+Calculate \|VSYNC_INTERVAL\| as the lowest vsync seen in the trace or the
+minimum delay between frames larger than zero.
+
+TODO(\~M130): Remove the lowest vsync since we should always have vsync_interval_ms.
+
+| Column | Type | Description |
+|---|---|---|
+| vsync_interval | DOUBLE | The lowest delay between frames larger than zero. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_janky_frames_no_cause**. Filter the frame view only to frames that had missed vsyncs.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| delay_since_last_frame | DOUBLE | Time elapsed since the previous frame was presented, will be more than \|VSYNC\| in this view. |
+| event_latency_id | INT | Event latency id of the presented frame. |
+| vsync_interval | DOUBLE | Vsync interval at the time of recording the trace. |
+| hardware_class | STRING | Device brand and model. |
+| scroll_id | INT | The scroll corresponding to this frame. |
+| prev_event_latency_id | INT | The event latency id that will be used as a reference to determine the jank cause. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_janky_frames_no_subcause**. Janky frame information including the jank cause.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| delay_since_last_frame | DOUBLE | Time elapsed since the previous frame was presented, will be more than \|VSYNC\| in this view. |
+| event_latency_id | INT | Event latency id of the presented frame. |
+| vsync_interval | DOUBLE | Vsync interval at the time of recording the trace. |
+| hardware_class | STRING | Device brand and model. |
+| scroll_id | INT | The scroll corresponding to this frame. |
+| prev_event_latency_id | INT | The event latency id that will be used as a reference to determine the jank cause. |
+| cause_id | INT | Id of the slice corresponding to the offending stage. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_janky_frames**. Finds all causes of jank for all janky frames, and a cause of sub jank if the cause of jank was GPU related.
+
+<br />
+
+TABLE
+Finds all causes of jank for all janky frames, and a cause of sub jank
+if the cause of jank was GPU related.
+
+| Column | Type | Description |
+|---|---|---|
+| cause_of_jank | STRING | The reason the Vsync was missed. |
+| sub_cause_of_jank | STRING | Further breakdown if the root cause was GPU related. |
+| delay_since_last_frame | DOUBLE | Time elapsed since the previous frame was presented, will be more than \|VSYNC\| in this view. |
+| event_latency_id | INT | Event latency id of the presented frame. |
+| vsync_interval | DOUBLE | Vsync interval at the time of recording the trace. |
+| hardware_class | STRING | Device brand and model. |
+| scroll_id | INT | The scroll corresponding to this frame. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_unique_frame_presentation_ts**. Counting all unique frame presentation timestamps.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| presentation_timestamp | INT | The unique frame presentation timestamp. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_janky_frames_percentage**. Dividing missed frames over total frames to get janky frame percentage. This represents the v3 scroll jank metrics. Reflects Event.Jank.DelayedFramesPercentage UMA metric.
+
+<br />
+
+TABLE
+Dividing missed frames over total frames to get janky frame percentage.
+This represents the v3 scroll jank metrics.
+Reflects Event.Jank.DelayedFramesPercentage UMA metric.
+
+| Column | Type | Description |
+|---|---|---|
+| delayed_frame_percentage | FLOAT | The percent of missed frames relative to total frames - aka the percent of janky frames. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_frames_per_scroll**. Number of frames and janky frames per scroll.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| scroll_id | INT | The ID of the scroll. |
+| num_frames | INT | The number of frames in the scroll. |
+| num_janky_frames | INT | The number of delayed/janky frames. |
+| scroll_jank_percentage | DOUBLE | The percentage of janky frames relative to total frames. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_causes_per_scroll**. Scroll jank causes per scroll.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| scroll_id | INT | The ID of the scroll. |
+| max_delay_since_last_frame | DOUBLE | The maximum time a frame was delayed after the presentation of the previous frame. |
+| vsync_interval | DOUBLE | The expected vsync interval. |
+| scroll_jank_causes | BYTES | A proto amalgamation of each scroll jank cause including cause name, sub cause and the duration of the delay since the previous frame was presented. |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.scroll_jank_v3_cause
+
+#### Functions
+
+<br />
+
+**chrome_get_v3_jank_cause_id** -\> LONG. Given two slice Ids A and B, find the maximum difference between the durations of it's direct children with matching names for example if slice A has children named (X, Y, Z) with durations of (10, 10, 5) and slice B has children named (X, Y) with durations of (9, 9), the function will return the slice id of the slice named Z that is A's child, as no matching slice named Z was found under B, making 5 - 0 = 5 the maximum delta between both slice's direct children
+
+<br />
+
+<br />
+
+<br />
+
+Given two slice Ids A and B, find the maximum difference
+between the durations of it's direct children with matching names
+for example if slice A has children named (X, Y, Z) with durations of (10, 10, 5)
+and slice B has children named (X, Y) with durations of (9, 9), the function will return
+the slice id of the slice named Z that is A's child, as no matching slice named Z was found
+under B, making 5 - 0 = 5 the maximum delta between both slice's direct children
+Returns LONG: The slice id of the breakdown that has the maximum duration delta.
+
+| Argument | Type | Description |
+|---|---|---|
+| janky_slice_id | LONG | The slice id of the parent slice that we want to cause among it's children. |
+| prev_slice_id | LONG | The slice id of the parent slice that's the reference in comparison to \|janky_slice_id\|. |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.scroll_offsets
+
+#### Views/Tables
+
+<br />
+
+**chrome_scroll_input_offsets**. The raw coordinates and pixel offsets for all input events which were part of a scroll.
+
+<br />
+
+TABLE
+The raw coordinates and pixel offsets for all input events which were part of
+a scroll.
+
+| Column | Type | Description |
+|---|---|---|
+| scroll_id | INT | An ID that ties all EventLatencies in a particular scroll. (implementation note: This is the EventLatency TraceId of the GestureScrollbegin). |
+| event_latency_slice_id | INT | An ID for this particular EventLatency regardless of it being presented or not. |
+| scroll_update_id | INT | An ID that ties this \|event_latency_id\| with the Trace Id (another event_latency_id) that it was presented with. |
+| ts | INT | Timestamp the of the scroll input event. |
+| delta_y | DOUBLE | The delta in raw coordinates between this scroll update event and the previous. |
+| relative_offset_y | DOUBLE | The pixel offset of this scroll update event compared to the initial one. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_presented_scroll_offsets**. The scrolling offsets for the actual (applied) scroll events
+
+<br />
+
+TABLE
+The scrolling offsets for the actual (applied) scroll events. These are not
+necessarily inclusive of all user scroll events, rather those scroll events
+that are actually processed.
+
+| Column | Type | Description |
+|---|---|---|
+| scroll_id | INT | An ID that ties all EventLatencies in a particular scroll. (implementation note: This is the EventLatency TraceId of the GestureScrollbegin). |
+| event_latency_slice_id | INT | An ID for this particular EventLatency regardless of it being presented or not. |
+| scroll_update_id | INT | An ID that ties this \|event_latency_id\| with the Trace Id (another event_latency_id) that it was presented with. |
+| ts | INT | Presentation timestamp. |
+| delta_y | DOUBLE | The delta in raw coordinates between this scroll update event and the previous. |
+| relative_offset_y | DOUBLE | The pixel offset of this scroll update event compared to the initial one. |
+
+<br />
+
+<br />
+
+### chrome.scroll_jank.utils
+
+#### Table Functions
+
+<br />
+
+**chrome_select_long_task_slices** . Extract mojo information for the long-task-tracking scenario for specific names
+
+<br />
+
+<br />
+
+<br />
+
+Extract mojo information for the long-task-tracking scenario for specific
+names. For example, LongTaskTracker slices may have associated IPC
+metadata, or InterestingTask slices for input may have associated IPC to
+determine whether the task is fling/etc.
+Argument \| Type \| Description
+--- \| --- \| ---
+name \| STRING \| The name of slice.
+
+| Column | Type | Description |
+|---|---|---|
+| interface_name | STRING | Name of the interface of the IPC call. |
+| ipc_hash | INT | Hash of the IPC call. |
+| message_type | STRING | Message type (e.g. reply). |
+| id | INT | The slice id. |
+
+<br />
+
+<br />
+
+### chrome.speedometer
+
+#### Views/Tables
+
+<br />
+
+**chrome_speedometer_measure**. Augmented slices for Speedometer measurements. These are the intervals of time Speedometer uses to compute the final score. There are two intervals that are measured for every test: sync and async
+
+<br />
+
+TABLE
+Augmented slices for Speedometer measurements.
+These are the intervals of time Speedometer uses to compute the final score.
+There are two intervals that are measured for every test: sync and async
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Start timestamp of the measure slice |
+| dur | INT | Duration of the measure slice |
+| name | STRING | Full measure name |
+| iteration | INT | Speedometer iteration the slice belongs to. |
+| suite_name | STRING | Suite name |
+| test_name | STRING | Test name |
+| measure_type | STRING | Type of the measure (sync or async) |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_speedometer_iteration**. Slice that covers one Speedometer iteration. Depending on the Speedometer version these slices might need to be estimated as older versions of Speedometer to not emit marks for this interval
+
+<br />
+
+TABLE
+Slice that covers one Speedometer iteration.
+Depending on the Speedometer version these slices might need to be estimated
+as older versions of Speedometer to not emit marks for this interval. The
+metrics associated are the same ones Speedometer would output, but note we
+use ns precision (Speedometer uses \~100us) so the actual values might differ
+a bit.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Start timestamp of the iteration |
+| dur | INT | Duration of the iteration |
+| name | STRING | Iteration name |
+| iteration | INT | Iteration number |
+| geomean | DOUBLE | Geometric mean of the suite durations for this iteration. |
+| score | DOUBLE | Speedometer score for this iteration (The total score for a run in the average of all iteration scores). |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**chrome_speedometer_score** -\> DOUBLE. Returns the Speedometer score for all iterations in the trace
+
+<br />
+
+<br />
+
+<br />
+
+Returns DOUBLE: Speedometer score
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_speedometer_renderer_main_utid** -\> INT. Returns the utid for the main thread that ran Speedometer 3
+
+<br />
+
+<br />
+
+<br />
+
+Returns INT: Renderer main utid
+
+<br />
+
+<br />
+
+### chrome.speedometer_2_1
+
+#### Views/Tables
+
+<br />
+
+**chrome_speedometer_2_1_measure**. Augmented slices for Speedometer measurements. These are the intervals of time Speedometer uses to compute the final score. There are two intervals that are measured for every test: sync and async sync is the time between the start and sync-end marks, async is the time between the sync-end and async-end marks.
+
+<br />
+
+TABLE
+Augmented slices for Speedometer measurements.
+These are the intervals of time Speedometer uses to compute the final score.
+There are two intervals that are measured for every test: sync and async
+sync is the time between the start and sync-end marks, async is the time
+between the sync-end and async-end marks.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Start timestamp of the measure slice |
+| dur | INT | Duration of the measure slice |
+| name | STRING | Full measure name |
+| iteration | INT | Speedometer iteration the slice belongs to. |
+| suite_name | STRING | Suite name |
+| test_name | STRING | Test name |
+| measure_type | STRING | Type of the measure (sync or async) |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_speedometer_2_1_iteration**. Slice that covers one Speedometer iteration. This slice is actually estimated as a default Speedometer run will not emit marks to cover this interval
+
+<br />
+
+TABLE
+Slice that covers one Speedometer iteration.
+This slice is actually estimated as a default Speedometer run will not emit
+marks to cover this interval. The metrics associated are the same ones
+Speedometer would output, but note we use ns precision (Speedometer uses
+\~100us) so the actual values might differ a bit. Also note Speedometer
+returns the values in ms these here and in ns.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Start timestamp of the iteration |
+| dur | INT | Duration of the iteration |
+| name | STRING | Iteration name |
+| iteration | INT | Iteration number |
+| geomean | DOUBLE | Geometric mean of the suite durations for this iteration. |
+| score | DOUBLE | Speedometer score for this iteration (The total score for a run in the average of all iteration scores). |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**chrome_speedometer_2_1_score** -\> DOUBLE. Returns the Speedometer 2.1 score for all iterations in the trace
+
+<br />
+
+<br />
+
+<br />
+
+Returns DOUBLE: Speedometer 2.1 score
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_speedometer_2_1_renderer_main_utid** -\> INT. Returns the utid for the main thread that ran Speedometer 2.1
+
+<br />
+
+<br />
+
+<br />
+
+Returns INT: Renderer main utid
+
+<br />
+
+<br />
+
+### chrome.speedometer_3
+
+#### Views/Tables
+
+<br />
+
+**chrome_speedometer_3_measure**. Augmented slices for Speedometer measurements. These are the intervals of time Speedometer uses to compute the final score. There are two intervals that are measured for every test: sync and async.
+
+<br />
+
+TABLE
+Augmented slices for Speedometer measurements.
+These are the intervals of time Speedometer uses to compute the final score.
+There are two intervals that are measured for every test: sync and async.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Start timestamp of the measure slice |
+| dur | INT | Duration of the measure slice |
+| name | STRING | Full measure name |
+| iteration | INT | Speedometer iteration the slice belongs to. |
+| suite_name | STRING | Suite name |
+| test_name | STRING | Test name |
+| measure_type | STRING | Type of the measure (sync or async) |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_speedometer_3_iteration**. Slice that covers one Speedometer iteration. The metrics associated are the same ones Speedometer would output, but note we use ns precision (Speedometer uses \~100us) so the actual values might differ a bit.
+
+<br />
+
+TABLE
+Slice that covers one Speedometer iteration.
+The metrics associated are the same ones
+Speedometer would output, but note we use ns precision (Speedometer uses
+\~100us) so the actual values might differ a bit.
+
+| Column | Type | Description |
+|---|---|---|
+| ts | INT | Start timestamp of the iteration |
+| dur | INT | Duration of the iteration |
+| name | STRING | Iteration name |
+| iteration | INT | Iteration number |
+| geomean | DOUBLE | Geometric mean of the suite durations for this iteration. |
+| score | DOUBLE | Speedometer score for this iteration (The total score for a run in the average of all iteration scores). |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**chrome_speedometer_3_score** -\> DOUBLE. Returns the Speedometer 3 score for all iterations in the trace
+
+<br />
+
+<br />
+
+<br />
+
+Returns DOUBLE: Speedometer 3 score
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_speedometer_3_renderer_main_utid** -\> INT. Returns the utid for the main thread that ran Speedometer 3
+
+<br />
+
+<br />
+
+<br />
+
+Returns INT: Renderer main utid
+
+<br />
+
+<br />
+
+### chrome.startups
+
+#### Views/Tables
+
+<br />
+
+**chrome_startups**. Chrome startups, including launch cause.
+
+<br />
+
+TABLE
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Unique ID |
+| activity_id | INT | Chrome Activity event id of the launch. |
+| name | STRING | Name of the launch start event. |
+| startup_begin_ts | INT | Timestamp that the startup occurred. |
+| first_visible_content_ts | INT | Timestamp to the first visible content. |
+| launch_cause | STRING | Launch cause. See Startup.LaunchCauseType in chrome_track_event.proto. |
+| browser_upid | INT | Process ID of the Browser where the startup occurred. |
+
+<br />
+
+<br />
+
+### chrome.tasks
+
+#### Views/Tables
+
+<br />
+
+**chrome_java_views**. A list of slices corresponding to operations on interesting (non-generic) Chrome Java views
+
+<br />
+
+VIEW
+A list of slices corresponding to operations on interesting (non-generic)
+Chrome Java views. The view is considered interested if it's not a system
+(ContentFrameLayout) or generic library (CompositorViewHolder) views.
+
+TODO(altimin): Add "columns_from slice" annotation.
+TODO(altimin): convert this to EXTEND_TABLE when it becomes available.
+
+| Column | Type | Description |
+|---|---|---|
+| filtered_name | STRING | Name of the view. |
+| is_software_screenshot | BOOL | Whether this slice is a part of non-accelerated capture toolbar screenshot. |
+| is_hardware_screenshot | BOOL | Whether this slice is a part of accelerated capture toolbar screenshot. |
+| slice_id | INT | Slice id. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_scheduler_tasks**. A list of tasks executed by Chrome scheduler.
+
+<br />
+
+VIEW
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Slice id. |
+| type | STRING | Type. |
+| name | STRING | Name of the task. |
+| ts | INT | Timestamp. |
+| dur | INT | Duration. |
+| utid | INT | Utid of the thread this task run on. |
+| thread_name | STRING | Name of the thread this task run on. |
+| upid | INT | Upid of the process of this task. |
+| process_name | STRING | Name of the process of this task. |
+| track_id | INT | Same as slice.track_id. |
+| category | STRING | Same as slice.category. |
+| depth | INT | Same as slice.depth. |
+| parent_id | INT | Same as slice.parent_id. |
+| arg_set_id | INT | Same as slice.arg_set_id. |
+| thread_ts | INT | Same as slice.thread_ts. |
+| thread_dur | INT | Same as slice.thread_dur. |
+| posted_from | STRING | Source location where the PostTask was called. |
+
+<br />
+
+<br />
+
+<br />
+
+**chrome_tasks**. A list of "Chrome tasks": top-level execution units (e.g
+
+<br />
+
+VIEW
+A list of "Chrome tasks": top-level execution units (e.g. scheduler tasks /
+IPCs / system callbacks) run by Chrome. For a given thread, the slices
+corresponding to these tasks will not intersect.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Id for the given task, also the id of the slice this task corresponds to. |
+| name | STRING | Name for the given task. |
+| task_type | STRING | Type of the task (e.g. "scheduler"). |
+| thread_name | STRING | Thread name. |
+| utid | INT | Utid. |
+| process_name | STRING | Process name. |
+| upid | INT | Upid. |
+| ts | INT | Alias of \|slice.ts\|. |
+| dur | INT | Alias of \|slice.dur\|. |
+| track_id | INT | Alias of \|slice.track_id\|. |
+| category | STRING | Alias of \|slice.category\|. |
+| arg_set_id | INT | Alias of \|slice.arg_set_id\|. |
+| thread_ts | INT | Alias of \|slice.thread_ts\|. |
+| thread_dur | INT | Alias of \|slice.thread_dur\|. |
+| full_name | STRING | STRING Legacy alias for \|name\|. |
+
+<br />
+
+<br />
+
+### chrome.vsync_intervals
+
+#### Views/Tables
+
+<br />
+
+**chrome_vsync_intervals**. A simple table that checks the time between VSync (this can be used to determine if we're refreshing at 90 FPS or 60 FPS). Note: In traces without the "Java" category there will be no VSync TraceEvents and this table will be empty.
+
+<br />
+
+TABLE
+A simple table that checks the time between VSync (this can be used to
+determine if we're refreshing at 90 FPS or 60 FPS).
+
+> [!NOTE]
+> **Note:** In traces without the "Java" category there will be no VSync TraceEvents and this table will be empty.
+
+| Column | Type | Description |
+|---|---|---|
+| slice_id | INT | Slice id of the vsync slice. |
+| ts | INT | Timestamp of the vsync slice. |
+| dur | INT | Duration of the vsync slice. |
+| track_id | INT | Track id of the vsync slice. |
+| time_to_next_vsync | INT | Duration until next vsync arrives. |
+
+<br />
+
+<br />
+
+#### Functions
+
+<br />
+
+**chrome_calculate_avg_vsync_interval** -\> FLOAT. Function: compute the average Vysnc interval of the gesture (hopefully this would be either 60 FPS for the whole gesture or 90 FPS but that isnt always the case) on the given time segment. If the trace doesnt contain the VSync TraceEvent we just fall back on assuming its 60 FPS (this is the 1.6e+7 in the COALESCE which corresponds to 16 ms or 60 FPS).
+
+<br />
+
+<br />
+
+<br />
+
+Function: compute the average Vysnc interval of the
+gesture (hopefully this would be either 60 FPS for the whole gesture or 90
+FPS but that isnt always the case) on the given time segment.
+If the trace doesnt contain the VSync TraceEvent we just fall back on
+assuming its 60 FPS (this is the 1.6e+7 in the COALESCE which
+corresponds to 16 ms or 60 FPS).
+Returns FLOAT: The average vsync interval on this time segment or 1.6e+7, if trace doesn't contain the VSync TraceEvent.
+
+| Argument | Type | Description |
+|---|---|---|
+| begin_ts | LONG | Interval start time. |
+| end_ts | LONG | Interval end time. |
+
+<br />
+
+<br />
+
+### chrome.web_content_interactions
+
+#### Views/Tables
+
+<br />
+
+**chrome_web_content_interactions**. Chrome web content interactions (InteractionToFirstPaint), including associated high-level metrics and properties. Multiple events may occur for the same interaction; each row in this table represents the primary (longest) event for the interaction. Web content interactions are discrete, as opposed to sustained (e.g. scrolling); and only occur with the web content itself, as opposed to other parts of Chrome (e.g
+
+<br />
+
+TABLE
+Chrome web content interactions (InteractionToFirstPaint), including
+associated high-level metrics and properties.
+
+Multiple events may occur for the same interaction; each row in this table
+represents the primary (longest) event for the interaction.
+
+Web content interactions are discrete, as opposed to sustained (e.g.
+scrolling); and only occur with the web content itself, as opposed to other
+parts of Chrome (e.g. omnibox). Interaction events include taps, clicks,
+keyboard input (typing), and drags.
+
+| Column | Type | Description |
+|---|---|---|
+| id | INT | Unique id for this interaction. |
+| ts | INT | Start timestamp of the event. Because multiple events may occur for the same interaction, this is the start timestamp of the longest event. |
+| dur | INT | Duration of the event. Because multiple events may occur for the same interaction, this is the duration of the longest event. |
+| interaction_type | STRING | The interaction type. |
+| total_duration_ms | INT | The total duration of all events that occurred for the same interaction. |
+| renderer_upid | INT | The process id this event occurred on. |
+
+<br />
+
+<br />
+
+## Package: counters
+
+### counters.intervals
+
+#### Macros
+
+<br />
+
+**counter_leading_intervals** . For a given counter timeline (e.g
+
+<br />
+
+<br />
+
+<br />
+
+For a given counter timeline (e.g. a single counter track), returns
+intervals of time where the counter has the same value.
+
+Intervals are computed in a "forward-looking" way. That is, if a counter
+changes value at some timestamp, it's assumed it *just* reached that
+value and it should continue to have that value until the next
+value change. The final value is assumed to hold until the very end of
+the trace.
+
+For example, suppose we have the following data:
+`ts=0, value=10, track_id=1
+ts=0, value=10, track_id=2
+ts=10, value=10, track_id=1
+ts=10, value=20, track_id=2
+ts=20, value=30, track_id=1
+[end of trace at ts = 40]`
+
+Then this macro will generate the following intervals:
+`ts=0, dur=20, value=10, track_id=1
+ts=20, dur=10, value=30, track_id=1
+ts=0, dur=10, value=10, track_id=2
+ts=10, dur=30, value=20, track_id=2`
+Returns: TableOrSubquery, Table with the schema (id UINT32, ts UINT64, dur UINT64, track_id UINT64, value DOUBLE, next_value DOUBLE, delta_value DOUBLE).
+
+| Argument | Type | Description |
+|---|---|---|
+| counter_table | TableOrSubquery | A table/view/subquery corresponding to a "counter-like" table. This table must have the columns "id" and "ts" and "track_id" and "value" corresponding to an id, timestamp, counter track_id and associated counter value. |
+
+<br />
+
+<br />
+
+## Package: graphs
+
+### graphs.dominator_tree
+
+#### Macros
+
+<br />
+
+**graph_dominator_tree** . Given a table containing a directed flow-graph and an entry node, computes the "dominator tree" for the graph
+
+<br />
+
+<br />
+
+<br />
+
+Given a table containing a directed flow-graph and an entry node, computes
+the "dominator tree" for the graph. See \[1\] for an explanation of what a
+dominator tree is.
+
+\[1\] https://en.wikipedia.org/wiki/Dominator_(graph_theory)
+
+Example usage on traces containing heap graphs:
+\`\`\`
+CREATE PERFETTO VIEW dominator_compatible_heap_graph AS
+-- Extract the edges from the heap graph which correspond to references
+-- between objects.
+SELECT
+owner_id AS source_node_id,
+owned_id as dest_node_id
+FROM heap_graph_reference
+JOIN heap_graph_object owner on heap_graph_reference.owner_id = owner.id
+WHERE owned_id IS NOT NULL AND owner.reachable
+UNION ALL
+-- Since a Java heap graph is a "forest" structure, we need to add a dummy
+-- "root" node which connects all the roots of the forest into a single
+-- connected component.
+SELECT
+(SELECT max(id) + 1 FROM heap_graph_object) as source_node_id,
+id
+FROM heap_graph_object
+WHERE root_type IS NOT NULL;
+
+SELECT \*
+FROM graph_dominator_tree!(
+dominator_compatible_heap_graph,
+(SELECT max(id) + 1 FROM heap_graph_object)
+);
+\`\`\`
+Returns: TableOrSubquery, The returned table has the schema (node_id UINT32, dominator_node_id UINT32). \|node_id\| is the id of the node from the input graph and \|dominator_node_id\| is the id of the node in the input flow-graph which is the "dominator" of \|node_id\|.
+
+| Argument | Type | Description |
+|---|---|---|
+| graph_table | TableOrSubquery | A table/view/subquery corresponding to a directed flow-graph on which the dominator tree should be computed. This table must have the columns "source_node_id" and "dest_node_id" corresponding to the two nodes on either end of the edges in the graph. Note: the columns must contain uint32 similar to ids in trace processor tables (i.e. the values should be relatively dense and close to zero). The implementation makes assumptions on this for performance reasons and, if this criteria is not, can lead to enormous amounts of memory being allocated. Note: this means that the graph *must* be a single fully connected component with \|root_node_id\| (see below) being the "entry node" for this component. Specifically, all nodes *must* be reachable by following paths from the root node. Failing to adhere to this property will result in undefined behaviour. If working with a "forest"-like structure, a dummy node should be added which links all the roots of the forest together into a single component; an example of this can be found in the heap graph example query above. |
+| root_node_id | Expr | The entry node to \|graph_table\| which will be the root of the dominator tree. |
+
+<br />
+
+<br />
+
+### graphs.partition
+
+#### Macros
+
+<br />
+
+**tree_structural_partition_by_group** . Partitions a tree into a forest of trees based on a given grouping key in a structure-preserving way. Specifically, for each tree in the output forest, all the nodes in that tree have the same ancestors and descendants as in the original tree *iff* that ancestor/descendent belonged to the same group. Example: Input id \| parent_id \| group_key ---\|---\|--- 1 \| NULL \| 1 2 \| 1 \| 1 3 \| NULL \| 2 4 \| NULL \| 2 5 \| 2 \| 1 6 \| NULL \| 3 7 \| 4 \| 2 8 \| 4 \| 1 Or as a graph: `1 (1) / 2 (1) / \ 3 (2) 4 (2) / \ 5 (1) 8 (1) / \ 6 (3) 7 (2)` Possible output (order of rows is implementation-defined) id \| parent_id \| group_key ---\|---\|--- 1 \| NULL \| 1 2 \| 1 \| 1 3 \| NULL \| 2 4 \| NULL \| 2 5 \| 2 \| 1 6 \| NULL \| 3 7 \| 4 \| 2 8 \| 2 \| 1 Or as a forest: `1 (1) 3 (2) 4 (2) 6 (3) | | 2 (1) 7 (2) / \ 5 (1) 8 (1)`
+
+<br />
+
+<br />
+
+<br />
+
+Partitions a tree into a forest of trees based on a given grouping key
+in a structure-preserving way.
+
+Specifically, for each tree in the output forest, all the nodes in that tree
+have the same ancestors and descendants as in the original tree *iff* that
+ancestor/descendent belonged to the same group.
+
+Example:
+Input
+
+| id | parent_id | group_key |
+|---|---|---|
+| 1 | NULL | 1 |
+| 2 | 1 | 1 |
+| 3 | NULL | 2 |
+| 4 | NULL | 2 |
+| 5 | 2 | 1 |
+| 6 | NULL | 3 |
+| 7 | 4 | 2 |
+| 8 | 4 | 1 |
+
+Or as a graph:
+`1 (1)
+/
+2 (1)
+/ \
+3 (2) 4 (2)
+/ \
+5 (1) 8 (1)
+/ \
+6 (3) 7 (2)`
+Possible output (order of rows is implementation-defined)
+
+| id | parent_id | group_key |
+|---|---|---|
+| 1 | NULL | 1 |
+| 2 | 1 | 1 |
+| 3 | NULL | 2 |
+| 4 | NULL | 2 |
+| 5 | 2 | 1 |
+| 6 | NULL | 3 |
+| 7 | 4 | 2 |
+| 8 | 2 | 1 |
+
+Or as a forest:
+`1 (1) 3 (2) 4 (2) 6 (3)
+| |
+2 (1) 7 (2)
+/ \
+5 (1) 8 (1)`
+Returns: TableOrSubquery, The returned table has the schema (id UINT32, parent_id UINT32, group_key UINT32).
+
+| Argument | Type | Description |
+|---|---|---|
+| tree_table | TableOrSubquery | A table/view/subquery corresponding to a tree which should be partitioned. This table must have the columns "id", "parent_id" and "group_key". Note: the columns must contain uint32 similar to ids in trace processor tables (i.e. the values should be relatively dense and close to zero). The implementation makes assumptions on this for performance reasons and, if this criteria is not, can lead to enormous amounts of memory being allocated. |
+
+<br />
+
+<br />
+
+### graphs.search
+
+#### Macros
+
+<br />
+
+**graph_reachable_dfs** . Computes the "reachable" set of nodes in a directed graph from a given set of starting nodes by performing a depth-first search on the graph
+
+<br />
+
+<br />
+
+<br />
+
+Computes the "reachable" set of nodes in a directed graph from a given set
+of starting nodes by performing a depth-first search on the graph. The
+returned nodes are structured as a tree with parent-child relationships
+corresponding to the order in which nodes were encountered by the DFS.
+
+While this macro can be used directly by end users (hence being public),
+it is primarily intended as a lower-level building block upon which higher
+level functions/macros in the standard library can be built.
+
+Example usage on traces containing heap graphs:
+`-- Compute the reachable nodes from the first heap root.
+SELECT *
+FROM graph_reachable_dfs!(
+(
+SELECT
+owner_id AS source_node_id,
+owned_id as dest_node_id
+FROM heap_graph_reference
+WHERE owned_id IS NOT NULL
+),
+(SELECT id FROM heap_graph_object WHERE root_type IS NOT NULL)
+);`
+Returns: TableOrSubquery, The returned table has the schema (node_id UINT32, parent_node_id UINT32). \|node_id\| is the id of the node from the input graph and \|parent_node_id\| is the id of the node which was the first encountered predecessor in a DFS search of the graph.
+
+| Argument | Type | Description |
+|---|---|---|
+| graph_table | TableOrSubquery | A table/view/subquery corresponding to a directed graph on which the reachability search should be performed. This table must have the columns "source_node_id" and "dest_node_id" corresponding to the two nodes on either end of the edges in the graph. Note: the columns must contain uint32 similar to ids in trace processor tables (i.e. the values should be relatively dense and close to zero). The implementation makes assumptions on this for performance reasons and, if this criteria is not, can lead to enormous amounts of memory being allocated. |
+| start_nodes | TableOrSubquery | A table/view/subquery corresponding to the list of start nodes for the BFS. This table must have a single column "node_id". |
+
+<br />
+
+<br />
+
+<br />
+
+**graph_reachable_bfs** . Computes the "reachable" set of nodes in a directed graph from a given starting node by performing a breadth-first search on the graph
+
+<br />
+
+<br />
+
+<br />
+
+Computes the "reachable" set of nodes in a directed graph from a given
+starting node by performing a breadth-first search on the graph. The returned
+nodes are structured as a tree with parent-child relationships corresponding
+to the order in which nodes were encountered by the BFS.
+
+While this macro can be used directly by end users (hence being public),
+it is primarily intended as a lower-level building block upon which higher
+level functions/macros in the standard library can be built.
+
+Example usage on traces containing heap graphs:
+`-- Compute the reachable nodes from all heap roots.
+SELECT *
+FROM graph_reachable_bfs!(
+(
+SELECT
+owner_id AS source_node_id,
+owned_id as dest_node_id
+FROM heap_graph_reference
+WHERE owned_id IS NOT NULL
+),
+(SELECT id FROM heap_graph_object WHERE root_type IS NOT NULL)
+);`
+Returns: TableOrSubquery, The returned table has the schema (node_id UINT32, parent_node_id UINT32). \|node_id\| is the id of the node from the input graph and \|parent_node_id\| is the id of the node which was the first encountered predecessor in a BFS search of the graph.
+
+| Argument | Type | Description |
+|---|---|---|
+| graph_table | TableOrSubquery | A table/view/subquery corresponding to a directed graph on which the reachability search should be performed. This table must have the columns "source_node_id" and "dest_node_id" corresponding to the two nodes on either end of the edges in the graph. Note: the columns must contain uint32 similar to ids in trace processor tables (i.e. the values should be relatively dense and close to zero). The implementation makes assumptions on this for performance reasons and, if this criteria is not, can lead to enormous amounts of memory being allocated. |
+| start_nodes | TableOrSubquery | A table/view/subquery corresponding to the list of start nodes for the BFS. This table must have a single column "node_id". |
+
+<br />
+
+<br />
+
+<br />
+
+**graph_next_sibling** . Computes the next sibling node in a directed graph
+
+<br />
+
+<br />
+
+<br />
+
+Computes the next sibling node in a directed graph. The next node under a parent node
+is determined by on the \|sort_key\|, which should be unique for every node under a parent.
+The order of the next sibling is undefined if the \|sort_key\| is not unique.
+
+Example usage:
+`-- Compute the next sibling:
+SELECT *
+FROM graph_next_sibling!(
+(
+SELECT
+id AS node_id,
+parent_id AS node_parent_id,
+ts AS sort_key
+FROM slice
+)
+);`
+Returns: TableOrSubquery, The returned table has the schema (node_id UINT32, next_node_id UINT32). \|node_id\| is the id of the node from the input graph and \|next_node_id\| is the id of the node which is its next sibling.
+
+| Argument | Type | Description |
+|---|---|---|
+| graph_table | TableOrSubquery | A table/view/subquery corresponding to a directed graph for which to find the next sibling. This table must have the columns "node_id", "node_parent_id" and "sort_key". |
+
+<br />
+
+<br />
+
+<br />
+
+**graph_reachable_weight_bounded_dfs** . Computes the "reachable" set of nodes in a directed graph from a set of starting (root) nodes by performing a depth-first search from each root node on the graph. The search is bounded by the sum of edge weights on the path and the root node specifies the max weight (inclusive) allowed before stopping the search. The returned nodes are structured as a tree with parent-child relationships corresponding to the order in which nodes were encountered by the DFS
+
+<br />
+
+<br />
+
+<br />
+
+Computes the "reachable" set of nodes in a directed graph from a set of
+starting (root) nodes by performing a depth-first search from each root node on the graph.
+The search is bounded by the sum of edge weights on the path and the root node specifies the
+max weight (inclusive) allowed before stopping the search.
+The returned nodes are structured as a tree with parent-child relationships corresponding
+to the order in which nodes were encountered by the DFS. Each row also has the root node from
+which where the edge was encountered.
+
+While this macro can be used directly by end users (hence being public),
+it is primarily intended as a lower-level building block upon which higher
+level functions/macros in the standard library can be built.
+
+Example usage on traces with sched info:
+\`\`\`
+-- Compute the reachable nodes from a sched wakeup chain
+INCLUDE PERFETTO MODULE sched.thread_executing_spans;
+
+SELECT \*
+FROM
+graph_reachable_dfs_bounded
+!(
+(
+SELECT
+id AS source_node_id,
+COALESCE(parent_id, id) AS dest_node_id,
+id - COALESCE(parent_id, id) AS edge_weight
+FROM _wakeup_chain
+),
+(
+SELECT
+id AS root_node_id,
+id - COALESCE(prev_id, id) AS root_target_weight
+FROM _wakeup_chain
+));
+\`\`\`
+Returns: TableOrSubquery, The returned table has the schema (root_node_id, node_id UINT32, parent_node_id UINT32). \|root_node_id\| is the id of the starting node under which this edge was encountered. \|node_id\| is the id of the node from the input graph and \|parent_node_id\| is the id of the node which was the first encountered predecessor in a DFS search of the graph.
+
+| Argument | Type | Description |
+|---|---|---|
+| graph_table | TableOrSubquery | A table/view/subquery corresponding to a directed graph on which the reachability search should be performed. This table must have the columns "source_node_id" and "dest_node_id" corresponding to the two nodes on either end of the edges in the graph and an "edge_weight" corresponding to the weight of the edge between the node. Note: the columns must contain uint32 similar to ids in trace processor tables (i.e. the values should be relatively dense and close to zero). The implementation makes assumptions on this for performance reasons and, if this criteria is not, can lead to enormous amounts of memory being allocated. |
+| root_table | TableOrSubquery | A table/view/subquery corresponding to start nodes to \|graph_table\| which will be the roots of the reachability trees. This table must have the columns "root_node_id" and "root_target_weight" corresponding to the starting node id and the max weight allowed on the tree. Note: the columns must contain uint32 similar to ids in trace processor tables (i.e. the values should be relatively dense and close to zero). The implementation makes assumptions on this for performance reasons and, if this criteria is not, can lead to enormous amounts of memory being allocated. |
+| is_target_weight_floor | Expr | Whether the target_weight is a floor weight or ceiling weight. If it's floor, the search stops right after we exceed the target weight, and we include the node that pushed just passed the target. If ceiling, the search stops right before the target weight and the node that would have pushed us passed the target is not included. |
+
+<br />
+
+<br />
+
+## Package: export
+
+### export.to_firefox_profile
+
+#### Functions
+
+<br />
+
+**export_to_firefox_profile** -\> STRING. Dumps all trace data as a Firefox profile json string See `Profile` in https://github.com/firefox-devtools/profiler/blob/main/src/types/profile.js Also https://firefox-source-docs.mozilla.org/tools/profiler/code-overview.html You would probably want to download the generated json and then open at https://https://profiler.firefox.com You can easily do this from the UI via the following SQL `SELECT CAST(export_to_firefox_profile() AS BLOB) AS profile;` The result will have a link for you to download this json as a file.
+
+<br />
+
+<br />
+
+<br />
+
+Dumps all trace data as a Firefox profile json string
+See `Profile` in
+https://github.com/firefox-devtools/profiler/blob/main/src/types/profile.js
+Also
+https://firefox-source-docs.mozilla.org/tools/profiler/code-overview.html
+
+You would probably want to download the generated json and then open at
+https://https://profiler.firefox.com
+You can easily do this from the UI via the following SQL
+`SELECT CAST(export_to_firefox_profile() AS BLOB) AS profile;`
+The result will have a link for you to download this json as a file.
+Returns STRING: Json profile
+
+<br />
+
+<br />

--- a/platforms/android/.agents/skills/perfetto-trace-analysis/references/sql.md
+++ b/platforms/android/.agents/skills/perfetto-trace-analysis/references/sql.md
@@ -1,0 +1,122 @@
+## Guidelines and Hints
+
+- **Idempotency:** Ensure queries are idempotent to prevent "already exists" errors during multiple executions.
+  - For Perfetto objects, always use `CREATE OR REPLACE`: `CREATE OR REPLACE
+    PERFETTO TABLE`, `CREATE OR REPLACE PERFETTO VIEW`, `CREATE OR REPLACE
+    PERFETTO FUNCTION`, `CREATE OR REPLACE PERFETTO MACRO`.
+  - For SQLite Virtual Tables (such as `SPAN_JOIN`), `CREATE OR REPLACE` is not supported. Explicitly drop them first: `DROP TABLE IF EXISTS
+    my_table; CREATE VIRTUAL TABLE my_table USING SPAN_JOIN(...);`
+  - For standard SQLite indexes, prepend `DROP INDEX IF EXISTS index_name;`.
+- `SPAN_JOIN` will crash if intervals **within the same input table** overlap. Always use the `PARTITIONED {column}` (for example, `PARTITIONED upid`) clause to isolate intervals.
+- Intermediate tables fed into a `SPAN_JOIN` must be materialized using `CREATE PERFETTO TABLE`, not `CREATE VIEW`.
+- **Trace Boundaries (`dur = -1`):** Slices or thread states that don't finish before the trace ends are recorded with `dur = -1`. When calculating a bounding box (for example, `ts + dur`) or summing durations (`SUM(dur)`), handle incomplete durations using: `IIF(dur = -1, trace_end() - ts, dur)`.
+- **Robust State Transitions:** Avoid manual timestamp arithmetic (for example, `ts + dur = next.ts`) to join adjacent events. Rely on standard library modules (for example, `sched.runnable`, `linux.perf.counters`, `intervals.overlap`) which safely handle trace gaps and preemptions.
+- **Unique Identifiers:** When writing SQL queries in Perfetto, you must join tables using `utid` (unique thread ID) or `upid` (unique process ID) instead of the regular `tid` or `pid`. **Why it's useful** : The operating system recycles `TIDs` and `PIDs`, while `UTIDs` and `UPIDs` remain unique for the lifetime of the trace, which prevents incorrect joins.
+- **Safe Argument Extraction:** Use `EXTRACT_ARG(arg_set_id, 'key')` to extract dictionary or JSON-like properties from slices or tracks. Don't attempt string parsing.
+- **String Matching (Always use GLOB):** Use `GLOB` instead of `LIKE`. `LIKE` causes performance bottlenecks and treats underscores (`_`) as wildcards, leading to bugs.
+  - **Exact matches:** Use `=`.
+  - **Substring matches:** Use `GLOB` with `*` (for example, `name GLOB
+    '*RenderThread*'`).
+  - **Case-insensitive matches:** Use `LOWER(name) GLOB` and make sure the search string is fully lowercase (for example, `LOWER(name) GLOB
+    '*renderthread*'`). Use this when dealing with inconsistent trace capitalization (for example, `WakeLock` versus `wakelock`).
+- **Calculating Time Overlaps:** To calculate the overlap duration between two
+  time intervals `[start1, end1]` and `[start2, end2]`:
+
+  > **Precedence Rule:** Always prefer using `SPAN_JOIN` or standard library
+  > functions (for example, `intervals.overlap`) to calculate overlaps
+  > **between two different sets of intervals** . Avoid manual arithmetic if a
+  > standard library feature or `SPAN_JOIN` can achieve the same result. Use
+  > the following logic if no built-in alternative exists.
+  1. **Condition:** The intervals overlap if `start1 < end2` and `start2 <
+     end1`.
+  2. **Duration:** The overlap duration is calculated as `MIN(end1, end2) -
+     MAX(start1, start2)`
+
+     > **Important:** Incomplete Perfetto slices have a duration of -1
+     > (`dur = -1`). Always calculate the effective end time using `ts +
+     > IIF(dur = -1, trace_end() - ts, dur)` before applying this logic.
+- Query `android_thread_slices_for_all_startups` for app startup requests.
+
+- Join `counter_track` with `counter` to get values of counter with a specific
+  name.
+
+- When querying for a CPU frequency counter, include the `linux.cpu.frequency`
+  module and use the `cpu_frequency_counters` table.
+
+- When looking for events around a specific timestamp, start with 100ms as the
+  window size.
+
+- Always prefix column names with table or view alias, that is:
+  `{alias}.{column_name}`.
+
+- To calculate the total time spent in slices matching a specific name pattern
+  (for example, `*{name_pattern}*`), you must sum their durations. **Why it's
+  useful** : This helps quantify the total impact of a specific function or
+  feature on performance across multiple calls. Here is an example query (note
+  the safe handling of incomplete slices): `sql SELECT count(*) as
+  total_count, sum(IIF(slice.dur = -1, trace_end() - slice.ts, slice.dur)) /
+  1000000.0 as total_dur_ms FROM slice WHERE slice.name GLOB
+  '*{name_pattern}*';`
+
+## Resources
+
+- **Documentation:** The Perfetto Standard Library documentation is in [`perfetto-stdlib.md`](perfetto-stdlib.md). Use this file as a reference to discover available modules, find schemas (columns and types) for specific tables or views, or determine the `INCLUDE PERFETTO MODULE` statements required before drafting SQL query.
+- **Execution Tool:** Queries are executed using the official `trace_processor` wrapper script downloaded directly from Perfetto. Output is returned in pure CSV format.
+
+## Execution Protocol
+
+You must follow these steps sequentially, mirroring a multi-agent pipeline:
+
+### Step 0: Tool Setup
+
+**Fetch the Wrapper:** You must use the top level of the current project workspace (`./trace_processor`).
+
+> **CRITICAL GUARDRAIL:** NEVER use filesystem search tools (`find`, `find_by_name`, `grep`, `dir /s`, `Get-ChildItem`) across the home directory or workspace to locate `trace_processor` — unconstrained searches across entire workspaces will stop responding or time out.
+
+Perform a direct file check at the top level of your workspace (e.g., `ls trace_processor`). If missing, download `https://get.perfetto.dev/trace_processor` directly into the root workspace (`curl -LO`), make it executable on macOS/Linux (`chmod +x`), and ensure `trace_processor` is added to `.gitignore`. Execute queries directly via `./trace_processor` (on Windows, explicitly invoke `python trace_processor`).
+
+> **Important:** The file served at this URL is a `~10KB` Python wrapper script. Don't assume the download failed because it is human-readable text. This is the intended behavior. This script handles lazy-loading the precompiled binary automatically on its first run. Use it directly.
+
+### Step 1: Dissection and Schema Research
+
+1. Identify the core question, required data points, and filtering conditions.
+2. **Precedence Rule:** If the user's request contains a SQL query, use it **without modification** and skip to Step 2 for validation.
+3. **Mandatory Schema and Module Search:** For every table or view you plan to use, you MUST find its schema in [`perfetto-stdlib.md`](perfetto-stdlib.md). **Don't read the entire documentation file** --- it consumes the context window. Follow this precise workflow:
+   - **Discovery and Search:** Use available search tools (`grep`, `read_file` or file search) with line limits to discover relevant views, tables or modules based on your problem domain and high-level intents (for example, 'CPU time', 'running time', 'overlap', 'jank').
+     - **Why:** Searching solely for exact table names misses comprehensive, pre-computed views built for these analyses.
+     - **Note:** You must verify if a Standard Library module already provides the needed abstraction before drafting manual arithmetic or custom functions.
+   - **Targeted Bounded Reads:** Once you identify the relevant modules, efficiently read the tables and views within that module section.
+   - **Extract:** Extract only the schema, columns, and the exact `INCLUDE
+     PERFETTO MODULE` statements for the required object from the documentation.
+   - **Verify:** Review the columns, types, and descriptions to ensure the table matches your needs.
+4. Print the research results before drafting the query:
+5. *Tables/Views:* `Schema for {name}:` listing columns and types.
+
+### Step 2: Draft and Validate Loop (Max 3 Iterations)
+
+Draft the SQL query in SQLite syntax using **only** the schemas retrieved in
+Step 1. After drafting, you must validate against this checklist:
+
+- \[ \] **SQLite Syntax:** Does the query parse successfully without syntax errors?
+- \[ \] **Idempotency:** Are all object creations safe to re-run? (Did you use `CREATE OR REPLACE PERFETTO` and `DROP TABLE IF EXISTS` for virtual tables?)
+- \[ \] **Existence:** Were all tables found in the documentation?
+- \[ \] **Intent Check:** Is there a pre-existing standard library table or view that will fulfill this intent before instead of writing manual arithmetic?
+- \[ \] **Column Accuracy:** Do columns match the retrieved schemas?
+- \[ \] **Alias Check:** Are ALL column names prefixed with their table or view alias (for example, `alias.column_name`)?
+- \[ \] **Module Check:** Are `INCLUDE PERFETTO MODULE` statements included for all non-prelude modules? **You must use the exact module names provided in
+  the documentation.**
+- \[ \] **Span Join Check:** If using `SPAN_JOIN`, are tables safely `PARTITIONED` to prevent overlapping interval crashes? Are intermediate tables materialized with `CREATE PERFETTO TABLE`?
+- \[ \] **No LIKE Constraint:** Did you map string matches using `GLOB` or `=` instead of prohibited `LIKE`?
+- \[ \] **Execution Check:** You MUST run queries using the standalone
+  `./trace_processor` wrapper with the `--query-string` flag:
+  `./trace_processor --query-string "QUERY" {trace_file}`.
+
+  **Execution Rules:**
+  - **File Usage** : If you must create a SQL file to execute queries (for example, due to query length or escaping issues), you must create them in the `/tmp/` directory.
+  - **State:** The execution is purely ephemeral. Database state does not persist across turns. You **cannot** share state (like views or tables) across queries in different turns. Every query must be standalone and fully self-contained.
+  - **Failure Resilience:** Debug and fix SQL syntax and logic errors when query fails.Don't simplify the analytical intent to pass validation. For example, if requested to calculate an overlap or intersection, you must fix the intersection math. Don't substitute with disjoint queries (for example, returning independent total durations) as a workaround.
+
+### Step 3: Final Output
+
+1. Explicitly return and state the final validated SQL and explain the results to the user.
+2. Before finishing your response, delete all temporary SQL files you created in `/tmp/` directory.

--- a/platforms/android/.agents/skills/play-billing-library-version-upgrade/SKILL.md
+++ b/platforms/android/.agents/skills/play-billing-library-version-upgrade/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: play-billing-library-version-upgrade
+description: Use this skill when upgrading or migrating an Android project from any
+  legacy Google Play Billing Library (PBL) version to the latest stable version of
+  PBL.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-07-02'
+  keywords:
+  - android
+  - play billing
+  - play billing library
+  - pbl
+  - upgrade
+  - migration
+  - deprecation
+  - google play
+---
+
+## Phase 0: Intent Message
+
+**Reporting Action**: Before proceeding, immediately tell the user: "I will
+upgrade Play Billing Library to the latest version."
+
+## Phase 1: Discovery \& Situational Awareness
+
+1. **Primary Check (Build Version)** : Locate the project's billing dependency (e.g., `com.android.billingclient:billing`) in `build.gradle`, `build.gradle.kts`, or `libs.versions.toml`.
+2. **Initial Compilation Test**: Attempt to sync and build the project immediately.
+3. **Fallback Discovery (Effective Version)** :
+   - **Trigger**: Only if the build fails immediately, scan the source code for deprecated artifacts.
+   - **Logic** : The presence of deprecated APIs indicates the **"Effective
+     Version"** ---defined as the version where those specific APIs were **last
+     available**, not when they were introduced.
+   - **Example** : If `SkuDetails` is present, treat the baseline as **PBL v7** or earlier (regardless of the version string in `build.gradle`).
+4. **Identify Target \& Path** : Access the version tool or release notes to find the latest stable version and calculate a \[Direct/Stepped\] migration path based on the **Effective Version** baseline.
+
+- **Calculate Migration Path** :
+  - If the **Effective Version** is within 2 major versions of the target: Plan a **Direct Migration**.
+  - If it is more than 2 major versions behind: Plan a **Stepped
+    Migration**. Migrate by two major versions at a time (e.g., v4 -\> v6 -\> v8) until you are within two versions of the target.
+- **Reporting Action**: Before proceeding, tell the user: "I've detected you are effectively on PBL \[Current\] and the latest is \[Target\]. I am planning a \[direct/stepped\] migration path."
+
+## Phase 2: Contextual Document Mapping \& Planning
+
+For every major version jump identified in your path, you **MUST** synthesize
+instructions from:
+
+- **[Migration Guide](https://developer.android.com/google/play/billing/migrate-gpblv%5BX%5D)** (where `[X]` is the target major version).
+- **Release Highlights** : The "Deprecations" and "Breaking Changes" sections of the relevant [Release Notes](references/android/google/play/billing/release-notes.md).
+- **Developer Documentation**: Consult your knowledge of the Google Play Billing documentation regarding the relevant features used in this app (e.g., Subscriptions, One-Time Products).
+- **Develop the Plan**: Identify every specific code change required (API removals, class replacements, logic shifts) and print this out as a checklist.
+
+## Phase 3: Instructions for Execution
+
+*Reporting Action: For each of the following steps, give a brief explanation of
+what you will be doing prior to execution, and a brief summary of what you
+accomplished afterwards.*
+
+### Step 1: SDK \& Environment Alignment
+
+- **Action** : Update `build.gradle` to meet SDK requirements (e.g., "PBL 9 requires `compileSdk` 35").
+- **Gradle Version**: Verify if the new library requires a newer Android Gradle Plugin (AGP) or Kotlin version.
+
+### Step 2: Intent-based Refactoring
+
+Analyze the intent of the existing code rather than performing purely textual
+string replacement.
+
+- **Action** : You **MUST** follow all deprecation instructions and refactor patterns from **both** the [references/migration-logic.md](references/migration-logic.md) section, the official migration guides, and the general documentation pages identified in Phase 2.
+- **Verification** : Verify you are doing **all steps from all documentation** and then making sure you follow the specific directions from the checklist in the references.
+
+### Step 3: Sequential Verification (Only applicable for Stepped Migrations)
+
+1. **Upgrade** to the first major intermediate version in your path.
+2. **Run `./gradlew assembleDebug`** to verify no intermediate breaking changes were missed.
+3. **Repeat** until you reach the final target version.
+
+### Step 4: Final Validation Checklist
+
+1. **Smart Checklist Verification**:
+2. Open [references/version-checklist.md](references/version-checklist.md) and locate the **Smart Version-Specific Checklist**.
+3. **Action**: For every version between your \[Detected Effective Version\] and \[Detected New Version\], verify that every item has been addressed in the code using "Find in Files" or structural analysis.
+4. **Tests** : Run all unit and implementation tests (`./gradlew test`).
+5. **Clean Build** : Verify the project completes a full clean build: `./gradlew clean assembleDebug`. Then, run `./gradlew sync` and `./gradlew build` so that the user can immediately test the new version manually.
+
+## Final Report
+
+Explain the "Why" to the developer:
+
+- "I updated your SDK to \[Version\] because PBL \[Version\] requires it for \[Reason from docs\]."
+- "I removed your custom `retryConnection()` logic because it is now handled natively by the library using `enableAutoServiceReconnection()`."
+- "Successfully upgraded from PBL \[Old\] to PBL \[New\] and verified with unit tests. Based on an analysis of features in the latest library and this application's current feature set, I suggest exploring \[New Feature\] (e.g., Prepaid Plans or Installments) from the latest release because it is now available but not yet implemented."

--- a/platforms/android/.agents/skills/play-billing-library-version-upgrade/references/android/google/play/billing/release-notes.md
+++ b/platforms/android/.agents/skills/play-billing-library-version-upgrade/references/android/google/play/billing/release-notes.md
@@ -1,0 +1,1226 @@
+This document contains release notes for the Google Play Billing Library.
+
+> [!NOTE]
+> **Note:** You can use the [Play Billing Library Version Upgrade Skill](https://github.com/android/skills/tree/main/play/play-billing-library-version-upgrade) to automate your upgrade to the latest version.
+
+## Google Play Billing Library 9.1.0 Release (2026-06-18)
+
+Version 9.1.0 of the Google Play Billing Library and Kotlin extensions are now available.
+
+### Summary of changes
+
+- New APIs for [Billing Choice](https://developer.android.com/google/play/billing/billingchoice):
+  - Added [`BillingClient.getBillingChoiceInfoAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#getBillingChoiceInfoAsync(com.android.billingclient.api.GetBillingChoiceInfoParams,com.android.billingclient.api.BillingChoiceInfoResponseListener)) to retrieve information about billing choices available to the user.
+  - Added [`BillingChoiceInfo`](https://developer.android.com/reference/com/android/billingclient/api/BillingChoiceInfo) class which contains the response details, including image URLs and loyalty information.
+  - Added [`GetBillingChoiceInfoParams`](https://developer.android.com/reference/com/android/billingclient/api/GetBillingChoiceInfoParams) to configure the request.
+  - Added [`BillingChoiceInfoResponseListener`](https://developer.android.com/reference/com/android/billingclient/api/BillingChoiceInfoResponseListener) to receive the callback.
+  - Added Kotlin extension [`BillingClient.getBillingChoiceInfo()`](https://developer.android.com/reference/kotlin/com/android/billingclient/api/package-summary#(com.android.billingclient.api.BillingClient).getBillingChoiceInfo(com.android.billingclient.api.GetBillingChoiceInfoParams)) suspend function.
+  - Added [`BillingClient.showBillingProgramInformationDialog()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#showBillingProgramInformationDialog(android.app.Activity,com.android.billingclient.api.BillingProgramInformationDialogParams,com.android.billingclient.api.BillingProgramInformationDialogListener)) to show an information dialog for a billing program.
+  - Added [`BillingProgramInformationDialogParams`](https://developer.android.com/reference/com/android/billingclient/api/BillingProgramInformationDialogParams) to configure the dialog.
+  - Added [`BillingProgramInformationDialogListener`](https://developer.android.com/reference/com/android/billingclient/api/BillingProgramInformationDialogListener) to receive the callback.
+  - Added [`BillingProgramAvailabilityDetails.BillingChoiceAvailabilityDetails`](https://developer.android.com/reference/com/android/billingclient/api/BillingProgramAvailabilityDetails.BillingChoiceAvailabilityDetails) to provide details about billing choice availability.
+  - Added [`ChoiceScreenType`](https://developer.android.com/reference/com/android/billingclient/api/BillingProgramAvailabilityDetails.BillingChoiceAvailabilityDetails.ChoiceScreenType) to specify the type of choice screen.
+
+## Google Play Billing Library 9.0.0 Release (2026-05-19)
+
+Version 9.0.0 of the Google Play Billing Library and Kotlin extensions are
+now available. See the [PBL 9 migration guide](https://developer.android.com/google/play/billing/migrate-pbl-latest) if you want to migrate from
+the previous versions of PBL.
+
+### Summary of changes
+
+- **Updated error codes for blocked Play Store activity** : Error codes for
+  blocked Play Store apps have been updated. For instances where
+  the Play Store app is blocked by the system
+  (for example, in OEM-customized kids mode), the response code has
+  changed from `ERROR` to `BILLING_UNAVAILABLE`. Additionally, the
+  `BillingResult` for such cases now provides a *Play Store is blocked*
+  debug message.
+
+  > [!NOTE]
+  > **Note:** For this feature to work, you need [AndroidX.core library](https://developer.android.com/jetpack/androidx/releases/core#core_and_core-ktx_version_190_2) version 1.9 or later.
+
+- **Nullability update for developer-provided billing** : The
+  [`DeveloperProvidedBillingDetails.getLinkUri()`](https://developer.android.com/reference/com/android/billingclient/api/DeveloperProvidedBillingDetails#getLinkUri()) method has
+  been updated to be `@Nullable`. This change supports scenarios where
+  the direct link URI for external payments is unavailable during the
+  payment selection stage.
+
+  To handle this change safely, ensure your integration code handles both
+  `null` and empty string (`""`) values from the
+  [`DeveloperProvidedBillingDetails.getLinkUri()`](https://developer.android.com/reference/com/android/billingclient/api/DeveloperProvidedBillingDetails#getLinkUri()) method before parsing
+  or launching browser intents.
+- Updated `targetSdkVersion` to 35.
+
+- You can now use [in-app messaging](https://developer.android.com/google/play/billing/subscriptions#in-app-messaging) to notify users
+  of an upcoming opt-in price increase. This lets users confirm the price increase without leaving the app. The message for an outstanding opt-in price increase is shown starting on the first day the user can accept the price increase, and the message is shown a maximum of once every 7 days.
+
+## Google Play Billing Library 8.3.0 Release (2025-12-23)
+
+Version 8.3.0 of the Google Play Billing Library and Kotlin extensions are now available.
+
+### Summary of changes
+
+- New APIs for [external payments](https://developer.android.com/google/play/billing/externalpaymentlinks):
+
+  - Added classes to support external payments flow:
+    - [`BillingProgram.EXTERNAL_PAYMENTS`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.BillingProgram#EXTERNAL_PAYMENTS)
+    - [`EnableBillingProgramParams`](https://developer.android.com/reference/com/android/billingclient/api/EnableBillingProgramParams)
+    - [`DeveloperBillingOptionParams`](https://developer.android.com/reference/com/android/billingclient/api/DeveloperBillingOptionParams)
+    - [`DeveloperProvidedBillingDetails`](https://developer.android.com/reference/com/android/billingclient/api/DeveloperProvidedBillingDetails)
+    - [`DeveloperProvidedBillingListener`](https://developer.android.com/reference/com/android/billingclient/api/DeveloperProvidedBillingListener)
+  - Added [`enableBillingProgram(EnableBillingProgramParams)`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder#enableBillingProgram(com.android.billingclient.api.EnableBillingProgramParams)) to enable external payments.
+  - Added [`BillingFlowParams.Builder.enableDeveloperBillingOption`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#enableDeveloperBillingOption(com.android.billingclient.api.DeveloperBillingOptionParams)) to launch the external payments flow.
+
+## Google Play Billing Library 8.2.1 Release (2025-12-15)
+
+Version 8.2.1 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+### Bug fixes
+
+- Fixed a bug in [`isBillingProgramAvailableAsync`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#isBillingProgramAvailableAsync(int,com.android.billingclient.api.BillingProgramAvailabilityListener)) and [`createBillingProgramReportingDetailsAsync`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#createBillingProgramReportingDetailsAsync(com.android.billingclient.api.BillingProgramReportingDetailsParams,com.android.billingclient.api.BillingProgramReportingDetailsListener)). Update to version 8.2.1 to use these APIs introduced in 8.2.0.
+
+## Google Play Billing Library 8.2.0 Release (2025-12-09)
+
+Version 8.2.0 of the Google Play Billing Library and Kotlin extensions are now available.
+
+### Summary of changes
+
+- New APIs for [external content links](https://developer.android.com/google/play/billing/externalcontentlinks) and [external offers](https://developer.android.com/google/play/billing/external):
+
+  - Added [`enableBillingProgram`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder#enableBillingProgram(int)) to setup the `BillingClient` for these programs.
+  - Added [`isBillingProgramAvailableAsync`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#isBillingProgramAvailableAsync(int,com.android.billingclient.api.BillingProgramAvailabilityListener)) to determine user eligibility.
+  - Added [`createBillingProgramReportingDetailsAsync`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#createBillingProgramReportingDetailsAsync(com.android.billingclient.api.BillingProgramReportingDetailsParams,com.android.billingclient.api.BillingProgramReportingDetailsListener)) to create the external transaction token that must be used for reporting.
+  - Added [`launchExternalLink`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#launchExternalLink(android.app.Activity,com.android.billingclient.api.LaunchExternalLinkParams,com.android.billingclient.api.LaunchExternalLinkResponseListener)) to initiate the external link to a digital content offer or an app download.
+- Changes to the [external offers program](https://developer.android.com/google/play/billing/external):
+
+  - There are policy changes for the external offers program. See [program changes](https://support.google.com/googleplay/android-developer/answer/16505463) for details. To understand how to launch external offer flows with the new APIs, see the [integration guide](https://developer.android.com/google/play/billing/external/integration).
+  - Deprecated the [`BillingClient.Builder.enableExternalOffer`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder#enableExternalOffer()) API.
+  - Deprecated the [`isExternalOfferAvailableAsync`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#isExternalOfferAvailableAsync(com.android.billingclient.api.ExternalOfferAvailabilityListener)) API.
+  - Deprecated the [`createExternalOfferReportingDetailsAsync`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#createExternalOfferReportingDetailsAsync(com.android.billingclient.api.ExternalOfferReportingDetailsListener)) API.
+  - Deprecated the [`showExternalOfferInformationDialog`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#showExternalOfferInformationDialog(android.app.Activity,com.android.billingclient.api.ExternalOfferInformationDialogListener)) API.
+
+## Google Play Billing Library 8.1.0 Release (2025-11-06)
+
+Version 8.1.0 of the Google Play Billing Library and Kotlin extensions are now available.
+
+### Summary of changes
+
+- Suspended subscriptions
+
+  A new parameter has been added to the
+  [`BillingClient.queryPurchasesAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryPurchasesAsync(com.android.billingclient.api.QueryPurchasesParams,com.android.billingclient.api.PurchasesResponseListener))
+  method to include suspended subscriptions when querying for subscriptions.
+  Suspended subscriptions are still attributed to the user, but are not active,
+  either because the user paused the subscription or their renewal payment method
+  was declined.
+
+  The [`Purchase`](https://developer.android.com/reference/com/android/billingclient/api/Purchase) object returned in the listener will return `isSuspended() = true`
+  for any suspended subscriptions. In this case, you shouldn't grant access
+  to the purchased subscription, and instead guide the user to the
+  [subscriptions center](https://play.google.com/store/account/subscriptions)
+  where the user can manage their payment methods
+  or pause state to re-activate their subscription.
+- Updates to [subscriptions](https://developer.android.com/google/play/billing/subscriptions):
+
+  - The [`BillingFlowParams.ProductDetailsParams`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProductDetailsParams)
+    object now has the `setSubscriptionProductReplacementParams()` method
+    in which you can specify product level replacement information.
+
+  - The `SubscriptionProductReplacementParams` object has
+    two setter methods:
+
+    - `setOldProductId`: The old product that needs to be replaced by the product in current [`ProductDetails`](https://developer.android.com/reference/com/android/billingclient/api/ProductDetails).
+    - `setReplacementMode`: This is the item level replacement mode. The modes are essentially the same as SubscriptionUpdateParams, but the value mapping has been updated. A new replacement mode `KEEP_EXISTING` is introduced that lets you keep the existing payment schedule unchanged for an item.
+  - [SubscriptionUpdateParams setSubscriptionReplacementMode](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.Builder#setSubscriptionReplacementMode(int)) will be
+    deprecated. You should use `SubscriptionProductReplacementParams.setReplacementMode`
+    instead.
+
+- Updated `minSdkVersion` to 23.
+
+- Enabled [pre-order APIs for one-time products](https://developer.android.com/google/play/billing/one-time-product-multi-purchase-options-offers#pre-order)
+
+  The `ProductDetails.oneTimePurchaseOfferDetails.getPreorderDetails()` API
+  that gets the pre-order details is now available for use.
+- Google Play Billing Library now supports [Kotlin version 2.2.0](https://kotlinlang.org/docs/whatsnew22.html).
+
+## Google Play Billing Library 8.0.0 Release (2025-06-30)
+
+Version 8.0.0 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+### Summary of changes
+
+- *In-app items* will now be referred to as *one-time products*.
+
+- Multiple purchase options and offers for one-time products.
+
+  You can now have multiple purchase options and offers for your one-time
+  products. This provides you flexibility in how you sell your products and
+  reduces the complexity of managing them.
+- Improved the [`queryProductDetailsAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryProductDetailsAsync(com.android.billingclient.api.QueryProductDetailsParams,com.android.billingclient.api.ProductDetailsResponseListener)) method.
+
+  Prior to PBL 8.0.0, the [`queryProductDetailsAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryProductDetailsAsync(com.android.billingclient.api.QueryProductDetailsParams,com.android.billingclient.api.ProductDetailsResponseListener)) method didn't
+  return products that couldn't be fetched. This could be due to reasons such
+  as the product is not found or no offers are available to the user. With PBL
+  8.0.0, unfetched products are returned with a new product-level status code
+  that provides information about unfetched products. Note that there is a
+  change in the signature of the
+  [`ProductDetailsResponseListener.onProductDetailsResponse()`](https://developer.android.com/google/play/billing/integrate#automatic-service-reconnection) which
+  requires changes in your app. For more information, see [process the
+  result](https://developer.android.com/google/play/billing/integrate#process-the-result).
+- Automatic service reconnection.
+
+  The new `BillingClient.Builder.enableAutoServiceReconnection()` builder
+  parameter lets developers opt-in to automatic service reconnection, which
+  simplifies connection management by handling reconnections to
+  the Play Billing Service automatically and eliminating the need to manually
+  call `startConnection()` in the event of a service disconnection.
+  For more information, see [Automatically Re-establish a Connection](https://developer.android.com/google/play/billing/integrate#automatic-service-reconnection).
+- Sub-response codes for the [`launchBillingFlow()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#launchBillingFlow(android.app.Activity,com.android.billingclient.api.BillingFlowParams)) method.
+
+  The [BillingResult](https://developer.android.com/reference/com/android/billingclient/api/BillingResult) returned from [`launchBillingFlow()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#launchBillingFlow(android.app.Activity,com.android.billingclient.api.BillingFlowParams)) will now
+  include a sub-response code field. This field will only be populated in some
+  cases to provide a more specific reason for the failure. The sub-response
+  field can have the following values:
+  - `PAYMENT_DECLINED_DUE_TO_INSUFFICIENT_FUNDS` - Returned when the user's funds are less than the price of the item they are attempting to purchase.
+  - `USER_INELIGIBLE` - Returned when the user doesn't meet the configured eligibility requirements for a subscription offer.
+  - `NO_APPLICABLE_SUB_RESPONSE_CODE` - The default value, returned when no other sub-response code is applicable.
+- Removed the `queryPurchaseHistory()` method.
+
+  The `queryPurchaseHistory()` method that was previously marked as
+  deprecated has now been removed. See [Query Purchase History](https://developer.android.com/google/play/billing/query-purchase-history) for
+  details on what alternative APIs to use instead.
+- Removed the `querySkuDetailsAsync()` method.
+
+  The `querySkuDetailsAsync()` method that was previously marked as deprecated
+  has now been removed. You should use [queryProductDetailsAsync](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryProductDetailsAsync(com.android.billingclient.api.QueryProductDetailsParams,com.android.billingclient.api.ProductDetailsResponseListener)) instead.
+- Removed the `BillingClient.Builder.enablePendingPurchases()` method.
+
+  The `enablePendingPurchases()` method with no parameters that was previously
+  marked as deprecated has now been removed. You should use
+  `enablePendingPurchases(PendingPurchaseParams params)` instead. Note that
+  the deprecated `enablePendingPurchases()` is functionally equivalent to
+  `enablePendingPurchases(PendingPurchasesParams.newBuilder().enableOneTimeProducts().build())`.
+- Removed the overloaded `queryPurchasesAsync()` method that takes a [skuType](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.SkuType).
+
+  The `queryPurchasesAsync(String skuType, PurchasesResponseListener
+  listener)` method that was previously marked as
+  deprecated has now been removed. Alternately, use
+  [`queryPurchasesAsync(QueryPurchasesParams queryPurchasesParams,
+  PurchasesResponseListener listener)`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryPurchasesAsync(com.android.billingclient.api.QueryPurchasesParams,com.android.billingclient.api.PurchasesResponseListener)).
+
+## Google Play Billing Library 7.1.1 Release (2024-10-03)
+
+Version 7.1.1 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+### Bug fixes
+
+- Fixed a bug in Play Billing Library 7.1.0 related to [testing
+  `BillingResult` response codes](https://developer.android.com/google/play/billing/test-response-codes).
+
+## Google Play Billing Library 7.1.0 Release (2024-09-19)
+
+Version 7.1.0 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+### Summary of changes
+
+- Improved thread safety related to connection status and management.
+- Introduced partial changes for testing [`BillingResult`](https://developer.android.com/reference/com/android/billingclient/api/BillingResult) response codes which is fully released in Play Billing Library 7.1.1. To test your integration using this feature, you'll need to upgrade to Play Billing Library 7.1.1. A bug exists that will only impact applications with [billing overrides testing enabled](https://developer.android.com/google/play/billing/test-response-codes#enable-billing-overrides-testing) and does not affect regular usage. For more information, see [Test `BillingResult`
+  response codes](https://developer.android.com/google/play/billing/test-response-codes).
+
+## Google Play Billing Library 7.0.0 Release (2024-05-14)
+
+Version 7.0.0 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+### Summary of changes
+
+- Added APIs to support installment subscriptions.
+
+  - Added [`ProductDetails.InstallmentPlanDetails`](https://developer.android.com/reference/com/android/billingclient/api/ProductDetails.InstallmentPlanDetails) for installment base plans that users are eligible to purchase. This API helps your app identify the installment plan and its commitment setup to provide related information to the user. To learn more, see our [subscription installments guide](https://developer.android.com/google/play/billing/subscriptions#installments).
+- Added [`PendingPurchasesParams`](https://developer.android.com/reference/com/android/billingclient/api/PendingPurchasesParams) and
+  [`BillingClient.Builder.enablePendingPurchases(PendingPurchaseParams)`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder#enablePendingPurchases(PendingPurchaseParams))
+  to replace
+  [`BillingClient.Builder.enablePendingPurchases()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder#enablePendingPurchases()),
+  which has been deprecated in this release.
+
+  - The deprecated `enablePendingPurchases()` is functionally equivalent to `enablePendingPurchases(PendingPurchasesParams.newBuilder().enableOneTimeProducts().build())`.
+- Added APIs to support pending transactions for subscription prepaid plans:
+
+  - Use [`PendingPurchasesParams.Builder.enablePrepaidPlans()`](https://developer.android.com/reference/com/android/billingclient/api/PendingPurchasesParams.Builder#enablePrepaidPlans()) along with [`BillingClient.Builder.enablePendingPurchases(PendingPurchaseParams)`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder#enablePendingPurchases(PendingPurchaseParams)) to enable pending transactions for subscription prepaid plans. When adding support, be sure that your app also correctly manages subscription lifecycles. To learn more see our [pending purchases
+    guide](https://developer.android.com/google/play/billing/subscriptions#pending).
+  - Added [`Purchase.PendingPurchaseUpdate`](https://developer.android.com/reference/com/android/billingclient/api/Purchase.PendingPurchaseUpdate) and [`Purchase.getPendingPurchaseUpdate()`](https://developer.android.com/reference/com/android/billingclient/api/Purchase.getPendingPurchaseUpdate()) for retrieving the pending top-up or upgrade or downgrade to an existing subscription.
+- Removed
+  [`BillingClient.Builder.enableAlternativeBilling()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder#enableAlternativeBilling(com.android.billingclient.api.AlternativeBillingListener)),
+  [`AlternativeBillingListener`](https://developer.android.com/reference/com/android/billingclient/api/AlternativeBillingListener), and
+  [`AlternativeChoiceDetails`](https://developer.android.com/reference/com/android/billingclient/api/AlternativeChoiceDetails).
+
+  - Developers should use [`BillingClient.Builder.enableUserChoiceBilling()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder#enableUserChoiceBilling(com.android.billingclient.api.UserChoiceBillingListener)) with [`UserChoiceBillingListener`](https://developer.android.com/reference/com/android/billingclient/api/UserChoiceBillingListener) and [`UserChoiceDetails`](https://developer.android.com/reference/com/android/billingclient/api/UserChoiceDetails) in the listener callback instead.
+- Removed [`BillingFlowParams.ProrationMode`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProrationMode),
+  [`BillingFlowParams.SubscriptionUpdateParams.Builder.setReplaceProrationMode()`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.Builder#setReplaceProrationMode(int)),
+  and
+  [`BillingFlowParams.SubscriptionUpdateParams.Builder.setReplaceSkusProrationMode()`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.Builder#setReplaceSkusProrationMode(int)).
+
+  - Developers should use [`BillingFlowParams.SubscriptionUpdateParams.ReplacementMode`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode) with [`BillingFlowParams.SubscriptionUpdateParams.Builder#setSubscriptionReplacementMode(int)`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.Builder#setSubscriptionReplacementMode(int)) instead.
+- Removed
+  [`BillingFlowParams.SubscriptionUpdateParams.Builder#setOldSkuPurchaseToken()`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.Builder#setOldSkuPurchaseToken(java.lang.String)).
+
+  - Developers should use [`BillingFlowParams.SubscriptionUpdateParams.Builder#setOldPurchaseToken(java.lang.String)`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.Builder#setOldPurchaseToken(java.lang.String)) instead.
+- [`BillingClient.queryPurchaseHistoryAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryPurchaseHistoryAsync(com.android.billingclient.api.QueryPurchaseHistoryParams,com.android.billingclient.api.PurchaseHistoryResponseListener))
+  has been deprecated and will be removed in a future release. Developers
+  should use the following alternatives instead:
+
+  - Acknowledged and pending purchases: Use [`BillingClient.queryPurchasesAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryPurchasesAsync(com.android.billingclient.api.QueryPurchasesParams,%20com.android.billingclient.api.PurchasesResponseListener)) to fetch the active purchases.
+  - Consumed purchases: Developers should keep track of consumed purchases on their own servers.
+  - Canceled purchases: Use the [voided-purchases](https://developers.google.com/android-publisher/voided-purchases) developer API.
+  - For more details, see [Query Purchase History](https://developer.android.com/google/play/billing/query-purchase-history)
+- [`BillingFlowParams.ProductDetailsParams.setOfferToken()`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProductDetailsParams.Builder#setOfferToken(java.lang.String))
+  now throws an exception when developers specify an empty `offerToken`.
+
+- Updated `minSdkVersion` to 21 and `targetSdkVersion` to 34.
+
+## Google Play Billing Library 6.2.1 Release (2024-04-16)
+
+Version 6.2.1 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+### Summary of changes
+
+- Fixed a bug in [`BillingClient.showAlternativeBillingOnlyInformationDialog()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#showAlternativeBillingOnlyInformationDialog(android.app.Activity,%20com.android.billingclient.api.AlternativeBillingOnlyInformationDialogListener)) where the [`AlternativeBillingOnlyInformationDialogListener`](https://developer.android.com/reference/com/android/billingclient/api/AlternativeBillingOnlyInformationDialogListener) may not be called in certain cases when the dialog completes.
+
+## Google Play Billing Library 6.2.0 Release (2024-03-06)
+
+Version 6.2.0 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+### Summary of changes
+
+- Added APIs to support [external offers](https://developer.android.com/google/play/billing/external)
+  - Added [`BillingClient.Builder.enableExternalOffer()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder#enableExternalOffer()) to enable the ability to provide external offers.
+  - Added [`BillingClient.isExternalOfferAvailableAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#isExternalOfferAvailableAsync(com.android.billingclient.api.ExternalOfferAvailabilityListener)) to check the availability of providing external offers functionality.
+  - Added [`BillingClient.showExternalOfferInformationDialog()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#showExternalOfferInformationDialog(android.app.Activity,%20com.android.billingclient.api.ExternalOfferInformationDialogListener)) to show an information dialog to users before leading users outside the app.
+  - Added [`BillingClient.createExternalOfferReportingDetailsAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#createExternalOfferReportingDetailsAsync(com.android.billingclient.api.ExternalOfferReportingDetailsListener)) to create a payload required to report transactions made through external offers.
+
+## Google Play Billing Library 6.1.0 Release (2023-11-14)
+
+Version 6.1.0 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+### Summary of changes
+
+- Added APIs to support [alternative billing only (i.e. without user choice)](https://developer.android.com/google/play/billing/alternative)
+  - Added [`BillingClient.Builder.enableAlternativeBillingOnly()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder#enableAlternativeBillingOnly()) to functionally enable the ability to offer alternative billing only.
+  - Added [`BillingClient.isAlternativeBillingOnlyAvailableAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#isAlternativeBillingOnlyAvailableAsync(com.android.billingclient.api.AlternativeBillingOnlyAvailabilityListener)) to check the availability of offering alternative billing only.
+  - Added [`BillingClient.showAlternativeBillingOnlyInformationDialog()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#showAlternativeBillingOnlyInformationDialog(android.app.Activity,%20com.android.billingclient.api.AlternativeBillingOnlyInformationDialogListener)) to show an information dialog to inform users when alternative billing only is being used.
+  - Added [`BillingClient.createAlternativeBillingOnlyReportingDetailsAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#createAlternativeBillingOnlyReportingDetailsAsync(com.android.billingclient.api.AlternativeBillingOnlyReportingDetailsListener)) to create a payload required to report transactions made through alternative billing only.
+- Updated the user choice billing APIs
+  - Added [`UserChoiceBillingListener`](https://developer.android.com/reference/com/android/billingclient/api/UserChoiceBillingListener) to replace [AlternativeBillingListener](https://developer.android.com/reference/com/android/billingclient/api/AlternativeBillingListener) which has been marked as deprecated.
+  - Added [`UserChoiceDetails`](https://developer.android.com/reference/com/android/billingclient/api/UserChoiceDetails) to replace [`AlternativeChoiceDetails`](https://developer.android.com/reference/com/android/billingclient/api/AlternativeChoiceDetails) which has been marked as deprecated.
+  - Added [`BillingClient.Builder.enableUserChoiceBilling()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder#enableUserChoiceBilling(com.android.billingclient.api.UserChoiceBillingListener)) to replace [`BillingClient.Builder.enableAlternativeBilling()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder#enableAlternativeBilling(com.android.billingclient.api.AlternativeBillingListener)) which has been marked as deprecated.
+- Added [`BillingClient.getBillingConfigAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#getBillingConfigAsync(com.android.billingclient.api.GetBillingConfigParams,%20com.android.billingclient.api.BillingConfigResponseListener)) to retrieve Google Play country.
+
+## Google Play Billing Library 6.0.1 Release (2023-06-22)
+
+Version 6.0.1 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+### Summary of changes
+
+Update Play Billing Library to be compatible with Android 14.
+
+## Google Play Billing Library 6.0 Release (2023-05-10)
+
+Version 6.0.0 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+### Summary of changes
+
+- Added new [`ReplacementMode`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode)
+  enum to replace
+  [`ProrationMode`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProrationMode).
+
+  Note that `ProrationMode` is still available for backward compatibility
+  reasons.
+- Removed order ID for [`PENDING`](https://developer.android.com/reference/com/android/billingclient/api/Purchase.PurchaseState#PENDING)
+  purchases.
+
+  Previously, the order ID would always be created even if the purchase was
+  pending. Starting with version 6.0.0, an order ID will not be created for
+  pending purchases, and for these purchases, the order ID will be populated
+  after the purchase is moved to the
+  [`PURCHASED`](https://developer.android.com/reference/com/android/billingclient/api/Purchase.PurchaseState#PURCHASED)
+  state.
+- Removed `queryPurchases` and `launchPriceConfirmationFlow` methods.
+
+  The `queryPurchases` and `launchPriceConfirmationFlow` methods that have
+  previously been marked as deprecated have now been removed in Play Billing
+  Library 6.0.0. Developers should use
+  [`queryPurchasesAsync`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryPurchasesAsync(com.android.billingclient.api.QueryPurchasesParams,%20com.android.billingclient.api.PurchasesResponseListener))
+  instead of `queryPurchases`. For `launchPriceConfirmationFlow` alternatives,
+  see [Price changes](https://developer.android.com/google/play/billing/price-changes).
+- Added new network error response code.
+
+  A new network error response code,
+  [`NETWORK_ERROR`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.BillingResponseCode#NETWORK_ERROR),
+  has been added starting with PBL version 6.0.0. This code is returned when
+  an error occurs due to a network connection issue. These network connection
+  errors were previously reported as `SERVICE_UNAVAILABLE`.
+- Updated [`SERVICE_UNAVAILABLE`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.BillingResponseCode#SERVICE_UNAVAILABLE)
+  and
+  [`SERVICE_TIMEOUT`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.BillingResponseCode#SERVICE_TIMEOUT).
+
+  Starting with PBL version 6.0.0, errors due to timeout in processing will be
+  returned as `SERVICE_UNAVAILABLE` instead of the current `SERVICE_TIMEOUT`.
+
+  The behavior does not change in earlier versions of PBL.
+- Removed
+  [`SERVICE_TIMEOUT`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.BillingResponseCode#SERVICE_TIMEOUT).
+
+  Starting with PBL version 6.0.0, `SERVICE_TIMEOUT` will no longer be
+  returned. Previous versions of PBL will still return this code.
+- Added additional logging.
+
+  The Play Billing Library 6 release includes additional logging, which
+  provides insight into API usage (such as success and failure) and service
+  connection issues. This information will be used to improve the performance
+  of the Play Billing Library and provide better support for errors.
+
+## Google Play Billing Library 5.2.1 Release (2023-06-22)
+
+Version 5.2.1 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+### Summary of changes
+
+Update Play Billing Library to be compatible with Android 14.
+
+## Google Play Billing Library 5.2 Release (2023-04-06)
+
+Version 5.2.0 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+### Summary of changes
+
+- Added classes to support alternative billing flows on mobile/tablet for users in South Korea:
+  - [`AlternativeBillingListener`](https://developer.android.com/reference/com/android/billingclient/api/AlternativeBillingListener)
+  - [`AlternativeChoiceDetails`](https://developer.android.com/reference/com/android/billingclient/api/AlternativeChoiceDetails)
+  - [`AlternativeChoiceDetails.Product`](https://developer.android.com/reference/com/android/billingclient/api/AlternativeChoiceDetails.Product)
+- Added [`BillingFlowParams.SubscriptionUpdateParams.Builder.setOriginalExternalTransactionId()`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.Builder#setOriginalExternalTransactionId(java.lang.String)) method to specify the external transaction id of the originating subscription.
+- Added [`BillingClient.Builder.enableAlternativeBilling()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder#enableAlternativeBilling(com.android.billingclient.api.AlternativeBillingListener)) method to allow users in South Korea to select an alternative billing option.
+
+## Google Play Billing Library 5.1 Release (2022-10-31)
+
+Version 5.1.0 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+This version contains the following changes.
+
+### Summary of changes
+
+- Added [`ProductDetails.SubscriptionOfferDetails.getOfferId()`](https://developer.android.com/reference/com/android/billingclient/api/ProductDetails.SubscriptionOfferDetails#getOfferId()) method to retrieve the offer ID.
+- Added [`ProductDetails.SubscriptionOfferDetails.getBasePlanId()`](https://developer.android.com/reference/com/android/billingclient/api/ProductDetails.SubscriptionOfferDetails#getBasePlanId()) method to retrieve the base plan ID.
+- Updated the `targetSdkVersion` to 31.
+
+## Google Play Billing Library 5.0 Release (2022-05-11)
+
+Version 5.0.0 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+This version contains the following changes.
+
+### Summary of changes
+
+- Introduced a new model for subscriptions, including new entities that enable you to create multiple offers for a single subscription product. For more information, see the [migration guide](https://developer.android.com/google/play/billing/migrate-gpblv5).
+- Added [`BillingClient.queryProductDetailsAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryProductDetailsAsync(com.android.billingclient.api.QueryProductDetailsParams,%20com.android.billingclient.api.ProductDetailsResponseListener)) to replace `BillingClient.querySkuDetailsAsync()`.
+- Added `setIsOfferPersonalized()` method for EU personalized pricing disclosure requirements. To learn more about how to use this method, see [Indicate a personalized
+  price](https://developer.android.com/google/play/billing/integrate#personalized-price).
+- Removed `queryPurchases()`, which was previously deprecated and replaced by queryPurchasesAsync introduced in Google Play Billing Library 4.0.0.
+- `launchPriceChangeFlow` has been deprecated and will be removed in a future release. To learn more about alternatives, see [Launch a price change
+  confirmation flow](https://developer.android.com/google/play/billing/subscriptions#price-change-launch).
+- Removed [`setVrPurchaseFlow()`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setVrPurchaseFlow(boolean)), which was previously used when instantiating a purchase flow. In previous versions, this method redirected the user to complete the purchase on their Android-powered device. Once you remove this method, users will complete the purchase through the standard purchase flow.
+
+## Google Play Billing Library 4.1 release (2022-02-23)
+
+Version 4.1.0 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+This version contains the following changes.
+
+### Summary of changes
+
+- Added [`BillingClient.showInAppMessages()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#showInAppMessages(android.app.Activity,%20com.android.billingclient.api.InAppMessageParams,%20com.android.billingclient.api.InAppMessageResponseListener)) to help with handling subscription payment declines. To learn more about how to use in-app messaging for handling subscriptions payment declines, see [Handling payment
+  declines](https://developer.android.com/google/play/billing/subscriptions#payment-declines).
+
+## Google Play Billing Library 4.0 Release (2021-05-18)
+
+Version 4.0.0 of the Google Play Billing Library and Kotlin extensions are now
+available.
+
+### Summary of changes
+
+- Added
+  [`BillingClient.queryPurchasesAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryPurchasesAsync(java.lang.String,%20com.android.billingclient.api.PurchasesResponseListener))
+  to replace
+  [`BillingClient.queryPurchases()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryPurchases(java.lang.String))
+  which will be removed in a future release.
+
+- Added new subscription replacement mode
+  [`IMMEDIATE_AND_CHARGE_FULL_PRICE`](https://developer.android.com/google/play/billing/subscriptions#change).
+
+- Added
+  [`BillingClient.getConnectionState()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#getConnectionState())
+  method to retrieve the Play Billing Library's connection state.
+
+- Updated Javadoc and implementation to indicate which thread a method can be
+  called on and which thread results are posted.
+
+- Added
+  [`BillingFlowParams.Builder.setSubscriptionUpdateParams()`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setSubscriptionUpdateParams(com.android.billingclient.api.BillingFlowParams.SubscriptionUpdateParams))
+  as a new way to initiate subscription updates. This replaces
+  `BillingFlowParams#getReplaceSkusProrationMode`,
+  `BillingFlowParams#getOldSkuPurchaseToken`, `BillingFlowParams#getOldSku`,
+  `BillingFlowParams.Builder#setReplaceSkusProrationMode`,
+  `BillingFlowParams.Builder#setOldSku` which have been removed.
+
+- Added
+  [`Purchase.getQuantity()`](https://developer.android.com/reference/com/android/billingclient/api/Purchase#getQuantity())
+  and
+  [`PurchaseHistoryRecord.getQuantity()`](https://developer.android.com/reference/com/android/billingclient/api/PurchaseHistoryRecord#getQuantity()).
+
+- Added
+  [`Purchase#getSkus()`](https://developer.android.com/reference/com/android/billingclient/api/Purchase#getSkus())
+  and
+  [`PurchaseHistoryRecord#getSkus()`](https://developer.android.com/reference/com/android/billingclient/api/PurchaseHistoryRecord#getSkus()).
+  These replace `Purchase#getSku` and `PurchaseHistoryRecord#getSku` which
+  have been removed.
+
+- Removed `BillingFlowParams#getSku`, `BillingFlowParams#getSkuDetails` and
+  `BillingFlowParams#getSkuType`.
+
+## Google Play Billing Library 3.0.3 Release (2021-03-12)
+
+Version 3.0.3 of the Google Play Billing Library, Kotlin extension, and Unity
+plugin are now available.
+
+### Java and Kotlin Bug fixes
+
+- Fix memory leak when [`endConnection()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#endConnection()) is called.
+- Fix issue when the Google Play Billing Library is used by apps which use the single task launch mode. A [`onPurchasesUpdated()`](https://developer.android.com/reference/com/android/billingclient/api/PurchasesUpdatedListener#onpurchasesupdated) callback will be triggered when an app is resumed from the Android launcher and the billing dialog was visible prior to being suspended.
+
+### Unity Bug fixes
+
+- Update to Java version 3.0.3 to fix memory leak and resolve issue preventing purchases when an app is resumed from the Android launcher and the billing dialog was visible prior to being suspended.
+
+## Google Play Billing Library 3.0.2 Release (2020-11-24)
+
+Version 3.0.2 of the Google Play Billing Library and Kotlin extension are now
+available.
+
+### Bug fixes
+
+- Fixed a bug in the Kotlin extension where the coroutine fails with error "Already resumed".
+- Fixed unresolved references when the Kotlin extension is used with the kotlinx.coroutines library version 1.4+.
+
+## Google Play Billing Library 3.0.1 Release (2020-09-30)
+
+Version 3.0.1 of the Google Play Billing Library and Kotlin extension are now
+available.
+
+### Bug fixes
+
+- Fixed a bug where if the app was killed and restored during the billing flow, `PurchasesUpdatedListener` may not be called with the purchase result.
+
+## Google Play Billing Library 3.0 Release (2020-06-08)
+
+Version 3.0.0 of the Google Play Billing Library, Kotlin extension, and Unity
+plugin are now available.
+
+### Summary of changes
+
+- Removed rewarded SKU support.
+- Removed the `ChildDirected` and `UnderAgeOfConsent` parameters.
+- Removed deprecated developer payload methods.
+- Removed deprecated methods `BillingFlowParams.setAccountId()` and `BillingFlowParams.setDeveloperId()`.
+- Removed deprecated methods `BillingFlowParams.setOldSkus(String oldSku)` and `BillingFlowParams.addOldSku(String oldSku)`.
+- Added nullability annotations.
+
+### Bug fixes
+
+- [`SkuDetails.getIntroductoryPriceCycles()`](https://developer.android.com/reference/com/android/billingclient/api/SkuDetails#getIntroductoryPriceCycles()) now returns `int` instead of `String`.
+- Fixed a bug where the billing flow would be treated as having extra params even if no extra params were set.
+
+## Google Play Billing Library 2.2.1 Release (2020-05-20)
+
+Version 2.2.1 of the Google Play Billing library is now available.
+
+### Bug fixes
+
+- Updated the default version of the Java Play Billing library that the Kotlin extension depends on.
+
+## Google Play Billing Library 2.2.0 release and Unity support (2020-03-23)
+
+Version 2.2.0 of the Google Play Billing provides functionality that helps
+developers ensure purchases are attributed to the correct user. These changes
+replace the need to build custom solutions based on developer payload. As part
+of this update, the developer payload functionality has been deprecated and will
+be removed in a future release. For more information, including recommended
+alternatives, see [Developer payload](https://developer.android.com/google/play/billing/developer-payload).
+
+### Google Play Billing Billing Library 2 for Unity
+
+In addition to the current Java and Kotlin versions of Google Play Billing
+Library 2, we released a version of the library for use with Unity. Game
+developers using the Unity in-app purchase API can upgrade now to take advantage
+of all Google Play Billing Library 2 features and to make the subsequent
+upgrades to future versions of the Google Play Billing Library easier.
+
+To learn more, see [Use Google Play Billing with
+Unity](https://developer.android.com/google/play/billing/unity).
+
+### Summary of changes
+
+- Java Google Play Billing Library
+  - In [`AcknowledgePurchaseParams`](https://developer.android.com/reference/com/android/billingclient/api/AcknowledgePurchaseParams), deprecated [`setDeveloperPayload()`](https://developer.android.com/reference/com/android/billingclient/api/AcknowledgePurchaseParams.Builder#setDeveloperPayload(java.lang.String)) and [`getDeveloperPayload()`](https://developer.android.com/reference/com/android/billingclient/api/AcknowledgePurchaseParams#getDeveloperPayload()) methods.
+  - In [`ConsumeParams`](https://developer.android.com/reference/com/android/billingclient/api/ConsumeParams), deprecated [`setDeveloperPayload()`](https://developer.android.com/reference/com/android/billingclient/api/ConsumeParams.Builder#setDeveloperPayload(java.lang.String)) and [`getDeveloperPayload()`](https://developer.android.com/reference/com/android/billingclient/api/ConsumeParams#getdeveloperpayload) methods.
+  - In [`BillingFlowParams`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder), renamed [`setAccountId()`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setAccountId(java.lang.String)) to [`setObfuscatedAccountId()`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setObfuscatedAccountId(java.lang.String)), and documented length restriction of 64 characters and restriction disallowing Personally Identifiable Information (PII) in this field. [`setAccountId()`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setaccountid) has been marked as deprecated and will be removed in a future library version.
+  - In `BillingFlowParams`, added [`setObfuscatedProfileId()`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setobfuscatedprofileid) which works similarly to [`setObfuscatedAccountId()`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setObfuscatedAccountId(java.lang.String)). For more information, see [Developer payload updates and
+    alternatives](https://developer.android.com/google/play/billing/developer-payload).
+  - In [`Purchase`](https://developer.android.com/reference/com/android/billingclient/api/Purchase), added the [`getAccountIdentifiers()`](https://developer.android.com/reference/com/android/billingclient/api/Purchase#getAccountIdentifiers()) method to return the obfuscated account identifiers set in `BillingFlowParams`.
+  - In [`BillingClient`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient), the [`loadRewardedSku()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#loadRewardedSku(com.android.billingclient.api.RewardLoadParams,%20com.android.billingclient.api.RewardResponseListener)) method has been marked deprecated as part of deprecating rewarded SKUs. You can find more information about the deprecation in the [Play Console
+    Help
+    Center](https://support.google.com/googleplay/android-developer/answer/9155268).
+
+## Google Play Billing Library 2.1.0 Release and Kotlin Extension 2.1.0 Release (2019-12-10)
+
+Version 2.1.0 of the Google Play Billing library and the new Kotlin extension
+are now available. The Play Billing Library Kotlin extension provides idiomatic
+API alternatives for Kotlin consumption, featuring better null-safety and
+coroutines. For code examples, see [Use the Google Play Billing
+Library](https://developer.android.com/google/play/billing/billing_library_overview).
+
+This version contains the following changes.
+
+### Summary of changes
+
+- In [`BillingFlowParams`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams), deprecated `setOldSku(String oldSku)` and replaced with `setOldSku(String
+  oldSku, String purchaseToken)`, to disambiguate when multiple accounts on the device own the same sku.
+
+## Google Play Billing Library 2.0.3 Release (2019-08-05)
+
+Version 2.0.3 of the Google Play Billing library is now available.
+
+### Bug fixes
+
+- Fixed a bug where `querySkuDetailsAsync()` would occasionally fail with code `DEVELOPER_ERROR` instead of returning a successful result.
+
+## Google Play Billing Library 2.0.2 Release (2019-07-08)
+
+Version 2.0.2 of the Google Play Billing library is now available. This release
+contains updates to the reference documentation and does not change library
+functionality.
+
+## Google Play Billing Library 2.0.1 Release (2019-06-06)
+
+Version 2.0.1 of the Google Play Billing library is now available. This version
+contains the following changes.
+
+### Bug fixes
+
+- Fixed a bug where debug messages were being returned as `null` in some cases.
+- Fixed a potential memory leak issue.
+
+## Google Play Billing Library 2.0 Release (2019-05-07)
+
+Version 2.0 of the Google Play Billing library is now available. This version
+contains the following changes.
+
+### Purchases must be acknowledged within three days
+
+> [!NOTE]
+> **Note:** This section describes a new requirement for acknowledging all purchases. If you are already consuming purchases using `consumeAsync()`, you don't need to make any further changes if you consume purchases within 3 days, as `consumeAsync()` automatically acknowledges a purchase. Failure to properly acknowledge purchases will result in purchases being refunded.
+
+> [!NOTE]
+> **Note:** This requirement applies only to apps that use the Google Play Billing Library version 2.0 and newer. This requirement doesn't apply if you use an older version of the Google Play Billing Library, or if you use the AIDL API.
+
+Google Play supports purchasing products from inside of your app (in-app) or
+outside of your app (out-of-app). In order for Google Play to ensure a
+consistent purchase experience regardless of where the user purchases your
+product, you must acknowledge all purchases received through the Google Play
+Billing Library as soon as possible after granting entitlement to the user. If
+you don't acknowledge a purchase within three days, the user automatically
+receives a refund, and Google Play revokes the purchase. For [pending
+transactions](https://developer.android.com/google/play/billing/release-notes#2_0_pending) (new in version 2.0), the three-day window starts
+when the purchase has moved to the `PURCHASED` state and does not apply while
+the purchase is in a `PENDING` state.
+
+For subscriptions, you must acknowledge any purchase that has a new purchase
+token. This means that all initial purchases, plan changes, and re-signups need
+to be acknowledged, but you don't need to acknowledge subsequent renewals. To
+determine if a purchase needs acknowledgment, you can check the acknowledgement
+field in the purchase.
+
+The `Purchase` object now includes an
+[`isAcknowledged()`](https://developer.android.com/reference/com/android/billingclient/api/Purchase#isacknowledged)
+method that indicates whether a purchase has been acknowledged. In addition, the
+Google Play Developer API includes acknowledgement boolean values for both
+[`Purchases.products`](https://developers.google.com/android-publisher/api-ref/purchases/products)
+and
+[`Purchases.subscriptions`](https://developers.google.com/android-publisher/api-ref/purchases/subscriptions).
+Before acknowledging a purchase, be sure to use these methods to determine if
+the purchase has already been acknowledged.
+
+You can acknowledge a purchase by using one of the following methods:
+
+- For consumable products, use `consumeAsync()`, found in the client API.
+- For products that aren't consumed, use `acknowledgePurchase()`, found in the client API.
+- A new `acknowledge()` method is also available in the Server API.
+
+### BillingFlowParams.setSku() has been removed
+
+The previously-deprecated `BillingFlowParams#setSku()` method has been removed
+in this release. Before rendering products in a purchase flow, you must now call
+[`BillingClient.querySkuDetailsAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryskudetailsasync),
+passing the resulting
+[`SkuDetails`](https://developer.android.com/reference/com/android/billingclient/api/SkuDetails) object to
+[`BillingFlowParams.Builder.setSkuDetails()`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setskudetails).
+
+> [!NOTE]
+> **Note:** Caching `SkuDetails` between user sessions is not recommended, as `SkuDetails` objects are valid only for a limited time before you must refresh them again by calling `querySkuDetailsAsync()`.
+
+For code examples, see [Use the Google Play Billing
+Library](https://developer.android.com/google/play/billing/billing_library_overview).
+
+### Developer payload is supported
+
+Version 2.0 of the Google Play Billing library adds support for *developer
+payload* ---arbitrary strings that can be attached to purchases. You can
+attach a developer payload parameter to a purchase, but only when the purchase
+is acknowledged or consumed. This is unlike developer payload in AIDL, where the
+payload could be specified when launching the purchase flow. Because purchases
+can now be initiated [from outside of your app](https://developer.android.com/google/play/billing/release-notes#2_0_acknowledge), this change
+ensures that you always have an opportunity to add a payload to purchases.
+
+To access the payload in the new library, `Purchase` objects now include a
+[`getDeveloperPayload()`](https://developer.android.com/reference/com/android/billingclient/api/Purchase#getdeveloperpayload)
+method.
+
+> [!NOTE]
+> **Note:** You cannot modify a payload after it is assigned.
+
+### Consistent offers
+
+> [!NOTE]
+> **Note:** This feature is being tested, and general availability is not guaranteed.
+
+When you offer a discounted SKU, Google Play now returns the original price of
+the SKU so that you can show users that they are receiving a discount.
+
+[`SkuDetails`](https://developer.android.com/reference/com/android/billingclient/api/SkuDetails) contains two
+new methods for retrieving the original SKU price:
+
+- [`getOriginalPriceAmountMicros()`](https://developer.android.com/reference/com/android/billingclient/api/SkuDetails#getOriginalPriceAmountMicros())
+  - returns the unformatted original price of the SKU before discount.
+- [`getOriginalPrice()`](https://developer.android.com/reference/com/android/billingclient/api/SkuDetails#getOriginalPrice())
+  - returns the original price with additional currency formatting.
+
+### Pending transactions
+
+With version 2.0 of the Google Play Billing library, you *must* support
+purchases where additional action is required before granting entitlement. For
+example, a user might choose to purchase your in-app product at a physical store
+using cash. This means that the transaction is completed outside of your app. In
+this scenario, you should grant entitlement only after the user has completed
+the transaction.
+
+To enable pending purchases, call
+[`enablePendingPurchases()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder#enablependingpurchases)
+as part of initializing your app.
+
+Use
+[`Purchase.getPurchaseState()`](https://developer.android.com/reference/com/android/billingclient/api/Purchase#getpurchasestate)
+to determine whether the purchase state is `PURCHASED` or `PENDING`. Note that
+you should grant entitlement only when the state is `PURCHASED`. You should
+check for `Purchase` status updates by doing the following:
+
+1. When starting your app, call [`BillingClient.queryPurchases()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#querypurchases) to retrieve the list of unconsumed products associated with the user.
+2. Call `Purchase.getPurchaseState()` on each returned `Purchase` object.
+3. Implement the [`onPurchasesUpdated()`](https://developer.android.com/reference/com/android/billingclient/api/PurchasesUpdatedListener#onpurchasesupdated) method to respond to changes to `Purchase` objects.
+
+In addition, the Google Play Developer API includes a `PENDING` state for
+[`Purchases.products`](https://developers.google.com/android-publisher/api-ref/purchases/products).
+Pending transactions are not supported for subscriptions.
+
+This release also introduces a new real-time developer notification type,
+`OneTimeProductNotification`. This notification type contains a single message
+whose value is either `ONE_TIME_PRODUCT_PURCHASED` or
+`ONE_TIME_PRODUCT_CANCELED`. This notification type is sent only for purchases
+associated with delayed forms of payment, such as cash.
+
+When acknowledging pending purchases, be sure to acknowledge only when the
+purchase state is `PURCHASED` and not `PENDING`.
+
+> [!NOTE]
+> **Note:** Pending transactions can be tested using license testers. In addition to two test credit cards, license testers have access to two new test instruments for delayed forms of payment which automatically complete or cancel after a couple of minutes. While testing your application, you should verify that your application does not grant entitlement or acknowledge the purchase immediately after purchasing with either of these two new instruments. When purchasing using the new test instrument that automatically completes, you should verify that your application grants entitlement and acknowledges the purchase once the purchase completes.
+
+### API changes
+
+Version 2.0 of the Google Play Billing library contains several API changes to
+support new features and clarify existing functionality.
+
+#### consumeAsync
+
+[`consumeAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#consumeasync)
+now takes a
+[`ConsumeParams`](https://developer.android.com/reference/com/android/billingclient/api/ConsumeParams) object
+instead of a `purchaseToken`. `ConsumeParams` contains the `purchaseToken` as
+well as an optional developer payload.
+
+The previous version of `consumeAsync()` has been removed in this release.
+
+#### queryPurchaseHistoryAsync
+
+To minimize confusion,
+[`queryPurchaseHistoryAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#queryPurchaseHistoryAsync(java.lang.String,%20com.android.billingclient.api.PurchaseHistoryResponseListener))
+now returns a
+[`PurchaseHistoryRecord`](https://developer.android.com/reference/com/android/billingclient/api/PurchaseHistoryRecord)
+object instead of a `Purchase` object. The `PurchaseHistoryRecord` object is the
+same as a `Purchase` object, except that it reflects only the values returned by
+`queryPurchaseHistoryAsync()` and does not contain the `autoRenewing`,
+`orderId`, and `packageName` fields. Note that nothing has changed with the
+returned data---`queryPurchaseHistoryAsync()` returns the same data as
+before.
+
+#### BillingResult return values
+
+APIs that previously returned a `BillingResponse` integer value now return a
+[`BillingResult`](https://developer.android.com/reference/com/android/billingclient/api/BillingResult)
+object. `BillingResult` contains the `BillingResponse` integer as well as a
+debug string that you can use to diagnose errors. The debug string uses an en-US
+locale and is not meant to be shown to end users.
+
+### Bug fixes
+
+- [`SkuDetails.getIntroductoryPriceAmountMicros()`](https://developer.android.com/reference/com/android/billingclient/api/SkuDetails#getIntroductoryPriceAmountMicros()) now returns a `long` instead of a `String`.
+
+## Google Play Billing Library 1.2.2 Release (2019-03-07)
+
+Version 1.2.2 of the Google Play Billing library is now available. This version
+contains the following changes.
+
+### Bug fixes
+
+- Fixed a threading issue introduced in v1.2.1. Background calls no longer block the main thread.
+
+### Other changes
+
+- Although using the main thread is still recommended, you can now instantiate the Google Play Billing Library from a background thread.
+- Instantiation has been fully migrated to the background thread to reduce the chance of causing ANRs.
+
+## Play Billing Library 1.2.1 Release (2019-03-04)
+
+Version 1.2.1 of the Google Play Billing library is now available. This version
+contains the following changes.
+
+### Major changes
+
+- Added support for [rewarded
+  products](https://developer.android.com/google/play/billing/billing_rewarded_products). For more information on monetization options, see [Add rewarded-product-specific
+  features](https://developer.android.com/distribute/best-practices/earn/monetization-options).
+
+### Other changes
+
+- Added public constructors for `PurchasesResult` and `SkuDetailsResult` to make testing easier.
+- `SkuDetails` objects can use a new method, `getOriginalJson()`.
+- All AIDL service calls are now handled by background threads.
+
+### Bug fixes
+
+- Null callback listeners are no longer passed into public APIs.
+
+## Google Play Billing Library 1.2 Release (2018-10-18)
+
+Version 1.2 of the Google Play Billing library is now available. This version
+contains the following changes.
+
+### Summary of changes
+
+- The Google Play Billing Library is now licensed under the [Android Software
+  Development Kit License Agreement](https://developer.android.com/studio/terms).
+- Added the `launchPriceChangeConfirmationFlow` API, which prompts users to review a pending change to a subscription price.
+- Added support for a new proration mode, `DEFERRED`, when upgrading or downgrading a user's subscription.
+- In the `BillingFlowParams` class, replaced `setSku()` with `setSkuDetails()`.
+- Minor bug fixes and code optimizations.
+
+#### Price change confirmation
+
+You can now change the price of a subscription in Google Play Console
+and prompt users to review and accept the new price when they enter your app.
+
+To use this API, create a `PriceChangeFlowParams` object by using the
+`skuDetails` of the subscription product, and then call
+`launchPriceChangeConfirmationFlow()`. Implement the
+`PriceChangeConfirmationListener` to handle the result when the price change
+confirmation flow finishes, as shown in the following code snippet:
+
+### Kotlin
+
+```kotlin
+val priceChangeFlowParams = PriceChangeFlowParams.newBuilder()
+    .setSkuDetails(skuDetailsOfThePriceChangedSubscription)
+    .build()
+
+billingClient.launchPriceChangeConfirmationFlow(activity,
+        priceChangeFlowParams,
+        object : PriceChangeConfirmationListener() {
+            override fun onPriceChangeConfirmationResult(responseCode: Int) {
+                // Handle the result.
+            }
+        })
+```
+
+### Java
+
+```java
+PriceChangeFlowParams priceChangeFlowParams =
+        PriceChangeFlowParams.newBuilder()
+    .setSkuDetails(skuDetailsOfThePriceChangedSubscription)
+    .build();
+
+billingClient.launchPriceChangeConfirmationFlow(activity,
+        priceChangeFlowParams,
+        new PriceChangeConfirmationListener() {
+            @Override
+            public void onPriceChangeConfirmationResult(int responseCode) {
+                // Handle the result.
+            }
+        });
+```
+
+The price change confirmation flow displays a dialog containing the new pricing
+information, asking users to accept the new price. This flow returns a response
+code of type
+[`BillingClient.BillingResponse`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.BillingResponse).
+
+#### New proration mode
+
+When upgrading or downgrading a user's subscription, you can use a new proration
+mode, `DEFERRED`. This mode updates the user's subscription when it next renews.
+To learn more about how to set this proration mode, see [Set proration
+mode](https://developer.android.com/google/play/billing/billing_subscriptions#set-proration-mode).
+
+#### New method for setting SKU details
+
+In the `BillingFlowParams` class, the `setSku()` method has been deprecated.
+This change serves to optimize the Google Play Billing flow.
+
+When constructing a new instance of `BillingFlowParams` in your in-app billing
+client, we recommend that you instead work with the JSON object directly using
+`setSkuDetails()`, as shown in the following code snippet:
+
+In the `BillingFlowParams` Builder class, the `setSku()` method has been
+deprecated. Instead, use the `setSkuDetails()` method, as shown in the following
+code snippet. The object passed into `setSkuDetails()` object comes from the
+[`querySkuDetailsAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#querySkuDetailsAsync(com.android.billingclient.api.SkuDetailsParams,%20com.android.billingclient.api.SkuDetailsResponseListener))
+method.
+
+### Kotlin
+
+```kotlin
+private lateinit var mBillingClient: BillingClient
+private val mSkuDetailsMap = HashMap<String, SkuDetails>()
+
+private fun querySkuDetails() {
+    val skuDetailsParamsBuilder = SkuDetailsParams.newBuilder()
+    mBillingClient.querySkuDetailsAsync(skuDetailsParamsBuilder.build()
+    ) { responseCode, skuDetailsList ->
+        if (responseCode == 0) {
+            for (skuDetails in skuDetailsList) {
+                mSkuDetailsMap[skuDetails.sku] = skuDetails
+            }
+        }
+    }
+}
+
+private fun startPurchase(skuId: String) {
+    val billingFlowParams = BillingFlowParams.newBuilder()
+    .setSkuDetails(mSkuDetailsMap[skuId])
+    .build()
+}
+```
+
+### Java
+
+```java
+private BillingClient mBillingClient;
+private Map<String, SkuDetails> mSkuDetailsMap = new HashMap<>();
+
+private void querySkuDetails() {
+    SkuDetailsParams.Builder skuDetailsParamsBuilder
+            = SkuDetailsParams.newBuilder();
+    mBillingClient.querySkuDetailsAsync(skuDetailsParamsBuilder.build(),
+            new SkuDetailsResponseListener() {
+                @Override
+                public void onSkuDetailsResponse(int responseCode,
+                        List<SkuDetails> skuDetailsList) {
+                    if (responseCode == 0) {
+                        for (SkuDetails skuDetails : skuDetailsList) {
+                            mSkuDetailsMap.put(skuDetails.getSku(), skuDetails);
+                        }
+                    }
+                }
+            });
+}
+
+private void startPurchase(String skuId) {
+    BillingFlowParams billingFlowParams = BillingFlowParams.newBuilder()
+            .setSkuDetails(mSkuDetailsMap.get(skuId))
+            .build();
+}
+```
+
+## Play Billing Library 1.1 Release (2018-05-07)
+
+Version 1.1 of the Google Play Billing library is now available. This version
+contains the following changes.
+
+### Summary of changes
+
+- Added support to specify a proration mode in [`BillingFlowParams`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams) when upgrading/downgrading an existing subscription.
+- The `replaceSkusProration` boolean flag in [`BillingFlowParams`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams) is no longer supported. Use `replaceSkusProrationMode` instead.
+- [`launchBillingFlow()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#launchBillingFlow(android.app.Activity,%0Acom.android.billingclient.api.BillingFlowParams)) now triggers a callback for failed responses.
+
+### Behavior changes
+
+Version 1.1 of the Google Play Billing library contains the following behavior
+changes.
+
+#### Developers can set `replaceSkusProrationMode` in [`BillingFlowParams`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams) class
+
+A `ProrationMode` provides further details on the type of proration when
+upgrading or downgrading a user's subscription.
+
+### Kotlin
+
+```kotlin
+BillingFlowParams.newBuilder()
+    .setSku(skuId)
+    .setType(billingType)
+    .setOldSku(oldSku)
+    .setReplaceSkusProrationMode(replaceSkusProrationMode)
+    .build()
+```
+
+<br />
+
+<br />
+
+### Java
+
+```java
+BillingFlowParams.newBuilder()
+    .setSku(skuId)
+    .setType(billingType)
+    .setOldSku(oldSku)
+    .setReplaceSkusProrationMode(replaceSkusProrationMode)
+    .build();
+```
+
+<br />
+
+Google Play supports following proration modes:
+
+|---|---|
+| `IMMEDIATE_WITH_TIME_PRORATION` | Replacement takes effect immediately, and the new expiration time will be prorated and credited or charged to the user. This is the current default behavior. |
+| `IMMEDIATE_AND_CHARGE_PRORATED_PRICE` | Replacement takes effect immediately, and the billing cycle remains the same. The price for the remaining period will be charged. **Note**: This option is only available for subscription upgrade. |
+| `IMMEDIATE_WITHOUT_PRORATION` | Replacement takes effect immediately, and the new price will be charged on next recurrence time. The billing cycle stays the same. |
+
+### `replaceSkusProration` is no longer supported in [`BillingFlowParams`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.html) class
+
+Developers used to be able to set a boolean flag to charge a prorated amount for
+a subscription upgrade request. Given that we are supporting `ProrationMode`,
+which contains more detailed proration instruction, this boolean flag is no
+longer supported.
+
+### [`launchBillingFlow()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#launchBillingFlow(android.app.Activity,%20com.android.billingclient.api.BillingFlowParams)) now triggers a callback for failed responses
+
+The Billing Library will always trigger the
+[`PurhcasesUpdatedListener`](https://developer.android.com/reference/com/android/billingclient/api/PurchasesUpdatedListener)
+callback and return a
+[`BillingResponse`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.BillingResponse)
+asynchronously. The synchronous return value of
+[`BillingResponse`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.BillingResponse)
+is kept as well.
+
+### Bug fixes
+
+- Properly exits early in async methods when service is disconnected.
+- [`Builder`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder) param objects no longer mutates built objects.
+- Issue [68087141](https://issuetracker.google.com/issues/68087141): [`launchBillingFlow()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#launchBillingFlow(android.app.Activity,%0Acom.android.billingclient.api.BillingFlowParams)) now trigger callback for failed responses.
+
+## Google Play Billing Library 1.0 Release (2017-09-19, [Announcement](https://android-developers.googleblog.com/2017/09/google-play-billing-library-10-released.html))
+
+Version 1.0 of the Google Play Billing library is now available. This version
+contains the following changes.
+
+### Important changes
+
+- Embedded billing permission inside library's manifest. It's not necessary to add the `com.android.vending.BILLING` permission inside Android manifest anymore.
+- New builder added to [`BillingClient.Builder`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder.html) class.
+- Introduced builder pattern for [`SkuDetailsParams`](https://developer.android.com/reference/com/android/billingclient/api/SkuDetailsParams.html) class to be used on methods to query SKUs.
+- Several API methods were updated for consistency (the same return argument names and order).
+
+### Behavior changes
+
+Version 1.0 of the Google Play Billing library contains the following behavior
+changes.
+
+#### BillingClient.Builder class
+
+[`BillingClient.Builder`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.Builder.html)
+is now initialized via the newBuilder pattern:
+
+### Kotlin
+
+```kotlin
+billingClient = BillingClient.newBuilder(context).setListener(this).build()
+```
+
+### Java
+
+```java
+billingClient = BillingClient.newBuilder(context).setListener(this).build();
+```
+
+#### launchBillingFlow method is now called using a BillingFlowParams class
+
+To initiate the billing flow for a purchase or subscription, the
+[`launchBillingFlow()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#launchBillingFlow(android.app.Activity,%0Acom.android.billingclient.api.BillingFlowParams)) method receives a
+[`BillingFlowParams`](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.html)
+instance initialized with parameters specific to the request:
+
+### Kotlin
+
+```kotlin
+BillingFlowParams.newBuilder().setSku(skuId)
+        .setType(billingType)
+        .setOldSku(oldSku)
+        .build()
+
+// Then, use the BillingFlowParams to start the purchase flow
+val responseCode = billingClient.launchBillingFlow(builder.build())
+```
+
+### Java
+
+```java
+BillingFlowParams.newBuilder().setSku(skuId)
+                              .setType(billingType)
+                              .setOldSku(oldSku)
+                              .build();
+
+// Then, use the BillingFlowParams to start the purchase flow
+int responseCode = billingClient.launchBillingFlow(builder.build());
+```
+
+#### New way to query available products
+
+Arguments for
+[`queryPurchaseHistoryAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#queryPurchaseHistoryAsync(java.lang.String,%0Acom.android.billingclient.api.PurchaseHistoryResponseListener)) and
+[`querySkuDetailsAsync()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#querySkuDetailsAsync(com.android.billingclient.api.SkuDetailsParams,%0Acom.android.billingclient.api.SkuDetailsResponseListener)) methods were wrapped
+into a Builder pattern:
+
+### Kotlin
+
+```kotlin
+val params = SkuDetailsParams.newBuilder()
+params.setSkusList(skuList)
+        .setType(itemType)
+billingClient.querySkuDetailsAsync(params.build(), object : SkuDetailsResponseListener() {
+    ...
+})
+```
+
+### Java
+
+```java
+SkuDetailsParams.Builder params = SkuDetailsParams.newBuilder();
+params.setSkusList(skuList)
+        .setType(itemType);
+billingClient.querySkuDetailsAsync(params.build(), new SkuDetailsResponseListener() {...})
+```
+
+The result is now returned via result code and a list of
+[`SkuDetails`](https://developer.android.com/reference/com/android/billingclient/api/SkuDetails.html)
+objects instead of previous wrapper class for your convenience and to be
+consistent across our API:
+
+### Kotlin
+
+```kotlin
+fun onSkuDetailsResponse(@BillingResponse responseCode: Int, skuDetailsList: List<SkuDetails>)
+```
+
+### Java
+
+```java
+public void onSkuDetailsResponse(@BillingResponse int responseCode, List<SkuDetails> skuDetailsList)
+```
+
+#### Parameters order changed on `onConsumeResponse()` method
+
+The order of arguments for
+[`onConsumeResponse`](https://developer.android.com/reference/com/android/billingclient/api/ConsumeResponseListener.html#onConsumeResponse(int,%0Ajava.lang.String)) from the
+[`ConsumeResponseListener`](https://developer.android.com/reference/com/android/billingclient/api/ConsumeResponseListener.html)
+interface has changed to be consistent across our API:
+
+### Kotlin
+
+```kotlin
+fun onConsumeResponse(@BillingResponse responseCode: Int, outToken: String)
+```
+
+### Java
+
+```java
+public void onConsumeResponse(@BillingResponse int responseCode, String outToken)
+```
+
+#### Unwrapped PurchaseResult object
+
+[`PurchaseResult`](https://developer.android.com/reference/com/android/billingclient/api/Purchase.PurchasesResult.html)
+has been unwraped to be consistent across our API:
+
+### Kotlin
+
+```kotlin
+fun onPurchaseHistoryResponse(@BillingResponse responseCode: Int, purchasesList: List<Purchase>)
+```
+
+### Java
+
+```java
+void onPurchaseHistoryResponse(@BillingResponse int responseCode, List<Purchase> purchasesList)
+```
+
+### Bug fixes
+
+- [No response code in PURCHASES_UPDATED Bundle](https://issuetracker.google.com/issues/64075043)
+- [Fix ProxyBillingActivity and PurchasesUpdatedListener issues during device
+  rotation](https://issuetracker.google.com/issues/63266562)
+
+## Developer Preview 1 Release (2017-06-12, [Announcement](https://android-developers.googleblog.com/2017/06/money-made-easily-with-new-google-play.html))
+
+Developer preview launched, aimed to simplify the development process when it
+comes to billing, allowing developers to focus their efforts on implementing
+logic specific to the Android app, such as application architecture and
+navigation structure.
+
+The library includes several convenient classes and features for you to use when
+integrating your Android apps with the Google Play Billing API. The library also
+provides an abstraction layer on top of the Android Interface Definition
+Language (AIDL) service, making it easier for developers to define the interface
+between the app and the Google Play Billing API.

--- a/platforms/android/.agents/skills/play-billing-library-version-upgrade/references/migration-logic.md
+++ b/platforms/android/.agents/skills/play-billing-library-version-upgrade/references/migration-logic.md
@@ -1,0 +1,78 @@
+## High-Impact Migration Logic
+
+### 1. Connection Management (The v8+ Reconnection Shift)
+
+**Intent**: Move from developer-managed state (manual retries) to
+library-managed state.
+
+- **Remove** : Manual `startConnection()` calls or retry timers inside `onServiceDisconnected()`.
+- **Add** : `.enableAutoServiceReconnection()` to `BillingClient.Builder`.
+- **Logic** : In v8+, the library handles transient disconnections. Your `onServiceDisconnected` must only be used for logging or updating UI state (e.g., "Billing service temporarily unavailable").
+
+### 2. Product Querying \& Models (The v5-v8 Architectural Shift)
+
+**Intent**: Support the "One Product, Multiple Offers" model introduced in v5
+and refined in v8.
+
+- **Data Model Swap** :
+  - **Legacy** : `SkuDetails` (1:1 mapping of ID to price).
+  - **Modern** : `ProductDetails`. A single `ProductDetails` can contain multiple `SubscriptionOfferDetails` (Base Plans + Offers).
+- **Result Handling (v8+ Logic)** :
+  - **Change** : `queryProductDetailsAsync` no longer returns a list in the listener.
+  - **New Intent** : You must receive a `QueryProductDetailsResult` object.
+  - **Refactor** : `kotlin
+    // PBL 8+ Pattern
+    billingClient.queryProductDetailsAsync(params) { result: QueryProductDetailsResult ->
+    val responseCode = result.billingResult.responseCode
+    val productDetailsList = result.productDetailsList // Retrieve list from result object
+    // Process list...
+    }`
+
+### 3. Subscription Modernization (v6 \& v7)
+
+**Intent**: Support "Base Plans" and "Offers" instead of legacy standalone SKUs.
+
+- **Subscription Upgrades/Downgrades (v6+)**:
+
+  - **Legacy** : `setOldSkuPurchaseToken()` in `BillingFlowParams`.
+  - **Modern** : Use `SubscriptionUpdateParams`. You must specify the `PurchaseToken` of the existing subscription and the `ReplacementMode` (which replaces the deprecated `ProrationMode`).
+  - **Logic** : Verify that the `ReplacementMode` matches the business intent (e.g., `CHARGE_FULL_PRICE` versus `WITH_TIME_PRORATION`).
+- **Installment Plans (v7+)**:
+
+  - **Intent**: Allow users to pay for a subscription in monthly installments.
+  - **Check** : Look for `InstallmentPlanDetails` within `SubscriptionOfferDetails`. If the app supports high-ticket subscriptions, it is mandatory to implement the `installmentPlanDetails` UI.
+
+### 4. Purchase Handling \& History (v6+)
+
+**Intent**: Move away from local-only purchase caches to real-time status
+checks.
+
+- **Active Purchases** :
+  - **Deprecated** : `queryPurchases()` (synchronous).
+  - **Mandatory** : `queryPurchasesAsync()`. You must pass `QueryPurchasesParams` containing the `ProductType` (`INAPP` or `SUBS`).
+- **Purchase History (Pagination Intent)** :
+  - **v6+ Change** : `queryPurchaseHistoryAsync` is optimized for pagination.
+  - **Logic** : If the app has thousands of historical transactions, verify you are using the `PurchaseHistoryRecord` list correctly to avoid memory overhead.
+
+### 5. Security \& Pending Transactions (The "Always On" Rule)
+
+- **Mandatory** : `enablePendingPurchases()` has been required since v3, but in v8+, verify that it is called before `.build()`. You must also include `.enableOneTimeProducts()` on the `enablePendingPurchases()` builder.
+- **Optional** : If the app sells prepaid subscriptions, you must also include `.enablePrepaidPlans()`.
+- **Intent**: This handles "Slow/Delayed" payments (like cash or bank transfers). Without this, the app will crash on initialization in modern versions.
+
+### 6. SDK \& Environment Requirements
+
+- **PBL 7.0** : Requires `compileSdk 34` or higher.
+- **PBL 8.0** : Requires `compileSdk 34` or higher.
+- **PBL 9.0** : Requires `compileSdk 35` or higher.
+- **Kotlin** : Verify that `kotlin-stdlib` is updated to at least 1.9.x to support new library coroutine extensions.
+
+### 7. User-Facing Features (Post-Upgrade Recommendations)
+
+Once the upgrade is complete, the following features are enabled by these
+versions:
+
+- **v7** : **Installments** (Monthly payments for annual plans).
+- **v8** : **Prepaid Plans** (Users can top-up time without auto-renewing).
+- **v8** : **Personalized Pricing** (Show legal disclosure if price varies by user).
+- **v9** : **In-App Price Reviews** (Users can accept upcoming subscription price increases directly inside the app without leaving for the Play Store; capped by Google at a maximum of once every 7 days).

--- a/platforms/android/.agents/skills/play-billing-library-version-upgrade/references/version-checklist.md
+++ b/platforms/android/.agents/skills/play-billing-library-version-upgrade/references/version-checklist.md
@@ -1,0 +1,54 @@
+## Play Billing Library: Smart Version-Specific Checklist
+
+Use this checklist to verify that every technical requirement between your
+\[Current Version\] and \[Target Version\] has been met.
+
+## PBL v1.x through v3.x
+
+- \[ \] **\[v1.0\] Builder Pattern** : Verify `BillingClient.newBuilder(context)` is used.
+- \[ \] **\[v2.0\] Mandatory Acknowledgment** : Verify `acknowledgePurchase()` or `consumeAsync()` is called within 3 days.
+- \[ \] **\[v2.0\] Response Types** : Logic must handle `BillingResult` objects instead of raw integers.
+- \[ \] **\[v3.0\] Legacy Removal** : Verify `ChildDirected` and `UnderAgeOfConsent` parameters are deleted.
+
+## PBL v4.x Series
+
+- \[ \] **Async Purchasing** : Confirm `queryPurchases()` is replaced with `queryPurchasesAsync()`.
+- \[ \] **Multi-SKU Accessors** : Replace `getSku()` with `getSkus()` (returns a list) in `Purchase` objects.
+- \[ \] **Subscription Refactor** : Verify `setSubscriptionUpdateParams()` is used for change logic.
+
+## PBL v5.x Series
+
+- \[ \] **Data Model Swap** : Replace all instances of `SkuDetails` with `ProductDetails`.
+- \[ \] **Personalized Pricing** : Implement `setIsOfferPersonalized()` for EU price disclosures.
+
+## PBL v6.x Series
+
+- \[ \] **Replacement Mode** : Replace `ProrationMode` with the `ReplacementMode` enum.
+- \[ \] **User Choice Billing** : Replace `AlternativeBillingListener` with `UserChoiceBillingListener`.
+
+## PBL v7.x Series
+
+- \[ \] **SDK Compliance** : `compileSdk` is set to 34 or higher.
+- \[ \] **Pending Purchases** : Replace parameterless `enablePendingPurchases()` with `enablePendingPurchases(PendingPurchaseParams)`.
+- \[ \] **API Cleanup** : Replace `setOldSkuPurchaseToken()` with `setOldPurchaseToken()`.
+
+## PBL v8.x Series
+
+- \[ \] **SDK Compliance** : `compileSdk` is set to 34 or higher.
+- \[ \] **Terminology Shift**: Rename "in-app items" to "one-time products" in UI/strings.
+- \[ \] **Signature Enforcement** : `onProductDetailsResponse` signature MUST be `(BillingResult, QueryProductDetailsResult)`.
+- \[ \] **SUBS Offer Token** : For `SUBS` type, `ProductDetailsParams` MUST include an `offerToken`.
+- \[ \] **Auto-Reconnection** : Verify `enableAutoServiceReconnection()` is used in the builder.
+- \[ \] **Min SDK Increase** : Verify `minSdkVersion` is at least 23.
+
+## PBL v9.x Series
+
+- \[ \] **SDK Compliance** : `compileSdk` is set to 35 or higher.
+- \[ \] **API Removals** : Ensure all usages of `SkuDetails`, `SkuDetailsParams`, and `SkuDetailsResponseListener` are removed and replaced with their `ProductDetails` equivalents.
+- \[ \] **Blocked Store Error Handling** : If targeting restricted device modes (e.g., kids modes), ensure `androidx.core` is at v1.9+ and update error logic to catch `BILLING_UNAVAILABLE` instead of `ERROR`.
+- \[ \] **External Payment Program Null-Safety** : If using developer-provided billing, update `DeveloperProvidedBillingDetails.getLinkUri()` logic to explicitly check for both `null` and empty string (`""`) values before parsing.
+
+## Future Versions (PBL 10.0.0+)
+
+- \[ \] **Dynamic Checklist Generation** : For any version \>=10.0.0, you **MUST** synthesize a new checklist for each new version header found in the [Release Notes](https://developer.android.com/google/play/billing/release-notes).
+- \[ \] **Identify Version Delta** : Review "Breaking Changes" and "Removed APIs" for the new version and create a list of terms to `grep`.

--- a/platforms/android/.agents/skills/r8-analyzer/SKILL.md
+++ b/platforms/android/.agents/skills/r8-analyzer/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: r8-analyzer
+description: Analyzes Android build files and R8 keep rules to identify redundancies,
+  broad package-wide rules, and rules that subsume library consumer keep rules. Use
+  when developers want to optimize their app's size, remove redundant or overly broad
+  keep rules, or troubleshoot Proguard configurations.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-06-09'
+  keywords:
+  - R8
+  - proguard
+  - keep rules
+  - app size
+  - optimization
+---
+
+## Step 1. Setup and configuration check
+
+- Inspect `build.gradle`, `build.gradle.kts`, and `gradle.properties`.
+- Use [references/CONFIGURATION.md](references/CONFIGURATION.md) to identify missing optimizations.
+- **AGP** : If \< 9.0, suggest migration to 9.0 for [build time improvement
+  performance](references/android/topic/performance/app-optimization/enable-app-optimization.md)
+- **Full Mode** : Verify `android.enableR8.fullMode=false` is removed from gradle.properties.
+
+## Step 2. Analysis path selection
+
+- Inspect `build.gradle`, `build.gradle.kts`, and `gradle.properties` and
+  `libs.versions.toml` to get the R8 version
+
+- **If R8 \>= 9.3.7-dev** : Proceed to **Path A (Quantitative)**.
+
+- **If R8 \< 9.3.7-dev** : Proceed to **Path B (Heuristic)**.
+
+### Path A: Quantitative data generation (R8 \>= 9.3.7-dev)
+
+- **Check requirements** : Python and `protobuf` package are mandatory.
+- **Generate and analyze** : You MUST run the shell commands described in [references/CONFIGURATION-ANALYZER.md](references/CONFIGURATION-ANALYZER.md) to generate the proto file using R8 configuration analyzer, convert it to json and analyze the result.
+- **Report** : Rely entirely on the generated file `analysis.txt` for scores and rule impact metrics. Proceed to Step 3.
+
+### Path B: Heuristic evaluation and recommendation (R8 \< 9.3.7-dev)
+
+*(Use ONLY if quantitative data generation is not possible)*
+
+- **Manual evaluation** : Inspect `proguard-rules.pro`.
+- **Library check** : Compare rules against [references/REDUNDANT-RULES.md](references/REDUNDANT-RULES.md). Suggest **Remove** for bundled rules.
+- **Custom rule check** : Use [references/KEEP-RULES-IMPACT-HIERARCHY.md](references/KEEP-RULES-IMPACT-HIERARCHY.md) and [references/REFLECTION-GUIDE.md](references/REFLECTION-GUIDE.md) to prioritize and evaluate. Suggest **Refine** for broad rules (for example, package-wide).
+- **Validation** : Suggest Macrobenchmark tests using [UI Automator](references/android/training/testing/other-components/ui-automator.md) for any proposed changes. Proceed to Step 3.
+
+## Step 3. Report generation
+
+- **Format** : Follow [references/REPORT_FORMAT.md](references/REPORT_FORMAT.md) strictly.
+- **Input**: Extract metrics (Scores, Impacts, Example Classes) directly from generated file analysis.txt if using Path A, or from manual findings if using Path B.
+- **Output** : Output ONLY the raw Markdown report in the chat. Do NOT output conversational filler (for example, "Here is your report..."). Do NOT provide recommendations, next steps, or any other text outside of the sections defined in [references/REPORT_FORMAT.md](references/REPORT_FORMAT.md) Do NOT mention the path used for analysis of the configuration
+
+## Constraints
+
+- **Strict output limit**: The final output MUST strictly be the Markdown report and nothing else.
+- **No code changes**: Research and suggest only; Do not modify files.
+- **No redundancy**: Do not explain R8 benefits or reference skill internal files in the report.
+- **Focus**: Omit sections (for example, Subsumed Rules, Configuration) if no issues or items are found.

--- a/platforms/android/.agents/skills/r8-analyzer/references/CONFIGURATION-ANALYZER.md
+++ b/platforms/android/.agents/skills/r8-analyzer/references/CONFIGURATION-ANALYZER.md
@@ -1,0 +1,287 @@
+On each step, keep the user informed of the progress by displaying the output.
+
+### 1. Requirements
+
+- R8 Version: 9.3.7-dev or later
+
+### 2. Generate proto
+
+The report and files must be generated at `{project_root}/tmp/r8analysis`. If
+the folder is not present, create it. For example:
+
+    mkdir -p "$PWD/tmp/r8analysis"
+
+### 3. Remove existing files
+
+To make sure that this invocation doesn't source data from previous runs, remove
+the intermediate files `keepruleradius.json` and `analysis_result.txt` and
+remove the proto files in the `{project_root}/tmp/r8analysis` folder. Example
+bash commands:
+
+    # Remove the intermediate JSON and the directory containing protobuf files
+    rm tmp/r8analysis/keepruleradius.json
+    rm tmp/r8analysis/*.pb
+
+    # Copy the previous result to history before deleting the analysis
+    if [ -f tmp/r8analysis/analysis_result.txt ];
+    then cat tmp/r8analysis/analysis_result.txt > tmp/r8analysis/history.txt &&
+     rm tmp/r8analysis/analysis_result.txt; fi
+
+### 4. Generate the Configuration Analyzer report
+
+Run the R8 enabled build with the system property
+"-Dcom.android.tools.r8.dumpkeepradiustodirectory=$PWD/tmp/r8analysis" to
+generate Configuration Analyzer report
+
+    ./gradlew assembleRelease \
+    -Dcom.android.tools.r8.dumpkeepradiustodirectory=$PWD/tmp/r8analysis
+
+### 5. Convert to JSON
+
+To convert the generated protobuf files in `{project_root}/tmp/r8analysis` into
+json, run the following script. The json must be generated in
+`{project_root}/tmp/r8analysis`. Ensure `keep_radius_pb2.py` (from Step 10) is
+in the same directory.
+
+    import sys
+    import os
+    import glob
+    from google.protobuf import json_format
+    import keep_radius_pb2
+
+    def convert_pb_to_json(input_pb_path, output_json_path):
+        bundle = keep_radius_pb2.BlastRadiusContainer()
+
+        try:
+            with open(input_pb_path, "rb") as pb_file:
+                binary_data = pb_file.read()
+        except Exception as e:
+            print(f"Error reading file {input_pb_path}: {e}", file=sys.stderr)
+            return False
+
+        try:
+            bundle.ParseFromString(binary_data)
+        except Exception as e:
+            print(f"Error parsing protobuf: {e}", file=sys.stderr)
+            return False
+
+        try:
+            json_string = json_format.MessageToJson(
+                bundle,
+                always_print_fields_with_no_presence=True,
+                preserving_proto_field_name=True,
+                indent=4
+            )
+            with open(output_json_path, "w", encoding="utf-8") as json_file:
+                json_file.write(json_string)
+            return True
+        except Exception as e:
+            print(f"Error writing JSON: {e}", file=sys.stderr)
+            return False
+
+    if __name__ == "__main__":
+     input_pb = sys.argv[1] if len(sys.argv) > 1 else None
+        if not input_pb:
+            pb_files = glob.glob("tmp/r8analysis/*.pb")
+            if not pb_files:
+                print("Error: No .pb file found in tmp/r8analysis", file=sys.stderr)
+                sys.exit(1)
+            input_pb = sorted(pb_files)[-1] # Use the most recent one
+        output_json = sys.argv[2] if len(sys.argv) > 2 else "tmp/r8analysis/keepruleradius.json"
+        if not convert_pb_to_json(input_pb, output_json):
+            sys.exit(1)
+
+### 6. Analyze
+
+Run the following analysis script on the generated JSON to get the impact of the
+keep rules and sort it.
+
+    import json, sys
+
+    def analyze(path):
+        try:
+            with open(path, 'r') as f:
+                d = json.load(f)
+        except Exception as e:
+            print(f"Error loading JSON: {e}")
+            return
+
+        # Build reference map
+        c_map = {c.get('id'): set(c.get('constraints', [])) for c in d.get('keep_constraints_table', [])}
+        r_map = {r.get('id'): c_map.get(r.get('constraints_id'), set()) for r in d.get('keep_rule_blast_radius_table', [])}
+
+        tot_opt = tot_obf = tot_shr = tot_items = 0
+
+        # Tally constraints across all kept items
+        for tbl in ('kept_class_info_table', 'kept_field_info_table', 'kept_method_info_table'):
+            for i in d.get(tbl, []):
+                tot_items += 1
+                kb = i.get('kept_by', [])
+                if any('DONT_OPTIMIZE' in r_map.get(r, set()) for r in kb): tot_opt += 1
+                if any('DONT_OBFUSCATE' in r_map.get(r, set()) for r in kb): tot_obf += 1
+                if any('DONT_SHRINK' in r_map.get(r, set()) for r in kb): tot_shr += 1
+
+        # Find denominator
+        bi = d.get('build_info', {})
+        live = sum(int(bi.get(k, 0)) for k in ('live_class_count', 'live_field_count', 'live_method_count'))
+        denom = live if live > 0 else tot_items
+
+        # Check for globals
+        globals_src = [g.get('source', '').lower() for g in d.get('global_keep_rule_blast_radius_table', [])]
+        def score(cnt, flag):
+            if any(flag in src for src in globals_src): return 0.0
+            return max(0.0, 100.0 - ((cnt / denom * 100) if denom > 0 else 0))
+
+        result = [
+            f"Optimization Score: {score(tot_opt, '-dontoptimize'):.2f}%",
+            f"Obfuscation Score:  {score(tot_obf, '-dontobfuscate'):.2f}%",
+            f"Shrinking Score:    {score(tot_shr, '-dontshrink'):.2f}%"
+        ]
+        for line in result:
+            print(line)
+        with open("tmp/r8analysis/analysis_result.txt", "w") as f:
+            f.write("\n".join(result))
+
+    if __name__ == "__main__":
+        path = sys.argv[1] if len(sys.argv) > 1 else "tmp/r8analysis/keepruleradius.json"
+        analyze(path)
+
+Outputs `analysis_result.txt` containing scores and rule impacts.
+
+### 7. Report impactful rules
+
+Identify the keep rules with the highest impact and the subsumed rules using the
+following script.
+
+    import json, sys
+
+    def report(path):
+        try:
+            with open(path, 'r') as f:
+                data = json.load(f)
+        except Exception as e:
+            print(f"Error loading JSON: {e}")
+            return
+
+        # Calculate denominator for percentage
+        bi = data.get('build_info', {})
+        live = sum(int(bi.get(k, 0)) for k in ('live_class_count', 'live_field_count', 'live_method_count'))
+        denom = live if live > 0 else sum(len(data.get(tbl, [])) for tbl in ('kept_class_info_table', 'kept_field_info_table', 'kept_method_info_table'))
+
+        processed = []
+        for r in data.get('keep_rule_blast_radius_table', []):
+            br = r.get('blast_radius', {})
+            c, f, m = len(br.get('class_blast_radius', [])), len(br.get('field_blast_radius', [])), len(br.get('method_blast_radius', []))
+            impact = c + f + m
+            if impact == 0:
+                continue
+            impact_pct = (impact / denom * 100) if denom > 0 else 0.0
+            processed.append({
+                'id': r.get('id'),
+                'source': r.get('source'),
+                'impact': impact,
+                'impact_pct': f"{impact_pct:.2f}%",
+                'classes': c,
+                'fields': f,
+                'methods': m,
+                'subsumed_by': br.get('subsumed_by', [])
+            })
+
+        processed.sort(key=lambda x: x['impact'], reverse=True)
+
+        # Output JSON for the agent to fetch and process
+        print(json.dumps({
+            "top_5_impact_keep_rules": [r for r in processed if not r['subsumed_by']][:5],
+            "subsumed": [r for r in processed if r['subsumed_by']]
+        }, indent=2))
+
+    if __name__ == "__main__":
+        report("tmp/r8analysis/keepruleradius.json")
+
+Add this data to the `analysis_result.txt` with the top impactful rules and
+subsumed rules.
+
+### 8. Compare with previous report
+
+If `{project_root}/tmp/r8analysis/history.txt` exists, use the following script
+to compare the previous run. Use this to compare with the current values
+
+### 9. Remove generated files
+
+After the final report and analysis results are generated, remove the
+intermediate files `keepruleradius.json` and `analysis_result.txt` and remove
+the proto files in "{project_root}/tmp/r8analysis" folder
+
+    rm tmp/r8analysis/keepruleradius.json
+    rm tmp/r8analysis/*.pb
+
+### 10. Protobuf Python bindings
+
+The following script `keep_radius_pb2.py` is required by the conversion script
+in Step 5.
+
+    from google.protobuf import descriptor as _descriptor
+    from google.protobuf import descriptor_pool as _descriptor_pool
+    from google.protobuf import runtime_version as _runtime_version
+    from google.protobuf import symbol_database as _symbol_database
+    from google.protobuf.internal import builder as _builder
+    _runtime_version.ValidateProtobufRuntimeVersion(
+        _runtime_version.Domain.PUBLIC,
+        6,
+        33,
+        4,
+        '',
+        'keep_radius.proto'
+    )
+    # @@protoc_insertion_point(imports)
+
+    _sym_db = _symbol_database.Default()
+    DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11keep_radius.proto\x12&com.android.tools.r8.blastradius.proto\"\x9f\x02\n\x13KeepRuleBlastRadius\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x0e\n\x06source\x18\x02 \x01(\t\x12\x16\n\x0e\x63onstraints_id\x18\x03 \x01(\x05\x12\x46\n\x06origin\x18\x04 \x01(\x0b\x32\x36.com.android.tools.r8.blastradius.proto.TextFileOrigin\x12I\n\x0c\x62last_radius\x18\x05 \x01(\x0b\x32\x33.com.android.tools.r8.blastradius.proto.BlastRadius\x12\x41\n\x04tags\x18\x06 \x03(\x0e\x32\x33.com.android.tools.r8.blastradius.proto.KeepRuleTag\"w\n\x0b\x42lastRadius\x12\x13\n\x0bsubsumed_by\x18\x01 \x03(\x05\x12\x1a\n\x12\x63lass_blast_radius\x18\x02 \x03(\x05\x12\x1a\n\x12\x66ield_blast_radius\x18\x03 \x03(\x05\x12\x1b\n\x13method_blast_radius\x18\x04 \x03(\x05\"\x7f\n\x19GlobalKeepRuleBlastRadius\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x0e\n\x06source\x18\x02 \x01(\t\x12\x46\n\x06origin\x18\x03 \x01(\x0b\x32\x36.com.android.tools.r8.blastradius.proto.TextFileOrigin\"j\n\x0fKeepConstraints\x12\n\n\x02id\x18\x01 \x01(\x05\x12K\n\x0b\x63onstraints\x18\x02 \x03(\x0e\x32\x36.com.android.tools.r8.blastradius.proto.KeepConstraint\"`\n\rKeptClassInfo\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x12\x63lass_reference_id\x18\x02 \x01(\x05\x12\x16\n\x0e\x66ile_origin_id\x18\x03 \x01(\x05\x12\x0f\n\x07kept_by\x18\x04 \x03(\x05\"`\n\rKeptFieldInfo\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x12\x66ield_reference_id\x18\x02 \x01(\x05\x12\x16\n\x0e\x66ile_origin_id\x18\x03 \x01(\x05\x12\x0f\n\x07kept_by\x18\x04 \x03(\x05\"b\n\x0eKeptMethodInfo\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1b\n\x13method_reference_id\x18\x02 \x01(\x05\x12\x16\n\x0e\x66ile_origin_id\x18\x03 \x01(\x05\x12\x0f\n\x07kept_by\x18\x04 \x03(\x05\"a\n\x0e\x46ieldReference\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x12\x63lass_reference_id\x18\x02 \x01(\x05\x12\x19\n\x11type_reference_id\x18\x03 \x01(\x05\x12\x0c\n\x04name\x18\x04 \x01(\t\"c\n\x0fMethodReference\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x12\x63lass_reference_id\x18\x02 \x01(\x05\x12\x1a\n\x12proto_reference_id\x18\x03 \x01(\x05\x12\x0c\n\x04name\x18\x04 \x01(\t\"K\n\x0eProtoReference\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x15\n\rparameters_id\x18\x02 \x01(\x05\x12\x16\n\x0ereturn_type_id\x18\x03 \x01(\x05\"4\n\rTypeReference\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x17\n\x0fjava_descriptor\x18\x02 \x01(\t\";\n\x11TypeReferenceList\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x1a\n\x12type_reference_ids\x18\x02 \x03(\x05\"\x9f\x01\n\nFileOrigin\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\x12Q\n\x10maven_coordinate\x18\x03 \x01(\x0b\x32\x37.com.android.tools.r8.blastradius.proto.MavenCoordinate\x12 \n\x18provided_by_build_system\x18\x04 \x01(\x08\"I\n\x14\x43lassFileInJarOrigin\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x16\n\x0e\x66ile_origin_id\x18\x02 \x01(\x05\x12\r\n\x05\x65ntry\x18\x03 \x01(\t\"T\n\x0eTextFileOrigin\x12\x16\n\x0e\x66ile_origin_id\x18\x01 \x01(\x05\x12\x13\n\x0bline_number\x18\x02 \x01(\x05\x12\x15\n\rcolumn_number\x18\x03 \x01(\x05\"U\n\x0fMavenCoordinate\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x10\n\x08group_id\x18\x02 \x01(\t\x12\x13\n\x0b\x61rtifact_id\x18\x03 \x01(\t\x12\x0f\n\x07version\x18\x04 \x01(\t\"\x9a\x01\n\tBuildInfo\x12\x13\n\x0b\x63lass_count\x18\x01 \x01(\x05\x12\x13\n\x0b\x66ield_count\x18\x02 \x01(\x05\x12\x14\n\x0cmethod_count\x18\x03 \x01(\x05\x12\x18\n\x10live_class_count\x18\x04 \x01(\x05\x12\x18\n\x10live_field_count\x18\x05 \x01(\x05\x12\x19\n\x11live_method_count\x18\x06 \x01(\x05\"\xd5\n\n\x14\x42lastRadiusContainer\x12M\n\x11\x66ile_origin_table\x18\x01 \x03(\x0b\x32\x32.com.android.tools.r8.blastradius.proto.FileOrigin\x12\x64\n\x1e\x63lass_file_in_jar_origin_table\x18\x02 \x03(\x0b\x32<.com.android.tools.r8.blastradius.proto.ClassFileInJarOrigin\x12W\n\x16maven_coordinate_table\x18\x03 \x03(\x0b\x32\x37.com.android.tools.r8.blastradius.proto.MavenCoordinate\x12U\n\x15\x66ield_reference_table\x18\x04 \x03(\x0b\x32\x36.com.android.tools.r8.blastradius.proto.FieldReference\x12W\n\x16method_reference_table\x18\x05 \x03(\x0b\x32\x37.com.android.tools.r8.blastradius.proto.MethodReference\x12U\n\x15proto_reference_table\x18\x06 \x03(\x0b\x32\x36.com.android.tools.r8.blastradius.proto.ProtoReference\x12S\n\x14type_reference_table\x18\x07 \x03(\x0b\x32\x35.com.android.tools.r8.blastradius.proto.TypeReference\x12\\\n\x19type_reference_list_table\x18\x08 \x03(\x0b\x32\x39.com.android.tools.r8.blastradius.proto.TypeReferenceList\x12T\n\x15kept_class_info_table\x18\t \x03(\x0b\x32\x35.com.android.tools.r8.blastradius.proto.KeptClassInfo\x12T\n\x15kept_field_info_table\x18\n \x03(\x0b\x32\x35.com.android.tools.r8.blastradius.proto.KeptFieldInfo\x12V\n\x16kept_method_info_table\x18\x0b \x03(\x0b\x32\x36.com.android.tools.r8.blastradius.proto.KeptMethodInfo\x12W\n\x16keep_constraints_table\x18\x0c \x03(\x0b\x32\x37.com.android.tools.r8.blastradius.proto.KeepConstraints\x12\x61\n\x1ckeep_rule_blast_radius_table\x18\r \x03(\x0b\x32;.com.android.tools.r8.blastradius.proto.KeepRuleBlastRadius\x12n\n#global_keep_rule_blast_radius_table\x18\x0e \x03(\x0b\x32\x41.com.android.tools.r8.blastradius.proto.GlobalKeepRuleBlastRadius\x12\x45\n\nbuild_info\x18\x0f \x01(\x0b\x32\x31.com.android.tools.r8.blastradius.proto.BuildInfo*\x1f\n\x0bKeepRuleTag\x12\x10\n\x0cPACKAGE_WIDE\x10\x00*H\n\x0eKeepConstraint\x12\x12\n\x0e\x44ONT_OBFUSCATE\x10\x00\x12\x11\n\rDONT_OPTIMIZE\x10\x01\x12\x0f\n\x0b\x44ONT_SHRINK\x10\x02\x42\x45\n&com.android.tools.r8.blastradius.protoB\x19KeepRuleBlastRadiusProtosP\001\x62\x06proto3')
+
+    _globals = globals()
+    _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
+    _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'keep_radius_pb2', _globals)
+    if not _descriptor._USE_C_DESCRIPTORS:
+        _globals['DESCRIPTOR']._loaded_options = None
+        _globals['DESCRIPTOR']._serialized_options = b'\n&com.android.tools.r8.blastradius.protoB\031KeepRuleBlastRadiusProtosP\001'
+        _globals['_KEEPRULETAG']._serialized_start = 3332
+        _globals['_KEEPRULETAG']._serialized_end = 3363
+        _globals['_KEEPCONSTRAINT']._serialized_start = 3365
+        _globals['_KEEPCONSTRAINT']._serialized_end = 3437
+        _globals['_KEEPRULEBLASTRADIUS']._serialized_start = 62
+        _globals['_KEEPRULEBLASTRADIUS']._serialized_end = 349
+        _globals['_BLASTRADIUS']._serialized_start = 351
+        _globals['_BLASTRADIUS']._serialized_end = 470
+        _globals['_GLOBALKEEPRULEBLASTRADIUS']._serialized_start = 472
+        _globals['_GLOBALKEEPRULEBLASTRADIUS']._serialized_end = 599
+        _globals['_KEEPCONSTRAINTS']._serialized_start = 601
+        _globals['_KEEPCONSTRAINTS']._serialized_end = 707
+        _globals['_KEPTCLASSINFO']._serialized_start = 709
+        _globals['_KEPTCLASSINFO']._serialized_end = 805
+        _globals['_KEPTFIELDINFO']._serialized_start = 807
+        _globals['_KEPTFIELDINFO']._serialized_end = 903
+        _globals['_KEPTMETHODINFO']._serialized_start = 905
+        _globals['_KEPTMETHODINFO']._serialized_end = 1003
+        _globals['_FIELDREFERENCE']._serialized_start = 1005
+        _globals['_FIELDREFERENCE']._serialized_end = 1102
+        _globals['_METHODREFERENCE']._serialized_start = 1104
+        _globals['_METHODREFERENCE']._serialized_end = 1203
+        _globals['_PROTOREFERENCE']._serialized_start = 1205
+        _globals['_PROTOREFERENCE']._serialized_end = 1280
+        _globals['_TYPEREFERENCE']._serialized_start = 1282
+        _globals['_TYPEREFERENCE']._serialized_end = 1334
+        _globals['_TYPEREFERENCELIST']._serialized_start = 1336
+        _globals['_TYPEREFERENCELIST']._serialized_end = 1395
+        _globals['_FILEORIGIN']._serialized_start = 1398
+        _globals['_FILEORIGIN']._serialized_end = 1557
+        _globals['_CLASSFILEINJARORIGIN']._serialized_start = 1559
+        _globals['_CLASSFILEINJARORIGIN']._serialized_end = 1632
+        _globals['_TEXTFILEORIGIN']._serialized_start = 1634
+        _globals['_TEXTFILEORIGIN']._serialized_end = 1718
+        _globals['_MAVENCOORDINATE']._serialized_start = 1720
+        _globals['_MAVENCOORDINATE']._serialized_end = 1805
+        _globals['_BUILDINFO']._serialized_start = 1808
+        _globals['_BUILDINFO']._serialized_end = 1962
+        _globals['_BLASTRADIUSCONTAINER']._serialized_start = 1965
+        _globals['_BLASTRADIUSCONTAINER']._serialized_end = 3330
+    # @@protoc_insertion_point(module_scope)

--- a/platforms/android/.agents/skills/r8-analyzer/references/CONFIGURATION.md
+++ b/platforms/android/.agents/skills/r8-analyzer/references/CONFIGURATION.md
@@ -1,0 +1,44 @@
+To achieve maximum utilization of R8, the codebase must be configured correctly
+depending on the build script language (Kotlin DSL versus Groovy DSL).
+
+## 1. App Modules (`com.android.application`)
+
+The app's `build.gradle` or `build.gradle.kts` file must enable minification
+and resource shrinking within the `release` build type or the apps custom build
+type for release and performance testing. It MUST use the optimized default file
+(`proguard-android-optimize.txt`).
+
+**Kotlin DSL (`build.gradle.kts`):**
+
+    buildTypes {
+       getByName("release") {
+           isMinifyEnabled = true
+           isShrinkResources = true
+           proguardFiles(
+               getDefaultProguardFile("proguard-android-optimize.txt"),
+               "proguard-rules.pro"
+           )
+       }
+    }
+
+**Groovy DSL (`build.gradle`):**
+
+    buildTypes {
+       release {
+           minifyEnabled = true
+           shrinkResources = true
+           proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+       }
+    }
+
+## 2. `gradle.properties` Flags
+
+**Full Mode:** R8 Full Mode enables the entire optimizations
+
+- **AGP 8.0+** : Enabled by default. Ensure `android.enableR8.fullMode=false` is **NOT** present.
+- **Pre-AGP 8.0** : Explicitly enable with `android.enableR8.fullMode=true`.
+
+**Optimized Resource Shrinking:** If the AGP version of the project is less than
+9.0 and more than 8.6, explicitly enable the new resource shrinker:
+
+    android.r8.optimizedResourceShrinking=true

--- a/platforms/android/.agents/skills/r8-analyzer/references/KEEP-RULES-IMPACT-HIERARCHY.md
+++ b/platforms/android/.agents/skills/r8-analyzer/references/KEEP-RULES-IMPACT-HIERARCHY.md
@@ -1,0 +1,83 @@
+Keep rules prevent optimization of R8, these rules are listed in the order of
+the scope of what it retains in the codebase.
+
+## 1. Package-Wide Wildcards
+
+The following types of keep rules prevents all the optimization of R8 in a
+package, these must be avoided at any costs and must be refined to target a
+specific class or classes.
+
+    -keep class com.example.package.** { *; } - Prevents optimization of all the classess including members in the package and subpackages
+    -keep class com.example.package.* { *; } - Prevents optimization of all the classes including members in the package
+    -keep class **.package.** { *; } - Prevents optimization of all the classess including members in all the package containing name - package.
+
+Depending on the package level the number of classes gets affected changes, so
+if the package level is higher, more classes are affected. Suggest to refine
+the keep rule
+
+## 2. Inversion operator
+
+Avoid using the inversion operator ! in keep rules because it will
+unintentionally prevent optimization in every class in your application. So if
+you have any keep rule with !operator, make sure you remove that with a narrow
+and specific keep rule
+
+    -keep class !com.example.MyClass{*;}
+
+This keeps the entire app
+other than this class. Optimization are disabled for the entire class other
+than this class.
+
+## 3. Keep Rules for both class and members
+
+Keep rules with -keep option and wildcard(`*`) inside braces forces R8 to retain
+specific classes and their members exactly as defined. These type of keep rules
+prevent any optimization in the entire class and keeps the entire class
+
+    -keep class com.example.MyClass { *; }
+
+## 4. Keepclassmembers
+
+Keep rules with -keepclassmembers and wildcard(`*`) inside braces option Forces
+R8 to retain the members that are defined.
+
+    -keepclassmembers class com.example.MyClass { *; }
+
+## 5. Modifiers with Keep Specification
+
+-Keeps the class and **all** members, but uses modifiers to allow specific
+optimizations (like obfuscation). Retains significant code (members) but allows
+some flexibility.
+
+    -keep,allowobfuscation class com.example.MyClass { *; }
+    -keep,allowshrinking class com.example.MyClass { *; }
+
+### 6. Modifiers with specific method but no modifier
+
+Keeps the class and modifier but no optimizations are enabled
+
+    -keep class com.example.MyClass { void myMethod(); }
+
+## 7. Class-Name Only Preservation
+
+Keeps only the class name. R8 will remove all methods and fields if they are not
+used.
+
+    -keep class com.example.MyClass
+
+## 8. Modifiers without Member Specification
+
+Keeps the class entry point using modifiers, but implies no specific member
+retention logic in the rule itself
+
+    -keep,allowobfuscation class com.example.MyClass
+    -keep,allowshrinking class com.example.MyClass
+    -keep,allowaccessmodification class com.example.MyClass
+
+## 9. Conditional Keep Rules
+
+Only triggers if specific conditions are met (e.g., if class members exist).
+These are the most narrow and optimization-friendly rules.
+
+    -keepclassmembers class com.example.MyClass { <fields>; }
+    -keepclasseswithmembers class * { native <methods>; }

--- a/platforms/android/.agents/skills/r8-analyzer/references/REDUNDANT-RULES.md
+++ b/platforms/android/.agents/skills/r8-analyzer/references/REDUNDANT-RULES.md
@@ -1,0 +1,222 @@
+This document outlines common "bad" or redundant keep rules for standard Android
+development and popular libraries. Modern toolchains and libraries include their
+own consumer keep rules embedded in their AAR/JAR files, making many manual
+configurations unnecessary or even harmful to code optimization.
+
+*** ** * ** ***
+
+## Case: Global Keep Rules
+
+**Common Mistakes:**
+`proguard
+-dontshrink
+-dontobfuscate
+-dontoptimize`
+
+**The Fix:** These keep rules completely disable the core optimizations of R8
+for the entire codebase. They must be removed from the codebase.
+
+*** ** * ** ***
+
+## Case: Android Components
+
+Keep rules required for Android components like Activity, Fragment, ViewModel,
+Views, Services or Broadcast receivers are redundant. AAPT2 and R8 contain the
+logic to automatically keep components declared in the `AndroidManifest.xml` or
+referenced in XML layout files.
+
+**Common Mistakes:**
+`proguard
+-keep public class * extends android.app.Activity
+-keep public class * extends android.app.Service
+-keep public class * extends android.view.View
+-keepclassmembers class * extends android.app.Fragment { public void *(android.view.View); }`
+
+**The Fix:** Delete these manual rules. AAPT2 handles this automatically.
+
+*** ** * ** ***
+
+## Case: Official Android and Kotlin Libraries
+
+Keep rules targeting official library packages like AndroidX, Kotlin, and
+Kotlinx are redundant as they are bundled within the libraries themselves.
+Manual rules are often broader than what is strictly needed.
+
+**Common Mistakes:**
+`proguard
+-keep class androidx.** { *; }
+-keep class kotlinx.** { *; }
+-keep class kotlin.** { *; }`
+
+**The Fix:** Delete these manual rules. Rely on the consumer keep rules packaged
+within these dependencies.
+
+*** ** * ** ***
+
+## Case: Gson
+
+### Overly Broad Data Model Rules
+
+The most common mistake is keeping entire packages of data models (POJOs/DTOs),
+keeping data models at all for deserialization is unnecessary.
+
+    -keep class com.example.app.models.** { *; }
+    -keep class com.example.app.package.models.* { *; }
+
+### Redundant Interface \& Adapter Rules
+
+These rules added for TypeAdapter are unnecessary and are already covered by
+the library, and prevent R8 from effectively shrinking and optimizing custom
+adapters. R8 can determine if the adapter implementation are used. Keeping them
+globally prevents the removal of unused adapter implementations.
+
+    -keep class * extends com.google.gson.TypeAdapter
+    -keep class * implements com.google.gson.TypeAdapterFactory
+    -keep class * implements com.google.gson.JsonSerializer
+    -keep class * implements com.google.gson.JsonDeserializer
+
+### Unnecessary TypeToken Rules
+
+There is no need to handle generic type erasure, Gson's own rules handle the
+necessary `TypeToken` preservation.
+
+    -keep class com.google.gson.reflect.TypeToken { *; }
+    -keep class * extends com.google.gson.reflect.TypeToken
+    -keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
+
+### Internal and Example Packages
+
+Keeping internal library logic prevents the compiler from stripping away dead
+code within the library.
+
+    -keep class com.google.gson.internal.** { *; }
+    -keep class com.google.gson.internal.reflect.** { *; }
+    -keep class com.google.gson.internal.UnsafeAllocator { *; }
+    -keep class com.google.gson.stream.** { *; }
+
+- **Keeps Unused Code:** Prevents R8 from removing models that are never actually used in the code.
+- **Prevents Method Stripping:** Keeps all getters, setters, `toString()`, `equals()`, and `hashCode()` methods, even if they are never called.
+- **Blocks Obfuscation:** Prevents the class names from being obfuscated, which is unnecessary for Gson if you use `@SerializedName`.
+
+**The Fix:**
+
+1. Use `@SerializedName` on every field in your data classes uses so that the field is retained after R8 optimization
+2. Modern Gson (**v2.11.0+** ) bundles its own rules ([View Gson's embedded
+   ProGuard
+   rules](https://github.com/google/gson/blob/main/gson/src/main/resources/META-INF/proguard/gson.pro)). The bundled keep rules retains the `@SerializedName` annotated fields. If you are on an older version, move towards Gson version 2.11 because it has the necessary keep rules and delete the keep rules that target the classes used for gson serialization and deserialization
+
+*** ** * ** ***
+
+## Case: Retrofit
+
+Retrofit has shipped with its own consumer keep rules from 2.9.0 and higher, so
+any keep rules for the library or classes depending on Retrofit is detrimental
+to the optimization process.
+
+### Blanket Library Preservation
+
+This is the most harmful Retrofit rule as it disables any shrinking for the
+entire library.
+
+    -keep class retrofit2.** { *; }
+    -keep class retrofit2.api.** { *; }
+    -keep class com.package.example.retrofit.api.** { *; }
+
+### Manual Annotation Keeps
+
+Retrofit's consumer rules automatically keep the interfaces annotated with
+`@GET`, `@POST`, `@DELETE`, `@PUT`, `@HEAD`, `@OPTIONS`, `@PATCH`, making these
+manual rules obsolete.
+
+`-keepclasseswithmembers class * { @retrofit2.http.* <methods>; }`
+
+### Redundant Network Response and Adapter Rules
+
+Network responses and third-party adapter wrappers (like RxJava) are often
+overly preserved by developers out of caution.
+
+    -keep,allowobfuscation,allowshrinking class retrofit2.Response
+    -keep class retrofit2.adapter.rxjava2.Result { *; }
+
+Fix: Verify you are using Retrofit 2.9.0 and higher. Retrofit from 2.9.0 bundles
+rules that detect its own HTTP annotations (@GET, @POST) ([View Retrofit's
+embedded ProGuard
+rules](https://github.com/square/retrofit/blob/master/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro)).
+It will automatically keep the method signatures it needs to work.
+
+*** ** * ** ***
+
+## Case: Kotlin Coroutines
+
+Kotlin Coroutines comes heavily optimized out of the box with embedded R8 rules
+(`kotlinx-coroutines-core` includes its own rules).
+
+### Blanket Coroutine Library Rules
+
+Keeping everything under `kotlinx.coroutines` is extremely detrimental to app
+size, as coroutines contain a vast amount of internal APIs that aren't used.
+
+`-keepclassmembers class kotlinx.coroutines.** { *; }`
+
+### Redundant Internal Continuations
+
+These low-level coroutine elements are preserved safely by the library's own
+consumer rules. Manually adding these prevents R8 from performing internal
+optimizations (such as removing unused continuations or inlining).
+
+    -keepclassmembers class kotlin.coroutines.SafeContinuation { *; }
+    -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+### Dispatcher and Exception Handler Rules
+
+Sometimes developers notice crashes related to Missing Classes on old Android
+versions and add these rules, but if you are using an up-to-date version of
+Coroutines, these are handled automatically or are not an issue.
+
+    -keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
+    -keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
+    -keepnames class kotlinx.coroutines.android.AndroidExceptionPreHandler {}
+    -keepnames class kotlinx.coroutines.android.AndroidDispatcherFactory {}
+
+**Fix** Remove any broad `kotlinx` keep rules. Coroutines (**v1.7.0+** ) bundle
+the necessary keep rules ([View Coroutines' embedded ProGuard
+rules](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro)).
+
+*** ** * ** ***
+
+## Case: Parcelable
+
+**Common Mistakes:** Legacy projects often contain `-keep class * implements
+android.os.Parcelable { public static final android.os.Parcelable$Creator *; }`.
+
+**The Fix:**
+
+1. Add the `kotlin-parcelize` plugin.
+2. **Use `@Parcelize`:** Replace manual `writeToParcel` logic with the `@Parcelize` annotation.
+3. **Delete All Parcelable Rules:** The plugin automatically generates the required rules.
+4. The default proguard file `proguard-android-optimize.txt` contains the keep rules for keeping all the parcelable classes
+5. **Ideal Rule:** **None.** Delete all manual Parcelable keeps.
+
+*** ** * ** ***
+
+## Case: Room Database
+
+**Common Mistakes:** Keeping DAO interfaces or the generated `_Impl` classes
+manually.
+
+    -keep class * extends androidx.room.RoomDatabase
+    -keep class *_*Impl { *; }
+
+**The Fix:** Room generates its own ProGuard rules for the code it creates.
+Manual rules are redundant and prevent R8 from optimizing the database access
+layers.
+
+- **Ideal Rule:** **None.** Delete all manual Room or DAO keeps.
+
+*** ** * ** ***
+
+## Summary
+
+If you have updated your libraries to the versions mentioned, your
+`proguard-rules.pro` must not contain any keep rules for the libraries
+mentioned here.

--- a/platforms/android/.agents/skills/r8-analyzer/references/REFLECTION-GUIDE.md
+++ b/platforms/android/.agents/skills/r8-analyzer/references/REFLECTION-GUIDE.md
@@ -1,0 +1,139 @@
+A categorized summary of the keep rule examples, including the code patterns to
+look for (imports/usage) and the corresponding suggested rules.
+
+### 1. Reflection: Classes Loaded by Name
+
+**Scenario:** A library or app loads a class dynamically using a string name
+
+- **Look for:**
+  `Class.forName("...")`,
+  `getDeclaredConstructor().newInstance()`, or interfaces used for dynamic loading.
+
+- **Example Code:**
+  `kotlin
+  val taskClass = Class.forName(className)
+  val task = taskClass.getDeclaredConstructor().newInstance() as StartupTask`
+
+- **Suggested Keep Rule:**
+  \`\`\`proguard
+
+  -keep class \* implements com.example.library.StartupTask {
+  (); } \`\`\`
+
+### 2. Reflection: Classes Passed using `::class.java`
+
+**Scenario:** An app passes a class reference directly to a library function.
+
+- **Look for:** `::class.java` (Kotlin) or `.class` (Java) passed as an argument.
+- **Example Code:**
+  `kotlin
+  fun <T> register(clazz: Class<T>) { }
+  // Usage:
+  register(MyService::class.java)`
+
+- **Suggested Keep Rule:**
+  \`\`\`proguard
+
+  # Keep the class itself (R8 usually handles this, but explicit rules ensure stability)
+
+  -keep class com.example.app.MyService {
+  (); } \`\`\`
+
+### 3. Annotation-Based Reflection (Methods/Classes)
+
+**Scenario:** Using custom annotations to mark methods or classes for reflective
+execution.
+
+**Look for:** Custom `@interface` definitions and `getDeclaredMethods()`
+filtered by annotation.
+**Example Code:**
+`kotlin
+annotation class ReflectiveExecutor
+// Logic: find methods annotated with @ReflectiveExecutor and invoke them`
+
+- **Suggested Keep Rule:** \`\`\`proguard # Keep the annotation itself -keep @interface com.example.library.ReflectiveExecutor
+
+# Keep members of any class annotated with this specific annotation
+-keepclassmembers class \* {
+@com.example.library.ReflectiveExecutor \*;
+}
+\`\`\`
+
+### 4. Optional Dependencies (Soft Dependencies)
+
+**Scenario:** A core library checks if an optional module is present in the
+classpath.
+
+- **Look for:** `try-catch` blocks around `Class.forName()` used to toggle features.
+- **Example Code:** \`\`\`kotlin private const val VIDEO_TRACKER_CLASS = "com.example.analytics.video.VideoEventTracker"
+
+try {
+Class.forName(VIDEO_TRACKER_CLASS).getDeclaredConstructor().newInstance()
+} catch (e: ClassNotFoundException) { /\* skip feature \*/ }
+\`\`\`
+
+- **Suggested Keep Rule:** `proguard
+  # Preserve the optional class so the check doesn't fail due to shrinking
+  -keep class com.example.analytics.video.VideoEventTracker {
+  <init>();
+  }`
+
+### 5. Accessing Private Members
+
+**Scenario:** Using reflection to access internal fields or methods not exposed
+with public APIs.
+
+- **Look for:** `getDeclaredField("...")` or `getDeclaredMethod("...")` followed by `isAccessible = true`.
+- **Example Code:**
+  `kotlin
+  val secretField = instance::class.java.getDeclaredField("secretMessage")
+  secretField.isAccessible = true`
+
+- **Suggested Keep Rule:**
+  \`\`\`proguard
+
+  # Specifically keep the private field/method by name and type
+
+  -keepclassmembers class com.example.LibraryClass {
+  private java.lang.String secretMessage;
+  }
+  \`\`\`
+
+### 6. Parcelable (Manual Implementation)
+
+**Scenario:** Implementing `Parcelable` without using the `@Parcelize`
+annotation.
+
+- **Look for:** `implements Parcelable` and a static `CREATOR` field.
+- **Example Code:**
+  `kotlin
+  class MyData : Parcelable {
+  // Manual implementation with CREATOR field
+  }`
+
+- **Suggested Keep Rule:**
+  *(Note: If using `import kotlinx.parcelize.Parcelize`, R8/ProGuard rules are
+  generated automatically. If manual, use the following:)*
+  `proguard
+  -keepclassmembers class * implements android.os.Parcelable {
+  static android.os.Parcelable$Creator CREATOR;
+  }`
+
+### 7. Enums and Obfuscation
+
+**Scenario:** App uses `Enum.valueOf("STRING_NAME")` indirectly (e.g.,using JSON
+deserialization) and the enum names get obfuscated.
+
+- **Look for:** Unnecessary generic Enum keep rules in ProGuard files.
+- **Example Code:**
+  \`\`\`proguard
+
+  # Unnecessary rule
+
+  -keepclassmembers enum \* { \*; }
+  \`\`\`
+- **Suggested Keep Rule:**
+  \*(Note: The default `proguard-android-optimize.txt` already contains the optimal
+  rules for Enums (keeping `values()` and `valueOf(String)`). Any additional
+  manual rules for Enums are redundant.) # No manual rule needed. Use default
+  proguard-android-optimize.txt.

--- a/platforms/android/.agents/skills/r8-analyzer/references/REPORT_FORMAT.md
+++ b/platforms/android/.agents/skills/r8-analyzer/references/REPORT_FORMAT.md
@@ -1,0 +1,51 @@
+## 1. Configuration
+
+*(Optional section for the report, omit if no relevant findings are present.)*
+
+- **AGP Version**: \[Current\] -\> Upgrade to 9.0.
+- **Full Mode** : Not enabled. Remove `android.enableR8.fullMode=false` from `gradle.properties`.
+
+## 2. Global disable rules
+
+*(Optional section for the report, omit if no relevant findings are present.)*
+
+- \[Rule\]: Disables R8 globally. **Action**: Remove.
+
+If there is -dontobfuscate, -dontoptimize or -dontshrink in the codebase,
+mention in this section
+
+## 3. Optimization summary
+
+- **Optimization score**: \[X\]% code is available for R8 optimizations (e.g., inlining, merging). \[100-X\]% of codebase can't be optimized by R8.
+- **Shrinking score**: \[X\]% of code will be optimized by R8 by removing unused classes, fields and methods. \[100-X\]% of codebase contains redundant classes, fields and methods that can't be removed by R8.
+- **Obfuscation score**: \[X\]% of the codebase is available for R8 to obfuscate.
+
+Increasing these scores increases the codebase available to R8 for
+optimizations.
+
+## 4. Keep rules evaluation
+
+### \[Rule text\]
+
+- **Keeps**: \[X\] items or \[X\] % of the codebase from optimization. Classes: \[X\], Fields: \[X\], Methods: \[X\] are prevented from optimization due to this keep rule
+- **Kept items**: \[Class1\], \[Class2\]
+- **Action** : **Remove** (Library bundles rules) OR **Refine** (Too broad, use \[Surgical Rule\]).
+
+## 5. Subsumed keep rules
+
+*(Optional section for the report, omit if no relevant findings are present.)*
+
+### \[Redundant rules\]
+
+- **Subsumed By**: \[Broader Rule\]
+- **Action** : **Remove**.
+
+## 6. Historical analysis summary
+
+*(Only include this section if a previous report existed. Summarize the changes
+in optimization scores here to track progress. For example:)* The previous app
+had scores: Optimization (XX%), Obfuscation (XX%), and Shrinking (XX%). The
+current app has scores: Optimization (YY%), Obfuscation (YY%), and Shrinking
+(YY%).
+**Change**: Optimization improved by ZZ%, Obfuscation improved by ZZ%, and
+Shrinking improved by ZZ%.

--- a/platforms/android/.agents/skills/r8-analyzer/references/android/topic/performance/app-optimization/enable-app-optimization.md
+++ b/platforms/android/.agents/skills/r8-analyzer/references/android/topic/performance/app-optimization/enable-app-optimization.md
@@ -1,0 +1,198 @@
+For the best user experience, you should optimize your app to make it as small
+and fast as possible. Our app optimizer, called R8, streamlines your app by
+removing unused code and resources, rewriting code to optimize runtime
+performance, and more. To your users, this means:
+
+- Faster startup time
+- Reduced memory usage
+- Improved rendering and runtime performance
+- Fewer [ANRs](https://developer.android.com/topic/performance/anrs/keep-your-app-responsive)
+
+> [!IMPORTANT]
+> **Important:** You should always enable optimization for your app's release build; however, you probably don't want to enable it for tests or libraries. For more information about using R8 with tests, see [Test and troubleshoot the
+> optimization](https://developer.android.com/topic/performance/app-optimization/test-and-troubleshoot-the-optimization). For more information about enabling R8 from libraries, see [Optimization for library authors](https://developer.android.com/topic/performance/app-optimization/library-optimization).
+
+> [!IMPORTANT]
+> **Important:** We released an agent skill that you can use to improve your app performance with R8. Try out the skill from the [Android skills repository](https://github.com/android/skills).
+
+## R8 optimization overview
+
+R8 uses a multi-phase process to optimize your app for size and speed. Key
+operations include the following:
+
+- **Code shrinking (also known as tree shaking)** : R8 identifies and removes
+  unreachable code from your application and its library dependencies. By
+  analyzing the entry points of your app (such as `Activities` or `Services`
+  defined in the manifest), R8 builds a graph of referenced code and removes
+  anything that remains unreferenced.
+
+- **Logical optimizations**: R8 rewrites your code to improve execution
+  efficiency and reduce overhead. Key techniques include:
+
+  - **Method inlining**: R8 replaces a method call site with the actual body
+    of the called method. This eliminates the overhead of a function call
+    and lets R8 conduct further optimizations.
+
+  - **Class merging**: R8 combines sets of classes and interfaces into a
+    single class. This reduces the number of classes in the app, lowering
+    memory pressure and improving startup speed.
+
+- **Obfuscation (also known as minification)** : To reduce the size of the DEX
+  file, R8 shortens the names of classes, fields, and methods (for example,
+  `com.example.MyActivity` could become `a.b.a`).
+
+Since 8.12.0 version of Android Gradle Plugin (AGP), R8 also optimizes resources
+as part of its optimization phases. For more information, see [Optimized
+resource shrinking](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization#optimize-resource-shrinking).
+
+## Enable optimization
+
+To enable app optimization, set `isMinifyEnabled = true` (for code optimization)
+and `isShrinkResources = true` (for resource optimization) in your [release
+build's](https://developer.android.com/studio/publish/preparing#turn-off-debugging) app-level build script as shown in the following code. We recommend
+that you always enable both settings. We also recommend enabling app
+optimization only in the final version of your app that you test before
+publishing---usually your release build---because the optimizations increase the
+build time of your project and can make debugging harder due to the way it
+modifies code.
+
+### Kotlin
+
+```kotlin
+android {
+    buildTypes {
+        release {
+
+            // Enables code-related app optimization.
+            isMinifyEnabled = true
+
+            // Enables resource shrinking.
+            isShrinkResources = true
+
+            proguardFiles(
+                // Default file with automatically generated optimization rules.
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+
+                ...
+            )
+            ...
+        }
+    }
+    ...
+}
+```
+
+### Groovy
+
+```groovy
+android {
+    buildTypes {
+        release {
+
+            // Enables code-related app optimization.
+            minifyEnabled = true
+
+            // Enables resource shrinking.
+            shrinkResources = true
+
+            // Default file with automatically generated optimization rules.
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt')
+
+            ...
+        }
+    }
+}
+```
+
+## Improve R8 optimization
+
+The performance benefits of R8 are directly correlated to how much of your
+codebase R8 is able to optimize. To get the maximum benefits out of R8, follow
+best practices:
+
+- Enable R8 in [full mode](https://developer.android.com/topic/performance/app-optimization/full-mode)
+- Enable [obfuscation, optimization, and shrinking](https://developer.android.com/topic/performance/app-optimization/adopt-optimizations-incrementally)
+- Enable resource shrinking and [optimized resource shrinking](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization#optimize-resource-shrinking)
+- [Refine keep rules](https://developer.android.com/topic/performance/app-optimization/keep-rules-best-practices) to allow maximum optimization of classes, fields and methods.
+
+To help you refine keep rules, use the [R8 Configuration Analyzer](https://developer.android.com/topic/performance/app-optimization/r8-configuration-analyzer).
+
+The R8 Configuration Analyzer lets you do the following:
+
+- Track and improve the overall R8 configuration quality by monitoring the metrics provided by the R8 Configuration Analyzer report.
+- Find the broadest keep rules - those which prevent the most optimization
+- and understand what optimization they prevent to refine them.
+
+The R8 Configuration Analyzer is available in AGP version 9.3.0-alpha05 or from
+R8 version 9.3.7-dev. For more information, see [Analyze R8 configuration](https://developer.android.com/topic/performance/app-optimization/r8-configuration-analyzer).
+
+## Optimize resource shrinking for even smaller apps
+
+The 8.12.0 version of Android Gradle Plugin (AGP) introduces optimized resource
+shrinking, which aims to integrate resource and code optimization to create even
+smaller and faster apps.
+
+Before optimized resource shrinking, Android Asset Packaging Tool (AAPT2)
+generated keep rules that effectively treating resource shrinking separately
+from code, often retaining inaccessible code or resources that referenced each
+other.
+
+With optimized resource shrinking, resources are considered like a part of
+program code, forming the reference graph. When a collection of code or
+resources is not referenced, it is not protected by a keep rule, and can be
+removed.
+
+### Enable optimized resource shrinking
+
+To enable the new optimized resource shrinking pipeline for AGP 8.12 or 8.13,
+add the following to your project's `gradle.properties` file:
+
+    android.r8.optimizedResourceShrinking=true
+
+If you are using AGP 9.0.0 or a newer version, you don't need to set
+`android.r8.optimizedResourceShrinking=true`. Optimized resource shrinking is
+automatically applied when `isShrinkResources = true` is enabled in your build
+configuration.
+
+## Verify and configure R8 optimization settings
+
+To enable R8 to use its [full optimization capabilities](https://developer.android.com/topic/performance/app-optimization/full-mode), remove the
+following line from your project's `gradle.properties` file, if it exists:
+
+    android.enableR8.fullMode=false # Remove this line from your codebase.
+
+Note that enabling app optimization makes stack traces difficult to understand,
+especially if R8 renames class or method names. To get stack traces that
+correctly correspond to your source code, see [Recover the original stack
+trace](https://developer.android.com/topic/performance/app-optimization/test-and-troubleshoot-the-optimization#recover-original-stack-trace).
+
+If R8 is enabled, you should also [create Startup Profiles](https://developer.android.com/topic/performance/baselineprofiles/dex-layout-optimizations) for even better
+startup performance.
+
+If you enable app optimization and it causes errors, here are some strategies to
+fix them:
+
+- [Add keep rules](https://developer.android.com/topic/performance/app-optimization/add-keep-rules) to keep some code untouched.
+- [Adopt optimizations incrementally](https://developer.android.com/topic/performance/app-optimization/adopt-optimizations-incrementally).
+- Update your code to [use libraries that are better suited for
+  optimization](https://developer.android.com/topic/performance/app-optimization/choose-libraries-wisely).
+
+> [!CAUTION]
+> **Caution:** Tools that replace or modify R8's output can negatively impact runtime performance. R8 is careful about including and testing many optimizations at the code level, in [DEX layout](https://developer.android.com/topic/performance/baselineprofiles/dex-layout-optimizations), and in correctly producing Baseline Profiles - other tools producing or modifying DEX files can break these optimizations, or otherwise regress performance.
+
+If you are interested in optimizing your build speed, see [Configure how R8
+runs](https://developer.android.com/build/r8-execution-profiles) for information on how to configure R8 based on your environment.
+
+## AGP and R8 version behavior changes
+
+The following table outlines the key features introduced in various versions of
+the Android Gradle Plugin (AGP) and the R8 compiler.
+
+| AGP version | Features introduced |
+|---|---|
+| 9.1 | **Classes repackaged by default:** R8 repackages classes (moving them to the unnamed package, at the top level) to compact DEX further, eliminating the need to specify `-repackageclasses` option. For information about how this works and how to opt out, see [global options](https://developer.android.com/topic/performance/app-optimization/global-options#global-options). |
+| 9.0 | **Optimized resource shrinking:** Enabled by default (controlled using `android.r8.optimizedResourceShrinking`). [Optimized resource shrinking](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization#optimize-resource-shrinking) helps integrate resource shrinking with the code optimization pipeline, leading to smaller, faster apps. By optimizing both code and resource references simultaneously, it identifies and removes resources referenced exclusively from unused code. This is a significant improvement over the previous separate optimization processes. This is especially useful for apps that share substantial resources and code across different form factor verticals, with measured improvements of over 50% in app size. The resulting size reduction leads to smaller downloads, faster installations, and a better user experience with faster startup, improved rendering, and fewer ANRs. **Library rule filtering:** Support for global options (for example, `-dontobfuscate`) in library consumer rules has been dropped, and apps will filter them out. For more information, see [Add global options](https://developer.android.com/topic/performance/app-optimization/global-options). **Kotlin null checks:** Optimized by default (controlled using `-processkotlinnullchecks`). This version also introduced significant improvements in build speed. For more information, see [Global options for additional optimization](https://developer.android.com/topic/performance/app-optimization/global-options#global-options). **Optimize specific packages:** You can use `packageScope` to optimize specific packages. This is in experimental support. For more information, see [Optimize specified packages with `packageScope`](https://developer.android.com/topic/performance/app-optimization/optimize-specified-packages). **Optimized by default:** Support for `getDefaultProguardFile("proguard-android.txt")` has been dropped, because it includes `-dontoptimize`, which should be avoided. Instead, use `"proguard-android-optimize.txt"`. If you need to globally disable optimization in your app, [add the flag manually to a proguard file](https://developer.android.com/topic/performance/app-optimization/global-options#global-options-2). |
+| 8.12 | **Optimized resource shrinking:** Initial support added (controlled using `android.r8.optimizedResourceShrinking`). [Optimized resource shrinking](https://developer.android.com/topic/performance/app-optimization/enable-app-optimization#optimize-resource-shrinking) helps integrate resource shrinking with the code optimization pipeline. You must manually enable it in this version of AGP. **Logcat retracing:** Support for automatic retracing in the Android Studio [Logcat window](https://developer.android.com/studio/debug/logcat). |
+| 8.6 | **Improved retracing:** Includes filename and line number retracing by default for all `minSdk` levels (previously required `minSdk` 26+ in version 8.2). Updating R8 helps ensure that stack traces from obfuscated builds are readily and clearly readable. This version improves how line numbers and source files are mapped, making it easier for tools like the Android Studio Logcat to automatically retrace crashes to the original source code. |
+| 8.0 | **Full mode by default:** [R8 full mode](https://developer.android.com/topic/performance/app-optimization/full-mode) provides significantly more powerful optimization. It is enabled by default. You can opt out using `android.enableR8.fullMode=false`. |
+| 7.0 | **Full mode available:** Introduced as an opt-in feature using `android.enableR8.fullMode=true`. Full mode applies more powerful optimizations by making stricter assumptions about how your code uses reflection and other dynamic features. While it reduces app size and improves performance, it might require additional keep rules to prevent necessary code from being stripped. |

--- a/platforms/android/.agents/skills/r8-analyzer/references/android/training/testing/other-components/ui-automator.md
+++ b/platforms/android/.agents/skills/r8-analyzer/references/android/training/testing/other-components/ui-automator.md
@@ -1,0 +1,312 @@
+The UI Automator testing framework provides a set of APIs to build UI tests that
+interact with user apps and system apps.
+
+> [!NOTE]
+> **Note:** This documentation covers the modern approach to writing UI Automator tests, introduced with [UI Automator 2.4](https://developer.android.com/jetpack/androidx/releases/test-uiautomator#2.4.0). This approach makes your tests more concise, readable, and robust. The API is under development, and we strongly recommend using it for any new development with UI Automator. The [legacy API guidance](https://developer.android.com/training/testing/other-components/ui-automator-legacy) is also available.
+
+## Introduction to modern UI Automator testing
+
+UI Automator 2.4 introduces a streamlined, Kotlin-friendly Domain Specific
+Language (DSL) that simplifies writing UI tests for Android. This new API
+surface focuses on predicate-based element finding and explicit control over app
+states. Use it to create more maintainable and reliable automated tests.
+
+UI Automator lets you test an app from outside of the app's process. This
+lets you test release versions with minification applied. UI Automator also
+helps when writing macrobenchmark tests.
+
+Key features of the modern approach include:
+
+- A dedicated `uiAutomator` test scope for cleaner and more expressive test code.
+- Methods like `onElement`, `onElements`, and `onElementOrNull` for finding UI elements with clear predicates.
+- Built-in waiting mechanism for conditional elements `onElement*(timeoutMs:
+  Long = 10000)`
+- Explicit app state management such as `waitForStable` and `waitForAppToBeVisible`.
+- Direct interaction with accessibility window nodes for multi-window testing scenarios.
+- Built-in screenshot capabilities and a `ResultsReporter` for visual testing and debugging.
+
+## Set up your project
+
+To begin using the modern UI Automator APIs, update your project's
+`build.gradle.kts` file to include the [latest dependency](https://developer.android.com/jetpack/androidx/releases/test-uiautomator#2.4.0):
+
+### Kotlin
+
+    dependencies {
+      ...
+      androidTestImplementation("androidx.test.uiautomator:uiautomator:2.4.0-alpha05")
+    }
+
+### Groovy
+
+    dependencies {
+      ...
+      androidTestImplementation "androidx.test.uiautomator:uiautomator:2.4.0-alpha05"
+    }
+
+## Core API concepts
+
+The following sections describe core concepts of the modern UI Automator API.
+
+### The uiAutomator test scope
+
+Access all new UI Automator APIs within the **`uiAutomator { ... }`**
+block. This function creates a `UiAutomatorTestScope` that provides a concise
+and type-safe environment for your test operations.
+
+    uiAutomator {
+      // All your UI Automator actions go here
+      startApp("com.example.targetapp")
+      onElement { textAsString() == "Hello, World!" }.click()
+    }
+
+### Find UI elements
+
+Use UI Automator APIs with predicates to locate UI elements. These predicates
+let you define conditions for properties such as text, selected or focused
+state, and content description.
+
+- `onElement { predicate }`: Returns the first UI element that matches the
+  predicate within a default timeout. The function throws an exception if it
+  doesn't locate a matching element.
+
+      // Find a button with the text "Submit" and click it
+      onElement { textAsString() == "Submit" }.click()
+
+      // Find a UI element by its resource ID
+      onElement { viewIdResourceName == "my_button_id" }.click()
+
+      // Allow a permission request
+      watchFor(PermissionDialog) {
+        clickAllow()
+      }
+
+- `onElementOrNull { predicate }`: Similar to `onElement`, but returns
+  `null` if the function finds no matching element within the timeout. It
+  doesn't throw an exception. Use this method for optional elements.
+
+      val optionalButton = onElementOrNull { textAsString() == "Skip" }
+      optionalButton?.click() // Click only if the button exists
+
+- `onElements { predicate }`: Waits until at least one UI element matches
+  the given predicate, then returns a list of all matching UI elements.
+
+      // Get all items in a list Ui element
+      val listItems = onElements { className == "android.widget.TextView" && isClickable }
+      listItems.forEach { it.click() }
+
+Here are some tips for using `onElement` calls:
+
+- Chain `onElement` calls for nested elements: You can chain `onElement`
+  calls to find elements within other elements, following a parent-child
+  hierarchy.
+
+      // Find a parent Ui element with ID "first", then its child with ID "second",
+      // then its grandchild with ID "third", and click it.
+      onElement { viewIdResourceName == "first" }
+        .onElement { viewIdResourceName == "second" }
+        .onElement { viewIdResourceName == "third" }
+        .click()
+
+- Specify a timeout for `onElement*` functions by passing a value representing
+  milliseconds.
+
+      // Find a Ui element with a zero timeout (instant check)
+      onElement(0) { viewIdResourceName == "something" }.click()
+
+      // Find a Ui element with a custom timeout of 10 seconds
+      onElement(10_000) { textAsString() == "Long loading text" }.click()
+
+### Interact with UI elements
+
+Interact with UI elements by simulating clicks or setting text in editable
+fields.
+
+    // Click a Ui element
+    onElement { textAsString() == "Tap Me" }.click()
+
+    // Set text in an editable field
+    onElement { className == "android.widget.EditText" }.setText("My input text")
+
+    // Perform a long click
+    onElement { contentDescription == "Context Menu" }.longClick()
+
+## Handle app states and watchers
+
+Manage the lifecycle of your app and handle unexpected UI elements that might
+appear during your tests.
+
+### App lifecycle management
+
+The APIs provide ways to control the state of the app under test:
+
+    // Start a specific app by package name. Used for benchmarking and other
+    // self-instrumenting tests.
+    startApp("com.example.targetapp")
+
+    // Start a specific activity within the target app
+    startActivity(SomeActivity::class.java)
+
+    // Start an intent
+    startIntent(myIntent)
+
+    // Clear the app's data (resets it to a fresh state)
+    clearAppData("com.example.targetapp")
+
+### Handle unexpected UI
+
+The `watchFor` API lets you define handlers for unexpected UI elements,
+such as permission dialogs, that might appear during your test flow. This
+uses the internal watcher mechanism but offers more flexibility.
+
+    import androidx.test.uiautomator.PermissionDialog
+
+    @Test
+    fun myTestWithPermissionHandling() = uiAutomator {
+      startActivity(MainActivity::class.java)
+
+      // Register a watcher to click "Allow" if a permission dialog appears
+      watchFor(PermissionDialog) { clickAllow() }
+
+      // Your test steps that might trigger a permission dialog
+      onElement { textAsString() == "Request Permissions" }.click()
+
+      // Example: You can register a different watcher later if needed
+      clearAppData("com.example.targetapp")
+
+      // Now deny permissions
+      startApp("com.example.targetapp")
+      watchFor(PermissionDialog) { clickDeny() }
+      onElement { textAsString() == "Request Permissions" }.click()
+    }
+
+`PermissionDialog` is an example of a `ScopedWatcher<T>`, where `T` is the
+object passed as a scope to the block in `watchFor`. You can create custom
+watchers based on this pattern.
+
+### Wait for app visibility and stability
+
+Sometimes tests need to wait for elements to become visible or stable.
+UI Automator offers several APIs to help with this.
+
+The `waitForAppToBeVisible("com.example.targetapp")` waits for a UI element with
+the given package name to appear on the screen within a customizable timeout.
+
+    // Wait for the app to be visible after launching it
+    startApp("com.example.targetapp")
+    waitForAppToBeVisible("com.example.targetapp")
+
+Use the `waitForStable()` API to verify that the app's UI is considered stable
+before interacting with it.
+
+    // Wait for the entire active window to become stable
+    activeWindow().waitForStable()
+
+    // Wait for a specific Ui element to become stable (e.g., after a loading animation)
+    onElement { viewIdResourceName == "my_loading_indicator" }.waitForStable()
+
+> [!NOTE]
+> **Note:** In most cases, `waitForStable()` isn't strictly necessary when using `onElement { ... }` because `onElement` already includes a timeout. Use `waitForStable()` primarily in combination with `onElements { ... }` to verify that all UI elements are visible, when you know that the UI is in an unstable state, or for specific screenshot testing scenarios where you need the UI to completely settle before capturing. `waitForStable()` works by waiting until no changes are detected in the accessibility tree for a set period. Note that this UI stability check doesn't guarantee that the app is fully idle, as background tasks might still be running.
+
+## Use UI Automator for Macrobenchmarks and Baseline Profiles
+
+Use UI Automator for performance testing with [Jetpack Macrobenchmark](https://developer.android.com/topic/performance/benchmarking/macrobenchmark-overview)
+and for generating [Baseline Profiles](https://developer.android.com/topic/performance/baselineprofiles/overview), as it provides a reliable way to
+interact with your app and measure performance from an end-user perspective.
+
+Macrobenchmark uses UI Automator APIs to drive the UI and measure interactions.
+For example, in startup benchmarks, you can use `onElement` to detect when UI
+content is fully loaded, enabling you to measure [Time to Full Display
+(TTFD)](https://developer.android.com/topic/performance/vitals/launch-time#time-full). In jank benchmarks, UI Automator APIs are used to scroll lists or
+run animations to measure frame timings. Functions like `startActivity()` or
+`startIntent()` are useful for getting the app into the correct state before
+measurement begins.
+
+When [generating Baseline Profiles](https://developer.android.com/topic/performance/baselineprofiles/create-baselineprofile), you automate your app's critical user
+journeys (CUJs) to record which classes and methods require pre-compilation. UI
+Automator is an ideal tool for writing these automation scripts. The modern
+DSL's predicate-based element finding and built-in wait mechanisms (`onElement`)
+lead to more robust and deterministic test execution compared to other methods.
+This stability reduces flakiness and ensures that the generated Baseline Profile
+accurately reflects the code paths executed during your most important user
+flows.
+
+## Advanced features
+
+The following features are useful for more complex testing scenarios.
+
+### Interact with multiple windows
+
+The UI Automator APIs let you directly interact with and inspect UI
+elements. This is particularly useful for scenarios involving multiple windows,
+such as Picture-in-Picture (PiP) mode or split-screen layouts.
+
+    // Find the first window that is in Picture-in-Picture mode
+    val pipWindow = windows()
+      .first { it.isInPictureInPictureMode == true }
+
+    // Now you can interact with elements within that specific window
+    pipWindow.onElement { textAsString() == "Play" }.click()
+
+### Screenshots and visual assertions
+
+Capture screenshots of the entire screen, specific windows, or
+individual UI elements directly within your tests. This is helpful for visual
+regression testing and debugging.
+
+    uiautomator {
+      // Take a screenshot of the entire active window
+      val fullScreenBitmap: Bitmap = activeWindow().takeScreenshot()
+      fullScreenBitmap.saveToFile(File("/sdcard/Download/full_screen.png"))
+
+      // Take a screenshot of a specific UI element (e.g., a button)
+      val buttonBitmap: Bitmap = onElement { viewIdResourceName == "my_button" }.takeScreenshot()
+      buttonBitmap.saveToFile(File("/sdcard/Download/my_button_screenshot.png"))
+
+      // Example: Take a screenshot of a PiP window
+      val pipWindowScreenshot = windows()
+        .first { it.isInPictureInPictureMode == true }
+        .takeScreenshot()
+      pipWindowScreenshot.saveToFile(File("/sdcard/Download/pip_screenshot.png"))
+    }
+
+The `saveToFile` extension function for Bitmap simplifies saving the captured
+image to a specified path.
+
+### Use ResultsReporter for debugging
+
+The `ResultsReporter` helps you associate test artifacts, like screenshots,
+directly with your test results in Android Studio for easier inspection and
+debugging.
+
+    uiAutomator {
+      startApp("com.example.targetapp")
+
+      val reporter = ResultsReporter("MyTestArtifacts") // Name for this set of results
+      val file = reporter.addNewFile(
+        filename = "my_screenshot",
+        title = "Accessible button image" // Title that appears in Android Studio test results
+      )
+
+      // Take a screenshot of an element and save it using the reporter
+      onElement { textAsString() == "Accessible button" }
+        .takeScreenshot()
+        .saveToFile(file)
+
+      // Report the artifacts to instrumentation, making them visible in Android Studio
+      reporter.reportToInstrumentation()
+    }
+
+## Migrate from older UI Automator versions
+
+If you have existing UI Automator tests written with older API surfaces, use the
+following table as a reference to migrate to the modern approach:
+
+| Action type | Old UI Automator method | New UI Automator method |
+|---|---|---|
+| Entry point | `UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())` | Wrap test logic in the `uiAutomator { ... }` scope. |
+| Find UI elements | `device.findObject(By.res("com.example.app:id/my_button"))` | `onElement { viewIdResourceName == "my\_button" }` |
+| Find UI elements | `device.findObject(By.text("Click Me"))` | `onElement { textAsString() == "Click Me" }` |
+| Wait for idle UI | `device.waitForIdle()` | Prefer `onElement`'s built-in timeout mechanism; otherwise, `activeWindow().waitForStable()` |
+| Find child elements | Manually nested `findObject` calls | `onElement().onElement()` chaining |
+| Handle permission dialogs | `UiAutomator.registerWatcher()` | `watchFor(PermissionDialog)` |

--- a/platforms/android/.agents/skills/styles/SKILL.md
+++ b/platforms/android/.agents/skills/styles/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: styles
+description: Use this skill to integrate the Jetpack Compose Styles API into an Android
+  project. This skill guides you through upgrading dependencies, setting up component
+  themes, making custom components styleable, and migrating existing layout properties
+  to use unified styles. Migrate custom design system components, replace hard coded
+  parameters with Style attributes, and use Modifier.styleable for interaction states.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-07-07'
+  keywords:
+  - Jetpack Compose
+  - Styles
+  - Theming with Styles
+  - Migrate to Styles
+  - Modifier.styleable
+---
+
+## Limitations
+
+- Warn the user that this skill is EXPERIMENTAL and requires updating to alpha version of Compose and opting in to the Experimental APIs.
+- This skill only supports custom UI components and custom themes.
+- This skill does not support Material Design component Styles.
+
+## Prerequisites
+
+### 1. Upgrade dependencies
+
+- The project must use `compileSdk` version 37 or higher.
+- The project must use `androidx.compose.foundation:foundation` version `1.12.0-alpha01` or higher.
+- Alternatively, the project must use Compose BOM version `2026.04.01` or higher.
+- The API requires this exact package: `import
+  androidx.compose.foundation.style.Style`
+
+### 2. Configure compiler options to enable experimental API
+
+You must opt-in to the experimental API at the project level. Add the following
+block to your module's `build.gradle.kts`:
+
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.fromTarget("17")
+            freeCompilerArgs.add("-opt-in=androidx.compose.foundation.style.ExperimentalFoundationStyleApi")
+        }
+    }
+
+## Core workflows and guides
+
+Refer to the official documentation to complete specific development tasks:
+
+- Basic Style Usage: To set backgrounds, sizes, and alignments on a component, follow the [Compose Styles Fundamentals
+  Guide](references/android/develop/ui/compose/styles/fundamentals.md).
+- State and Transitions: To configure property changes for state shifts (like pressed or hovered), follow the [Animations and State-Based Styling
+  Guide](references/android/develop/ui/compose/styles/state-animations.md).
+- Architecture Trade offs: To decide when to use a Style versus a standard Modifier, follow the [Styles versus Modifiers
+  Comparison](references/android/develop/ui/compose/styles/styles-vs-modifiers.md).
+- Theme Level Integration: To connect style definitions with custom themes, follow [Theming with Styles](references/android/develop/ui/compose/styles/theming.md) and [Custom Themes in Compose](references/android/develop/ui/compose/designsystems/custom.md).
+
+## Step-by-Step Migration Workflow
+
+### Step 1: Analyze theme structure
+
+1. Locate your central theme file (such as `Theme.kt`).
+2. Identify design tokens. Note references for colors, typography, and shapes (for example, `LocalColorScheme`, `LocalTypography`, or `LocalShapes`).
+3. If the project lacks Jetpack Compose dependencies, stop. Instruct the user to migrate to Jetpack Compose first.
+4. If the project imports `androidx.compose.material.MaterialTheme`, recommend migrating to Material 3 before proceeding.
+
+### Step 2: Establish `ComponentStyles`
+
+1. Create a new file named `ComponentStyles.kt` in your theme directory.
+2. Define a top-level data class to hold your component styles, for example, the Jetsnack one is called `JetsnackStyles`:
+
+
+   ```kotlin
+   object ExampleComponentStyles {
+       val customButtonStyle: Style = {
+
+       }
+       val customTextFieldStyle: Style = {
+
+       }
+   }
+   ```
+
+   <br />
+
+3. Expose this class through your custom theme with a static reference, don't
+   use `CompositionLocals` here as it's not required.
+
+
+   ```kotlin
+   @Immutable
+   class JetsnackTheme(
+       // other Design system properties
+   ) {
+       companion object {
+           val colors: CustomThemingWithStyles.JetsnackColors
+               @Composable @ReadOnlyComposable
+               get() = LocalJetsnackTheme.current.colors
+           // ...
+
+           // add helper static reference
+           val styles: ComponentStyles = ComponentStyles
+       }
+   }
+   ```
+
+   <br />
+
+4. Provide extensions on `StyleScope` to reference theme tokens directly if
+   they are exposed using `CompositionLocals`. For example:
+
+
+   ```kotlin
+   val StyleScope.colors: JetsnackColors
+       get() = LocalJetsnackTheme.currentValue.colors
+
+   val StyleScope.typography: androidx.compose.material3.Typography
+       get() = LocalJetsnackTheme.currentValue.typography
+
+   val StyleScope.shapes: Shapes
+       get() = LocalJetsnackTheme.currentValue.shapes
+   ```
+
+   <br />
+
+### Step 3: Migrate a component to Styles API
+
+For each custom component (for example, `CustomButton`), complete the following
+sequence:
+
+1. **Establish a visual baseline (If an emulator is available):**
+   - **If you CANNOT run an Android emulator:** Skip this step entirely and proceed to Step 2.
+   - **If you CAN run an Android emulator:** Perform the following to capture a baseline screenshot:
+     - **Option A:** Locate and run an existing screenshot test for the component.
+     - **Option B (If no test exists):** Create a test using the project's existing testing framework, then run it.
+     - **Option C (If no framework exists):** Create a minimal screenshot test using UI Automator or Espresso, then run it.
+2. **Remove individual styling parameters** : Remove styling parameters such as `backgroundColor`, `shape`, `textStyle`, and `contentPadding` from the signature - anything that `StyleScope` supports.
+3. **Add the style parameter** : Add `style: Style = Style` to the function signature. Always ensure the default value is exactly `Style` (e.g., `style:
+   Style = Style`) and not a specific style default like `ChipStyleDefault` or any other value.
+4. **Declare state tracking** : If the component is interactable, create a `MutableStyleState` using the interaction source. Update state fields (such as `isEnabled`) inside the Composable to track the state correctly.
+5. **Apply styleable modifier** : Replace specific layout modifiers on the root element with `Modifier.styleable()`.
+6. **Move defaults to ComponentStyles** : Move hardcoded values from the component definition to a dedicated `Style` instance in `ComponentStyles.kt`.
+7. **Validate component:** Compare the baseline screenshot image taken at the start with the rendered Compose Preview of the new composable. Ignore string content; focus on layout and styling. Iterate on the Compose code until visual parity is achieved. Once verified, write a Compose UI test for the new composable.
+
+#### Migration example
+
+Before Migration:
+
+
+```kotlin
+@Composable
+fun CustomButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = JetsnackTheme.colors.brandLight,
+    disabledBackgroundColor: Color = JetsnackTheme.colors.brandSecondary,
+    shape: Shape = JetsnackTheme.shapes.extraLarge,
+    textStyle: TextStyle = JetsnackTheme.typography.labelLarge,
+    enabled: Boolean = true,
+    content: @Composable RowScope.() -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    Row(
+        modifier
+            .clickable(onClick = onClick, indication = null, interactionSource = interactionSource)
+            .background(if (enabled) backgroundColor else disabledBackgroundColor, shape)
+            .defaultMinSize(58.dp, 40.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+        content = content,
+    )
+}
+```
+
+<br />
+
+After Migration:
+
+
+```kotlin
+// Exposed via ComponentStyles.kt
+object ComponentStyles {
+    val buttonStyle = Style {
+        background(colors.brandLight)
+        shape(shapes.extraLarge)
+        minWidth(58.dp)
+        minHeight(40.dp)
+        textStyle(typography.labelLarge)
+        disabled {
+            background(colors.brandSecondary)
+        }
+    }
+}
+
+@Composable
+fun CustomButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    style: Style = Style,
+    enabled: Boolean = true,
+    content: @Composable RowScope.() -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val styleState = rememberUpdatedStyleState(interactionSource) {
+        it.isEnabled = enabled
+    }
+    Row(
+        modifier
+            .clickable(onClick = onClick, indication = null, interactionSource = interactionSource)
+            .styleable(styleState, JetsnackTheme.styles.buttonStyle, style),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+        content = content,
+    )
+}
+```
+
+<br />
+
+### Step 4: Validate Changes
+
+1. Build the project. Verify that there are no compilation errors.
+2. Run your module's screenshot tests.
+3. Compare visual outputs of the whole app between the previous and updated components. Verify that no visual layout regressions occur.

--- a/platforms/android/.agents/skills/styles/references/android/develop/ui/compose/designsystems/custom.md
+++ b/platforms/android/.agents/skills/styles/references/android/develop/ui/compose/designsystems/custom.md
@@ -1,0 +1,459 @@
+While Material is our recommended design system and Jetpack Compose ships an
+implementation of Material, you are not forced to use it. Material is built
+entirely on public APIs, so it's possible to create your own design system in
+the same manner.
+
+There are several approaches you might take:
+
+- [Extend `MaterialTheme`](https://developer.android.com/develop/ui/compose/designsystems/custom#extending-material) with additional theming values.
+- [Replace one or more Material systems](https://developer.android.com/develop/ui/compose/designsystems/custom#replacing-systems) --- `Colors`, `Typography`, or `Shapes` --- with custom implementations while keeping the others.
+- [Implement a fully custom design system](https://developer.android.com/develop/ui/compose/designsystems/custom#implementing-fully-custom) to replace `MaterialTheme`.
+
+You may also want to continue using Material components with a custom design
+system. It's possible to do this but there are things to keep in mind to suit
+the approach you've taken.
+
+To learn more about the lower-level constructs and APIs used by `MaterialTheme`
+and custom design systems, check out the [Anatomy of a theme in Compose](https://developer.android.com/develop/ui/compose/designsystems/anatomy) guide.
+
+## Extend Material Theming
+
+Compose Material closely models
+[Material Theming](https://m3.material.io/)
+to make it straightforward and type-safe to follow the Material guidelines.
+However, it's possible to extend the color, typography, and shape sets with
+additional values. The simplest approach is to add extension properties:
+
+
+```kotlin
+// Use with MaterialTheme.colorScheme.snackbarAction
+val ColorScheme.snackbarAction: Color
+    @Composable
+    get() = if (isSystemInDarkTheme()) Red300 else Red700
+
+// Use with MaterialTheme.typography.textFieldInput
+val Typography.textFieldInput: TextStyle
+    get() = TextStyle(/* ... */)
+
+// Use with MaterialTheme.shapes.card
+val Shapes.card: Shape
+    get() = RoundedCornerShape(size = 20.dp)
+```
+
+<br />
+
+This provides consistency with `MaterialTheme` usage APIs. An example of this
+defined by Compose itself is
+[`surfaceColorAtElevation`](https://developer.android.com/reference/kotlin/androidx/compose/material3/package-summary#(androidx.compose.material3.ColorScheme).surfaceColorAtElevation(androidx.compose.ui.unit.Dp)),
+which determines the surface color that should be used depending on the
+elevation.
+
+> [!NOTE]
+> **Note:** This approach is only recommended for straightforward theming value additions, or for values that are the same in different themes. If you have multiple themes, it's better to define a class with new properties instead.
+
+Another approach is to define an extended theme that "wraps" `MaterialTheme` and
+its values.
+
+Suppose you want to add two additional colors --- `caution` and `onCaution`, a
+yellow color used for actions that are semi-dangerous --- whilst keeping the
+existing Material colors:
+
+
+```kotlin
+@Immutable
+data class ExtendedColors(
+    val caution: Color,
+    val onCaution: Color
+)
+
+val LocalExtendedColors = staticCompositionLocalOf {
+    ExtendedColors(
+        caution = Color.Unspecified,
+        onCaution = Color.Unspecified
+    )
+}
+
+@Composable
+fun ExtendedTheme(
+    /* ... */
+    content: @Composable () -> Unit
+) {
+    val extendedColors = ExtendedColors(
+        caution = Color(0xFFFFCC02),
+        onCaution = Color(0xFF2C2D30)
+    )
+    CompositionLocalProvider(LocalExtendedColors provides extendedColors) {
+        MaterialTheme(
+            /* colors = ..., typography = ..., shapes = ... */
+            content = content
+        )
+    }
+}
+
+// Use with eg. ExtendedTheme.colors.caution
+object ExtendedTheme {
+    val colors: ExtendedColors
+        @Composable
+        get() = LocalExtendedColors.current
+}
+```
+
+<br />
+
+This is similar to `MaterialTheme` usage APIs. It also supports multiple themes
+as you can nest `ExtendedTheme`s in the same way as `MaterialTheme`.
+
+### Use Material components
+
+When extending Material Theming, existing `MaterialTheme` values are maintained
+and Material components still have reasonable defaults.
+
+If you want to use extended values in components, wrap them in your own
+composable functions, directly setting the values you want to alter, and
+exposing others as parameters to the containing composable:
+
+
+```kotlin
+@Composable
+fun ExtendedButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit
+) {
+    Button(
+        colors = ButtonDefaults.buttonColors(
+            containerColor = ExtendedTheme.colors.caution,
+            contentColor = ExtendedTheme.colors.onCaution
+            /* Other colors use values from MaterialTheme */
+        ),
+        onClick = onClick,
+        modifier = modifier,
+        content = content
+    )
+}
+```
+
+<br />
+
+You would then replace usages of `Button` with `ExtendedButton` where
+appropriate.
+
+
+```kotlin
+@Composable
+fun ExtendedApp() {
+    ExtendedTheme {
+        /*...*/
+        ExtendedButton(onClick = { /* ... */ }) {
+            /* ... */
+        }
+    }
+}
+```
+
+<br />
+
+## Replace Material subsystems
+
+Instead of extending Material Theming, you may want to replace one or more
+systems --- `Colors`, `Typography`, or `Shapes` --- with a custom implementation,
+while maintaining the others.
+
+Suppose you want to replace the type and shape systems while keeping the color
+system:
+
+
+```kotlin
+@Immutable
+data class ReplacementTypography(
+    val body: TextStyle,
+    val title: TextStyle
+)
+
+@Immutable
+data class ReplacementShapes(
+    val component: Shape,
+    val surface: Shape
+)
+
+val LocalReplacementTypography = staticCompositionLocalOf {
+    ReplacementTypography(
+        body = TextStyle.Default,
+        title = TextStyle.Default
+    )
+}
+val LocalReplacementShapes = staticCompositionLocalOf {
+    ReplacementShapes(
+        component = RoundedCornerShape(ZeroCornerSize),
+        surface = RoundedCornerShape(ZeroCornerSize)
+    )
+}
+
+@Composable
+fun ReplacementTheme(
+    /* ... */
+    content: @Composable () -> Unit
+) {
+    val replacementTypography = ReplacementTypography(
+        body = TextStyle(fontSize = 16.sp),
+        title = TextStyle(fontSize = 32.sp)
+    )
+    val replacementShapes = ReplacementShapes(
+        component = RoundedCornerShape(percent = 50),
+        surface = RoundedCornerShape(size = 40.dp)
+    )
+    CompositionLocalProvider(
+        LocalReplacementTypography provides replacementTypography,
+        LocalReplacementShapes provides replacementShapes
+    ) {
+        MaterialTheme(
+            /* colors = ... */
+            content = content
+        )
+    }
+}
+
+// Use with eg. ReplacementTheme.typography.body
+object ReplacementTheme {
+    val typography: ReplacementTypography
+        @Composable
+        get() = LocalReplacementTypography.current
+    val shapes: ReplacementShapes
+        @Composable
+        get() = LocalReplacementShapes.current
+}
+```
+
+<br />
+
+### Use Material components
+
+When one or more systems of `MaterialTheme` have been replaced, using Material
+components as-is may result in unwanted Material color, type, or shape values.
+
+If you want to use replacement values in components, wrap them in your own
+composable functions, directly setting the values for the relevant system, and
+exposing others as parameters to the containing composable.
+
+> [!NOTE]
+> **Note:** Not all values may be exposed as parameters in Material composables, in particular with `CompositionLocal` composables (such as `LocalTextStyle`). In such cases you may need to wrap `content` lambdas in provider functions (like `ProvideTextStyle`).
+
+
+```kotlin
+@Composable
+fun ReplacementButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit
+) {
+    Button(
+        shape = ReplacementTheme.shapes.component,
+        onClick = onClick,
+        modifier = modifier,
+        content = {
+            ProvideTextStyle(
+                value = ReplacementTheme.typography.body
+            ) {
+                content()
+            }
+        }
+    )
+}
+```
+
+<br />
+
+You would then replace usages of `Button` with `ReplacementButton` where
+appropriate.
+
+
+```kotlin
+@Composable
+fun ReplacementApp() {
+    ReplacementTheme {
+        /*...*/
+        ReplacementButton(onClick = { /* ... */ }) {
+            /* ... */
+        }
+    }
+}
+```
+
+<br />
+
+## Implement a fully custom design system
+
+You may want to replace Material Theming with a fully custom design system.
+Consider that `MaterialTheme` provides the following systems:
+
+- `Colors`, `Typography`, and `Shapes`: Material Theming systems
+- `TextSelectionColors`: Colors used for text selection by `Text` and `TextField`
+- `Ripple` and `RippleTheme`: Material implementation of `Indication`
+
+If you want to continue using Material components, you must replace some of
+these systems in your custom themes or handle the systems in your
+components to avoid unwanted behavior.
+
+However, design systems are not limited to the concepts Material relies on. You
+can modify existing systems and introduce entirely new ones --- with new classes
+and types --- to make other concepts compatible with themes.
+
+In the following code, we model a custom color system that includes gradients
+(`List<Color>`), include a type system, introduce a new elevation system,
+and exclude other systems provided by `MaterialTheme`:
+
+![Screenshot of a mobile app UI demonstrating a custom design system with elements using gradients for colors, custom typography, and elevation.](https://developer.android.com/static/develop/ui/compose/images/themes/custom-color-gradients.png)
+
+
+```kotlin
+@Immutable
+data class CustomColors(
+    val content: Color,
+    val component: Color,
+    val background: List<Color>
+)
+
+@Immutable
+data class CustomTypography(
+    val body: TextStyle,
+    val title: TextStyle
+)
+
+@Immutable
+data class CustomElevation(
+    val default: Dp,
+    val pressed: Dp
+)
+
+val LocalCustomColors = staticCompositionLocalOf {
+    CustomColors(
+        content = Color.Unspecified,
+        component = Color.Unspecified,
+        background = emptyList()
+    )
+}
+val LocalCustomTypography = staticCompositionLocalOf {
+    CustomTypography(
+        body = TextStyle.Default,
+        title = TextStyle.Default
+    )
+}
+val LocalCustomElevation = staticCompositionLocalOf {
+    CustomElevation(
+        default = Dp.Unspecified,
+        pressed = Dp.Unspecified
+    )
+}
+
+@Composable
+fun CustomTheme(
+    /* ... */
+    content: @Composable () -> Unit
+) {
+    val customColors = CustomColors(
+        content = Color(0xFFDD0D3C),
+        component = Color(0xFFC20029),
+        background = listOf(Color.White, Color(0xFFF8BBD0))
+    )
+    val customTypography = CustomTypography(
+        body = TextStyle(fontSize = 16.sp),
+        title = TextStyle(fontSize = 32.sp)
+    )
+    val customElevation = CustomElevation(
+        default = 4.dp,
+        pressed = 8.dp
+    )
+    CompositionLocalProvider(
+        LocalCustomColors provides customColors,
+        LocalCustomTypography provides customTypography,
+        LocalCustomElevation provides customElevation,
+        content = content
+    )
+}
+
+// Use with eg. CustomTheme.elevation.small
+object CustomTheme {
+    val colors: CustomColors
+        @Composable
+        get() = LocalCustomColors.current
+    val typography: CustomTypography
+        @Composable
+        get() = LocalCustomTypography.current
+    val elevation: CustomElevation
+        @Composable
+        get() = LocalCustomElevation.current
+}
+```
+
+<br />
+
+### Use Material components
+
+When no `MaterialTheme` is present, using Material components as-is will result
+in unwanted Material color, type, and shape values and indication behavior.
+
+If you want to use custom values in components, wrap them in your own composable
+functions, directly setting the values for the relevant system, and exposing
+others as parameters to the containing composable.
+
+We recommend that you access values you set from your custom theme.
+Alternatively, if your theme doesn't provide `Color`, `TextStyle`, `Shape`, or
+other systems, you can hardcode them.
+
+
+```kotlin
+@Composable
+fun CustomButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit
+) {
+    Button(
+        colors = ButtonDefaults.buttonColors(
+            containerColor = CustomTheme.colors.component,
+            contentColor = CustomTheme.colors.content,
+            disabledContainerColor = CustomTheme.colors.content
+                .copy(alpha = 0.12f)
+                .compositeOver(CustomTheme.colors.component),
+            disabledContentColor = CustomTheme.colors.content
+                .copy(alpha = 0.38f)
+
+        ),
+        shape = ButtonShape,
+        elevation = ButtonDefaults.elevatedButtonElevation(
+            defaultElevation = CustomTheme.elevation.default,
+            pressedElevation = CustomTheme.elevation.pressed
+            /* disabledElevation = 0.dp */
+        ),
+        onClick = onClick,
+        modifier = modifier,
+        content = {
+            ProvideTextStyle(
+                value = CustomTheme.typography.body
+            ) {
+                content()
+            }
+        }
+    )
+}
+
+val ButtonShape = RoundedCornerShape(percent = 50)
+```
+
+<br />
+
+> [!NOTE]
+> **Note:** `Button` uses `rememberRipple()` internally to provide a `Ripple` `Indication`. It's a good idea to check the source code when implementing other custom components that wrap existing components.
+
+If you've introduced new class types --- such as `List<Color>` to represent
+gradients --- then it may be better to implement components from scratch instead
+of wrapping them. For an example, take a look at
+[`JetsnackButton`](https://github.com/android/compose-samples/blob/main/Jetsnack/app/src/main/java/com/example/jetsnack/ui/components/Button.kt)
+from the Jetsnack sample.
+
+## Recommended for you
+
+- Note: link text is displayed when JavaScript is off
+- [Material Design 3 in Compose](https://developer.android.com/develop/ui/compose/designsystems/material3)
+- [Migrate from Material 2 to Material 3 in Compose](https://developer.android.com/develop/ui/compose/designsystems/material2-material3)
+- [Anatomy of a theme in Compose](https://developer.android.com/develop/ui/compose/designsystems/anatomy)

--- a/platforms/android/.agents/skills/styles/references/android/develop/ui/compose/styles/fundamentals.md
+++ b/platforms/android/.agents/skills/styles/references/android/develop/ui/compose/styles/fundamentals.md
@@ -1,0 +1,421 @@
+There are three ways you can adopt Styles throughout your app:
+
+1. Use directly on existing components that expose a [`Style`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/style/Style) parameter.
+2. Apply a style with [`Modifier.styleable`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/style/styleable.modifier#(androidx.compose.ui.Modifier).styleable(androidx.compose.foundation.style.StyleState,androidx.compose.foundation.style.Style)) on layout composables that don't accept a `Style` parameter.
+3. In your own custom design system, use `Modifier.styleable{}` and expose a style parameter on your own components.
+
+## Available properties on Styles
+
+Styles support many of the same properties that modifiers support; however, not
+everything that is a modifier can be replicated with a Style. You still need
+modifiers for certain behaviors, like interactions, custom drawing, or stacking
+of properties.
+
+| Grouping | Properties | Inherited by children |
+|---|---|---|
+| **Layout and sizing** |   |   |
+| Content Padding (inner) | - `contentPadding(all: Dp)` - `contentPadding(horizontal: Dp, vertical: Dp)` - `contentPadding(start: Dp, top: Dp, end: Dp, bottom: Dp)` - `contentPaddingHorizontal(value: Dp)` / `contentPaddingVertical(value: Dp)` - `contentPaddingStart(value: Dp)` / `contentPaddingTop(value: Dp)` / `contentPaddingEnd(value: Dp)` / `contentPaddingBottom(value: Dp)` | No |
+| External Padding (outer) | - `externalPadding(all: Dp)` - `externalPadding(horizontal: Dp, vertical: Dp)` - `externalPadding(start: Dp, top: Dp, end: Dp, bottom: Dp)` - `externalPaddingHorizontal(value: Dp)` / `externalPaddingVertical(value: Dp)` - `externalPaddingStart(value: Dp)` / `externalPaddingTop(value: Dp)` / `externalPaddingEnd(value: Dp)` / `externalPaddingBottom(value: Dp)` | No |
+| Dimensions | `fillWidth()/fillHeight()/fillSize()` and `width`, `height`, and `size` (supports `Dp`, `DpSize`, or `Float` fractions). | No |
+| Positioning | `left/top/right/bottom` offsets. | No |
+| **Visual Appearance** |   |   |
+| Fills | `background` and `foreground` (supports `Color` or `Brush`). | No |
+| Borders | `borderWidth`, `borderColor`, and `borderBrush`. | No |
+| Shape | `shape` | No - but used in conjunction with other properties. `clip` and `border` use this defined shape. |
+| Shadows | `dropShadow`, `innerShadow` | No |
+| **Transformations** |   |   |
+| Graphics layer spatial movement | `translationX`, `translationY`, `scaleX/scaleY`, `rotationX/rotationY/rotationZ` | No |
+| Control | `alpha`, `zIndex` (stacking order), and `transformOrigin` (pivot point) | No |
+| **Typography** |   |   |
+| Styling | `textStyle`, `fontSize`, `fontWeight`, `fontStyle`, and `fontFamily` | Yes |
+| Coloration | `contentColor` and `contentBrush`. This is also used for Icons styling. | Yes |
+| Paragraph | `lineHeight`, `letterSpacing`, `textAlign`, `textDirection`, `lineBreak`, and `hyphens`. | Yes |
+| Decoration | `textDecoration`, `textIndent`, and `baselineShift`. | Yes |
+
+## Use Styles directly on components with Style parameters
+
+Components that expose a `Style` parameter allow you to set their styling:
+
+
+```kotlin
+BaseButton(
+    onClick = { },
+    style = { }
+) {
+    BaseText("Click me")
+}
+```
+
+<br />
+
+Within the style lambda, you can set various properties, such as `externalPadding`
+or `background`:
+
+
+```kotlin
+BaseButton(
+    onClick = { },
+    style = { background(Color.Blue) }
+) {
+    BaseText("Click me")
+}
+```
+
+<br />
+
+For the full list of supported properties, see [Available properties on
+Styles](https://developer.android.com/develop/ui/compose/styles/fundamentals#properties-styles).
+
+## Apply Styles using modifiers for components with no existing parameter
+
+For components that lack a built-in style parameter, you can still apply styles
+with the `styleable` modifier. This approach is also useful when developing your
+own custom components.
+
+
+```kotlin
+Row(
+    modifier = Modifier.styleable { }
+) {
+    BaseText("Content")
+}
+```
+
+<br />
+
+Similar to the `style` parameter, you can include properties like `background`,
+`contentPadding`, or `externalPadding` inside the lambda.
+
+
+```kotlin
+Row(
+    modifier = Modifier.styleable {
+        background(Color.Blue)
+    }
+) {
+    BaseText("Content")
+}
+```
+
+<br />
+
+> [!NOTE]
+> **Note:** When using `Modifier.styleable`, the child composables won't have those properties applied to them, unless they are inherited properties. Only the container with the `styleable` modifier has those properties applied.
+
+Multiple chained `Modifier.styleable` modifiers are additive with non-inherited
+properties on the applied composable, behaving similarly to multiple modifiers
+defining the same properties. For inherited properties, these are overridden,
+and the last `styleable` modifier in the chain sets the values.
+
+When using `Modifier.styleable`, you may also want to create and supply a
+`StyleState` to be used with the modifier to apply state-based styling. For more
+details, see [State and animations with
+Styles](https://developer.android.com/develop/ui/compose/styles/state-animations).
+
+## Define a standalone Style
+
+You can define a standalone Style for reusability purposes:
+
+
+```kotlin
+val style = Style { background(Color.Blue) }
+```
+
+<br />
+
+You can then pass that defined style into a composable's style parameter or with
+`Modifier.styleable`. When using `Modifier.styleable`, you also need to create a
+`StyleState` object. `StyleState` is covered in detail in the [State and
+animations with Styles](https://developer.android.com/develop/ui/compose/styles/state-animations) documentation.
+
+The following example shows how you can apply a Style either directly through a
+component's built-in parameters, or through a `Modifier.styleable`:
+
+
+```kotlin
+val style = Style { background(Color.Blue) }
+
+// built in parameter
+BaseButton(onClick = { }, style = style) {
+    BaseText("Button")
+}
+
+// modifier styleable
+val styleState = remember { MutableStyleState(null) }
+Column(
+    Modifier.styleable(styleState, style)
+) {
+    BaseText("Column content")
+}
+```
+
+<br />
+
+You can also pass that Style into multiple components:
+
+
+```kotlin
+val style = Style { background(Color.Blue) }
+
+// built in parameter
+BaseButton(onClick = { }, style = style) {
+    BaseText("Button")
+}
+BaseText("Different text that uses the same style parameter", style = style)
+
+// modifier styleable
+val columnStyleState = remember { MutableStyleState(null) }
+Column(
+    Modifier.styleable(columnStyleState, style)
+) {
+    BaseText("Column")
+}
+val rowStyleState = remember { MutableStyleState(null) }
+Row(
+    Modifier.styleable(rowStyleState, style)
+) {
+    BaseText("Row")
+}
+```
+
+<br />
+
+## Add multiple Style properties
+
+You can add multiple Style properties by setting different properties on each
+line:
+
+
+```kotlin
+BaseButton(
+    onClick = { },
+    style = {
+        background(Color.Blue)
+        contentPaddingStart(16.dp)
+    }
+) {
+    BaseText("Button")
+}
+```
+
+<br />
+
+> [!IMPORTANT]
+> **Important:** Unlike modifier-based styling, properties in Styles override one another; the last property defined takes precedence.
+
+Properties in Styles are not additive, unlike modifier-based styling. Styles
+take the last set value in the list of properties within one style block. In the
+following example, with the background set twice, the `TealColor` is the applied
+background. For padding, `contentPaddingTop` overrides the top
+padding set by `contentPadding` and does not combine the values.
+
+
+```kotlin
+BaseButton(
+    style = {
+        background(Color.Red)
+        // Background of Red is now overridden with TealColor instead
+        background(TealColor)
+        // All directions of padding are set to 64.dp (top, start, end, bottom)
+        contentPadding(64.dp)
+        // Top padding is now set to 16.dp, all other paddings remain at 64.dp
+        contentPaddingTop(16.dp)
+    },
+    onClick = {
+        //
+    }
+) {
+    BaseText("Click me!")
+}
+```
+
+<br />
+
+![Button with two background colors set, and two contentPadding
+overrides](https://developer.android.com/static/develop/ui/compose/styles/images/basic_style_button.png) **Figure 1.** Button with two background colors set and two `contentPadding` overrides.
+
+## Merge multiple style objects
+
+You can create multiple Style objects and pass them into the style parameter of
+your composable.
+
+
+```kotlin
+val style1 = Style { background(TealColor) }
+val style2 = Style { contentPaddingTop(16.dp) }
+
+BaseButton(
+    style = style1 then style2,
+    onClick = {
+
+    },
+) {
+    BaseText("Click me!")
+}
+```
+
+<br />
+
+![Button with background color and contentPaddingTop
+set](https://developer.android.com/static/develop/ui/compose/styles/images/button_content_padding_top.png) **Figure 2.** Button with background color and `contentPaddingTop` set.
+
+When multiple Styles specify the same property, the last set
+property is chosen. Because properties are not additive in Styles, the last
+padding passed in overrides the `contentPaddingHorizontal` set by the initial
+`contentPadding`. Additionally, the last background color overrides the
+background color set by the initial style passed in.
+
+
+```kotlin
+val style1 = Style {
+    background(Color.Red)
+    contentPadding(32.dp)
+}
+
+val style2 = Style {
+    contentPaddingHorizontal(8.dp)
+    background(Color.LightGray)
+}
+
+BaseButton(
+    style = style1 then style2,
+    onClick = {
+
+    },
+) {
+    BaseText("Click me!")
+}
+```
+
+<br />
+
+In this case, the styling applied has a light gray background and `32.dp` padding,
+except for the left and right padding, which has a value of `8.dp`.
+![Button with contentPadding that's overridden by different
+Styles](https://developer.android.com/static/develop/ui/compose/styles/images/button_content_padding_overrides.png) **Figure 3.** Button with `contentPadding` that's overridden by different Styles.
+
+## Style inheritance
+
+> [!NOTE]
+> **Note:** While the Style APIs are experimental, you need to opt-in to enable Style inheritance by setting the flag `ComposeFoundationFlags.isInheritedTextStyleEnabled = true`.
+
+Certain style properties, such as `contentColor` and text style-related
+properties, propagate to the child composables. A style set on a child
+composable overrides the inherited parent styling for that specific child.
+![Style propagation with Style, styleable, and direct
+parameters](https://developer.android.com/static/develop/ui/compose/styles/images/styles_modifiers_precedence_ordering.png) **Figure 4.** Style propagation with `Style`, `styleable`, and direct parameters.
+
+| Priority | Method | Effect |
+|---|---|---|
+| 1 (Highest) | Direct arguments on a composable | Overrides everything; for example, `Text(color = Color.Red)` |
+| 2 | Style parameter | Local style overrides `Text(style = Style { contentColor(Color.Red)}` |
+| 3 | Modifier chain | `Modifier.styleable{ contentColor(Color.Red)` on the component itself. |
+| 4 (Lowest) | Parent styles | For properties that can be inherited (Typography/Color) passed down from the parent. |
+
+> [!NOTE]
+> **Note:** Multiple chained `Modifier.styleable` modifiers are additive with non-inherited properties on the applied composable, similar to having multiple modifiers defining the same properties. For inherited properties, these are overridden; the last `styleable` modifier in the chain sets the values.
+
+### Parent styling
+
+You can set text properties (such as `contentColor`) from the parent composable,
+and they propagate to all child `Text` composables.
+
+
+```kotlin
+val styleState = remember { MutableStyleState(null) }
+Column(
+    modifier = Modifier.styleable(styleState) {
+        background(Color.LightGray)
+        val blue = Color(0xFF4285F4)
+        val purple = Color(0xFFA250EA)
+        val colors = listOf(blue, purple)
+        contentBrush(Brush.linearGradient(colors))
+    },
+) {
+    BaseText("Children inherit", style = { width(60.dp) })
+    BaseText("certain properties")
+    BaseText("from their parents")
+}
+```
+
+<br />
+
+![Child composables' property
+inheritance](https://developer.android.com/static/develop/ui/compose/styles/images/children_inherit_styles_parents.png) **Figure 5.** Child composables' property inheritance.
+
+### Child override of properties
+
+You can also set styling on a specific `Text` composable. If the parent composable
+has styling set, the styling set on the child composable overrides the
+parent composable's styling.
+
+
+```kotlin
+val styleState = remember { MutableStyleState(null) }
+Column(
+    modifier = Modifier.styleable(styleState) {
+        background(Color.LightGray)
+        val blue = Color(0xFF4285F4)
+        val purple = Color(0xFFA250EA)
+        val colors = listOf(blue, purple)
+        contentBrush(Brush.linearGradient(colors))
+    },
+) {
+    BaseText("Children can ", style = {
+        contentBrush(Brush.linearGradient(listOf(Color.Red, Color.Blue)))
+    })
+    BaseText("override properties")
+    BaseText("set by their parents")
+}
+```
+
+<br />
+
+![Child composables override parent
+properties](https://developer.android.com/static/develop/ui/compose/styles/images/children_override_styles.png) **Figure 6.** Child composables override parent properties.
+
+## Implement custom Style properties
+
+You can create custom properties that map to existing Style definitions by using
+extension functions on the `StyleScope`, as shown in the following example:
+
+
+```kotlin
+fun StyleScope.outlinedBackground(color: Color) {
+    border(1.dp, color)
+    background(color)
+}
+```
+
+<br />
+
+Apply this new property within a Style definition:
+
+
+```kotlin
+val customExtensionStyle = Style {
+    outlinedBackground(Color.Blue)
+}
+```
+
+<br />
+
+Creating new styleable properties is unsupported. If your use case
+requires such support, submit a [feature request](https://issuetracker.google.com/issues/new?component=612128).
+
+## Read `CompositionLocal` values
+
+It's a common pattern to store design system tokens within a `CompositionLocal`,
+to access the variables without needing to pass them as parameters. Styles
+can access `CompositionLocal`s to retrieve system-wide values within a style:
+
+
+```kotlin
+val buttonStyle = Style {
+    contentPadding(12.dp)
+    shape(RoundedCornerShape(50))
+    background(Brush.verticalGradient(LocalCustomColors.currentValue.background))
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/styles/references/android/develop/ui/compose/styles/state-animations.md
+++ b/platforms/android/.agents/skills/styles/references/android/develop/ui/compose/styles/state-animations.md
@@ -1,0 +1,461 @@
+<br />
+
+The Styles API offers a declarative and streamlined approach to managing UI
+changes during interaction states like `hovered`, `focused`, and `pressed`. With
+this API, you can significantly decrease the boilerplate code typically required
+when using modifiers.
+
+To facilitate reactive styling, `StyleState` acts as a stable, read-only
+interface that tracks the active state of an element (such as its enabled,
+pressed, or focused status). Within a `StyleScope`, you can access this through
+the `state` property to implement conditional logic directly in your Style
+definitions.
+
+## State-based interaction: Hovered, focused, pressed, selected, enabled, toggled
+
+Styles come with built-in support for common interactions:
+
+- Pressed
+- Hovered
+- Selected
+- Enabled
+- Toggled
+
+It's also possible to support custom states. See the [Custom State Styling with
+StyleState](https://developer.android.com/develop/ui/compose/styles/state-animations#custom-state) section for more information.
+
+### Handle interaction states with Style parameters
+
+The following example demonstrates modifying the `background` and `borderColor`
+in response to interaction states, specifically switching to purple when hovered
+and blue when focused:
+
+
+```kotlin
+@Preview
+@Composable
+private fun OpenButton() {
+    BaseButton(
+        style = outlinedButtonStyle then {
+            background(Color.White)
+            hovered {
+                background(lightPurple)
+                border(2.dp, lightPurple)
+            }
+            focused {
+                background(lightBlue)
+            }
+        },
+        onClick = {  },
+        content = {
+            BaseText("Open in Studio", style = {
+                contentColor(Color.Black)
+                fontSize(26.sp)
+                textAlign(TextAlign.Center)
+            })
+        }
+    )
+}
+```
+
+<br />
+
+**Figure 1.** Changing background color based on hovered and focused states.
+
+You can also create nested state definitions. For example, you can define a
+specific style for when a button is being both pressed and hovered
+simultaneously:
+
+
+```kotlin
+@Composable
+private fun OpenButton_CombinedStates() {
+    BaseButton(
+        style = outlinedButtonStyle then {
+            background(Color.White)
+            hovered {
+                // light purple
+                background(lightPurple)
+                pressed {
+                    // When running on a device that can hover, whilst hovering and then pressing the button this would be invoked
+                    background(lightOrange)
+                }
+            }
+            pressed {
+                // when running on a device without a mouse attached, this would be invoked as you wouldn't be in a hovered state only
+                background(lightRed)
+            }
+            focused {
+                background(lightBlue)
+            }
+        },
+        onClick = {  },
+        content = {
+            BaseText("Open in Studio", style = {
+                contentColor(Color.Black)
+                fontSize(26.sp)
+                textAlign(TextAlign.Center)
+            })
+        }
+    )
+}
+```
+
+<br />
+
+**Figure 2.** Hovered and pressed state together on a button.
+
+### Custom composables with Modifier.styleable
+
+When creating your own `styleable` components, you must connect an
+`interactionSource` to a `styleState`. Then, pass this state into
+`Modifier.styleable` to utilize it.
+
+Consider a scenario where your design system includes a `GradientButton`. You
+may want to create a `LoginButton` that inherits from `GradientButton`, but
+alters its colors during interactions, like being pressed.
+
+- To enable `interactionSource` style updates, include an `interactionSource` as a parameter within your composable. Use the provided parameter or, if one is not supplied, initialize a new `MutableInteractionSource`.
+- Initialize the `styleState` by providing the `interactionSource`. Make sure the `styleState`'s enabled status reflects the value of the provided enabled parameter.
+- Assign the `interactionSource` to the `focusable` and `clickable` modifiers. Finally, apply the `styleState` to the modifier's `styleable` parameter.
+
+
+```kotlin
+@Composable
+private fun GradientButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    style: Style = Style,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource? = null,
+    content: @Composable RowScope.() -> Unit,
+) {
+    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
+    val styleState = rememberUpdatedStyleState(interactionSource) {
+        it.isEnabled = enabled
+    }
+    Row(
+        modifier =
+            modifier
+                .clickable(
+                    onClick = onClick,
+                    enabled = enabled,
+                    interactionSource = interactionSource,
+                    indication = null,
+                )
+                .styleable(styleState, baseGradientButtonStyle then style),
+        content = content,
+    )
+}
+```
+
+<br />
+
+You can now use the `interactionSource` state to drive style modifications with
+the pressed, focused, and hovered options inside the style block:
+
+
+```kotlin
+@Preview
+@Composable
+fun LoginButton() {
+    val loginButtonStyle = Style {
+        pressed {
+            background(
+                Brush.linearGradient(
+                    listOf(Color.Magenta, Color.Red)
+                )
+            )
+        }
+    }
+    GradientButton(onClick = {
+        // Login logic
+    }, style = loginButtonStyle) {
+        BaseText("Login")
+    }
+}
+```
+
+<br />
+
+**Figure 3.** Changing a custom composable state based on `interactionSource`.
+
+## Animate style changes
+
+Styles state changes come with built-in animation support. You can wrap the new
+property within any state change block with `animate` to automatically add
+animations between different states. This is similar to the `animate*AsState`
+APIs. The following example animates the `borderColor` from black to blue when
+the state changes to focused:
+
+
+```kotlin
+val animatingStyle = Style {
+    externalPadding(48.dp)
+    border(3.dp, Color.Black)
+    background(Color.White)
+    size(100.dp)
+
+    pressed {
+        animate {
+            borderColor(Color.Magenta)
+            background(Color(0xFFB39DDB))
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun AnimatingStyleChanges() {
+    val interactionSource = remember { MutableInteractionSource() }
+    val styleState = remember(interactionSource) { MutableStyleState(interactionSource) }
+    Box(modifier = Modifier
+        .clickable(
+            interactionSource,
+            enabled = true,
+            indication = null,
+            onClick = {
+
+            }
+        )
+        .styleable(styleState, animatingStyle)) {
+
+    }
+}
+```
+
+<br />
+
+**Figure 4.** Animating color changes on press.
+
+The `animate` API accepts an `animationSpec` to change the duration or shape of
+the animation curve. The following example animates the size of the box with a
+`spring` spec:
+
+
+```kotlin
+val animatingStyleSpec = Style {
+    externalPadding(48.dp)
+    border(3.dp, Color.Black)
+    background(Color.White)
+    size(100.dp)
+    transformOrigin(TransformOrigin.Center)
+    pressed {
+        animate {
+            borderColor(Color.Magenta)
+            background(Color(0xFFB39DDB))
+        }
+        animate(spring(dampingRatio = Spring.DampingRatioMediumBouncy)) {
+            scale(1.2f)
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun AnimatingStyleChangesSpec() {
+    val interactionSource = remember { MutableInteractionSource() }
+    val styleState = remember(interactionSource) { MutableStyleState(interactionSource) }
+    Box(modifier = Modifier
+        .clickable(
+            interactionSource,
+            enabled = true,
+            indication = null,
+            onClick = {
+
+            }
+        )
+        .styleable(styleState, animatingStyleSpec))
+}
+```
+
+<br />
+
+**Figure 5.** Animating size and color changes on press.
+
+## Custom state styling with StyleState
+
+Depending on your composable use case, you may have different styles that are
+backed by custom states. For example, if you have a media app, you may want to
+have different styling for the buttons in your `MediaPlayer` composable
+depending on the playback state of the player. Follow these steps to create and
+use your own custom state:
+
+1. Define custom key
+2. Create `StyleState` extension
+3. Link to custom state
+
+### Define custom key
+
+To create a custom state-based style, first create a
+[`StyleStateKey`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/style/StyleStateKey) and pass in the default state value. When the
+app launches, the media player is in the `Stopped` state, so it's initialized in
+this way:
+
+
+```kotlin
+enum class PlayerState {
+    Stopped,
+    Playing,
+    Paused
+}
+
+val playerStateKey = StyleStateKey(PlayerState.Stopped)
+```
+
+<br />
+
+### Create StyleState extension functions
+
+Define an extension function on `StyleState` to query the current `playState`.
+Then, create extension functions on `StyleScope` with your custom states passing
+in the `playStateKey`, a lambda with the specific state, and the style.
+
+
+```kotlin
+// Extension Function on MutableStyleState to query and set the current playState
+var MutableStyleState.playerState
+    get() = this[playerStateKey]
+    set(value) { this[playerStateKey] = value }
+
+fun StyleScope.playerPlaying(block: () -> Unit) {
+    state(playerStateKey, block, { key, state -> state[key] == PlayerState.Playing })
+}
+fun StyleScope.playerPaused(block: () -> Unit) {
+    state(playerStateKey, block, { key, state -> state[key] == PlayerState.Paused })
+}
+```
+
+<br />
+
+### Link to custom state
+
+Define the `styleState` in your composable and set the `styleState.playState`
+equal to incoming state. Pass `styleState` into the `styleable` function on the
+modifier.
+
+
+```kotlin
+@Composable
+fun MediaPlayer(
+    url: String,
+    modifier: Modifier = Modifier,
+    style: Style = Style,
+    state: PlayerState = remember { PlayerState.Paused }
+) {
+    // Hoist style state, set playstate as a parameter,
+    val styleState = remember { MutableStyleState(null) }
+    // Set equal to incoming state to link the two together
+    styleState.playerState = state
+    Box(
+        modifier = modifier.styleable(styleState, style)) {
+        ///..
+    }
+}
+```
+
+<br />
+
+Within the `style` lambda, you can apply state-based styling for custom states,
+using the previously defined extension functions.
+
+
+```kotlin
+@Composable
+fun StyleStateKeySample() {
+    // Using the extension function to change the border color to green while playing
+    val style = Style {
+        borderColor(Color.Gray)
+        playerPlaying {
+            animate {
+                borderColor(Color.Green)
+            }
+        }
+        playerPaused {
+            animate {
+                borderColor(Color.Blue)
+            }
+        }
+    }
+    val styleState = remember { MutableStyleState(null) }
+    styleState[playerStateKey] = PlayerState.Playing
+
+    // Using the style in a composable that sets the state -> notice if you change the state parameter, the style changes. You can link this up to an ViewModel and change the state from there too.
+    MediaPlayer(url = "https://example.com/media/video",
+        style = style,
+        state = PlayerState.Stopped)
+}
+```
+
+<br />
+
+The following code is the full snippet for this example:
+
+
+```kotlin
+enum class PlayerState {
+    Stopped,
+    Playing,
+    Paused
+}
+val playerStateKey = StyleStateKey<PlayerState>(PlayerState.Stopped)
+var MutableStyleState.playerState
+    get() = this[playerStateKey]
+    set(value) { this[playerStateKey] = value }
+
+fun StyleScope.playerPlaying(block: () -> Unit) {
+    state(playerStateKey, block, { key, state -> state[key] == PlayerState.Playing })
+}
+fun StyleScope.playerPaused(block: () -> Unit) {
+    state(playerStateKey, block, { key, state -> state[key] == PlayerState.Paused })
+
+}
+
+@Composable
+fun MediaPlayer(
+    url: String,
+    modifier: Modifier = Modifier,
+    style: Style = Style,
+    state: PlayerState = remember { PlayerState.Paused }
+) {
+    // Hoist style state, set playstate as a parameter,
+    val styleState = remember { MutableStyleState(null) }
+    // Set equal to incoming state to link the two together
+    styleState.playerState = state
+    Box(
+        modifier = modifier.styleable(styleState, Style {
+            size(100.dp)
+            border(2.dp, Color.Red)
+
+        }, style, )) {
+
+        ///..
+    }
+}
+@Composable
+fun StyleStateKeySample() {
+    // Using the extension function to change the border color to green while playing
+    val style = Style {
+        borderColor(Color.Gray)
+        playerPlaying {
+            animate {
+                borderColor(Color.Green)
+            }
+        }
+        playerPaused {
+            animate {
+                borderColor(Color.Blue)
+            }
+        }
+    }
+    val styleState = remember { MutableStyleState(null) }
+    styleState[playerStateKey] = PlayerState.Playing
+
+    // Using the style in a composable that sets the state -> notice if you change the state parameter, the style changes. You can link this up to an ViewModel and change the state from there too.
+    MediaPlayer(url = "https://example.com/media/video",
+        style = style,
+        state = PlayerState.Stopped)
+}
+```
+
+<br />

--- a/platforms/android/.agents/skills/styles/references/android/develop/ui/compose/styles/styles-vs-modifiers.md
+++ b/platforms/android/.agents/skills/styles/references/android/develop/ui/compose/styles/styles-vs-modifiers.md
@@ -1,0 +1,48 @@
+Styles differ from modifiers by design. Styles don't replace modifiers; instead,
+the two systems coexist with different goals. Internally, a Style is a modifier.
+You can do everything Styles can do with modifiers, but not all functionality in
+modifiers is available in Styles.
+**Important:**
+
+- **Choose Styles if:** You need to override a default of an existing component, perform high-performance animations, or define a theme-wide set of properties for a component.
+- **Choose Modifiers if:** You need to add behavior (for example, clickable, gestures), define unique one-off layouts, or need additive properties.
+
+The following is a comparison between Styles versus modifiers:
+
+| Feature | Modifiers | Styles |
+|---|---|---|
+| **Primary Goal** | Define behaviors, semantics, and complex layouts. Modifiers manipulate individual elements on the fly for a particular composable and don't trickle down from the theme. | Define visual appearance, individual item sizing and themeable properties. Styles operate at a theme level and are over-writeable at a component level. They trickle down and apply styling across different composables. |
+| **Logic** | Additive - the modifiers combine together to form a new result. | Over-writable - the last property set in the Style wins. Styles act as a single layer of properties that override each other based on a defined precedence hierarchy. |
+| **Theming** | Challenging to lift into a theme, normally used individually. | By design, Styles are themeable (they can access `CompositionLocal`s) and can be defined once and used across components. |
+| **Performance** | Updates often require all three phases of Compose: composition, layout and draw. Achieving good animation performance of modifiers often requires writing lambda-based versions. | Skips composition phase, only active in layout and draw phase, reducing recompositions. Requires less object allocation. |
+| **Animations** | Requires using separate animation primitives like `animate*AsState` | Features built-in `animate { }` API that handles some animations for you. |
+
+## Limitations of modifiers
+
+Modifiers have many benefits in the current Compose landscape. However, Styles
+address some limitations of modifiers, which the following list describes:
+
+- Modifiers are typically created in the Composition phase. Updates can force a full rerun of Composition, Layout, and Draw, even for small visual changes like color, unless you create lambda-based modifiers.
+- Conditional modifiers require disruptive if-else logic within fluent chains. Animating them requires manual state boilerplate and lacks a high-performance "auto-animate" mechanism.
+- Modifiers stack rather than replace. You can't override a component's default border; you can only draw a second one on top.
+- Modifiers are difficult to abstract into global themes. Consequently, themes usually store raw values instead of reusable modifier configurations.
+
+## Limitations of Styles
+
+While Styles can fill in some of the gaps that modifiers have, they also have
+some limitations, which show how they cannot entirely replace modifiers:
+
+- Styles are specialized Modifiers. While a modifier can do anything a Style does, the reverse is not true. Consequently, Styles can supplement, but cannot replace, modifiers.
+- Styles are limited to visual configuration (backgrounds, padding, borders). They cannot handle behaviors like click logic, gesture detection, or accessibility semantics.
+- Resolving a Style into its final state is *more expensive than applying a
+  single modifier*. The system must generate a data structure containing all possible property values, and the lookup of inherited properties further complicates this.
+
+## When to use Styles over modifiers
+
+While the choice to use Styles is largely dependent on your app and use cases,
+the following guidance helps determine when to prefer a style over a modifier:
+
+- **To achieve theme-wide consistency:** Styles are designed to be "lifted" into a global theme. Instead of passing repetitive Modifiers to every component, you can define a single Style in your theme to create a unified look across the entire app.
+- **When performing frequent animations:** Styles evaluate during the Layout and Draw phases, allowing properties like color or scale to animate while bypassing the Composition phase entirely. This significantly reduces performance overhead. Use a Style instead of a modifier when doing visual property animations.
+- **Overriding vs. stacking:** Use Styles when you need to replace a default property. Modifiers are additive (adding a border stacks a second one), whereas Styles use "last-write-wins" logic, making it easier to swap out backgrounds or padding without visual clutter.
+- **Customizing Material components:** If a Material component provides a Style parameter, it is the suggested approach for customization. These styles allow you to access and modify specific properties within the composable's internal structure that might otherwise be inaccessible.

--- a/platforms/android/.agents/skills/styles/references/android/develop/ui/compose/styles/theming.md
+++ b/platforms/android/.agents/skills/styles/references/android/develop/ui/compose/styles/theming.md
@@ -1,0 +1,257 @@
+> [!NOTE]
+> **Note:** Styles are `@Experimental` and likely to change in upcoming releases, with Material support for Styles added in future releases. If you have any feedback, [file Styles issues](https://issuetracker.google.com/issues/new?component=612128).
+
+There are several ways you can build out your apps using Styles. What you choose
+depends on where your app sits in relation to its adoption of Material Design:
+
+1. Fully custom design system, not using Material Design
+   - **Recommendation**: Define component styles that consume values from the theme, and expose style parameters on design system components.
+2. Using Material Design
+   - **Recommendation**: Await Material adoption to integrate with Styles. Use styles on your own components where possible.
+
+## The Style layer
+
+In the traditional Compose model, customization often relies heavily on
+overriding global tokens (colors and typography) provided by `MaterialTheme`, or
+wrapping and overriding properties of a design system composable where possible.
+Sometimes, there are properties within the Material layer that are not exposed
+through the subsystems or parameters, but are hardcoded defaults on the
+component itself.
+
+With the Styles API, there's a new layer of abstraction that's a bridge between
+subsystems and components: **Styles**.
+
+| Layer | Responsibility | Example |
+|---|---|---|
+| **Subsystem values** | Named values | `val Primary = Color(0xFF34A85E)` |
+| **Atomic Styles** | Style that does exactly one property change | `val largeSizeAtomic = Style { size(100.dp, 40.dp) }` |
+| **Component Styles** | Component-specific configurations | A Button with Primary background and 16dp padding. `val buttonStyle = Style { contentPadding(16.dp) shape(RoundedCornerShape(8.dp)) background(Color.Blue) }` |
+| **Components** | The functional UI element that consumes a Style. | `Button(style = buttonStyle) { ... }` |
+
+![Diagram showing Theming with Styles with the new layer introduction](https://developer.android.com/static/develop/ui/compose/styles/images/theming_styles_layer.png) **Figure 1.** An example of a component and how it accesses styles from a theme.
+
+### Atomic versus monolithic Styles
+
+With the Styles API, you can break down a Style into separate atomic styles.
+Instead of defining complex, component-specific styles like `baseButtonStyle`,
+you can also create small, single-purpose utility styles. These act as your
+"atoms".
+
+
+```kotlin
+// Define single-purpose "atomic" styles
+val paddingAtomic = Style {
+    contentPadding(16.dp)
+}
+val roundedCornerShapeAtomic = Style {
+    shape(RoundedCornerShape(8.dp))
+}
+val primaryBackgroundAtomic = Style {
+    background(Color.Blue)
+}
+val largeSizeAtomic = Style {
+    size(100.dp, 40.dp)
+}
+val interactiveShadowAtomic = Style {
+    hovered {
+        animate {
+            dropShadow(
+                Shadow(
+                    offset = DpOffset(
+                        0.dp,
+                        0.dp
+                    ),
+                    radius = 2.dp,
+                    spread = 0.dp,
+                    color = Color.Blue,
+                )
+            )
+        }
+    }
+}
+```
+
+<br />
+
+#### Composition using "then"
+
+One of the powerful features of the new Styles API is the `then` operator, which
+lets you merge multiple `Style` objects. This lets you build a component using
+atomic utility classes.
+
+**Traditional (non-atomic)**:
+
+
+```kotlin
+// One large monolithic style
+val buttonStyle = Style {
+    contentPadding(16.dp)
+    shape(RoundedCornerShape(8.dp))
+    background(Color.Blue)
+}
+```
+
+<br />
+
+**Atomic refactor**:
+
+
+```kotlin
+// Combine atoms to create the final appearance
+val buttonStyle = paddingAtomic then roundedCornerShapeAtomic then primaryBackgroundAtomic then interactiveShadowAtomic
+```
+
+<br />
+
+## Adopt Styles in your design system
+
+Consider the following options when adopting Styles within your design system,
+depending on where in the spectrum your design system lies.
+
+### Custom design system with Styles
+
+***Consider when**: You've been handed an extensive brand guide that is not
+based on Material Design, and you are not planning to use Material Design*.
+
+***Strategy**: Implement a fully custom design system, and expose styles as part
+of the theme*.
+
+This option is the custom path if you don't use Material as your main design
+system language. You bypass `MaterialTheme` entirely for visual definitions and
+have created your [own custom theme already](https://developer.android.com/develop/ui/compose/designsystems/custom#implementing-fully-custom). You build a `CompanyTheme` that
+acts as a container for your Styles.
+
+- **How it works** : Create a `CompanyTheme` object that holds `Style` objects for every component in your system. Your components (either wrappers around Material logic or custom `Box` or `Layout` implementations) consume these styles directly, and expose a `Style` parameter for consumers of your design system.
+- **The Style layer**: Styles are the primary definition of your design system. Tokens are named variables fed into these styles. This allows for deep customization, such as defining unique animations for state changes (for example, animating scale and color on press).
+
+If you are building out your own [custom theme](https://developer.android.com/develop/ui/compose/designsystems/custom) without using Material, and
+want to adopt styles, add your list of styles to your Theme. This lets you
+access your base styles from anywhere in your project.
+
+1. Create a `Styles` class that stores the various styles in your application
+   and create the defaults. For example, in the Jetsnack app - the class is
+   named `JetsnackStyles`:
+
+
+   ```kotlin
+   object JetsnackStyles{
+       val buttonStyle: Style = Style {
+           shape(shapes.medium)
+           background(colors.brand)
+           contentColor(colors.textPrimary)
+           contentPaddingVertical(8.dp)
+           contentPaddingHorizontal(24.dp)
+           textStyle(typography.labelLarge)
+           disabled {
+               animate {
+                   background(colors.brandSecondary)
+               }
+           }
+       }
+       val cardStyle: Style = Style {
+           shape(shapes.medium)
+           background(colors.uiBackground)
+           contentColor(colors.textPrimary)
+       }
+   }
+   ```
+
+   <br />
+
+2. Provide `Styles` as part of your overall theme, and expose helper extension
+   functions on `StyleScope` to access the subsystems:
+
+
+   ```kotlin
+   @Immutable
+   class JetsnackTheme(
+       val colors: JetsnackColors = LightJetsnackColors,
+       val typography: androidx.compose.material3.Typography = androidx.compose.material3.Typography(),
+       val shapes: Shapes = Shapes()
+   ) {
+       companion object {
+           val colors: JetsnackColors
+               @Composable @ReadOnlyComposable
+               get() = LocalJetsnackTheme.current.colors
+
+           val typography: androidx.compose.material3.Typography
+               @Composable @ReadOnlyComposable
+               get() = LocalJetsnackTheme.current.typography
+
+           val shapes: Shapes
+               @Composable @ReadOnlyComposable
+               get() = LocalJetsnackTheme.current.shapes
+
+           val styles: JetsnackStyles = JetsnackStyles
+
+           val LocalJetsnackTheme: ProvidableCompositionLocal<JetsnackTheme>
+               get() = LocalJetsnackThemeInstance
+       }
+   }
+
+   val StyleScope.colors: JetsnackColors
+       get() = LocalJetsnackTheme.currentValue.colors
+
+   val StyleScope.typography: androidx.compose.material3.Typography
+       get() = LocalJetsnackTheme.currentValue.typography
+
+   val StyleScope.shapes: Shapes
+       get() = LocalJetsnackTheme.currentValue.shapes
+
+   internal val LocalJetsnackThemeInstance = staticCompositionLocalOf { JetsnackTheme() }
+
+   @Composable
+   fun JetsnackTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
+       val colors = if (darkTheme) DarkJetsnackColors else LightJetsnackColors
+       val theme = JetsnackTheme(colors = colors)
+
+       CompositionLocalProvider(
+           LocalJetsnackTheme provides theme,
+       ) {
+           MaterialTheme(
+               typography = LocalJetsnackTheme.current.typography,
+               shapes = LocalJetsnackTheme.current.shapes,
+               content = content,
+           )
+       }
+   }
+   ```
+
+   <br />
+
+3. Access `JetsnackStyles` within your composable:
+
+
+   ```kotlin
+   @Composable
+   fun CustomButton(modifier: Modifier,
+                    style: Style = Style,
+                    text: String) {
+       val interactionSource = remember { MutableInteractionSource() }
+       val styleState = remember(interactionSource) { MutableStyleState(interactionSource) }
+
+       // Apply style to top level container in combination with incoming style from parameter.
+       Box(modifier = modifier
+           .clickable(
+               interactionSource = interactionSource,
+               indication = null,
+               enabled = true,
+               role = Role.Button,
+               onClick = {
+
+               },
+           )
+           .styleable(styleState, JetsnackTheme.styles.buttonStyle, style)) {
+           Text(text)
+       }
+   }
+   ```
+
+   <br />
+
+Beyond global theme adoption, there are alternative strategies for incorporating
+`Styles` into your apps. You can leverage `Styles` inline for specific call
+sites or use static definitions when full theming capabilities are unnecessary.
+`Styles` shouldn't be swapped conditionally unless the whole style is
+fundamentally different. You should prefer accessing dynamic tokens inside a
+visual definition rather than switching between distinct style objects.

--- a/platforms/android/.agents/skills/testing-setup/SKILL.md
+++ b/platforms/android/.agents/skills/testing-setup/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: testing-setup
+description: Analyze and create a testing strategy for native Android apps - install
+  testing libraries, set up test infrastructure, create harnesses for unit tests,
+  UI tests, screenshot tests, and end-to-end tests.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-06-25'
+  keywords:
+  - android
+  - testing
+  - ui tests
+  - screenshot tests
+  - coverage
+---
+
+## Step 1: analyze the current testing setup
+
+To understand the testing setup of an existing project, look for these
+dependencies in the libs.versions.toml file, or build files:
+
+1. Dependency Injection framework used. Examples: Hilt, Koin, Anvil, vanilla Dagger...
+2. Unit (local) testing framework this project uses, Example JUnit4, JUnit5...
+3. Mocking framework (if any) used for unit tests, and for Instrumented and UI tests. Examples: Mockito, Mockk...
+4. Robolectric. It can be used in 3 ways:
+   1. Used in unit tests to have fakes for platform entities
+   2. To run behavior UI tests without a device or emulator. For example, used to run Espresso or Compose tests.
+   3. To do screenshot testing with Roborazzi
+5. Is the app 100% Compose, Views or hybrid?
+6. Behavior UI tests:
+   1. Compose Tests (`androidx.compose.ui:ui-test-*`)
+   2. Espresso Tests for Views. Might use wrappers like Kaspresso. Dependencies: `androidx.test.espresso:espresso-core`, `androidx.test:runner`, `androidx.test:rules`.
+7. Screenshot tests can be:
+   1. Instrumented (device-based). For example, using Dropshots.
+   2. Based on Robolectric, so they run locally. For example, using Roborazzi.
+   3. Based on LayoutLib, so they run locally. For example, Paparazzi, or the Compose Preview Screenshot Testing tool.
+8. End to end tests (also known as Release Candidate tests) always run on device and use high-level frameworks such as UIAutomator, Appium, or Robotium.
+9. Generate a Markdown report with the analysis
+
+## Step 2: Set up Dependency Injection frameworks for testing
+
+If there is no Dependency Injection framework, install one: if it's a
+multiplatform application, ask the user whether they want to install Koin, or
+kotlin-inject. If it's not multiplatform, install Hilt.
+
+Install the testing dependencies (for example `com.google.dagger:hilt-compiler`
+that should be applied with a `kspAndroidTest` configuration).
+
+> [!IMPORTANT]
+> **Important:** Always consult the documentation of the applicable framework to learn about testing (for example: [Hilt testing guide](references/android/training/dependency-injection/hilt-testing.md), [Koin Instrumented tests](https://insert-koin.io/docs/reference/koin-android/instrumented-testing)).
+
+For instrumented tests, create and configure (by adding
+`testInstrumentationRunner` to the build gradle files) a new test runner and
+apply the testing rules required by the framework (for example in Hilt, annotate
+your test classes with `@HiltAndroidTest` and apply the `HiltAndroidRule`).
+Other frameworks use other mechanisms, consult their documentation.
+
+## Step 3: Install frameworks
+
+Unless otherwise specified, respect the current stack of testing frameworks.
+
+If there are no testing frameworks, and the user didn't specify any preference,
+install the following:
+
+- JUnit4 for local and instrumented tests
+- Jacoco for test coverage
+- For UI tests: if the project has views, Espresso. If it's fully Compose, use the Compose Testing APIs.
+- Robolectric to run UI Tests
+- Compose Preview Screenshot Testing tool for screenshot tests - check [setup
+  documentation](references/android/studio/preview/compose-screenshot-testing.md) and follow it strictly.
+- Dropshots for device screenshot tests
+- If a mocking framework is necessary, install Mockk (`io.mockk:mockk`). Do not install it unless it is clearly necessary.
+
+If instrumented screenshot tests are requested, install Dropshots.
+
+If end-to-end testing is requested, install UI Automator.
+
+## Step 4: Refactor and create fakes for testing
+
+### **Refactor for unit tests**
+
+In the next sections you'll be asked to create tests. If you have dependencies
+on Android framework classes, or entities that are not part of the codebase:
+
+- First, use a fake. If it doesn't exist, create an interface for the class
+  and a "Default" implementation with the existing code. Add the Fake version
+  to the test sourceset (test or androidTest).
+
+- If not possible to use a fake (example: no access to the class or
+  interface), mock the dependencies.
+
+### **Refactor for UI tests**
+
+If you need to fake components to make testing easier and faster and more
+reliable, replace slow and problematic dependencies with fakes. Use runtime
+fakes using the Dependency Injection framework installed to:
+
+- **Simulate** different scenarios with the user (wrong credentials, reset password flow...), with a server (no connection, server down, bad JSON from server...) or with a platform component (insufficient permissions, no disk space, no front camera available)
+- **Improve** speed and reliability (replacing a database with an in-memory database, replacing a repository with an in-memory fake to avoid hitting the network)
+
+## Step 5: Unit testing
+
+Create a task to add or review unit tests in every file that contains business
+logic (ViewModels, Repositories, database-related classes such as DAOs, etc.).
+Don't create unit tests for Activities, Compose layouts, or dependency injection
+configuration files.
+
+## Step 6: UI testing
+
+Espresso or Compose UI tests live in the `test` sourceset because they will be
+run with Robolectric. If instrumented (emulator or device) tests are requested,
+put them in the `androidTest` sourceset.
+
+## Step 7: Test databases
+
+If the database is using SQLite (using Room, SQLDelight, etc.), create
+instrumented tests using an in-memory database to make sure that they work with
+the SQLite engine on device.
+
+## Step 8: Screenshot tests
+
+Irrespective of the framework used, screenshot tests focus on 2 types of tests:
+
+- Screen-level screenshot tests, where each screen is tested in 9 different sizes, combining compact, medium and expanded widths (400, 610, 900 dp) and heights (400, 500 and 1000 dp).
+- Screen-level variations. Add a mobile (400x500) screenshot of:
+  - All the alternative themes, if used.
+  - Font scale set to 1.5.
+- Component-level screenshot tests, where each component is tested in different themes and font scales.
+
+Behavior isn't tested with screenshots, but do test different common scenarios
+if their UIs change a lot depending on the state. For example, test loading
+screens by injecting a loading state to the UI or simulating it with a fake.
+
+## Step 9: UI Behavior tests
+
+Test the UI logic using behavior tests, which ensures that the UIs react as
+expected when different states are passed, and when user actions are performed.
+
+### **Compose UI behavior tests**
+
+- Use the ComposeTestRule with a `ComponentActivity` to access resources such as strings.
+- Always try to match with semantic matchers first. If the matcher is too complicated to write (using more than 3 matchers to find a single element), use `testTag`.
+- Always verify state restoration
+
+### **Views (XML) UI behavior tests**
+
+Use Espresso to match views and interact with them.
+
+## Step 10: Navigation tests
+
+Create a test suite to verify navigation logic. Include:
+
+- Back handling
+- Deeplinks
+- Special patterns like "exit through home" with multiple backstacks.
+
+## Step 11: Simulate different window sizes and settings
+
+For Compose layouts, use `DeviceConfigurationOverride` described in "[UI testing
+common patterns](references/android/develop/ui/compose/testing/common-patterns.md)" to simulate different window sizes, font scales
+
+## Step 12: End-to-end tests
+
+Create a low number (about 5% of all tests) of end-to-end tests that cover big
+user journeys. Use Compose Test APIs or Espresso for that. If you have to access
+platform features (notifications, system UI...), use UI Automator.
+
+If you need to take screenshots of the app running in a device, use
+[Dropshots](https://raw.githubusercontent.com/dropbox/dropshots/refs/heads/main/README.md). You need a device for screenshot tests when verifying
+interaction with the system UI (examples: edge-to-edge rendering, notifications,
+picture-in-picture)
+
+### Step 13: Instrumented Screenshot tests
+
+Install the `com.dropbox.dropshots` plugin in the module and a `Dropshots()`
+JUnit Rule. Create a new instrumented screenshot test for one of the app's
+features.
+
+### Step 14: Install jacoco
+
+Install jacoco for local testing code coverage.
+
+- Add the `jacoco` plugin to each module that contains tests.
+
+## Final touches
+
+- Ask whether to document the findings of the analysis and the changes applied
+  to the testing strategy. If the user agrees:
+
+  - If there is an AGENTS.md file present in the project, update it with any
+    changes you've made to the testing strategy.
+
+  - If there is no AGENTS.md file, create a new file (docs/testing.md) with
+    a description of the testing strategy, including the commands needed to
+    run every type of test, where the screenshot reference files live, etc.
+    Also create a new AGENTS.md file in the root and create a link to
+    docs/testing.md.

--- a/platforms/android/.agents/skills/testing-setup/references/android/develop/ui/compose/testing/common-patterns.md
+++ b/platforms/android/.agents/skills/testing-setup/references/android/develop/ui/compose/testing/common-patterns.md
@@ -1,0 +1,181 @@
+[Video](https://www.youtube.com/watch?v=Y9GWnwi9D0I)
+
+You can test your Compose app with well-established approaches and patterns.
+
+### Test in isolation
+
+[`ComposeTestRule`](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/junit4/ComposeTestRule) lets you start an activity displaying any composable:
+your full application, a single screen, or a small element. It's also a good
+practice to check that your composables are correctly encapsulated and they work
+independently, allowing for easier and more focused UI testing.
+
+This doesn't mean you should *only* create unit UI tests. UI tests scoping
+larger parts of your UI are also very important.
+
+### Access the activity and resources after setting your own content
+
+Oftentimes you need to set the content under test using
+`composeTestRule.setContent` and you also need to access activity resources, for
+example to assert that a displayed text matches a string resource. However, you
+can't call `setContent` on a rule created with `createAndroidComposeRule()` if
+the activity already calls it.
+
+A common pattern to achieve this is to create an `AndroidComposeTestRule` using
+an empty activity such as [`ComponentActivity`](https://developer.android.com/reference/androidx/activity/ComponentActivity).
+
+    class MyComposeTest {
+
+        @get:Rule
+        val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+        @Test
+        fun myTest() {
+            // Start the app
+            composeTestRule.setContent {
+                MyAppTheme {
+                    MainScreen(uiState = exampleUiState, /*...*/)
+                }
+            }
+            val continueLabel = composeTestRule.activity.getString(R.string.next)
+            composeTestRule.onNodeWithText(continueLabel).performClick()
+        }
+    }
+
+Note that `ComponentActivity` needs to be added to your app's
+`AndroidManifest.xml` file. Enable that by adding this dependency to your
+module:
+
+    debugImplementation("androidx.compose.ui:ui-test-manifest:$compose_version")
+
+### Custom semantics properties
+
+You can create custom [semantics](https://developer.android.com/develop/ui/compose/testing/semantics) properties to expose information to tests.
+To do this, define a new `SemanticsPropertyKey` and make it available using the
+`SemanticsPropertyReceiver`.
+
+    // Creates a semantics property of type Long.
+    val PickedDateKey = SemanticsPropertyKey<Long>("PickedDate")
+    var SemanticsPropertyReceiver.pickedDate by PickedDateKey
+
+Now use that property in the `semantics` modifier:
+
+    val datePickerValue by remember { mutableStateOf(0L) }
+    MyCustomDatePicker(
+        modifier = Modifier.semantics { pickedDate = datePickerValue }
+    )
+
+From tests, use `SemanticsMatcher.expectValue` to assert the value of the
+property:
+
+    composeTestRule
+        .onNode(SemanticsMatcher.expectValue(PickedDateKey, 1445378400)) // 2015-10-21
+        .assertExists()
+
+> [!WARNING]
+> **Warning:** You should only use custom Semantics properties when it's hard to match a specific item using the given finders and matchers. Using custom Semantics properties to expose visual properties such as colors, font size or rounded corner radius is not recommended, as it can pollute production code and wrong implementations can lead to bugs that are hard to find.
+
+### Verify state restoration
+
+Verify that the state of your Compose elements is correctly restored when the
+activity or process is recreated. Perform such checks without relying on
+activity recreation with the [`StateRestorationTester`](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/junit4/StateRestorationTester) class.
+
+This class lets you simulate the recreation of a composable. It's especially
+useful to verify the implementation of [`rememberSaveable`](https://developer.android.com/reference/kotlin/androidx/compose/runtime/saveable/rememberSaveable.composable#rememberSaveable(kotlin.Array,androidx.compose.runtime.saveable.Saver,kotlin.String,kotlin.Function0)).
+
+
+    class MyStateRestorationTests {
+
+        @get:Rule
+        val composeTestRule = createComposeRule()
+
+        @Test
+        fun onRecreation_stateIsRestored() {
+            val restorationTester = StateRestorationTester(composeTestRule)
+
+            restorationTester.setContent { MainScreen() }
+
+            // TODO: Run actions that modify the state
+
+            // Trigger a recreation
+            restorationTester.emulateSavedInstanceStateRestore()
+
+            // TODO: Verify that state has been correctly restored.
+        }
+    }
+
+### Test different device configurations
+
+Android apps need to adapt to many changing conditions: window sizes, locales,
+font sizes, dark and light themes, and more. Most of these conditions are
+derived from device-level values controlled by the user and exposed with the
+current [`Configuration`](https://developer.android.com/reference/android/content/res/Configuration) instance. Testing different configurations
+directly in a test is difficult since the test must configure device-level
+properties.
+
+[`DeviceConfigurationOverride`](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/DeviceConfigurationOverride) is a test-only API that lets you simulate
+different device configurations in a localized way for the `@Composable` content
+under test.
+
+The companion object of `DeviceConfigurationOverride` has the following
+extension functions, which override device-level configuration properties:
+
+- [`DeviceConfigurationOverride.DarkMode()`](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/DeviceConfigurationOverride.Companion#(androidx.compose.ui.test.DeviceConfigurationOverride.Companion).DarkMode(kotlin.Boolean)): Overrides the system to dark theme or light theme.
+- [`DeviceConfigurationOverride.FontScale()`](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/DeviceConfigurationOverride.Companion#(androidx.compose.ui.test.DeviceConfigurationOverride.Companion).FontScale(kotlin.Float)): Overrides the [system font
+  scale](https://developer.android.com/training/multiscreen/screendensities#TaskUseDP).
+- [`DeviceConfigurationOverride.FontWeightAdjustment()`](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/DeviceConfigurationOverride.Companion#(androidx.compose.ui.test.DeviceConfigurationOverride.Companion).FontWeightAdjustment(kotlin.Int)): Overrides the system font weight adjustment.
+- [`DeviceConfigurationOverride.ForcedSize()`](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/DeviceConfigurationOverride.Companion#(androidx.compose.ui.test.DeviceConfigurationOverride.Companion).ForcedSize(androidx.compose.ui.unit.DpSize)): Forces a specific amount of space regardless of device size.
+- [`DeviceConfigurationOverride.LayoutDirection()`](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/DeviceConfigurationOverride.Companion#(androidx.compose.ui.test.DeviceConfigurationOverride.Companion).LayoutDirection(androidx.compose.ui.unit.LayoutDirection)): Overrides the [layout
+  direction](https://developer.android.com/training/basics/supporting-devices/languages#SupportLayoutMirroring) (left-to-right or right-to-left).
+- [`DeviceConfigurationOverride.Locales()`](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/DeviceConfigurationOverride.Companion#(androidx.compose.ui.test.DeviceConfigurationOverride.Companion).Locales(androidx.compose.ui.text.intl.LocaleList)): Overrides the [locale](https://developer.android.com/guide/topics/resources/localization).
+- [`DeviceConfigurationOverride.RoundScreen()`](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/DeviceConfigurationOverride.Companion#(androidx.compose.ui.test.DeviceConfigurationOverride.Companion).RoundScreen(kotlin.Boolean)): Overrides if the screen is [round](https://developer.android.com/design/ui/wear/guides/foundations/getting-started#design-for-round).
+
+To apply a specific override, wrap the content under test in a call to the
+[`DeviceConfigurationOverride()`](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/DeviceConfigurationOverride.composable#DeviceConfigurationOverride(androidx.compose.ui.test.DeviceConfigurationOverride,kotlin.Function0)) top-level function, passing the override
+to apply as a parameter.
+
+For example, the following code applies the
+`DeviceConfigurationOverride.ForcedSize()` override to change the density
+locally, forcing the `MyScreen` composable to be rendered in a large landscape
+window, even if the device the test is running on doesn't support that window
+size directly:
+
+
+```kotlin
+composeTestRule.setContent {
+    DeviceConfigurationOverride(
+        DeviceConfigurationOverride.ForcedSize(DpSize(1280.dp, 800.dp))
+    ) {
+        MyScreen() // Will be rendered in the space for 1280dp by 800dp without clipping.
+    }
+}
+```
+
+<br />
+
+To apply multiple overrides together, use
+[`DeviceConfigurationOverride.then()`](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/DeviceConfigurationOverride#(androidx.compose.ui.test.DeviceConfigurationOverride).then(androidx.compose.ui.test.DeviceConfigurationOverride)):
+
+
+```kotlin
+composeTestRule.setContent {
+    DeviceConfigurationOverride(
+        DeviceConfigurationOverride.FontScale(1.5f) then
+            DeviceConfigurationOverride.FontWeightAdjustment(200)
+    ) {
+        Text(text = "text with increased scale and weight")
+    }
+}
+```
+
+<br />
+
+## Additional Resources
+
+- **[Test apps on Android](https://developer.android.com/training/testing)**: The main Android testing landing page provides a broader view of testing fundamentals and techniques.
+- **[Fundamentals of testing](https://developer.android.com/training/testing/fundamentals):** Learn more about the core concepts behind testing an Android app.
+- **[Local tests](https://developer.android.com/training/testing/local-tests):** You can run some tests locally, on your own workstation.
+- **[Instrumented tests](https://developer.android.com/training/testing/instrumented-tests):** It is good practice to also run instrumented tests. That is, tests that run directly on-device.
+- **[Continuous integration](https://developer.android.com/training/testing/continuous-integration):** Continuous integration lets you integrate your tests into your deployment pipeline.
+- **[Test different screen sizes](https://developer.android.com/training/testing/different-screens):** With some many devices available to users, you should test for different screen sizes.
+- **[Espresso](https://developer.android.com/training/testing/espresso)**: While intended for View-based UIs, Espresso knowledge can still be helpful for some aspects of Compose testing.

--- a/platforms/android/.agents/skills/testing-setup/references/android/studio/preview/compose-screenshot-testing.md
+++ b/platforms/android/.agents/skills/testing-setup/references/android/studio/preview/compose-screenshot-testing.md
@@ -1,0 +1,227 @@
+> [!WARNING]
+> **Experimental:** Compose Preview Screenshot Testing is still in development. Its features and APIs are subject to change substantially during the alpha phase. Report any feedback and issues through the [issue tracker](https://issuetracker.google.com/issues/new?component=192708&template=840533).
+
+Screenshot testing is an effective way to verify how your UI looks to users.
+The Compose Preview Screenshot Testing tool combines the simplicity and
+features of [composable previews](https://developer.android.com/develop/ui/compose/tooling/previews) with the productivity
+gains of running host-side screenshot tests. Compose Preview Screenshot Testing
+is designed to be as straightforward to use as composable previews.
+
+A screenshot test is an automated test that takes a screenshot of a piece of UI
+and then compares it against a previously approved reference image. If the
+images don't match, the test fails and produces an HTML report to help you
+compare and find the differences.
+
+With the Compose Preview Screenshot Testing tool, you can:
+
+- Use `@PreviewTest` to create screenshot tests for existing or new composable previews.
+- Generate reference images from those composable previews.
+- Generate an HTML report that identifies changes to those previews after you make code changes.
+- Use `@Preview` parameters, such as `uiMode` or `fontScale`, and multi-previews to help you scale your tests.
+- Modularize your tests with the new `screenshotTest` source set.
+
+![](https://developer.android.com/static/studio/images/compose-screenshot-testing.png) **Figure 1.** Example HTML report.
+
+## IDE integration
+
+While you can use the Compose Preview Screenshot Testing tool by running the
+underlying Gradle tasks (`updateScreenshotTest` and `validateScreenshotTest`)
+manually, Android Studio Otter 3 Feature Drop Canary 4 introduces a full IDE
+integration. This lets you generate reference images, run tests, and analyze
+validation failures entirely within the IDE. Here are some of the key features:
+
+- **In-editor gutter icons.** You can now run tests or update reference images directly from the source code. Green run icons appear in the gutter next to composables and classes annotated with `@PreviewTest`.
+  - **Run screenshot tests.** Execute tests specifically for a single function or for an entire class.
+  - **Add or update reference images.** Trigger the update flow specifically for the selected scope.
+
+- **Interactive reference management.** Updating reference images is now safer and more granular.
+  - **New reference image generation dialog.** Instead of running a bulk Gradle task, a new dialog lets you visualize and select exactly which previews to generate or update.
+  - **Preview variations.** The dialog lists all preview variations (such as light theme or dark theme, or different devices) individually, allowing you to select or clear specific items before generating images.
+
+- **Integrated test results and diff viewer.** View results without leaving the IDE.
+  - **Unified run panel.** Screenshot test results appear in the standard **Run** tool window. Tests are grouped by class and function, with pass or fail status clearly marked.
+  - **Visual diff tool.** When a test fails, the **Screenshot** tab lets you compare the *Reference* , *Actual* , and *Diff* images side-by-side.
+  - **Detailed attributes.** An **Attributes** tab provides metadata on failed tests, including match percentage, image dimensions, and the specific preview configuration used (for example, `uiMode` or `fontScale`).
+
+- **Flexible test scoping.** You can now execute screenshot tests with various scopes directly from the Project View. Right-click a module, directory, file, or class to run screenshot tests specifically for that selection.
+
+## Requirements
+
+To use Compose Preview Screenshot Testing through the full IDE integration, your
+project must meet the following requirements:
+
+- Android Studio Panda 1 Canary 4 or higher.
+- Android Gradle Plugin (AGP) version 9.0 or higher.
+- Compose Preview Screenshot Testing plugin version [0.0.1-alpha15](https://developer.android.com/studio/preview/compose-screenshot-testing-release-notes#alpha15) or higher.
+- Kotlin version 2.2.10 or higher.
+- JDK version 17 or higher.
+- Compose enabled for your project. We recommend enabling Compose using the [Compose Compiler Gradle plugin](https://developer.android.com/develop/ui/compose/compiler).
+
+If you only want to use the underlying Gradle tasks without the IDE integration,
+the requirements are as follows:
+
+- Android Gradle Plugin (AGP) version 8.5.0 or higher.
+- Compose Preview Screenshot Testing plugin version [0.0.1-alpha15](https://developer.android.com/studio/preview/compose-screenshot-testing-release-notes#alpha15) or higher.
+- Kotlin version 1.9.20 or higher. We recommend using Kotlin 2.0 or higher so you can use the Compose Compiler Gradle plugin.
+- JDK version 17 or higher.
+- Compose enabled for your project. We recommend enabling Compose using the [Compose Compiler Gradle plugin](https://developer.android.com/develop/ui/compose/compiler).
+
+> [!NOTE]
+> **Note:** If you can't use the Compose Compiler Gradle plugin, you can enable Compose by [declaring a dependency on the Compose Compiler directly](https://developer.android.com/jetpack/androidx/releases/compose-kotlin#kts). Make sure you use `kotlinCompilerExtensionVersion` version 1.5.4 or higher.
+
+## Setup
+
+Both the integrated tool and the underlying Gradle tasks rely on the Compose
+Preview Screenshot Testing plugin. To set up the plugin, follow these steps:
+
+1. Enable the experimental property in your project's `gradle.properties` file.
+
+       android.experimental.enableScreenshotTest=true
+
+2. In the `android {}` block of your module-level `build.gradle.kts` file,
+   enable the experimental flag to use the `screenshotTest` source set.
+
+       android {
+           experimentalProperties["android.experimental.enableScreenshotTest"] = true
+       }
+
+3. Add the `com.android.compose.screenshot` plugin, version `0.0.1-alpha15` to
+   your project.
+
+   1. Add the plugin to your version catalogs file:
+
+          [versions]
+          agp = "9.0.0-rc03"
+          kotlin = "2.2.10"
+          screenshot = "0.0.1-alpha15"
+
+          [plugins]
+          screenshot = { id = "com.android.compose.screenshot", version.ref = "screenshot"}
+
+   2. In your module-level `build.gradle.kts` file, add the plugin in the
+      `plugins {}` block:
+
+          plugins {
+              alias(libs.plugins.screenshot)
+          }
+
+4. Add the [`screenshot-validation-api`](https://maven.google.com/web/index.html?q=screenshot-validation-api#com.android.tools.screenshot:screenshot-validation-api)
+   and [`ui-tooling`](https://maven.google.com/web/index.html?q=tooling#androidx.compose.ui:ui-tooling)
+   dependencies.
+
+   1. Add them to your version catalogs:
+
+          [libraries]
+          screenshot-validation-api = { group = "com.android.tools.screenshot", name = "screenshot-validation-api", version.ref = "screenshot"}
+          androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling"}
+
+   2. Add them to your module-level `build.gradle.kts` file:
+
+          dependencies {
+            screenshotTestImplementation(libs.screenshot.validation.api)
+            screenshotTestImplementation(libs.androidx.ui.tooling)
+          }
+
+## Designate composable previews to use for screenshot tests
+
+To designate the composable previews you want to use for screenshot tests, mark
+the previews with the `@PreviewTest` annotation. The previews must be located in
+the new `screenshotTest` source set, for example:
+
+`app/src/screenshotTest/kotlin/com/example/yourapp/`
+`ExamplePreviewScreenshotTest.kt`
+
+You can add more composables or previews, including multi-previews, in
+this file or other files created in the same source set.
+
+    package com.example.yourapp
+
+    import androidx.compose.runtime.Composable
+    import androidx.compose.ui.tooling.preview.Preview
+    import com.android.tools.screenshot.PreviewTest
+    import com.example.yourapp.ui.theme.MyApplicationTheme
+
+    @PreviewTest
+    @Preview(showBackground = true)
+    @Composable
+    fun GreetingPreview() {
+        MyApplicationTheme {
+            Greeting("Android!")
+        }
+    }
+
+## Generate reference images
+
+After you set up a test class, you need to generate reference images for each
+preview. These reference images are used to identify changes later, after you
+make code changes. To generate reference images for your composable preview
+screenshot tests, follow the instructions in this section for the IDE
+integration or for the Gradle tasks.
+
+### In the IDE
+
+Click the gutter icon next to a `@PreviewTest` function and select **Add/Update
+Reference Images** . Select the previews in the dialog and click **Add**.
+
+### With the Gradle tasks
+
+Run the following Gradle task:
+
+- Linux and macOS: `./gradlew updateDebugScreenshotTest` (`./gradlew :{module}:update{Variant}ScreenshotTest`)
+- Windows: `gradlew updateDebugScreenshotTest` (`gradlew :{module}:update{Variant}ScreenshotTest`)
+
+After the task completes, find the reference images in
+`app/src/screenshotTestDebug/reference`
+(`{module}/src/screenshotTest{Variant}/reference`).
+
+> [!NOTE]
+> **Note:** The reference images are named with a concatenation of the fully-qualified name of the test function and a hash of the preview parameters, for example `com.sample.screenshottests.test1_da39a3ee_c2200e98_0.png`.
+
+## Generate a test report
+
+Once the reference images exist, generate a test report by following the
+instructions in this section for the IDE integration or for the Gradle tasks.
+
+### In the IDE
+
+Click the gutter icon next to a `@PreviewTest` function and select **Run
+'ScreenshotTests'**.
+
+If a test fails, click the test name in the **Run** panel. Select the
+**Screenshot** tab to inspect the image diff using the integrated zoom and pan
+controls.
+
+> [!NOTE]
+> **Note:** Renaming a function annotated with `@PreviewTest` breaks the association with existing reference images. In that case, you must [regenerate reference images](https://developer.android.com/studio/preview/compose-screenshot-testing#generate-reference-images) for the new function name.
+
+### With the Gradle tasks
+
+Run the validate task to take a new screenshot and compare it with the
+reference image:
+
+- Linux and macOS: `./gradlew validateDebugScreenshotTest` (`./gradlew :{module}:validate{Variant}ScreenshotTest`)
+- Windows: `gradlew validateDebugScreenshotTest` (`gradlew :{module}:validate{Variant}ScreenshotTest`)
+
+The verification task creates an HTML report at
+`{module}/build/reports/screenshotTest/preview/{variant}/index.html`.
+
+## Troubleshooting
+
+Compose Preview Screenshot Testing runs host-side tests, which can be
+memory-intensive. You can increase the maximum heap size for the test JVM by
+adding the following property to your `gradle.properties` file:
+
+    android.compose.screenshot.maxHeapSize=4g
+
+## Known issues
+
+- **Kotlin Multiplatform (KMP):** Both the IDE and the underlying plugin are engineered exclusively for Android projects. They don't support non-Android targets in KMP projects.
+
+You can find the complete list of current known issues in the tool's
+[issue tracker component](https://issuetracker.google.com/issues?q=status:open+componentid:1581441&s=created_time:desc). Report any other feedback and issues
+through the [issue tracker](https://issuetracker.google.com/issues/new?component=192708&template=840533).
+
+## Release updates
+
+For a full list of release updates, see the
+[release notes](https://developer.android.com/studio/preview/compose-screenshot-testing-release-notes).

--- a/platforms/android/.agents/skills/testing-setup/references/android/training/dependency-injection/hilt-testing.md
+++ b/platforms/android/.agents/skills/testing-setup/references/android/training/dependency-injection/hilt-testing.md
@@ -1,0 +1,447 @@
+One of the benefits of using dependency injection frameworks like Hilt is that
+it makes testing your code easier.
+
+## Unit tests
+
+Hilt isn't necessary for unit tests, since when testing a class that uses
+constructor injection, you don't need to use Hilt to instantiate that class.
+Instead, you can directly call a class constructor by passing in fake or mock
+dependencies, just as you would if the constructor weren't annotated:
+
+```kotlin
+@ActivityScoped
+class AnalyticsAdapter @Inject constructor(
+  private val service: AnalyticsService
+) { ... }
+
+class AnalyticsAdapterTest {
+
+  @Test
+  fun `Happy path`() {
+    // You don't need Hilt to create an instance of AnalyticsAdapter.
+    // You can pass a fake or mock AnalyticsService.
+    val adapter = AnalyticsAdapter(fakeAnalyticsService)
+    assertEquals(...)
+  }
+}
+```
+
+The same applies to ViewModel classes obtained by calling `hiltViewModel()` in
+your composables. In unit tests, construct the ViewModel directly with fakes.
+For information on how state flows from a ViewModel into composables, see
+[State and Jetpack Compose](https://developer.android.com/develop/ui/compose/state) and [Where to hoist state](https://developer.android.com/develop/ui/compose/state-hoisting).
+
+## End-to-end tests
+
+For integration tests, Hilt injects dependencies as it would in your production
+code. Testing with Hilt requires no maintenance because Hilt automatically
+generates a new set of components for each test.
+
+### Adding testing dependencies
+
+To use Hilt in your tests, include the `hilt-android-testing` dependency in your
+project:
+
+```kotlin
+dependencies {
+    // For Robolectric tests.
+    testImplementation("com.google.dagger:hilt-android-testing:2.57.1")
+    kspTest("com.google.dagger:hilt-android-compiler:2.57.1")
+
+    // For instrumented tests.
+    androidTestImplementation("com.google.dagger:hilt-android-testing:2.57.1")
+    kspAndroidTest("com.google.dagger:hilt-android-compiler:2.57.1")
+
+    // Compose UI test rule.
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+}
+```
+
+> [!NOTE]
+> **Note:** If you use [Jetpack integrations](https://developer.android.com/training/dependency-injection/hilt-jetpack) (like `hilt-navigation-compose` to obtain a ViewModel through `hiltViewModel()`), you must also add their annotation processors to your test dependencies.
+
+### UI test setup
+
+You must annotate any UI test that uses Hilt with `@HiltAndroidTest`. This
+annotation is responsible for generating the Hilt components for each test.
+
+Also, you need to add the `HiltAndroidRule` to the test class. It manages the
+components' state and is used to perform injection on your test:
+
+```kotlin
+@HiltAndroidTest
+class SettingsScreenTest {
+
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<HiltTestActivity>()
+
+    // Compose UI tests here.
+}
+```
+
+> [!NOTE]
+> **Note:** If you have other rules in your test, see [Multiple TestRule objects in
+> your instrumented test](https://developer.android.com/training/dependency-injection/hilt-testing#multiple-testrules).
+
+Next, your test needs to know about the `Application` class that Hilt
+automatically generates for you.
+
+To let Hilt inject dependencies, you must create an empty activity named
+`HiltTestActivity` in your `androidTest` source set and annotate it with
+`@AndroidEntryPoint`. `createAndroidComposeRule` then uses this activity as the
+host for your composable content.
+
+#### Test application
+
+You must execute instrumented tests that use Hilt in an `Application` object
+that supports Hilt. The library provides `HiltTestApplication` for use in tests.
+If your tests need a different base application, see [Custom application for
+tests](https://developer.android.com/training/dependency-injection/hilt-testing#custom-application).
+
+You must set your test application to run in your [instrumented
+tests](https://developer.android.com/training/testing/ui-testing) or [Robolectric
+tests](http://robolectric.org/). The following instructions aren't
+specific to Hilt, but are general guidelines on how to specify a custom
+application to run in tests.
+
+##### Set the test application in instrumented tests
+
+To use the Hilt test application in [instrumented
+tests](https://developer.android.com/training/testing/ui-testing), you need to configure a new test runner.
+This makes Hilt work for all of the instrumented tests in your project. Perform
+the following steps:
+
+1. Create a custom class that extends [`AndroidJUnitRunner`](https://developer.android.com/reference/kotlin/androidx/test/runner/AndroidJUnitRunner) in the `androidTest` folder.
+2. Override the `newApplication` function and pass in the name of the generated Hilt test application.
+
+```kotlin
+// A custom runner to set up the instrumented application class for tests.
+class CustomTestRunner : AndroidJUnitRunner() {
+
+    override fun newApplication(cl: ClassLoader?, name: String?, context: Context?): Application {
+        return super.newApplication(cl, HiltTestApplication::class.java.name, context)
+    }
+}
+```
+
+Next, configure this test runner in your Gradle file as described in the
+[instrumented unit test
+guide](https://developer.android.com/training/testing/unit-testing/instrumented-unit-tests#setup). Make sure
+you use the full classpath:
+
+```kotlin
+android {
+    defaultConfig {
+        // Replace com.example.android.dagger with your class path.
+        testInstrumentationRunner = "com.example.android.dagger.CustomTestRunner"
+    }
+}
+```
+
+##### Set the test application in Robolectric tests
+
+If you use Robolectric to test your UI layer, you can specify which application
+to use in the `robolectric.properties` file:
+
+`application = dagger.hilt.android.testing.HiltTestApplication`
+
+Alternatively, you can configure the application on each test individually by
+using Robolectric's `@Config` annotation:
+
+```kotlin
+@HiltAndroidTest
+@Config(application = HiltTestApplication::class)
+class SettingsScreenTest {
+
+  @get:Rule
+  var hiltRule = HiltAndroidRule(this)
+
+  // Robolectric tests here.
+}
+```
+
+### Testing features
+
+Once Hilt is ready to use in your tests, you can use several features to
+customize the testing process.
+
+#### Inject types in tests
+
+To inject types into a test, use `@Inject` for field injection. To tell Hilt to
+populate the `@Inject` fields, call `hiltRule.inject()`.
+
+See the following example of an instrumented test:
+
+```kotlin
+@HiltAndroidTest
+class SettingsScreenTest {
+
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<HiltTestActivity>()
+
+    @Inject
+    lateinit var analyticsAdapter: AnalyticsAdapter
+
+    @Before
+    fun init() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun settingsScreen_showsTitle() {
+        composeRule.setContent {
+            SettingsScreen()
+        }
+        composeRule.onNodeWithText("Settings").assertIsDisplayed()
+        // analyticsRepository is available here.
+    }
+}
+```
+
+#### Replace a binding
+
+If you need to inject a fake or mock instance of a dependency, you need to tell
+Hilt not to use the binding that it used in production code and to use a
+different one instead. To replace a binding, you need to replace the module that
+contains the binding with a test module that contains the bindings that you want
+to use in the test.
+
+For example, suppose your production code declares a binding for
+`AnalyticsService` as follows:
+
+```kotlin
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AnalyticsModule {
+
+  @Singleton
+  @Binds
+  abstract fun bindAnalyticsService(
+    analyticsServiceImpl: AnalyticsServiceImpl
+  ): AnalyticsService
+}
+```
+
+To replace the `AnalyticsService` binding in tests, create a new Hilt module in
+the `test` or `androidTest` folder with the fake dependency and annotate it
+with `@TestInstallIn`. All the tests in that folder are injected with the fake
+dependency instead.
+
+```kotlin
+@Module
+@TestInstallIn(
+    components = [SingletonComponent::class],
+    replaces = [AnalyticsModule::class]
+)
+abstract class FakeAnalyticsModule {
+
+  @Singleton
+  @Binds
+  abstract fun bindAnalyticsService(
+    fakeAnalyticsService: FakeAnalyticsService
+  ): AnalyticsService
+}
+```
+
+Because composables typically consume these dependencies indirectly through a
+ViewModel obtained with `hiltViewModel()`, replacing the binding in Hilt is
+enough. The composable under test picks up the fake automatically.
+
+#### Replace a binding in a single test
+
+To replace a binding in a single test instead of all tests, uninstall a Hilt
+module from a test using the `@UninstallModules` annotation and create a new
+test module inside the test.
+
+Following the `AnalyticsService` example from the previous version, begin by
+telling Hilt to ignore the production module by using the `@UninstallModules`
+annotation in the test class:
+
+```kotlin
+@UninstallModules(AnalyticsModule::class)
+@HiltAndroidTest
+class SettingsScreenTest { ... }
+```
+
+Next, you must replace the binding. Create a new module within the test class
+that defines the test binding:
+
+```kotlin
+@UninstallModules(AnalyticsModule::class)
+@HiltAndroidTest
+class SettingsScreenTest {
+
+  @Module
+  @InstallIn(SingletonComponent::class)
+  abstract class TestModule {
+
+    @Singleton
+    @Binds
+    abstract fun bindAnalyticsService(
+      fakeAnalyticsService: FakeAnalyticsService
+    ): AnalyticsService
+  }
+
+  // ...
+}
+```
+
+This only replaces the binding for a single test class. If you want to replace
+the binding for all test classes, use the `@TestInstallIn` annotation from the
+section above. Alternatively, you can put the test binding in the `test` module
+for Robolectric tests, or in the `androidTest` module for instrumented tests.
+The recommendation is to use `@TestInstallIn` whenever possible.
+
+> [!WARNING]
+> **Warning:** You cannot uninstall modules that are not annotated with `@InstallIn`. Attempting to do so causes a compilation error.
+
+> [!WARNING]
+> **Warning:** `@UninstallModules` can only uninstall `@InstallIn` modules, not `@TestInstallIn` modules. Attempting to do so causes a compilation error.
+
+> [!NOTE]
+> **Note:** As Hilt creates new components for tests that use `@UninstallModules`, it can significantly impact unit test build times. Use it when necessary and prefer using `@TestInstallIn` when the bindings need to be replaced in all test classes.
+
+#### Binding new values
+
+Use the `@BindValue` annotation to easily bind fields in your test into the Hilt
+dependency graph. Annotate a field with `@BindValue` and it will be bound under
+the declared field type with any qualifiers that are present for that field.
+
+In the `AnalyticsService` example, you can replace `AnalyticsService` with a
+fake by using `@BindValue`:
+
+```kotlin
+@UninstallModules(AnalyticsModule::class)
+@HiltAndroidTest
+class SettingsScreenTest {
+
+  @BindValue @JvmField
+  val analyticsService: AnalyticsService = FakeAnalyticsService()
+
+  ...
+}
+```
+
+This simplifies both replacing a binding and referencing a binding in your test
+by allowing you to do both at the same time.
+
+`@BindValue` works with qualifiers and other testing annotations. For example,
+if you use testing libraries such as
+[Mockito](https://site.mockito.org/), you could use it in a
+Robolectric test as follows:
+
+```kotlin
+...
+class SettingsScreenTest {
+  ...
+
+  @BindValue @ExampleQualifier @Mock
+  lateinit var qualifiedVariable: ExampleCustomType
+
+  // Robolectric tests here
+}
+```
+
+If you need to add a [multibinding](https://dagger.dev/dev-guide/multibindings),
+you can use the `@BindValueIntoSet` and `@BindValueIntoMap` annotations in place
+of `@BindValue`. `@BindValueIntoMap` requires you to also annotate the field
+with a map key annotation.
+
+## Special cases
+
+Hilt also provides features to support nonstandard use cases.
+
+### Custom application for tests
+
+If you cannot use `HiltTestApplication` because your test application needs to
+extend another application, annotate a new class or interface with
+`@CustomTestApplication`, passing in the value of the base class you want the
+generated Hilt application to extend.
+
+`@CustomTestApplication` will generate an `Application` class ready for testing
+with Hilt that extends the application you passed as a parameter.
+
+```kotlin
+@CustomTestApplication(BaseApplication::class)
+interface HiltTestApplication
+```
+
+In the example, Hilt generates an `Application` named
+`HiltTestApplication_Application` that extends the `BaseApplication` class. In
+general, the name of the generated application is the name of the annotated
+class appended with `_Application`. You must set the generated Hilt test
+application to run in your [instrumented tests](https://developer.android.com/training/testing/ui-testing) or
+[Robolectric tests](http://robolectric.org/) as described in [Test
+application](https://developer.android.com/training/dependency-injection/hilt-testing#test-application).
+
+> [!NOTE]
+> **Note:** Because `HiltTestApplication_Application` is code that Hilt generates at runtime, the IDE might highlight it in red until you run your tests.
+
+### Multiple TestRule objects in your instrumented test
+
+Compose UI tests already combine `HiltAndroidRule` with a Compose test rule
+such as `createAndroidComposeRule`. If you have additional `TestRule` objects,
+make sure `HiltAndroidRule` runs first. Declare the execution order with the
+`order` attribute on `@Rule`:
+
+```kotlin
+@HiltAndroidTest
+class SettingsScreenTest {
+
+  @get:Rule(order = 0)
+  var hiltRule = HiltAndroidRule(this)
+
+  @get:Rule(order = 1)
+  val composeRule = createAndroidComposeRule<HiltTestActivity>()
+
+  @get:Rule(order = 2)
+  val otherRule = SomeOtherRule()
+
+  // UI tests here.
+}
+```
+
+Alternatively, you can wrap the rules with `RuleChain`, placing
+`HiltAndroidRule` as the outer rule.
+
+```kotlin
+@HiltAndroidTest
+class SettingsScreenTest {
+
+  @get:Rule
+  var rule = RuleChain.outerRule(HiltAndroidRule(this)).
+        around(SettingsScreenTestRule(...))
+
+  // UI tests here.
+}
+```
+
+### Use an entry point before the singleton component is available
+
+The `@EarlyEntryPoint` annotation provides an escape hatch when a Hilt entry
+point needs to be created before the singleton component is available in a
+Hilt test.
+
+More information about `@EarlyEntryPoint` in the
+[Hilt documentation](https://dagger.dev/hilt/early-entry-point).
+
+## Additional resources
+
+To learn more about testing, see the following additional resources:
+
+### Documentation
+
+- [Test your Compose layout](https://developer.android.com/develop/ui/compose/testing)
+- [Testing cheatsheet](https://developer.android.com/develop/ui/compose/testing/testing-cheatsheet)
+
+### Views content
+
+- [Hilt testing guide (Views)](https://developer.android.com/topic/architecture/views/dependency-injection/hilt-testing-views)

--- a/platforms/android/.agents/skills/verified-email/SKILL.md
+++ b/platforms/android/.agents/skills/verified-email/SKILL.md
@@ -1,0 +1,417 @@
+---
+name: verified-email
+description: Provides a complete workflow for implementing verified email retrieval
+  on Android Credential Manager API. Use this skill to integrate a secure, OTP-less
+  email verification flow into an Android app. This skill solves the problem of high-friction
+  sign-up processes by leveraging cryptographically verified credentials from trusted
+  providers like Google.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-07-02'
+  keywords:
+  - implementation
+  - Android
+  - Credential Manager
+  - Digital Credentials
+  - Verified Email
+  - OpenID4VP
+  - SD-JWT
+  - OTP-less
+  - authentication
+  - passkeys
+  - CredMan
+  - identity.
+---
+
+## Fundamentals
+
+- *[Overview of Digital Credentials](references/android/identity/digital-credentials/email-verification.md)*: Learn about cryptographically verifiable documents and the role of Credential Manager.
+- *[Glossary](references/android/identity/digital-credentials/email-verification-implementation.md)* : Definitions for `dcql_query`, `UserInfoCredential`, and `GetDigitalCredentialOption`.
+
+### Standards \& Examples
+
+- *[OpenID4VP Standard](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-introduction)*: The specification used to create digital credentials requests.
+- *[Digital Credentials Demo](https://digital-credentials.dev/)*: Example requests and cross-platform testing tool.
+- *[W3C Verifiable Credentials](https://www.w3.org/TR/vc-data-model-2.0/)*: The data model for cryptographically secured claims.
+- *[SD-JWT](https://datatracker.ietf.org/doc/draft-ietf-oauth-selective-disclosure-jwt/)*: Selective Disclosure JSON Web Token format used for responses.
+- *[mdoc](https://www.iso.org/standard/69084.html)*: ISO/IEC 18013-5 standard for mobile documents.
+
+### Requirements
+
+- **SDK Version**: Minimum SDK 28 (Android 9) is required.
+- **GMS Version**: Google Play services version 25.49.x or higher.
+
+### Use Cases
+
+Email verification is applicable for the following use cases:
+
+- **Account Creation/Sign-up**: Remove friction by skipping manual email verification.
+- **Account Recovery**: Securely verify email ownership during recovery flows.
+- **Re-authentication**: Versatile verification for high-risk actions, independent of the initial sign-in method.
+
+### Limitations \& Nuances
+
+- **Workspace Accounts**: Google does not issue verifiable credentials for Google Workspace Accounts.
+- **Freshness**: For non-@gmail.com addresses, Google verifies the email at account creation but there is no freshness claim; implement an additional challenge like an OTP.
+
+### Scope \& Pre-requisites
+
+**Crucial** : This skill focuses exclusively on the **Android client-side
+integration** . It does **not** implement the app's server-side cryptographic
+validation logic. Server-side validation of the returned credential is required
+for security and must be implemented in your backend.
+
+## Codebase exploration for Use Cases
+
+Get started with the following queries in project source code to find relevant
+screens with different use cases to implement verified email:
+
+- `SignUpScreen`
+- `"Email address"`
+- `"Recover Account"`
+- `"Account Recovery"`
+- `"Forgot password?"`
+- `"Delete Account"`
+
+## Identifying Integration Points
+
+To implement this feature effectively, you must first locate the relevant
+flows in your codebase. To initiate, start with the following strategies to
+cater to different use cases using verified email:
+
+### 1. Search for Navigation Routes
+
+If your app uses Navigation, search for routes or destinations related
+to authentication:
+
+Look for:
+
+- **Keywords** : `signup`, `registration`, `create_account`, `forgot_password`, `recovery`, `verify_email`.
+- **Code Pattern** : Search for `NavHost` or `composable` destinations using these strings.
+
+### 2. Locate Authentication ViewModels
+
+Find the business logic handling user attributes and account creation, account
+recovery:
+
+- **Keywords** : `SignUpViewModel`, `AuthViewModel`, `RegistrationRepository`.
+- **Code Pattern** : Look for methods like `onCreateAccount`, `onRecoverAccount`, or `validateEmail`.
+
+### 3. Find instances of reauthentication for sensitive actions
+
+For reauthentication use cases, find areas where users perform sensitive
+actions:
+
+- **Keywords** : `ChangePassword`, `UpdatePayment`, `DeleteAccount`, `UpdateDetails`, `EditUserDetails`
+
+## Important pointers for Implementation
+
+- Construct a Digital Credential Request and present it to the user.
+- Make sure to follow the request JSON structure as mentioned in [documentation](references/android/identity/digital-credentials/email-verification-implementation.md).
+- While presenting the request to the user, check if result credential is DigitalCredential and credential.credentialJson as responseJsonString
+- Parse the response from the client.
+- Offer a passkey creation option if one is not already present.
+- Assume a local `SdJwtParser` to parse raw SD-JWT and return a `JSONObject`.
+- Use a `VerifiedUserInfo` data class to store the parsed name and email.
+- Leave a TODO for developers to handle the app's server-side validation and parsing.
+- Direct users to the home screen after API call success and show a snackbar with user details for reference purpose only.
+
+This guide describes how to implement verified email retrieval using the
+[Digital Credentials Verifier API](references/android/identity/digital-credentials/credential-verifier.md) through an [OpenID for Verifiable
+Presentations (OpenID4VP)](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html) request.
+
+## Add dependencies
+
+In your app's `build.gradle` file, add the following dependencies for Credential
+Manager:
+
+### Kotlin
+
+```kotlin
+dependencies {
+    implementation("androidx.credentials:credentials:1.7.0-alpha02")
+    implementation("androidx.credentials:credentials-play-services-auth:1.7.0-alpha02")
+}
+```
+
+### Groovy
+
+```groovy
+dependencies {
+    implementation "androidx.credentials:credentials:1.7.0-alpha02"
+    implementation "androidx.credentials:credentials-play-services-auth:1.7.0-alpha02"
+}
+```
+
+## Initialize Credential Manager
+
+Use your app or activity context to create a `CredentialManager` object.
+
+    // Use your app or activity context to instantiate a client instance of
+    // CredentialManager.
+    private val credentialManager = CredentialManager.create(context)
+
+## Construct the Digital Credential request
+
+To request a verified email, construct a [`GetCredentialRequest`](https://developer.android.com/reference/android/credentials/GetCredentialRequest)
+containing a [`GetDigitalCredentialOption`](https://developer.android.com/reference/androidx/credentials/GetDigitalCredentialOption). This option requires a
+`requestJson` string formatted as an OpenID for Verifiable Presentations
+(OpenID4VP) request.
+
+The OpenID4VP request JSON must follow a specific structure. The current
+providers support a JSON structure with an outer `"digital": {"requests":
+[...]}` wrapper.
+
+        val nonce = generateSecureRandomNonce()
+
+        // This request follows the OpenID4VP spec
+        val openId4vpRequest = """
+    {
+      "requests": [
+        {
+          "protocol": "openid4vp-v1-unsigned",
+          "data": {
+            "response_type": "vp_token",
+            "response_mode": "dc_api",
+            "nonce": "$nonce",
+            "dcql_query": {
+              "credentials": [
+                {
+                  "id": "user_info_query",
+                  "format": "dc+sd-jwt",
+                   "meta": { 
+                      "vct_values": ["UserInfoCredential"] 
+                   },
+                  "claims": [ 
+                    {"path": ["email"]}, 
+                    {"path": ["name"]},  
+                    {"path": ["given_name"]},
+                    {"path": ["family_name"]},
+                    {"path": ["picture"]},
+                    {"path": ["hd"]},
+                    {"path": ["email_verified"]}
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+    """
+
+        val getDigitalCredentialOption = GetDigitalCredentialOption(requestJson = openId4vpRequest)
+        val request = GetCredentialRequest(listOf(getDigitalCredentialOption))
+
+The request contains the following key information:
+
+- **DCQL query** : The `dcql_query` specifies the credential type and the
+  claims being requested (`email_verified`). You can request other claims to
+  determine the level of verification. A few possible claims are as follows:
+
+  - `email_verified`: In the response, this is a Boolean that indicates whether the email is verified.
+  - `hd` (hosted domain): In the response, this is empty.
+
+  > [!NOTE]
+  > **Note:** If `email_verified` is `true` and `hd` is empty in the response, it implies that the account is an authorized Google Account. Google does not issue [verifiable credentials](references/android/identity/digital-credentials/index.md) for Google Workspace Accounts. However, the `hd` field is present in verifiable credentials issued for non-workspace accounts. You are encouraged to implement handling this field to future-proof your app. If the email is non-@gmail.com, Google verified this email when the Google Account was created, but there is no freshness claim. Therefore, for non-Google emails, you should consider an additional challenge, such as an OTP, to verify the user. To understand the schema of the credential and the specific rules for validating fields like `email_verified`, refer to the [Google
+  > Identity guides](https://developers.google.com/identity/gsi/web/guides/verify-google-id-token).
+
+- **nonce**: A unique, cryptographically secure random value is generated for
+  each request. This is critical for security, as it prevents replay attacks.
+
+- `UserInfoCredential`: This value implies a specific type of digital
+  credential that contains user attributes. Including this in the request is
+  pivotal to distinguish the email verification use case.
+
+Next, wrap the `openId4vpRequest` JSON in a `GetDigitalCredentialOption`, create
+a `GetCredentialRequest`, and call `getCredential()`.
+
+> [!NOTE]
+> **Note:** The `hd` and `email_verified` fields are hidden from users in Credential Manager's built-in UI. You cannot make a request with only these hidden fields- in case of such requests, the response is the [`GetCredentialCancellationException`](https://developer.android.com/reference/kotlin/androidx/credentials/exceptions/GetCredentialCancellationException).
+
+## Present the request to the user
+
+Present the user with the request, using the Credential Manager built-in UI.
+
+    try {
+        // Requesting Digital Credential from user...
+        val result = credentialManager.getCredential(activity, request)
+
+        when (val credential = result.credential) {
+            is DigitalCredential -> {
+                val responseJsonString = credential.credentialJson
+
+                // Successfully received digital credential response.
+
+                // Next, parse this response and send it to your server.
+                // ...
+            }
+
+            else -> {
+                // handle Unexpected State() - Up to the developer
+            }
+        }
+    } catch (e: Exception) {
+        // handle exceptions - Up to the developer
+    }
+
+> [!NOTE]
+> **Note:** There is no equivalent of Sign in with Google's `preferImmediatelyAvailableCredentials` for Digital Credentials. If no verifiable credential is found (for example, no eligible account on device), the user will be shown a "No options available" or similar system screen.
+
+## Parse the response on the client
+
+After receiving the response, you can perform a preliminary parse on the client.
+This is useful for immediately updating the UI, for example, by showing the
+user's name.
+
+> [!IMPORTANT]
+> **Important:** This step is not for validation. Full cryptographic verification must be performed on your server.
+
+The following code extracts the raw [Selective Disclosure JWT
+(SD-JWT)](https://datatracker.ietf.org/doc/rfc9901/) and uses a helper to decode its claims.
+
+    // 1. Parse the outer JSON wrapper to get the `vp_token`
+    val responseData = JSONObject(responseJsonString)
+    val vpToken = responseData.getJSONObject("vp_token")
+
+    // 2. Extract the raw SD-JWT string
+    val credentialId = vpToken.keys().next()
+    val rawSdJwt = vpToken.getJSONArray(credentialId).getString(0)
+
+    // 3. Use your parser to get the verified claims
+    // Server-side validation/parsing is highly recommended.
+
+    // Assumes a local parser like the one in our SdJwtParser.kt sample
+    val claims = SdJwtParser.parse(rawSdJwt)
+    Log.d("TAG", "Parsed Claims: ${claims.toString(2)}")
+
+    // 4. Create your VerifiedUserInfo object with REAL data
+    val userInfo = VerifiedUserInfo(
+        email = claims.getString("email"),
+        displayName = claims.optString("name", claims.getString("email"))
+    )
+
+## Handle the response
+
+The Credential Manager API will return a [`DigitalCredential`](https://developer.android.com/reference/androidx/credentials/DigitalCredential)
+response.
+
+The following is an example of what the raw `responseJsonString` looks like, and
+what the claims look like after parsing the inner SD-JWT where you get
+additional metadata as well along with verified email:
+
+    /*
+    // Example of the raw JSON response from credential.credentialJson:
+    {
+      "vp_token": {
+        // This key matches the 'id' you set in your dcql_query
+        "user_info_query": [
+          // The SD-JWT string (Issuer JWT ~ Disclosures ~ Key Binding JWT)
+          "eyJhbGciOiJ...~WyI...IiwgImVtYWlsIiwgInVzZXJAZXhhbXBsZS5jb20iXQ~...~eyJhbGciOiJ..."
+        ]
+      }
+    }
+
+    // Example of the parsed and verified claims from the SD-JWT on your server:
+    {
+      "cnf": {
+        "jwk": {..}
+      },
+      "exp": 1775688222,
+      "iat": 1775083422,
+      "iss": "https://verifiablecredentials-pa.googleapis.com",
+      "vct": "UserInfoCredential",
+      "email": "jane.doe.246745@gmail.com",
+      "email_verified": true,
+      "given_name": "Jane",
+      "family_name": "Doe",
+      "name": "Jane Doe",
+      "picture": "http://example.com/janedoe/me.jpg",
+      "hd": ""
+    }
+     */
+
+> [!IMPORTANT]
+> **Important:** We highly recommend that after receiving the verified email, you trigger Credential Manager's [passkey creation](https://developer.android.com/identity/credential-manager/passkeys/create-passkeys).
+
+## Server-side validation for account creation
+
+Since the retrieved email is cryptographically verified, you can omit the email
+OTP verification step, significantly reducing sign-up friction and potentially
+increasing conversion. This process is best handled on your server. The client
+sends the raw response (containing the `vp_token`) and the original nonce to a
+new server endpoint.
+
+For verification, your application must send the full `responseJsonString` to
+your server for cryptographic validation before creating an account or logging
+the user in.
+
+The digital credential provides two critical levels of verification for your
+server:
+
+- **Authenticity of the data** : Verifying the issuer (`iss`) URL and the `SD-JWT` signature proves that a trusted authority issued this data.
+- **Identity of the presenter** : Verifying the `cnf` field and the Key Binding (`kb`) signature confirms that the credential is being shared by the same device it was originally issued to, preventing it from being intercepted or used on another device.
+
+The validation on the server must achieve the following:
+
+- **Verify issuer** : Ensure the `iss` (issuer) field matches `https://verifiablecredentials-pa.googleapis.com`.
+- **Verify signature**: Check the signature of the SD-JWT using the public keys (JWKs) available at https://verifiablecredentials-pa.googleapis.com/.well-known/vc-public-jwks.
+
+> [!NOTE]
+> **Note:** Use a standard library (such as [@sd-jwt/sd-jwt-vc](https://datatracker.ietf.org/doc/rfc9901/) for Node.js) to perform the verification steps as outlined in the [OpenID for Verifiable
+> Presentations specification](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html).
+
+For full security, make sure that you also validate the `nonce` to prevent
+replay attacks.
+
+By combining these steps, your server can validate both the authenticity of the
+data and the identity of the presenter, ensuring the credential wasn't
+intercepted or spoofed before provisioning the new account.
+
+    try {
+        // Send the raw credential response and the original nonce to your server.
+        // Your server must validate the response. createAccountWithVerifiedCredentials
+        // is a custom implementation per each RP for server side verification and account creation.
+        val serverResponse = createAccountWithVerifiedCredentials(responseJsonString, nonce)
+
+        // Server returns the new account info (e.g., email, name)
+        val claims = JSONObject(serverResponse.json)
+
+        val userInfo = VerifiedUserInfo(
+            email = claims.getString("email"),
+            displayName = claims.optString("name", claims.getString("email"))
+        )
+
+        // handle response - Up to the developer
+    } catch (e: Exception) {
+        // handle exceptions - Up to the developer
+    }
+
+## Passkey creation
+
+An optional but highly recommended next step after provisioning an account is to
+immediately [create a passkey](references/android/identity/passkeys/create-passkeys.md) for that account. This provides a secure,
+passwordless method for the user to sign in. This flow is identical to a
+standard passkey registration.
+
+## WebView support
+
+For the flow to work on a [`WebView`](https://developer.android.com/reference/android/webkit/WebView), developers should implement a
+[JavaScript bridge](references/android/identity/sign-in/credential-manager-webview.md) (JS Bridge) to facilitate the handoff. This bridge
+allows the `WebView` object to signal the native app, which can then perform the
+actual call to the Credential Manager API.
+
+## See also
+
+- [Overview of verified email retrieval](references/android/identity/digital-credentials/email-verification.md)
+- [Credential Manager](references/android/identity/credential-manager/index.md)
+
+## Critical Security Guidelines
+
+To maintain the integrity of the email verification flow, the following security
+requirements are mandatory:
+
+- **Server-side Validation** : Never trust claims parsed on the client for security-sensitive operations like account creation. Send the complete, raw `responseJsonString` and the original `nonce` to the app's server for full verification.
+- **Nonce Integrity** : Generate a unique, cryptographically secure nonce for every request and **never** reuse a nonce across multiple requests to prevent replay attacks.
+- **Cryptographic Checks** : The app's server must validate the issuer (`iss`) field, the SD-JWT signature, and the presenter identity using the `cnf` field.

--- a/platforms/android/.agents/skills/verified-email/references/android/identity/credential-manager/index.md
+++ b/platforms/android/.agents/skills/verified-email/references/android/identity/credential-manager/index.md
@@ -1,0 +1,67 @@
+[Credential Manager](https://developer.android.com/reference/kotlin/androidx/credentials/package-summary) is the recommended Jetpack API for credential exchange
+in Android apps. The Credential Manager API streamlines credential exchange
+across form factors for use cases spanning authentication and authorization. You
+can also use Credential Manager to handle digital credentials and restore user
+credentials on new Android devices.
+
+## Credential Manager features
+
+Credential Manager streamlines the sign-in process and enhances security by
+offering a robust set of capabilities, including:
+
+- **Support for various authentication mechanisms** : Enables users to sign up or sign in to your app using:
+  - [Passkeys](https://developer.android.com/identity/passkeys)
+  - [Sign-in with Google](https://developer.android.com/identity/sign-in/credential-manager-siwg) and other federated sign-in mechanisms
+  - [Passwords](https://developer.android.com/identity/passwords)
+  - [Digital credentials](https://developer.android.com/identity/digital-credentials)
+- **Cross-device credential restore** : Provides integration with [Restore
+  Credentials](https://developer.android.com/identity/sign-in/restore-credentials), allowing users to seamlessly start using your app on a new device.
+- **Seamless integration with credential providers** : Offers support for [credential providers](https://developer.android.com/identity/sign-in/credential-provider), including password managers such as Google Password Manager.
+- **Credential management**: Enables updating the metadata for user credentials, helping to keep credentials consistent across your app and credential providers.
+- **WebView compatibility** : Works with apps that use [WebView](https://developer.android.com/identity/sign-in/credential-manager-webview).
+- **Autofill integration** : Integrates with [autofill](https://developer.android.com/identity/autofill/credential-manager-autofill) to display credentials within the autofill UI.
+
+## Benefits of using Credential Manager
+
+Adopting Credential Manager provides several key advantages for both your
+application and your users:
+
+- **Enhanced security**: Passkeys offer enhanced security and protect users from phishing attempts.
+- **Support for various form factors** : The APIs work across Android [form
+  factors](https://developer.android.com/identity/form-factors), including mobile, Android XR, and Wear OS devices.
+- **Simplified authentication across use cases** : [Digital credentials](https://developer.android.com/identity/digital-credentials), such as digital driver's licenses, corporate IDs, and national ID cards, enable authentication across various use cases, including those requiring [phone number verification](https://developer.android.com/identity/digital-credentials/phone-number-verification).
+- **Improved user experience**: Credential Manager's unified interface gives users a familiar and consistent experience and improves registration and sign-in speeds. The bottom sheet UI appears inline to your app's content, so your users remain within your app's context during sign-in. The following image shows Credential Manager's built-in UI:
+
+![The Credential Manager user interface for passkeys, passwords, and federated sign-ins](https://developer.android.com/static/identity/credential-manager/images/credman-ui.png) **Figure 1.**Credential Manager's built-in unified interface for passkeys, passwords, and federated sign-ins
+
+## Authentication terminology
+
+An entity that requires authentication for its users is known as a **relying
+party**. An authentication workflow typically includes the following components:
+
+- **Relying party client app**: The client---in this case, your Android app---that handles the user interface to create and use passkeys.
+- **Relying party server**: An app server that helps with the creation, storage, and verification of passkeys.
+- **Credential provider** : A component that stores and provides user credentials, such as Google Password Manager. Note that the [FIDO documentation](https://fidoalliance.org/passkeys/) refers to credential providers as credential managers.
+
+## Credential storage
+
+Credential providers, such as Google Password Manager, provide a centralized and
+secure location for users to manage credentials across their devices, further
+simplifying the authentication process. To integrate with Credential Manager as
+a credential provider, see
+[Implement authentication as a credential provider](https://developer.android.com/identity/sign-in/credential-provider).
+
+For more information about how Google Password Manager keeps your credentials
+secure, see
+[Security of Passkeys in the Google Password Manager](https://security.googleblog.com/2022/10/SecurityofPasskeysintheGooglePasswordManager.html).
+
+## Migrate to Credential Manager
+
+Credential Manager is intended to replace legacy Android authentication APIs and
+local FIDO2 credentials. For more information about migrating to Credential
+Manager, see the following guides:
+
+- [Google Sign-In](https://developer.android.com/identity/sign-in/legacy-gsi-migration)
+- [One Tap](https://developer.android.com/identity/legacy/one-tap)
+- [Smart Lock for Passwords](https://developer.android.com/identity/sign-in/smart-lock-migration)
+- [FIDO2](https://developer.android.com/identity/sign-in/fido2-migration)

--- a/platforms/android/.agents/skills/verified-email/references/android/identity/digital-credentials/credential-verifier.md
+++ b/platforms/android/.agents/skills/verified-email/references/android/identity/digital-credentials/credential-verifier.md
@@ -1,0 +1,166 @@
+Digital credential verification within Android apps can be used to authenticate
+and authorize a user's identity (such as a government ID), properties about that
+user (such as a driver's license, academic degree, or attributes such as age or
+address), or other scenarios where a credential needs to be issued and verified
+to assert the authenticity of an entity.
+
+Digital Credentials is a public W3C standard that specifies how to access a
+user's verifiable digital credentials from a digital wallet, and is implemented
+for web use cases with the [W3C Credential Management API](https://www.w3.org/TR/credential-management-1/). On
+Android, Credential Manager's [`DigitalCredential`](https://developer.android.com/reference/kotlin/androidx/credentials/DigitalCredential) API is used for
+verifying digital credentials.
+
+### Android version compatibility
+
+The Verifier API is supported on Android 9 (API level 28) and higher.
+
+### Implementation
+
+To verify digital credentials in your Android project, do the following:
+
+1. Add dependencies to your app's build script and initialize a `CredentialManager` class.
+2. Construct a digital credential request and use it to initialize a `DigitalCredentialOption`, followed by building the `GetCredentialRequest`.
+3. Launch the `getCredential` flow with the constructed request to receive a successful `GetCredentialResponse` or handle any exceptions that may occur. Upon successful retrieval, validate the response.
+
+#### Add dependencies and initialize
+
+Add the following dependencies to your Gradle build script:
+
+    dependencies {
+        implementation("androidx.credentials:credentials:1.6.0-beta01")
+        implementation("androidx.credentials:credentials-play-services-auth:1.6.0-beta01")
+    }
+
+Next, Initialize an instance of the `CredentialManager` class.
+
+    val credentialManager = CredentialManager.create(context)
+
+#### Construct a digital credential request
+
+Construct a digital credential request and use it to initialize a
+`DigitalCredentialOption`.
+
+    // The request in the JSON format to conform with
+    // the JSON-ified Credential Manager - Verifier API request definition.
+    val requestJson = generateRequestFromServer()
+    val digitalCredentialOption =
+        GetDigitalCredentialOption(requestJson = requestJson)
+
+    // Use the option from the previous step to build the `GetCredentialRequest`.
+    val getCredRequest = GetCredentialRequest(
+        listOf(digitalCredentialOption)
+    )
+
+Here is an example of an OpenId4Vp request. A full reference can be found at
+this [website](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html).
+
+    {
+      "requests": [
+        {
+          "protocol": "openid4vp-v1-unsigned",
+          "data": {
+            "response_type": "vp_token",
+            "response_mode": "dc_api",
+            "nonce": "OD8eP8BYfr0zyhgq4QCVEGN3m7C1Ht_No9H5fG5KJFk",
+            "dcql_query": {
+              "credentials": [
+                {
+                  "id": "cred1",
+                  "format": "mso_mdoc",
+                  "meta": {
+                    "doctype_value": "org.iso.18013.5.1.mDL"
+                  },
+                  "claims": [
+                    {
+                      "path": [
+                        "org.iso.18013.5.1",
+                        "family_name"
+                      ]
+                    },
+                    {
+                      "path": [
+                        "org.iso.18013.5.1",
+                        "given_name"
+                      ]
+                    },
+                    {
+                      "path": [
+                        "org.iso.18013.5.1",
+                        "age_over_21"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+
+#### Get the credential
+
+Launch the `getCredential` flow with the constructed request. You will receive
+either a successful `GetCredentialResponse`, or a `GetCredentialException` if
+the request fails.
+
+The `getCredential` flow triggers Android system dialogs to present the user's
+available credential options and collect their selection. Next, the wallet app
+that contains the chosen credential option will display UIs to collect consent
+and perform actions needed to generate a digital credential response.
+
+    coroutineScope.launch {
+        try {
+            val result = credentialManager.getCredential(
+                context = activityContext,
+                request = getCredRequest
+            )
+            verifyResult(result)
+        } catch (e : GetCredentialException) {
+            handleFailure(e)
+        }
+    }
+
+    // Handle the successfully returned credential.
+    fun verifyResult(result: GetCredentialResponse) {
+        val credential = result.credential
+        when (credential) {
+            is DigitalCredential -> {
+                val responseJson = credential.credentialJson
+                validateResponseOnServer(responseJson)
+            }
+            else -> {
+                // Catch any unrecognized credential type here.
+                Log.e(TAG, "Unexpected type of credential ${credential.type}")
+            }
+        }
+    }
+
+    // Handle failure.
+    fun handleFailure(e: GetCredentialException) {
+      when (e) {
+            is GetCredentialCancellationException -> {
+                // The user intentionally canceled the operation and chose not
+                // to share the credential.
+            }
+            is GetCredentialInterruptedException -> {
+                // Retry-able error. Consider retrying the call.
+            }
+            is NoCredentialException -> {
+                // No credential was available.
+            }
+            is CreateCredentialUnknownException -> {
+                // An unknown, usually unexpected, error has occurred. Check the
+                // message error for any additional debugging information.
+            }
+            is CreateCredentialCustomException -> {
+                // You have encountered a custom error thrown by the wallet.
+                // If you made the API call with a request object that's a
+                // subclass of CreateCustomCredentialRequest using a 3rd-party SDK,
+                // then you should check for any custom exception type constants
+                // within that SDK to match with e.type. Otherwise, drop or log the
+                // exception.
+            }
+            else -> Log.w(TAG, "Unexpected exception type ${e::class.java}")
+        }
+    }

--- a/platforms/android/.agents/skills/verified-email/references/android/identity/digital-credentials/email-verification-implementation.md
+++ b/platforms/android/.agents/skills/verified-email/references/android/identity/digital-credentials/email-verification-implementation.md
@@ -1,0 +1,293 @@
+> [!IMPORTANT]
+> **Important:** We released an agent skill to help you implement email verification with the Digital Credentials API. Try out the skill from the [Android skills
+> repository](https://github.com/android/skills).
+
+This guide describes how to implement verified email retrieval using the
+[Digital Credentials Verifier API](https://developer.android.com/identity/digital-credentials/credential-verifier) through an [OpenID for Verifiable
+Presentations (OpenID4VP)](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html) request.
+
+## Add dependencies
+
+In your app's `build.gradle` file, add the following dependencies for Credential
+Manager:
+
+### Kotlin
+
+```kotlin
+dependencies {
+    implementation("androidx.credentials:credentials:1.7.0-alpha02")
+    implementation("androidx.credentials:credentials-play-services-auth:1.7.0-alpha02")
+}
+```
+
+### Groovy
+
+```groovy
+dependencies {
+    implementation "androidx.credentials:credentials:1.7.0-alpha02"
+    implementation "androidx.credentials:credentials-play-services-auth:1.7.0-alpha02"
+}
+```
+
+## Initialize Credential Manager
+
+Use your app or activity context to create a `CredentialManager` object.
+
+    // Use your app or activity context to instantiate a client instance of
+    // CredentialManager.
+    private val credentialManager = CredentialManager.create(context)
+
+## Construct the Digital Credential request
+
+To request a verified email, construct a [`GetCredentialRequest`](https://developer.android.com/reference/android/credentials/GetCredentialRequest)
+containing a [`GetDigitalCredentialOption`](https://developer.android.com/reference/androidx/credentials/GetDigitalCredentialOption). This option requires a
+`requestJson` string formatted as an OpenID for Verifiable Presentations
+(OpenID4VP) request.
+
+The OpenID4VP request JSON must follow a specific structure. The current
+providers support a JSON structure with an outer `"digital": {"requests":
+[...]}` wrapper.
+
+        val nonce = generateSecureRandomNonce()
+
+        // This request follows the OpenID4VP spec
+        val openId4vpRequest = """
+    {
+      "requests": [
+        {
+          "protocol": "openid4vp-v1-unsigned",
+          "data": {
+            "response_type": "vp_token",
+            "response_mode": "dc_api",
+            "nonce": "$nonce",
+            "dcql_query": {
+              "credentials": [
+                {
+                  "id": "user_info_query",
+                  "format": "dc+sd-jwt",
+                   "meta": { 
+                      "vct_values": ["UserInfoCredential"] 
+                   },
+                  "claims": [ 
+                    {"path": ["email"]}, 
+                    {"path": ["name"]},  
+                    {"path": ["given_name"]},
+                    {"path": ["family_name"]},
+                    {"path": ["picture"]},
+                    {"path": ["hd"]},
+                    {"path": ["email_verified"]}
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+    """
+
+        val getDigitalCredentialOption = GetDigitalCredentialOption(requestJson = openId4vpRequest)
+        val request = GetCredentialRequest(listOf(getDigitalCredentialOption))
+
+The request contains the following key information:
+
+- **DCQL query** : The `dcql_query` specifies the credential type and the
+  claims being requested (`email_verified`). You can request other claims to
+  determine the level of verification. A few possible claims are as follows:
+
+  - `email_verified`: In the response, this is a Boolean that indicates whether the email is verified.
+  - `hd` (hosted domain): In the response, this is empty.
+
+  > [!NOTE]
+  > **Note:** If `email_verified` is `true` and `hd` is empty in the response, it implies that the account is an authorized Google Account. Google does not issue [verifiable credentials](https://developer.android.com/identity/digital-credentials#verifiable-credentials) for Google Workspace Accounts. However, the `hd` field is present in verifiable credentials issued for non-workspace accounts. You are encouraged to implement handling this field to future-proof your app. If the email is non-@gmail.com, Google verified this email when the Google Account was created, but there is no freshness claim. Therefore, for non-Google emails, you should consider an additional challenge, such as an OTP, to verify the user. To understand the schema of the credential and the specific rules for validating fields like `email_verified`, refer to the [Google
+  > Identity guides](https://developers.google.com/identity/gsi/web/guides/verify-google-id-token).
+
+- **nonce**: A unique, cryptographically secure random value is generated for
+  each request. This is critical for security, as it prevents replay attacks.
+
+- `UserInfoCredential`: This value implies a specific type of digital
+  credential that contains user attributes. Including this in the request is
+  pivotal to distinguish the email verification use case.
+
+Next, wrap the `openId4vpRequest` JSON in a `GetDigitalCredentialOption`, create
+a `GetCredentialRequest`, and call `getCredential()`.
+
+> [!NOTE]
+> **Note:** The `hd` and `email_verified` fields are hidden from users in Credential Manager's built-in UI. You cannot make a request with only these hidden fields- in case of such requests, the response is the [`GetCredentialCancellationException`](https://developer.android.com/reference/kotlin/androidx/credentials/exceptions/GetCredentialCancellationException).
+
+## Present the request to the user
+
+Present the user with the request, using the Credential Manager built-in UI.
+
+    try {
+        // Requesting Digital Credential from user...
+        val result = credentialManager.getCredential(activity, request)
+
+        when (val credential = result.credential) {
+            is DigitalCredential -> {
+                val responseJsonString = credential.credentialJson
+
+                // Successfully received digital credential response.
+
+                // Next, parse this response and send it to your server.
+                // ...
+            }
+
+            else -> {
+                // handle Unexpected State() - Up to the developer
+            }
+        }
+    } catch (e: Exception) {
+        // handle exceptions - Up to the developer
+    }
+
+> [!NOTE]
+> **Note:** There is no equivalent of Sign in with Google's `preferImmediatelyAvailableCredentials` for Digital Credentials. If no verifiable credential is found (for example, no eligible account on device), the user will be shown a "No options available" or similar system screen.
+
+## Parse the response on the client
+
+After receiving the response, you can perform a preliminary parse on the client.
+This is useful for immediately updating the UI, for example, by showing the
+user's name.
+
+> [!IMPORTANT]
+> **Important:** This step is not for validation. Full cryptographic verification must be performed on your server.
+
+The following code extracts the raw [Selective Disclosure JWT
+(SD-JWT)](https://datatracker.ietf.org/doc/rfc9901/) and uses a helper to decode its claims.
+
+    // 1. Parse the outer JSON wrapper to get the `vp_token`
+    val responseData = JSONObject(responseJsonString)
+    val vpToken = responseData.getJSONObject("vp_token")
+
+    // 2. Extract the raw SD-JWT string
+    val credentialId = vpToken.keys().next()
+    val rawSdJwt = vpToken.getJSONArray(credentialId).getString(0)
+
+    // 3. Use your parser to get the verified claims
+    // Server-side validation/parsing is highly recommended.
+
+    // Assumes a local parser like the one in our SdJwtParser.kt sample
+    val claims = SdJwtParser.parse(rawSdJwt)
+    Log.d("TAG", "Parsed Claims: ${claims.toString(2)}")
+
+    // 4. Create your VerifiedUserInfo object with REAL data
+    val userInfo = VerifiedUserInfo(
+        email = claims.getString("email"),
+        displayName = claims.optString("name", claims.getString("email"))
+    )
+
+## Handle the response
+
+The Credential Manager API will return a [`DigitalCredential`](https://developer.android.com/reference/androidx/credentials/DigitalCredential)
+response.
+
+The following is an example of what the raw `responseJsonString` looks like, and
+what the claims look like after parsing the inner SD-JWT where you get
+additional metadata as well along with verified email:
+
+    /*
+    // Example of the raw JSON response from credential.credentialJson:
+    {
+      "vp_token": {
+        // This key matches the 'id' you set in your dcql_query
+        "user_info_query": [
+          // The SD-JWT string (Issuer JWT ~ Disclosures ~ Key Binding JWT)
+          "eyJhbGciOiJ...~WyI...IiwgImVtYWlsIiwgInVzZXJAZXhhbXBsZS5jb20iXQ~...~eyJhbGciOiJ..."
+        ]
+      }
+    }
+
+    // Example of the parsed and verified claims from the SD-JWT on your server:
+    {
+      "cnf": {
+        "jwk": {..}
+      },
+      "exp": 1775688222,
+      "iat": 1775083422,
+      "iss": "https://verifiablecredentials-pa.googleapis.com",
+      "vct": "UserInfoCredential",
+      "email": "jane.doe.246745@gmail.com",
+      "email_verified": true,
+      "given_name": "Jane",
+      "family_name": "Doe",
+      "name": "Jane Doe",
+      "picture": "http://example.com/janedoe/me.jpg",
+      "hd": ""
+    }
+     */
+
+> [!IMPORTANT]
+> **Important:** We highly recommend that after receiving the verified email, you trigger Credential Manager's [passkey creation](https://developer.android.com/identity/credential-manager/passkeys/create-passkeys).
+
+## Server-side validation for account creation
+
+Since the retrieved email is cryptographically verified, you can omit the email
+OTP verification step, significantly reducing sign-up friction and potentially
+increasing conversion. This process is best handled on your server. The client
+sends the raw response (containing the `vp_token`) and the original nonce to a
+new server endpoint.
+
+For verification, your application must send the full `responseJsonString` to
+your server for cryptographic validation before creating an account or logging
+the user in.
+
+The digital credential provides two critical levels of verification for your
+server:
+
+- **Authenticity of the data** : Verifying the issuer (`iss`) URL and the `SD-JWT` signature proves that a trusted authority issued this data.
+- **Identity of the presenter** : Verifying the `cnf` field and the Key Binding (`kb`) signature confirms that the credential is being shared by the same device it was originally issued to, preventing it from being intercepted or used on another device.
+
+The validation on the server must achieve the following:
+
+- **Verify issuer** : Ensure the `iss` (issuer) field matches `https://verifiablecredentials-pa.googleapis.com`.
+- **Verify signature**: Check the signature of the SD-JWT using the public keys (JWKs) available at https://verifiablecredentials-pa.googleapis.com/.well-known/vc-public-jwks.
+
+> [!NOTE]
+> **Note:** Use a standard library (such as [@sd-jwt/sd-jwt-vc](https://datatracker.ietf.org/doc/rfc9901/) for Node.js) to perform the verification steps as outlined in the [OpenID for Verifiable
+> Presentations specification](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html).
+
+For full security, make sure that you also validate the `nonce` to prevent
+replay attacks.
+
+By combining these steps, your server can validate both the authenticity of the
+data and the identity of the presenter, ensuring the credential wasn't
+intercepted or spoofed before provisioning the new account.
+
+    try {
+        // Send the raw credential response and the original nonce to your server.
+        // Your server must validate the response. createAccountWithVerifiedCredentials
+        // is a custom implementation per each RP for server side verification and account creation.
+        val serverResponse = createAccountWithVerifiedCredentials(responseJsonString, nonce)
+
+        // Server returns the new account info (e.g., email, name)
+        val claims = JSONObject(serverResponse.json)
+
+        val userInfo = VerifiedUserInfo(
+            email = claims.getString("email"),
+            displayName = claims.optString("name", claims.getString("email"))
+        )
+
+        // handle response - Up to the developer
+    } catch (e: Exception) {
+        // handle exceptions - Up to the developer
+    }
+
+## Passkey creation
+
+An optional but highly recommended next step after provisioning an account is to
+immediately [create a passkey](https://developer.android.com/identity/passkeys/create-passkeys) for that account. This provides a secure,
+passwordless method for the user to sign in. This flow is identical to a
+standard passkey registration.
+
+## WebView support
+
+For the flow to work on a [`WebView`](https://developer.android.com/reference/android/webkit/WebView), developers should implement a
+[JavaScript bridge](https://developer.android.com/identity/sign-in/credential-manager-webview) (JS Bridge) to facilitate the handoff. This bridge
+allows the `WebView` object to signal the native app, which can then perform the
+actual call to the Credential Manager API.
+
+## See also
+
+- [Overview of verified email retrieval](https://developer.android.com/identity/digital-credentials/email-verification)
+- [Credential Manager](https://developer.android.com/identity/credential-manager)

--- a/platforms/android/.agents/skills/verified-email/references/android/identity/digital-credentials/email-verification.md
+++ b/platforms/android/.agents/skills/verified-email/references/android/identity/digital-credentials/email-verification.md
@@ -1,0 +1,145 @@
+This document describes using Credential Manager to get a cryptographically
+verified email address from a user's device. This process removes the need for
+your app users to verify their email with one-time passwords (OTPs) or magic
+links.
+
+This document explains the following areas:
+
+- Android compatibility
+- User experience
+- Accounts supported
+- Implication of email deliverability
+- Comparison with [Sign in with Google](https://developer.android.com/identity/sign-in/credential-manager-siwg)
+
+This guide assumes you are familiar with the following concepts:
+
+- [Credential Manager](https://developer.android.com/identity/credential-manager)
+- [Digital Credentials](https://developer.android.com/identity/digital-credentials)
+- [Verifiable Credentials](https://developer.android.com/identity/digital-credentials#verifiable-credentials)
+
+## Android compatibility
+
+This feature is supported on mobiles, tablets, and foldable devices running
+Android 9 (API level 28) and higher. The minimum version of Google Play services
+(GMS) required is 25.49.x.
+
+## User experience
+
+The following sections describe the user experience during the verification
+flow, the need to include fallback verification methods, as well as the
+recommended user experience for various use cases.
+
+### The verification flow
+
+The user experience for sharing a verified email is as follows:
+
+1. The user either focuses on an input field or taps a button that calls the
+   Credential Manager API. Depending on the design of the screen, you can also
+   call the API on your app's screen load.
+
+2. A bottom sheet appears, showing the information that will be shared with the
+   app. If no information is available on that device, the user sees a generic
+   error message.
+
+3. After the user taps **Agree and Continue**, display a success or failure
+   message.
+
+   > [!NOTE]
+   > **Note:** If the verified email you receive does not match what you expect, inform the user about the mismatch and either ask them to try again with a different credential or provide an alternate verification method, such as through OTPs.
+
+4. (Optional, recommended) If the user is signing up for your service, you
+   should prompt the user to [create](https://developer.android.com/identity/passkeys/create-passkeys) a [passkey](https://developer.android.com/identity/passkeys) to make it easier for
+   them to sign in subsequently.
+
+   > [!NOTE]
+   > **Note:** The email verification process doesn't automatically trigger passkey creation. However, it is highly recommended to include the steps for passkey creation. Passkeys help users by making it easier and more secure for them to sign in, and remove the need for the conventional username and password interaction.
+
+### Include primary and fallback flows
+
+To ensure a streamlined user experience, include the following options on
+screens that require email verification:
+
+- **Primary verification option**: An email field or button to trigger the Credential Manager API flow for quick verification.
+- **Alternate verification options**: A link or button for users to "Verify another way" or with "Other options" for manual email entry in case of failures, such as no information available on the device, or a mismatch between the retrieved and expected email. This should allow users to try verification with a different credential or by providing a manual OTP.
+
+### Use cases
+
+The following sections describe the recommended use cases, as well as the
+suggested user experience, for email verification.
+
+#### Sign up
+
+Users can immediately create an account with a verified email without a separate
+verification step. Optionally, prompt the user to add a passkey. If they opt to
+add a passkey, trigger the [passkey creation](https://developer.android.com/identity/passkeys/create-passkeys) flow.
+![Using email verification during sign up, and then creating passkeys](https://developer.android.com/static/identity/digital-credentials/images/signup_ux.png) Email verification during sign up
+
+#### Account recovery
+
+To eliminate the frustration of users searching for recovery codes in their spam
+folders, allow them to recover their account using the verified email securely
+stored on their device. Additionally, suggest that they create a passkey for
+future use.
+![Using email verification during account recovery](https://developer.android.com/static/identity/digital-credentials/images/account_recovery_ux.png) Email verification during account recovery
+
+#### Reauthentication for sensitive actions
+
+Protect sensitive user actions, such as changing settings or updating profile
+details, by requiring a quick reauthentication step.
+![Using email verification during reauthentication](https://developer.android.com/static/identity/digital-credentials/images/reauthentication_ux.png) Email verification during reauthentication
+
+## Accounts supported
+
+Email verification through Credential Manager only supports verification of
+consumer Google Accounts. [Workspace accounts](https://knowledge.workspace.google.com/admin/getting-started/set-up-google-workspace-for-your-organization) and [supervised
+accounts](https://support.google.com/families/answer/9499054) are not supported.
+
+A consumer Google Account can be created with an email address from any
+provider, not necessarily @gmail.com. However, Google verifies these accounts
+differently:
+
+- For @gmail.com accounts: Google is the authoritative source, and the email is known to be verified.
+- For non-@gmail.com accounts: Google is not the authoritative source for these email addresses in the long term. While Google verifies the email when the account is created, the ownership of that email address might change over time. Therefore, for non-@gmail.com addresses, you should consider an additional verification step, such as sending an OTP, to ensure that the user still has access to the email account.
+
+For more information about what verification implies, see [Digital
+Credentials](https://developer.android.com/identity/digital-credentials#verified).
+
+> [!NOTE]
+> **Note:** Apart from a user's email information, you can request other unverified fields, such as the user's given name, family name, name, and the profile picture of their Google Account. However, only the email is verified by Google.   
+> For phone number verification, see [Verify phone numbers with digital credentials](https://developer.android.com/identity/digital-credentials/phone-number-verification). For a Firebase solution, see [Firebase Phone Number Verification](https://firebase.google.com/docs/phone-number-verification). Note that you can't verify a phone number and email in the same invocation as these are separate capabilities.
+
+## Validity and freshness
+
+The system issues [verifiable credentials](https://developer.android.com/identity/digital-credentials#verified) (VCs) based on the user's current
+email from the active Google Accounts on the device. These credentials are
+issued to the device in advance, typically while the device is idle. While these
+credentials might remain valid for multiple days, the system performs a check at
+the moment of sharing the credentials to ensure that the account still exists,
+is on the device, and that the email address is valid---effectively prioritizing
+the account's immediate status over the credential's validity window.
+
+To help ensure authenticity, a Key Binding (kb) signature is generated at the
+time of sharing, incorporating the nonce.
+
+If a device is offline or the account is removed, the process fails rather than
+providing an expired VC or a VC for an inactive Google Account.
+
+### Email deliverability
+
+While the process confirms the account's legitimacy, it does not guarantee inbox
+delivery (for instance, the email might be diverted to spam). An OTP remains the
+definitive method for confirming email deliverability.
+
+## Comparison with Sign in with Google
+
+While both Digital Credentials and [Sign in with Google](https://developer.android.com/identity/sign-in/credential-manager-siwg) solutions provide a
+verified email, the user flows and use cases are different:
+
+- **Use cases**: The Credential Manager email verification flow is not exclusively used in sign up or sign in use cases, but rather can be used in any use case involving the retrieval of verified email. This could include account recovery as well.
+- **Registration**: The Credential Manager flow does not require Google registration, unlike Sign in with Google.
+- **Platform support**: The Credential Manager flow is an Android-only solution.
+- **Scopes** : Unlike Sign in with Google, which can use OAuth 2.0 to request access to user data (such as Calendar or Drive through scopes), the Digital Credentials API is strictly for retrieving verified identity attributes. It cannot be used to request additional [authorization scopes](https://developers.google.com/identity/protocols/oauth2/scopes).
+
+## Next steps
+
+To implement this feature in your app, see the [Implementation guide](https://developer.android.com/identity/digital-credentials/email-verification-implementation).

--- a/platforms/android/.agents/skills/verified-email/references/android/identity/digital-credentials/index.md
+++ b/platforms/android/.agents/skills/verified-email/references/android/identity/digital-credentials/index.md
@@ -1,0 +1,96 @@
+Digital credentials are cryptographically verifiable documents that can be used
+to authenticate, authorize, or otherwise provide information about a user. These
+are typically things such as mobile driver's licenses, digital passports,
+boarding passes, etc. They reside in virtual containers called digital wallets,
+and are part of a W3C standard that specifies how to access and retrieve them.
+This standard is implemented for web use cases with the [W3C Credential
+Management API](https://www.w3.org/TR/credential-management-1/) and on Android, with Credential Manager's
+[DigitalCredential API](https://developer.android.com/reference/kotlin/androidx/credentials/DigitalCredential).
+
+## Understand digital credentials
+
+In the physical world, a person might keep their identity in their wallet, and
+present it to a requesting party when asked:
+![Image showing the flow of a normal wallet interaction](https://developer.android.com/static/identity/digital-credentials/images/normal_wallet_flowchart.svg) **Figure 1.** The process of fulfilling a physical-world credential request. The requestor asks the user for a specific credential. Then, the user selects and retrieves it from their physical wallet. Finally, the user provides the credential to the requestor.
+
+In this case, a user generally has a single wallet, and retrieves the requested
+credentials from the wallet to present to the requestor. Wallets are mostly
+interchangeable, and can generally store the same things.
+
+Digital credentials have the following differences from credentials in the
+physical world:
+
+1. Users are expected to have multiple wallets - also known as **holders** - which can contain various different credentials. Wallets determine which credentials may be stored inside of them.
+2. The app or service asking for the credential to grant access or verify an identity is called the **verifier**.
+3. The entity that creates the credential and asserts claims about the subject (such as, a university, a government, or a tech company) is referred to as the **issuer**.
+4. The credential presentation happens in software, which means an API surface retrieves and presents the credentials - in Android, this is Credential Manager.
+
+As such, Credential Manager takes on several roles that were formerly handled by
+the user:
+
+1. On Android, wallets must register their credentials metadata with Credential Manager to be listed in the Credential Manager UI.
+2. Credential Manager matches credentials across wallets based on the request and presents a list for the user to select.
+3. When the user selects a credential in the list, Credential Manager then invokes the wallet, which will handle the remainder of the transaction (showing UIs, etc.) and return the credential to the application.
+
+This flow is shown here:
+![Image showing the flow of a digital credential interaction](https://developer.android.com/static/identity/digital-credentials/images/digital_credentials_flowchart.svg) **Figure 2.** Interaction model for digital credential verification. Credential Manager uses pre-registered credentials metadata across user wallet(s) to match a verifier's request and prompts the user to select a credential. Credential Manager then directs the activity flow to the corresponding wallet which handles the remainder of the transaction and returns the credential to the verifier. Note: The verifier needs to handle and verify the credential response once it is returned.
+
+## Verifiable credentials
+
+Verifiable credentials are a subset of digital credentials governed by strict
+standards (like the W3C Verifiable Credentials Data Model). These credentials
+contain claims that are cryptographically secured, making them tamper-evident
+and proving exactly who issued them.
+
+Not all digital credentials are verifiable credentials, but all verifiable
+credentials are digital credentials.
+
+## What it means for a claim to be verified
+
+When a credential arrives through the Android Credential Manager API and a claim
+within it is marked as "verified," it implies that the issuer is asserting that
+they performed a check on that specific piece of data. However, it does not mean
+the data is an absolute, universal truth. "Verified" is an assertion of process,
+not an automatic guarantee of trust.
+
+The core philosophy of this ecosystem is that trust is always resolved at the
+verifier. When the verifier (your app) receives the cryptographically secure
+data, and sees that the issuer marked it as "verified," it must determine
+whether it trusts the issuer to have verified the claim to its standards.
+
+### User experience
+
+As shown in the Android flow, the user only needs to interact once with the
+Credential Manager UI to select the appropriate credential. Here is an example
+of how the selector looks:
+![Image showing the digital credentials UI in Credential Manager](https://developer.android.com/static/identity/digital-credentials/images/digital_credentials_ui.png) **Figure 3.** The digital credentials UI.
+
+### Standards
+
+Digital credentials requests are created using the [OpenID4VP
+standard](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-introduction). You can see example requests at the [Digital
+Credentials Demo site](https://digital-credentials.dev/).
+
+Digital credential responses are typically returned in a standardized credential
+format. These are maintained by different standards bodies, and include [W3C
+Verifiable Credentials](https://www.w3.org/TR/vc-data-model-2.0/), [sd-jwt](https://datatracker.ietf.org/doc/draft-ietf-oauth-selective-disclosure-jwt/), and
+[mdoc](https://www.iso.org/standard/69084.html).
+
+Custom protocols are also feasible, though we recommend using one of the
+standard protocols in your application.
+
+### Try it out
+
+You can test out the digital credentials flow across platforms with an Android
+wallet and web-based verifier:
+
+1. Install the [CMWallet public sample](https://github.com/digitalcredentialsdev/CMWallet) on your Android phone. You can do this by pulling from the repository and installing directly from Android Studio or navigating to <https://github.com/digitalcredentialsdev/CMWallet/actions> and selecting the latest build to access the latest `app-debug.apk` file.
+2. Open the CMWallet to register the metadata with Credential Manager. Make sure Bluetooth is enabled to allow your devices to connect to each other.
+3. Navigate to <https://digital-credentials.dev/> and select `Request Credentials (OpenID4VP)`.
+4. Accept the warning prompts and scan the QR Code with your phone, then select "Use passkey" and tap through the confirmation to show the available credentials.
+5. Select the credential from CMWallet to return to the browser. The browser should show the returned credential.
+
+### See also
+
+- To learn more about using Credential Manager to request digital credentials in your app, read the [Credential Manager - Verifier API](https://developer.android.com/identity/digital-credentials/credential-verifier) page.
+- To learn more about building a digital wallet using Credential Manager, read the [Credential Manager - Holder API](https://developer.android.com/identity/digital-credentials/credential-holder) page.

--- a/platforms/android/.agents/skills/verified-email/references/android/identity/passkeys/create-passkeys.md
+++ b/platforms/android/.agents/skills/verified-email/references/android/identity/passkeys/create-passkeys.md
@@ -1,0 +1,327 @@
+Before your users can authenticate with passkeys, your app must first register
+or create the passkey for their account.
+
+To create the passkey, obtain details required to create the passkey from your
+app server, and then call the Credential Manager API, which returns a public and
+private key pair. The returned private key is stored in a credential provider,
+such as Google Password Manager, as a passkey. The public key is stored on your
+app server.
+
+> [!TIP]
+> **Tip:** While designing authentication flows with passkeys, make sure that you follow the [UX guidelines for passkeys](https://developer.android.com/design/ui/mobile/guides/patterns/passkeys).
+
+![Passkeys are stored in a credential provider and public keys are stored on the app server](https://developer.android.com/static/identity/passkeys/images/create-passkeys.png) **Figure 1:**Creation of passkeys
+
+## Prerequisites
+
+Make sure that you have set up [Digital Asset Links](https://developer.android.com/identity/credential-manager/prerequisites) and that you target
+devices running Android 9 (API level 28) or higher.
+
+## Overview
+
+This guide focuses on the changes required in your [relying party client app](https://developer.android.com/identity/credential-manager#authentication-terminology)
+to create a passkey, and gives a brief overview of the [relying party app
+server](https://developer.android.com/identity/credential-manager#authentication-terminology) implementation. To learn more about the server-side integration, see
+[Server-side passkey registration](https://developers.google.com/identity/passkeys/developer-guides/server-registration).
+
+1. [**Add dependencies to your app**](https://developer.android.com/identity/passkeys/create-passkeys#add-dependencies): Add the required Credential Manager libraries.
+2. [**Instantiate Credential Manager**](https://developer.android.com/identity/passkeys/create-passkeys#instantiate): Create a Credential Manager instance.
+3. [**Get credential creation options from the app server**](https://developer.android.com/identity/passkeys/create-passkeys#get-options): From your app server, send the client app the details required to create the passkey, such as information about the app, the user, as well as a `challenge` and other fields.
+4. [**Request a passkey**](https://developer.android.com/identity/passkeys/create-passkeys#request-passkey): In your app, use the details received from the app server to create a [`GetPublicKeyCredentialOption`](https://developer.android.com/reference/androidx/credentials/GetPublicKeyCredentialOption) object and use this object to invoke the `credentialManager.getCredential()` method to create a passkey.
+5. [**Handle the passkey creation response**](https://developer.android.com/identity/passkeys/create-passkeys#handle-response): When you receive the credentials on your client app, you must encode, serialize and then send the public key to the app server. You must also handle each of the exceptions that can occur in case of passkey creation.
+6. [**Verify and save the public key on the server**](https://developer.android.com/identity/passkeys/create-passkeys#verify): Complete the server-side steps to verify the origin of the credential and then save the public key.
+7. [**Notify the user**](https://developer.android.com/identity/passkeys/create-passkeys#notify): Notify the user that their passkey has been created.
+
+> [!TIP]
+> **Tip:** To enhance the user experience during sign up, add functionality to [restore credentials](https://developer.android.com/identity/sign-in/restore-credentials) on a new device to let users seamlessly set up their existing accounts on new Android devices, and [suppressing autofill dialogs on
+> credential fields](https://developer.android.com/identity/passkeys/create-passkeys#suppress-autofill).
+
+## Add dependencies to your app
+
+Add the following dependencies to your app module's `build.gradle` file:
+
+### Kotlin
+
+```kotlin
+dependencies {
+    implementation("androidx.credentials:credentials:1.7.0-alpha02")
+    implementation("androidx.credentials:credentials-play-services-auth:1.7.0-alpha02")
+}
+```
+
+### Groovy
+
+```groovy
+dependencies {
+    implementation "androidx.credentials:credentials:1.7.0-alpha02"
+    implementation "androidx.credentials:credentials-play-services-auth:1.7.0-alpha02"
+}
+```
+
+> [!NOTE]
+> **Note:** Use the latest available versions of the dependencies. Versions of [`androidx.credentials`](https://developer.android.com/identity/passkeys/create-passkeys#automatic-upgrade) earlier than version 1.2 throw an `UnsupportedOperationException("Post-U not supported yet")` exception on Android 14.
+
+## Instantiate Credential Manager
+
+Use your app or activity context to create a `CredentialManager` object.
+
+    // Use your app or activity context to instantiate a client instance of
+    // CredentialManager.
+    private val credentialManager = CredentialManager.create(context)
+
+## Get credential creation options from your app server
+
+When the user clicks a "Create Passkey" button or when a new user signs up, make
+a request from your app to your app server to obtain the information required to
+start the passkey registration process.
+
+Use a FIDO-compliant library in your app server to send your client app the
+information required to create a passkey, such as information about the user,
+the app, and additional configuration properties. To learn more, see [Server
+side passkey registration](https://developers.google.com/identity/passkeys/developer-guides/server-registration).
+
+In the client app, decode the public key creation options sent by the app
+server. These are usually represented in JSON format. To learn more about how
+this decoding is done for web clients, see [Encoding and
+Decoding](https://developers.google.com/identity/passkeys/developer-guides/server-registration#encoding_and_decoding). For Android client apps, you must handle the decoding
+separately.
+
+> [!NOTE]
+> **Note:** On your app server, securely store the `challenge` so that you can later verify the origin of the credential.
+
+The following snippet shows the structure the public key creation options sent
+by the app server:
+
+    {
+      "challenge": "<base64url-encoded challenge>",
+      "rp": {
+        "name": "<relying party name>",
+        "id": "<relying party host name>"
+      },
+      "user": {
+        "id": "<base64url-encoded user ID>",
+        "name": "<user name>",
+        "displayName": "<user display name>"
+      },
+      "pubKeyCredParams": [
+        {
+          "type": "public-key",
+          "alg": -7
+        }
+      ],
+      "attestation": "none",
+      "excludeCredentials": [
+        {
+            "id": "<base64url-encoded credential ID to exclude>", 
+            "type": "public-key"
+        }
+      ],
+      "authenticatorSelection": {
+        "requireResidentKey": true,
+        "residentKey": "required",
+        "userVerification": "required"
+      }
+    }
+
+Key fields in the public key creation options include:
+
+- `challenge`: A server-generated random string that is used to prevent replay attacks.
+- `rp`: Details about the app.
+  - `rp.name`: The app's name.
+  - `rp.id`: The app's domain or subdomain.
+- `user`: Details about the user.
+  - `id`: The user's unique ID. This value must not include personally identifying information, for example, email addresses or usernames. You can use a random, 16-byte value.
+  - `name`: A unique identifier for the account that the user will recognise, such as their email address or username. This will be displayed in the account selector. If using a username, use the same value as in password authentication.
+  - `displayName`: An optional, user-friendly name for the account intended for display in the account selector.
+- `authenticatorSelection`: Details about the device that will be used for authentication.
+  - `authenticatorAttachment`: Indicates the preferred [authenticator](https://www.w3.org/TR/webauthn/#authenticator). The possible values are as follows:
+    - `platform`: This value is used for an authenticator built into the user's device, such as a fingerprint sensor.
+    - `cross-platform`: This value is used for roaming devices such as security keys. It is not typically used in the passkey context.
+    - Unspecified (recommended): Leaving this value unspecified provides users with the flexibility to create passkeys on their preferred devices. In most cases, leaving the parameter unspecified is the best option.
+  - `requireResidentKey`: To create a passkey, set the value of this `Boolean` field to `true`.
+  - `residentKey`: To create a passkey, set the value to `required`.
+  - `userVerification`: Used to specify the requirements for user verification during a passkey registration. The possible values are as follows:
+    - `preferred`: Use this value if you prioritize user experience over protection, such as in environments where user verification causes more friction than protection.
+    - `required`: Use this value if invoking a user verification method available on the device is required.
+    - `discouraged`: Use this value if using a user verification method is discouraged.   
+      To learn more about `userVerification`, see [userVerification deep dive](https://web.dev/articles/webauthn-user-verification).
+- `excludeCredentials`: List credential IDs in an [array](https://w3c.github.io/webauthn/#dom-publickeycredentialcreationoptions-excludecredentials) to prevent the creation of a duplicate passkey if one already exists with the same credential provider.
+
+## Create a passkey
+
+After you have parsed the server-side public key creation options, create a
+passkey by wrapping these options in a `CreatePublicKeyCredentialRequest` object
+and calling `createCredential()`.
+
+The `createPublicKeyCredentialRequest` includes the following:
+
+- `requestJson`: The credential creation options sent by the app server.
+- `preferImmediatelyAvailableCredentials`: This is an optional Boolean field that defines whether to only use locally-available or credential provider-synced credentials to fulfill the request, instead of credentials from security keys or [hybrid](https://w3c.github.io/webauthn/#dom-authenticatortransport-hybrid) key flows. The possible usages are as follows:
+  - `false` (default): Use this value if the call to Credential Manager was triggered by an explicit user action.
+  - `true`: Use this value if Credential Manager is opportunistically called, such as when first opening the app.   
+    If you set the value to `true` and there are no immediately available credentials, Credential Manager won't show any UI and the request will fail immediately, returning NoCredentialException for get requests and [`CreateCredentialNoCreateOptionException`](https://developer.android.com/reference/kotlin/androidx/credentials/exceptions/CreateCredentialNoCreateOptionException) for create requests.
+- `origin`: This field is automatically set for Android apps. For browsers and similarly privileged apps that need to set `origin`, see [Make Credential
+  Manager calls on behalf of other parties for privileged apps](https://developer.android.com/training/sign-in/privileged-apps).
+- `isConditional`: This is an optional field that defaults to `false`. For more information, see [Automatically create a passkey](https://developer.android.com/identity/passkeys/create-passkeys#automatic-upgrade).
+
+Calling the `createCredential()` function launches Credential Manager's built-in
+bottom sheet UI that prompts the user to use a passkey and to select a
+credential provider and account for storage. However, if `isConditional` is set
+to `true`, the bottom sheet UI does not display, and the passkey is
+automatically created.
+
+### Automatically create a passkey
+
+You can automatically create a passkey for a user after a successful password
+login by setting the `isConditional` parameter to `true` in your
+`CreatePublicKeyCredentialRequest` while creating a passkey. If the user doesn't
+already have a passkey, your app will automatically attempt to create one in the
+background and store it in the user's credential provider, such as Google
+Password Manager. For an example of how this is implemented, see the [public
+sample](https://github.com/android/identity-samples/blob/main/Shrine/app/src/main/java/com/authentication/shrine/ui/AuthenticationScreen.kt#L98).
+![An example of the notification Google Password Manager shows after passkey creation](https://developer.android.com/static/identity/passkeys/images/conditional-create-gpm.svg) **Figure 2:**Google Password Manager notification
+
+> [!NOTE]
+> **Note:** If a passkey is created automatically, credential providers are responsible for notifying users about a newly created passkey. Google Password Manager notifies users when a passkey is automatically created. However, other credential providers might have their own conditions and notifications for this feature.
+
+## Handle the response
+
+After the user is verified using the device's screen lock, a passkey is created
+and stored in the user's selected credential provider.
+
+The response after you successfully call `createCredential()` is a
+[PublicKeyCredential](https://developer.android.com/jetpack/androidx/releases/credentials) object.
+
+The `PublicKeyCredential` looks as follows:
+
+    {
+      "id": "<identifier>",
+      "type": "public-key",
+      "rawId": "<identifier>",
+      "response": {
+        "clientDataJSON": "<ArrayBuffer encoded object with the origin and signed challenge>",
+        "attestationObject": "<ArrayBuffer encoded object with the public key and other information.>"
+      },
+      "authenticatorAttachment": "platform"
+    }
+
+In the client app, serialize the object and send it to the app server.
+
+Add code to handle failures as shown in the following snippet:
+
+    fun handleFailure(e: CreateCredentialException) {
+        when (e) {
+            is CreatePublicKeyCredentialDomException -> {
+                // Handle the passkey DOM errors thrown according to the
+                // WebAuthn spec.
+            }
+            is CreateCredentialCancellationException -> {
+                // The user intentionally canceled the operation and chose not
+                // to register the credential.
+            }
+            is CreateCredentialInterruptedException -> {
+                // Retry-able error. Consider retrying the call.
+            }
+            is CreateCredentialProviderConfigurationException -> {
+                // Your app is missing the provider configuration dependency.
+                // Most likely, you're missing the
+                // "credentials-play-services-auth" module.
+            }
+            is CreateCredentialCustomException -> {
+                // You have encountered an error from a 3rd-party SDK. If you
+                // make the API call with a request object that's a subclass of
+                // CreateCustomCredentialRequest using a 3rd-party SDK, then you
+                // should check for any custom exception type constants within
+                // that SDK to match with e.type. Otherwise, drop or log the
+                // exception.
+            }
+            else -> Log.w(TAG, "Unexpected exception type ${e::class.java.name}")
+        }
+    }
+
+## Verify and save the public key on the app server
+
+On the app server, you must verify the public key credential and then [save the
+public key](https://web.dev/articles/passkey-registration#save-credential).
+
+To verify the public key credential's origin, compare it against an allow list
+of approved apps. If a key has an unrecognized origin, reject it.
+
+> [!NOTE]
+> **Note:** An app's origin is based on its unique identity, which is the SHA-256 fingerprint of its signing certificate.
+
+To obtain the app's SHA 256 fingerprint:
+
+1. Print your release app's signing certificate by running the following
+   command in a terminal:
+
+       keytool -list -keystore <path-to-apk-signing-keystore>
+
+   In the response, identify the signing certificate's SHA 256 fingerprint,
+   mentioned as `Certificate fingerprints block` : `SHA256`.
+2. Encode the SHA256 fingerprint with base64url encoding. This Python example
+   demonstrates how to properly encode the fingerprint:
+
+       import binascii
+       import base64
+       fingerprint = '<SHA256 finerprint>' # your app's SHA256 fingerprint
+       print(base64.urlsafe_b64encode(binascii.a2b_hex(fingerprint.replace(':', ''))).decode('utf8').replace('=', ''))
+
+3. Append `android:apk-key-hash`: to the start of the output from the previous
+   step so that you get something that is similar to the following:
+
+       android:apk-key-hash:<encoded SHA 256 fingerprint>
+
+   The result should match with an allowed origin on your app server. If you
+   have multiple signing certificates, such as certificates for debugging and
+   release, or multiple apps, then repeat the process and accept all the
+   origins as valid on the app server.
+
+> [!NOTE]
+> **Note:** When you save the passkey on the app server, make sure that you save the Authenticator Attestation Globally Unique Identifier ([AAGUID](https://web.dev/articles/webauthn-aaguid)) from the client data. The AAGUID is a unique number that identifies the model of the authenticator. For more information, see [Manage passkeys](https://developer.android.com/identity/passkeys/manage-passkeys).
+
+## Notify the user
+
+After the passkey is successfully created, notify your users about the passkey
+and inform them that they can manage their passkeys from their credential
+provider app or from [within the app settings](https://developer.android.com/identity/passkeys/manage-passkeys). Notify users by using a
+custom dialog, notification, or snackbar. Since an unexpected passkey creation
+by a malicious entity requires an immediate security alert, consider
+supplementing these in-app methods with external communication, such as an
+email.
+
+## Enhance the user experience
+
+To enhance the user experience while implementing sign up with Credential
+Manager, consider adding functionality for restore credentials and suppress
+autofill dialogs.
+
+### Add functionality to restore credentials on a new device
+
+To allow users to seamlessly log into their accounts on a new device, implement
+the [Restore Credentials](https://developer.android.com/identity/sign-in/restore-credentials) functionality. Adding restore credentials with
+`BackupAgent` logs users in when they open your restored app on a new device,
+letting them use your app right away.
+
+### Suppress autofill on credential fields (optional)
+
+For app screens where users are expected to use Credential Manager's bottom
+sheet UI for authentication, add the `isCredential` attribute to the username
+and password fields. This suppresses autofill dialogs (`FillDialog` and
+`SaveDialog`) from overlapping with Credential Manager's bottom sheet UI.
+
+The `isCredential` attribute is supported on Android 14 and higher.
+
+The following example demonstrates how you can add the `isCredential` attribute
+to the relevant username and password fields in the relevant views for your app:
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+    android:isCredential="true" /\>
+
+## Next steps
+
+- [Sign in with passkeys](https://developer.android.com/identity/passkeys/sign-in-with-passkeys)
+- [Manage passkeys](https://developer.android.com/identity/passkeys/manage-passkeys)
+- [Understand passkey user experience flows](https://developer.android.com/design/ui/mobile/guides/patterns/passkeys)

--- a/platforms/android/.agents/skills/verified-email/references/android/identity/sign-in/credential-manager-webview.md
+++ b/platforms/android/.agents/skills/verified-email/references/android/identity/sign-in/credential-manager-webview.md
@@ -1,0 +1,84 @@
+This document describes how to integrate the Credential Manager API with an
+Android app that uses WebView. Credential Manager is supported natively in the
+`android.webkit.WebView` library in [version 1.12.0](https://developer.android.com/jetpack/androidx/releases/webkit#1.12.0) and later.
+
+## Prerequisites
+
+To use Credential Manager in WebView, add the following dependencies to your app
+module's build script:
+
+    dependencies {
+      implementation("androidx.credentials:credentials:1.6.0-beta02")   
+      implementation("androidx.credentials:credentials-play-services-auth:1.6.0-beta02")
+      implementation("androidx.webkit:webkit:1.14.0")
+    }
+
+You will also need to associate your app with a website that your app owns using
+digital asset linking. For more information, see
+[adding digital asset linking](https://developer.android.com/identity/credential-manager/prerequisites).
+
+## Use the WebKit library
+
+To use the WebKit library, check for feature support, and then enable support by
+calling `setWebAuthenticationSupport()`:
+
+    class WebViewActivity : ComponentActivity() {
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+            setContent {
+                // Put your webview link here.
+                val url = "https://project-sesame-426206.appspot.com/passkey-signup"
+                AndroidView(
+                    factory = { context ->
+                        WebView(context).apply {
+                            settings.javaScriptEnabled = true
+
+                            webViewClient = WebViewClientImpl()
+                        }
+                    },
+                    update = { webView ->
+                        run {
+                            webView.loadUrl(url)
+                            if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_AUTHENTICATION)) {
+                                WebSettingsCompat.setWebAuthenticationSupport(
+                                    webView.settings,
+                                    WebSettingsCompat.WEB_AUTHENTICATION_SUPPORT_FOR_APP,
+                                )
+                                // Check if getWebauthenticationSupport may have been disabled by the WebView.
+                                Log.e(
+                                    "WebViewPasskeyDemo",
+                                    "getWebAuthenticationSupport result: " + WebSettingsCompat.getWebAuthenticationSupport(
+                                        webView.settings
+                                    ),
+                                )
+                            } else {
+                                Log.e("WebViewPasskeyDemo", "WebView does not support passkeys.")
+                            }
+                        }
+                    },
+                )
+            }
+        }
+    }
+
+> [!NOTE]
+> **Note:** The WebKit library doesn't support `mediation:"conditional"` requests.
+
+## Web integration
+
+To learn how to build Web integration see
+[Create a passkey for passwordless logins](https://web.dev/passkey-registration/).
+You can also reference the [demo site source](https://github.com/deephand/webauthn-in-webview).
+
+## Testing and deployment
+
+Test the entire flow thoroughly in a controlled environment to verify proper
+communication between the Android app, the web page, and the backend.
+
+Deploy the integrated solution to production, verifying that the backend can
+handle incoming registration and authentication requests. The backend code
+should generate initial JSON for registration (create) and authentication (get)
+processes. It should also handle validation and verification of the responses
+received from the web page.
+
+Verify the implementation corresponds to the [UX recommendations](https://developer.android.com/design/ui/mobile/guides/patterns/passkeys).

--- a/platforms/android/.agents/skills/wear-compose-m3/SKILL.md
+++ b/platforms/android/.agents/skills/wear-compose-m3/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: wear-compose-m3
+description: Expert guidance for working with Wear OS Compose Material3. Use this
+  skill when creating, updating, or migrating Wear OS projects. This includes the
+  androidx.wear.compose.material3, androidx.wear.compose.foundation, and androidx.wear.compose.navigation3
+  libraries. Also working with core components such as AppScaffold, ScreenScaffold,
+  and TransformingLazyColumn, and core Wear OS concepts such as ambient mode. Migration
+  from lower versions such as Material 2.5 and Horologist.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  last-updated: '2026-07-08'
+  keywords:
+  - Wear OS
+  - Compose
+  - Material3
+  - Horologist
+  - TransformingLazyColumn
+  - AppScaffold
+  - ScreenScaffold
+---
+
+## Prerequisites and compatibility
+
+1. **Current Wear OS Compose version in-use:** To find the installed library version, read `gradle/libs.versions.toml` or `build.gradle.kts` directly. Don't run `./gradlew dependencies` or other shell commands to resolve versions.
+2. **Wear OS Compose Material3 version:** If an internal tool is available to establish the **latest stable version** `{VERSION}` of `androidx.wear.compose:compose-material3`, use that tool.
+   - Otherwise, fetch the [official Maven metadata XML](https://dl.google.com/dl/android/maven2/androidx/wear/compose/compose-material3/maven-metadata.xml) to identify `{VERSION}` (highest number, ignoring `-alpha`, `-beta`, or `-rc`).
+3. **Strict compliance:** If a version is listed as stable, you MUST use it, unless overridden by the user. Do not downgrade based on initial "Unresolved reference" errors in the editor or outdated web search results.
+4. **Kotlin version:** For Wear Compose Material3, use Kotlin **2.0.0 or
+   higher**.
+5. **Compose compiler:**
+   - If Kotlin version is **2.0.0+** , the project must use the `org.jetbrains.kotlin.plugin.compose` Gradle plugin.
+   - If Kotlin version is **\< 2.0.0** , the project must use `kotlinCompilerExtensionVersion` in `composeOptions`, matching the [Compose to Kotlin Compatibility Map](https://developer.android.com/jetpack/androidx/releases/compose-kotlin).
+6. **Min SDK:** Ensure `minSdk` is at least **25**.
+7. **Sample extraction mandate**: Wear Compose libraries ship with an additional JAR file which contains individual samples for each and every component. You mustn't propose code changes, other than previews or basic changes such as color changes, until the samples in Capability 3 are extracted to the local cache. Library source files are incomplete and NOT a substitute for these samples; bypassing extraction is an environment setup failure.
+
+## Gotchas
+
+1. **Mandatory sync and validation:** After updating versions in `libs.versions.toml` or `build.gradle.kts`, you **must** perform a Gradle sync before refactoring any code. This ensures the environment has resolved the libraries correctly.
+2. **Prohibition of guessing (error protocol):** If you encounter an 'Unresolved Reference' or API mismatch after a successful sync, do not attempt to 'fix' it by downgrading the library version.
+
+## Capabilities and tools
+
+### Capability 1: Migration
+
+Use this guidance when migrating from an older version of Wear OS Compose or
+Horologist.
+
+1. Unless otherwise indicated by the developer, use the latest stable version of Wear Compose Material3 from `{VERSION}`.
+2. Read the [migration guide](references/android/training/wearables/compose/migrate-to-material3.md).
+3. Use the official component mappings from the migration guide.
+4. Before refactoring any component (for example, `Chip` -\> `Button`), check the parameter names, slot types, and "Expressive" design tokens.
+5. Do not use the Horologist Composables, Compose Layout, or Compose Material libraries.
+6. **Always** check against the component guidance in Capability 4.
+7. Expect screenshot tests to fail when a migration has been performed: Even when migrating to very similar components, expected defaults for padding and positioning will have changed. Do not seek to artificially match the pre-migration screenshot, but give preference to the Material3 defaults.
+
+### Capability 2: Adding Wear OS Compose Material3 features or updating the app
+
+Use this guidance when the developer asks to update a project which is using an
+earlier version of Wear OS Compose Material3, or when they ask to add further
+features.
+
+1. Unless otherwise indicated by the developer, use the latest stable version of Wear Compose Material3 from `{VERSION}`.
+2. Do not use the Horologist Composables, Compose Layout, or Compose Material libraries.
+3. **Always** check against the component guidance in Capability 4.
+4. Expect screenshot tests to fail when a migration has been performed: Even when migrating to very similar components, expected defaults for padding and positioning will have changed. Do not seek to artificially match the pre-migration screenshot, but give preference to the Material3 defaults.
+
+### Capability 3: Component samples
+
+Wear Compose includes individual component samples for each and every component,
+within the `<artifact>-<version>-samples-sources.jar` file. Gradle automatically
+downloads these JAR files along with the main library JAR when using any of
+`compose-material3`, `compose-foundation` or `compose-navigation3`.
+
+Use the canonical component samples whenever adding or adjusting a Wear Compose
+Material3 component.
+
+STRICT COMPLIANCE: Extraction is NOT optional. You are FORBIDDEN from
+implementing any code until samples are extracted and read. Bypassing this step
+with alternative search tools or by assuming library documentation is sufficient
+is a protocol breach. You MUST verify the local cache by reading a sample file
+before proceeding.
+
+Exception: You don't need to extract samples if the request is strictly related
+to tooling (for example, adding @WearPreviewDevices), updating text/colors, or
+basic refactoring that doesn't involve adding new Wear Compose components.
+
+#### Step 1: Prepare
+
+1. Check the `build.gradle.kts` or `libs.versions.toml` to ensure the Wear Compose version matches `{VERSION}`.
+2. Ensure that the necessary dependencies are downloaded by doing a Gradle sync.
+
+#### Step 2: Check the local cache
+
+1. Define the cache directory path: `/tmp/wear-compose-samples/{VERSION}/`. Do NOT choose your own different location.
+2. Check if this directory exists and contains subdirectories with `.kt` files.
+   - **IF YES (cache hit):** Proceed to **Step 4**.
+   - **IF NO (cache miss):** Proceed to **Step 3**.
+
+#### Step 3: Network-based sample retrieval
+
+Google Maven publishes a `-samples-sources.jar` alongside every library release.
+Download and extract it directly without needing a local Gradle sync or cache
+lookup.
+
+1. Determine the `{VERSION}` of `androidx.wear.compose:compose-material3` from `build.gradle.kts` or `libs.versions.toml`.
+2. Define `{ARTIFACT}` as the items in the list `["material3", "foundation"]`. Also include `navigation3` if `androidx.wear.compose.navigation3` is used.
+3. For each `{ARTIFACT}`, run the following commands to download and extract
+   the samples:
+
+       # Download the samples-sources JAR
+       curl -sSL "https://dl.google.com/dl/android/maven2/androidx/wear/compose/compose-{ARTIFACT}/{VERSION}/compose-{ARTIFACT}-{VERSION}-samples-sources.jar" -o {ARTIFACT}-{VERSION}-samples.jar
+
+       # Extract and flatten into the cache directory
+       unzip -q -o {ARTIFACT}-{VERSION}-samples.jar -d /tmp/wear-compose-samples/{VERSION}/{ARTIFACT}/
+
+       # Clean up
+       rm {ARTIFACT}-{VERSION}-samples.jar
+
+4. If this works, proceed directly to step 4.
+
+#### Step 4: Read samples and implement
+
+1. Read the relevant `.kt` sample files.
+2. Use these official, version-matched samples as the source of truth for:
+   - Required parameters and slot names.
+   - Default styling and typography tokens.
+   - Interactive behaviors (for example: `onClick`, `onLongClick`).
+   - Component nesting (for example: `AppScaffold` -\> `ScreenScaffold`).
+
+### Capability 4: Component guidance
+
+**Mandatory**: Use this capability as a checklist against any component use. It
+provides more holistic guidance on how to use each component in practice, beyond
+the component syntax.
+
+1. `AppScaffold` and `ScreenScaffold`
+   - \[ \] Use `AppScaffold` as the outer container, with `ScreenScaffold` children.
+   - \[ \] Use only **ONE** `AppScaffold` and any number of `ScreenScaffold`.
+2. `ScalingLazyColumn` - Use `TransformingLazyColumn` instead.
+3. `TransformingLazyColumn` - You will need the following imports:
+
+
+   ```kotlin
+   import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+   import androidx.wear.compose.foundation.lazy.TransformingLazyColumnDefaults
+   import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+   // ...
+   import androidx.wear.compose.material3.lazy.rememberTransformationSpec
+   import androidx.wear.compose.material3.lazy.transformedHeight
+   ```
+
+   <br />
+
+   **Canonical example**:
+
+
+   ```kotlin
+   val columnState = rememberTransformingLazyColumnState()
+   val transformationSpec = rememberTransformationSpec()
+   ScreenScaffold(
+       scrollState = columnState
+   ) { contentPadding ->
+       TransformingLazyColumn(
+           state = columnState,
+           contentPadding = contentPadding
+       ) {
+           item {
+               ListHeader(
+                   modifier = Modifier
+                       .fillMaxWidth()
+                       .transformedHeight(this, transformationSpec)
+                       .minimumVerticalContentPadding(ListHeaderDefaults.minimumTopListContentPadding),
+                   transformation = SurfaceTransformation(transformationSpec)
+               ) {
+                   Text(text = "Header")
+               }
+           }
+           // ... other items
+           item {
+               Button(
+                   modifier = Modifier
+                       .fillMaxWidth()
+                       .transformedHeight(this, transformationSpec)
+                       .minimumVerticalContentPadding(ButtonDefaults.minimumVerticalListContentPadding),
+                   transformation = SurfaceTransformation(transformationSpec),
+                   onClick = { /* ... */ },
+                   icon = {
+                       Icon(
+                           imageVector = Icons.Default.Build,
+                           contentDescription = "build",
+                       )
+                   },
+               ) {
+                   Text(
+                       text = "Build",
+                       maxLines = 1,
+                       overflow = TextOverflow.Ellipsis,
+                   )
+               }
+           }
+       }
+   }
+   ```
+
+   <br />
+
+   - \[ \] Use `TransformingLazyColumn` instead of `ScalingLazyColumn`.
+   - \[ \] You must pass the `contentPadding` parameter from `ScreenScaffold` to the `TransformingLazyColumn`.
+   - \[ \] Use the `minimumVerticalContentPadding` modifier to achieve required padding top and bottom.
+     - This expects a value from defaults, such as `ButtonDefaults`, `CardDefaults`, \`ListHeaderDefaults.
+     - Note: This is a scoped modifier available within `TransformingLazyColumnItemScope`.
+   - \[ \] Ensure the list morphs and scales.
+   - \[ \] Use `transformedHeight` modifier.
+   - \[ \] Use `transform = SurfaceTransform(...)`.
+   - \[ \] If configuring a list for snapping, use `flingBehavior` and `rotaryScrollableBehavior` **together**:
+
+
+   ```kotlin
+   val columnState = rememberTransformingLazyColumnState()
+   ScreenScaffold(scrollState = columnState) { contentPadding ->
+       TransformingLazyColumn(
+           state = columnState,
+           flingBehavior = TransformingLazyColumnDefaults.snapFlingBehavior(columnState),
+           rotaryScrollableBehavior = RotaryScrollableDefaults.snapBehavior(columnState)
+       ) {
+           // ...
+           // ...
+       }
+   }
+   ```
+
+   <br />
+
+4. `ScreenScaffold`
+
+   - \[ \] Guard the `scrollIndicator` with `!LocalScrollCaptureInProgress.current`.
+5. `EdgeButton`
+
+   - \[ \] Do **NOT** use as the final item within a `TransformingLazyColumn`. Instead, use the slot in `ScreenScaffold`.
+   - \[ \] When used in a `TransformingLazyColumn`, add the required overscroll behavior:
+
+
+   ```kotlin
+   val columnState = rememberTransformingLazyColumnState()
+   ScreenScaffold(
+       scrollState = columnState,
+       edgeButton = {
+           EdgeButton(
+               onClick = { /* TODO */ },
+               modifier = Modifier.scrollable(
+                   columnState,
+                   orientation = Orientation.Vertical,
+                   reverseDirection = true,
+                   // Apply overscroll to the EdgeButton for proper scrolling behavior.
+                   overscrollEffect = rememberOverscrollEffect(),
+               )
+           ) {
+               Text("More")
+           }
+       }
+   ) { contentPadding ->
+       TransformingLazyColumn(
+           contentPadding = contentPadding,
+           state = columnState,
+       ) {
+           // ...
+           // ...
+       }
+   }
+   ```
+
+   <br />
+
+6. `Column`
+
+   - \[ \] USE as a direct child of `ScreenScaffold` *if* the screen is will **never** scroll, even with the largest system font.
+   - \[ \] Use `TransformingLazyColumn` instead for all other cases.
+7. Styles
+
+   - \[ \] Do **NOT** hard-code text sizes, use `typography` from `MaterialTheme`.
+   - \[ \] Do **NOT** hard-code colors, use `colorScheme` from `MaterialTheme`.
+8. Use component defaults:
+
+   - \[ \] Components such as `Button` have a corresponding `ButtonDefaults` object.
+   - \[ \] Check for and use the `*Defaults` object for any component when working with padding and styling values, in preference to hard-coded values.
+9. Use Wear specific previews:
+
+   - \[ \] `WearPreviewDevices`
+   - \[ \] `WearPreviewFontScales`
+10. Ambient mode
+
+    - \[ \] Use `LocalAmbientModeManager` instead of `AmbientLifecycleObserver`.
+11. Navigation
+
+    - \[ \] When adding navigation fresh, use Navigation3.
+    - \[ \] For Navigation3 in Wear OS, use `SwipeDismissableSceneStrategy()` from the Wear Compose `compose-navigation3` library.
+12. Comments
+
+    - \[ \] Where any Kotlin file has been modified, ensure that the existing comments are up to date and accurately reflect any changes to the implementation.
+13. `HorizontalPager` or `VerticalPager`
+
+    - \[ \] Use the Composable hierarchy in this order: `AppScaffold`, `HorizontalPagerScaffold`, `HorizontalPager`, `AnimatedPage`, `ScreenScaffold`. Or similarly for `VerticalPager`.

--- a/platforms/android/.agents/skills/wear-compose-m3/references/android/training/wearables/compose/migrate-to-material3.md
+++ b/platforms/android/.agents/skills/wear-compose-m3/references/android/training/wearables/compose/migrate-to-material3.md
@@ -1,0 +1,677 @@
+[Material 3 Expressive](https://developer.android.com/design/ui/wear/guides/get-started) is the next evolution of Material Design. It includes
+updated theming, components, and personalization features like dynamic color.
+
+This guide focuses on migrating from the [Wear Compose Material 2.5
+(androidx.wear.compose)](https://developer.android.com/jetpack/androidx/releases/wear-compose#wear_compose_version_15_2) Jetpack library to the [Wear Compose Material 3
+(androidx.wear.compose.material3)](https://developer.android.com/jetpack/androidx/releases/wear-compose-m3) Jetpack library for apps.
+
+> [!NOTE]
+> **Note:** This guide uses abbreviation "M3" to refer to the interchangeable terms of "Material 3 Expressive" and the equivalent Jetpack library for Compose on Wear OS (androidx.wear.compose.material3). The abbreviation "M2.5" is used to refer to the interchangeable terms of "Material 2.5" and the equivalent Jetpack library for Compose on Wear OS (androidx.wear.compose.material).
+
+## Approaches
+
+For migrating your app code from M2.5 to M3, follow the same approach described
+in the [Compose Material migration phone guidance](https://developer.android.com/develop/ui/compose/designsystems/material2-material3), in particular:
+
+- You shouldn't use both [M2.5 and M3 in a single app long-term](https://developer.android.com/develop/ui/compose/designsystems/material2-material3#approaches).
+- You should no longer use the Horologist Composables, Compose Layout, or Compose Material libraries. Instead, use the components in M3.
+- Adopt a [phased approach](https://developer.android.com/develop/ui/compose/designsystems/material2-material3#phased-approach).
+
+## Dependencies
+
+M3 has a separate package and version to M2.5:
+
+### M2.5
+
+    implementation("androidx.wear.compose:compose-material:1.4.0")
+
+### M3
+
+    implementation("androidx.wear.compose:compose-material3:1.7.0-alpha05")
+
+See the latest M3 versions on the [Wear Compose Material 3 releases page](https://developer.android.com/jetpack/androidx/releases/wear-compose-m3).
+
+Wear Compose Foundation library version 1.7.0-alpha05 introduced
+some new components that are designed to work with Material 3 components.
+Similarly, `SwipeDismissableNavHost` from Wear Compose Navigation library has an
+updated animation when running on Wear OS 6 (API level 36) or higher. When
+updating to Wear Compose Material 3 version, we suggest to also update the Wear
+Compose Foundation and Navigation libraries:
+
+    implementation("androidx.wear.compose:compose-foundation:1.7.0-alpha05")
+    implementation("androidx.wear.compose:compose-navigation:1.7.0-alpha05")
+
+## Theme
+
+In both M2.5 and M3, the theme composable is named [`MaterialTheme`](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#MaterialTheme(androidx.wear.compose.material3.ColorScheme,androidx.wear.compose.material3.Typography,androidx.wear.compose.material3.Shapes,androidx.wear.compose.material3.MotionScheme,kotlin.Function0)), but the
+import packages and parameters differ. In M3, the `Colors` parameter has been
+renamed to `ColorScheme` and `MotionScheme` has been introduced for implementing
+transitions.
+
+### M2.5
+
+    import androidx.wear.compose.material.MaterialTheme
+
+    MaterialTheme(
+        colors = AppColors,
+        typography = AppTypography,
+        shapes = AppShapes,
+        content = content
+    )
+
+### M3
+
+
+```kotlin
+import androidx.wear.compose.material3.MaterialTheme
+// ...
+    MaterialTheme(
+        colorScheme = ColorScheme(),
+        typography = Typography(),
+        shapes = Shapes(),
+        motionScheme = MotionScheme.standard(),
+        content = { /*content here*/ }
+    )
+```
+
+<br />
+
+### Color
+
+The color system in M3 is significantly different from M2.5. The number of color
+parameters has increased, they have different names, and they map differently to
+M3 components. In Compose, this applies to the M2.5 [`Colors`](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/Colors) class, the M3
+[`ColorScheme`](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/ColorScheme) class, and related functions:
+
+### M2.5
+
+    import androidx.wear.compose.material.Colors
+
+    val appColorScheme: Colors = Colors(
+       // M2.5 Color parameters
+    )
+
+### M3
+
+
+```kotlin
+import androidx.wear.compose.material3.ColorScheme
+// ...
+    val appColorScheme: ColorScheme = ColorScheme(
+        // M3 ColorScheme parameters
+    )
+```
+
+<br />
+
+The following table describes the key differences between M2.5 and M3:
+
+| M2.5 | M3 |
+|---|---|
+| `Color` | Has been renamed to `ColorScheme` |
+| 13 colors | 28 colors |
+| N/A | New dynamic color theming |
+| N/A | New tertiary colors for more expression |
+
+#### Dynamic color theming
+
+A new feature in M3 is [dynamic color theming](https://m3.material.io/styles/color/dynamic-color/overview). If users change
+the watch face colors, the colors in the UI change to match.
+
+Use the [`dynamicColorScheme`](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#dynamicColorScheme(android.content.Context)) function to implement dynamic color scheme
+and provide a `defaultColorScheme` as a fallback in case dynamic color scheme is
+not available.
+
+
+```kotlin
+@Composable
+fun myApp() {
+    val dynamicColorScheme = dynamicColorScheme(LocalContext.current)
+    MaterialTheme(colorScheme = dynamicColorScheme ?: myBrandColors) {}
+}
+
+internal val myBrandColors: ColorScheme = ColorScheme( /* Specify colors here */)
+```
+
+<br />
+
+### Typography
+
+The [typography system](https://m3.material.io/styles/typography/overview) in M3 is different from M2.5 and it includes
+the following features:
+
+- Nine new [text styles](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/Typography#public-properties_1)
+- Flex fonts, which allow for customization of the type scales for different weights, widths, and roundness
+- `AnimatedText`, which uses flex fonts
+
+### M2.5
+
+    import androidx.wear.compose.material.Typography
+
+    val Typography = Typography(
+       // M2.5 TextStyle parameters
+    )
+
+### M3
+
+
+```kotlin
+import androidx.wear.compose.material3.Typography
+
+val Typography = Typography(
+    // M3 TextStyle parameters
+)
+```
+
+<br />
+
+#### Flex fonts
+
+Flex Fonts allow designers to specify the type width and weight for specific
+sizes.
+
+#### Text styles
+
+The following [TextStyles](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:wear/compose/compose-material3/src/main/java/androidx/wear/compose/material3/Typography.kt;l=115?q=displayLarge&ss=androidx/platform/frameworks/support) are available in M3. These are
+employed by default by various M3 components.
+
+| Typography | TextStyle |
+|---|---|
+| Display | displayLarge, displayMedium, displaySmall |
+| Title | titleLarge, titleMedium, titleSmall |
+| Label | labelLarge, labelMedium, labelSmall |
+| Body | bodyLarge, bodyMedium, bodySmall, bodyExtraSmall |
+| Numeral | numeralExtraLarge, numeralLarge, numeralMedium, numeralSmall, numeralExtraSmall |
+| Arc | arcLarge, arcMedium, arcSmall |
+
+### Shape
+
+The [shape system](https://m3.material.io/styles/shape/overview) in M3 is different from M2.5. The number of shape
+parameters has increased, they're named differently, and they map differently to
+M3 components. The following shape sizes are available:
+
+- Extra-small
+- Small
+- Medium
+- Large
+- Extra-large
+
+In Compose, this applies to the M2 [`Shapes`](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/Shapes) class and the M3
+[`Shapes`](https://developer.android.com/reference/kotlin/androidx/compose/material3/Shapes) class:
+
+### M2.5
+
+    import androidx.wear.compose.material.Shapes
+
+    val Shapes = Shapes(
+       // M2.5 Shapes parameters
+    )
+
+### M3
+
+
+```kotlin
+import androidx.wear.compose.material3.Shapes
+
+val Shapes = Shapes(
+    // M3 Shapes parameters
+)
+```
+
+<br />
+
+> [!NOTE]
+> **Note:** For shapes, we generally recommend using the default Material 3 Wear shapes which are optimized for round devices.
+
+Use the Shapes parameter mapping from [Migrate from Material 2 to Material 3 in
+Compose](https://developer.android.com/training/wearables/compose/migrate-to-material3#shape) as a starting point.
+
+### Shape morphing
+
+M3 introduces Shape Morphing: shapes now morph in response to interactions.
+
+Shape Morphing behavior is available as a variation on a number of round
+buttons, see the following list of buttons that support Shape Morphing:
+
+| Buttons | Shape morphing function |
+|---|---|
+| `IconButton` | [IconButtonDefaults.animatedShape](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/IconButtonDefaults#animatedShapes(androidx.compose.foundation.shape.CornerBasedShape,androidx.compose.foundation.shape.CornerBasedShape)) animates the icon button on press |
+| `IconToggleButton` | [IconToggleButtonDefaults.animatedShape](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/IconToggleButtonDefaults#animatedShapes(androidx.compose.foundation.shape.CornerBasedShape,androidx.compose.foundation.shape.CornerBasedShape)) animates the icon toggle button on press and [IconToggleButtonDefaults.variantAnimatedShapes](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/IconToggleButtonDefaults#variantAnimatedShapes()) animates the icon toggle button on press and check/uncheck |
+| `TextButton` | [TextButtonDefaults.animatedShape](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/TextButtonDefaults#animatedShapes(androidx.compose.foundation.shape.CornerBasedShape,androidx.compose.foundation.shape.CornerBasedShape)) animates the text button on press |
+| `TextToggleButton` | [TextToggleButtonDefaults.animatedShapes](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/TextToggleButtonDefaults#animatedShapes(androidx.compose.foundation.shape.CornerBasedShape,androidx.compose.foundation.shape.CornerBasedShape)) animates the text toggle on press and [TextToggleButtonDefaults.variantAnimatedShapes](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/TextToggleButtonDefaults#variantAnimatedShapes()) animates the text toggle on press and check/uncheck |
+
+## Components and Layout
+
+Most components and layouts from M2.5 are available in M3. However, some M3
+components and layouts didn't exist in M2.5. Furthermore, some M3 components
+have more variations than their equivalents in M2.5.
+
+While some components require special considerations, the following function
+mappings are recommended as a starting point:
+
+| Material 2.5 | Material 3 |
+|---|---|
+| [androidx.wear.compose.material.dialog.Alert](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/dialog/package-summary#Alert(kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1,androidx.wear.compose.foundation.lazy.ScalingLazyListState,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.foundation.layout.Arrangement.Vertical,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1)) | [androidx.wear.compose.material3.AlertDialog](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#AlertDialog(kotlin.Boolean,kotlin.Function0,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.Function0,androidx.compose.foundation.layout.Arrangement.Vertical,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.window.DialogProperties,kotlin.Function1)) |
+| [androidx.wear.compose.material.Button](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Button(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.wear.compose.material.ButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material.ButtonBorder,kotlin.Function1)) | [androidx.wear.compose.material3.IconButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#IconButton(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Boolean,androidx.wear.compose.material3.IconButtonShapes,androidx.wear.compose.material3.IconButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)) or [androidx.wear.compose.material3.TextButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#TextButton(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Boolean,androidx.wear.compose.material3.TextButtonShapes,androidx.wear.compose.material3.TextButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)) |
+| [androidx.wear.compose.material.Card](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Card(kotlin.Function0,androidx.compose.ui.Modifier,androidx.compose.ui.graphics.painter.Painter,androidx.compose.ui.graphics.Color,kotlin.Boolean,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.ui.semantics.Role,kotlin.Function1)) | [androidx.wear.compose.material3.Card](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#Card(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.CardColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)) |
+| [androidx.wear.compose.material.TitleCard](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#TitleCard(kotlin.Function0,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,kotlin.Function1,androidx.compose.ui.graphics.painter.Painter,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,kotlin.Function1)) | [androidx.wear.compose.material3.TitleCard](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#TitleCard(kotlin.Function0,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Function0,kotlin.Function1,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.CardColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function0)) |
+| [androidx.wear.compose.material.AppCard](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#AppCard(kotlin.Function0,kotlin.Function1,kotlin.Function1,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,kotlin.Function1,androidx.compose.ui.graphics.painter.Painter,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,kotlin.Function1)) | [androidx.wear.compose.material3.AppCard](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#AppCard(kotlin.Function0,kotlin.Function1,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.CardColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1,kotlin.Function1,kotlin.Function1)) |
+| [androidx.wear.compose.material.Checkbox](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Checkbox(kotlin.Boolean,androidx.compose.ui.Modifier,androidx.wear.compose.material.CheckboxColors,kotlin.Boolean,kotlin.Function1,androidx.compose.foundation.interaction.MutableInteractionSource)) | No M3 equivalent, migrate to [androidx.wear.compose.material3.CheckboxButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#CheckboxButton(kotlin.Boolean,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.CheckboxButtonColors,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.SurfaceTransformation,kotlin.Function1,kotlin.Function1,kotlin.Function1)) or [androidx.wear.compose.material3.SplitCheckboxButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SplitCheckboxButton(kotlin.Boolean,kotlin.Function1,kotlin.String,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.SplitCheckboxButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.SurfaceTransformation,kotlin.String,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1,kotlin.Function1)) |
+| [androidx.wear.compose.material.Chip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Chip(kotlin.Function0,androidx.wear.compose.material.ChipColors,androidx.wear.compose.material.ChipBorder,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.ui.semantics.Role,kotlin.Function1)) | [androidx.wear.compose.material3.Button](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#Button(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.ButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)) or [androidx.wear.compose.material3.OutlinedButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#OutlinedButton(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.ButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)) or [androidx.wear.compose.material3.FilledTonalButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#FilledTonalButton(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.ButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.SurfaceTransformation,kotlin.Function1)) or [androidx.wear.compose.material3.ChildButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#ChildButton(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Function1,kotlin.Function1,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.ButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.SurfaceTransformation,kotlin.Function1)) |
+| [androidx.wear.compose.material.CompactChip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#CompactChip(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1,androidx.wear.compose.material.ChipColors,kotlin.Boolean,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material.ChipBorder)) | [androidx.wear.compose.material3.CompactButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#CompactButton(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Function1,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.ButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)) |
+| [androidx.wear.compose.material.InlineSlider](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#InlineSlider(kotlin.Int,kotlin.Function1,kotlin.ranges.IntProgression,kotlin.Function0,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,kotlin.Boolean,androidx.wear.compose.material.InlineSliderColors)) | [androidx.wear.compose.material3.Slider](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#Slider(kotlin.Int,kotlin.Function1,kotlin.ranges.IntProgression,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.Function0,kotlin.Boolean,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.SliderColors)) |
+| [androidx.wear.compose.material.LocalContentAlpha()](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#LocalContentAlpha()) | Has been removed as not used by `Text` or `Icon` in Material 3 |
+| [androidx.wear.compose.material.PositionIndicator](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#PositionIndicator(androidx.compose.foundation.lazy.LazyListState,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.animation.core.AnimationSpec,androidx.compose.animation.core.AnimationSpec,androidx.compose.animation.core.AnimationSpec)) | [androidx.wear.compose.material3.ScrollIndicator](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#ScrollIndicator(androidx.compose.foundation.lazy.LazyListState,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.animation.core.AnimationSpec)) |
+| [androidx.wear.compose.material.RadioButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#RadioButton(kotlin.Boolean,androidx.compose.ui.Modifier,androidx.wear.compose.material.RadioButtonColors,kotlin.Boolean,kotlin.Function0,androidx.compose.foundation.interaction.MutableInteractionSource)) | No M3 equivalent, migrate to [androidx.wear.compose.material3.RadioButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#RadioButton(kotlin.Boolean,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.RadioButtonColors,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.SurfaceTransformation,kotlin.Function1,kotlin.Function1,kotlin.Function1)) or [androidx.wear.compose.material3.SplitRadioButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SplitRadioButton(kotlin.Boolean,kotlin.Function0,kotlin.String,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.SplitRadioButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.SurfaceTransformation,kotlin.String,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1,kotlin.Function1)) |
+| [androidx.wear.compose.material.SwipeToRevealCard](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#Stepper(kotlin.Int,kotlin.Function1,kotlin.ranges.IntProgression,kotlin.Function0,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.wear.compose.material3.StepperColors,kotlin.Function1)) | [androidx.wear.compose.material3.SwipeToReveal](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SwipeToReveal(kotlin.Function1,androidx.compose.ui.Modifier,androidx.wear.compose.foundation.RevealState,androidx.compose.ui.unit.Dp,kotlin.Function0)) |
+| [androidx.wear.compose.material.SwipeToRevealChip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#SwipeToRevealChip(kotlin.Function1,androidx.wear.compose.foundation.RevealState,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1,kotlin.Function1,androidx.wear.compose.material.SwipeToRevealActionColors,androidx.compose.ui.graphics.Shape,kotlin.Function0)) | [androidx.wear.compose.material3.SwipeToReveal](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SwipeToReveal(kotlin.Function1,androidx.compose.ui.Modifier,androidx.wear.compose.foundation.RevealState,androidx.compose.ui.unit.Dp,kotlin.Function0)) |
+| [android.wear.compose.material.Scaffold](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Scaffold(androidx.compose.ui.Modifier,kotlin.Function0,kotlin.Function0,kotlin.Function0,kotlin.Function0,kotlin.Function0)) | [androidx.wear.compose.material3.AppScaffold](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#AppScaffold(androidx.compose.ui.Modifier,kotlin.Function0,kotlin.Function1)) and [androidx.wear.compose.material3.ScreenScaffold](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#ScreenScaffold(androidx.compose.ui.Modifier,kotlin.Function0,androidx.wear.compose.foundation.ScrollInfoProvider,kotlin.Function1,kotlin.Function1)) |
+| [androidx.wear.compose.material.SplitToggleChip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#SplitToggleChip(kotlin.Boolean,kotlin.Function1,kotlin.Function1,kotlin.Function0,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1,androidx.wear.compose.material.SplitToggleChipColors,kotlin.Boolean,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape)) | No M3 equivalent, migrate to [androidx.wear.compose.material3.SplitCheckboxButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SplitCheckboxButton(kotlin.Boolean,kotlin.Function1,kotlin.String,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.SplitCheckboxButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.String,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1,kotlin.Function1)), [androidx.wear.compose.material3.SplitSwitchButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SplitSwitchButton(kotlin.Boolean,kotlin.Function1,kotlin.String,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.SplitSwitchButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.SurfaceTransformation,kotlin.String,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1,kotlin.Function1)), or [androidx.wear.compose.material3.SplitRadioButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SplitRadioButton(kotlin.Boolean,kotlin.Function0,kotlin.String,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.SplitRadioButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.SurfaceTransformation,kotlin.String,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1,kotlin.Function1)) |
+| [androidx.wear.compose.material.Switch](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Switch(kotlin.Boolean,androidx.compose.ui.Modifier,androidx.wear.compose.material.SwitchColors,kotlin.Boolean,kotlin.Function1,androidx.compose.foundation.interaction.MutableInteractionSource)) | No M3 equivalent, migrate to [androidx.wear.compose.material3.SwitchButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SwitchButton(kotlin.Boolean,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.SwitchButtonColors,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1,kotlin.Function1,kotlin.Function1)) or [androidx.wear.compose.material3.SplitSwitchButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SplitSwitchButton(kotlin.Boolean,kotlin.Function1,kotlin.String,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.SplitSwitchButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.String,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1,kotlin.Function1)) |
+| [androidx.wear.compose.material.ToggleButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#ToggleButton(kotlin.Boolean,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.wear.compose.material.ToggleButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.ui.graphics.Shape,androidx.compose.ui.semantics.Role,kotlin.Function1)) | [androidx.wear.compose.material3.IconToggleButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#IconToggleButton(kotlin.Boolean,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.wear.compose.material3.IconToggleButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.IconToggleButtonShapes,androidx.compose.foundation.BorderStroke,kotlin.Function1)) or [androidx.wear.compose.material3.TextToggleButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#TextToggleButton(kotlin.Boolean,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.wear.compose.material3.TextToggleButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.TextToggleButtonShapes,androidx.compose.foundation.BorderStroke,kotlin.Function1)) |
+| [androidx.wear.compose.material.ToggleChip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#ToggleChip(kotlin.Boolean,kotlin.Function1,kotlin.Function1,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1,androidx.wear.compose.material.ToggleChipColors,kotlin.Boolean,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape)) | [androidx.wear.compose.material3.CheckboxButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#CheckboxButton(kotlin.Boolean,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.CheckboxButtonColors,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1,kotlin.Function1,kotlin.Function1)) or [androidx.wear.compose.material3.RadioButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#RadioButton(kotlin.Boolean,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.RadioButtonColors,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.SurfaceTransformation,kotlin.Function1,kotlin.Function1,kotlin.Function1)) or [androidx.wear.compose.material3.SwitchButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SwitchButton(kotlin.Boolean,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.SwitchButtonColors,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1,kotlin.Function1,kotlin.Function1)) |
+| [androidx.wear.compose.material.Vignette](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Vignette(androidx.wear.compose.material.VignettePosition,androidx.compose.ui.Modifier)) | Removed as not included in Material 3 Expressive design for Wear OS |
+
+Here is a full list of all the Material 3 components:
+
+| Material 3 | Material 2.5 equivalent component (if not new in M3) |
+|---|---|
+| [androidx.wear.compose.material3.AlertDialog](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#AlertDialog(kotlin.Boolean,kotlin.Function0,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.Function0,androidx.compose.foundation.layout.Arrangement.Vertical,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.window.DialogProperties,kotlin.Function1)) | [androidx.wear.compose.material.dialog.Alert](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/dialog/package-summary#Alert(kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1,androidx.wear.compose.foundation.lazy.ScalingLazyListState,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.foundation.layout.Arrangement.Vertical,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1)) |
+| [androidx.wear.compose.material3.AnimatedPage](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#AnimatedPage(kotlin.Int,androidx.wear.compose.foundation.pager.PagerState,androidx.compose.ui.graphics.Color,kotlin.Function0)) | New |
+| [androidx.wear.compose.material3.AnimatedText](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#AnimatedText(kotlin.String,androidx.wear.compose.material3.AnimatedTextFontRegistry,kotlin.Function0,androidx.compose.ui.Modifier,androidx.compose.ui.Alignment)) | New |
+| [androidx.wear.compose.material3.AppScaffold](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#AppScaffold(androidx.compose.ui.Modifier,kotlin.Function0,kotlin.Function1)) | [android.wear.compose.material.Scaffold](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Scaffold(androidx.compose.ui.Modifier,kotlin.Function0,kotlin.Function0,kotlin.Function0,kotlin.Function0,kotlin.Function0)) (with [androidx.wear.compose.material3.ScreenScaffold](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#ScreenScaffold(androidx.compose.ui.Modifier,kotlin.Function0,androidx.wear.compose.foundation.ScrollInfoProvider,kotlin.Function1,kotlin.Function1)) ) |
+| [androidx.wear.compose.material3.Button](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#Button(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.ButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)) | [androidx.wear.compose.material.Chip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Chip(kotlin.Function0,androidx.wear.compose.material.ChipColors,androidx.wear.compose.material.ChipBorder,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.ui.semantics.Role,kotlin.Function1)) |
+| [androidx.wear.compose.material3.ButtonGroup](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#ButtonGroup(androidx.compose.ui.Modifier,androidx.compose.ui.unit.Dp,androidx.compose.ui.unit.Dp,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.Alignment.Vertical,kotlin.Function1)) | New |
+| [androidx.wear.compose.material3.Card](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#Card(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.CardColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)) | [androidx.wear.compose.material.Card](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Card(kotlin.Function0,androidx.compose.ui.Modifier,androidx.compose.ui.graphics.painter.Painter,androidx.compose.ui.graphics.Color,kotlin.Boolean,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.ui.semantics.Role,kotlin.Function1)) |
+| [androidx.wear.compose.material3.CheckboxButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#CheckboxButton(kotlin.Boolean,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.CheckboxButtonColors,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1,kotlin.Function1,kotlin.Function1)) | [androidx.wear.compose.material.ToggleChip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#ToggleChip(kotlin.Boolean,kotlin.Function1,kotlin.Function1,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1,androidx.wear.compose.material.ToggleChipColors,kotlin.Boolean,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape)) with a checkbox toggle control |
+| [androidx.wear.compose.material3.ChildButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#ChildButton(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.ButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)) | [androidx.wear.compose.material.Chip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Chip(kotlin.Function0,androidx.wear.compose.material.ChipColors,androidx.wear.compose.material.ChipBorder,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.ui.semantics.Role,kotlin.Function1)) (only when no background is required) |
+| [androidx.wear.compose.material3.CircularProgressIndicator](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#CircularProgressIndicator(androidx.compose.ui.Modifier,androidx.wear.compose.material3.ProgressIndicatorColors,androidx.compose.ui.unit.Dp,androidx.compose.ui.unit.Dp)) | [androidx.wear.compose.material.CircularProgressIndicator](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#CircularProgressIndicator(androidx.compose.ui.Modifier,kotlin.Float,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.unit.Dp)) |
+| [androidx.wear.compose.material3.CompactButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#CompactButton(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Function1,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.ButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)) | [androidx.wear.compose.material.CompactChip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#CompactChip(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1,androidx.wear.compose.material.ChipColors,kotlin.Boolean,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material.ChipBorder)) |
+| [androidx.wear.compose.material3.ConfirmationDialog](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#ConfirmationDialog(kotlin.Boolean,kotlin.Function0,kotlin.Function1,androidx.compose.ui.Modifier,androidx.wear.compose.material3.ConfirmationDialogColors,androidx.compose.ui.window.DialogProperties,kotlin.Long,kotlin.Function0)) | [androidx.wear.compose.material.dialog.Confirmation](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/dialog/package-summary#Confirmation(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function1,androidx.wear.compose.foundation.lazy.ScalingLazyListState,kotlin.Long,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.foundation.layout.Arrangement.Vertical,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1)) |
+| [androidx.wear.compose.material3.curvedText](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#(androidx.wear.compose.foundation.CurvedScope).curvedText(kotlin.String,androidx.wear.compose.foundation.CurvedModifier,kotlin.Float,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.unit.TextUnit,androidx.compose.ui.text.font.FontFamily,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,androidx.compose.ui.text.font.FontSynthesis,androidx.wear.compose.foundation.CurvedTextStyle,androidx.wear.compose.foundation.CurvedDirection.Angular,androidx.compose.ui.text.style.TextOverflow)) | [androidx.wear.compose.material.curvedText](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#(androidx.wear.compose.foundation.CurvedScope).curvedText(kotlin.String,androidx.wear.compose.foundation.CurvedModifier,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.unit.TextUnit,androidx.compose.ui.text.font.FontFamily,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontStyle,androidx.compose.ui.text.font.FontSynthesis,androidx.wear.compose.foundation.CurvedTextStyle,androidx.wear.compose.foundation.CurvedDirection.Angular,androidx.compose.ui.text.style.TextOverflow)) |
+| [androidx.wear.compose.material3.DatePicker](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#DatePicker(java.time.LocalDate,kotlin.Function1,androidx.compose.ui.Modifier,java.time.LocalDate,java.time.LocalDate,androidx.wear.compose.material3.DatePickerType,androidx.wear.compose.material3.DatePickerColors)) | New |
+| [androidx.wear.compose.material3.Dialog](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#Dialog(kotlin.Boolean,kotlin.Function0,androidx.compose.ui.Modifier,androidx.compose.ui.window.DialogProperties,kotlin.Function0)) | [androidx.wear.compose.material.dialog.Dialog](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/dialog/package-summary#Dialog(kotlin.Boolean,kotlin.Function0,androidx.compose.ui.Modifier,androidx.wear.compose.foundation.lazy.ScalingLazyListState,androidx.compose.ui.window.DialogProperties,kotlin.Function0)) |
+| [androidx.wear.compose.material3.EdgeButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#EdgeButton(kotlin.Function0,androidx.compose.ui.Modifier,androidx.wear.compose.material3.EdgeButtonSize,kotlin.Boolean,androidx.wear.compose.material3.ButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)) | New |
+| [androidx.wear.compose.material3.FadingExpandingLabel](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#FadingExpandingLabel(kotlin.String,androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Color,androidx.compose.ui.unit.TextUnit,androidx.compose.ui.text.font.FontStyle,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontFamily,androidx.compose.ui.unit.TextUnit,androidx.compose.ui.text.style.TextDecoration,androidx.compose.ui.text.style.TextAlign,androidx.compose.ui.unit.TextUnit,kotlin.Boolean,kotlin.Int,kotlin.Int,androidx.compose.ui.text.TextStyle,androidx.compose.animation.core.FiniteAnimationSpec)) | New |
+| [androidx.wear.compose.material3.FilledTonalButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#FilledTonalButton(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.ButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)) | [androidx.wear.compose.material.Chip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Chip(kotlin.Function0,androidx.wear.compose.material.ChipColors,androidx.wear.compose.material.ChipBorder,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.ui.semantics.Role,kotlin.Function1)) when a tonal button background is required |
+| [androidx.wear.compose.material3.HorizontalPageIndicator](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#HorizontalPageIndicator(androidx.wear.compose.foundation.pager.PagerState,androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color)) | [androidx.wear.compose.material.HorizontalPageIndicator](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#HorizontalPageIndicator(androidx.wear.compose.material.PageIndicatorState,androidx.compose.ui.Modifier,androidx.wear.compose.material.PageIndicatorStyle,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.unit.Dp,androidx.compose.ui.unit.Dp,androidx.compose.ui.graphics.Shape)) |
+| [androidx.wear.compose.material3.HorizontalPagerScaffold](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#HorizontalPagerScaffold(androidx.wear.compose.foundation.pager.PagerState,androidx.compose.ui.Modifier,kotlin.Function1,androidx.compose.animation.core.AnimationSpec,androidx.wear.compose.foundation.rotary.RotaryScrollableBehavior,kotlin.Function2)) | New |
+| [androidx.wear.compose.material3.Icon](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#Icon(androidx.compose.ui.graphics.ImageBitmap,kotlin.String,androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Color)) | [androidx.wear.compose.material.Icon](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Icon(androidx.compose.ui.graphics.ImageBitmap,kotlin.String,androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Color)) |
+| [androidx.wear.compose.material3.IconButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#IconButton(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Boolean,androidx.wear.compose.material3.IconButtonShapes,androidx.wear.compose.material3.IconButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)) | [androidx.wear.compose.material.Button](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Button(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.wear.compose.material.ButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material.ButtonBorder,kotlin.Function1)) |
+| [androidx.wear.compose.material3.IconToggleButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#IconToggleButton(kotlin.Boolean,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.wear.compose.material3.IconToggleButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.IconToggleButtonShapes,androidx.compose.foundation.BorderStroke,kotlin.Function1)) | [androidx.wear.compose.material.ToggleButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#ToggleButton(kotlin.Boolean,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.wear.compose.material.ToggleButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.ui.graphics.Shape,androidx.compose.ui.semantics.Role,kotlin.Function1)) |
+| [androidx.wear.compose.material3.LevelIndicator](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#LevelIndicator(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.ranges.ClosedFloatingPointRange,kotlin.Boolean,androidx.wear.compose.material3.LevelIndicatorColors,androidx.compose.ui.unit.Dp,kotlin.Float,kotlin.Boolean)) | New |
+| [androidx.wear.compose.material3.LinearProgressIndicator](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#LinearProgressIndicator(kotlin.Function0,androidx.compose.ui.Modifier,androidx.wear.compose.material3.ProgressIndicatorColors,androidx.compose.ui.unit.Dp,kotlin.Boolean)) | New |
+| [androidx.wear.compose.material3.ListHeader](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#ListHeader(androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1)) | [androidx.wear.compose.material.ListHeader](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#ListHeader(androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,kotlin.Function1)) |
+| [androidx.wear.compose.material3.ListSubHeader](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#ListSubHeader(androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1,kotlin.Function1)) | New |
+| [androidx.wear.compose.material3.MaterialTheme](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#MaterialTheme(androidx.wear.compose.material3.ColorScheme,androidx.wear.compose.material3.Typography,androidx.wear.compose.material3.Shapes,androidx.wear.compose.material3.MotionScheme,kotlin.Function0)) | [androidx.wear.compose.material.MaterialTheme](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#MaterialTheme(androidx.wear.compose.material.Colors,androidx.wear.compose.material.Typography,androidx.wear.compose.material.Shapes,kotlin.Function0)) |
+| [androidx.wear.compose.material3.OpenOnPhoneDialog](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#OpenOnPhoneDialog(kotlin.Boolean,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function1,androidx.wear.compose.material3.OpenOnPhoneDialogColors,androidx.compose.ui.window.DialogProperties,kotlin.Long,kotlin.Function1)) | New |
+| [androidx.wear.compose.material3.Picker](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#Picker(androidx.wear.compose.material3.PickerState,kotlin.String,androidx.compose.ui.Modifier,kotlin.Boolean,kotlin.Function1,kotlin.Function0,androidx.compose.ui.unit.Dp,kotlin.Float,androidx.compose.ui.graphics.Color,kotlin.Boolean,androidx.wear.compose.foundation.rotary.RotaryScrollableBehavior,kotlin.Function2)) | [androidx.wear.compose.material.Picker](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Picker(androidx.wear.compose.material.PickerState,kotlin.String,androidx.compose.ui.Modifier,kotlin.Boolean,kotlin.Function1,kotlin.Function0,androidx.wear.compose.foundation.lazy.ScalingParams,androidx.compose.ui.unit.Dp,kotlin.Float,androidx.compose.ui.graphics.Color,androidx.compose.foundation.gestures.FlingBehavior,kotlin.Boolean,androidx.wear.compose.foundation.rotary.RotaryScrollableBehavior,kotlin.Function2)) |
+| [androidx.wear.compose.material3.PickerGroup](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#PickerGroup(kotlin.Int,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,kotlin.Function1,kotlin.Boolean,kotlin.Function1)) | [androidx.wear.compose.material.PickerGroup](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#PickerGroup(kotlin.Array,androidx.compose.ui.Modifier,androidx.wear.compose.material.PickerGroupState,kotlin.Function1,kotlin.Boolean,kotlin.Boolean,androidx.wear.compose.material.TouchExplorationStateProvider,kotlin.Function1)) |
+| [androidx.wear.compose.material3.RadioButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#RadioButton(kotlin.Boolean,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.RadioButtonColors,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.SurfaceTransformation,kotlin.Function1,kotlin.Function1,kotlin.Function1)) | [androidx.wear.compose.material.ToggleChip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#ToggleChip(kotlin.Boolean,kotlin.Function1,kotlin.Function1,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1,androidx.wear.compose.material.ToggleChipColors,kotlin.Boolean,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape)) with a radio button toggle control |
+| [androidx.wear.compose.material3.ScreenScaffold](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#ScreenScaffold(androidx.compose.ui.Modifier,kotlin.Function0,androidx.wear.compose.foundation.ScrollInfoProvider,kotlin.Function1,kotlin.Function1)) | [android.wear.compose.material.Scaffold](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Scaffold(androidx.compose.ui.Modifier,kotlin.Function0,kotlin.Function0,kotlin.Function0,kotlin.Function0,kotlin.Function0)) (with [androidx.wear.compose.material3.AppScaffold](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#AppScaffold(androidx.compose.ui.Modifier,kotlin.Function0,kotlin.Function1))) |
+| [androidx.wear.compose.material3.ScrollIndicator](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#ScrollIndicator(androidx.compose.foundation.lazy.LazyListState,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.animation.core.AnimationSpec)) | [androidx.wear.compose.material.PositionIndicator](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#PositionIndicator(androidx.compose.foundation.lazy.LazyListState,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.animation.core.AnimationSpec,androidx.compose.animation.core.AnimationSpec,androidx.compose.animation.core.AnimationSpec)) |
+| [androidx.wear.compose.material3.scrollAway](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#(androidx.compose.ui.Modifier).scrollAway(androidx.wear.compose.foundation.ScrollInfoProvider,kotlin.Function0)) | [androidx.wear.compose.material.scrollAway](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#(androidx.compose.ui.Modifier).scrollAway(androidx.compose.foundation.lazy.LazyListState,kotlin.Int,androidx.compose.ui.unit.Dp)) |
+| [androidx.wear.compose.material3.SegmentedCircularProgressIndicator](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SegmentedCircularProgressIndicator(kotlin.Int,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Float,kotlin.Float,androidx.wear.compose.material3.ProgressIndicatorColors,androidx.compose.ui.unit.Dp,androidx.compose.ui.unit.Dp,kotlin.Boolean)) | New |
+| [androidx.wear.compose.material3.Slider](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#Slider(kotlin.Int,kotlin.Function1,kotlin.ranges.IntProgression,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.Function0,kotlin.Boolean,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.SliderColors)) | [androidx.wear.compose.material.InlineSlider](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#InlineSlider(kotlin.Int,kotlin.Function1,kotlin.ranges.IntProgression,kotlin.Function0,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,kotlin.Boolean,androidx.wear.compose.material.InlineSliderColors)) |
+| [androidx.wear.compose.material3.SplitRadioButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SplitRadioButton(kotlin.Boolean,kotlin.Function0,kotlin.String,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.SplitRadioButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.String,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1,kotlin.Function1)) | [androidx.wear.compose.material.SplitToggleChip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#SplitToggleChip(kotlin.Boolean,kotlin.Function1,kotlin.Function1,kotlin.Function0,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1,androidx.wear.compose.material.SplitToggleChipColors,kotlin.Boolean,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape)) |
+| [androidx.wear.compose.material3.SplitCheckboxButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SplitCheckboxButton(kotlin.Boolean,kotlin.Function1,kotlin.String,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.SplitCheckboxButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.String,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1,kotlin.Function1)) | [androidx.wear.compose.material.SplitToggleChip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#SplitToggleChip(kotlin.Boolean,kotlin.Function1,kotlin.Function1,kotlin.Function0,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1,androidx.wear.compose.material.SplitToggleChipColors,kotlin.Boolean,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape)) |
+| [androidx.wear.compose.material3.SplitSwitchButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SplitSwitchButton(kotlin.Boolean,kotlin.Function1,kotlin.String,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.SplitSwitchButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.SurfaceTransformation,kotlin.String,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1,kotlin.Function1)) | [androidx.wear.compose.material.SplitToggleChip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#SplitToggleChip(kotlin.Boolean,kotlin.Function1,kotlin.Function1,kotlin.Function0,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1,androidx.wear.compose.material.SplitToggleChipColors,kotlin.Boolean,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape)) |
+| [androidx.wear.compose.material3.Stepper](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#Stepper(kotlin.Int,kotlin.Function1,kotlin.ranges.IntProgression,kotlin.Function0,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.wear.compose.material3.StepperColors,kotlin.Function1)) | [androidx.wear.compose.material.Stepper](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Stepper(kotlin.Int,kotlin.Function1,kotlin.ranges.IntProgression,kotlin.Function0,kotlin.Function0,androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,kotlin.Boolean,kotlin.Function1)) |
+| [androidx.wear.compose.material3.SwipeToDismissBox](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SwipeToDismissBox(androidx.wear.compose.foundation.SwipeToDismissBoxState,androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,kotlin.Any,kotlin.Any,kotlin.Boolean,kotlin.Function2)) | [androidx.wear.compose.material.SwipeToDismissBox](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#SwipeToDismissBox(androidx.wear.compose.foundation.SwipeToDismissBoxState,androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,kotlin.Any,kotlin.Any,kotlin.Boolean,kotlin.Function2)) |
+| [androidx.wear.compose.material3.SwipeToReveal](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SwipeToReveal(kotlin.Function1,androidx.compose.ui.Modifier,androidx.wear.compose.foundation.RevealState,androidx.compose.ui.unit.Dp,kotlin.Function0)) | [androidx.wear.compose.material.SwipeToRevealCard](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#Stepper(kotlin.Int,kotlin.Function1,kotlin.ranges.IntProgression,kotlin.Function0,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.wear.compose.material3.StepperColors,kotlin.Function1)) and [androidx.wear.compose.material.SwipeToRevealChip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#SwipeToRevealChip(kotlin.Function1,androidx.wear.compose.foundation.RevealState,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1,kotlin.Function1,androidx.wear.compose.material.SwipeToRevealActionColors,androidx.compose.ui.graphics.Shape,kotlin.Function0)) |
+| [androidx.wear.compose.material3.SwitchButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#SwitchButton(kotlin.Boolean,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.SwitchButtonColors,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1,kotlin.Function1,kotlin.Function1)) | [androidx.wear.compose.material.ToggleChip](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#ToggleChip(kotlin.Boolean,kotlin.Function1,kotlin.Function1,kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1,androidx.wear.compose.material.ToggleChipColors,kotlin.Boolean,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.foundation.layout.PaddingValues,androidx.compose.ui.graphics.Shape)) with a switch toggle control |
+| [androidx.wear.compose.material3.Text](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#Text(kotlin.String,androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Color,androidx.compose.ui.unit.TextUnit,androidx.compose.ui.text.font.FontStyle,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontFamily,androidx.compose.ui.unit.TextUnit,androidx.compose.ui.text.style.TextDecoration,androidx.compose.ui.text.style.TextAlign,androidx.compose.ui.unit.TextUnit,androidx.compose.ui.text.style.TextOverflow,kotlin.Boolean,kotlin.Int,kotlin.Int,kotlin.Function1,androidx.compose.ui.text.TextStyle)) | [androidx.wear.compose.material.Text](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Text(kotlin.String,androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Color,androidx.compose.ui.unit.TextUnit,androidx.compose.ui.text.font.FontStyle,androidx.compose.ui.text.font.FontWeight,androidx.compose.ui.text.font.FontFamily,androidx.compose.ui.unit.TextUnit,androidx.compose.ui.text.style.TextDecoration,androidx.compose.ui.text.style.TextAlign,androidx.compose.ui.unit.TextUnit,androidx.compose.ui.text.style.TextOverflow,kotlin.Boolean,kotlin.Int,kotlin.Int,kotlin.Function1,androidx.compose.ui.text.TextStyle)) |
+| [androidx.wear.compose.material3.TextButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#TextButton(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Boolean,androidx.wear.compose.material3.TextButtonShapes,androidx.wear.compose.material3.TextButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)) | [androidx.wear.compose.material.Button](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#Button(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.wear.compose.material.ButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material.ButtonBorder,kotlin.Function1)) |
+| [androidx.wear.compose.material3.TextToggleButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#TextToggleButton(kotlin.Boolean,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.wear.compose.material3.TextToggleButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.TextToggleButtonShapes,androidx.compose.foundation.BorderStroke,kotlin.Function1)) | [androidx.wear.compose.material.ToggleButton](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#ToggleButton(kotlin.Boolean,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Boolean,androidx.wear.compose.material.ToggleButtonColors,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.compose.ui.graphics.Shape,androidx.compose.ui.semantics.Role,kotlin.Function1)) |
+| [androidx.wear.compose.material3.TimeText](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#TimeText(androidx.compose.ui.Modifier,androidx.wear.compose.foundation.CurvedModifier,kotlin.Float,androidx.wear.compose.material3.TimeSource,androidx.compose.ui.text.TextStyle,androidx.compose.ui.graphics.Color,androidx.compose.foundation.layout.PaddingValues,kotlin.Function1)) | [androidx.wear.compose.material.TimeText](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#TimeText(androidx.compose.ui.Modifier,androidx.wear.compose.material.TimeSource,androidx.compose.ui.text.TextStyle,androidx.compose.foundation.layout.PaddingValues,kotlin.Function0,kotlin.Function1,kotlin.Function0,kotlin.Function1,kotlin.Function0,kotlin.Function1)) |
+| [androidx.wear.compose.material3.VerticalPagerScaffold](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#VerticalPagerScaffold(androidx.wear.compose.foundation.pager.PagerState,androidx.compose.ui.Modifier,kotlin.Function1,androidx.compose.animation.core.AnimationSpec,androidx.wear.compose.foundation.rotary.RotaryScrollableBehavior,kotlin.Function2)) | New |
+
+And finally a list of some relevant components from Wear Compose Foundation
+library:
+
+| Wear Compose Foundation 1.7.0-alpha05 |   |
+|---|---|
+| [androidx.wear.compose.foundation.hierarchicalFocusGroup](https://developer.android.com/reference/kotlin/androidx/wear/compose/foundation/package-summary#(androidx.compose.ui.Modifier).hierarchicalFocusGroup(kotlin.Boolean)) | Used to annotate composables in an application, to keep track of the active part of the composition and coordinate focus. |
+| [androidx.wear.compose.foundation.pager.HorizontalPager](https://developer.android.com/reference/kotlin/androidx/wear/compose/foundation/pager/package-summary#HorizontalPager(androidx.wear.compose.foundation.pager.PagerState,androidx.compose.ui.Modifier,androidx.compose.foundation.layout.PaddingValues,kotlin.Int,androidx.compose.foundation.gestures.TargetedFlingBehavior,kotlin.Boolean,androidx.wear.compose.foundation.GestureInclusion,kotlin.Boolean,kotlin.Function1,androidx.wear.compose.foundation.rotary.RotaryScrollableBehavior,kotlin.Function2)) | A horizontally scrolling pager, built on the Compose Foundation components with Wear-specific enhancements to improve performance and adherence to Wear OS guidelines. |
+| [androidx.wear.compose.foundation.pager.VerticalPager](https://developer.android.com/reference/kotlin/androidx/wear/compose/foundation/pager/package-summary#VerticalPager(androidx.wear.compose.foundation.pager.PagerState,androidx.compose.ui.Modifier,androidx.compose.foundation.layout.PaddingValues,kotlin.Int,androidx.compose.foundation.gestures.TargetedFlingBehavior,kotlin.Boolean,kotlin.Boolean,kotlin.Function1,androidx.wear.compose.foundation.rotary.RotaryScrollableBehavior,kotlin.Function2)) | A vertically scrolling pager, built on the Compose Foundation components with Wear-specific enhancements to improve performance and adherence to Wear OS guidelines. |
+| [androidx.wear.compose.foundation.lazy.TransformingLazyColumn](https://developer.android.com/reference/kotlin/androidx/wear/compose/foundation/lazy/package-summary#TransformingLazyColumn(androidx.compose.ui.Modifier,androidx.wear.compose.foundation.lazy.TransformingLazyColumnState,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.layout.Arrangement.Vertical,androidx.compose.ui.Alignment.Horizontal,androidx.compose.foundation.gestures.FlingBehavior,kotlin.Boolean,androidx.wear.compose.foundation.rotary.RotaryScrollableBehavior,androidx.compose.foundation.OverscrollEffect,kotlin.Function1)) | Can be used instead of [`ScalingLazyColumn`](https://developer.android.com/reference/kotlin/androidx/wear/compose/foundation/lazy/package-summary#ScalingLazyColumn(androidx.compose.ui.Modifier,androidx.wear.compose.foundation.lazy.ScalingLazyListState,androidx.compose.foundation.layout.PaddingValues,kotlin.Boolean,androidx.compose.foundation.layout.Arrangement.Vertical,androidx.compose.ui.Alignment.Horizontal,androidx.compose.foundation.gestures.FlingBehavior,kotlin.Boolean,androidx.wear.compose.foundation.lazy.ScalingParams,androidx.wear.compose.foundation.lazy.ScalingLazyListAnchorType,androidx.wear.compose.foundation.lazy.AutoCenteringParams,androidx.wear.compose.foundation.rotary.RotaryScrollableBehavior,androidx.compose.foundation.OverscrollEffect,kotlin.Function1)) to add scroll transform effects to each item. |
+|   |   |
+
+### Buttons
+
+Buttons in M3 are different from M2.5. The M2.5 Chip has been replaced by
+Button. [`Button`](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#Button(kotlin.Function0,androidx.compose.ui.Modifier,kotlin.Function0,kotlin.String,kotlin.Boolean,androidx.compose.ui.graphics.Shape,androidx.wear.compose.material3.ButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.layout.PaddingValues,androidx.compose.foundation.interaction.MutableInteractionSource,androidx.wear.compose.material3.SurfaceTransformation,kotlin.Function1)) implementation provides default values for `Text`
+`maxLines` and `textAlign`. Those default values can be overridden in the `Text`
+element.
+
+### M2.5
+
+    import androidx.wear.compose.material.Chip
+
+    //M2.5 Buttons
+    Chip(...)
+    CompactChip(...)
+    Button(...)
+
+### M3
+
+
+```kotlin
+//M3 Buttons
+Button(onClick = { }){}
+CompactButton(onClick = { }){}
+IconButton(onClick = { }){}
+TextButton(onClick = { }){}
+```
+
+<br />
+
+M3 also includes new button variations. Check them out on the [Compose Material
+3 API reference overview](https://developer.android.com/jetpack/androidx/releases/wear-compose#wear_compose_version_15_2).
+
+M3 introduces a new button: [`EdgeButton`](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#EdgeButton(kotlin.Function0,androidx.compose.ui.Modifier,androidx.wear.compose.material3.EdgeButtonSize,kotlin.Boolean,androidx.wear.compose.material3.ButtonColors,androidx.compose.foundation.BorderStroke,androidx.compose.foundation.interaction.MutableInteractionSource,kotlin.Function1)). `EdgeButton` is available in 4
+different sizes: extra small, small, medium, and large. `EdgeButton`
+implementation provide a default value for `maxLines` depending on the size
+which can be customized.
+
+If you are using `TransformingLazyColumn` or `ScalingLazyColumn`, pass the
+`EdgeButton` into the `ScreenScaffold` so that it morphs, changing its shape
+with scrolling, instead of adding an `EdgeButton` as the final list item. See
+the following code to check how to use `EdgeButton` with `ScreenScaffold` and
+`TransformingLazyColumn`.
+
+
+```kotlin
+val state = rememberTransformingLazyColumnState()
+ScreenScaffold(
+    scrollState = state,
+    contentPadding =
+        rememberResponsiveColumnPadding(
+            first = ColumnItemType.ListHeader
+        ),
+    edgeButton = {
+        EdgeButton(
+            onClick = { }
+        ) {
+            Text(stringResource(R.string.show))
+        }
+    }
+){ contentPadding ->
+    TransformingLazyColumn(state = state, contentPadding = contentPadding,){
+        // additional code here
+    }
+}
+```
+
+<br />
+
+### Scaffold
+
+Scaffold in M3 is different from M2.5. In M3, `AppScaffold` and the new
+`ScreenScaffold` composable have replaced Scaffold. `AppScaffold` and
+`ScreenScaffold` lay out the structure of a screen and coordinate transitions of
+the `ScrollIndicator` and `TimeText` components.
+
+`AppScaffold` allows static screen elements such as `TimeText` to remain visible
+during in-app transitions such as swipe-to-dismiss. ​​It provides a slot for the
+main application content, which will usually be supplied by a navigation
+component such as `SwipeDismissableNavHost`
+
+You declare one `AppScaffold` for Activity and use a `ScreenScaffold` for each
+Screen.
+`AppScaffold` adds a default `TimeText`component to the screens. You can
+override it if you want to customize it by using the `timeText` parameter.
+
+### M2.5
+
+    import androidx.wear.compose.material.Scaffold
+
+    Scaffold {...}
+
+### M3
+
+
+```kotlin
+    AppScaffold {
+        val navController = rememberSwipeDismissableNavController()
+        SwipeDismissableNavHost(
+            navController = navController,
+            startDestination = "message_list"
+        ) {
+            composable("message_list") {
+                MessageList(onMessageClick = { id ->
+                    navController.navigate("message_detail/$id")
+                })
+            }
+            composable("message_detail/{id}") {
+                MessageDetail(id = it.arguments?.getString("id")!!)
+            }
+        }
+    }
+}
+
+// Implementation of one of the screens in the navigation
+@Composable
+fun MessageDetail(id: String) {
+    // .. Screen level content goes here
+    val scrollState = rememberTransformingLazyColumnState()
+
+    val padding = rememberResponsiveColumnPadding(
+        first = ColumnItemType.BodyText
+    )
+
+    ScreenScaffold(
+        scrollState = scrollState,
+        contentPadding = padding
+    ) { scaffoldPaddingValues ->
+        // Screen content goes here
+        // ...
+```
+
+<br />
+
+> [!NOTE]
+> **Note:** `AppScaffold` and `ScreenScaffold` from [Horologist](https://github.com/google/horologist) haven't been migrated to M3. To maintain correct scrolling behavior and `TimeText` elements, migrate to the `AppScaffold` and `ScreenScaffold` from M3.
+
+If you are using a `HorizontalPager` with [HorizontalPagerIndicator](https://developer.android.com/reference/kotlin/androidx/wear/compose/material/package-summary#HorizontalPageIndicator(androidx.wear.compose.material.PageIndicatorState,androidx.compose.ui.Modifier,androidx.wear.compose.material.PageIndicatorStyle,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.unit.Dp,androidx.compose.ui.unit.Dp,androidx.compose.ui.graphics.Shape)), you
+can migrate to `HorizontalPagerScaffold`. [`HorizontalPagerScaffold`](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#HorizontalPagerScaffold(androidx.wear.compose.foundation.pager.PagerState,androidx.compose.ui.Modifier,kotlin.Function1,androidx.compose.animation.core.AnimationSpec,androidx.wear.compose.foundation.rotary.RotaryScrollableBehavior,kotlin.Function2)) is
+placed within an `AppScaffold`. `AppScaffold` and `HorizontalPagerScaffold` lay
+out the structure of a Pager and coordinate transitions of the
+`HorizontalPageIndicator` and `TimeText` components.
+
+`HorizontalPagerScaffold` displays the `HorizontalPageIndicator` at the
+center-end of the screen by default and coordinates showing and hiding
+`TimeText` and `HorizontalPageIndicator` according to whether the `Pager` is
+being paged, this is determined by the `PagerState`.
+
+There's also a new `AnimatedPage` component, which animates a page within a
+Pager with a scaling and scrim effect based on its position.
+
+
+```kotlin
+AppScaffold {
+    val pagerState = rememberPagerState(pageCount = { 10 })
+    val columnState = rememberTransformingLazyColumnState()
+    val contentPadding = rememberResponsiveColumnPadding(
+        first = ColumnItemType.ListHeader,
+        last = ColumnItemType.BodyText,
+    )
+    HorizontalPagerScaffold(pagerState = pagerState) {
+        HorizontalPager(
+            state = pagerState,
+        ) { page ->
+            AnimatedPage(pageIndex = page, pagerState = pagerState) {
+                ScreenScaffold(
+                    scrollState = columnState,
+                    contentPadding = contentPadding
+                ) { contentPadding ->
+                    TransformingLazyColumn(
+                        state = columnState,
+                        contentPadding = contentPadding
+                    ) {
+                        item {
+                            ListHeader(
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Text(text = "Pager sample")
+                            }
+                        }
+                        item {
+                            if (page == 0) {
+                                Text(text = "Page #$page. Swipe right")
+                            }
+                            else{
+                                Text(text = "Page #$page. Swipe left and right")
+                            }
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+}
+```
+
+<br />
+
+Finally, M3 introduces a [`VerticalPagerScaffold`](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#VerticalPagerScaffold(androidx.wear.compose.foundation.pager.PagerState,androidx.compose.ui.Modifier,kotlin.Function1,androidx.compose.animation.core.AnimationSpec,androidx.wear.compose.foundation.rotary.RotaryScrollableBehavior,kotlin.Function2)) which follows the same
+pattern as the `HorizontalPagerScaffold`:
+
+
+```kotlin
+AppScaffold {
+    val pagerState = rememberPagerState(pageCount = { 10 })
+
+    VerticalPagerScaffold(pagerState = pagerState) {
+        VerticalPager(
+            state = pagerState
+        ) { page ->
+            AnimatedPage(pageIndex = page, pagerState = pagerState) {
+                ScreenScaffold {
+                    ///...
+                }
+            }
+        }
+    }
+}
+```
+
+<br />
+
+### Placeholder
+
+There are some API changes between M2.5 and M3.
+`Placeholder.PlaceholderDefaults` now provides two modifiers:
+
+- [`Modifier.placeholder`](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#(androidx.compose.ui.Modifier).placeholder(androidx.wear.compose.material3.PlaceholderState,androidx.compose.ui.graphics.Shape,androidx.compose.ui.graphics.Color)), which is drawn instead of content that is not yet loaded
+- A placeholder shimmer effect [`Modifier.placeholderShimmer`](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary#(androidx.compose.ui.Modifier).placeholderShimmer(androidx.wear.compose.material3.PlaceholderState,androidx.compose.ui.graphics.Shape,androidx.compose.ui.graphics.Color)) which provides a placeholder shimmer effect which runs in an animation loop while waiting for the data to load.
+
+See the following table for additional changes to the `Placeholder` component.
+
+| M2.5 | M3 |
+|---|---|
+| `PlaceholderState.startPlaceholderAnimation` | Has been removed |
+| `PlaceholderState.placeholderProgression` | Has been removed |
+| `PlaceholderState.isShowContent` | Has been renamed to `!PlaceholderState.isVisible` |
+| `PlaceholderState.isWipeOff` | Has been removed |
+| `PlaceholderDefaults.painterWithPlaceholderOverlayBackgroundBrush` | Has been removed |
+| `PlaceholderDefaults.placeholderBackgroundBrush` | Has been removed |
+| `PlaceholderDefaults.placeholderChipColors` | Has been removed |
+
+### SwipeDismissableNavHost
+
+`SwipeDismissableNavHost` is part of `wear.compose.navigation`. When this
+component is used with M3, the M3 MaterialTheme updates the
+`LocalSwipeToDismissBackgroundScrimColor` and
+`LocalSwipeToDismissContentScrimColor`.
+
+### TransformingLazyColumn
+
+`TransformingLazyColumn` is part of `wear.compose.lazy.foundation` and adds
+support for scaling and morphing animations on list items during scrolling ,
+enhancing the user experience. It is strongly recommended that apps migrate from
+`ScalingLazyColumn` to `TransformingLazyColumn`
+
+Similarly to `ScalingLazyColumn`, it provides
+`rememberTransformingLazyColumnState()` to create a
+`TransformingLazyColumnState` that is remembered across compositions.
+
+For adding scaling and morphing animations, add the following to each list item:
+
+- `Modifier.transformedHeight`, which lets you calculate transformed height of the items using a `TransformationSpec`, you can use `rememberTransformationSpec()` unless you need further customization.
+- A `SurfaceTransformation`
+
+To verify that the padding is correct at the top and bottom of the list, use the
+`minimumVerticalContentPadding` modifier.
+
+
+```kotlin
+val columnState = rememberTransformingLazyColumnState()
+val transformationSpec = rememberTransformationSpec()
+ScreenScaffold(
+    scrollState = columnState
+) { contentPadding ->
+    TransformingLazyColumn(
+        state = columnState,
+        contentPadding = contentPadding
+    ) {
+        item {
+            ListHeader(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .transformedHeight(this, transformationSpec)
+                    .minimumVerticalContentPadding(ListHeaderDefaults.minimumTopListContentPadding),
+                transformation = SurfaceTransformation(transformationSpec)
+            ) {
+                Text(text = "Header")
+            }
+        }
+        // ... other items
+        item {
+            Button(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .transformedHeight(this, transformationSpec)
+                    .minimumVerticalContentPadding(ButtonDefaults.minimumVerticalListContentPadding),
+                transformation = SurfaceTransformation(transformationSpec),
+                onClick = { /* ... */ },
+                icon = {
+                    Icon(
+                        imageVector = Icons.Default.Build,
+                        contentDescription = "build",
+                    )
+                },
+            ) {
+                Text(
+                    text = "Build",
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+```
+
+<br />
+
+## Useful links
+
+To learn more about migrating from M2.5 to M3 in Compose, consult the following
+additional resources.
+
+### Samples
+
+- [Wear OS samples on GitHub](https://github.com/android/wear-os-samples/)
+- [Compose for Wear OS codelab](https://developer.android.com/codelabs/compose-for-wear-os#0)
+- [Jetcaster sample](https://github.com/android/compose-samples/tree/main/Jetcaster)
+
+### API reference and source code
+
+- [Compose Material 3 API reference](https://developer.android.com/reference/kotlin/androidx/wear/compose/material3/package-summary)
+- [Compose Material 3 samples in source code](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:wear/compose/compose-material3/samples/src/main/java/androidx/wear/compose/material3/samples/)
+
+### Design
+
+- [Design guidance](https://developer.android.com/design/ui/wear/guides/get-started)

--- a/platforms/android/.cursor/rules/00-general.mdc
+++ b/platforms/android/.cursor/rules/00-general.mdc
@@ -1,0 +1,25 @@
+---
+description: Funput Android – always-on project conventions
+globs:
+alwaysApply: true
+---
+
+# Funput Android
+
+Funput là IME tiếng Việt mã nguồn mở. Module Android là lớp UI/IME bao quanh
+lõi `funput-engine` (Rust) dùng chung với macOS, kết nối qua JNI/UniFFI.
+
+**Giới hạn cứng**
+- Mỗi file Kotlin / Rust-glue ≤ 150 dòng. Tách theo trách nhiệm, không xuống
+  dòng gian lận để né giới hạn.
+- Tối đa 5 file / thư mục. Đến file thứ 6 → tạo subfolder theo tên
+  sub-concern, không để phẳng.
+
+**Nguyên tắc**
+- Kiến trúc module theo feature, sạch
+- Không viết lại logic ngữ âm / đặt dấu bằng Kotlin — logic đó chỉ tồn tại
+  một nơi (Rust), gọi qua FFI bridge.
+- Chuẩn OSS: mọi public symbol có 1 dòng KDoc; không TODO trống, phải gắn
+  link issue.
+- Ưu tiên composition hơn inheritance; sealed type hơn enum-with-when cho
+  domain state.

--- a/platforms/android/gradle/libs.versions.toml
+++ b/platforms/android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.3.0"
+agp = "9.3.1"
 coreKtx = "1.19.0"
 customView = "1.2.0"
 emoji2 = "1.6.0"

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/AndroidCompositionSession.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/AndroidCompositionSession.kt
@@ -82,6 +82,33 @@ internal class AndroidCompositionSession(
         }
     }
 
+    /**
+     * Re-opens the word the caret now sits behind, so the next keystroke edits it
+     * instead of typing a literal letter (`chào` ⌫ then `s` gives `cháo`).
+     *
+     * Called only from the Backspace path that did *not* have a live composition, so
+     * typing never pays for it. Uses one bounded [wordBeforeCursor] read, on a
+     * keystroke where the editor is already being consulted, and
+     * asks the engine before touching the document, so a non-Vietnamese word is left
+     * exactly as it was.
+     */
+    fun reopenPreviousWord(connection: InputConnection?): Boolean {
+        if (connection == null || isComposing) return false
+        if (!connection.getSelectedText(0).isNullOrEmpty()) return false
+        val word = connection.wordBeforeCursor() ?: return false
+        if (!engine.adopt(word)) return false
+
+        connection.beginBatchEdit()
+        val reopened = try {
+            connection.deleteSurroundingText(word.length, 0) &&
+                connection.setComposingText(composingTextFactory(word), CursorAfterText)
+        } finally {
+            connection.endBatchEdit()
+        }
+        if (reopened) composingText = word else engine.clear()
+        return reopened
+    }
+
     private fun commitRaw(connection: InputConnection, text: String): Boolean {
         finish(connection)
         return connection.commitText(text, CursorAfterText)

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/ImeKeyActionHandler.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/ImeKeyActionHandler.kt
@@ -89,9 +89,26 @@ internal class ImeKeyActionHandler(
 
     private fun backspace() {
         if (!composition.backspace(connection())) {
-            execute(ImeEditCommand.DeleteBackward)
-            if (usesComposition) composition.reopenPreviousWord(connection())
-            suggestionTracker.reset()
+            // Delete the previous grapheme and (when Vietnamese) re-open the word
+            // behind the caret as one batch. Two top-level edits would each fire
+            // onUpdateSelection; the first arrives with candidatesEnd=-1 after
+            // reopen has already set isComposing, and onSelectionChanged finishes
+            // the composition we just restored — which is exactly the real-device
+            // failure unit tests miss (they never invoke onSelectionChanged).
+            val current = connection()
+            if (current != null && usesComposition) {
+                current.beginBatchEdit()
+                try {
+                    execute(ImeEditCommand.DeleteBackward)
+                    composition.reopenPreviousWord(current)
+                } finally {
+                    current.endBatchEdit()
+                }
+                if (composition.isComposing) updateSuggestionTracker() else suggestionTracker.reset()
+            } else {
+                execute(ImeEditCommand.DeleteBackward)
+                suggestionTracker.reset()
+            }
         } else {
             updateSuggestionTracker()
         }

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/ImeKeyActionHandler.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/ImeKeyActionHandler.kt
@@ -90,6 +90,7 @@ internal class ImeKeyActionHandler(
     private fun backspace() {
         if (!composition.backspace(connection())) {
             execute(ImeEditCommand.DeleteBackward)
+            if (usesComposition) composition.reopenPreviousWord(connection())
             suggestionTracker.reset()
         } else {
             updateSuggestionTracker()

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/WordBeforeCursor.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/WordBeforeCursor.kt
@@ -1,0 +1,24 @@
+package app.funput.funput.ime.editing
+
+import android.view.inputmethod.InputConnection
+
+/** Longest Vietnamese syllable is 7 characters (`nghiêng`); this leaves slack. */
+private const val WordLookback = 12
+
+/**
+ * The unbroken run of non-boundary characters immediately before the caret, or null
+ * when the caret sits on a boundary (or the editor returns nothing).
+ *
+ * Reads at most [WordLookback] characters: enough for any Vietnamese syllable, and
+ * small enough to stay cheap on the one keystroke that asks for it.
+ */
+internal fun InputConnection.wordBeforeCursor(): String? {
+    val tail = getTextBeforeCursor(WordLookback, 0)?.toString() ?: return null
+    var start = tail.length
+    while (start > 0) {
+        val codePoint = tail.codePointBefore(start)
+        if (CompositionBoundary.isBoundary(codePoint)) break
+        start -= Character.charCount(codePoint)
+    }
+    return tail.substring(start).ifEmpty { null }
+}

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/nativebridge/FunputNative.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/nativebridge/FunputNative.kt
@@ -22,6 +22,9 @@ internal object FunputNative {
 
     /** Runtime VI/EN state — flipped per field and by the language key, not durable config. */
     external fun nativeSetEnabled(handle: Long, enabled: Boolean)
+    /** Re-opens an already-committed word for editing; false when it is not adoptable. */
+    external fun nativeAdopt(handle: Long, word: String): Boolean
+
     external fun nativeProcess(handle: Long, codePoint: Int): String
     external fun nativeBoundary(handle: Long, codePoint: Int): String
     external fun nativeBackspace(handle: Long): String

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/nativebridge/VietnameseEngine.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/nativebridge/VietnameseEngine.kt
@@ -24,6 +24,13 @@ internal interface VietnameseEngine : AutoCloseable {
     /** Single writer for durable configuration; see [EngineConfiguration]. */
     fun configure(configuration: EngineConfiguration)
     fun setEnabled(enabled: Boolean)
+
+    /**
+     * Re-opens an already-committed [word] as the live composition so the next
+     * keystroke edits it. Returns false when the word is not a Vietnamese syllable —
+     * the caller must then leave the document alone.
+     */
+    fun adopt(word: String): Boolean
     fun process(codePoint: Int): String
     fun processBoundary(codePoint: Int): String?
     fun backspace(): String
@@ -50,6 +57,10 @@ internal class NativeVietnameseEngine : VietnameseEngine {
 
     override fun setEnabled(enabled: Boolean) = withHandle { value ->
         FunputNative.nativeSetEnabled(value, enabled)
+    }
+
+    override fun adopt(word: String): Boolean = withHandle { value ->
+        FunputNative.nativeAdopt(value, word)
     }
 
     override fun process(codePoint: Int): String = withHandle { value ->

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AndroidCompositionSessionTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AndroidCompositionSessionTest.kt
@@ -100,12 +100,19 @@ internal class ScriptedEngine(
         private set
     var enabled: Boolean? = null
         private set
+    /** Words this fake accepts for re-opening; mirrors the engine's syllable gate. */
+    var adoptable: Set<String> = emptySet()
+    var adopted: String? = null
+        private set
 
     override fun process(codePoint: Int): String = processed.removeFirst()
     override fun processBoundary(codePoint: Int): String? = boundaryOutput
     override fun backspace(): String = backspaceOutput
     override fun configure(configuration: EngineConfiguration) {
         this.configuration = configuration
+    }
+    override fun adopt(word: String): Boolean = adoptable.contains(word).also {
+        if (it) adopted = word
     }
     override fun setEnabled(enabled: Boolean) {
         this.enabled = enabled

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/ImeKeyActionHandlerTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/ImeKeyActionHandlerTest.kt
@@ -38,6 +38,7 @@ private class RecordingEngine : VietnameseEngine {
     override fun processBoundary(codePoint: Int): String? = null
     override fun backspace(): String = ""
     override fun configure(configuration: EngineConfiguration) = Unit
+    override fun adopt(word: String): Boolean = false
     override fun setEnabled(enabled: Boolean) { enabledValue = enabled }
     override fun clear() = Unit
     override fun close() = Unit

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/ReopenPreviousWordTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/ReopenPreviousWordTest.kt
@@ -1,0 +1,141 @@
+package app.funput.funput.ime.editing
+
+import android.view.inputmethod.InputConnection
+import app.funput.funput.ime.nativebridge.EngineConfiguration
+import app.funput.funput.ime.nativebridge.VietnameseEngine
+import java.lang.reflect.Proxy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Re-opening a committed word after Backspace, so the next keystroke retones it.
+ * The document must be left untouched whenever the engine refuses the word.
+ */
+class ReopenPreviousWordTest {
+    @Test
+    fun `reopens the word before the caret`() {
+        val editor = FakeEditor(textBeforeCursor = "chào")
+        val engine = AdoptingEngine(adoptable = setOf("chào"))
+        val session = testSession(engine)
+
+        assertTrue(session.reopenPreviousWord(editor.proxy))
+
+        assertEquals("chào", engine.adopted)
+        assertEquals(listOf(4), editor.deletedBefore)
+        assertEquals(listOf("chào"), editor.composingTexts)
+        assertEquals("chào", session.composingText)
+        assertEquals(1, editor.batchDepthPeak) // one atomic edit, not two
+    }
+
+    @Test
+    fun `takes only the last word, not the text before it`() {
+        val editor = FakeEditor(textBeforeCursor = "xin chào")
+        val engine = AdoptingEngine(adoptable = setOf("chào"))
+
+        assertTrue(testSession(engine).reopenPreviousWord(editor.proxy))
+        assertEquals(listOf(4), editor.deletedBefore)
+    }
+
+    @Test
+    fun `leaves the document alone when the engine refuses the word`() {
+        val editor = FakeEditor(textBeforeCursor = "hello")
+        val engine = AdoptingEngine(adoptable = emptySet())
+        val session = testSession(engine)
+
+        assertFalse(session.reopenPreviousWord(editor.proxy))
+
+        assertTrue(editor.deletedBefore.isEmpty())
+        assertTrue(editor.composingTexts.isEmpty())
+        assertEquals("", session.composingText)
+    }
+
+    @Test
+    fun `skips when the caret sits on a boundary`() {
+        val editor = FakeEditor(textBeforeCursor = "chào ")
+        val engine = AdoptingEngine(adoptable = setOf("chào"))
+
+        assertFalse(testSession(engine).reopenPreviousWord(editor.proxy))
+        assertNull(engine.adopted)
+    }
+
+    @Test
+    fun `skips while a selection is active`() {
+        val editor = FakeEditor(textBeforeCursor = "chào", selectedText = "chào")
+        val engine = AdoptingEngine(adoptable = setOf("chào"))
+
+        assertFalse(testSession(engine).reopenPreviousWord(editor.proxy))
+        assertNull(engine.adopted)
+    }
+
+    @Test
+    fun `skips while a composition is already live`() {
+        val editor = FakeEditor(textBeforeCursor = "chào")
+        val engine = AdoptingEngine(adoptable = setOf("chào"))
+        val session = testSession(engine)
+        session.input(editor.proxy, "a") // starts composing
+        editor.composingTexts.clear()
+
+        assertFalse(session.reopenPreviousWord(editor.proxy))
+        assertNull(engine.adopted)
+        assertTrue(editor.composingTexts.isEmpty())
+    }
+
+    @Test
+    fun `skips when there is no connection`() {
+        assertFalse(testSession(AdoptingEngine(setOf("chào"))).reopenPreviousWord(null))
+    }
+}
+
+/** Editor stub covering the calls the re-open path makes. */
+private class FakeEditor(
+    private val textBeforeCursor: String,
+    private val selectedText: String? = null,
+) {
+    val composingTexts = mutableListOf<String>()
+    val deletedBefore = mutableListOf<Int>()
+    var batchDepthPeak = 0
+        private set
+    private var batchDepth = 0
+
+    val proxy: InputConnection = Proxy.newProxyInstance(
+        InputConnection::class.java.classLoader,
+        arrayOf(InputConnection::class.java),
+    ) { _, method, arguments ->
+        when (method.name) {
+            "getTextBeforeCursor" -> textBeforeCursor.takeLast(arguments?.first() as Int)
+            "getSelectedText" -> selectedText
+            "deleteSurroundingText" -> true.also { deletedBefore += arguments?.first() as Int }
+            "setComposingText" -> true.also {
+                composingTexts += (arguments?.first() as CharSequence).toString()
+            }
+            "beginBatchEdit" -> true.also {
+                batchDepth += 1
+                batchDepthPeak = maxOf(batchDepthPeak, batchDepth)
+            }
+            "endBatchEdit" -> true.also { batchDepth -= 1 }
+            "finishComposingText" -> true
+            "toString" -> "FakeEditor"
+            else -> false
+        }
+    } as InputConnection
+}
+
+/** Engine stub whose `adopt` accepts a fixed word set, standing in for the syllable gate. */
+private class AdoptingEngine(private val adoptable: Set<String>) : VietnameseEngine {
+    var adopted: String? = null
+        private set
+
+    override fun adopt(word: String): Boolean =
+        adoptable.contains(word).also { if (it) adopted = word }
+
+    override fun process(codePoint: Int): String = "a"
+    override fun processBoundary(codePoint: Int): String? = null
+    override fun backspace(): String = ""
+    override fun configure(configuration: EngineConfiguration) = Unit
+    override fun setEnabled(enabled: Boolean) = Unit
+    override fun clear() = Unit
+    override fun close() = Unit
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/RetoneAfterBackspaceTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/RetoneAfterBackspaceTest.kt
@@ -1,0 +1,173 @@
+package app.funput.funput.ime.editing
+
+import android.view.inputmethod.InputConnection
+import app.funput.funput.ime.nativebridge.EngineConfiguration
+import app.funput.funput.ime.nativebridge.VietnameseEngine
+import app.funput.funput.keyboard.model.KeyAction
+import java.lang.reflect.Proxy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Retone-after-Backspace through [ImeKeyActionHandler].
+ *
+ * Real-device failure: DeleteBackward and reopenPreviousWord were two top-level
+ * edits. EditText posted onUpdateSelection for the delete with candidatesEnd=-1
+ * *after* reopen had set isComposing, and [ImeKeyActionHandler.onSelectionChanged]
+ * finished the restored composition. Unit tests never called onSelectionChanged,
+ * so they stayed green.
+ */
+class RetoneAfterBackspaceTest {
+    @Test
+    fun `backspace delete and reopen share one outer batch edit`() {
+        val editor = MutableEditor(text = "chào ")
+        val engine = RetoneAdoptingEngine(adoptable = setOf("chào"))
+        val session = testSession(engine)
+        val handler = retoneHandler(session, editor)
+
+        handler.start(allowComposition = true)
+        handler.onKeyAction(KeyAction.Backspace)
+
+        assertEquals("chào", session.composingText)
+        assertEquals("chào", editor.text)
+        assertTrue(
+            "DeleteBackward and reopen must nest under one outer beginBatchEdit " +
+                "so EditText posts a single onUpdateSelection with the composing " +
+                "region already set (candidatesEnd == caret).",
+            editor.deleteOccurredInsideOuterBatch,
+        )
+        assertEquals(0, editor.batchDepth)
+    }
+
+    @Test
+    fun `selection update matching the composing end keeps the reopened word`() {
+        val editor = MutableEditor(text = "chào ")
+        val session = testSession(RetoneAdoptingEngine(adoptable = setOf("chào")))
+        val handler = retoneHandler(session, editor)
+
+        handler.start(allowComposition = true)
+        handler.onKeyAction(KeyAction.Backspace)
+        // Final state after one batched edit: caret and composing end coincide.
+        handler.onSelectionChanged(newStart = 4, newEnd = 4, composingEnd = 4)
+
+        assertTrue(session.isComposing)
+        assertEquals("chào", session.composingText)
+    }
+
+    @Test
+    fun `stale selection update with cleared composing region finishes the word`() {
+        val editor = MutableEditor(text = "chào ")
+        val session = testSession(RetoneAdoptingEngine(adoptable = setOf("chào")))
+        val handler = retoneHandler(session, editor)
+
+        handler.start(allowComposition = true)
+        handler.onKeyAction(KeyAction.Backspace)
+        // What arrives when DeleteBackward is its own top-level edit: the delete's
+        // onUpdateSelection is delivered after reopen has set isComposing.
+        handler.onSelectionChanged(newStart = 4, newEnd = 4, composingEnd = -1)
+
+        assertFalse(session.isComposing)
+        assertEquals(1, editor.finishCount)
+    }
+}
+
+private fun retoneHandler(
+    session: AndroidCompositionSession,
+    editor: MutableEditor,
+) = ImeKeyActionHandler(
+    composition = session,
+    editor = InputConnectionEditor(),
+    connection = { editor.proxy },
+    enterCommand = { ImeEditCommand.CommitText("\n") },
+)
+
+/**
+ * Mutable InputConnection double.
+ *
+ * [InputConnectionEditor.deleteBackward] uses `BreakIterator`, which is unavailable
+ * on plain JVM android stubs. Returning empty for the grapheme lookback (128)
+ * forces the code-point fallback; [wordBeforeCursor] uses lookback 12 and still
+ * sees the real tail after the space is removed.
+ */
+private class MutableEditor(var text: String) {
+    var batchDepth = 0
+        private set
+    var deleteOccurredInsideOuterBatch = false
+        private set
+    var finishCount = 0
+        private set
+    private var sawOuterBatch = false
+
+    val proxy: InputConnection = Proxy.newProxyInstance(
+        InputConnection::class.java.classLoader,
+        arrayOf(InputConnection::class.java),
+    ) { _, method, arguments ->
+        when (method.name) {
+            "getTextBeforeCursor" -> {
+                val n = arguments?.first() as Int
+                if (n >= GraphemeLookback) "" else text.takeLast(n)
+            }
+            "getSelectedText" -> null
+            "deleteSurroundingText" -> {
+                val before = arguments?.first() as Int
+                recordDeleteInBatch()
+                if (before > 0 && text.length >= before) {
+                    text = text.dropLast(before)
+                }
+                true
+            }
+            "deleteSurroundingTextInCodePoints" -> {
+                val before = arguments?.first() as Int
+                recordDeleteInBatch()
+                repeat(before) {
+                    if (text.isEmpty()) return@repeat
+                    val cp = text.codePointBefore(text.length)
+                    text = text.substring(0, text.length - Character.charCount(cp))
+                }
+                true
+            }
+            "setComposingText" -> {
+                text = (arguments?.first() as CharSequence).toString()
+                true
+            }
+            "beginBatchEdit" -> {
+                batchDepth += 1
+                if (batchDepth == 1) sawOuterBatch = true
+                true
+            }
+            "endBatchEdit" -> {
+                batchDepth -= 1
+                true
+            }
+            "finishComposingText" -> true.also { finishCount++ }
+            "commitText" -> {
+                text += arguments?.first().toString()
+                true
+            }
+            "toString" -> "MutableEditor"
+            else -> false
+        }
+    } as InputConnection
+
+    private fun recordDeleteInBatch() {
+        if (sawOuterBatch && batchDepth > 0) deleteOccurredInsideOuterBatch = true
+    }
+
+    private companion object {
+        // Mirrors InputConnectionEditor.GraphemeLookback.
+        const val GraphemeLookback = 128
+    }
+}
+
+private class RetoneAdoptingEngine(private val adoptable: Set<String>) : VietnameseEngine {
+    override fun adopt(word: String): Boolean = adoptable.contains(word)
+    override fun process(codePoint: Int): String = ""
+    override fun processBoundary(codePoint: Int): String? = null
+    override fun backspace(): String = ""
+    override fun configure(configuration: EngineConfiguration) = Unit
+    override fun setEnabled(enabled: Boolean) = Unit
+    override fun clear() = Unit
+    override fun close() = Unit
+}


### PR DESCRIPTION
## Summary

Type `chào`, Space, Backspace — the caret is back on the word, but the engine had already
cleared its state, so `s` typed a literal letter. Now the word is **re-opened as the live
composition** and `s` gives **`cháo`**.

The composition logic needed nothing new: `apply_checked` works from the buffer alone, so
an already-toned word retones in place (`chaofs` has always produced `cháo`). The only
missing piece was **restoring state**, which is all this adds.

## Changes

- **`funput-engine`** — `Engine::adopt(&str) -> bool` seeds `buffer`/`keys`/`vn_form` from
  the text. The keystrokes that produced the word are gone and aren't needed: this is
  exactly the state `on_backspace` already leaves behind. Only a **complete Vietnamese
  syllable** is taken, so English words and URLs never silently become editable — the
  host leaves the document alone when it returns `false`.
- **`funput-jni`** — `nativeAdopt`, reusing the `JString` pattern from `nativeLearn`.
- **Android** — `AndroidCompositionSession.reopenPreviousWord` asks the engine **before**
  touching the document, then re-marks the word inside one
  `beginBatchEdit`/`endBatchEdit` (one atomic edit, one undo step — the pattern
  `acceptSuggestion` already uses). The word scan is a pure `InputConnection` extension in
  `WordBeforeCursor.kt`. `ImeKeyActionHandler.backspace` calls it in **one line**, only on
  the branch that had no live composition.

## Performance & memory (the constraint you set)

**Nothing new runs while typing.** The code sits exclusively on the *Backspace without a
live composition* branch; letters, space and boundaries never reach it.

On that one keystroke: a single bounded read of **12 characters** — against the **128**
that `InputConnectionEditor.deleteBackward` already reads on the same keystroke — and
guards ordered cheapest-first: in-memory flags → the read → the Rust syllable check →
only then a document write.

**Memory:** seeding refills the session strings in place. Measured `adopt` = **1 alloc /
8 B**, and *all* of it is the `is_complete_syllable` gate building its rhyme string — the
same allocation every word boundary already pays.

> I had claimed "allocation-free" while planning. The new budget assertion proved that
> wrong (`adopt: 64 allocs over 64 calls`), so I traced it to
> `funput-core`'s `toneless_rhyme` and corrected both the code comment and the budget
> rather than leaving an inaccurate claim. `tests/alloc_budget.rs` now guards it — I
> verified it **fails at 2 allocs/call** if the seeding is switched to `to_string()`.

## Tests

**Engine (`tests/adopt.rs`, 8 cases)** — the exact Space→Backspace→retone scenario;
`Chào` capitalized (sentence-initial words must work); toneless `chao` + VNI `2`; refusals
for `""`/`text`/`tẽt`/`hello`/`funput.app`/`chào bạn` and while disabled; flip is a no-op
on an adopted word; a boundary after editing commits `cháo `, not the raw keys.

**Android (`ReopenPreviousWordTest`, 7 cases)** — reopens the word; takes only the last
word out of `xin chào`; leaves the document untouched when refused; skips on a boundary,
during a selection, while already composing, and with no connection; asserts the edit
happens in a single batch.

- `cargo test --workspace` green (30 suites); `clippy --workspace --all-targets -D
  warnings`, `fmt`, `scripts/check-loc.sh` clean.
- `./gradlew :ime:testDebugUnitTest` → **76 tests, 0 failures**;
  `:ime:assembleDebug` builds the `.so` per ABI and `nm` confirms `nativeAdopt` is
  exported — the library's **9 symbols match the 9 `external fun`** declarations.
- `check-kotlin-loc.sh` passes (I split `WordBeforeCursor.kt` out to keep
  `AndroidCompositionSession.kt` under 150).

⚠️ **Worth a device/emulator pass**: `chào` → Space → Backspace → `s` ⇒ `cháo`; and the
cases that should *not* re-open — after punctuation, after an English word, inside a
password field, while text is selected.

## Scope

Android only. iOS/macOS/Linux can reuse `Engine::adopt` later; **Windows cannot** — its
global hook+inject shell has no way to read the document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
