### PR TITLE
feat(android): add the Blossom and Orchid gradient themes

### DIFF
--- a/platforms/android/app/build.gradle.kts
+++ b/platforms/android/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "app.funput.funput"
         minSdk = 26
         targetSdk = 37
-        versionCode = 15
-        versionName = "1.2026.52"
+        versionCode = 17
+        versionName = "1.2026.53"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/platforms/android/keyboard-ui/src/androidTest/java/app/funput/funput/keyboard/ui/EmojiPanelInstrumentedTest.kt
+++ b/platforms/android/keyboard-ui/src/androidTest/java/app/funput/funput/keyboard/ui/EmojiPanelInstrumentedTest.kt
@@ -9,7 +9,9 @@ import app.funput.funput.keyboard.ui.emoji.EmojiPanelPalette
 import app.funput.funput.keyboard.ui.emoji.EmojiSearchContentView
 import app.funput.funput.keyboard.ui.emoji.EmojiSearchMode
 import app.funput.funput.keyboard.ui.emoji.EmojiSearchState
+import app.funput.funput.theme.KeyboardThemeDescriptor
 import app.funput.funput.theme.KeyboardThemes
+import app.funput.funput.theme.LocalKeyboardThemeCatalog
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -23,13 +25,9 @@ class EmojiPanelInstrumentedTest {
                 val panel = EmojiPanelView(activity)
                 parent.addView(panel, LinearLayout.LayoutParams(-1, -1))
                 activity.setContentView(parent)
-                listOf(
-                    KeyboardThemes.Ink,
-                    KeyboardThemes.Paper,
-                    KeyboardThemes.GlassDark,
-                    KeyboardThemes.GlassLight,
-                    KeyboardThemes.Slate,
-                ).forEach(panel::updateTheme)
+                LocalKeyboardThemeCatalog.themes
+                    .map(KeyboardThemeDescriptor::theme)
+                    .forEach(panel::updateTheme)
             }
         }
     }

--- a/platforms/android/keyboard-ui/src/test/java/app/funput/funput/keyboard/ui/emoji/EmojiPanelPaletteTest.kt
+++ b/platforms/android/keyboard-ui/src/test/java/app/funput/funput/keyboard/ui/emoji/EmojiPanelPaletteTest.kt
@@ -1,19 +1,14 @@
 package app.funput.funput.keyboard.ui.emoji
 
-import app.funput.funput.theme.KeyboardThemes
+import app.funput.funput.theme.KeyboardThemeDescriptor
+import app.funput.funput.theme.LocalKeyboardThemeCatalog
 import app.funput.funput.theme.validation.ContrastRatio
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class EmojiPanelPaletteTest {
     @Test fun `all presets keep panel text readable`() {
-        val themes = listOf(
-            KeyboardThemes.Ink,
-            KeyboardThemes.Paper,
-            KeyboardThemes.GlassDark,
-            KeyboardThemes.GlassLight,
-            KeyboardThemes.Slate,
-        )
+        val themes = LocalKeyboardThemeCatalog.themes.map(KeyboardThemeDescriptor::theme)
         themes.forEach { theme ->
             val palette = EmojiPanelPalette.from(theme)
             assertTrue(ContrastRatio.between(palette.label, palette.searchSurface, palette.backgroundEnd) >= 3.0)

--- a/platforms/android/theme-runtime/src/main/java/app/funput/funput/theme/BlossomKeyboardTheme.kt
+++ b/platforms/android/theme-runtime/src/main/java/app/funput/funput/theme/BlossomKeyboardTheme.kt
@@ -1,0 +1,31 @@
+package app.funput.funput.theme
+
+/**
+ * Light floral preset: a blush-to-lilac gradient under near-white keycaps.
+ *
+ * The keycaps keep a little translucency so the gradient tints them as it runs across the
+ * keyboard, instead of five identical white rows stamped over it. Modifier keys wash in at half
+ * that strength so the letters stay dominant while every key still shows its touch area.
+ */
+internal val BlossomKeyboardTheme = GradientThemePalette(
+    backgroundStart = 0xFFFFE3EF.toInt(),
+    backgroundEnd = 0xFFDCD6F7.toInt(),
+    key = 0xF2FFFFFF.toInt(),
+    specialKey = 0x8FFFFFFF.toInt(),
+    label = 0xFF3A2233.toInt(),
+    secondaryLabel = 0xFF7A5C72.toInt(),
+    specialLabel = 0xFF5C3F55.toInt(),
+    accent = 0xFFC24A80.toInt(),
+    accentLabel = 0xFFFFF2F8.toInt(),
+    popupSurface = 0xFFFFFBFD.toInt(),
+    // Deeper than the accent rose: the leading suggestion has no plate under it, and the accent
+    // alone measures 3.2:1 against the lilac end of the gradient.
+    suggestionHighlight = 0xFFA83A6B.toInt(),
+    divider = 0x338A6B80,
+    keyShadow = 0x24512A47,
+    keyShadowOffsetDp = 1.5f,
+    popupShadow = 0x33512A47,
+    // A translucent rose over pale keycaps barely registers, so press and shift stay near solid.
+    pressedAlpha = 0xE0,
+    activatedAlpha = 0xC2,
+).toKeyboardTheme()

--- a/platforms/android/theme-runtime/src/main/java/app/funput/funput/theme/BuiltInKeyboardThemeSource.kt
+++ b/platforms/android/theme-runtime/src/main/java/app/funput/funput/theme/BuiltInKeyboardThemeSource.kt
@@ -45,5 +45,21 @@ object BuiltInKeyboardThemeSource : InstalledThemeSource {
             origin = KeyboardThemeOrigin.BUILT_IN,
             theme = KeyboardThemes.Slate,
         ),
+        KeyboardThemeDescriptor(
+            id = KeyboardThemeId.Blossom,
+            version = 1,
+            name = "Blossom",
+            author = FunputAuthor,
+            origin = KeyboardThemeOrigin.BUILT_IN,
+            theme = KeyboardThemes.Blossom,
+        ),
+        KeyboardThemeDescriptor(
+            id = KeyboardThemeId.Orchid,
+            version = 1,
+            name = "Orchid",
+            author = FunputAuthor,
+            origin = KeyboardThemeOrigin.BUILT_IN,
+            theme = KeyboardThemes.Orchid,
+        ),
     )
 }

--- a/platforms/android/theme-runtime/src/main/java/app/funput/funput/theme/GradientThemePalette.kt
+++ b/platforms/android/theme-runtime/src/main/java/app/funput/funput/theme/GradientThemePalette.kt
@@ -1,0 +1,84 @@
+package app.funput.funput.theme
+
+/**
+ * The colors that separate one gradient preset from another, without the tokens they share.
+ *
+ * Presets in this family are built the same way: borderless plates over a two-stop background
+ * gradient, and one accent color that also carries press and activation feedback. Deriving that
+ * feedback from [accent] instead of writing it out per preset is what keeps a theme from ending up
+ * with a rose Enter key and a gold press highlight.
+ *
+ * Defaults describe the dark end of the family. A light preset overrides the shadow and the
+ * feedback strength, because a translucent accent painted over a pale ground barely registers.
+ */
+internal data class GradientThemePalette(
+    val backgroundStart: Int,
+    val backgroundEnd: Int,
+    val key: Int,
+    val specialKey: Int,
+    val label: Int,
+    val secondaryLabel: Int,
+    val specialLabel: Int,
+    val accent: Int,
+    val accentLabel: Int,
+    val popupSurface: Int,
+    val suggestionHighlight: Int,
+    val divider: Int,
+    val gradientDirection: KeyboardThemeGradientDirection = KeyboardThemeGradientDirection.Default,
+    val keyShadow: Int = Transparent,
+    val keyShadowOffsetDp: Float = 0f,
+    val popupShadow: Int = DefaultPopupShadow,
+    val pressedAlpha: Int = DefaultPressedAlpha,
+    val activatedAlpha: Int = DefaultActivatedAlpha,
+    val pressedKeyScale: Float = DefaultPressedKeyScale,
+) {
+    init {
+        require(pressedAlpha in AlphaRange) { "Pressed alpha must be within $AlphaRange" }
+        require(activatedAlpha in AlphaRange) { "Activated alpha must be within $AlphaRange" }
+    }
+
+    /** Expands the palette into the full token set the renderer reads. */
+    fun toKeyboardTheme(): KeyboardTheme = KeyboardTheme(
+        backgroundStartColor = backgroundStart,
+        backgroundEndColor = backgroundEnd,
+        keyColor = key,
+        specialKeyColor = specialKey,
+        keyBorderColor = Transparent,
+        keyShadowColor = keyShadow,
+        pressedKeyColor = accent.withAlpha(pressedAlpha),
+        pressedKeyBorderColor = Transparent,
+        activatedKeyColor = accent.withAlpha(activatedAlpha),
+        activatedKeyBorderColor = Transparent,
+        labelColor = label,
+        secondaryLabelColor = secondaryLabel,
+        accentColor = accent,
+        keyCornerRadiusDp = KeyCornerRadiusDp,
+        keyBorderWidthDp = 0f,
+        keyShadowOffsetDp = keyShadowOffsetDp,
+        pressedKeyShadowOffsetDp = 0f,
+        specialLabelColor = specialLabel,
+        accentKeyColor = accent,
+        accentLabelColor = accentLabel,
+        popupSurfaceColor = popupSurface,
+        suggestionHighlightColor = suggestionHighlight,
+        pressedKeyScale = pressedKeyScale,
+        backgroundGradientDirection = gradientDirection,
+        suggestionDividerColor = divider,
+        popupShadowColor = popupShadow,
+    )
+
+    private fun Int.withAlpha(alpha: Int): Int = (alpha shl AlphaShift) or (this and RgbMask)
+}
+
+private const val Transparent = 0x00000000
+private const val DefaultPopupShadow = 0x66000000
+private const val DefaultPressedAlpha = 0x66
+private const val DefaultActivatedAlpha = 0x44
+private const val DefaultPressedKeyScale = 1.04f
+
+/** The borderless key shape every bundled preset shares with the iOS keyboard. */
+private const val KeyCornerRadiusDp = 6f
+
+private const val AlphaShift = 24
+private const val RgbMask = 0x00FFFFFF
+private val AlphaRange = 0x00..0xFF

--- a/platforms/android/theme-runtime/src/main/java/app/funput/funput/theme/KeyboardThemeId.kt
+++ b/platforms/android/theme-runtime/src/main/java/app/funput/funput/theme/KeyboardThemeId.kt
@@ -20,6 +20,8 @@ value class KeyboardThemeId private constructor(val value: String) {
         val GlassDark: KeyboardThemeId = KeyboardThemeId("glass-dark")
         val GlassLight: KeyboardThemeId = KeyboardThemeId("glass-light")
         val Slate: KeyboardThemeId = KeyboardThemeId("slate")
+        val Blossom: KeyboardThemeId = KeyboardThemeId("blossom")
+        val Orchid: KeyboardThemeId = KeyboardThemeId("orchid")
         val Default: KeyboardThemeId = Dark
 
         /** Creates an identifier or throws when [value] is not safe to persist. */

--- a/platforms/android/theme-runtime/src/main/java/app/funput/funput/theme/KeyboardThemes.kt
+++ b/platforms/android/theme-runtime/src/main/java/app/funput/funput/theme/KeyboardThemes.kt
@@ -3,10 +3,10 @@ package app.funput.funput.theme
 /**
  * Named keyboard theme presets.
  *
- * Both presets are built from the same Funput accent gold, which is the only saturated color on
- * the keyboard and appears in exactly three places: the leading suggestion, the held key, and
- * Enter. Preset names describe the design; the persisted identifiers in [KeyboardThemeId] stay
- * `dark` and `light` because they are what the appearance setting stores on device.
+ * Preset names describe the design; the persisted identifiers in [KeyboardThemeId] stay `dark` and
+ * `light` for the first pair because they are what the appearance setting stores on device. A
+ * preset that carries its own palette lives in its own file next to this one and is exposed here,
+ * so callers still have a single place to look one up.
  */
 object KeyboardThemes {
     private const val AccentGold = 0xFFC8A951.toInt()
@@ -140,4 +140,10 @@ object KeyboardThemes {
         popupShadowColor = 0x52000000,
         keySurfaceStyle = KeyboardKeySurfaceStyle.GLASS,
     )
+
+    /** Light floral preset: a blush-to-lilac gradient under near-white keycaps. */
+    val Blossom: KeyboardTheme = BlossomKeyboardTheme
+
+    /** Dark floral preset: an orchid-to-midnight gradient under translucent plates. */
+    val Orchid: KeyboardTheme = OrchidKeyboardTheme
 }

--- a/platforms/android/theme-runtime/src/main/java/app/funput/funput/theme/OrchidKeyboardTheme.kt
+++ b/platforms/android/theme-runtime/src/main/java/app/funput/funput/theme/OrchidKeyboardTheme.kt
@@ -1,0 +1,28 @@
+package app.funput.funput.theme
+
+/**
+ * Dark floral preset: an orchid-to-midnight gradient under translucent plates.
+ *
+ * Plates are a faint white wash rather than a solid fill, which keeps the violet visible through
+ * the whole keyboard and lets the same wash sit over a background image if one is set. Orchid pink
+ * is the only saturated color and marks the leading suggestion, the held key, and Enter.
+ *
+ * The gradient runs the opposite way to [BlossomKeyboardTheme], so the pair reads as two sides of
+ * one design rather than the same picture twice.
+ */
+internal val OrchidKeyboardTheme = GradientThemePalette(
+    backgroundStart = 0xFF421650.toInt(),
+    backgroundEnd = 0xFF140A22.toInt(),
+    key = 0x1FFFFFFF,
+    specialKey = 0x12FFFFFF,
+    label = 0xFFF9EFF7.toInt(),
+    secondaryLabel = 0xFFBBA0C8.toInt(),
+    specialLabel = 0xFFC9B4D6.toInt(),
+    accent = 0xFFE86FA9.toInt(),
+    accentLabel = 0xFF2A0E22.toInt(),
+    popupSurface = 0xFF2A163A.toInt(),
+    suggestionHighlight = 0xFFFFA8CE.toInt(),
+    divider = 0x2BFFFFFF,
+    gradientDirection = KeyboardThemeGradientDirection.DIAGONAL_UP,
+    pressedKeyScale = 1.06f,
+).toKeyboardTheme()

--- a/platforms/android/theme-runtime/src/test/java/app/funput/funput/theme/InstalledThemeRepositoryTest.kt
+++ b/platforms/android/theme-runtime/src/test/java/app/funput/funput/theme/InstalledThemeRepositoryTest.kt
@@ -17,6 +17,8 @@ class InstalledThemeRepositoryTest {
                 KeyboardThemeId.GlassDark,
                 KeyboardThemeId.GlassLight,
                 KeyboardThemeId.Slate,
+                KeyboardThemeId.Blossom,
+                KeyboardThemeId.Orchid,
             ),
             repository.themes.map(KeyboardThemeDescriptor::id),
         )

--- a/platforms/android/theme-runtime/src/test/java/app/funput/funput/theme/KeyboardThemeCatalogTest.kt
+++ b/platforms/android/theme-runtime/src/test/java/app/funput/funput/theme/KeyboardThemeCatalogTest.kt
@@ -15,11 +15,13 @@ class KeyboardThemeCatalogTest {
                 KeyboardThemeId.GlassDark,
                 KeyboardThemeId.GlassLight,
                 KeyboardThemeId.Slate,
+                KeyboardThemeId.Blossom,
+                KeyboardThemeId.Orchid,
             ),
             LocalKeyboardThemeCatalog.themes.map(KeyboardThemeDescriptor::id),
         )
         assertEquals(
-            List(5) { KeyboardThemeOrigin.BUILT_IN },
+            List(7) { KeyboardThemeOrigin.BUILT_IN },
             LocalKeyboardThemeCatalog.themes.map(KeyboardThemeDescriptor::origin),
         )
     }
@@ -60,6 +62,14 @@ class KeyboardThemeCatalogTest {
         assertSame(
             KeyboardThemes.Slate,
             LocalKeyboardThemeCatalog.resolve(KeyboardThemeId.Slate).theme,
+        )
+        assertSame(
+            KeyboardThemes.Blossom,
+            LocalKeyboardThemeCatalog.resolve(KeyboardThemeId.Blossom).theme,
+        )
+        assertSame(
+            KeyboardThemes.Orchid,
+            LocalKeyboardThemeCatalog.resolve(KeyboardThemeId.Orchid).theme,
         )
     }
 

--- a/platforms/android/theme-runtime/src/test/java/app/funput/funput/theme/validation/ThemeValidatorTest.kt
+++ b/platforms/android/theme-runtime/src/test/java/app/funput/funput/theme/validation/ThemeValidatorTest.kt
@@ -1,18 +1,23 @@
 package app.funput.funput.theme.validation
 
+import app.funput.funput.theme.KeyboardThemeDescriptor
 import app.funput.funput.theme.KeyboardThemes
+import app.funput.funput.theme.LocalKeyboardThemeCatalog
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ThemeValidatorTest {
+    /** Reads the catalog rather than a list, so a preset cannot ship without being measured. */
     @Test
     fun bundledThemesAreReadable() {
-        assertEquals(emptyList<ThemeIssue>(), ThemeValidator.validate(KeyboardThemes.Ink))
-        assertEquals(emptyList<ThemeIssue>(), ThemeValidator.validate(KeyboardThemes.Paper))
-        assertEquals(emptyList<ThemeIssue>(), ThemeValidator.validate(KeyboardThemes.GlassDark))
-        assertEquals(emptyList<ThemeIssue>(), ThemeValidator.validate(KeyboardThemes.GlassLight))
-        assertEquals(emptyList<ThemeIssue>(), ThemeValidator.validate(KeyboardThemes.Slate))
+        LocalKeyboardThemeCatalog.themes.forEach { descriptor: KeyboardThemeDescriptor ->
+            assertEquals(
+                "${descriptor.name} pairs colors the reader cannot resolve",
+                emptyList<ThemeIssue>(),
+                ThemeValidator.validate(descriptor.theme),
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
Adds two built-in keyboard themes built around a colour gradient.

| | |
|---|---|
| **Blossom** (`blossom`, light) | Blush-to-lilac gradient under near-white keycaps. The caps stay slightly translucent so the gradient tints them across the keyboard; modifiers wash in at half that strength. Press and shift stay near solid, because a translucent rose over a pale ground barely registers. |
| **Orchid** (`orchid`, dark) | Orchid-to-midnight gradient under a faint white wash instead of solid plates, so the violet reads through the whole keyboard. Orchid pink is the only saturated colour: leading suggestion, held key, Enter. The gradient runs the opposite diagonal to Blossom. |

## How they are built

Both go through a new `GradientThemePalette`, which takes the colours that differ between the two and expands them into the full token set. It derives `pressedKeyColor` and `activatedKeyColor` from a single `accent`, which is what stops the accent family drifting apart — the failure mode that once left a purple theme with a gold Enter key.

Everything else follows the existing shape: a file per preset next to `SlateKeyboardTheme.kt`, one line each in `KeyboardThemes`, an id, and a descriptor in `BuiltInKeyboardThemeSource`. No renderer change, no `KeyboardTheme` token added, no glass or blur. The gallery lists them because they are `BUILT_IN`, and either can be assigned to the light or dark appearance slot.

## Tests

`ThemeValidatorTest` and `EmojiPanelPaletteTest` now iterate `LocalKeyboardThemeCatalog` instead of a hand-written list of presets, so a new theme cannot ship without being measured. Both new themes clear the 3:1 bar on all five pairings the validator checks, and on the emoji panel's three.

Unit tests pass for `:theme-runtime`, `:keyboard-ui`, `:theme-store`, `:app`, `:ime`; instrumented sources compile; `scripts/check-kotlin-loc.sh` passes.

## Not verified

Nothing has run on a device — the install would need the release build uninstalled first, which wipes custom themes and settings. Colours below are from the token values, not a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)