### PR TITLE
fix(ios): anchor settings dialogs, and actually run the Liquid Glass tests

### DIFF
--- a/platforms/ios/Funput/Settings/PersonalSuggestionSettingsCard.swift
+++ b/platforms/ios/Funput/Settings/PersonalSuggestionSettingsCard.swift
@@ -4,6 +4,8 @@ struct PersonalSuggestionSettingsCard: View {
     @Binding var isEnabled: Bool
     let reset: () -> Void
 
+    @State private var confirms = false
+
     var body: some View {
         SettingsSectionCard(title: "Gợi ý từ cá nhân", systemImage: "text.badge.star") {
             SettingsToggleRow(
@@ -11,10 +13,22 @@ struct PersonalSuggestionSettingsCard: View {
                 summary: "Chỉ học chữ Funput gõ và lưu trên thiết bị.",
                 isOn: $isEnabled
             )
-            Button("Xóa từ đã học", role: .destructive, action: reset)
+            Button("Xóa từ đã học", role: .destructive) { confirms = true }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.vertical, 10)
                 .accessibilityHint("Xóa lexicon cá nhân ở lần mở bàn phím tiếp theo")
+                // Anchored to the button rather than to the screen: iOS 26 points a
+                // confirmation dialog at whatever presents it, so one hung off the
+                // root view surfaces at the top instead of beside its control.
+                .confirmationDialog(
+                    "Xóa toàn bộ từ đã học?",
+                    isPresented: $confirms,
+                    titleVisibility: .visible
+                ) {
+                    Button("Xóa từ đã học", role: .destructive, action: reset)
+                } message: {
+                    Text("Lệnh xóa được thực hiện cục bộ khi Funput mở bàn phím lần tiếp theo.")
+                }
         }
     }
 }

--- a/platforms/ios/Funput/Settings/SettingsResetCard.swift
+++ b/platforms/ios/Funput/Settings/SettingsResetCard.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct SettingsResetCard: View {
     let action: () -> Void
 
+    @State private var confirms = false
+
     var body: some View {
         AdaptiveGlassCard {
             VStack(alignment: .leading, spacing: 10) {
@@ -12,6 +14,18 @@ struct SettingsResetCard: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                 resetButton
+                    // Anchored to the button rather than to the screen: iOS 26 points a
+                    // confirmation dialog at whatever presents it, so one hung off the
+                    // root view surfaces at the top instead of beside its control.
+                    .confirmationDialog(
+                        "Khôi phục cài đặt mặc định?",
+                        isPresented: $confirms,
+                        titleVisibility: .visible
+                    ) {
+                        Button("Khôi phục", role: .destructive, action: action)
+                    } message: {
+                        Text("Các tùy chỉnh bộ gõ hiện tại sẽ bị thay thế.")
+                    }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
@@ -19,10 +33,10 @@ struct SettingsResetCard: View {
 
     @ViewBuilder private var resetButton: some View {
         if #available(iOS 26, *) {
-            Button("Khôi phục cài đặt", role: .destructive, action: action)
+            Button("Khôi phục cài đặt", role: .destructive) { confirms = true }
                 .buttonStyle(.glass)
         } else {
-            Button("Khôi phục cài đặt", role: .destructive, action: action)
+            Button("Khôi phục cài đặt", role: .destructive) { confirms = true }
                 .buttonStyle(.bordered)
         }
     }

--- a/platforms/ios/Funput/Settings/SettingsScreen.swift
+++ b/platforms/ios/Funput/Settings/SettingsScreen.swift
@@ -7,10 +7,8 @@ struct SettingsScreen: View {
     @Environment(\.openURL) private var openURL
     @State private var model: SettingsModel
     @State private var picker: SettingsPicker?
-    @State private var confirmsReset = false
     @State private var requestsHapticAccess = false
     @State private var requestsSoundAccess = false
-    @State private var confirmsSuggestionReset = false
 
     init(store: any FunputConfigurationStoring = FunputConfigurationStore()) {
         _model = State(initialValue: SettingsModel(store: store))
@@ -57,7 +55,7 @@ struct SettingsScreen: View {
             }
             PersonalSuggestionSettingsCard(
                 isEnabled: model.boolBinding(\.personalSuggestionsEnabled),
-                reset: { confirmsSuggestionReset = true }
+                reset: { model.requestPersonalSuggestionReset() }
             )
             ClipboardSettingsCard(
                 isEnabled: model.boolBinding(\.clipboardEnabled),
@@ -86,22 +84,10 @@ struct SettingsScreen: View {
                     isOn: model.boolBinding(\.showsKeyPreviews)
                 )
             }
-            SettingsResetCard { confirmsReset = true }
+            SettingsResetCard { model.reset() }
         }
         .navigationTitle("Cài đặt")
         .sheet(item: $picker) { SettingsSelectionSheet(picker: $0, model: model) }
-        .confirmationDialog("Khôi phục cài đặt mặc định?", isPresented: $confirmsReset) {
-            Button("Khôi phục", role: .destructive) { model.reset() }
-        } message: {
-            Text("Các tùy chỉnh bộ gõ hiện tại sẽ bị thay thế.")
-        }
-        .confirmationDialog("Xóa toàn bộ từ đã học?", isPresented: $confirmsSuggestionReset) {
-            Button("Xóa từ đã học", role: .destructive) {
-                model.requestPersonalSuggestionReset()
-            }
-        } message: {
-            Text("Lệnh xóa được thực hiện cục bộ khi Funput mở bàn phím lần tiếp theo.")
-        }
         .alert("Không thể lưu cài đặt", isPresented: model.saveErrorBinding) {
             Button("Đóng", role: .cancel) {}
         } message: {

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/AlphabeticSurfaceTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/AlphabeticSurfaceTests.swift
@@ -13,7 +13,9 @@ struct AlphabeticSurfaceTests {
         surface.frame = CGRect(x: 0, y: 0, width: 390, height: 304)
         surface.layoutIfNeeded()
 
-        let keys = accessibleControls(in: surface)
+        // Keycaps only. The toolbar carries controls of its own — the clipboard chip's
+        // paste button among them — and a hidden one has no frame to speak of.
+        let keys = accessibleControls(in: surface).compactMap { $0 as? KeyboardKeyControl }
         #expect(layout.rows.count == 5)
         #expect(keys.filter { $0.accessibilityLabel?.count == 1 }.count >= 26)
         #expect(keys.allSatisfy { !$0.frame.isEmpty })
@@ -85,65 +87,18 @@ struct AlphabeticSurfaceTests {
         #expect(before == after)
     }
 
-    @Test("Liquid Glass keys use native adaptive styling")
-    func nativeGlassStyling() {
-        guard #available(iOS 26.0, *) else { return }
-        let layout = StandardKeyboardLayouts.letters(.telex)
-        let surface = KeyboardSurfaceView(presentation: KeyboardPresentation(layout: layout))
-        surface.frame = CGRect(x: 0, y: 0, width: 390, height: 304)
-        surface.layoutIfNeeded()
-
-        let letter = accessibleControls(in: surface).first { $0.accessibilityLabel == "a" }!
-        let enter = accessibleControls(in: surface).first { $0.accessibilityLabel == "Enter" }!
-        let letterEffect = glassEffects(in: letter).first
-        let enterEffect = glassEffects(in: enter).first
-        let containerEffect = visualEffects(in: surface)
-            .compactMap { $0.effect as? UIGlassContainerEffect }
-            .first
-
-        #expect(letterEffect?.isInteractive == true)
-        #expect(letterEffect?.tintColor?.cgColor.alpha == 0)
-        #expect(enterEffect?.tintColor?.cgColor.alpha == 0)
-        #expect(containerEffect?.spacing == 0)
-        #expect(glassViews(in: letter).first?.cornerConfiguration == .corners(radius: .fixed(6)))
-    }
-
-    @Test("Liquid Glass uses the keyboard host material as its backdrop")
-    func nativeGlassBackdrop() {
-        guard #available(iOS 26.0, *) else { return }
-        let surface = KeyboardSurfaceView()
-        let backdrop = surface.subviews.compactMap { $0 as? KeyboardBackdropView }.first
-
-        #expect(backdrop?.usesHostMaterial == true)
-        #expect(backdrop?.effect == nil)
-        #expect(backdrop?.backgroundColor == .clear)
-        #expect(backdrop?.isOpaque == false)
-    }
-
     private func accessibleControls(in view: UIView) -> [UIControl] {
         view.subviews.flatMap { child -> [UIControl] in
-            let own = (child as? UIControl).map {
-                $0.isAccessibilityElement && !$0.isHidden ? [$0] : []
-            } ?? []
+            let own = (child as? UIControl).map { [$0] } ?? []
             return own + accessibleControls(in: child)
         }
     }
 
     private func visualEffects(in view: UIView) -> [UIVisualEffectView] {
-        view.subviews.flatMap { child in
+        view.subviews.flatMap { child -> [UIVisualEffectView] in
             let own = (child as? UIVisualEffectView).map { [$0] } ?? []
             return own + visualEffects(in: child)
         }
-    }
-
-    @available(iOS 26.0, *)
-    private func glassEffects(in view: UIView) -> [UIGlassEffect] {
-        visualEffects(in: view).compactMap { $0.effect as? UIGlassEffect }
-    }
-
-    @available(iOS 26.0, *)
-    private func glassViews(in view: UIView) -> [UIVisualEffectView] {
-        visualEffects(in: view).filter { $0.effect is UIGlassEffect }
     }
 }
 #endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/LiquidGlassSurfaceTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/LiquidGlassSurfaceTests.swift
@@ -1,0 +1,80 @@
+#if canImport(UIKit)
+@testable import KeyboardRenderer
+import KeyboardLayout
+import Testing
+import UIKit
+
+/// The Liquid Glass path only exists on iOS 26+, so these bodies return early on
+/// anything older — and `test-funput-kit.sh` picks the first available iOS simulator,
+/// which is where two stale assertions here survived unnoticed for weeks. Run them on
+/// an iOS 26 simulator when touching the glass surfaces.
+@MainActor
+struct LiquidGlassSurfaceTests {
+    @Test("Liquid Glass keys use native adaptive styling")
+    func nativeGlassStyling() {
+        guard #available(iOS 26.0, *) else { return }
+        let layout = StandardKeyboardLayouts.letters(.telex)
+        let surface = KeyboardSurfaceView(presentation: KeyboardPresentation(layout: layout))
+        surface.frame = CGRect(x: 0, y: 0, width: 390, height: 304)
+        surface.layoutIfNeeded()
+
+        let letter = accessibleControls(in: surface).first { $0.accessibilityLabel == "a" }!
+        let enter = accessibleControls(in: surface).first { $0.accessibilityLabel == "Enter" }!
+        let letterEffect = glassEffects(in: letter).first
+        let enterEffect = glassEffects(in: enter).first
+        let containerEffect = visualEffects(in: surface)
+            .compactMap { $0.effect as? UIGlassContainerEffect }
+            .first
+
+        // Non-interactive on purpose: the keycap runs its own press animation
+        // (scale plus the tint overlay in `KeyboardKeySurfaceView.setPressed`), and
+        // native interactive glass would answer the same touch a second time.
+        #expect(letterEffect?.isInteractive == false)
+        #expect(letterEffect?.tintColor?.cgColor.alpha == 0)
+        #expect(enterEffect?.tintColor?.cgColor.alpha == 0)
+        #expect(containerEffect?.spacing == 0)
+        #expect(glassViews(in: letter).first?.cornerConfiguration == .corners(radius: .fixed(6)))
+    }
+
+    @Test("Liquid Glass uses the keyboard host material as its backdrop")
+    func nativeGlassBackdrop() {
+        guard #available(iOS 26.0, *) else { return }
+        let surface = KeyboardSurfaceView()
+        let backdrop = surface.subviews.compactMap { $0 as? KeyboardBackdropView }.first
+
+        #expect(backdrop?.usesHostMaterial == true)
+        #expect(backdrop?.effect == nil)
+        #expect(backdrop?.isOpaque == false)
+        // Nothing of its own painted over the host material. Asserted by alpha rather
+        // than against `.clear`, which the backdrop has never actually been set to —
+        // an unset background is just as transparent.
+        #expect((backdrop?.backgroundColor?.cgColor.alpha ?? 0) == 0)
+    }
+
+    private func accessibleControls(in view: UIView) -> [UIControl] {
+        view.subviews.flatMap { child -> [UIControl] in
+            let own = (child as? UIControl).map {
+                $0.isAccessibilityElement && !$0.isHidden ? [$0] : []
+            } ?? []
+            return own + accessibleControls(in: child)
+        }
+    }
+
+    private func visualEffects(in view: UIView) -> [UIVisualEffectView] {
+        view.subviews.flatMap { child in
+            let own = (child as? UIVisualEffectView).map { [$0] } ?? []
+            return own + visualEffects(in: child)
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private func glassEffects(in view: UIView) -> [UIGlassEffect] {
+        visualEffects(in: view).compactMap { $0.effect as? UIGlassEffect }
+    }
+
+    @available(iOS 26.0, *)
+    private func glassViews(in view: UIView) -> [UIVisualEffectView] {
+        visualEffects(in: view).filter { $0.effect is UIGlassEffect }
+    }
+}
+#endif


### PR DESCRIPTION
Hai việc nhỏ nhưng tách bạch, mỗi việc một commit.

## 1. Hộp thoại xác nhận neo sai chỗ

iOS 26 neo confirmation dialog vào thứ gọi nó ra. Cả ba dialog trong màn Cài đặt đều gắn vào **view gốc**, nên chúng nổi lên đỉnh màn hình với cái đuôi nhọn chỉ vào khoảng không, thay vì hiện cạnh nút vừa bấm.

Mỗi thẻ giờ tự giữ phần xác nhận của nó, gắn thẳng lên nút huỷ; `SettingsScreen` chỉ truyền xuống hành động thật và bỏ được ba `@State` cùng ba khối `.confirmationDialog`.

Thêm `titleVisibility: .visible`: ở dạng neo, dialog ẩn tiêu đề mặc định — người dùng chỉ còn thấy một nút đỏ mà không biết mình đang xác nhận điều gì.

## 2. Hai test Liquid Glass chưa từng chạy

Cả hai mở đầu bằng `guard #available(iOS 26.0, *)`, mà `test-funput-kit.sh` chọn simulator iOS đầu tiên tìm thấy (18.6) — nên chúng luôn thoát sớm và xanh một cách rỗng. Chạy trên sim iOS 26 mới lộ ra hai khẳng định sai:

- `isInteractive` kỳ vọng `true`, nhưng `79a7337` đã đổi code thành `false` **hai ngày sau** khi test được viết. `false` mới đúng: keycap tự chạy animation nhấn của nó, để glass tương tác nữa là hai lớp cùng phản hồi một cú chạm.
- `backgroundColor == .clear` **chưa từng đúng** — không commit nào gán `.clear` cho backdrop. Đổi sang khẳng định theo alpha, đúng cho cả `nil` lẫn `.clear`.

Một lỗi thứ ba là **do phần clipboard gây ra**: `vniSurface` khẳng định mọi phím có khung dùng được, nhưng helper của nó quét mọi `UIControl` trong cây — kể cả `UIPasteControl` của chip clipboard, vốn không có khung khi chip đang ẩn. Đã thu hẹp về đúng keycap.

Tách thành `LiquidGlassSurfaceTests` riêng, kèm chú thích rằng chúng cần simulator iOS 26 mới có ý nghĩa.
