### PR TITLE
feat(ios): add Lotus Silk and Jade Current themes

### DIFF
--- a/platforms/ios/FunputTests/Appearance/AppearanceSignatureThemeTests.swift
+++ b/platforms/ios/FunputTests/Appearance/AppearanceSignatureThemeTests.swift
@@ -1,0 +1,50 @@
+import FunputShared
+import Testing
+import ThemeRuntime
+import ThemeSchema
+@testable import Funput
+
+@MainActor
+struct AppearanceSignatureThemeTests {
+    @Test(
+        "Signature themes preview, apply, customize, save, and reset",
+        arguments: [KeyboardTheme.lotusSilk, .jadeCurrent]
+    )
+    func fullLifecycle(_ base: KeyboardTheme) {
+        let settings = SettingsTestStore(configuration: .default)
+        let customThemes = ThemeTestStore()
+        let model = AppearanceModel(store: settings, customStore: customThemes)
+
+        model.selectTheme(base.id)
+        #expect(model.previewTheme == base)
+        model.applyPreview()
+        #expect(settings.configuration.selectedThemeID == base.id)
+
+        var draft = model.makeDraft(for: .create(baseThemeID: base.id))
+        assertDraft(draft, matches: base)
+        draft.customTheme.theme.palette.label = base.palette.accent
+        draft.customTheme.theme.metrics.cornerRadius = 20
+        draft.customTheme.theme.gradientDirection = .vertical
+        draft.resetToBase()
+        assertDraft(draft, matches: base)
+
+        draft.customTheme.theme.metadata.name = "\(base.metadata.name) Personal"
+        #expect(model.save(draft))
+        #expect(model.previewThemeID == draft.customTheme.id)
+        #expect(customThemes.load() == [draft.customTheme])
+        #expect(model.catalog.baseTheme(for: draft.customTheme) == base)
+    }
+
+    private func assertDraft(_ draft: ThemeEditorDraft, matches base: KeyboardTheme) {
+        #expect(draft.isNew)
+        #expect(draft.baseTheme == base)
+        #expect(draft.customTheme.baseThemeID == base.id)
+        #expect(draft.customTheme.theme.palette == base.palette)
+        #expect(draft.customTheme.theme.metrics == base.metrics)
+        #expect(draft.customTheme.theme.geometry == base.geometry)
+        #expect(draft.customTheme.theme.colorEffects == base.colorEffects)
+        #expect(draft.customTheme.theme.surfaceEffects == base.surfaceEffects)
+        #expect(draft.customTheme.theme.gradientDirection == base.gradientDirection)
+        #expect(draft.customTheme.theme.backgroundEffects == base.backgroundEffects)
+    }
+}

--- a/platforms/ios/FunputTests/Appearance/AppearanceTests.swift
+++ b/platforms/ios/FunputTests/Appearance/AppearanceTests.swift
@@ -101,7 +101,7 @@ struct AppearanceTests {
         let ids = model.themes.map(\.id)
 
         #expect(ids == BundledThemes.all.map(\.id))
-        #expect(Set(ids).count == 3)
+        #expect(Set(ids).count == 5)
         #expect(model.presentation(for: KeyboardTheme.midnight.id).theme != .funputGlass)
         #expect(AppearancePreviewMode.light.interfaceStyle == .light)
         #expect(AppearancePreviewMode.dark.interfaceStyle == .dark)

--- a/platforms/ios/Packages/FunputKit/Sources/ThemeRuntime/Bundled/BundledTheme+JadeCurrent.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/ThemeRuntime/Bundled/BundledTheme+JadeCurrent.swift
@@ -1,0 +1,45 @@
+import ThemeSchema
+
+public extension KeyboardTheme {
+    /// A fresh jade-and-amber Liquid Glass theme with a calm, modern character.
+    static let jadeCurrent = FunputSignatureGlassTheme.make(
+        id: "app.funput.theme.jade-current",
+        name: "Jade Current",
+        palette: ThemePalette(
+            backgroundStart: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0xDDEFE9, alpha: 0.86),
+                dark: ThemeRGBA(hex: 0x133638, alpha: 0.70)
+            ),
+            backgroundEnd: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0x83B9A8, alpha: 0.72),
+                dark: ThemeRGBA(hex: 0x081D20, alpha: 0.78)
+            ),
+            characterKey: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0xF7FFFC),
+                dark: ThemeRGBA(hex: 0x295653)
+            ),
+            specialKey: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0xA6CEC1),
+                dark: ThemeRGBA(hex: 0x1B4140)
+            ),
+            border: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0x255E58, alpha: 0.28),
+                dark: ThemeRGBA(hex: 0xB9E9DB, alpha: 0.18)
+            ),
+            label: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0x173C39),
+                dark: ThemeRGBA(hex: 0xF4FFFC)
+            ),
+            secondaryLabel: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0x3F625D),
+                dark: ThemeRGBA(hex: 0xC0DDD6)
+            ),
+            accent: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0x755000),
+                dark: ThemeRGBA(hex: 0xF2BE55)
+            )
+        ),
+        gradientDirection: .horizontal,
+        cornerRadius: 7
+    )
+}

--- a/platforms/ios/Packages/FunputKit/Sources/ThemeRuntime/Bundled/BundledTheme+LotusSilk.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/ThemeRuntime/Bundled/BundledTheme+LotusSilk.swift
@@ -1,0 +1,45 @@
+import ThemeSchema
+
+public extension KeyboardTheme {
+    /// A pearl-and-rose Liquid Glass theme inspired by lotus petals and silk.
+    static let lotusSilk = FunputSignatureGlassTheme.make(
+        id: "app.funput.theme.lotus-silk",
+        name: "Lotus Silk",
+        palette: ThemePalette(
+            backgroundStart: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0xFFF7F5, alpha: 0.88),
+                dark: ThemeRGBA(hex: 0x3A172C, alpha: 0.68)
+            ),
+            backgroundEnd: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0xEBC8CD, alpha: 0.76),
+                dark: ThemeRGBA(hex: 0x160D18, alpha: 0.74)
+            ),
+            characterKey: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0xFFFDFC),
+                dark: ThemeRGBA(hex: 0x5B324C)
+            ),
+            specialKey: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0xDCB0B8),
+                dark: ThemeRGBA(hex: 0x422338)
+            ),
+            border: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0x8A4C66, alpha: 0.28),
+                dark: ThemeRGBA(hex: 0xFFD9E2, alpha: 0.18)
+            ),
+            label: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0x512D46),
+                dark: ThemeRGBA(hex: 0xFFF7FA)
+            ),
+            secondaryLabel: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0x735266),
+                dark: ThemeRGBA(hex: 0xE9C8D7)
+            ),
+            accent: AdaptiveThemeColor(
+                light: ThemeRGBA(hex: 0x8A571C),
+                dark: ThemeRGBA(hex: 0xF1BE88)
+            )
+        ),
+        gradientDirection: .diagonalLeft,
+        cornerRadius: 8
+    )
+}

--- a/platforms/ios/Packages/FunputKit/Sources/ThemeRuntime/Bundled/BundledThemes.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/ThemeRuntime/Bundled/BundledThemes.swift
@@ -6,7 +6,13 @@ import ThemeSchema
 /// fallback when a selected or downloaded theme is missing or fails to load.
 public enum BundledThemes {
     /// Every theme shipped with the app, in display order.
-    public static let all: [KeyboardTheme] = [.funputGlass, .classicLight, .midnight]
+    public static let all: [KeyboardTheme] = [
+        .funputGlass,
+        .classicLight,
+        .midnight,
+        .lotusSilk,
+        .jadeCurrent,
+    ]
 
     /// The theme used when no valid selection exists.
     public static let `default`: KeyboardTheme = .funputGlass

--- a/platforms/ios/Packages/FunputKit/Sources/ThemeRuntime/Bundled/FunputSignatureGlassTheme.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/ThemeRuntime/Bundled/FunputSignatureGlassTheme.swift
@@ -1,0 +1,40 @@
+import ThemeSchema
+
+enum FunputSignatureGlassTheme {
+    static func make(
+        id: String,
+        name: String,
+        palette: ThemePalette,
+        gradientDirection: ThemeGradientDirection,
+        cornerRadius: Double
+    ) -> KeyboardTheme {
+        KeyboardTheme(
+            id: id,
+            metadata: ThemeMetadata(name: name, author: "Funput"),
+            material: .glass,
+            palette: palette,
+            metrics: ThemeMetrics(
+                keyOpacity: 0.78,
+                specialKeyOpacity: 0.86,
+                cornerRadius: cornerRadius,
+                borderWidth: 0.6,
+                shadowOpacity: 0.18,
+                shadowRadius: 2.5,
+                pressedScale: 0.96,
+                pressedOpacityMultiplier: 1.16,
+                fontScale: 1
+            ),
+            colorEffects: ThemeColorEffects(
+                glassBackgroundTintEnabled: true,
+                glassKeyTintEnabled: true,
+                pressedOverlayEnabled: true,
+                pressedOverlay: palette.accent
+            ),
+            surfaceEffects: ThemeSurfaceEffects(
+                glassBorderOverrideEnabled: true,
+                glassShadowOverrideEnabled: false
+            ),
+            gradientDirection: gradientDirection
+        )
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Tests/ThemeRuntimeTests/ThemeCodableTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/ThemeRuntimeTests/ThemeCodableTests.swift
@@ -14,12 +14,21 @@ struct ThemeCodableTests {
     @Test("Bundled theme identifiers are unique")
     func uniqueIdentifiers() {
         let ids = BundledThemes.all.map(\.id)
+        #expect(ids == [
+            KeyboardTheme.funputGlass.id,
+            KeyboardTheme.classicLight.id,
+            KeyboardTheme.midnight.id,
+            KeyboardTheme.lotusSilk.id,
+            KeyboardTheme.jadeCurrent.id,
+        ])
         #expect(Set(ids).count == ids.count)
     }
 
     @Test("Lookup returns the matching bundled theme, or nil")
     func lookup() {
         #expect(BundledThemes.theme(id: BundledThemes.default.id) == .funputGlass)
+        #expect(BundledThemes.theme(id: KeyboardTheme.lotusSilk.id) == .lotusSilk)
+        #expect(BundledThemes.theme(id: KeyboardTheme.jadeCurrent.id) == .jadeCurrent)
         #expect(BundledThemes.theme(id: "does.not.exist") == nil)
     }
 

--- a/platforms/ios/Packages/FunputKit/Tests/ThemeRuntimeTests/ThemeValidatorTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/ThemeRuntimeTests/ThemeValidatorTests.swift
@@ -3,6 +3,14 @@ import ThemeSchema
 import ThemeRuntime
 
 struct ThemeValidatorTests {
+    @Test(
+        "Signature themes pass every contrast check",
+        arguments: [KeyboardTheme.lotusSilk, .jadeCurrent]
+    )
+    func signatureThemesAreValid(_ theme: KeyboardTheme) {
+        #expect(ThemeValidator.validate(theme).isEmpty)
+    }
+
     @Test("Bundled themes preserve readable primary and secondary labels", arguments: BundledThemes.all)
     func bundledLabelsAreValid(_ theme: KeyboardTheme) {
         let issues = ThemeValidator.validate(theme)


### PR DESCRIPTION
## Summary
- add Lotus Silk and Jade Current bundled Liquid Glass themes
- share signature Glass metrics and effects through a reusable factory
- register both themes in the system gallery with Light and Dark palettes
- verify both themes can be previewed, applied, customized, saved, and reset

## Validation
- iOS Simulator compilation passed for FunputKit and all package test targets
- Swift LOC check passed with the 150-line limit
- diff whitespace check passed
- contrast validation covers both new themes

## Known baseline blockers
- the full Funput app test scheme is currently blocked by pre-existing missing diagnostic symbols in KeyboardTouchDiagnosticMapper.swift
- host SwiftPM test execution is blocked because FunputKit does not declare a macOS deployment platform