### PR TITLE
fix(ios): stop cancelling keystrokes the user really made

### DIFF
--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController+Lifecycle.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController+Lifecycle.swift
@@ -27,7 +27,12 @@ extension KeyboardSurfaceInteractionController {
     }
 
     func reconcileActiveTouches(_ activeTokens: Set<TouchToken>) {
-        let orphaned = Set(touches.keys).subtracting(activeTokens)
+        // Toolbar and accessibility presses never reach the overlay, so they are
+        // absent from `activeTokens` by construction and must not be read as
+        // abandoned — an unrelated keycap touch would otherwise cancel them.
+        let orphaned = Set(touches.keys)
+            .subtracting(activeTokens)
+            .filter { $0 < Self.firstLegacyToken }
         for token in orphaned { cancelTouch(token: token) }
     }
 

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController.swift
@@ -37,7 +37,10 @@ final class KeyboardSurfaceInteractionController {
     var repeatTouch: TouchToken?
     var hapticsEnabled = true
     var legacyTokensByKeyID: [String: [TouchToken]] = [:]
-    var nextLegacyToken: TouchToken = 1 << 63
+    /// Toolbar and accessibility presses are minted from here up, which keeps them
+    /// distinguishable from the overlay's tokens without a second bookkeeping map.
+    static let firstLegacyToken: TouchToken = 1 << 63
+    var nextLegacyToken: TouchToken = KeyboardSurfaceInteractionController.firstLegacyToken
 
     var activeKey: KeySpec? { commitQueue.activeKey }
     var queueDepth: Int { commitQueue.depth }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardTouchOverlayView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardTouchOverlayView.swift
@@ -18,8 +18,7 @@ final class KeyboardTouchOverlayView: UIView {
     private static let outerTolerance: CGFloat = 12
     private var keys: [ResolvedKey] = []
     private var trackingBounds = CGRect.null
-    private var tokens: [ObjectIdentifier: TouchToken] = [:]
-    private var nextToken: TouchToken = 1
+    private var ledger = KeyboardTouchTokenLedger()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -27,7 +26,6 @@ final class KeyboardTouchOverlayView: UIView {
         isOpaque = false
         backgroundColor = .clear
         isAccessibilityElement = false
-        tokens.reserveCapacity(10)
     }
 
     @available(*, unavailable)
@@ -52,11 +50,11 @@ final class KeyboardTouchOverlayView: UIView {
         for touch in touches {
             let point = touch.location(in: self)
             guard let hit = hit(at: point) else { continue }
-            let identifier = ObjectIdentifier(touch)
-            guard tokens[identifier] == nil else { continue }
-            let token = nextToken
-            nextToken &+= 1
-            tokens[identifier] = token
+            let (token, stale) = ledger.beginToken(for: touch)
+            // Retire a stale mapping rather than skipping the press as a duplicate:
+            // UIKit recycles touch objects, so a leftover entry must never cost the
+            // user a keystroke.
+            if let stale { onCancel?(stale) }
             onBegin?(token, hit, point)
         }
         reconcile(event)
@@ -64,7 +62,7 @@ final class KeyboardTouchOverlayView: UIView {
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
         for touch in touches {
-            guard let token = tokens[ObjectIdentifier(touch)] else { continue }
+            guard let token = ledger.token(for: touch) else { continue }
             let point = touch.location(in: self)
             onMove?(token, trackingBounds.contains(point) ? hit(at: point) : nil, point)
         }
@@ -73,8 +71,7 @@ final class KeyboardTouchOverlayView: UIView {
 
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         for touch in touches {
-            let identifier = ObjectIdentifier(touch)
-            guard let token = tokens.removeValue(forKey: identifier) else { continue }
+            guard let token = ledger.removeToken(for: touch) else { continue }
             let point = touch.location(in: self)
             onMove?(token, trackingBounds.contains(point) ? hit(at: point) : nil, point)
             onEnd?(token)
@@ -84,16 +81,14 @@ final class KeyboardTouchOverlayView: UIView {
 
     override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
         for touch in touches {
-            guard let token = tokens.removeValue(forKey: ObjectIdentifier(touch)) else { continue }
+            guard let token = ledger.removeToken(for: touch) else { continue }
             onCancel?(token)
         }
         reconcile(event)
     }
 
     func cancelAllTrackedTouches() {
-        let active = Array(tokens.values)
-        tokens.removeAll(keepingCapacity: true)
-        active.forEach { onCancel?($0) }
+        ledger.removeAllTokens().forEach { onCancel?($0) }
         onReconcile?([])
     }
 
@@ -118,17 +113,11 @@ final class KeyboardTouchOverlayView: UIView {
     }
 
     private func reconcile(_ event: UIEvent?) {
-        guard let allTouches = event?.allTouches else {
-            onReconcile?(Set(tokens.values))
+        guard let event, let allTouches = event.allTouches else {
+            onReconcile?(ledger.trackedTokens)
             return
         }
-        let activeIdentifiers = Set(allTouches.lazy.filter {
-            $0.phase == .began || $0.phase == .moved || $0.phase == .stationary
-        }.map { ObjectIdentifier($0) })
-        let activeTokens = Set(tokens.compactMap { identifier, token in
-            activeIdentifiers.contains(identifier) ? token : nil
-        })
-        onReconcile?(activeTokens)
+        onReconcile?(ledger.survivors(in: allTouches, at: event.timestamp))
     }
 }
 #endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardTouchTokenLedger.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardTouchTokenLedger.swift
@@ -1,0 +1,95 @@
+#if canImport(UIKit)
+import UIKit
+
+/// Maps UIKit's touch objects to commit tokens and decides when a tracked touch
+/// has really been abandoned.
+///
+/// UIKit dispatches one `touches…` callback per phase group of an event, so a
+/// finger that has just lifted already reports `.ended` while its own terminal
+/// callback is still queued behind the next finger's `touchesBegan`. Reading the
+/// phase alone therefore cannot tell "lifted, delivery pending" from "abandoned":
+/// a touch is only given up once UIKit stops listing it, or once a *later* event
+/// still reports it finished. Anything stricter cancels a real keystroke.
+struct KeyboardTouchTokenLedger {
+    typealias TouchToken = KeyboardPressCommitQueue.TouchToken
+
+    private var tokens: [ObjectIdentifier: TouchToken] = [:]
+    private var finishedSince: [ObjectIdentifier: TimeInterval] = [:]
+    private var nextToken: TouchToken = 1
+
+    init() {
+        tokens.reserveCapacity(10)
+    }
+
+    var trackedTokens: Set<TouchToken> { Set(tokens.values) }
+
+    func token(for touch: UITouch) -> TouchToken? {
+        tokens[ObjectIdentifier(touch)]
+    }
+
+    /// Starts tracking `touch`. A mapping that survives for the same object is
+    /// stale by definition — a touch object never begins twice, and UIKit recycles
+    /// them — so it is handed back to be retired instead of the new press being
+    /// discarded as a duplicate.
+    mutating func beginToken(for touch: UITouch) -> (token: TouchToken, stale: TouchToken?) {
+        let identifier = ObjectIdentifier(touch)
+        let stale = tokens.removeValue(forKey: identifier)
+        finishedSince.removeValue(forKey: identifier)
+        let token = nextToken
+        nextToken &+= 1
+        tokens[identifier] = token
+        return (token, stale)
+    }
+
+    mutating func removeToken(for touch: UITouch) -> TouchToken? {
+        let identifier = ObjectIdentifier(touch)
+        finishedSince.removeValue(forKey: identifier)
+        return tokens.removeValue(forKey: identifier)
+    }
+
+    mutating func removeAllTokens() -> [TouchToken] {
+        let tracked = Array(tokens.values)
+        tokens.removeAll(keepingCapacity: true)
+        finishedSince.removeAll(keepingCapacity: true)
+        return tracked
+    }
+
+    /// Forgets the touches UIKit has stopped reporting and returns the survivors.
+    mutating func survivors(
+        in allTouches: Set<UITouch>,
+        at timestamp: TimeInterval
+    ) -> Set<TouchToken> {
+        var isFinishedByIdentifier: [ObjectIdentifier: Bool] = [:]
+        isFinishedByIdentifier.reserveCapacity(allTouches.count)
+        for touch in allTouches {
+            isFinishedByIdentifier[ObjectIdentifier(touch)] =
+                touch.phase == .ended || touch.phase == .cancelled
+        }
+
+        var abandoned: [ObjectIdentifier] = []
+        for identifier in tokens.keys {
+            guard let isFinished = isFinishedByIdentifier[identifier] else {
+                abandoned.append(identifier) // UIKit no longer knows this touch
+                continue
+            }
+            guard isFinished else {
+                finishedSince.removeValue(forKey: identifier)
+                continue
+            }
+            guard let since = finishedSince[identifier] else {
+                finishedSince[identifier] = timestamp // terminal callback still in flight
+                continue
+            }
+            // A later event still reports it finished, so the callback is never
+            // coming; give it up rather than block the commit queue behind it.
+            if timestamp > since { abandoned.append(identifier) }
+        }
+
+        for identifier in abandoned {
+            tokens.removeValue(forKey: identifier)
+            finishedSince.removeValue(forKey: identifier)
+        }
+        return Set(tokens.values)
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardTouchTokenLedger.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardTouchTokenLedger.swift
@@ -10,6 +10,10 @@ import UIKit
 /// phase alone therefore cannot tell "lifted, delivery pending" from "abandoned":
 /// a touch is only given up once UIKit stops listing it, or once a *later* event
 /// still reports it finished. Anything stricter cancels a real keystroke.
+///
+/// Touch delivery is main-thread only, and reading `UITouch.phase` requires the
+/// main actor, so the whole ledger is isolated to it.
+@MainActor
 struct KeyboardTouchTokenLedger {
     typealias TouchToken = KeyboardPressCommitQueue.TouchToken
 

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardTouchAbandonmentTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardTouchAbandonmentTests.swift
@@ -1,0 +1,103 @@
+#if canImport(UIKit)
+@testable import KeyboardRenderer
+import KeyboardLayout
+import Testing
+import UIKit
+
+/// What may count as an abandoned touch.
+///
+/// UIKit dispatches one callback per phase group of an event, so a finger that has
+/// lifted already reports `.ended` while its own `touchesEnded` is still queued
+/// behind the next finger's `touchesBegan`. Reading that as abandonment cancelled
+/// the press — and a cancelled press produces no text — which dropped keys during
+/// fast typing. These cases pin the boundary down.
+@MainActor
+struct KeyboardTouchAbandonmentTests {
+    @Test("A finger lifting as the next one lands keeps its press")
+    func liftedFingerKeepsItsPress() {
+        let recorder = OverlayTouchRecorder()
+        let first = recorder.touch(at: OverlayTouchRecorder.keyAPoint)
+        recorder.began(first, at: 1)
+
+        // Same event: the first finger has lifted, the second lands, and UIKit
+        // happens to dispatch `began` before the first finger's `ended`.
+        let second = recorder.touch(at: OverlayTouchRecorder.keyBPoint)
+        first.stubPhase = .ended
+        recorder.began(second, alongside: [first], at: 2)
+
+        #expect(recorder.lastReconcile.contains(1), "the lifted finger is still tracked")
+        recorder.ended(first, alongside: [second], at: 2)
+        #expect(recorder.log == ["begin(1,key-a)", "begin(2,key-b)", "move(1,key-a)", "end(1)"])
+    }
+
+    @Test("A touch UIKit stops reporting is given up")
+    func vanishedTouchIsAbandoned() {
+        let recorder = OverlayTouchRecorder()
+        let first = recorder.touch(at: OverlayTouchRecorder.keyAPoint)
+        let second = recorder.touch(at: OverlayTouchRecorder.keyBPoint)
+        recorder.began(first, at: 1)
+        recorder.began(second, alongside: [first], at: 2)
+
+        // The first finger's terminal callback never arrived and UIKit no longer
+        // lists it, so nothing more is coming for it.
+        recorder.moved(second, at: 3)
+
+        #expect(recorder.lastReconcile == [2])
+    }
+
+    @Test("A finished touch is given up once a later event still reports it")
+    func stuckFinishedTouchIsAbandoned() {
+        let recorder = OverlayTouchRecorder()
+        let touch = recorder.touch(at: OverlayTouchRecorder.keyAPoint)
+        recorder.began(touch, at: 1)
+
+        touch.stubPhase = .ended
+        recorder.moved(touch, at: 2)
+        #expect(recorder.lastReconcile == [1], "its callback may still be in flight")
+
+        recorder.moved(touch, at: 3)
+        #expect(recorder.lastReconcile.isEmpty, "a later event proves it is stuck")
+    }
+
+    @Test("A press on a recycled touch object is not swallowed")
+    func recycledTouchObjectStillPresses() {
+        let recorder = OverlayTouchRecorder()
+        let touch = recorder.touch(at: OverlayTouchRecorder.keyAPoint)
+        recorder.began(touch, at: 1)
+
+        // UIKit recycles touch objects. If a mapping outlives its touch, the next
+        // press landing on the same object must still register.
+        touch.stubLocation = OverlayTouchRecorder.keyBPoint
+        recorder.began(touch, at: 2)
+
+        #expect(recorder.log == ["begin(1,key-a)", "cancel(1)", "begin(2,key-b)"])
+    }
+
+    @Test("A toolbar press is not mistaken for an abandoned touch")
+    func toolbarPressSurvivesReconcile() {
+        var events: [KeyboardKeyEvent] = []
+        let controller = KeyboardSurfaceInteractionController(
+            onEvent: { events.append($0) },
+            onPreview: { _, _ in }
+        )
+        var presentation = KeyboardPresentation()
+        presentation.isHapticFeedbackEnabled = false
+        let emoji = KeySpec(id: "key-emoji", label: "☺", role: .emoji)
+
+        controller.handle(
+            KeyboardKeyEvent(key: emoji, phase: .pressed),
+            sourceFrame: .zero,
+            presentation: presentation
+        )
+        // A keycap touch elsewhere reports only the overlay's own tokens.
+        controller.reconcileActiveTouches([])
+        controller.handle(
+            KeyboardKeyEvent(key: emoji, phase: .released),
+            sourceFrame: .zero,
+            presentation: presentation
+        )
+
+        #expect(events.map(\.phase) == [.pressed, .released])
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardTouchStubs.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardTouchStubs.swift
@@ -1,0 +1,86 @@
+#if canImport(UIKit)
+@testable import KeyboardRenderer
+import KeyboardLayout
+import UIKit
+
+/// Fabricated touches for driving `KeyboardTouchOverlayView`'s UIResponder entry
+/// points directly. Nothing here goes through UIKit's own dispatch, which is what
+/// makes it work at all — synthesized touches cannot be delivered by the system.
+final class StubTouch: UITouch {
+    var stubPhase: UITouch.Phase = .began
+    var stubLocation: CGPoint = .zero
+
+    override var phase: UITouch.Phase { stubPhase }
+    override func location(in view: UIView?) -> CGPoint { stubLocation }
+}
+
+final class StubTouchEvent: UIEvent {
+    var stubTouches: Set<UITouch> = []
+    var stubTimestamp: TimeInterval = 0
+
+    override var allTouches: Set<UITouch>? { stubTouches }
+    override var timestamp: TimeInterval { stubTimestamp }
+}
+
+/// Two keycaps and a log of everything the overlay reports upward.
+@MainActor
+final class OverlayTouchRecorder {
+    static let keyAPoint = CGPoint(x: 10, y: 20)
+    static let keyBPoint = CGPoint(x: 60, y: 20)
+
+    let overlay = KeyboardTouchOverlayView(frame: CGRect(x: 0, y: 0, width: 100, height: 50))
+    var log: [String] = []
+    var lastReconcile: Set<KeyboardPressCommitQueue.TouchToken> = []
+
+    init() {
+        let a = KeySpec(id: "key-a", label: "a", role: .character)
+        let b = KeySpec(id: "key-b", label: "b", role: .character)
+        overlay.updateGeometry(
+            ResolvedKeyboard(
+                size: CGSize(width: 100, height: 50),
+                toolbarFrame: nil,
+                rows: [[
+                    ResolvedKey(spec: a, frame: CGRect(x: 0, y: 0, width: 40, height: 40)),
+                    ResolvedKey(spec: b, frame: CGRect(x: 50, y: 0, width: 40, height: 40)),
+                ]]
+            )
+        )
+        overlay.onBegin = { [weak self] token, hit, _ in
+            self?.log.append("begin(\(token),\(hit.key.id))")
+        }
+        overlay.onMove = { [weak self] token, hit, _ in
+            self?.log.append("move(\(token),\(hit?.key.id ?? "nil"))")
+        }
+        overlay.onEnd = { [weak self] in self?.log.append("end(\($0))") }
+        overlay.onCancel = { [weak self] in self?.log.append("cancel(\($0))") }
+        overlay.onReconcile = { [weak self] in self?.lastReconcile = $0 }
+    }
+
+    func touch(at point: CGPoint) -> StubTouch {
+        let touch = StubTouch()
+        touch.stubLocation = point
+        return touch
+    }
+
+    /// Every callback carries the event, so `allTouches` is what UIKit currently
+    /// knows — including fingers whose own callback has not been dispatched yet.
+    private func event(_ touches: [UITouch], at timestamp: TimeInterval) -> StubTouchEvent {
+        let event = StubTouchEvent()
+        event.stubTouches = Set(touches)
+        event.stubTimestamp = timestamp
+        return event
+    }
+
+    func began(_ touch: StubTouch, alongside others: [UITouch] = [], at timestamp: TimeInterval) {
+        overlay.touchesBegan([touch], with: event([touch] + others, at: timestamp))
+    }
+
+    func moved(_ touch: StubTouch, alongside others: [UITouch] = [], at timestamp: TimeInterval) {
+        overlay.touchesMoved([touch], with: event([touch] + others, at: timestamp))
+    }
+
+    func ended(_ touch: StubTouch, alongside others: [UITouch] = [], at timestamp: TimeInterval) {
+        overlay.touchesEnded([touch], with: event([touch] + others, at: timestamp))
+    }
+}
+#endif


### PR DESCRIPTION
Fast typing on a real device occasionally lost a letter. The touch layer threw it away — the engine and the input coordinator are not involved.

## Root cause

`KeyboardTouchOverlayView.reconcile` decided a tracked touch was abandoned from its phase alone:

```swift
$0.phase == .began || $0.phase == .moved || $0.phase == .stationary
```

UIKit dispatches **one callback per phase group of an event**. A finger that has just lifted therefore already reports `.ended` in `allTouches` while its own `touchesEnded` is still queued *behind* the next finger's `touchesBegan`. With `began` dispatched first, the lifted finger was declared an orphan → `reconcileActiveTouches` cancelled it → `handleKeyEvent` returns without inserting text for a `.cancelled` press → the finger's real `touchesEnded` found no state left. The keystroke was gone.

It needs two presses to overlap — fast typing — and the dispatch order decides whether the key survives, which is why it was intermittent.

Reproduced in-process before the fix, by driving the overlay's real `touchesBegan`/`touchesEnded` with an event whose `allTouches` phases the test controls:

```
begin(1,key-a)
reconcile([1])
begin(2,key-b)
reconcile([2])   ← token 1 dropped while finger A had not ended yet
end(1)           ← arrives after the controller discarded it
```

## Fix

A touch is given up only when UIKit stops listing it, or when a *later* event still reports it finished. The one-event grace window closes the race while preserving what the orphan check was written for: a touch UIKit forgets must not block the commit queue behind it (`KeyboardTouchPipelineTests.orphanedTouchDoesNotBlock` still passes unchanged).

Two further losses in the same seam:

- **Divergent bookkeeping.** The overlay kept its own identifier→token map while `reconcile` tore down only the controller's state. UIKit recycles `UITouch` objects, so a leftover entry made the next press on that object be skipped as a duplicate — silently: no highlight, no haptic, no event. Bookkeeping now lives in one place (`KeyboardTouchTokenLedger`), and a press landing on a stale mapping retires it instead of being discarded.
- **Toolbar and accessibility presses.** They are minted from `1 << 63` up and never reach the overlay, so they were absent from every reported active set and any keycap touch cancelled them. `reconcileActiveTouches` now leaves them alone.

## Why the existing tests missed it

Every touch test goes through `KeyboardTouchTestDriver`, which calls `beginTouch`/`endTouch`/`reconcile` on the controller directly and so skips the `UITouch`/`allTouches` layer where the bug lives. On the simulator the XCTest synthesizer corrupts overlapping pointer playback, so the UI test could not see it either.

`KeyboardTouchAbandonmentTests` now covers that layer with five cases: a finger lifting as the next lands, a touch UIKit stops reporting, a touch stuck in a finished phase, a press on a recycled touch object, and a toolbar press surviving reconcile.

## Verification

- `Scripts/test-funput-kit.sh` → `** TEST SUCCEEDED **`, 25 suites; the 5 new cases pass and `KeyboardInteractionTests`, `KeyboardInteractionOrderingTests`, `KeyboardRepeatInteractionTests`, `LanguageSwipeInteractionTests` are unchanged.
- `xcodebuild test -only-testing:FunputTests/KeyboardTouchPipelineTests` on iPhone 17e / iOS 27.0 — all 5 pass, including the orphan-does-not-block guarantee.
- `Scripts/check-swift-loc.sh` passes.

**Needs a device test:** type Vietnamese fast for a while, especially with overlapping thumbs, and confirm no letter goes missing.

Still open from the same investigation, deliberately not in this PR: a character key cancelled by the *system* (notification banner, incoming call, edge gesture) is still discarded even though the user did press it, and `layoutChanged` cancels a finger already down on the next key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
