### PR TITLE
fix(core): enhance vowel shape handling in Vietnamese input

### DIFF
--- a/crates/funput-core/src/composition/intent/target.rs
+++ b/crates/funput-core/src/composition/intent/target.rs
@@ -1,5 +1,4 @@
-use crate::unicode::marks::vowel_stem;
-use crate::unicode::shapes::{VowelShape, shape_on_vowel, strip_shape};
+use crate::unicode::shapes::base_vowel;
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct Target {
@@ -15,11 +14,9 @@ pub(super) fn rightmost_stem(buffer: &str, stem: char) -> Option<Target> {
             target = None;
             continue;
         }
-        if !matches!(shape_on_vowel(vowel), None | Some(VowelShape::Circumflex)) {
-            continue;
-        }
-        let plain = strip_shape(vowel).unwrap_or(vowel);
-        if vowel_stem(plain).is_some_and(|value| value.eq_ignore_ascii_case(&stem)) {
+        // Compared on the base letter, so a vowel that already carries a trần/móc
+        // is still a mũ target and switches shape (`chặn` + `a` → `chận`).
+        if base_vowel(vowel).is_some_and(|value| value.eq_ignore_ascii_case(&stem)) {
             target = Some(Target {
                 char_index,
                 byte_offset,

--- a/crates/funput-core/src/input_method/telex/modifiers/circumflex.rs
+++ b/crates/funput-core/src/input_method/telex/modifiers/circumflex.rs
@@ -1,6 +1,6 @@
 use crate::input_method::{CircumflexStem, KeyAction};
 use crate::unicode::marks::{tone_on_vowel, vowel_stem};
-use crate::unicode::shapes::{VowelShape, shape_on_vowel, strip_shape};
+use crate::unicode::shapes::{VowelShape, base_vowel, shape_on_vowel};
 
 use super::super::last_char;
 
@@ -17,10 +17,11 @@ pub(crate) fn classify(buffer: &str, key: char) -> Option<KeyAction> {
         if is_plain_stem(last, stem_char) {
             return Some(KeyAction::Shape(VowelShape::Circumflex));
         }
-        if shape_on_vowel(last) == Some(VowelShape::Circumflex)
-            && strip_shape(last)
-                .and_then(vowel_stem)
-                .is_some_and(|base| base.eq_ignore_ascii_case(&stem_char))
+        // Any shaped vowel on the same base letter is a target: an existing mũ
+        // means the key reverts it (`aaa` → `aa`), a trần/móc means it switches
+        // to mũ (`ăa` → `â`). `apply_shape_to_vowel` tells the two apart.
+        if shape_on_vowel(last).is_some()
+            && base_vowel(last).is_some_and(|base| base.eq_ignore_ascii_case(&stem_char))
         {
             return Some(KeyAction::Shape(VowelShape::Circumflex));
         }
@@ -52,11 +53,7 @@ fn free_position(buffer: &str, stem: CircumflexStem) -> Option<KeyAction> {
         .rev()
         .take_while(|ch| ch.is_alphabetic())
         .find(|&vowel| {
-            matches!(shape_on_vowel(vowel), None | Some(VowelShape::Circumflex))
-                && strip_shape(vowel)
-                    .or(Some(vowel))
-                    .and_then(vowel_stem)
-                    .is_some_and(|target| target.eq_ignore_ascii_case(&stem_char))
+            base_vowel(vowel).is_some_and(|target| target.eq_ignore_ascii_case(&stem_char))
         })
         .map(|_| KeyAction::FreeCircumflex(stem))
 }

--- a/crates/funput-core/src/input_method/telex/modifiers/w.rs
+++ b/crates/funput-core/src/input_method/telex/modifiers/w.rs
@@ -1,7 +1,7 @@
 use crate::composition::uo_horn::uo_pair_in_vowel_cluster;
 use crate::input_method::KeyAction;
 use crate::unicode::marks::{is_vowel, tone_on_vowel, vowel_stem};
-use crate::unicode::shapes::{VowelShape, shape_on_vowel, shape_target_index};
+use crate::unicode::shapes::{VowelShape, base_vowel, shape_on_vowel, shape_target_index};
 
 use super::super::last_char;
 
@@ -31,8 +31,11 @@ pub(crate) fn classify(buffer: &str) -> Option<KeyAction> {
     if is_vowel(last) {
         if let Some(shape) = shape_on_vowel(last) {
             return match shape {
+                // Same shape again: the revert (`aww` → `aw`), resolved downstream.
                 VowelShape::Breve | VowelShape::Horn => Some(KeyAction::Shape(shape)),
-                VowelShape::Circumflex => None,
+                // A mũ switches to the trần/móc its base letter takes (`âw` → `ă`,
+                // `ôw` → `ơ`); `ê` has neither, so the key stays a normal letter.
+                VowelShape::Circumflex => w_shape_for(last),
             };
         }
         if plain(last, 'a') {
@@ -66,4 +69,13 @@ fn ends_with_qu_glide(buffer: &str) -> bool {
 
 fn horn() -> Option<KeyAction> {
     Some(KeyAction::Shape(VowelShape::Horn))
+}
+
+/// The trần/móc that `vowel`'s base letter can take: `a` → ă, `o`/`u` → ơ/ư.
+fn w_shape_for(vowel: char) -> Option<KeyAction> {
+    match base_vowel(vowel)?.to_ascii_lowercase() {
+        'a' => Some(KeyAction::Shape(VowelShape::Breve)),
+        'o' | 'u' => horn(),
+        _ => None,
+    }
 }

--- a/crates/funput-core/src/unicode/shapes.rs
+++ b/crates/funput-core/src/unicode/shapes.rs
@@ -24,9 +24,23 @@ pub fn apply_shape(base: char, shape: VowelShape) -> Option<char> {
 }
 
 /// Apply a shape to any vowel, stripping an existing tone first.
+///
+/// A vowel already carrying a *different* shape is re-shaped from its base
+/// letter, so the shape keys switch instead of stalling: `ặ` + mũ → `ậ`
+/// (`chặn` + `a` → `chận`), `ậ` + trần → `ặ`. Asking for the shape the vowel
+/// already has returns `None` — that is the revert case (`ă` + `w` → `aw`),
+/// which callers resolve before they reach here.
 pub fn apply_shape_to_vowel(vowel: char, shape: VowelShape) -> Option<char> {
-    let stem = vowel_stem(vowel)?;
-    apply_shape(stem, shape)
+    if shape_on_vowel(vowel) == Some(shape) {
+        return None;
+    }
+    apply_shape(base_vowel(vowel)?, shape)
+}
+
+/// Vowel stripped of both tone and shape (`ặ` → `a`, `ế` → `e`, `á` → `a`).
+pub(crate) fn base_vowel(vowel: char) -> Option<char> {
+    let stem = vowel_stem(vowel)?; // tone off, shape kept
+    Some(strip_shape(stem).unwrap_or(stem))
 }
 
 /// Index of the last vowel that can *receive* `shape` (for applying 6/7/8).

--- a/crates/funput-core/tests/telex/basic.rs
+++ b/crates/funput-core/tests/telex/basic.rs
@@ -44,6 +44,34 @@ fn telex_reposition() {
 }
 
 #[test]
+fn telex_shape_switch() {
+    // A shape key aimed at a vowel that already carries a *different* shape
+    // switches it, rather than stalling and dropping the syllable back to raw
+    // keys. `w` is the trần/móc key, `a`/`o` the mũ keys for their base letter.
+    assert_eq!(type_keys("awa"), "â");
+    assert_eq!(type_keys("aaw"), "ă");
+    assert_eq!(type_keys("owo"), "ô");
+    assert_eq!(type_keys("oow"), "ơ");
+
+    // The switch key may sit anywhere in the syllable, and the tone rides along.
+    assert_eq!(type_keys("chawnja"), "chận"); // chặn + a
+    assert_eq!(type_keys("chanajw"), "chặn"); // chận + w
+    assert_eq!(type_keys("chaajw"), "chặ");
+    assert_eq!(type_keys("conwo"), "côn");
+    assert_eq!(type_keys("conow"), "cơn");
+
+    // Only shapes the base letter actually has: `ê` takes neither trần nor móc,
+    // so `w` stays a literal key here (the engine restores the raw run).
+    assert_eq!(type_keys("eew"), "êw");
+
+    // The *same* key twice is still the revert, not a switch.
+    assert_eq!(type_keys("aaa"), "aa");
+    assert_eq!(type_keys("aww"), "aw");
+    assert_eq!(type_keys("uww"), "uw");
+    assert_eq!(type_keys("chanaa"), "chana");
+}
+
+#[test]
 fn telex_revert() {
     // Double modifier restores raw keystrokes: strip diacritic + append the key.
     assert_eq!(type_keys("ass"), "as");

--- a/crates/funput-core/tests/vni/basic.rs
+++ b/crates/funput-core/tests/vni/basic.rs
@@ -94,6 +94,25 @@ fn vni_shape_basic() {
 }
 
 #[test]
+fn vni_shape_switch() {
+    let keys = |k| crate::support::type_keys(InputMethod::Vni, k);
+    // 6/7/8 on a vowel that already carries a different shape switches it.
+    assert_eq!(keys("a86"), "â");
+    assert_eq!(keys("a68"), "ă");
+    assert_eq!(keys("o76"), "ô");
+    assert_eq!(keys("o67"), "ơ");
+    // Free position, tone preserved: chặn + 6 → chận, chận + 8 → chặn.
+    assert_eq!(keys("cha8n56"), "chận");
+    assert_eq!(keys("cha6n58"), "chặn");
+    // Shapes the base letter does not have are still a no-op: `a` has no móc,
+    // so `7` is ignored here (unchanged — the engine restores the raw run).
+    assert_eq!(keys("a67"), "â");
+    // Same digit twice is still the revert.
+    assert_eq!(keys("a66"), "a6");
+    assert_eq!(keys("a88"), "a8");
+}
+
+#[test]
 fn vni_shape_syllables() {
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "uo7"), "uơ");
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "uo73"), "uở");


### PR DESCRIPTION
- Introduced a new `base_vowel` function to streamline the identification of base letters for vowel shapes.
- Updated the logic in various modules to utilize the new base vowel functionality, improving shape switching behavior.
- Added tests to validate the correct switching of vowel shapes in different input scenarios, ensuring accurate tonal representation.