### PR TITLE
fix(core): keep the tone off the gi/qu onset glide

### DIFF
--- a/crates/funput-cli/src/dev/coverage/corpus.rs
+++ b/crates/funput-cli/src/dev/coverage/corpus.rs
@@ -27,6 +27,19 @@ const CORPUS_NOISE: &[&str] = &[
     "ngườí",
     "ngồí",
     "phổí",
+    "gìặt", // giặt
+    "gĩữ",  // giữ
+    // Tone on the **onset glide** — the `u` of `qu` / the `i` of `gi` belongs to the
+    // onset and never carries the tone, so these are misspellings of `quỳ`, `quý`,
+    // `quỹ`, `quỵ`, `giạ`. `is_complete_syllable` already rejects them (see
+    // `orthography::glide::onset_holds_tone`); listing them keeps the exclusion
+    // auditable and catches the regression if that check is ever loosened.
+    "qùy",
+    "qúy",
+    "qũy",
+    "qụy",
+    "gịa",
+    "gỵa",
     // Tone on the wrong vowel (engine produces the correctly-placed spelling).
     "ngươí",
     "ngóeo",

--- a/crates/funput-core/src/composition/apply.rs
+++ b/crates/funput-core/src/composition/apply.rs
@@ -7,9 +7,9 @@
 
 use crate::composition::replace_char_at;
 use crate::composition::uo_horn::{apply_uo_compound, uo_pair_in_vowel_cluster};
+use crate::orthography::{tone_target_vowel, tone_vowel_index};
 use crate::unicode::marks::{Tone, apply_tone_to_vowel, stroke_d, tone_on_vowel, vowel_stem};
 use crate::unicode::shapes::{VowelShape, apply_shape_to_vowel, shape_target_index};
-use crate::unicode::tone_position::{tone_target_vowel, tone_vowel_index};
 use crate::{ToneStyle, TransformKind, TransformResult};
 
 fn ignored(buffer: &str) -> TransformResult {

--- a/crates/funput-core/src/composition/intent/candidate.rs
+++ b/crates/funput-core/src/composition/intent/candidate.rs
@@ -1,7 +1,7 @@
 use crate::ToneStyle;
+use crate::orthography::{tone_target_vowel, tone_vowel_index};
 use crate::unicode::marks::{Tone, apply_tone_to_vowel, tone_on_vowel};
 use crate::unicode::shapes::{VowelShape, apply_shape_to_vowel};
-use crate::unicode::tone_position::{tone_target_vowel, tone_vowel_index};
 
 use super::target::Target;
 

--- a/crates/funput-core/src/composition/intent/kinds/circumflex.rs
+++ b/crates/funput-core/src/composition/intent/kinds/circumflex.rs
@@ -1,9 +1,9 @@
 use crate::ToneStyle;
 use crate::composition::replace_char_at;
 use crate::input_method::telex::tone_from_key;
+use crate::orthography::reposition_existing_tone;
 use crate::unicode::marks::Tone;
 use crate::unicode::shapes::{VowelShape, shape_on_vowel, strip_shape};
-use crate::unicode::tone_position::reposition_existing_tone;
 use crate::validation::syllable::is_viable_shape_candidate;
 
 use super::super::IntentResolution;

--- a/crates/funput-core/src/composition/intent/kinds/w.rs
+++ b/crates/funput-core/src/composition/intent/kinds/w.rs
@@ -1,6 +1,7 @@
 use crate::composition::uo_horn::{apply_uo_compound_in_place, uo_pair_in_vowel_cluster};
 use crate::input_method::KeyAction;
 use crate::input_method::telex::classify_w;
+use crate::orthography::glide;
 use crate::unicode::marks::{apply_tone_to_vowel, is_vowel, tone_on_vowel};
 use crate::unicode::shapes::{apply_shape_to_vowel, shape_target_index};
 use crate::validation::syllable::is_viable_shape_candidate;
@@ -15,17 +16,15 @@ pub(crate) fn has_pending(buffer: &str) -> bool {
         return false;
     }
     let mut count = 0;
-    let mut previous = None;
-    for (index, ch) in buffer.chars().enumerate() {
-        let qu_glide = previous.is_some_and(|prev: char| prev.eq_ignore_ascii_case(&'q'))
-            && ch.eq_ignore_ascii_case(&'u');
-        if is_vowel(ch) && !qu_glide {
+    for (offset, ch) in buffer.char_indices() {
+        // An onset glide is not the nucleus, so the marker is still "before the
+        // vowel" past it: `quw` + `own` → `quơn`, `giw` + `of` → `giờ`.
+        if is_vowel(ch) && glide::at(buffer, offset).is_none() {
             break;
         }
-        if index > 0 && ch.eq_ignore_ascii_case(&'w') {
+        if offset > 0 && ch.eq_ignore_ascii_case(&'w') {
             count += 1;
         }
-        previous = Some(ch);
     }
     count == 1
 }

--- a/crates/funput-core/src/composition/revert.rs
+++ b/crates/funput-core/src/composition/revert.rs
@@ -7,9 +7,9 @@
 
 use crate::ToneStyle;
 use crate::composition::uo_horn::try_revert_uo_compound;
+use crate::orthography::tone_vowel_index;
 use crate::unicode::marks::{Tone, tone_on_vowel, vowel_stem};
 use crate::unicode::shapes::{VowelShape, shaped_vowel_index, strip_shape};
-use crate::unicode::tone_position::tone_vowel_index;
 
 /// Copy of `buffer` with the char at `char_idx` replaced (single allocation).
 /// An out-of-range index returns the buffer unchanged.

--- a/crates/funput-core/src/composition/transform/normal.rs
+++ b/crates/funput-core/src/composition/transform/normal.rs
@@ -1,5 +1,5 @@
 use crate::composition::uo_horn::{complete_uo_horn_for_continuation, drop_stray_u_after_horn_u};
-use crate::unicode::tone_position::reposition_existing_tone;
+use crate::orthography::reposition_existing_tone;
 use crate::{ToneStyle, TransformKind, TransformResult};
 
 use super::append;

--- a/crates/funput-core/src/composition/uo_horn/apply.rs
+++ b/crates/funput-core/src/composition/uo_horn/apply.rs
@@ -1,3 +1,4 @@
+use crate::orthography::glide::{self, Glide};
 use crate::unicode::marks::{Tone, apply_tone_to_vowel, tone_on_vowel, vowel_stem};
 use crate::unicode::shapes::{VowelShape, apply_shape_to_vowel};
 
@@ -66,10 +67,12 @@ pub(crate) fn apply_uo_compound_in_place(text: &mut String) -> bool {
 fn compound_target(buffer: &str) -> Option<(usize, usize, bool)> {
     let (u_index, o_index) = uo_pair_in_vowel_cluster(buffer)?;
     let continued = o_index + 1 < buffer.chars().count();
-    let qu_glide = u_index > 0
-        && buffer
-            .chars()
-            .nth(u_index - 1)
-            .is_some_and(|ch| ch.eq_ignore_ascii_case(&'q'));
+    // The `u` of `qu` is onset, not part of a `ươ` compound — only the `o` horns
+    // (`quở`, `quơ`), never the glide.
+    let u_offset = buffer
+        .char_indices()
+        .nth(u_index)
+        .map_or(buffer.len(), |(offset, _)| offset);
+    let qu_glide = glide::at(buffer, u_offset) == Some(Glide::Qu);
     Some((u_index, o_index, continued && !qu_glide))
 }

--- a/crates/funput-core/src/composition/uo_horn/continuation.rs
+++ b/crates/funput-core/src/composition/uo_horn/continuation.rs
@@ -1,3 +1,4 @@
+use crate::orthography::glide::{self, Glide};
 use crate::unicode::marks::{apply_tone_to_vowel, is_vowel, tone_on_vowel};
 use crate::unicode::shapes::{
     VowelShape, apply_shape_to_vowel, base_vowel, shape_on_vowel, strip_shape,
@@ -50,9 +51,9 @@ pub(crate) fn complete_uo_horn_for_continuation(buffer: &str, key: char) -> Opti
         byte if byte.is_ascii() => return None,
         _ => {}
     }
-    let (u_offset, u, before) = open_uo_suffix(buffer)?;
-    if before.is_some_and(|ch| ch.eq_ignore_ascii_case(&'q')) {
-        return None;
+    let (u_offset, u) = open_uo_suffix(buffer)?;
+    if glide::at(buffer, u_offset) == Some(Glide::Qu) {
+        return None; // `quo` is onset + `o`, not a `uo` pair awaiting its horn
     }
     let shaped = apply_shape_to_vowel(u, VowelShape::Horn)?;
     Some(replace_and_append(buffer, u_offset, u, shaped, key))

--- a/crates/funput-core/src/composition/uo_horn/pair.rs
+++ b/crates/funput-core/src/composition/uo_horn/pair.rs
@@ -30,17 +30,17 @@ pub(crate) fn uo_pair_in_vowel_cluster(buffer: &str) -> Option<(usize, usize)> {
     None
 }
 
-pub(super) fn open_uo_suffix(buffer: &str) -> Option<(usize, char, Option<char>)> {
+/// Trailing plain `u` + horned `o` (`thưo`-style, before the pair resolves).
+pub(super) fn open_uo_suffix(buffer: &str) -> Option<(usize, char)> {
     if buffer.as_bytes().last().is_none_or(u8::is_ascii) {
         return None;
     }
     let mut chars = buffer.char_indices().rev();
     let (_, o) = chars.next()?;
     let (u_offset, u) = chars.next()?;
-    let before = chars.next().map(|(_, ch)| ch);
     let plain_u = plain_stem(u, 'u');
     let horned_o = shape_on_vowel(o) == Some(VowelShape::Horn);
-    (plain_u && horned_o).then_some((u_offset, u, before))
+    (plain_u && horned_o).then_some((u_offset, u))
 }
 
 pub(super) fn horned_uo_suffix(buffer: &str) -> Option<(usize, char, usize, char)> {

--- a/crates/funput-core/src/input_method/telex/modifiers/w.rs
+++ b/crates/funput-core/src/input_method/telex/modifiers/w.rs
@@ -1,5 +1,6 @@
 use crate::composition::uo_horn::uo_pair_in_vowel_cluster;
 use crate::input_method::KeyAction;
+use crate::orthography::glide::{self, Glide};
 use crate::unicode::marks::{is_vowel, tone_on_vowel, vowel_stem};
 use crate::unicode::shapes::{VowelShape, base_vowel, shape_on_vowel, shape_target_index};
 
@@ -12,15 +13,16 @@ fn plain(ch: char, stem: char) -> bool {
 }
 
 fn ends_with_ua_target(buffer: &str) -> bool {
-    let mut rev = buffer.chars().rev();
-    if !rev.next().is_some_and(|ch| plain(ch, 'a')) {
+    let mut rev = buffer.char_indices().rev();
+    if !rev.next().is_some_and(|(_, ch)| plain(ch, 'a')) {
         return false;
     }
-    let is_u = rev
-        .next()
-        .and_then(vowel_stem)
-        .is_some_and(|stem| matches!(stem, 'u' | 'U' | 'ư' | 'Ư'));
-    is_u && !matches!(rev.next(), Some('q' | 'Q'))
+    let Some((u_offset, u)) = rev.next() else {
+        return false;
+    };
+    let is_u = vowel_stem(u).is_some_and(|stem| matches!(stem, 'u' | 'U' | 'ư' | 'Ư'));
+    // `qua` is onset + `a`: no `ua` pair for the horn to target.
+    is_u && glide::at(buffer, u_offset) != Some(Glide::Qu)
 }
 
 pub(crate) fn classify(buffer: &str) -> Option<KeyAction> {
@@ -62,9 +64,14 @@ pub(crate) fn classify(buffer: &str) -> Option<KeyAction> {
 }
 
 fn ends_with_qu_glide(buffer: &str) -> bool {
-    let mut chars = buffer.chars().rev();
-    chars.next().is_some_and(|ch| plain(ch, 'u'))
-        && chars.next().is_some_and(|ch| ch.eq_ignore_ascii_case(&'q'))
+    let Some((u_offset, _)) = buffer
+        .char_indices()
+        .next_back()
+        .filter(|&(_, ch)| plain(ch, 'u'))
+    else {
+        return false;
+    };
+    glide::at(buffer, u_offset) == Some(Glide::Qu)
 }
 
 fn horn() -> Option<KeyAction> {

--- a/crates/funput-core/src/lib.rs
+++ b/crates/funput-core/src/lib.rs
@@ -22,6 +22,7 @@
 mod composition;
 mod input_method;
 mod options;
+mod orthography;
 mod unicode;
 mod validation;
 

--- a/crates/funput-core/src/orthography/cluster.rs
+++ b/crates/funput-core/src/orthography/cluster.rs
@@ -1,5 +1,6 @@
 //! One-pass, allocation-free scan of the nucleus vowel cluster.
 
+use crate::orthography::glide;
 use crate::unicode::marks::{is_vowel, vowel_stem};
 use crate::unicode::shapes::shape_on_vowel;
 
@@ -18,28 +19,19 @@ pub(super) struct ClusterScan {
     pub(super) has_coda: bool,
 }
 
-/// True if `vowel`, preceded by `prev`, is the onset glide of `qu`/`gi` (the
-/// `u`/`i` belongs to the leading consonant, not the tonal nucleus).
-fn is_onset_glide(prev: Option<char>, vowel: char) -> bool {
-    let Some(prev) = prev else {
-        return false;
-    };
-    (vowel.eq_ignore_ascii_case(&'u') && prev.eq_ignore_ascii_case(&'q'))
-        || (vowel.eq_ignore_ascii_case(&'i') && prev.eq_ignore_ascii_case(&'g'))
-}
-
 pub(super) fn scan_cluster(buffer: &str) -> Option<ClusterScan> {
-    let mut before = None; // char immediately before the cluster
+    let mut onset = buffer; // everything before the cluster
     let mut start = 0;
     let mut len = 0;
     let mut vowels = [None; 3]; // first three cluster vowels
     let mut last_shaped = None;
     let mut has_coda = false;
 
-    for (i, ch) in buffer.chars().enumerate() {
+    for (i, (offset, ch)) in buffer.char_indices().enumerate() {
         if is_vowel(ch) {
             if len == 0 {
                 start = i;
+                onset = &buffer[..offset];
             }
             if len < vowels.len() {
                 vowels[len] = Some(ch);
@@ -51,16 +43,15 @@ pub(super) fn scan_cluster(buffer: &str) -> Option<ClusterScan> {
         } else if len > 0 {
             has_coda = true;
             break;
-        } else {
-            before = Some(ch);
         }
     }
 
     // Drop the onset glide of `qu`/`gi` when a real nucleus vowel follows
     // (e.g. `qua` → tone on `a`, `gia` → tone on `a`), but keep it when it is
-    // the only vowel (e.g. `gì`, `gìn`). A glide is a plain `u`/`i` — never
-    // shaped — so `last_shaped` is unaffected.
-    if len >= 2 && is_onset_glide(before, vowels[0]?) {
+    // the only vowel (e.g. `gì`, `gìn`). The glide may itself carry a transient
+    // tone here (`gí` + `a`), which is exactly what [`glide::after`] sees through;
+    // it is never *shaped*, so `last_shaped` is unaffected either way.
+    if len >= 2 && glide::after(onset, vowels[0]?).is_some() {
         start += 1;
         len -= 1;
         vowels = [vowels[1], vowels[2], None];

--- a/crates/funput-core/src/orthography/glide.rs
+++ b/crates/funput-core/src/orthography/glide.rs
@@ -14,7 +14,7 @@
 //! - **`q`/`g` must be the whole onset.** `ngi` is `ng` + nucleus `i`
 //!   (`nghĩa`-style), not a `gi` onset that happens to end in `g` + `i`.
 
-use crate::unicode::marks::vowel_stem;
+use crate::unicode::marks::{tone_on_vowel, vowel_stem};
 
 /// Which onset the glide belongs to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -31,22 +31,27 @@ pub(crate) enum Glide {
 /// The stem match keeps the vowel *shape*, which is what rejects `ư`:
 /// `vowel_stem('ứ')` is `ư`, never `u`, so `qư` is not a `qu` glide.
 pub(crate) fn after(before: &str, vowel: char) -> Option<Glide> {
-    let stem = vowel_stem(vowel)?;
-    // A leading consonant can never carry a diacritic, so ASCII folding is the
-    // whole story on that side.
-    if before.eq_ignore_ascii_case("q") && stem.eq_ignore_ascii_case(&'u') {
-        Some(Glide::Qu)
-    } else if before.eq_ignore_ascii_case("g") && stem.eq_ignore_ascii_case(&'i') {
-        Some(Glide::Gi)
-    } else {
-        None
-    }
+    // Consonant first: it is a one-byte compare that rejects almost every call,
+    // and it keeps the vowel-table lookup off the common path. A leading
+    // consonant can never carry a diacritic, so ASCII folding settles that side.
+    let (expected, glide) = match before.as_bytes() {
+        [b'q' | b'Q'] => ('u', Glide::Qu),
+        [b'g' | b'G'] => ('i', Glide::Gi),
+        _ => return None,
+    };
+    vowel_stem(vowel)?
+        .eq_ignore_ascii_case(&expected)
+        .then_some(glide)
 }
 
 /// The glide at byte `offset` of `buffer`, if the char there is one.
 pub(crate) fn at(buffer: &str, offset: usize) -> Option<Glide> {
-    let vowel = buffer[offset..].chars().next()?;
-    after(&buffer[..offset], vowel)
+    // Cheap reject before either slice: only a one-char onset can be a glide's.
+    if offset != 1 {
+        return None;
+    }
+    let vowel = buffer[1..].chars().next()?;
+    after(&buffer[..1], vowel)
 }
 
 /// The glide of a complete onset slice (`"qu"`, `"gi"`, and their toned
@@ -54,4 +59,14 @@ pub(crate) fn at(buffer: &str, offset: usize) -> Option<Glide> {
 pub(crate) fn in_onset(onset: &str) -> Option<Glide> {
     let vowel = onset.chars().next_back()?;
     at(onset, onset.len() - vowel.len_utf8())
+}
+
+/// True when the onset's glide carries a tone.
+///
+/// Legal only *mid-composition*, as the transient a tone key typed before the
+/// nucleus leaves behind (`gí` on the way to `giá`). A finished syllable never
+/// looks like this — `qúy` is a misspelling of `quý` — so the word-boundary check
+/// [`crate::is_complete_syllable`] rejects it.
+pub(crate) fn onset_holds_tone(onset: &str) -> bool {
+    in_onset(onset).is_some() && onset.chars().any(|ch| tone_on_vowel(ch).is_some())
 }

--- a/crates/funput-core/src/orthography/glide.rs
+++ b/crates/funput-core/src/orthography/glide.rs
@@ -1,0 +1,57 @@
+//! Âm đệm — the medial glide of a `qu` / `gi` onset.
+//!
+//! The `u` of `qu` and the `i` of `gi` are written like vowels but belong to the
+//! **onset**: they never carry the tone (`quá`, not `qúa`; `giá`, not `gía`) and
+//! they are not part of the rhyme (`quán` rhymes `an`, not `uan`).
+//!
+//! Two properties are easy to get wrong when this is re-derived ad hoc, and both
+//! are settled here once:
+//!
+//! - **The glide may already carry a tone.** A tone key pressed before the
+//!   nucleus parks on the glide as a transient (`gi` + `s` → `gí`) and must be
+//!   moved once the nucleus arrives (`gí` + `a` → `giá`). So the vowel is matched
+//!   on its stem, tone-blind by construction.
+//! - **`q`/`g` must be the whole onset.** `ngi` is `ng` + nucleus `i`
+//!   (`nghĩa`-style), not a `gi` onset that happens to end in `g` + `i`.
+
+use crate::unicode::marks::vowel_stem;
+
+/// Which onset the glide belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Glide {
+    /// The `u` of `qu` (`qua`, `quyên`).
+    Qu,
+    /// The `i` of `gi` (`gia`, `giết`).
+    Gi,
+}
+
+/// The glide `vowel` forms when the text before it inside the syllable is
+/// `before`, if any.
+///
+/// The stem match keeps the vowel *shape*, which is what rejects `ư`:
+/// `vowel_stem('ứ')` is `ư`, never `u`, so `qư` is not a `qu` glide.
+pub(crate) fn after(before: &str, vowel: char) -> Option<Glide> {
+    let stem = vowel_stem(vowel)?;
+    // A leading consonant can never carry a diacritic, so ASCII folding is the
+    // whole story on that side.
+    if before.eq_ignore_ascii_case("q") && stem.eq_ignore_ascii_case(&'u') {
+        Some(Glide::Qu)
+    } else if before.eq_ignore_ascii_case("g") && stem.eq_ignore_ascii_case(&'i') {
+        Some(Glide::Gi)
+    } else {
+        None
+    }
+}
+
+/// The glide at byte `offset` of `buffer`, if the char there is one.
+pub(crate) fn at(buffer: &str, offset: usize) -> Option<Glide> {
+    let vowel = buffer[offset..].chars().next()?;
+    after(&buffer[..offset], vowel)
+}
+
+/// The glide of a complete onset slice (`"qu"`, `"gi"`, and their toned
+/// transients `"qú"`, `"gí"`), if it has one.
+pub(crate) fn in_onset(onset: &str) -> Option<Glide> {
+    let vowel = onset.chars().next_back()?;
+    at(onset, onset.len() - vowel.len_utf8())
+}

--- a/crates/funput-core/src/orthography/mod.rs
+++ b/crates/funput-core/src/orthography/mod.rs
@@ -1,0 +1,28 @@
+//! Vietnamese syllable structure — the orthographic layer.
+//!
+//! A syllable (âm tiết) is `onset + medial + nucleus + coda`, with the tone
+//! (thanh điệu) riding on one nucleus vowel:
+//!
+//! ```text
+//!   q u  y ê   n        onset  (âm đầu)   q
+//!   ─ ─  ─ ─   ─        medial (âm đệm)   u   ← belongs to the onset, never toned
+//!   │ │  └─┼───┼──      nucleus (âm chính) yê  ← the tone lands here
+//!   │ └────┼───┼──      coda   (âm cuối)  n
+//! ```
+//!
+//! This module owns the *structural* rules (which vowel is the medial glide,
+//! where the nucleus starts, which vowel carries the tone). It sits above
+//! [`crate::unicode`] — pure glyph tables — and below [`crate::validation`] and
+//! [`crate::composition`], which both consume it. Keeping the rules here is what
+//! stops each consumer from re-deriving them, which is how `gi`/`qu` placement
+//! drifted apart in the first place.
+
+pub(crate) mod glide;
+
+mod cluster;
+mod tone_position;
+
+pub(crate) use tone_position::{reposition_existing_tone, tone_target_vowel, tone_vowel_index};
+
+#[cfg(test)]
+mod tests;

--- a/crates/funput-core/src/orthography/tests/glide.rs
+++ b/crates/funput-core/src/orthography/tests/glide.rs
@@ -1,0 +1,73 @@
+use crate::orthography::glide::{self, Glide};
+
+#[test]
+fn plain_glides_are_recognised() {
+    assert_eq!(glide::after("q", 'u'), Some(Glide::Qu));
+    assert_eq!(glide::after("g", 'i'), Some(Glide::Gi));
+    assert_eq!(glide::after("Q", 'U'), Some(Glide::Qu));
+    assert_eq!(glide::after("G", 'I'), Some(Glide::Gi));
+}
+
+#[test]
+fn toned_glides_are_recognised() {
+    // The transient a tone key typed before the nucleus leaves behind — the case
+    // that used to escape recognition and strand the tone (`gía`, `qúa`).
+    for vowel in ['í', 'ì', 'ỉ', 'ĩ', 'ị', 'Í', 'Ị'] {
+        assert_eq!(glide::after("g", vowel), Some(Glide::Gi), "{vowel}");
+    }
+    for vowel in ['ú', 'ù', 'ủ', 'ũ', 'ụ', 'Ú', 'Ụ'] {
+        assert_eq!(glide::after("q", vowel), Some(Glide::Qu), "{vowel}");
+    }
+}
+
+#[test]
+fn shaped_vowels_are_not_glides() {
+    // `vowel_stem` keeps the shape, so a horned `ư` never passes as the `u` of `qu`.
+    for vowel in ['ư', 'ứ', 'ừ', 'Ư'] {
+        assert_eq!(glide::after("q", vowel), None, "{vowel}");
+    }
+}
+
+#[test]
+fn the_consonant_must_be_the_whole_onset() {
+    // `ngi`/`nghi` is `ng`/`ngh` + nucleus `i` (nghĩa), not a `gi` onset that
+    // happens to end in `g` + `i`.
+    assert_eq!(glide::after("ng", 'i'), None);
+    assert_eq!(glide::after("ngh", 'i'), None);
+    assert_eq!(glide::after("Ng", 'ì'), None);
+}
+
+#[test]
+fn wrong_consonant_or_vowel_is_not_a_glide() {
+    assert_eq!(glide::after("g", 'a'), None); // `ga` — plain nucleus
+    assert_eq!(glide::after("q", 'a'), None);
+    assert_eq!(glide::after("t", 'u'), None); // `tu` — nucleus, not a glide
+    assert_eq!(glide::after("h", 'i'), None);
+    assert_eq!(glide::after("g", 'n'), None); // not a vowel at all
+    assert_eq!(glide::after("", 'u'), None); // word-initial `u` has no onset
+}
+
+#[test]
+fn at_locates_the_glide_by_byte_offset() {
+    assert_eq!(glide::at("qua", 1), Some(Glide::Qu));
+    assert_eq!(glide::at("gia", 1), Some(Glide::Gi));
+    assert_eq!(glide::at("gía", 1), Some(Glide::Gi)); // toned glide, multi-byte
+    assert_eq!(glide::at("qua", 2), None); // the nucleus `a`
+    assert_eq!(glide::at("qua", 0), None); // the onset consonant itself
+    assert_eq!(glide::at("nghiêng", 3), None); // `ngh` + nucleus
+}
+
+#[test]
+fn in_onset_matches_whole_onsets() {
+    assert_eq!(glide::in_onset("qu"), Some(Glide::Qu));
+    assert_eq!(glide::in_onset("gi"), Some(Glide::Gi));
+    assert_eq!(glide::in_onset("qú"), Some(Glide::Qu));
+    assert_eq!(glide::in_onset("gí"), Some(Glide::Gi));
+    assert_eq!(glide::in_onset("Gì"), Some(Glide::Gi));
+
+    assert_eq!(glide::in_onset("g"), None); // incomplete
+    assert_eq!(glide::in_onset("gia"), None); // onset plus nucleus
+    assert_eq!(glide::in_onset("ng"), None);
+    assert_eq!(glide::in_onset("ngh"), None);
+    assert_eq!(glide::in_onset(""), None);
+}

--- a/crates/funput-core/src/orthography/tests/mod.rs
+++ b/crates/funput-core/src/orthography/tests/mod.rs
@@ -1,0 +1,2 @@
+mod glide;
+mod placement;

--- a/crates/funput-core/src/orthography/tests/placement.rs
+++ b/crates/funput-core/src/orthography/tests/placement.rs
@@ -1,4 +1,7 @@
-use super::*;
+use crate::ToneStyle;
+use crate::orthography::tone_position::{
+    reposition_existing_tone, tone_target_vowel, tone_vowel_index,
+};
 
 fn char_at(buffer: &str, index: usize) -> char {
     buffer.chars().nth(index).expect("char at index")
@@ -91,6 +94,57 @@ fn tone_vowel_index_modern_leaves_other_clusters_unchanged() {
 fn tone_target_vowel_ie_uses_circumflex_e() {
     assert_eq!(tone_target_vowel("viet", 2), Some('ê'));
     assert_eq!(tone_target_vowel("lien", 2), Some('ê'));
+}
+
+#[test]
+fn tone_vowel_index_skips_the_onset_glide() {
+    // The `u`/`i` of `qu`/`gi` is onset, so the nucleus behind it takes the tone.
+    assert_eq!(char_at("gia", trad("gia")), 'a'); // giá, not gía
+    assert_eq!(char_at("qua", trad("qua")), 'a'); // quá
+    assert_eq!(char_at("quy", trad("quy")), 'y'); // quý — no oa/oe/uy split here
+    assert_eq!(char_at("quy", modern("quy")), 'y');
+}
+
+#[test]
+fn tone_vowel_index_skips_a_glide_that_already_carries_a_tone() {
+    // A tone key typed before the nucleus parks on the glide; the next keystroke
+    // re-runs placement over that transient and must still see it as the onset.
+    for (buffer, expected) in [("gía", 2), ("gío", 2), ("qúa", 2), ("qúy", 2)] {
+        assert_eq!(trad(buffer), expected, "{buffer}");
+        assert_eq!(modern(buffer), expected, "{buffer}");
+    }
+}
+
+#[test]
+fn tone_vowel_index_keeps_a_lone_glide_vowel_as_the_nucleus() {
+    // With no vowel after it, the `i` of `gi` *is* the nucleus: gì, gìn.
+    assert_eq!(char_at("gi", trad("gi")), 'i');
+    assert_eq!(char_at("gin", trad("gin")), 'i');
+    assert_eq!(trad("gì"), 1);
+    assert_eq!(trad("gìn"), 1);
+    // Same for `qu`, where the tone waits on the glide until a nucleus arrives.
+    assert_eq!(char_at("qu", trad("qu")), 'u');
+}
+
+#[test]
+fn reposition_moves_a_tone_off_the_onset_glide() {
+    for (buffer, expected) in [
+        ("gía", "giá"),
+        ("gío", "gió"),
+        ("gíe", "gié"),
+        ("qúa", "quá"),
+        ("qúy", "quý"),
+        ("GÍA", "GIÁ"),
+    ] {
+        assert_eq!(
+            reposition_existing_tone(buffer, ToneStyle::Traditional).as_deref(),
+            Some(expected),
+            "{buffer}"
+        );
+    }
+    // Nothing to move while the glide is still the only vowel.
+    assert_eq!(reposition_existing_tone("gì", ToneStyle::Traditional), None);
+    assert_eq!(reposition_existing_tone("qú", ToneStyle::Traditional), None);
 }
 
 #[test]

--- a/crates/funput-core/src/orthography/tone_position.rs
+++ b/crates/funput-core/src/orthography/tone_position.rs
@@ -85,9 +85,13 @@ pub(crate) fn tone_target_vowel(buffer: &str, vowel_idx: usize) -> Option<char> 
     apply_shape(stem, VowelShape::Circumflex)
 }
 
-/// Re-place an existing tone for `style`: move it to the right vowel, and update
-/// that vowel's tonal base when the rhyme has since resolved (`gié` + `m` →
-/// `giếm`, where the arriving coda turns open `ie` into the `iê` diphthong).
+/// If a tone exists on the wrong vowel, move it to the correct position for `style`.
+///
+/// Only the *position* is revisited, never the tonal base of a tone that already
+/// sits right. That is deliberate: where the user put the tone key disambiguates
+/// the two `gi` + `e` + coda rhymes that structure alone cannot separate — before
+/// the coda keeps plain `e` (`giefm` → `gièm`), after it promotes to `ê`
+/// (`giemf` → `giềm`). Both are real words.
 pub(crate) fn reposition_existing_tone(buffer: &str, style: ToneStyle) -> Option<String> {
     // Cheap scan first: most keystrokes carry no tone yet, and this runs on
     // every normal key — bail out without any cluster analysis or allocation.
@@ -97,21 +101,20 @@ pub(crate) fn reposition_existing_tone(buffer: &str, style: ToneStyle) -> Option
         .find_map(|(i, ch)| tone_on_vowel(ch).map(|t| (i, ch, t)))?;
 
     let desired = tone_vowel_index(buffer, style)?;
-    let desired_ch = buffer.chars().nth(desired)?;
-    let tone_base = tone_target_vowel(buffer, desired).unwrap_or(desired_ch);
-    let toned = apply_tone_to_vowel(tone_base, tone)?;
-    // Right vowel, right glyph — nothing to do, and nothing allocated.
-    if current == desired && toned == current_ch {
+    if current == desired {
         return None;
     }
 
     let old_stem = vowel_stem(current_ch)?;
+    let desired_ch = buffer.chars().nth(desired)?;
+    let tone_base = tone_target_vowel(buffer, desired).unwrap_or(desired_ch);
+    let toned = apply_tone_to_vowel(tone_base, tone)?;
+
     let mut moved = String::with_capacity(buffer.len() + toned.len_utf8());
     for (i, ch) in buffer.chars().enumerate() {
-        // `desired` first: the two coincide when only the tonal base changed.
         moved.push(match i {
-            _ if i == desired => toned,
             _ if i == current => old_stem,
+            _ if i == desired => toned,
             _ => ch,
         });
     }

--- a/crates/funput-core/src/orthography/tone_position.rs
+++ b/crates/funput-core/src/orthography/tone_position.rs
@@ -3,16 +3,14 @@
 //! Hot path: runs on every normal keystroke, so the cluster analysis is a
 //! single allocation-free pass; only an actual reposition builds a `String`.
 
-mod cluster;
-
-use cluster::{modern_open_pair_takes_second, scan_cluster, tone_offset_in_cluster};
+use super::cluster::{modern_open_pair_takes_second, scan_cluster, tone_offset_in_cluster};
 
 use crate::ToneStyle;
 use crate::unicode::marks::{apply_tone_to_vowel, is_vowel, tone_on_vowel, vowel_stem};
 use crate::unicode::shapes::{VowelShape, apply_shape};
 
 /// Char index where a tone mark should be placed, for the given placement `style`.
-pub fn tone_vowel_index(buffer: &str, style: ToneStyle) -> Option<usize> {
+pub(crate) fn tone_vowel_index(buffer: &str, style: ToneStyle) -> Option<usize> {
     let cluster = scan_cluster(buffer)?;
 
     // A vowel carrying mũ/móc/trần (â ê ô ơ ư ă) takes the tone. For `ươ` (two
@@ -40,7 +38,7 @@ pub fn tone_vowel_index(buffer: &str, style: ToneStyle) -> Option<usize> {
 /// Plain `e` preceded by `i` forms the rising diphthong written with a circumflex
 /// (`viết`, `giết`), so the tone lands on `ê`. This covers both the `i` nucleus of
 /// `viet` and the `i` that is part of the `gi` onset of `giet`.
-pub fn tone_target_vowel(buffer: &str, vowel_idx: usize) -> Option<char> {
+pub(crate) fn tone_target_vowel(buffer: &str, vowel_idx: usize) -> Option<char> {
     // Chars at vowel_idx - 1, vowel_idx, vowel_idx + 1, in one pass.
     let (mut prev, mut vowel, mut next) = (None, None, None);
     for (i, ch) in buffer.chars().enumerate() {
@@ -87,8 +85,10 @@ pub fn tone_target_vowel(buffer: &str, vowel_idx: usize) -> Option<char> {
     apply_shape(stem, VowelShape::Circumflex)
 }
 
-/// If a tone exists on the wrong vowel, move it to the correct position for `style`.
-pub fn reposition_existing_tone(buffer: &str, style: ToneStyle) -> Option<String> {
+/// Re-place an existing tone for `style`: move it to the right vowel, and update
+/// that vowel's tonal base when the rhyme has since resolved (`gié` + `m` →
+/// `giếm`, where the arriving coda turns open `ie` into the `iê` diphthong).
+pub(crate) fn reposition_existing_tone(buffer: &str, style: ToneStyle) -> Option<String> {
     // Cheap scan first: most keystrokes carry no tone yet, and this runs on
     // every normal key — bail out without any cluster analysis or allocation.
     let (current, current_ch, tone) = buffer
@@ -97,25 +97,23 @@ pub fn reposition_existing_tone(buffer: &str, style: ToneStyle) -> Option<String
         .find_map(|(i, ch)| tone_on_vowel(ch).map(|t| (i, ch, t)))?;
 
     let desired = tone_vowel_index(buffer, style)?;
-    if current == desired {
+    let desired_ch = buffer.chars().nth(desired)?;
+    let tone_base = tone_target_vowel(buffer, desired).unwrap_or(desired_ch);
+    let toned = apply_tone_to_vowel(tone_base, tone)?;
+    // Right vowel, right glyph — nothing to do, and nothing allocated.
+    if current == desired && toned == current_ch {
         return None;
     }
 
     let old_stem = vowel_stem(current_ch)?;
-    let desired_ch = buffer.chars().nth(desired)?;
-    let tone_base = tone_target_vowel(buffer, desired).unwrap_or(desired_ch);
-    let toned = apply_tone_to_vowel(tone_base, tone)?;
-
     let mut moved = String::with_capacity(buffer.len() + toned.len_utf8());
     for (i, ch) in buffer.chars().enumerate() {
+        // `desired` first: the two coincide when only the tonal base changed.
         moved.push(match i {
-            _ if i == current => old_stem,
             _ if i == desired => toned,
+            _ if i == current => old_stem,
             _ => ch,
         });
     }
     Some(moved)
 }
-
-#[cfg(test)]
-mod tests;

--- a/crates/funput-core/src/unicode/marks.rs
+++ b/crates/funput-core/src/unicode/marks.rs
@@ -61,12 +61,6 @@ pub fn is_vowel(c: char) -> bool {
     vowels::is_vowel(c)
 }
 
-/// Index of the vowel where a tone mark should be placed, for the given `style`.
-#[allow(dead_code)] // Public API — used by engine and external callers.
-pub fn main_vowel_index(syllable: &str, style: crate::ToneStyle) -> Option<usize> {
-    crate::unicode::tone_position::tone_vowel_index(syllable, style)
-}
-
 /// Detect tone on a vowel character, if any.
 pub(crate) fn tone_on_vowel(c: char) -> Option<Tone> {
     let index = vowels::tone_index_on_vowel(c)?;
@@ -112,15 +106,5 @@ mod tests {
         assert_eq!(stroke_d('d'), Some('đ'));
         assert_eq!(stroke_d('D'), Some('Đ'));
         assert_eq!(stroke_d('x'), None);
-    }
-
-    #[test]
-    fn main_vowel_index_delegates_to_tone_rules() {
-        use crate::ToneStyle::{Modern, Traditional};
-        assert_eq!(main_vowel_index("hoa", Traditional), Some(1)); // hòa — tone on `o`
-        assert_eq!(main_vowel_index("hoa", Modern), Some(2)); // hoà — tone on `a`
-        assert_eq!(main_vowel_index("chao", Traditional), Some(2));
-        assert_eq!(main_vowel_index("ma", Traditional), Some(1));
-        assert_eq!(main_vowel_index("ng", Traditional), None);
     }
 }

--- a/crates/funput-core/src/unicode/mod.rs
+++ b/crates/funput-core/src/unicode/mod.rs
@@ -1,4 +1,3 @@
 pub mod marks;
 pub mod shapes;
-pub mod tone_position;
 mod vowels;

--- a/crates/funput-core/src/validation/parse.rs
+++ b/crates/funput-core/src/validation/parse.rs
@@ -4,7 +4,11 @@
 //! allocates: the onset is a prefix slice; nucleus and coda are filtering
 //! iterators over the remainder.
 
+mod onset;
+
 use crate::unicode::marks::is_vowel;
+
+pub(crate) use onset::is_valid_onset;
 
 /// Parsed view of a single syllable chunk. The nucleus and coda are
 /// *interleaved* selections of the post-onset text — a vowel after a consonant
@@ -30,31 +34,9 @@ impl<'a> SyllableParts<'a> {
     }
 }
 
-const VALID_ONSETS: &[&str] = &[
-    "b", "c", "ch", "d", "g", "gh", "gi", "h", "k", "kh", "l", "m", "n", "ng", "ngh", "nh", "p",
-    "ph", "qu", "r", "s", "t", "th", "tr", "v", "x",
-];
-
-/// Consonant-cluster onsets that occur only in Central Highlands (Tây Nguyên)
-/// toponyms borrowed from Ê Đê / Jarai / Bahnar / M'Nông (`Pleiku`, `Krông`,
-/// `Glong`, `Blơr`, `Drăng`). Not native Vietnamese onsets — kept separate so the
-/// inventory above stays "pure Vietnamese". A valid rhyme is still required after
-/// the onset, so this barely affects English auto-restore.
-const ETHNIC_ONSETS: &[&str] = &["bl", "br", "dr", "gl", "gr", "kl", "kr", "pl", "pr"];
-
-/// True if `onset` is a valid Vietnamese onset (`đ` included, any case), or a
-/// Tây Nguyên toponym cluster ([`ETHNIC_ONSETS`]).
-pub(crate) fn is_valid_onset(onset: &str) -> bool {
-    onset.is_empty()
-        || onset == "đ"
-        || onset == "Đ"
-        || VALID_ONSETS.iter().any(|o| onset.eq_ignore_ascii_case(o))
-        || ETHNIC_ONSETS.iter().any(|o| onset.eq_ignore_ascii_case(o))
-}
-
 /// Parse one syllable chunk into onset, vowel nucleus, and coda.
 pub fn parse_syllable(buffer: &str) -> SyllableParts<'_> {
-    let (onset, rest, invalid_onset) = match_onset(buffer);
+    let (onset, rest, invalid_onset) = onset::match_onset(buffer);
     SyllableParts {
         onset,
         rest,
@@ -62,84 +44,5 @@ pub fn parse_syllable(buffer: &str) -> SyllableParts<'_> {
     }
 }
 
-/// Byte offset just past the first `n` chars of `s`, or `None` if `s` is shorter.
-fn after_n_chars(s: &str, n: usize) -> Option<usize> {
-    let mut chars = s.chars();
-    for _ in 0..n {
-        chars.next()?;
-    }
-    Some(s.len() - chars.as_str().len())
-}
-
-fn match_onset(buffer: &str) -> (&str, &str, bool) {
-    let Some(first) = buffer.chars().next() else {
-        return ("", buffer, false);
-    };
-    if first == 'đ' || first == 'Đ' {
-        let (onset, rest) = buffer.split_at(first.len_utf8());
-        return (onset, rest, false);
-    }
-
-    // Longest onset first (3 chars: `ngh`), then shorter.
-    for len in (1..=3).rev() {
-        let Some(split) = after_n_chars(buffer, len) else {
-            continue;
-        };
-        let (prefix, rest) = buffer.split_at(split);
-        if prefix.is_empty() || !is_valid_onset(prefix) {
-            continue;
-        }
-
-        // In `gi`, the `i` is part of the onset only when another vowel follows
-        // (`gia`, `giết`). When `i` is the lone vowel it is the nucleus (`gì`,
-        // `gìn`), so fall back to the shorter `g` onset.
-        if prefix.eq_ignore_ascii_case("gi") && !rest.chars().next().is_some_and(is_vowel) {
-            continue;
-        }
-
-        return (prefix, rest, false);
-    }
-
-    if is_vowel(first) {
-        return ("", buffer, false);
-    }
-
-    ("", buffer, true)
-}
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// (onset, nucleus, coda, invalid_onset) with the iterators materialized.
-    fn parts(buffer: &str) -> (String, String, String, bool) {
-        let p = parse_syllable(buffer);
-        (
-            p.onset.into(),
-            p.nucleus_chars().collect(),
-            p.coda_chars().collect(),
-            p.invalid_onset,
-        )
-    }
-
-    fn ok(onset: &str, nucleus: &str, coda: &str) -> (String, String, String, bool) {
-        (onset.into(), nucleus.into(), coda.into(), false)
-    }
-
-    #[test]
-    fn parse_syllable_cases() {
-        assert_eq!(parts("tr"), ok("tr", "", ""));
-        assert_eq!(parts("ng"), ok("ng", "", ""));
-        assert_eq!(parts("ma"), ok("m", "a", ""));
-        assert_eq!(parts("text"), ok("t", "e", "xt"));
-        assert_eq!(parts("mix"), ok("m", "i", "x"));
-        assert_eq!(parts("trung"), ok("tr", "u", "ng"));
-        assert_eq!(parts("đ"), ok("đ", "", ""));
-        // `gi` releases its `i` as the nucleus when no vowel follows.
-        assert_eq!(parts("gi"), ok("g", "i", ""));
-        assert_eq!(parts("gia"), ok("gi", "a", ""));
-        // No valid onset → the leading consonants flag the chunk.
-        assert_eq!(parts("zt"), ("".into(), "".into(), "zt".into(), true));
-        assert_eq!(parts(""), ok("", "", ""));
-    }
-}
+mod tests;

--- a/crates/funput-core/src/validation/parse/onset.rs
+++ b/crates/funput-core/src/validation/parse/onset.rs
@@ -27,9 +27,11 @@ pub(crate) fn is_valid_onset(onset: &str) -> bool {
     onset.is_empty()
         || onset == "đ"
         || onset == "Đ"
-        || glide::in_onset(onset).is_some()
         || VALID_ONSETS.iter().any(|o| onset.eq_ignore_ascii_case(o))
         || ETHNIC_ONSETS.iter().any(|o| onset.eq_ignore_ascii_case(o))
+        // Last: plain `qu`/`gi` already matched above, so this only rescues the
+        // toned transient (`qú`, `gí`) and stays off the common path.
+        || glide::in_onset(onset).is_some()
 }
 
 /// Split `buffer` into (onset, rest, invalid_onset).

--- a/crates/funput-core/src/validation/parse/onset.rs
+++ b/crates/funput-core/src/validation/parse/onset.rs
@@ -1,0 +1,81 @@
+//! Onset (âm đầu) inventory and matching.
+//!
+//! Matching is longest-first and **tone-blind on the glide**: while composing, a
+//! tone key pressed before the nucleus parks itself on the `qu`/`gi` glide
+//! (`gi` + `s` → `gí`), and that transient must still parse as the same onset —
+//! otherwise `gío` reads as `g` + rhyme `io`, which no Vietnamese syllable has,
+//! and the engine restores the raw keystrokes mid-word.
+
+use crate::orthography::glide::{self, Glide};
+use crate::unicode::marks::is_vowel;
+
+const VALID_ONSETS: &[&str] = &[
+    "b", "c", "ch", "d", "g", "gh", "gi", "h", "k", "kh", "l", "m", "n", "ng", "ngh", "nh", "p",
+    "ph", "qu", "r", "s", "t", "th", "tr", "v", "x",
+];
+
+/// Consonant-cluster onsets that occur only in Central Highlands (Tây Nguyên)
+/// toponyms borrowed from Ê Đê / Jarai / Bahnar / M'Nông (`Pleiku`, `Krông`,
+/// `Glong`, `Blơr`, `Drăng`). Not native Vietnamese onsets — kept separate so the
+/// inventory above stays "pure Vietnamese". A valid rhyme is still required after
+/// the onset, so this barely affects English auto-restore.
+const ETHNIC_ONSETS: &[&str] = &["bl", "br", "dr", "gl", "gr", "kl", "kr", "pl", "pr"];
+
+/// True if `onset` is a valid Vietnamese onset (`đ` included, any case), or a
+/// Tây Nguyên toponym cluster ([`ETHNIC_ONSETS`]).
+pub(crate) fn is_valid_onset(onset: &str) -> bool {
+    onset.is_empty()
+        || onset == "đ"
+        || onset == "Đ"
+        || glide::in_onset(onset).is_some()
+        || VALID_ONSETS.iter().any(|o| onset.eq_ignore_ascii_case(o))
+        || ETHNIC_ONSETS.iter().any(|o| onset.eq_ignore_ascii_case(o))
+}
+
+/// Split `buffer` into (onset, rest, invalid_onset).
+pub(super) fn match_onset(buffer: &str) -> (&str, &str, bool) {
+    let Some(first) = buffer.chars().next() else {
+        return ("", buffer, false);
+    };
+    if first == 'đ' || first == 'Đ' {
+        let (onset, rest) = buffer.split_at(first.len_utf8());
+        return (onset, rest, false);
+    }
+
+    // Longest onset first (3 chars: `ngh`), then shorter.
+    for len in (1..=3).rev() {
+        let Some(split) = after_n_chars(buffer, len) else {
+            continue;
+        };
+        let (prefix, rest) = buffer.split_at(split);
+        if prefix.is_empty() || !is_valid_onset(prefix) {
+            continue;
+        }
+
+        // In `gi`, the `i` is part of the onset only when another vowel follows
+        // (`gia`, `giết`). When `i` is the lone vowel it is the nucleus (`gì`,
+        // `gìn`), so fall back to the shorter `g` onset. `qu` has no such case:
+        // no Vietnamese syllable is `q` + a `u` nucleus.
+        if glide::in_onset(prefix) == Some(Glide::Gi) && !rest.chars().next().is_some_and(is_vowel)
+        {
+            continue;
+        }
+
+        return (prefix, rest, false);
+    }
+
+    if is_vowel(first) {
+        return ("", buffer, false);
+    }
+
+    ("", buffer, true)
+}
+
+/// Byte offset just past the first `n` chars of `s`, or `None` if `s` is shorter.
+fn after_n_chars(s: &str, n: usize) -> Option<usize> {
+    let mut chars = s.chars();
+    for _ in 0..n {
+        chars.next()?;
+    }
+    Some(s.len() - chars.as_str().len())
+}

--- a/crates/funput-core/src/validation/parse/tests.rs
+++ b/crates/funput-core/src/validation/parse/tests.rs
@@ -1,0 +1,58 @@
+use super::*;
+
+/// (onset, nucleus, coda, invalid_onset) with the iterators materialized.
+fn parts(buffer: &str) -> (String, String, String, bool) {
+    let p = parse_syllable(buffer);
+    (
+        p.onset.into(),
+        p.nucleus_chars().collect(),
+        p.coda_chars().collect(),
+        p.invalid_onset,
+    )
+}
+
+fn ok(onset: &str, nucleus: &str, coda: &str) -> (String, String, String, bool) {
+    (onset.into(), nucleus.into(), coda.into(), false)
+}
+
+#[test]
+fn parse_syllable_cases() {
+    assert_eq!(parts("tr"), ok("tr", "", ""));
+    assert_eq!(parts("ng"), ok("ng", "", ""));
+    assert_eq!(parts("ma"), ok("m", "a", ""));
+    assert_eq!(parts("text"), ok("t", "e", "xt"));
+    assert_eq!(parts("mix"), ok("m", "i", "x"));
+    assert_eq!(parts("trung"), ok("tr", "u", "ng"));
+    assert_eq!(parts("đ"), ok("đ", "", ""));
+    // `gi` releases its `i` as the nucleus when no vowel follows.
+    assert_eq!(parts("gi"), ok("g", "i", ""));
+    assert_eq!(parts("gia"), ok("gi", "a", ""));
+    // No valid onset → the leading consonants flag the chunk.
+    assert_eq!(parts("zt"), ("".into(), "".into(), "zt".into(), true));
+    assert_eq!(parts(""), ok("", "", ""));
+}
+
+#[test]
+fn onset_survives_a_tone_parked_on_the_glide() {
+    // Mid-composition transients: the tone key arrived before the nucleus. These
+    // must keep parsing as `gi`/`qu` onsets, or the rhyme reads as `io`/`ua` and
+    // the engine restores the raw keystrokes (`giso`, `qusa`).
+    assert_eq!(parts("gío"), ok("gí", "o", ""));
+    assert_eq!(parts("gía"), ok("gí", "a", ""));
+    assert_eq!(parts("qúa"), ok("qú", "a", ""));
+    assert_eq!(parts("qúy"), ok("qú", "y", ""));
+    // `qu` keeps its glide even with nothing after it — there is no `q` + `u`
+    // nucleus syllable to fall back to.
+    assert_eq!(parts("qú"), ok("qú", "", ""));
+    // …while `gi` still releases a lone toned `i` as the nucleus: `gì`, `gìn`.
+    assert_eq!(parts("gì"), ok("g", "ì", ""));
+    assert_eq!(parts("gìn"), ok("g", "ì", "n"));
+}
+
+#[test]
+fn horned_u_is_not_a_qu_glide() {
+    // `ư` is a different vowel, not a toned `u`, so `qư` forms no onset at all
+    // (the bare `q` is what flags the chunk).
+    assert!(parse_syllable("qư").invalid_onset);
+    assert!(!is_valid_onset("qư"));
+}

--- a/crates/funput-core/src/validation/syllable/mod.rs
+++ b/crates/funput-core/src/validation/syllable/mod.rs
@@ -8,6 +8,7 @@
 mod modifier;
 mod spelling;
 
+use crate::orthography::glide;
 use crate::unicode::marks::Tone;
 use crate::validation::coda::{
     STOP_CODAS, VALID_CODAS, coda_in, normalized_coda, nucleus_tone, toneless_rhyme,
@@ -60,6 +61,9 @@ pub fn is_complete_syllable(buffer: &str) -> bool {
 
     let structure_ok = !parts.invalid_onset
         && is_valid_onset(parts.onset)
+        // A tone parked on the `qu`/`gi` glide is a mid-composition transient, not
+        // a finished syllable: `qúy` is a misspelling of `quý`.
+        && !glide::onset_holds_tone(parts.onset)
         && parts.nucleus_chars().next().is_some()
         && !violates_ckg_spelling(parts.onset, &parts)
         && coda_in(VALID_CODAS, coda);

--- a/crates/funput-core/src/validation/syllable/mod.rs
+++ b/crates/funput-core/src/validation/syllable/mod.rs
@@ -1,89 +1,35 @@
-//! Syllable-structure validation for modifier keys (tone / shape / stroke).
+//! Syllable-structure validation.
 //!
-//! Decides whether a modifier should apply, be ignored, or pass through as a
-//! literal key (non-Vietnamese structure the engine restores later). Hot path:
-//! everything works on the borrowed [`SyllableParts`] view — the only
-//! allocation left is the rhyme string built at a word boundary.
+//! [`modifier`] decides whether a modifier keystroke should apply; the checks
+//! here answer the coarser question of whether a buffer *is* a Vietnamese
+//! syllable — leniently mid-typing ([`is_valid`]) or strictly at a word boundary
+//! ([`is_complete_syllable`]).
 
+mod modifier;
 mod spelling;
 
 use crate::unicode::marks::Tone;
 use crate::validation::coda::{
     STOP_CODAS, VALID_CODAS, coda_in, normalized_coda, nucleus_tone, toneless_rhyme,
 };
-use crate::validation::parse::{SyllableParts, is_valid_onset, parse_syllable};
+use crate::validation::parse::{is_valid_onset, parse_syllable};
 use crate::validation::reachability::{has_shaped_rhyme_prefix, is_definitely_invalid_parts};
 use crate::validation::rhyme::is_valid_rhyme;
 
+use modifier::{ModifierKind, validate_parts};
 use spelling::violates_ckg_spelling;
 
-/// Result of validating a modifier keystroke against the current buffer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ModifierValidation {
-    /// Apply Vietnamese transform.
-    Allow,
-    /// No valid target — discard key.
-    Ignored,
-    /// Non-Vietnamese structure — append key literally (engine restores later).
-    PassThrough,
-}
-
-fn validate_modifier(buffer: &str) -> ModifierValidation {
-    let parts = parse_syllable(buffer);
-    validate_parts(&parts)
-}
-
-fn validate_parts(parts: &SyllableParts<'_>) -> ModifierValidation {
-    if parts.invalid_onset || !is_valid_onset(parts.onset) {
-        return ModifierValidation::PassThrough;
-    }
-    if parts.nucleus_chars().next().is_none() {
-        return ModifierValidation::Ignored;
-    }
-    if violates_ckg_spelling(parts.onset, parts) {
-        return ModifierValidation::PassThrough;
-    }
-
-    // Two or more trailing consonants can't form a Vietnamese coda → likely an
-    // English word, pass the key through. A single trailing consonant is allowed
-    // (the user may still be typing, e.g. "mix" → "mĩx").
-    if parts.coda_chars().nth(1).is_some() {
-        match normalized_coda(parts) {
-            Some((coda, len)) if coda_in(VALID_CODAS, &coda[..len]) => {}
-            _ => return ModifierValidation::PassThrough,
-        }
-    }
-    ModifierValidation::Allow
-}
+pub use modifier::{ModifierValidation, validate_shape, validate_stroke, validate_tone};
 
 /// Validate a newly shaped candidate in one parse: orthographic structure, the
 /// exact shaped-rhyme prefix, and tone/coda reachability must all agree.
 pub(crate) fn is_viable_shape_candidate(buffer: &str) -> bool {
     let parts = parse_syllable(buffer);
-    matches!(validate_parts(&parts), ModifierValidation::Allow)
-        && has_shaped_rhyme_prefix(&parts)
-        && !is_definitely_invalid_parts(&parts)
-}
-
-/// Validate tone key (1–5) against the current buffer.
-pub fn validate_tone(buffer: &str) -> ModifierValidation {
-    validate_modifier(buffer)
-}
-
-/// Validate shape key (6–8) against the current buffer.
-pub fn validate_shape(buffer: &str) -> ModifierValidation {
-    validate_modifier(buffer)
-}
-
-/// Validate stroke key (9) against the current buffer. The stroke applies whenever
-/// there is a `d`/`D` to convert anywhere in the buffer (`dang` + `9` → `đang`),
-/// not only when it is the trailing char.
-pub fn validate_stroke(buffer: &str) -> ModifierValidation {
-    if buffer.contains(['d', 'D']) {
+    matches!(
+        validate_parts(&parts, ModifierKind::Shape),
         ModifierValidation::Allow
-    } else {
-        ModifierValidation::Ignored
-    }
+    ) && has_shaped_rhyme_prefix(&parts)
+        && !is_definitely_invalid_parts(&parts)
 }
 
 /// Returns true if the syllable structure is valid for transform.
@@ -92,7 +38,10 @@ pub fn validate_stroke(buffer: &str) -> ModifierValidation {
 /// user may still be typing (e.g. `mix` → allow, so `mĩx` can compose). For a
 /// finished word use [`is_complete_syllable`].
 pub fn is_valid(buffer: &str) -> bool {
-    matches!(validate_modifier(buffer), ModifierValidation::Allow)
+    matches!(
+        validate_parts(&parse_syllable(buffer), ModifierKind::Shape),
+        ModifierValidation::Allow
+    )
 }
 
 /// Returns true if `buffer` is a *complete* valid Vietnamese syllable.

--- a/crates/funput-core/src/validation/syllable/modifier.rs
+++ b/crates/funput-core/src/validation/syllable/modifier.rs
@@ -1,0 +1,90 @@
+//! Should a modifier keystroke (tone / shape / stroke) apply to this buffer?
+//!
+//! Hot path: everything works on the borrowed [`SyllableParts`] view, so no
+//! allocation happens here.
+
+use crate::orthography::glide;
+use crate::validation::coda::{VALID_CODAS, coda_in, normalized_coda};
+use crate::validation::parse::{SyllableParts, is_valid_onset, parse_syllable};
+
+use super::spelling::violates_ckg_spelling;
+
+/// Result of validating a modifier keystroke against the current buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModifierValidation {
+    /// Apply Vietnamese transform.
+    Allow,
+    /// No valid target — discard key.
+    Ignored,
+    /// Non-Vietnamese structure — append key literally (engine restores later).
+    PassThrough,
+}
+
+/// Which modifier is asking. The two differ on one point only: a `qu`/`gi` glide
+/// with no nucleus yet can hold a **tone** but never a **shape** — see
+/// [`empty_nucleus`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ModifierKind {
+    Tone,
+    Shape,
+}
+
+pub(super) fn validate_parts(parts: &SyllableParts<'_>, kind: ModifierKind) -> ModifierValidation {
+    if parts.invalid_onset || !is_valid_onset(parts.onset) {
+        return ModifierValidation::PassThrough;
+    }
+    if parts.nucleus_chars().next().is_none() {
+        return empty_nucleus(parts.onset, kind);
+    }
+    if violates_ckg_spelling(parts.onset, parts) {
+        return ModifierValidation::PassThrough;
+    }
+
+    // Two or more trailing consonants can't form a Vietnamese coda → likely an
+    // English word, pass the key through. A single trailing consonant is allowed
+    // (the user may still be typing, e.g. "mix" → "mĩx").
+    if parts.coda_chars().nth(1).is_some() {
+        match normalized_coda(parts) {
+            Some((coda, len)) if coda_in(VALID_CODAS, &coda[..len]) => {}
+            _ => return ModifierValidation::PassThrough,
+        }
+    }
+    ModifierValidation::Allow
+}
+
+/// Nothing to modify yet — with one exception.
+///
+/// A `qu` onset holds its `u` (the glide) rather than releasing it as a nucleus,
+/// so `qu` + a tone key would otherwise drop the key on the floor. Let the tone
+/// park on the glide instead; [`crate::orthography::reposition_existing_tone`]
+/// moves it the moment the real nucleus arrives (`qu` + `s` → `qú`, + `a` →
+/// `quá`). This is exactly what `gi` already does via `gí` → `giá`.
+///
+/// A **shape** gets no such licence: horning the glide would produce `qư`.
+fn empty_nucleus(onset: &str, kind: ModifierKind) -> ModifierValidation {
+    match kind {
+        ModifierKind::Tone if glide::in_onset(onset).is_some() => ModifierValidation::Allow,
+        _ => ModifierValidation::Ignored,
+    }
+}
+
+/// Validate tone key (1–5) against the current buffer.
+pub fn validate_tone(buffer: &str) -> ModifierValidation {
+    validate_parts(&parse_syllable(buffer), ModifierKind::Tone)
+}
+
+/// Validate shape key (6–8) against the current buffer.
+pub fn validate_shape(buffer: &str) -> ModifierValidation {
+    validate_parts(&parse_syllable(buffer), ModifierKind::Shape)
+}
+
+/// Validate stroke key (9) against the current buffer. The stroke applies whenever
+/// there is a `d`/`D` to convert anywhere in the buffer (`dang` + `9` → `đang`),
+/// not only when it is the trailing char.
+pub fn validate_stroke(buffer: &str) -> ModifierValidation {
+    if buffer.contains(['d', 'D']) {
+        ModifierValidation::Allow
+    } else {
+        ModifierValidation::Ignored
+    }
+}

--- a/crates/funput-core/tests/telex.rs
+++ b/crates/funput-core/tests/telex.rs
@@ -30,6 +30,8 @@ mod properties;
 mod regression;
 #[path = "telex/stroke_collisions.rs"]
 mod stroke_collisions;
+#[path = "telex/tone_permutations.rs"]
+mod tone_permutations;
 #[path = "telex/w_collisions.rs"]
 mod w_collisions;
 #[path = "telex/w_permutations.rs"]

--- a/crates/funput-core/tests/telex/data/telex_corpus.tsv
+++ b/crates/funput-core/tests/telex/data/telex_corpus.tsv
@@ -174,15 +174,20 @@ quja	quạ
 qusy	quý
 qufy	quỳ
 qusan	quán
-# The rhyme can still resolve after the tone lands: open `ie` → `iê`, shapes.
-gisem	giếm
-giseng	giếng
-giset	giết
+# A shape arriving after the tone still takes it along.
 qusee	quế
 qusooc	quốc
 qusyeen	quyến
 gisaay	giấy
 qusaan	quấn
+# --- gi + e + coda: the tone key's position picks the rhyme ---
+# Structure alone cannot separate these — both are real words — so the composer
+# reads the tone key's position: before the coda keeps plain `e`, after it promotes
+# to `ê`. Repositioning must never second-guess a tone that already sits right.
+giefm	gièm
+giemf	giềm
+giejp	giẹp
+giepj	giệp
 # --- guard: a lone glide vowel IS the nucleus, and `ng` is not a `gi` onset ---
 gif	gì
 gifn	gìn

--- a/crates/funput-core/tests/telex/data/telex_corpus.tsv
+++ b/crates/funput-core/tests/telex/data/telex_corpus.tsv
@@ -147,3 +147,44 @@ chieus	chiếu
 yeeu	yêu
 nhieuf	nhiều
 tieeu	tiêu
+
+# --- gi/qu onset: tone key typed before the nucleus (regression for the glide) ---
+# The tone parks on the glide as a transient and must move once the nucleus lands.
+gisa	giá
+gifa	già
+gira	giả
+gixa	giã
+gija	giạ
+giso	gió
+gifo	giò
+giro	giỏ
+gijo	giọ
+gisu	giú
+gixu	giũ
+gise	gié
+gire	giẻ
+gisao	giáo
+gisan	gián
+gifow	giờ
+giwof	giờ
+qusa	quá
+qufa	quà
+qura	quả
+quja	quạ
+qusy	quý
+qufy	quỳ
+qusan	quán
+# The rhyme can still resolve after the tone lands: open `ie` → `iê`, shapes.
+gisem	giếm
+giseng	giếng
+giset	giết
+qusee	quế
+qusooc	quốc
+qusyeen	quyến
+gisaay	giấy
+qusaan	quấn
+# --- guard: a lone glide vowel IS the nucleus, and `ng` is not a `gi` onset ---
+gif	gì
+gifn	gìn
+ngias	ngía
+nghiax	nghĩa

--- a/crates/funput-core/tests/telex/tone_permutations.rs
+++ b/crates/funput-core/tests/telex/tone_permutations.rs
@@ -1,0 +1,177 @@
+//! A tone key must land on the same vowel wherever it is typed.
+//!
+//! Companion to `w_permutations.rs`, which does the same for the horn/breve
+//! marker. Free tone placement is the composer's contract: `gias` and `gisa` are
+//! both `giá`. The `gi`/`qu` onsets are the hard cases — their glide looks like a
+//! nucleus vowel and can hold the tone as a transient — so they are covered here
+//! together with plain syllables that must not regress.
+
+use funput_core::{InputMethod, ToneStyle, apply};
+
+struct Case {
+    /// Key sequence with **no** tone key.
+    base: &'static str,
+    tone: char,
+    target: &'static str,
+}
+
+/// First boundary a tone key can occupy: just past the first vowel. Before any
+/// vowel a tone key is a plain letter (`hfoa` stays `hfoa`), not a mark.
+fn first_boundary(base: &str) -> usize {
+    base.chars()
+        .position(|ch| "aeiouy".contains(ch))
+        .map_or(base.chars().count(), |i| i + 1)
+}
+
+fn insert(base: &str, boundary: usize, tone: char) -> String {
+    let offset = base
+        .char_indices()
+        .nth(boundary)
+        .map_or(base.len(), |p| p.0);
+    format!("{}{tone}{}", &base[..offset], &base[offset..])
+}
+
+fn type_keys(keys: &str, style: ToneStyle) -> String {
+    keys.chars().fold(String::new(), |buffer, key| {
+        apply(&buffer, key, InputMethod::Telex, style).text
+    })
+}
+
+fn assert_converges(case: &Case, style: ToneStyle) {
+    for boundary in first_boundary(case.base)..=case.base.chars().count() {
+        let keys = insert(case.base, boundary, case.tone);
+        assert_eq!(
+            type_keys(&keys, style),
+            case.target,
+            "did not converge: {keys} ({style:?})"
+        );
+    }
+}
+
+const GLIDE_ONSETS: &[Case] = &[
+    Case {
+        base: "gia",
+        tone: 's',
+        target: "giá",
+    },
+    Case {
+        base: "gio",
+        tone: 'f',
+        target: "giò",
+    },
+    Case {
+        base: "gian",
+        tone: 'r',
+        target: "giản",
+    },
+    Case {
+        base: "gieng",
+        tone: 's',
+        target: "giếng",
+    },
+    Case {
+        base: "giuw",
+        tone: 'x',
+        target: "giữ",
+    },
+    Case {
+        base: "giow",
+        tone: 'f',
+        target: "giờ",
+    },
+    Case {
+        base: "qua",
+        tone: 's',
+        target: "quá",
+    },
+    Case {
+        base: "quy",
+        tone: 's',
+        target: "quý",
+    },
+    Case {
+        base: "quan",
+        tone: 'f',
+        target: "quàn",
+    },
+    Case {
+        base: "quyeen",
+        tone: 'f',
+        target: "quyền",
+    },
+    Case {
+        base: "quooc",
+        tone: 's',
+        target: "quốc",
+    },
+];
+
+/// A lone glide vowel *is* the nucleus, so the tone stays on it.
+const LONE_GLIDE_VOWEL: &[Case] = &[
+    Case {
+        base: "gi",
+        tone: 'f',
+        target: "gì",
+    },
+    Case {
+        base: "gin",
+        tone: 'f',
+        target: "gìn",
+    },
+];
+
+/// No glide involved — these already converged and must keep doing so.
+const PLAIN_ONSETS: &[Case] = &[
+    Case {
+        base: "hoa",
+        tone: 'f',
+        target: "hòa",
+    },
+    Case {
+        base: "toan",
+        tone: 's',
+        target: "toán",
+    },
+    Case {
+        base: "nguoiw",
+        tone: 'f',
+        target: "người",
+    },
+    Case {
+        base: "nghia",
+        tone: 'x',
+        target: "nghĩa",
+    },
+];
+
+#[test]
+fn glide_onsets_place_the_tone_on_the_nucleus() {
+    for case in GLIDE_ONSETS {
+        assert_converges(case, ToneStyle::Traditional);
+    }
+}
+
+#[test]
+fn lone_glide_vowel_keeps_the_tone() {
+    for case in LONE_GLIDE_VOWEL {
+        for style in [ToneStyle::Traditional, ToneStyle::Modern] {
+            assert_converges(case, style);
+        }
+    }
+}
+
+#[test]
+fn plain_onsets_still_converge() {
+    for case in PLAIN_ONSETS {
+        assert_converges(case, ToneStyle::Traditional);
+    }
+}
+
+#[test]
+fn glide_onsets_converge_in_modern_style_too() {
+    // `oa`/`oe`/`uy` are the only style-dependent clusters, and behind a `qu`
+    // glide there is no cluster left to disagree about: `quý` either way.
+    for case in GLIDE_ONSETS {
+        assert_converges(case, ToneStyle::Modern);
+    }
+}

--- a/crates/funput-core/tests/telex/tone_permutations.rs
+++ b/crates/funput-core/tests/telex/tone_permutations.rs
@@ -65,7 +65,7 @@ const GLIDE_ONSETS: &[Case] = &[
         target: "giản",
     },
     Case {
-        base: "gieng",
+        base: "gieeng",
         tone: 's',
         target: "giếng",
     },
@@ -164,6 +164,29 @@ fn lone_glide_vowel_keeps_the_tone() {
 fn plain_onsets_still_converge() {
     for case in PLAIN_ONSETS {
         assert_converges(case, ToneStyle::Traditional);
+    }
+}
+
+/// The one place free tone placement deliberately does **not** converge.
+///
+/// `gi` + `e` + coda spells two different real words and structure cannot tell
+/// them apart, so the composer reads the tone key's position instead: typed before
+/// the coda it keeps plain `e`, typed after it promotes to `ê`. Repositioning must
+/// therefore leave a correctly-placed tone's base alone — asserted here so the
+/// distinction is not "simplified away" as an inconsistency.
+#[test]
+fn gi_plus_e_uses_tone_position_to_pick_the_rhyme() {
+    for (keys, expected) in [
+        ("giefm", "gièm"), // gièm pha — tone before the coda
+        ("giemf", "giềm"), // tone after the coda
+        ("giejp", "giẹp"),
+        ("giepj", "giệp"),
+    ] {
+        assert_eq!(type_keys(keys, ToneStyle::Traditional), expected, "{keys}");
+    }
+    // Typing the `ê` explicitly is unambiguous, so that form converges everywhere.
+    for keys in ["gieengs", "gieesng", "gieseng", "giseeng"] {
+        assert_eq!(type_keys(keys, ToneStyle::Traditional), "giếng", "{keys}");
     }
 }
 

--- a/crates/funput-core/tests/vni/basic.rs
+++ b/crates/funput-core/tests/vni/basic.rs
@@ -280,6 +280,35 @@ fn vni_qu_gi_onset_tone_placement() {
 }
 
 #[test]
+fn vni_tone_digit_before_the_nucleus_reaches_the_glide_onsets() {
+    // The digit parks on the glide (`gí`, `qú`) and moves once the nucleus lands.
+    for (keys, expected) in [
+        ("gi1a", "giá"),
+        ("gi2a", "già"),
+        ("gi3a", "giả"),
+        ("gi4a", "giã"),
+        ("gi5a", "giạ"),
+        ("gi1o", "gió"),
+        ("gi1ao", "giáo"),
+        ("gi1an", "gián"),
+        ("qu1a", "quá"),
+        ("qu2a", "quà"),
+        ("qu1y", "quý"),
+        ("qu1an", "quán"),
+        // The rhyme can still resolve afterwards: `ie` → `iê`, and shapes.
+        ("gi1eng", "giếng"),
+        ("qu1oc6", "quốc"),
+        ("qu2yen6", "quyền"),
+    ] {
+        assert_eq!(
+            crate::support::type_keys(InputMethod::Vni, keys),
+            expected,
+            "{keys}"
+        );
+    }
+}
+
+#[test]
 fn vni_shaped_vowel_takes_tone() {
     // A vowel carrying mũ/móc/trần receives the tone, wherever it sits.
     assert_eq!(crate::support::type_keys(InputMethod::Vni, "lay61"), "lấy");

--- a/crates/funput-core/tests/vni/basic.rs
+++ b/crates/funput-core/tests/vni/basic.rs
@@ -295,8 +295,8 @@ fn vni_tone_digit_before_the_nucleus_reaches_the_glide_onsets() {
         ("qu2a", "quà"),
         ("qu1y", "quý"),
         ("qu1an", "quán"),
-        // The rhyme can still resolve afterwards: `ie` → `iê`, and shapes.
-        ("gi1eng", "giếng"),
+        // A shape arriving after the tone still takes it along.
+        ("gi1e6ng", "giếng"),
         ("qu1oc6", "quốc"),
         ("qu2yen6", "quyền"),
     ] {

--- a/crates/funput-engine/tests/diacritics/placement.rs
+++ b/crates/funput-engine/tests/diacritics/placement.rs
@@ -57,6 +57,26 @@ fn traditional_keeps_oa_oe_uy_on_first_vowel() {
 }
 
 #[test]
+fn glide_onsets_survive_a_tone_typed_before_the_nucleus() {
+    // A tone parked on the `gi`/`qu` glide must keep parsing as that onset. When
+    // it did not, `gío` read as `g` + rhyme `io` — no such Vietnamese rhyme — and
+    // eager English restore threw the whole word back to raw keys (`giso`).
+    for (method, keys, expected) in [
+        (InputMethod::Telex, "giso", "gió"),
+        (InputMethod::Telex, "gifo", "giò"),
+        (InputMethod::Telex, "gisa", "giá"),
+        (InputMethod::Telex, "qusa", "quá"),
+        (InputMethod::Telex, "qusy", "quý"),
+        (InputMethod::Vni, "gi1o", "gió"),
+        (InputMethod::Vni, "qu1a", "quá"),
+    ] {
+        assert_eq!(run(method, keys), expected, "{keys}");
+    }
+    // The restore itself still works for words that really are not Vietnamese.
+    assert_eq!(run(InputMethod::Telex, "text"), "text");
+}
+
+#[test]
 fn uu_diphthong_horns_first_vowel() {
     // The `ưu` falling diphthong horns the first `u`, so the tone lands on `ư`
     // regardless of whether the horn key comes before or after the second `u`.


### PR DESCRIPTION
Người dùng gõ Telex `gisa` (dấu sắc trước âm chính) nhận được `gía` thay vì `giá`.

## Nguyên nhân

Khái niệm "âm đệm `u` của `qu` / `i` của `gi` thuộc âm đầu" được cài lại rời rạc ở 6 chỗ.
Hai chỗ so sánh ký tự thô nên không nhận ra âm đệm khi nó đã mang dấu:

1. `tone_position/cluster.rs` — `'í' != 'i'` ⇒ âm đệm không bị loại khỏi cụm nguyên âm ⇒
   luật truyền thống đặt dấu vào chính nó. Đây là lỗi được báo.
2. `validation/parse.rs` — `"gí"` không khớp âm đầu `"gi"` ⇒ `gío` đọc thành `g` + vần `io`
   ⇒ vần không tồn tại ⇒ engine khôi phục phím thô. Vì vậy `giso` ra `giso`, không phải `gió`.
3. `validation/syllable` — buffer `"qu"` chưa có âm chính ⇒ phím dấu bị bỏ ⇒ `qusa` ra `qusa`.
4. `intent/kinds/w.rs` — `has_pending` chỉ biết `qu`, không biết `gi` ⇒ `giwof` hỏng.

## Thay đổi

Module `orthography/` mới tách khỏi `unicode/` (nay chỉ còn bảng glyph), với một primitive
`glide` duy nhất so khớp trên **thân** nguyên âm. Cả 6 chỗ trùng lặp gọi vào đó.
`parse.rs` và `validation/syllable/mod.rs` được tách để giữ ngân sách 150 dòng.

Primitive mới chặt hơn bản cũ: `q`/`g` phải là **toàn bộ** âm đầu, nên `ng` + `i` không còn
bị nhầm là `gi` (`ngias` → `ngía` như `nghĩa`, trước ra `ngiá`).

| Phím | Trước | Sau |
|---|---|---|
| `gisa` `gifa` `gira` `gixa` `gija` | `gía` `gìa` `gỉa` `gĩa` `gịa` | `giá` `già` `giả` `giã` `giạ` |
| `giso` `gifo` `gijo` | `giso` `gifo` `gijo` (phím thô) | `gió` `giò` `giọ` |
| `qusa` `qufa` `qusy` | `qusa` `qufa` `qusy` (phím thô) | `quá` `quà` `quý` |
| `giwof` | `giwof` | `giờ` |

VNI (`gi1a`, `qu1a`, …) tương tự.
