### PR TITLE
feat(ios): add Advanced Telex input method support and enhance settings

### DIFF
--- a/docs/features/advanced-telex.md
+++ b/docs/features/advanced-telex.md
@@ -2,9 +2,9 @@
 
 ## Trạng thái
 
-V5 đã hiện thực core/engine và C FFI/JNI. macOS, Windows và Linux expose UI,
-persistence và selection. Đây là tính năng desktop: iOS/Android không
-expose hoặc persist mode này, còn wire ID `2` trong FFI/JNI vẫn được giữ dormant.
+V5 đã hiện thực core/engine và C FFI/JNI. macOS, Windows, Linux và iOS expose UI,
+persistence và selection. Android chưa expose hoặc persist mode này, còn wire ID `2`
+trong JNI vẫn được giữ dormant.
 Tên hiển thị là **Telex nâng cao**; tên kỹ thuật là `TelexAdvanced` và giá trị cấu
 hình ổn định là `telex_advanced`.
 
@@ -104,13 +104,14 @@ chứng lại `size_of::<Engine>()` và ABI tests.
 
 ### Platform
 
-Platform không tự hiện thực quy tắc gõ. macOS, Windows và Linux hiển thị **Telex**,
-**Telex nâng cao**, **VNI** theo thứ tự đó và persist `telex_advanced`. macOS và
-hai backend Linux (Fcitx5/IBus) truyền mode qua C FFI; Windows dùng trực tiếp Rust engine.
+Platform không tự hiện thực quy tắc gõ. macOS, Windows, Linux và iOS hiển thị
+**Telex**, **Telex nâng cao**, **VNI** theo thứ tự đó và persist `telex_advanced`.
+macOS, iOS và hai backend Linux (Fcitx5/IBus) truyền mode qua C FFI; Windows dùng
+trực tiếp Rust engine.
 
-iOS/Android không thêm UI, persistence hoặc wiring cho mode này. Khi một consumer
-không hỗ trợ đọc `telex_advanced`, nó phải giữ input method hiện tại thay vì ép về
-một method khác.
+Android chưa thêm UI, persistence hoặc wiring cho mode này. Khi một consumer không
+hỗ trợ đọc `telex_advanced`, nó phải giữ input method hiện tại thay vì ép về một
+method khác.
 
 Config interchange mở rộng `preferences.inputMethod` thành:
 
@@ -127,8 +128,8 @@ Config interchange mở rộng `preferences.inputMethod` thành:
 - Core, engine và FFI common-path không chậm quá 3% so với baseline trước V5.
 - Viet74K đạt 100% với cả Telex canonical và Full Telex shortcut encoding.
 - Không nới allocation budget hiện tại; kiểm tra lại kích thước Engine và ABI.
-- Core, engine, C FFI và JNI dùng cùng behavior và wire mapping; macOS, Windows và
-  Linux đã tích hợp selection, còn mobile giữ mapping dormant.
+- Core, engine, C FFI và JNI dùng cùng behavior và wire mapping; macOS, Windows,
+  Linux và iOS đã tích hợp selection, còn Android giữ mapping dormant.
 
 ## Ngoài phạm vi V5
 

--- a/platforms/ios/Funput/Settings/SettingsModel.swift
+++ b/platforms/ios/Funput/Settings/SettingsModel.swift
@@ -98,7 +98,21 @@ final class SettingsModel {
 }
 
 extension KeyboardInputMethod {
-    var settingsTitle: String { self == .vni ? "VNI" : "Telex" }
+    var settingsTitle: String {
+        switch self {
+        case .telex: "Telex"
+        case .telexAdvanced: "Telex nâng cao"
+        case .vni: "VNI"
+        }
+    }
+
+    var settingsSummary: String {
+        switch self {
+        case .telex: "Dùng tổ hợp chữ để nhập dấu."
+        case .telexAdvanced: "Full Telex — [→ư, ]→ơ, w đầu từ→ư."
+        case .vni: "Dùng các phím số để nhập dấu."
+        }
+    }
 }
 
 extension ToneStyleOption {

--- a/platforms/ios/Funput/Settings/SettingsPicker.swift
+++ b/platforms/ios/Funput/Settings/SettingsPicker.swift
@@ -48,7 +48,7 @@ extension SettingsPicker {
             KeyboardInputMethod.allCases.map { value in
                 SettingsChoice(
                     id: value.rawValue, title: value.settingsTitle,
-                    summary: value == .vni ? "Dùng các phím số để nhập dấu." : "Dùng tổ hợp chữ để nhập dấu.",
+                    summary: value.settingsSummary,
                     isSelected: model.configuration.inputMethod == value,
                     select: { model.update(\.inputMethod, to: value) }
                 )

--- a/platforms/ios/Funput/Settings/SettingsScreen.swift
+++ b/platforms/ios/Funput/Settings/SettingsScreen.swift
@@ -25,7 +25,7 @@ struct SettingsScreen: View {
                 SettingsSelectionRow(option: .inputMethod, value: model.inputMethodLabel) { picker = .inputMethod }
                 SettingsToggleRow(
                     title: "Hàng phím số",
-                    summary: "Hiển thị 0–9 khi dùng Telex. VNI luôn cần hàng số để nhập dấu.",
+                    summary: "Hiển thị 0–9 với các kiểu Telex. VNI luôn cần hàng số để nhập dấu.",
                     isOn: model.numberRowBinding
                 )
                 .disabled(model.isNumberRowLocked)

--- a/platforms/ios/FunputTests/AdvancedTelex/AdvancedTelexSettingsTests.swift
+++ b/platforms/ios/FunputTests/AdvancedTelex/AdvancedTelexSettingsTests.swift
@@ -1,0 +1,30 @@
+import FunputShared
+import KeyboardLayout
+import Testing
+@testable import Funput
+
+@MainActor
+struct AdvancedTelexSettingsTests {
+    @Test("Input method picker exposes the stable display order")
+    func pickerOrder() {
+        let model = SettingsModel(store: SettingsTestStore(configuration: .default))
+        let choices = SettingsPicker.inputMethod.choices(model: model)
+
+        #expect(choices.map(\.id) == ["telex", "telex_advanced", "vni"])
+        #expect(choices.map(\.title) == ["Telex", "Telex nâng cao", "VNI"])
+        #expect(choices[1].summary == "Full Telex — [→ư, ]→ơ, w đầu từ→ư.")
+    }
+
+    @Test("Advanced Telex persists and leaves number row editable")
+    func selection() {
+        let store = SettingsTestStore(configuration: .default)
+        let model = SettingsModel(store: store)
+        let advanced = SettingsPicker.inputMethod.choices(model: model)[1]
+
+        advanced.select()
+
+        #expect(model.configuration.inputMethod == .telexAdvanced)
+        #expect(store.configuration.inputMethod == .telexAdvanced)
+        #expect(!model.isNumberRowLocked)
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Sources/FunputEngine/FunputCompositionTypes.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputEngine/FunputCompositionTypes.swift
@@ -1,6 +1,7 @@
 public enum FunputInputMethod: UInt8, CaseIterable, Sendable {
     case telex = 0
     case vni = 1
+    case telexAdvanced = 2
 }
 
 public enum FunputToneStyle: UInt8, CaseIterable, Sendable {

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Configuration/FunputConfiguration+Codable.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Configuration/FunputConfiguration+Codable.swift
@@ -42,6 +42,9 @@ extension FunputConfiguration {
         if config.schemaVersion < 6 {
             config.schemaVersion = 6
         }
+        if config.schemaVersion < 7 {
+            config.schemaVersion = 7
+        }
         self = config
     }
 }

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Configuration/FunputConfiguration.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Configuration/FunputConfiguration.swift
@@ -77,5 +77,5 @@ public struct FunputConfiguration: Codable, Hashable, Sendable {
     public static let defaultThemeID = "app.funput.theme.glass"
 
     /// Schema version emitted by this build. Bump when the stored shape changes.
-    public static let currentSchemaVersion = 6
+    public static let currentSchemaVersion = 7
 }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Configuration/KeyboardInputCoordinator+Configuration.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Configuration/KeyboardInputCoordinator+Configuration.swift
@@ -12,6 +12,9 @@ public extension KeyboardInputCoordinator {
     /// language chosen here can still be toggled at runtime afterward.
     func apply(_ configuration: FunputConfiguration) {
         composer.clear()
+        if configuration.inputMethod.isTelexFamily {
+            preferredTelexMethod = configuration.inputMethod
+        }
         composer.configure(
             FunputCompositionOptions(
                 inputMethod: configuration.inputMethod.engineMethod,

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardInputCoordinator+State.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardInputCoordinator+State.swift
@@ -39,9 +39,16 @@ extension KeyboardInputCoordinator {
     }
 
     func toggleInputMethod() {
-        let next: KeyboardInputMethod = state.inputMethod == .vni ? .telex : .vni
+        let next: KeyboardInputMethod
+        if state.inputMethod == .vni {
+            next = preferredTelexMethod
+        } else {
+            preferredTelexMethod = state.inputMethod
+            next = .vni
+        }
         composer.clear()
         composer.setInputMethod(next.engineMethod)
+        documentSynchronizer.invalidate()
         resetPersonalSuggestionTracking()
         replaceState(inputMethod: next)
     }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardInputCoordinator.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/KeyboardInputCoordinator.swift
@@ -13,6 +13,7 @@ public final class KeyboardInputCoordinator {
     var suggestionTracker = AuthoredTokenTracker()
     var personalSuggestionsEnabled = true
     var suggestionTrackingActive = true
+    var preferredTelexMethod: KeyboardInputMethod
 
     public init(
         inputMethod: KeyboardInputMethod = .vni,
@@ -21,6 +22,7 @@ public final class KeyboardInputCoordinator {
             ProcessInfo.processInfo.systemUptime
         }
     ) {
+        preferredTelexMethod = inputMethod.isTelexFamily ? inputMethod : .telex
         state = KeyboardInputState(
             inputMethod: inputMethod,
             shiftState: .lowercase,
@@ -40,7 +42,9 @@ public final class KeyboardInputCoordinator {
         synchronizeBeforeInput(document)
         let mutatesDocument = key.role.mutatesDocument
         if mutatesDocument {
-            documentSynchronizer.beginMutation(closesEpoch: key.role.closesCompositionEpoch)
+            documentSynchronizer.beginMutation(
+                closesEpoch: closesCompositionEpoch(for: key)
+            )
         }
         defer {
             if mutatesDocument {
@@ -77,6 +81,18 @@ public final class KeyboardInputCoordinator {
             break
         }
     }
+
+    private func closesCompositionEpoch(for key: KeySpec) -> Bool {
+        if state.inputMethod == .telexAdvanced,
+           key.role == .punctuation,
+           (key.label == "[" || key.label == "]") {
+            return false
+        }
+        return switch key.role {
+        case .space, .punctuation, .enter: true
+        default: false
+        }
+    }
 }
 
 private extension KeyRole {
@@ -88,19 +104,13 @@ private extension KeyRole {
             false
         }
     }
-
-    var closesCompositionEpoch: Bool {
-        switch self {
-        case .space, .punctuation, .enter: true
-        default: false
-        }
-    }
 }
 
 extension KeyboardInputMethod {
     var engineMethod: FunputInputMethod {
         switch self {
         case .telex: .telex
+        case .telexAdvanced: .telexAdvanced
         case .vni: .vni
         }
     }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Models/KeyboardContext.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Models/KeyboardContext.swift
@@ -1,6 +1,14 @@
 public enum KeyboardInputMethod: String, CaseIterable, Hashable, Sendable, Codable {
     case telex
+    case telexAdvanced = "telex_advanced"
     case vni
+
+    public var isTelexFamily: Bool {
+        switch self {
+        case .telex, .telexAdvanced: true
+        case .vni: false
+        }
+    }
 }
 
 public enum KeyboardLayoutMode: String, CaseIterable, Hashable, Sendable {

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/Factory/QWERTYLayoutFactory.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/Factory/QWERTYLayoutFactory.swift
@@ -6,7 +6,7 @@ func qwertyLayout(
     showsTelexHints: Bool = false,
     showsToolbar: Bool = true
 ) -> KeyboardLayout {
-    let displaysTelexHints = showsTelexHints && inputMethod == .telex
+    let displaysTelexHints = showsTelexHints && inputMethod.isTelexFamily
     return KeyboardLayout(
         id: id,
         inputMethod: inputMethod,

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/KeyboardLayoutResolver.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/KeyboardLayoutResolver.swift
@@ -7,7 +7,7 @@ public enum KeyboardLayoutResolver {
         showsNumberRow: Bool = true
     ) -> KeyboardLayout {
         let usesCompactLayout = editorMode == .text
-            && inputMethod == .telex
+            && inputMethod.isTelexFamily
             && !showsNumberRow
         let layout = switch mode {
         case .letters:

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/StandardKeyboardLayouts.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/StandardKeyboardLayouts.swift
@@ -9,7 +9,7 @@ public enum StandardKeyboardLayouts {
             inputMethod: inputMethod,
             leadingRows: hasNumberRow ? [topNumberRowForLetters(inputMethod)] : [],
             actionKeys: standardActionRow().keys,
-            showsTelexHints: inputMethod == .telex
+            showsTelexHints: inputMethod.isTelexFamily
         )
     }
 }

--- a/platforms/ios/Packages/FunputKit/Tests/FunputEngineTests/AdvancedTelex/AdvancedTelexComposerTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputEngineTests/AdvancedTelex/AdvancedTelexComposerTests.swift
@@ -1,0 +1,69 @@
+#if os(iOS) && canImport(FunputCore)
+import FunputEngine
+import Testing
+
+@MainActor
+struct AdvancedTelexComposerTests {
+    @Test("Input method wire values remain stable")
+    func wireValues() {
+        #expect(FunputInputMethod.telex.rawValue == 0)
+        #expect(FunputInputMethod.vni.rawValue == 1)
+        #expect(FunputInputMethod.telexAdvanced.rawValue == 2)
+    }
+
+    @Test("Advanced Telex shortcuts compose through the FFI wrapper")
+    func shortcuts() {
+        let cases = [
+            ("w", "ư"), ("wf", "ừ"), ("t[", "tư"), ("m]", "mơ"),
+            ("tr[]ngf", "trường"), ("ng[]if", "người"), ("ww", "w"),
+        ]
+        for (keys, expected) in cases {
+            #expect(compose(keys) == expected, "Failed input: \(keys)")
+        }
+    }
+
+    @Test("Advanced Telex preserves capitalization and tone style")
+    func options() {
+        #expect(compose("Wf") == "Ừ")
+        #expect(compose("hoaf", toneStyle: .traditional) == "hòa")
+        #expect(compose("hoaf", toneStyle: .modern) == "hoà")
+    }
+
+    @Test("Changing method clears an active composition")
+    func methodChangeClearsComposition() {
+        let composer = configuredComposer()
+        composer.process("w")
+        #expect(composer.buffer() == "ư")
+        composer.setInputMethod(.telex)
+        #expect(composer.buffer().isEmpty)
+    }
+
+    private func compose(
+        _ keys: String,
+        toneStyle: FunputToneStyle = .traditional
+    ) -> String {
+        let composer = configuredComposer(toneStyle: toneStyle)
+        for scalar in keys.unicodeScalars {
+            composer.process(scalar)
+        }
+        return composer.buffer()
+    }
+
+    private func configuredComposer(
+        toneStyle: FunputToneStyle = .traditional
+    ) -> FunputComposer {
+        let composer = FunputComposer()
+        composer.configure(
+            FunputCompositionOptions(
+                inputMethod: .telexAdvanced,
+                toneStyle: toneStyle,
+                smartRestore: true,
+                eagerRestore: true,
+                spellCheck: false,
+                autoCapitalize: false
+            )
+        )
+        return composer
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/AdvancedTelex/AdvancedTelexConfigurationTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/AdvancedTelex/AdvancedTelexConfigurationTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import FunputShared
+import KeyboardLayout
+import Testing
+
+struct AdvancedTelexConfigurationTests {
+    @Test("Advanced Telex uses its stable persistence identifier")
+    func stableIdentifier() {
+        #expect(KeyboardInputMethod.allCases == [.telex, .telexAdvanced, .vni])
+        #expect(KeyboardInputMethod.telexAdvanced.rawValue == "telex_advanced")
+    }
+
+    @Test("Advanced Telex survives configuration round-trip")
+    func roundTrip() throws {
+        var configuration = FunputConfiguration.default
+        configuration.inputMethod = .telexAdvanced
+
+        let data = try JSONEncoder().encode(configuration)
+        let decoded = try JSONDecoder().decode(FunputConfiguration.self, from: data)
+
+        #expect(decoded.inputMethod == .telexAdvanced)
+        #expect(decoded.schemaVersion == 7)
+    }
+
+    @Test("Legacy schema preserves its input method while migrating")
+    func legacyMigration() throws {
+        let data = Data(
+            #"{"inputMethod":"telex","schemaVersion":6}"#.utf8
+        )
+        let decoded = try JSONDecoder().decode(FunputConfiguration.self, from: data)
+
+        #expect(decoded.inputMethod == .telex)
+        #expect(decoded.schemaVersion == 7)
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/FunputConfigurationTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/FunputConfigurationTests.swift
@@ -22,7 +22,7 @@ struct FunputConfigurationTests {
         #expect(config.heightScale == 1.1)
         #expect(config.personalSuggestionsEnabled)
         #expect(config.personalSuggestionResetToken == nil)
-        #expect(config.schemaVersion == 6)
+        #expect(config.schemaVersion == 7)
     }
 
     @Test("Configuration survives a JSON round-trip")
@@ -60,7 +60,7 @@ struct FunputConfigurationTests {
         #expect(!decoded.isKeySoundEnabled)
         #expect(!decoded.showsNumberRow)
         #expect(!decoded.showsGlobeKey)
-        #expect(decoded.schemaVersion == 6)
+        #expect(decoded.schemaVersion == 7)
     }
 
     @Test("Schema 3 migrates to the compact Telex default")
@@ -69,7 +69,7 @@ struct FunputConfigurationTests {
         let decoded = try JSONDecoder().decode(FunputConfiguration.self, from: data)
         #expect(!decoded.showsNumberRow)
         #expect(!decoded.showsGlobeKey)
-        #expect(decoded.schemaVersion == 6)
+        #expect(decoded.schemaVersion == 7)
     }
 
     @Test("Schema 4 migrates to a hidden Globe key")
@@ -77,6 +77,6 @@ struct FunputConfigurationTests {
         let data = Data(#"{"showsGlobeKey":true,"schemaVersion":4}"#.utf8)
         let decoded = try JSONDecoder().decode(FunputConfiguration.self, from: data)
         #expect(!decoded.showsGlobeKey)
-        #expect(decoded.schemaVersion == 6)
+        #expect(decoded.schemaVersion == 7)
     }
 }

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/AdvancedTelex/AdvancedTelexInputTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/AdvancedTelex/AdvancedTelexInputTests.swift
@@ -1,0 +1,72 @@
+#if os(iOS) && canImport(FunputCore)
+import FunputShared
+import KeyboardInput
+import KeyboardLayout
+import Testing
+
+@MainActor
+struct AdvancedTelexInputTests {
+    @Test("Configuration applies Advanced Telex composition")
+    func configuration() {
+        let coordinator = KeyboardInputCoordinator()
+        coordinator.apply(FunputConfiguration(inputMethod: .telexAdvanced))
+        let document = TestKeyboardDocument()
+
+        typeAdvanced("tr[]ngf", with: coordinator, into: document)
+
+        #expect(coordinator.state.inputMethod == .telexAdvanced)
+        #expect(document.text == "trường")
+    }
+
+    @Test("Runtime toggle returns to the preferred Telex variant")
+    func preferredToggle() {
+        let coordinator = KeyboardInputCoordinator(inputMethod: .telexAdvanced)
+        let document = TestKeyboardDocument()
+
+        coordinator.handle(testKey(.inputMethod), document: document)
+        #expect(coordinator.state.inputMethod == .vni)
+        coordinator.handle(testKey(.inputMethod), document: document)
+        #expect(coordinator.state.inputMethod == .telexAdvanced)
+    }
+
+    @Test("Brackets remain inside the delayed synchronization epoch")
+    func delayedBracketEchoes() {
+        let coordinator = KeyboardInputCoordinator(inputMethod: .telexAdvanced)
+        let document = TestKeyboardDocument()
+        document.delaysContextUpdates = true
+        document.publishContext()
+
+        type("tr", with: coordinator, into: document)
+        type("[", role: .punctuation, with: coordinator, into: document)
+        type("]", role: .punctuation, with: coordinator, into: document)
+        coordinator.synchronizeDocument(document, event: .textChanged)
+        type("ngf", with: coordinator, into: document)
+
+        #expect(document.text == "trường")
+    }
+
+    @Test("Standard Telex and VNI keep brackets literal")
+    func bracketsStayLiteral() {
+        for method in [KeyboardInputMethod.telex, .vni] {
+            let coordinator = KeyboardInputCoordinator(inputMethod: method)
+            let document = TestKeyboardDocument()
+            type("[", role: .punctuation, with: coordinator, into: document)
+            type("]", role: .punctuation, with: coordinator, into: document)
+            #expect(document.text == "[]")
+        }
+    }
+
+    private func typeAdvanced(
+        _ keys: String,
+        with coordinator: KeyboardInputCoordinator,
+        into document: TestKeyboardDocument
+    ) {
+        for character in keys {
+            let role: KeyRole = character == "[" || character == "]"
+                ? .punctuation
+                : .character
+            type(String(character), role: role, with: coordinator, into: document)
+        }
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardLayoutTests/AdvancedTelex/AdvancedTelexLayoutTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardLayoutTests/AdvancedTelex/AdvancedTelexLayoutTests.swift
@@ -1,0 +1,49 @@
+import CoreGraphics
+import KeyboardLayout
+import Testing
+
+struct AdvancedTelexLayoutTests {
+    @Test("Advanced Telex shares compact Telex geometry and hints")
+    func compactGeometryAndHints() {
+        let telex = KeyboardLayoutResolver.resolve(
+            inputMethod: .telex,
+            mode: .letters,
+            showsNumberRow: false
+        )
+        let advanced = KeyboardLayoutResolver.resolve(
+            inputMethod: .telexAdvanced,
+            mode: .letters,
+            showsNumberRow: false
+        )
+
+        #expect(advanced.rows.count == 4)
+        #expect(advanced.rows.flatMap(\.keys).first { $0.label == "s" }?.secondaryLabel == "´")
+        #expect(frames(telex) == frames(advanced))
+    }
+
+    @Test("Advanced Telex keeps brackets on the second symbol page")
+    func bracketPlacement() {
+        let layout = KeyboardLayoutResolver.resolve(
+            inputMethod: .telexAdvanced,
+            mode: .symbolsSecondary,
+            showsNumberRow: false
+        )
+        let labels = layout.rows.flatMap(\.keys).map(\.label)
+
+        #expect(labels.contains("["))
+        #expect(labels.contains("]"))
+        #expect(!KeyboardLayoutResolver.resolve(
+            inputMethod: .telexAdvanced,
+            mode: .letters,
+            showsNumberRow: false
+        ).rows.flatMap(\.keys).map(\.label).contains("["))
+    }
+
+    private func frames(_ layout: KeyboardLayout) -> [CGRect] {
+        KeyboardGeometry.resolve(
+            layout: layout,
+            size: CGSize(width: 390, height: 204),
+            sizing: .default
+        ).keys.map(\.frame)
+    }
+}


### PR DESCRIPTION
- Introduced the `telexAdvanced` input method, allowing for advanced Telex input with new shortcuts and behaviors.
- Updated settings UI to include titles and summaries for both Telex and Advanced Telex methods.
- Enhanced configuration persistence to support the new input method, ensuring compatibility with existing settings.
- Incremented schema version to 7 to accommodate changes in configuration structure.
- Added comprehensive tests for Advanced Telex functionality, including input method selection and composition behavior.