### PR TITLE
fix(core): improve handling of leading 'w' in Vietnamese input

### DIFF
--- a/crates/funput-core/src/composition/transform/full_telex.rs
+++ b/crates/funput-core/src/composition/transform/full_telex.rs
@@ -15,8 +15,14 @@ pub(super) fn apply(
             text: buffer.to_owned(),
         };
     }
-    if shortcut == TelexShortcut::LeadingW && !buffer.is_empty() {
-        let text = if buffer == "Ư" { "W" } else { "w" }.to_owned();
+    // `w` on the `ư` a leading `w` produced puts the literal key back, keeping the
+    // onset in front of it: `ư` → `w`, `thư` → `thw`, `sư` → `sw`.
+    if shortcut == TelexShortcut::LeadingW
+        && let Some((prefix, horn_u)) = split_trailing_horn_u(buffer)
+    {
+        let mut text = String::with_capacity(prefix.len() + 1);
+        text.push_str(prefix);
+        text.push(if horn_u == 'Ư' { 'W' } else { 'w' });
         return TransformResult {
             kind: TransformKind::Reverted,
             text,
@@ -37,6 +43,15 @@ pub(super) fn apply(
         text,
     };
     gates::spell_check(buffer, key, spell_check, result)
+}
+
+/// Split a buffer that ends in `ư`/`Ư` into the part before it and that vowel.
+fn split_trailing_horn_u(buffer: &str) -> Option<(&str, char)> {
+    let horn_u = buffer
+        .chars()
+        .next_back()
+        .filter(|c| matches!(c, 'ư' | 'Ư'))?;
+    Some((&buffer[..buffer.len() - horn_u.len_utf8()], horn_u))
 }
 
 #[cfg(test)]

--- a/crates/funput-core/src/composition/transform/normal.rs
+++ b/crates/funput-core/src/composition/transform/normal.rs
@@ -1,10 +1,13 @@
-use crate::composition::uo_horn::complete_uo_horn_for_continuation;
+use crate::composition::uo_horn::{complete_uo_horn_for_continuation, drop_stray_u_after_horn_u};
 use crate::unicode::tone_position::reposition_existing_tone;
 use crate::{ToneStyle, TransformKind, TransformResult};
 
 use super::append;
 
 pub(super) fn apply(buffer: &str, key: char, style: ToneStyle) -> TransformResult {
+    if let Some(reparsed) = drop_stray_u_after_horn_u(buffer, key) {
+        return repositioned_or(reparsed, style, TransformKind::Applied);
+    }
     if let Some(completed) = complete_uo_horn_for_continuation(buffer, key) {
         return repositioned_or(completed, style, TransformKind::Applied);
     }

--- a/crates/funput-core/src/composition/uo_horn/continuation.rs
+++ b/crates/funput-core/src/composition/uo_horn/continuation.rs
@@ -1,7 +1,41 @@
-use crate::unicode::marks::{apply_tone_to_vowel, tone_on_vowel};
-use crate::unicode::shapes::{VowelShape, apply_shape_to_vowel, strip_shape};
+use crate::unicode::marks::{apply_tone_to_vowel, is_vowel, tone_on_vowel};
+use crate::unicode::shapes::{
+    VowelShape, apply_shape_to_vowel, base_vowel, shape_on_vowel, strip_shape,
+};
 
 use super::pair::{horned_uo_suffix, open_uo_suffix};
+
+/// Drop the stray `u` of a `ưu` that a vowel key continues past.
+///
+/// `ưu` is a closed rhyme: across Viet74K's 73 901 entries, 658 contain it and
+/// **none** carry another letter after it. So a vowel arriving here means the `u`
+/// was never part of the rhyme — it is the literal keystroke left over when a
+/// horn key already produced the `ư` on its own. Dropping it hands the syllable
+/// back to the ordinary horn compound: `trưu` + `o` → `trưo` → `trươ` → `trường`.
+///
+/// This is what lets a horn typed *before* the nucleus still reach `ươ`, whether
+/// it came from Full Telex's leading `w` (`trwuongf`), the `[` shortcut
+/// (`tr[uongf`) or VNI's `7`.
+pub(crate) fn drop_stray_u_after_horn_u(buffer: &str, key: char) -> Option<String> {
+    if !is_vowel(key) {
+        return None;
+    }
+    let mut chars = buffer.char_indices().rev();
+    let (u_offset, u) = chars.next()?;
+    if !matches!(u, 'u' | 'U') {
+        return None;
+    }
+    let (_, horn) = chars.next()?;
+    if shape_on_vowel(horn) != Some(VowelShape::Horn)
+        || !base_vowel(horn).is_some_and(|base| base.eq_ignore_ascii_case(&'u'))
+    {
+        return None;
+    }
+    let mut text = String::with_capacity(u_offset + key.len_utf8());
+    text.push_str(&buffer[..u_offset]);
+    text.push(key);
+    Some(text)
+}
 
 #[inline]
 pub(crate) fn complete_uo_horn_for_continuation(buffer: &str, key: char) -> Option<String> {

--- a/crates/funput-core/src/composition/uo_horn/mod.rs
+++ b/crates/funput-core/src/composition/uo_horn/mod.rs
@@ -6,7 +6,9 @@ mod pair;
 mod revert;
 
 pub(crate) use apply::{apply_uo_compound, apply_uo_compound_in_place};
-pub(crate) use continuation::{complete_uo_horn_for_continuation, normalize_horned_uo_open};
+pub(crate) use continuation::{
+    complete_uo_horn_for_continuation, drop_stray_u_after_horn_u, normalize_horned_uo_open,
+};
 pub(crate) use pair::{ends_with_open_uo_horn, uo_pair_in_vowel_cluster};
 pub(crate) use revert::try_revert_uo_compound;
 

--- a/crates/funput-core/src/input_method/telex/advanced.rs
+++ b/crates/funput-core/src/input_method/telex/advanced.rs
@@ -12,9 +12,7 @@ pub(super) fn classify(buffer: &str, key: char) -> AdvancedAction {
     match key {
         '[' => AdvancedAction::Shortcut(TelexShortcut::HornU),
         ']' => AdvancedAction::Shortcut(TelexShortcut::HornO),
-        'w' | 'W' if buffer.is_empty() || standalone_horn_u(buffer) => {
-            AdvancedAction::Shortcut(TelexShortcut::LeadingW)
-        }
+        'w' | 'W' if leading_w(buffer) => AdvancedAction::Shortcut(TelexShortcut::LeadingW),
         'w' | 'W' if ends_with_w_after_vowel(buffer) => {
             AdvancedAction::Shortcut(TelexShortcut::RepeatedW)
         }
@@ -30,8 +28,27 @@ fn ends_with_w_after_vowel(buffer: &str) -> bool {
         && buffer.chars().any(is_vowel)
 }
 
-fn standalone_horn_u(buffer: &str) -> bool {
-    matches!(buffer, "ư" | "Ư")
+/// Full Telex `w` stands in for `ư` as long as the syllable has no nucleus for
+/// it to modify: `w` → `ư`, and equally `th` + `w` → `thư`. It also owns the
+/// undo of that `ư` (`thư` + `w` → `thw`), which is what keeps a Latin run
+/// escapable — `swwap` → `swap`.
+fn leading_w(buffer: &str) -> bool {
+    onset_only(buffer) || horn_u_after_onset(buffer)
+}
+
+/// No nucleus yet: the buffer is empty or a bare onset cluster.
+///
+/// A lone `q` is excluded — no Vietnamese syllable reads `qư`, `q` is always
+/// followed by the `u` glide, so a `w` there is the ordinary trần/móc waiting on
+/// the vowel behind it (`qwuangj` → `quặng`).
+fn onset_only(buffer: &str) -> bool {
+    !matches!(buffer, "q" | "Q") && !buffer.chars().any(is_vowel)
+}
+
+/// An onset plus the single `ư` a leading `w` just produced — the undo target.
+fn horn_u_after_onset(buffer: &str) -> bool {
+    let mut chars = buffer.chars();
+    matches!(chars.next_back(), Some('ư' | 'Ư')) && !chars.any(is_vowel)
 }
 
 #[cfg(test)]

--- a/crates/funput-core/tests/telex/advanced.rs
+++ b/crates/funput-core/tests/telex/advanced.rs
@@ -41,10 +41,108 @@ fn tone_styles_and_existing_telex_converge() {
         }
         assert_eq!(buffer, "trường");
     }
-    for keys in ["chana", "trwuongf", "dwduocj", "booong"] {
+    for keys in ["chana", "booong"] {
         assert_eq!(
             typed(keys),
             crate::support::type_keys(InputMethod::Telex, keys)
+        );
+    }
+}
+
+#[test]
+fn leading_w_covers_the_whole_onset() {
+    // `w` is the `ư` key wherever the syllable still lacks a nucleus, not only at
+    // position 0 — the same rule `[` already follows.
+    for (keys, output) in [
+        ("thw", "thư"),
+        ("Thw", "Thư"),
+        ("THW", "THƯ"),
+        ("nhwng", "nhưng"),
+        ("thwongf", "thường"),
+        ("ngwoif", "người"),
+        ("chwa", "chưa"),
+        ("thws", "thứ"),
+        ("cwuf", "cừu"),
+    ] {
+        assert_eq!(typed(keys), output, "{keys}");
+    }
+
+    // A second `w` puts the literal key back and keeps the onset, so a Latin run
+    // stays escapable: `sww` → `sw`, not the bare `w` the old rule produced.
+    for (keys, output) in [("sww", "sw"), ("thww", "thw"), ("ww", "w"), ("thWW", "thW")] {
+        assert_eq!(typed(keys), output, "{keys}");
+    }
+}
+
+#[test]
+fn leading_w_still_reaches_the_uo_horn() {
+    // The leading `w` consumes the key as `ư`, so it can no longer be the pending
+    // horn that plain Telex resolves against a later `uo`. The `ưu` re-parse in
+    // `uo_horn` covers the gap — the stray `u` is dropped and the compound
+    // completes as usual, so these keep composing exactly as in plain Telex.
+    for (keys, output) in [
+        ("trwuongf", "trường"),
+        ("dwduocj", "được"),
+        ("thwuong", "thương"),
+        ("nwuocs", "nước"),
+        ("ngwuowif", "người"),
+        ("bwuoms", "bướm"),
+        ("chwua", "chưa"),
+        ("hwuou", "hươu"),
+        ("mwuownj", "mượn"),
+    ] {
+        assert_eq!(typed(keys), output, "{keys}");
+        assert_eq!(
+            crate::support::type_keys(InputMethod::Telex, keys),
+            output,
+            "plain {keys}"
+        );
+    }
+
+    // The same re-parse fixes the `[` shortcut, which never reached `ươ` before.
+    assert_eq!(typed("tr[uongf"), "trường");
+    assert_eq!(typed("tr[ongf"), "trường");
+    assert_eq!(typed("tr[]ngf"), "trường");
+
+    // `ưu` itself is untouched — it is a closed rhyme, so only a *following*
+    // vowel marks the `u` as stray.
+    for (keys, output) in [
+        ("cwuf", "cừu"),
+        ("hwuu", "hưu"),
+        ("lwuu", "lưu"),
+        ("c[uf", "cừu"),
+        ("tr[uf", "trừu"),
+    ] {
+        assert_eq!(typed(keys), output, "{keys}");
+    }
+}
+
+#[test]
+fn leading_w_skips_the_q_onset() {
+    // No syllable reads `qư`, so `w` after a lone `q` stays the ordinary trần.
+    assert_eq!(typed("qwuangj"), "quặng");
+    assert_eq!(typed("quawngj"), "quặng");
+    assert_eq!(typed("quangwj"), "quặng");
+}
+
+#[test]
+fn leading_w_loses_the_onset_placed_non_uo_horn() {
+    // Remaining divergence, documented in docs/features/advanced-telex.md: when a
+    // `w` typed straight after the onset was meant as the trần/móc of a *later*
+    // vowel that is not the `uo` compound, Full Telex now reads it as `ư`. Those
+    // words stay reachable through every other free position (`conw`, `lamws`).
+    assert_eq!(typed("cwon"), "cươn"); // plain Telex: cơn
+    assert_eq!(typed("lwams"), "lứam"); // plain Telex: lắm
+    assert_eq!(typed("nwux"), "nữu"); // plain Telex: nữ
+    for (keys, output) in [("conw", "cơn"), ("lamws", "lắm"), ("nuwx", "nữ")] {
+        assert_eq!(typed(keys), output, "{keys}");
+    }
+    // Plain Telex keeps the deferred `w` in every position.
+    for (keys, output) in [("cwon", "cơn"), ("lwams", "lắm"), ("nwux", "nữ")] {
+        assert_eq!(
+            crate::support::type_keys(InputMethod::Telex, keys),
+            output,
+            "plain {keys}"
         );
     }
 }

--- a/crates/funput-engine/tests/methods/telex_advanced.rs
+++ b/crates/funput-engine/tests/methods/telex_advanced.rs
@@ -89,11 +89,20 @@ fn brackets_are_boundaries_only_outside_advanced_telex() {
 }
 
 #[test]
-fn inherited_pending_intent_restores_at_boundary() {
+fn unresolvable_composition_restores_at_boundary() {
+    // `h` + `w` takes the `ư`, then `d` leaves it unspellable — the raw run comes
+    // back at the word boundary, as in plain Telex.
+    assert_eq!(
+        crate::support::app_text(InputMethod::TelexAdvanced, "hwd "),
+        "hwd "
+    );
+    // `dwd` does resolve here: `w` is the `ư` key and `d` is the stroke, so Full
+    // Telex commits `đư` where plain Telex restores the pending `w` as `dwd`.
     assert_eq!(
         crate::support::app_text(InputMethod::TelexAdvanced, "dwd "),
-        "dwd "
+        "đư "
     );
+    assert_eq!(crate::support::app_text(InputMethod::Telex, "dwd "), "dwd ");
 }
 
 #[test]

--- a/docs/features/advanced-telex.md
+++ b/docs/features/advanced-telex.md
@@ -23,7 +23,8 @@ Telex nâng cao phải giữ nguyên toàn bộ tính năng Telex V1–V3:
 
 - Telex chuẩn: tone, `z`, `aa/ee/oo`, `aw/ow/uw`, `dd`.
 - Free-position `aa/ee/oo`, tone convergence và non-adjacent revert.
-- Deferred `w`, chuẩn hóa `ươ/ưa/ưu` và Vietnamese-first sau onset.
+- Chuẩn hóa `ươ/ưa/ưu` và Vietnamese-first sau onset. Deferred `w` **sau onset**
+  là ngoại lệ — xem "Leading `w` và deferred `w`" bên dưới.
 - Hội tụ bounded multi-intent `w + dd`.
 - Traditional/Modern tone placement.
 - Spell check, smart/eager restore, raw keys, Flip và sticky Latin.
@@ -37,7 +38,7 @@ Mọi regression test của Telex hiện tại phải chạy lại cho Telex nâ
 |---|---|---|
 | `[` | `ư` | `t[` → `tư` |
 | `]` | `ơ` | `m]` → `mơ` |
-| `w` ở đầu từ hoặc đứng riêng | `ư` | `w` → `ư`, `wf` → `ừ` |
+| `w` khi âm tiết chưa có nguyên âm | `ư` | `w` → `ư`, `wf` → `ừ`, `th` + `w` → `thư` |
 
 Các phím mới phải kết hợp với pipeline hiện tại:
 
@@ -54,8 +55,54 @@ Tone nhập sau đó vẫn dùng quy tắc Traditional/Modern hiện tại.
 gán behavior cho `{` và `}`; hai phím này tiếp tục là ký tự literal cho đến khi có
 quyết định sản phẩm riêng.
 
-Nhấn `w` lần hai dùng semantics revert hiện có: `w → ư`, `ww → w`. Raw keystrokes
-phải luôn được giữ để Flip khôi phục chính xác input ban đầu.
+Nhấn `w` lần hai dùng semantics revert hiện có: `w → ư`, `ww → w`. Revert giữ lại
+onset đứng trước, nên `sww → sw` và `thww → thw`; Latin run vẫn escape được.
+Raw keystrokes phải luôn được giữ để Flip khôi phục chính xác input ban đầu.
+
+### Leading `w` và deferred `w`
+
+`w` là phím `ư` ở **mọi vị trí âm tiết chưa có nguyên âm**, không chỉ ở ký tự đầu:
+`thw` → `thư`, `nhwng` → `nhưng`, `thwongf` → `thường`, `ngwoif` → `người`.
+
+Hệ quả: `w` sau onset không còn là deferred `w` (pending horn chờ nguyên âm phía
+sau) trong Telex nâng cao. Telex thường **không đổi**.
+
+Vần `ươ` — nhóm lớn nhất — vẫn về đích nhờ chuẩn hoá `ưu` (mục kế tiếp):
+
+| Input | Telex | Telex nâng cao |
+|---|---|---|
+| `thw` | `thw` | `thư` |
+| `thwongf` | `thờng` | `thường` |
+| `nhwng` | `nhwng` | `nhưng` |
+| `trwuongf` | `trường` | `trường` |
+| `dwduocj` | `được` | `được` |
+| `cwon` | `cơn` | `cươn` |
+| `lwams` | `lắm` | `lứam` |
+
+Chênh lệch còn lại chỉ xảy ra khi `w` gõ **ngay sau onset** và nhắm tới trần/móc
+của một nguyên âm phía sau **không** thuộc cặp `uo`: `cwon`, `lwams`, `nwux`,
+`gwiux`. Đây là ambiguity không gỡ được — `lưa`/`cưa` là âm tiết hợp lệ, nên không
+phân biệt được với `lắm`/`cơn`. Các từ này vẫn gõ được ở mọi vị trí tự do khác
+(`conw`, `lamws`, `nuwx`) và bằng cách gõ canonical.
+
+`q` được loại khỏi luật: không có âm tiết `qư`, nên `w` sau `q` đứng một mình vẫn
+là trần thường (`qwuangj` → `quặng`).
+
+### Chuẩn hoá `ưu` + nguyên âm
+
+`ưu` là vần đóng. Kiểm chứng trên Viet74K (73.901 mục): 658 từ chứa `ưu`, **không
+từ nào** có ký tự nào đi sau. Nên một nguyên âm đến sau `ưu` chứng tỏ chữ `u` chưa
+bao giờ thuộc vần — nó là keystroke thừa còn lại khi phím móc đã tự tạo ra `ư`.
+
+Bỏ chữ `u` đó rồi trả âm tiết về cho horn compound thông thường:
+
+```text
+trưu + o  →  trưo  →  trươ  →  trường
+```
+
+Luật này nằm ở `uo_horn` nên dùng chung cho mọi cách tạo ra `ư` sớm: leading `w`
+của Telex nâng cao (`trwuongf`), shortcut `[` (`tr[uongf`) và `7` của VNI
+(`tru7uong2`). Nó đồng thời sửa một lỗi có sẵn: `tr[uongf` trước đây ra `trừuong`.
 
 ## So sánh hai mode
 


### PR DESCRIPTION
- Enhanced the logic for interpreting leading 'w' as 'ư' in various contexts, allowing it to function correctly when no nucleus is present.
- Introduced a new function to drop stray 'u' characters after horned vowels, ensuring accurate syllable formation.
- Updated tests to validate the new behavior of leading 'w' and its interaction with other input methods, maintaining compatibility with existing Telex functionality.