### PR TITLE
fix(linux): let the IME framework commit the composing word on focus loss

### DIFF
--- a/platforms/linux/fcitx5/src/funput_engine.cpp
+++ b/platforms/linux/fcitx5/src/funput_engine.cpp
@@ -1,5 +1,6 @@
 #include "funput_engine.h"
 
+#include <fcitx/event.h>
 #include <fcitx/inputcontext.h>
 
 FunputEngine::FunputEngine(fcitx::Instance *instance) : instance_(instance) {
@@ -52,7 +53,19 @@ void FunputEngine::activate(const fcitx::InputMethodEntry &, fcitx::InputContext
 }
 
 void FunputEngine::deactivate(const fcitx::InputMethodEntry &, fcitx::InputContextEvent &event) {
-    commitBuffer(event.inputContext());
+    auto *context = event.inputContext();
+    if (event.type() == fcitx::EventType::InputContextFocusOut) {
+        // The composing word is already on its way to the client: Fcitx5 commits
+        // clientPreedit() in its ReservedFirst focus-out watcher, which runs before
+        // this one, or the client commits it itself when it advertises
+        // ClientUnfocusCommit. A second commit here would duplicate the word.
+        handle_.clear();
+        clearPreedit(context);
+        return;
+    }
+    // Input-method switch (group change, capability change): nothing else flushes
+    // the preedit, so commit it ourselves.
+    commitBuffer(context);
 }
 
 FCITX_ADDON_FACTORY(FunputEngineFactory)

--- a/platforms/linux/fcitx5/src/funput_engine.h
+++ b/platforms/linux/fcitx5/src/funput_engine.h
@@ -2,7 +2,9 @@
 // using Fcitx5's preedit/commit model — the same shape as the macOS IMKit shell
 // (platforms/macos/.../FunputInputController.swift), NOT the Windows backspace-
 // injection path. The composing word is shown as underlined preedit and committed
-// on a word boundary, navigation key, focus change, or VI/EN toggle.
+// on a word boundary, navigation key, or VI/EN toggle. On focus loss Fcitx5 itself
+// commits the client preedit before calling deactivate(), so the word survives a
+// click into another field — see deactivate(), which must not commit again.
 
 #ifndef FUNPUT_ENGINE_H
 #define FUNPUT_ENGINE_H

--- a/platforms/linux/fcitx5/src/funput_input.cpp
+++ b/platforms/linux/fcitx5/src/funput_input.cpp
@@ -13,9 +13,14 @@ void FunputEngine::updatePreedit(fcitx::InputContext *context) {
     if (!buffer.empty()) preedit.append(buffer, fcitx::TextFormatFlag::Underline);
     preedit.setCursor(static_cast<int>(buffer.size()));
     auto &panel = context->inputPanel();
-    if (context->capabilityFlags().test(fcitx::CapabilityFlag::Preedit)) {
-        panel.setClientPreedit(preedit);
-    } else {
+    // Always publish the client preedit, even for clients that cannot render one:
+    // Fcitx5 commits clientPreedit() itself when the input context loses focus
+    // (Instance's ReservedFirst focus-out watcher), which is what keeps a half-typed
+    // word from vanishing on a click into another field or window. Display is
+    // unaffected — InputContext::updatePreedit() returns early without the Preedit
+    // capability, so those clients still get the Fcitx5-drawn panel preedit below.
+    panel.setClientPreedit(preedit);
+    if (!context->capabilityFlags().test(fcitx::CapabilityFlag::Preedit)) {
         panel.setPreedit(preedit);
     }
     context->updatePreedit();

--- a/platforms/linux/ibus/src/engine.h
+++ b/platforms/linux/ibus/src/engine.h
@@ -1,8 +1,11 @@
 // IBus input-method engine for Funput. Drives `funput-engine` (via the C ABI)
 // using IBus's preedit/commit model — the same shape as the Fcitx5 addon
 // (platforms/linux/fcitx5/src/funput_engine.cpp) and the macOS IMKit shell, NOT
-// the Windows backspace-injection path. The composing word is shown as preedit
-// and committed on a word boundary, navigation key, focus change, or VI/EN toggle.
+// the Windows backspace-injection path. The composing word is shown as preedit and
+// committed on a word boundary, navigation key, or VI/EN toggle. The preedit is
+// published with IBUS_ENGINE_PREEDIT_COMMIT, so IBus itself flushes the word on
+// focus loss, reset and engine switch — see updatePreedit() in engine_runtime.cpp
+// and the focusOut()/disable()/reset() handlers, which must not commit again.
 //
 // Unlike the Fcitx5 addon (an in-process .so), an IBus engine is a separate
 // process launched by ibus-daemon over D-Bus; see main.cpp for the bus glue.

--- a/platforms/linux/ibus/src/engine_input.cpp
+++ b/platforms/linux/ibus/src/engine_input.cpp
@@ -64,16 +64,20 @@ void enable(IBusEngine *engine) {
     if (state->settings.reloadIfChanged()) applySettings(state);
 }
 
+// Focus loss, reset and engine switch all commit the composing word — but IBus does
+// it, not us: updatePreedit() publishes the preedit with IBUS_ENGINE_PREEDIT_COMMIT,
+// and the daemon flushes it to the client before dispatching these callbacks.
+// Committing again here would type the word twice, so only drop our own state.
 void focusOut(IBusEngine *engine) {
-    commitBuffer(engine, stateOf(engine));
+    stateOf(engine)->handle.clear();
 }
 
 void disable(IBusEngine *engine) {
-    commitBuffer(engine, stateOf(engine));
+    stateOf(engine)->handle.clear();
 }
 
 void reset(IBusEngine *engine) {
-    commitBuffer(engine, stateOf(engine));
+    stateOf(engine)->handle.clear();
 }
 
 } // namespace funput_ibus

--- a/platforms/linux/ibus/src/engine_runtime.cpp
+++ b/platforms/linux/ibus/src/engine_runtime.cpp
@@ -19,8 +19,18 @@ void updatePreedit(IBusEngine *engine, EngineState *state) {
     const std::string buffer = state->handle.buffer();
     IBusText *text = ibus_text_new_from_string(buffer.c_str());
     const glong length = g_utf8_strlen(buffer.c_str(), -1);
-    ibus_engine_update_preedit_text(engine, text, static_cast<guint>(length),
-                                    buffer.empty() ? FALSE : TRUE);
+    // IBUS_ENGINE_PREEDIT_COMMIT, not the default CLEAR: this is what makes IBus
+    // flush a half-typed word into the client when focus moves away, instead of
+    // throwing it out. bus_input_context_{focus_out,disable,unset_engine} and
+    // _ic_reset all clear the preedit *before* calling into the engine, and only
+    // commit it first when the mode is COMMIT — so with CLEAR the word is already
+    // gone by the time focusOut()/reset() run here, and a commit from those
+    // handlers has nowhere left to go (unset_engine even disconnects our
+    // commit-text handler first). With COMMIT set, IBus owns the flush and our
+    // focus/reset handlers only drop state; see engine_input.cpp.
+    ibus_engine_update_preedit_text_with_mode(engine, text, static_cast<guint>(length),
+                                              buffer.empty() ? FALSE : TRUE,
+                                              IBUS_ENGINE_PREEDIT_COMMIT);
 }
 
 void commitBuffer(IBusEngine *engine, EngineState *state) {


### PR DESCRIPTION
## Vấn đề

Đang gõ dở một từ tiếng Việt (preedit gạch chân), click sang field/cửa sổ khác → **từ biến mất** thay vì được commit. Người dùng phải bấm Space hoặc phím mũi tên để "chốt" từ trước khi chuyển focus.

PR #44 từng nhắm vào lỗi này với giả thuyết thứ tự clear-preedit/commit. Giả thuyết đó **sai** với đường focus-out (phần reorder vẫn đúng và vẫn giữ, nó fix lỗi Enter nhân đôi trên Electron).

## Nguyên nhân

Quy tắc chung của cả hai framework: **framework tự commit preedit khi mất focus; engine mà commit thêm thì hoặc là quá muộn, hoặc là nhân đôi.**

### ibus

`bus_input_context_{focus_out,disable,unset_engine}` và `_ic_reset` đều gọi `bus_input_context_clear_preedit_text()` *trước* khi dispatch vào engine, và hàm đó chỉ commit khi engine đã publish preedit với `IBUS_ENGINE_PREEDIT_COMMIT`:

```c
/* bus/inputcontext.c */
if (preedit_visible && preedit_mode == IBUS_ENGINE_PREEDIT_COMMIT) {
    bus_input_context_commit_text (context, preedit_text);
}
```

Ta đang dùng `ibus_engine_update_preedit_text()` — mode mặc định là `CLEAR` ⇒ daemon vứt từ đi. `focusOut()` của ta có commit, nhưng đến sau; riêng đường `unset_engine` thì daemon đã `g_signal_handlers_disconnect_by_func` handler `commit-text` trước khi gọi engine, nên commit đó rơi vào hư không.

Đường code này giống hệt nhau từ ibus 1.5.22 → 1.5.31, nên không cần gate theo version.

### fcitx5

`Instance` commit sẵn `inputPanel().clientPreedit()` trong watcher FocusOut ở phase `ReservedFirst`, chạy **trước** `deactivate()`. Chính `fcitx/event.h` ghi rõ ở `InputContextFocusOut`:

> Input method need to notice, that the commit is already DONE, do not do extra commit.

Nên ở fcitx5 thực ra là **hai lỗi khác nhau**:
- Client **có** `CapabilityFlag::Preedit` (Chromium/Electron, Firefox, GTK, Qt): fcitx5 commit rồi, `deactivate()` commit lần nữa → **nhân đôi từ**.
- Client **không có** capability đó: trước đây ta không hề set client preedit ⇒ fcitx5 chẳng có gì để commit, chỉ còn commit muộn của ta — mà `fcitx5-qt` gửi commit vào `qApp->focusObject()` vốn đã đổi → **mất từ**.

## Thay đổi

| File | Thay đổi |
|---|---|
| `ibus/src/engine_runtime.cpp` | `ibus_engine_update_preedit_text_with_mode(..., IBUS_ENGINE_PREEDIT_COMMIT)` |
| `ibus/src/engine_input.cpp` | `focusOut`/`disable`/`reset` chỉ `handle.clear()`, bỏ commit |
| `fcitx5/src/funput_input.cpp` | luôn `setClientPreedit`; panel preedit chỉ thêm cho client thiếu capability |
| `fcitx5/src/funput_engine.cpp` | `deactivate` bỏ commit khi `event.type() == InputContextFocusOut` |

Cộng hai comment đầu file cho khớp cơ chế mới.

### Những chỗ cố ý **không** đổi

- **`fcitx5::reset()` vẫn commit.** Khác ibus, fcitx5 không commit preedit lúc reset — watcher `InputContextReset` chỉ gọi `inputState->reset()`.
- **`deactivate` khi đổi input method vẫn commit.** Các call site khác của `deactivateInputMethod()` truyền `InputContextSwitchInputMethodEvent`, và không có gì flush preedit ở đó. Guard chỉ bắt đúng `InputContextFocusOut`.
- **Đường space/Enter/boundary không bị commit đôi.** `hide_preedit_text` đặt `preedit_visible = FALSE` ở cả daemon lẫn client trước khi ta commit, nên `clear_preedit_text` sau đó không commit lại.
- **`setClientPreedit` cho client không hỗ trợ preedit là vô hại.** `InputContext::updatePreedit()` return sớm khi thiếu `CapabilityFlag::Preedit`, nên hiển thị không đổi — client đó vẫn dùng panel preedit do fcitx5 vẽ.

