### PR TITLE
feat(ios): honour a press the system cancelled

### DIFF
--- a/platforms/ios/FunputTests/KeyboardTouchPipelineTests.swift
+++ b/platforms/ios/FunputTests/KeyboardTouchPipelineTests.swift
@@ -31,7 +31,7 @@ struct KeyboardTouchPipelineTests {
         #expect(!driver.events.contains { $0.phase == .released })
     }
 
-    @Test("Missing terminal event is reconciled without blocking successors")
+    @Test("A press UIKit abandons still commits, and does not block successors")
     func orphanedTouchDoesNotBlock() {
         let driver = KeyboardTouchTestDriver()
         let a = key("a"), b = key("b")
@@ -41,7 +41,10 @@ struct KeyboardTouchPipelineTests {
         driver.reconcile(activeTokens: [2])
         driver.end(token: 2)
 
-        #expect(driver.events.suffix(2).map(\.phase) == [.cancelled, .released])
+        // Losing the terminal event is UIKit's failure, not the user changing
+        // their mind: the finger was on "a", so "a" is typed. The queue drains in
+        // touch-down order either way.
+        #expect(driver.events.suffix(2).map(\.phase) == [.released, .released])
         #expect(driver.events.suffix(2).map(\.key.id) == [a.id, b.id])
         #expect(driver.queueDepth == 0)
     }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController+Lifecycle.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController+Lifecycle.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import KeyboardLayout
 import UIKit
 
 extension KeyboardSurfaceInteractionController {
@@ -16,14 +17,41 @@ extension KeyboardSurfaceInteractionController {
         flushCompletedKeys()
     }
 
-    func cancelTouch(token: TouchToken) {
+    func cancelTouch(token: TouchToken, reason: Cancellation) {
         guard let state = touches.removeValue(forKey: token) else { return }
         if let key = state.currentKey { setHighlighted(key, false) }
-        if repeatTouch == token { clearKeyRepeat() }
-        commitQueue.complete(token: token, as: .cancelled)
+        let wasRepeating = repeatTouch == token && repeatController.finish()
+        if repeatTouch == token { repeatTouch = nil }
+        commitQueue.complete(
+            token: token,
+            as: completion(cancelling: state, reason: reason, wasRepeating: wasRepeating)
+        )
         endSignpost(state, token: token, phase: 2)
         refreshPreview()
         flushCompletedKeys()
+    }
+
+    /// A press the system took away is still a press the user made, so a key that
+    /// was under the finger commits anyway. Three exclusions keep that from
+    /// inventing input nobody asked for:
+    ///
+    /// - keys that are destructive or hard to undo. Losing one Backspace is
+    ///   annoying; an extra one damages text, and an extra Return sends a message.
+    /// - a finger that wandered, which is a gesture that merely started on a
+    ///   keycap: a swipe up from the home indicator begins as a touch on the
+    ///   bottom row and ends as a system cancellation.
+    /// - a held key whose repeats already fired.
+    private func completion(
+        cancelling state: TouchState,
+        reason: Cancellation,
+        wasRepeating: Bool
+    ) -> KeyboardPressCommitQueue.Completion {
+        guard reason == .system,
+              let key = state.currentKey,
+              key.role.commitsOnSystemCancellation,
+              !state.hasWandered
+        else { return .cancelled }
+        return wasRepeating ? .suppressed : .released
     }
 
     func reconcileActiveTouches(_ activeTokens: Set<TouchToken>) {
@@ -33,9 +61,11 @@ extension KeyboardSurfaceInteractionController {
         let orphaned = Set(touches.keys)
             .subtracting(activeTokens)
             .filter { $0 < Self.firstLegacyToken }
-        for token in orphaned { cancelTouch(token: token) }
+        for token in orphaned { cancelTouch(token: token, reason: .system) }
     }
 
+    /// Teardown: the surface is going away, so pending presses are discarded
+    /// rather than routed through `cancelTouch`, which would honour them.
     func cancelAll() {
         for (token, state) in touches {
             if let key = state.currentKey { setHighlighted(key, false) }
@@ -69,7 +99,12 @@ extension KeyboardSurfaceInteractionController {
         case .released:
             if let token = takeLegacyToken(for: event.key.id) { endTouch(token: token) }
         case .cancelled:
-            if let token = takeLegacyToken(for: event.key.id) { cancelTouch(token: token) }
+            // The toolbar and accessibility controls report drag-off and system
+            // cancellation through one action, so this path cannot tell them apart
+            // and keeps discarding the press.
+            if let token = takeLegacyToken(for: event.key.id) {
+                cancelTouch(token: token, reason: .userIntent)
+            }
         case let .swiped(action):
             if let token = legacyTokensByKeyID[event.key.id]?.first,
                let state = touches[token] {
@@ -81,6 +116,17 @@ extension KeyboardSurfaceInteractionController {
             }
         case .repeated:
             break
+        }
+    }
+}
+
+private extension KeyRole {
+    /// Text-producing keys that are safe to honour when the system cancels the
+    /// touch. Backspace and Return are deliberately absent.
+    var commitsOnSystemCancellation: Bool {
+        switch self {
+        case .character, .vniModifier, .punctuation, .space: true
+        default: false
         }
     }
 }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController+Tracking.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController+Tracking.swift
@@ -53,6 +53,12 @@ extension KeyboardSurfaceInteractionController {
     ) {
         guard var state = touches[token] else { return }
         hapticsEnabled = presentation.isHapticFeedbackEnabled
+        if !state.hasWandered {
+            let dx = point.x - state.startPoint.x
+            let dy = point.y - state.startPoint.y
+            let slop = KeyboardSurfaceInteractionController.tapSlop
+            state.hasWandered = dx * dx + dy * dy > slop * slop
+        }
         if let action = state.swipeTracker.update(
             translation: CGPoint(x: point.x - state.startPoint.x, y: point.y - state.startPoint.y),
             action: state.initialKey.horizontalSwipeAction

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardSurfaceInteractionController.swift
@@ -12,14 +12,28 @@ final class KeyboardSurfaceInteractionController {
     typealias PreviewHandler = (_ key: KeySpec?, _ sourceFrame: CGRect?) -> Void
     typealias HighlightHandler = (_ key: KeySpec, _ highlighted: Bool) -> Void
 
+    /// Why a tracked touch is ending without a release.
+    enum Cancellation {
+        /// UIKit took the touch away, or stopped reporting it. The user did press.
+        case system
+        /// The user lifted or dragged off on purpose.
+        case userIntent
+    }
+
     struct TouchState {
         let initialKey: KeySpec
         let startPoint: CGPoint
         var currentKey: KeySpec?
         var currentFrame: CGRect?
         var swipeTracker = KeySwipeGestureTracker()
+        /// Set once the finger travels past `tapSlop`, which separates a tap from a
+        /// gesture that merely started on a keycap.
+        var hasWandered = false
         let signpostID: OSSignpostID
     }
+
+    /// Half the swipe threshold: past this a touch is no longer a tap.
+    static let tapSlop: CGFloat = 16
 
     let haptics: KeyboardHaptics
     let onEvent: (KeyboardKeyEvent) -> Void

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardTouchOverlayView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardTouchOverlayView.swift
@@ -87,9 +87,12 @@ final class KeyboardTouchOverlayView: UIView {
         reconcile(event)
     }
 
-    func cancelAllTrackedTouches() {
-        ledger.removeAllTokens().forEach { onCancel?($0) }
-        onReconcile?([])
+    /// Drops the overlay's bookkeeping without reporting anything upward. Both
+    /// call sites pair this with the controller's own `cancelAll()`, which is what
+    /// discards the pending presses; reporting them as cancellations instead would
+    /// now commit them.
+    func forgetTrackedTouches() {
+        ledger.removeAllTokens()
     }
 
     func resolvedHit(at point: CGPoint) -> Hit? {

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardTouchTokenLedger.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/KeyboardTouchTokenLedger.swift
@@ -51,11 +51,9 @@ struct KeyboardTouchTokenLedger {
         return tokens.removeValue(forKey: identifier)
     }
 
-    mutating func removeAllTokens() -> [TouchToken] {
-        let tracked = Array(tokens.values)
+    mutating func removeAllTokens() {
         tokens.removeAll(keepingCapacity: true)
         finishedSince.removeAll(keepingCapacity: true)
-        return tracked
     }
 
     /// Forgets the touches UIKit has stopped reporting and returns the survivors.

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/KeyboardSurfaceView+Presentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/KeyboardSurfaceView+Presentation.swift
@@ -9,7 +9,7 @@ extension KeyboardSurfaceView {
         let themeChanged = oldValue.theme != presentation.theme
         let edgeBlendChanged = oldValue.blendsSystemEdge != presentation.blendsSystemEdge
         if layoutChanged {
-            touchOverlay.cancelAllTrackedTouches()
+            touchOverlay.forgetTrackedTouches()
             interactionController.cancelAll()
             rebuildKeys()
         }
@@ -103,7 +103,7 @@ extension KeyboardSurfaceView {
             self?.interactionController.endTouch(token: token)
         }
         touchOverlay.onCancel = { [weak self] token in
-            self?.interactionController.cancelTouch(token: token)
+            self?.interactionController.cancelTouch(token: token, reason: .system)
         }
         touchOverlay.onReconcile = { [weak self] active in
             self?.interactionController.reconcileActiveTouches(active)

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/KeyboardSurfaceView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/KeyboardSurfaceView.swift
@@ -78,7 +78,7 @@ public final class KeyboardSurfaceView: UIView {
     public override func didMoveToWindow() {
         super.didMoveToWindow()
         if window == nil {
-            touchOverlay.cancelAllTrackedTouches()
+            touchOverlay.forgetTrackedTouches()
             interactionController.cancelAll()
         }
     }

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardSystemCancellationTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardSystemCancellationTests.swift
@@ -1,0 +1,115 @@
+#if canImport(UIKit)
+@testable import KeyboardRenderer
+import KeyboardLayout
+import Testing
+import UIKit
+
+/// A press the system takes away is still a press the user made, so it commits —
+/// with the exclusions that keep that from inventing input nobody asked for.
+@MainActor
+struct KeyboardSystemCancellationTests {
+    private func makeController(
+        _ events: @escaping (KeyboardKeyEvent) -> Void
+    ) -> KeyboardSurfaceInteractionController {
+        KeyboardSurfaceInteractionController(onEvent: events, onPreview: { _, _ in })
+    }
+
+    private var presentation: KeyboardPresentation {
+        var presentation = KeyboardPresentation()
+        presentation.isHapticFeedbackEnabled = false
+        return presentation
+    }
+
+    private func press(
+        _ key: KeySpec,
+        on controller: KeyboardSurfaceInteractionController,
+        token: KeyboardPressCommitQueue.TouchToken = 1
+    ) {
+        controller.beginTouch(
+            token: token,
+            key: key,
+            point: .zero,
+            sourceFrame: nil,
+            presentation: presentation
+        )
+    }
+
+    @Test("A letter the system cancels is still typed")
+    func systemCancellationCommitsALetter() {
+        var events: [KeyboardKeyEvent] = []
+        let controller = makeController { events.append($0) }
+        let letter = KeySpec(id: "key-a", label: "a", role: .character)
+
+        press(letter, on: controller)
+        controller.cancelTouch(token: 1, reason: .system)
+
+        #expect(events.map(\.phase) == [.pressed, .released])
+        #expect(events.last?.key.id == letter.id)
+    }
+
+    @Test("Backspace and Return are not invented on a system cancellation")
+    func destructiveKeysStayCancelled() {
+        for role in [KeyRole.backspace, .enter] {
+            var events: [KeyboardKeyEvent] = []
+            let controller = makeController { events.append($0) }
+            press(KeySpec(id: "key-\(role)", label: "x", role: role), on: controller)
+
+            controller.cancelTouch(token: 1, reason: .system)
+
+            #expect(events.map(\.phase) == [.pressed, .cancelled], "role: \(role)")
+        }
+    }
+
+    @Test("A finger that wandered is a gesture, not a press")
+    func wanderedTouchStaysCancelled() {
+        var events: [KeyboardKeyEvent] = []
+        let controller = makeController { events.append($0) }
+        let space = KeySpec(id: "key-space", label: " ", role: .space)
+
+        press(space, on: controller)
+        // A swipe up from the home indicator starts on the bottom row and ends as
+        // a system cancellation; it must not leave a space behind.
+        controller.moveTouch(
+            token: 1,
+            key: space,
+            point: CGPoint(x: 0, y: -40),
+            sourceFrame: nil,
+            presentation: presentation
+        )
+        controller.cancelTouch(token: 1, reason: .system)
+
+        #expect(events.map(\.phase) == [.pressed, .cancelled])
+    }
+
+    @Test("Lifting outside a toolbar control still discards the press")
+    func userIntentStaysCancelled() {
+        var events: [KeyboardKeyEvent] = []
+        let controller = makeController { events.append($0) }
+        let emoji = KeySpec(id: "key-emoji", label: "☺", role: .emoji)
+
+        controller.handle(
+            KeyboardKeyEvent(key: emoji, phase: .pressed),
+            sourceFrame: .zero,
+            presentation: presentation
+        )
+        controller.handle(
+            KeyboardKeyEvent(key: emoji, phase: .cancelled),
+            sourceFrame: .zero,
+            presentation: presentation
+        )
+
+        #expect(events.map(\.phase) == [.pressed, .cancelled])
+    }
+
+    @Test("Teardown discards pending presses instead of committing them")
+    func teardownStaysCancelled() {
+        var events: [KeyboardKeyEvent] = []
+        let controller = makeController { events.append($0) }
+        press(KeySpec(id: "key-a", label: "a", role: .character), on: controller)
+
+        controller.cancelAll()
+
+        #expect(events.map(\.phase) == [.pressed, .cancelled])
+    }
+}
+#endif


### PR DESCRIPTION
Stacked on #106 — review that one first; this PR's diff is only items 4 and 5 of the dropped-keys investigation.

#106 stopped Funput from cancelling presses itself. This one stops a press from being lost when **UIKit** cancels the touch: a notification banner, an incoming call, an edge gesture, or a touch the system simply stops reporting. The user pressed the key; `handleKeyEvent` returning early for `.cancelled` meant nothing was typed.

## What changed

`cancelTouch` now takes why the touch ended without a release:

| Reason | Source | Outcome |
|---|---|---|
| `.system` | `touchesCancelled`, an abandoned touch, a retired stale mapping | commits the key under the finger |
| `.userIntent` | lifted or dragged off a toolbar/accessibility control | discarded, as before |

Lifting outside the keyboard still aborts a press — that path goes through `endTouch` with no current key and is untouched (`outsideReleaseCancels` still passes).

## Exclusions

Committing on cancellation can invent input, so three cases opt out:

- **Backspace and Return never commit.** Losing one Backspace is annoying; an extra one damages text, and an extra Return sends a message. The allowlist is `.character`, `.vniModifier`, `.punctuation`, `.space`.
- **A wandered finger is a gesture.** Past `tapSlop` (16pt, half the swipe threshold) the touch is no longer a tap. This is what keeps a swipe up from the home indicator — which begins as a touch on the bottom row and ends as a system cancellation — from leaving a stray space.
- **A held key whose repeats already fired** completes as `.suppressed`, exactly as a normal release does, rather than emitting one more.

## Teardown still discards

`cancelAll()` is reached when the surface leaves its window or the layout is rebuilt, so its pending presses must not be honoured. The overlay's bookkeeping is now dropped via `forgetTrackedTouches()` instead of being routed through the cancel path — routing it there would have committed exactly the presses teardown is meant to drop.

## Contract change

`KeyboardTouchPipelineTests.orphanedTouchDoesNotBlock` asserted that an abandoned press is cancelled. It now asserts the press commits, while still pinning what it was written for: the queue drains in touch-down order and one lost terminal event cannot block its successors.

## Verification

- `Scripts/test-funput-kit.sh` → `** TEST SUCCEEDED **`, 26 suites. Five new `KeyboardSystemCancellationTests`: a cancelled letter is typed, Backspace and Return are not, a wandered finger stays cancelled, lifting outside a toolbar control stays cancelled, teardown stays cancelled.
- `xcodebuild test -only-testing:FunputTests/KeyboardTouchPipelineTests` on iPhone 17e / iOS 27.0 — all 5 pass, including `outsideReleaseCancels`.
- `Scripts/check-swift-loc.sh` passes.

**Residual risk worth watching on TestFlight:** a system cancellation that arrives before any `touchesMoved` cannot be told from a tap, so a very fast flick starting on the space bar could still leave a space. The gesture would have to be recognised inside a single frame for that; if it shows up in practice, the next lever is to also require a minimum press duration.

Not addressed here: `layoutChanged` still discards a finger already down on the next key. Committing there would re-enter `presentationDidChange` from its own `didSet` while it is halfway through rebuilding, which is not worth the risk for a case that needs two thumbs across a layout switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
