### PR TITLE
fix(core): implement tone repositioning for circumflex handling in Vietnamese input

### DIFF
--- a/crates/funput-core/src/composition/intent/kinds/circumflex.rs
+++ b/crates/funput-core/src/composition/intent/kinds/circumflex.rs
@@ -3,6 +3,7 @@ use crate::composition::replace_char_at;
 use crate::input_method::telex::tone_from_key;
 use crate::unicode::marks::Tone;
 use crate::unicode::shapes::{VowelShape, shape_on_vowel, strip_shape};
+use crate::unicode::tone_position::reposition_existing_tone;
 use crate::validation::syllable::is_viable_shape_candidate;
 
 use super::super::IntentResolution;
@@ -19,6 +20,13 @@ pub(crate) fn resolve(buffer: &str, stem: char, key: char, style: ToneStyle) -> 
 
     let mut text = String::with_capacity(buffer.len() + 2);
     candidate::build(&mut text, buffer, target, None);
+    // The new mũ makes the shaped vowel the tonal nucleus, so a tone already
+    // placed on another vowel has to follow it: `duỵ` + `et` + `e` → `duyệt`,
+    // not `duỵêt`. Without the move the candidate is also mis-spelled and would
+    // fail the viability check below, dropping the key as a literal.
+    if let Some(moved) = reposition_existing_tone(&text, style) {
+        text = moved;
+    }
     if is_viable_shape_candidate(&text) {
         return IntentResolution::Applied(text);
     }

--- a/crates/funput-core/tests/telex/basic.rs
+++ b/crates/funput-core/tests/telex/basic.rs
@@ -123,6 +123,25 @@ fn telex_free_position_circumflex() {
     assert_eq!(type_keys("kenhe"), "kênh");
     assert_eq!(type_keys("congo"), "công");
 
+    // The mũ may land on a vowel that is not the one already carrying the tone:
+    // in `uyê` the tone belongs on `ê`, so the free-position circumflex has to
+    // pull it across ("duyjete" → duyệt, not duỵêt).
+    for (tone_after, tone_before, expected) in [
+        ("duyeetj", "duyjete", "duyệt"),
+        ("chuyeenj", "chuyjene", "chuyện"),
+        ("tuyeets", "tuysete", "tuyết"),
+        ("nguyeenx", "nguyxene", "nguyễn"),
+    ] {
+        assert_eq!(type_keys(tone_after), expected);
+        assert_eq!(type_keys(tone_before), expected);
+    }
+
+    // A repeated tone key still undoes the tone once the mark has been pulled
+    // across, and every order of the pulled mark converges on the same undo.
+    for keys in ["duyeetjj", "duyjetej", "duyjeetj", "duyejtej"] {
+        assert_eq!(type_keys(keys), "duyêtj", "{keys}");
+    }
+
     assert_eq!(type_keys("Chana"), "Chân");
     assert_eq!(type_keys("CHANA"), "CHÂN");
     assert_eq!(type_keys("chanaa"), "chana");


### PR DESCRIPTION
- Added functionality to reposition existing tones when a new shaped vowel is introduced, ensuring correct tonal placement.
- Updated tests to validate the behavior of tone repositioning and its impact on input accuracy.