### PR TITLE
feat(android): add Advanced Telex input method support

### DIFF
--- a/platforms/CONFIG_FORMAT.md
+++ b/platforms/CONFIG_FORMAT.md
@@ -64,7 +64,7 @@ one machine imports on another. macOS is the first implementation
 | `version` | — | Format version (currently `1`). Required. |
 | `exportedAt` | — | ISO-8601 timestamp. Metadata only. |
 | `source` | — | `platform` + `appVersion` that produced the file. Metadata only. |
-| `preferences.inputMethod` | ✅ | `telex`, `telex_advanced`, or `vni`. Advanced Telex is desktop-only and exposed on macOS/Windows; unsupported consumers keep their current selection. |
+| `preferences.inputMethod` | ✅ | `telex`, `telex_advanced`, or `vni`. Exposed on macOS, Windows, Linux, iOS, and Android; unsupported consumers keep their current selection. |
 | `preferences.*` | ✅ | Other typing options; each is optional and applied only if present. |
 | `shortcuts[]` | ✅ | `{ trigger, expansion }`. Local UUIDs are dropped; recreated on import. |
 | `platform.macos.toggleShortcut` | ❌ | `KeyCombo` (`keyCode` is AppKit-specific). Applied only on macOS, only if present. |

--- a/platforms/android/README.md
+++ b/platforms/android/README.md
@@ -21,11 +21,11 @@ app --------> keyboard-ui ----------------------> theme-runtime
 ```
 
 The app persists the Vietnamese input method with Preferences DataStore. VNI is
-the first-run default; selecting Telex in the app updates the active IME through
-the same observable setting.
+the first-run default; selecting Telex, Advanced Telex, or VNI in the app updates
+the active IME through the same observable setting.
 
 The IME owns Android composing spans while `funput-engine` remains the only
-source of truth for Telex and VNI rules.
+source of truth for Telex, Advanced Telex, and VNI rules.
 
 ## Build
 

--- a/platforms/android/app/build.gradle.kts
+++ b/platforms/android/app/build.gradle.kts
@@ -15,7 +15,7 @@ android {
         applicationId = "app.funput.funput"
         minSdk = 26
         targetSdk = 37
-        versionCode = 17
+        versionCode = 18
         versionName = "1.2026.53"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/platforms/android/app/src/androidTest/java/app/funput/funput/ui/settings/AdvancedTelexSettingsTest.kt
+++ b/platforms/android/app/src/androidTest/java/app/funput/funput/ui/settings/AdvancedTelexSettingsTest.kt
@@ -1,0 +1,48 @@
+package app.funput.funput.ui.settings
+
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import app.funput.funput.ime.settings.AppearanceMode
+import app.funput.funput.ime.settings.ToneStyle
+import app.funput.funput.keyboard.layout.KeyboardSizingProfile
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+import app.funput.funput.ui.theme.FunputTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class AdvancedTelexSettingsTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun inputMethodPickerShowsIosParityContentAndSelectsAdvancedTelex() {
+        var selected = KeyboardInputMethod.TELEX
+        compose.setContent {
+            FunputTheme {
+                SettingsPickerSheet(
+                    picker = SettingsPicker.INPUT_METHOD,
+                    inputMethod = selected,
+                    toneStyle = ToneStyle.TRADITIONAL,
+                    keySizeProfile = KeyboardSizingProfile.Default,
+                    appearanceMode = AppearanceMode.SYSTEM,
+                    onInputMethodSelected = { selected = it },
+                    onToneStyleSelected = {},
+                    onKeySizeSelected = {},
+                    onAppearanceSelected = {},
+                    onDismiss = {},
+                )
+            }
+        }
+
+        compose.onNodeWithText("Telex").assertExists()
+        compose.onNodeWithText("Dùng tổ hợp chữ để nhập dấu.").assertExists()
+        compose.onNodeWithText("Telex nâng cao").assertExists()
+        compose.onNodeWithText("Full Telex — [→ư, ]→ơ, w đầu từ→ư.").assertExists()
+        compose.onNodeWithText("VNI").assertExists()
+        compose.onNodeWithText("Dùng các phím số để nhập dấu.").assertExists()
+        compose.onNodeWithText("Telex nâng cao").performClick()
+        compose.runOnIdle { assertEquals(KeyboardInputMethod.TELEX_ADVANCED, selected) }
+    }
+}

--- a/platforms/android/app/src/androidTest/java/app/funput/funput/ui/settings/NumberRowSettingsTest.kt
+++ b/platforms/android/app/src/androidTest/java/app/funput/funput/ui/settings/NumberRowSettingsTest.kt
@@ -1,0 +1,94 @@
+package app.funput.funput.ui.settings
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import app.funput.funput.ime.settings.ToneStyle
+import app.funput.funput.keyboard.layout.KeyboardSizingProfile
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+import app.funput.funput.ui.settings.keyboard.KeyboardSettingsSection
+import app.funput.funput.ui.settings.setup.KeyboardSetupStatus
+import app.funput.funput.ui.theme.FunputTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class NumberRowSettingsTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun telexAllowsTogglingNumberRow() {
+        var showsNumberRow = false
+        setSection(
+            inputMethod = KeyboardInputMethod.TELEX,
+            showsNumberRow = showsNumberRow,
+            onShowsNumberRowChanged = { showsNumberRow = it },
+        )
+
+        compose.onNodeWithText("Hàng phím số").assertIsDisplayed().performClick()
+        compose.runOnIdle { assertTrue(showsNumberRow) }
+    }
+
+    @Test
+    fun vniLocksNumberRowOnWithoutWritingPreference() {
+        var showsNumberRow = false
+        var writes = 0
+        setSection(
+            inputMethod = KeyboardInputMethod.VNI,
+            showsNumberRow = showsNumberRow,
+            onShowsNumberRowChanged = {
+                showsNumberRow = it
+                writes += 1
+            },
+        )
+
+        compose.onNodeWithText("Hàng phím số").assertIsDisplayed().assertIsNotEnabled()
+        compose.onNodeWithText("Hàng phím số").performClick()
+        compose.runOnIdle {
+            assertFalse(showsNumberRow)
+            assertEquals(0, writes)
+        }
+    }
+
+    @Test
+    fun advancedTelexKeepsNumberRowEditable() {
+        var showsNumberRow = false
+        setSection(
+            inputMethod = KeyboardInputMethod.TELEX_ADVANCED,
+            showsNumberRow = showsNumberRow,
+            onShowsNumberRowChanged = { showsNumberRow = it },
+        )
+
+        compose.onNodeWithText("Hàng phím số").assertIsDisplayed().performClick()
+        compose.runOnIdle { assertTrue(showsNumberRow) }
+    }
+
+    private fun setSection(
+        inputMethod: KeyboardInputMethod,
+        showsNumberRow: Boolean,
+        onShowsNumberRowChanged: (Boolean) -> Unit,
+    ) {
+        compose.setContent {
+            FunputTheme {
+                KeyboardSettingsSection(
+                    setupStatus = KeyboardSetupStatus.READY,
+                    inputMethod = inputMethod,
+                    showsNumberRow = showsNumberRow,
+                    toneStyle = ToneStyle.TRADITIONAL,
+                    keySizeProfile = KeyboardSizingProfile.Normal,
+                    keyboardThemeLabel = "Ink",
+                    onOpenPicker = {},
+                    onShowsNumberRowChanged = onShowsNumberRowChanged,
+                    onOpenThemeGallery = {},
+                    onEnableKeyboard = {},
+                    onSelectKeyboard = {},
+                )
+            }
+        }
+    }
+}

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/FunputSettingsState.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/FunputSettingsState.kt
@@ -14,15 +14,15 @@ import app.funput.funput.ime.settings.KeyboardFeedbackSettings
 import app.funput.funput.ime.settings.KeyboardSizingSettings
 import app.funput.funput.ime.settings.KeyboardThemeSelection
 import app.funput.funput.ime.settings.KeyboardThemeSettings
+import app.funput.funput.ime.settings.NumberRowSettings
 import app.funput.funput.ime.settings.PersonalSuggestionPreferences
 import app.funput.funput.ime.settings.PersonalSuggestionSettings
 import app.funput.funput.ime.settings.SmartCompositionPreferences
 import app.funput.funput.ime.settings.SmartCompositionSettings
+import app.funput.funput.ime.settings.ToneStyle
 import app.funput.funput.ime.settings.ToneStyleSettings
 import app.funput.funput.keyboard.layout.KeyboardSizingProfile
 import app.funput.funput.keyboard.model.KeyboardInputMethod
-import app.funput.funput.ime.settings.ToneStyle
-import app.funput.funput.theme.KeyboardThemeId
 
 /**
  * Every persisted setting the app screens read, plus the stores they write back through.
@@ -38,6 +38,7 @@ internal class FunputSettingsState(
     val toneStyleStore: ToneStyleSettings,
     val appearance: AppearanceSettings,
     val feedbackStore: KeyboardFeedbackSettings,
+    val numberRowStore: NumberRowSettings,
     val smartCompositionStore: SmartCompositionSettings,
     val personalSuggestionStore: PersonalSuggestionSettings,
     val inputMethod: KeyboardInputMethod,
@@ -46,6 +47,7 @@ internal class FunputSettingsState(
     val themeSelection: KeyboardThemeSelection,
     val appearanceMode: AppearanceMode,
     val feedback: KeyboardFeedbackPreferences,
+    val showsNumberRow: Boolean,
     val smartComposition: SmartCompositionPreferences,
     val personalSuggestions: PersonalSuggestionPreferences,
 )
@@ -53,42 +55,38 @@ internal class FunputSettingsState(
 @Composable
 internal fun rememberFunputSettings(): FunputSettingsState {
     val context = LocalContext.current
-    val input = remember(context) { InputMethodSettings(context) }
-    val sizing = remember(context) { KeyboardSizingSettings(context) }
-    val keyboardTheme = remember(context) { KeyboardThemeSettings(context) }
-    val toneStyleStore = remember(context) { ToneStyleSettings(context) }
-    val appearance = remember(context) { AppearanceSettings(context) }
-    val feedbackStore = remember(context) { KeyboardFeedbackSettings(context) }
-    val smartCompositionStore = remember(context) { SmartCompositionSettings(context) }
-    val personalSuggestionStore = remember(context) { PersonalSuggestionSettings(context) }
-
-    val inputMethod by input.inputMethod.collectAsState(InputMethodSettings.DefaultInputMethod)
-    val toneStyle by toneStyleStore.toneStyle.collectAsState(ToneStyleSettings.DefaultToneStyle)
-    val keySizeProfile by sizing.profile.collectAsState(KeyboardSizingSettings.DefaultProfile)
-    val themeSelection by keyboardTheme.selection
+    val stores = remember(context) { FunputSettingsStores(context) }
+    val inputMethod by stores.input.inputMethod.collectAsState(InputMethodSettings.DefaultInputMethod)
+    val toneStyle by stores.toneStyleStore.toneStyle.collectAsState(ToneStyleSettings.DefaultToneStyle)
+    val keySizeProfile by stores.sizing.profile.collectAsState(KeyboardSizingSettings.DefaultProfile)
+    val themeSelection by stores.keyboardTheme.selection
         .collectAsState(KeyboardThemeSettings.DefaultSelection)
-    val appearanceMode by appearance.mode.collectAsState(AppearanceSettings.DefaultMode)
-    val feedback by feedbackStore.preferences.collectAsState(KeyboardFeedbackPreferences.Default)
-    val smartComposition by smartCompositionStore.preferences
+    val appearanceMode by stores.appearance.mode.collectAsState(AppearanceSettings.DefaultMode)
+    val feedback by stores.feedbackStore.preferences.collectAsState(KeyboardFeedbackPreferences.Default)
+    val showsNumberRow by stores.numberRowStore.showsNumberRow
+        .collectAsState(NumberRowSettings.DefaultShowsNumberRow)
+    val smartComposition by stores.smartCompositionStore.preferences
         .collectAsState(SmartCompositionPreferences.Default)
-    val personalSuggestions by personalSuggestionStore.preferences
+    val personalSuggestions by stores.personalSuggestionStore.preferences
         .collectAsState(PersonalSuggestionPreferences.Default)
 
     return FunputSettingsState(
-        input = input,
-        sizing = sizing,
-        keyboardTheme = keyboardTheme,
-        toneStyleStore = toneStyleStore,
-        appearance = appearance,
-        feedbackStore = feedbackStore,
-        smartCompositionStore = smartCompositionStore,
-        personalSuggestionStore = personalSuggestionStore,
+        input = stores.input,
+        sizing = stores.sizing,
+        keyboardTheme = stores.keyboardTheme,
+        toneStyleStore = stores.toneStyleStore,
+        appearance = stores.appearance,
+        feedbackStore = stores.feedbackStore,
+        numberRowStore = stores.numberRowStore,
+        smartCompositionStore = stores.smartCompositionStore,
+        personalSuggestionStore = stores.personalSuggestionStore,
         inputMethod = inputMethod,
         toneStyle = toneStyle,
         keySizeProfile = keySizeProfile,
         themeSelection = themeSelection,
         appearanceMode = appearanceMode,
         feedback = feedback,
+        showsNumberRow = showsNumberRow,
         smartComposition = smartComposition,
         personalSuggestions = personalSuggestions,
     )

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/FunputSettingsStores.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/FunputSettingsStores.kt
@@ -1,0 +1,25 @@
+package app.funput.funput.ui
+
+import android.content.Context
+import app.funput.funput.ime.settings.AppearanceSettings
+import app.funput.funput.ime.settings.InputMethodSettings
+import app.funput.funput.ime.settings.KeyboardFeedbackSettings
+import app.funput.funput.ime.settings.KeyboardSizingSettings
+import app.funput.funput.ime.settings.KeyboardThemeSettings
+import app.funput.funput.ime.settings.NumberRowSettings
+import app.funput.funput.ime.settings.PersonalSuggestionSettings
+import app.funput.funput.ime.settings.SmartCompositionSettings
+import app.funput.funput.ime.settings.ToneStyleSettings
+
+/** Remembers the DataStore wrappers used by [rememberFunputSettings]. */
+internal class FunputSettingsStores(context: Context) {
+    val input = InputMethodSettings(context)
+    val sizing = KeyboardSizingSettings(context)
+    val keyboardTheme = KeyboardThemeSettings(context)
+    val toneStyleStore = ToneStyleSettings(context)
+    val appearance = AppearanceSettings(context)
+    val feedbackStore = KeyboardFeedbackSettings(context)
+    val numberRowStore = NumberRowSettings(context)
+    val smartCompositionStore = SmartCompositionSettings(context)
+    val personalSuggestionStore = PersonalSuggestionSettings(context)
+}

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/SettingsRoute.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/SettingsRoute.kt
@@ -32,6 +32,7 @@ internal fun SettingsRoute(
     SettingsScreen(
         keyboardSetupStatus = rememberKeyboardSetupStatus(),
         inputMethod = settings.inputMethod,
+        showsNumberRow = settings.showsNumberRow,
         toneStyle = settings.toneStyle,
         keySizeProfile = settings.keySizeProfile,
         keyboardThemeLabel = keyboardThemeLabel,
@@ -43,6 +44,9 @@ internal fun SettingsRoute(
         personalSuggestionsEnabled = settings.personalSuggestions.enabled,
         versionName = versionName,
         onInputMethodSelected = { method -> scope.launch { settings.input.setInputMethod(method) } },
+        onShowsNumberRowChanged = { enabled ->
+            scope.launch { settings.numberRowStore.setShowsNumberRow(enabled) }
+        },
         onToneStyleSelected = { style -> scope.launch { settings.toneStyleStore.setToneStyle(style) } },
         onKeySizeSelected = { profile -> scope.launch { settings.sizing.setProfile(profile) } },
         onAppearanceSelected = { mode -> scope.launch { settings.appearance.setMode(mode) } },

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/settings/SettingsOptions.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/settings/SettingsOptions.kt
@@ -18,8 +18,16 @@ internal fun ToneStyle.label(): String = when (this) {
 
 @Composable
 internal fun KeyboardInputMethod.label(): String = when (this) {
-    KeyboardInputMethod.VNI -> stringResource(R.string.input_method_vni)
     KeyboardInputMethod.TELEX -> stringResource(R.string.input_method_telex)
+    KeyboardInputMethod.TELEX_ADVANCED -> stringResource(R.string.input_method_telex_advanced)
+    KeyboardInputMethod.VNI -> stringResource(R.string.input_method_vni)
+}
+
+@Composable
+internal fun KeyboardInputMethod.summary(): String = when (this) {
+    KeyboardInputMethod.TELEX -> stringResource(R.string.input_method_telex_summary)
+    KeyboardInputMethod.TELEX_ADVANCED -> stringResource(R.string.input_method_telex_advanced_summary)
+    KeyboardInputMethod.VNI -> stringResource(R.string.input_method_vni_summary)
 }
 
 @Composable
@@ -43,7 +51,9 @@ internal fun KeyboardThemeId.label(): String = when (this) {
 }
 
 @Composable
-internal fun inputMethodOptions() = KeyboardInputMethod.entries.map { PickerOption(it, it.label()) }
+internal fun inputMethodOptions() = KeyboardInputMethod.entries.map {
+    PickerOption(it, it.label(), it.summary())
+}
 
 @Composable
 internal fun toneStyleOptions() = ToneStyle.entries.map { PickerOption(it, it.label()) }

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/settings/SettingsPreviews.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/settings/SettingsPreviews.kt
@@ -53,6 +53,7 @@ private fun SettingsPreview(
         SettingsScreen(
             keyboardSetupStatus = keyboardSetupStatus,
             inputMethod = KeyboardInputMethod.VNI,
+            showsNumberRow = false,
             toneStyle = ToneStyle.TRADITIONAL,
             keySizeProfile = KeyboardSizingProfile.Normal,
             keyboardThemeLabel = "Tối",
@@ -64,6 +65,7 @@ private fun SettingsPreview(
             personalSuggestionsEnabled = true,
             versionName = "1.2026.1",
             onInputMethodSelected = {},
+            onShowsNumberRowChanged = {},
             onToneStyleSelected = {},
             onKeySizeSelected = {},
             onAppearanceSelected = {},

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/settings/SettingsScreen.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/settings/SettingsScreen.kt
@@ -1,42 +1,24 @@
 package app.funput.funput.ui.settings
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import app.funput.funput.R
 import app.funput.funput.ime.settings.AppearanceMode
 import app.funput.funput.ime.settings.ToneStyle
 import app.funput.funput.keyboard.layout.KeyboardSizingProfile
 import app.funput.funput.keyboard.model.KeyboardInputMethod
-import app.funput.funput.theme.KeyboardThemeId
-import app.funput.funput.ui.settings.about.AboutSettingsSection
-import app.funput.funput.ui.settings.appearance.AppearanceSettingsSection
-import app.funput.funput.ui.settings.components.SettingsHero
-import app.funput.funput.ui.settings.feedback.FeedbackSettingsSection
-import app.funput.funput.ui.settings.keyboard.KeyboardSettingsSection
 import app.funput.funput.ui.settings.setup.KeyboardSetupStatus
-import app.funput.funput.ui.settings.smart.SmartSettingsSection
-import app.funput.funput.ui.settings.smart.PersonalSuggestionSettingsSection
 
 @Composable
 internal fun SettingsScreen(
     keyboardSetupStatus: KeyboardSetupStatus,
     inputMethod: KeyboardInputMethod,
+    showsNumberRow: Boolean,
     toneStyle: ToneStyle,
     keySizeProfile: KeyboardSizingProfile,
     keyboardThemeLabel: String,
@@ -48,6 +30,7 @@ internal fun SettingsScreen(
     personalSuggestionsEnabled: Boolean,
     versionName: String,
     onInputMethodSelected: (KeyboardInputMethod) -> Unit,
+    onShowsNumberRowChanged: (Boolean) -> Unit,
     onToneStyleSelected: (ToneStyle) -> Unit,
     onKeySizeSelected: (KeyboardSizingProfile) -> Unit,
     onAppearanceSelected: (AppearanceMode) -> Unit,
@@ -65,69 +48,33 @@ internal fun SettingsScreen(
 ) {
     var picker by rememberSaveable { mutableStateOf<SettingsPicker?>(null) }
     Box(modifier = modifier.fillMaxSize()) {
-        LazyColumn(
-            verticalArrangement = Arrangement.spacedBy(18.dp),
-            contentPadding = PaddingValues(horizontal = 20.dp, vertical = 18.dp),
-            modifier = Modifier
-                .fillMaxSize()
-                .windowInsetsPadding(WindowInsets.safeDrawing),
-        ) {
-            item(key = "title") {
-                Text(
-                    text = stringResource(R.string.settings_title),
-                    style = MaterialTheme.typography.headlineLarge,
-                )
-            }
-            item(key = "hero") { SettingsHero() }
-            item(key = "keyboard") {
-                KeyboardSettingsSection(
-                    setupStatus = keyboardSetupStatus,
-                    inputMethod = inputMethod,
-                    toneStyle = toneStyle,
-                    keySizeProfile = keySizeProfile,
-                    keyboardThemeLabel = keyboardThemeLabel,
-                    onOpenPicker = { picker = it },
-                    onOpenThemeGallery = onOpenThemeGallery,
-                    onEnableKeyboard = onEnableKeyboard,
-                    onSelectKeyboard = onSelectKeyboard,
-                )
-            }
-            item(key = "smart") {
-                SmartSettingsSection(
-                    smartRestoreEnabled = smartRestoreEnabled,
-                    spellCheckEnabled = spellCheckEnabled,
-                    onSmartRestoreChanged = onSmartRestoreChanged,
-                    onSpellCheckChanged = onSpellCheckChanged,
-                )
-            }
-            item(key = "personal-suggestions") {
-                PersonalSuggestionSettingsSection(
-                    enabled = personalSuggestionsEnabled,
-                    onEnabledChanged = onPersonalSuggestionsChanged,
-                    onReset = onResetPersonalSuggestions,
-                )
-            }
-            item(key = "appearance") {
-                AppearanceSettingsSection(
-                    appearanceMode = appearanceMode,
-                    onOpenPicker = { picker = it },
-                )
-            }
-            item(key = "feedback") {
-                FeedbackSettingsSection(
-                    hapticsEnabled = hapticsEnabled,
-                    soundsEnabled = soundsEnabled,
-                    onHapticsChanged = onHapticsChanged,
-                    onSoundsChanged = onSoundsChanged,
-                )
-            }
-            item(key = "about") {
-                AboutSettingsSection(
-                    versionName = versionName,
-                    onOpenWebsite = onOpenWebsite,
-                )
-            }
-        }
+        SettingsScreenSections(
+            keyboardSetupStatus = keyboardSetupStatus,
+            inputMethod = inputMethod,
+            showsNumberRow = showsNumberRow,
+            toneStyle = toneStyle,
+            keySizeProfile = keySizeProfile,
+            keyboardThemeLabel = keyboardThemeLabel,
+            appearanceMode = appearanceMode,
+            hapticsEnabled = hapticsEnabled,
+            soundsEnabled = soundsEnabled,
+            smartRestoreEnabled = smartRestoreEnabled,
+            spellCheckEnabled = spellCheckEnabled,
+            personalSuggestionsEnabled = personalSuggestionsEnabled,
+            versionName = versionName,
+            onOpenPicker = { picker = it },
+            onShowsNumberRowChanged = onShowsNumberRowChanged,
+            onHapticsChanged = onHapticsChanged,
+            onSoundsChanged = onSoundsChanged,
+            onSmartRestoreChanged = onSmartRestoreChanged,
+            onSpellCheckChanged = onSpellCheckChanged,
+            onPersonalSuggestionsChanged = onPersonalSuggestionsChanged,
+            onResetPersonalSuggestions = onResetPersonalSuggestions,
+            onEnableKeyboard = onEnableKeyboard,
+            onSelectKeyboard = onSelectKeyboard,
+            onOpenThemeGallery = onOpenThemeGallery,
+            onOpenWebsite = onOpenWebsite,
+        )
     }
     SettingsPickerSheet(
         picker = picker,

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/settings/SettingsScreenSections.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/settings/SettingsScreenSections.kt
@@ -1,0 +1,124 @@
+package app.funput.funput.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import app.funput.funput.R
+import app.funput.funput.ime.settings.AppearanceMode
+import app.funput.funput.ime.settings.ToneStyle
+import app.funput.funput.keyboard.layout.KeyboardSizingProfile
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+import app.funput.funput.ui.settings.about.AboutSettingsSection
+import app.funput.funput.ui.settings.appearance.AppearanceSettingsSection
+import app.funput.funput.ui.settings.components.SettingsHero
+import app.funput.funput.ui.settings.feedback.FeedbackSettingsSection
+import app.funput.funput.ui.settings.keyboard.KeyboardSettingsSection
+import app.funput.funput.ui.settings.setup.KeyboardSetupStatus
+import app.funput.funput.ui.settings.smart.PersonalSuggestionSettingsSection
+import app.funput.funput.ui.settings.smart.SmartSettingsSection
+
+@Composable
+internal fun SettingsScreenSections(
+    keyboardSetupStatus: KeyboardSetupStatus,
+    inputMethod: KeyboardInputMethod,
+    showsNumberRow: Boolean,
+    toneStyle: ToneStyle,
+    keySizeProfile: KeyboardSizingProfile,
+    keyboardThemeLabel: String,
+    appearanceMode: AppearanceMode,
+    hapticsEnabled: Boolean,
+    soundsEnabled: Boolean,
+    smartRestoreEnabled: Boolean,
+    spellCheckEnabled: Boolean,
+    personalSuggestionsEnabled: Boolean,
+    versionName: String,
+    onOpenPicker: (SettingsPicker) -> Unit,
+    onShowsNumberRowChanged: (Boolean) -> Unit,
+    onHapticsChanged: (Boolean) -> Unit,
+    onSoundsChanged: (Boolean) -> Unit,
+    onSmartRestoreChanged: (Boolean) -> Unit,
+    onSpellCheckChanged: (Boolean) -> Unit,
+    onPersonalSuggestionsChanged: (Boolean) -> Unit,
+    onResetPersonalSuggestions: () -> Unit,
+    onEnableKeyboard: () -> Unit,
+    onSelectKeyboard: () -> Unit,
+    onOpenThemeGallery: () -> Unit,
+    onOpenWebsite: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(18.dp),
+        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 18.dp),
+        modifier = modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing),
+    ) {
+        item(key = "title") {
+            Text(
+                text = stringResource(R.string.settings_title),
+                style = MaterialTheme.typography.headlineLarge,
+            )
+        }
+        item(key = "hero") { SettingsHero() }
+        item(key = "keyboard") {
+            KeyboardSettingsSection(
+                setupStatus = keyboardSetupStatus,
+                inputMethod = inputMethod,
+                showsNumberRow = showsNumberRow,
+                toneStyle = toneStyle,
+                keySizeProfile = keySizeProfile,
+                keyboardThemeLabel = keyboardThemeLabel,
+                onOpenPicker = onOpenPicker,
+                onShowsNumberRowChanged = onShowsNumberRowChanged,
+                onOpenThemeGallery = onOpenThemeGallery,
+                onEnableKeyboard = onEnableKeyboard,
+                onSelectKeyboard = onSelectKeyboard,
+            )
+        }
+        item(key = "smart") {
+            SmartSettingsSection(
+                smartRestoreEnabled = smartRestoreEnabled,
+                spellCheckEnabled = spellCheckEnabled,
+                onSmartRestoreChanged = onSmartRestoreChanged,
+                onSpellCheckChanged = onSpellCheckChanged,
+            )
+        }
+        item(key = "personal-suggestions") {
+            PersonalSuggestionSettingsSection(
+                enabled = personalSuggestionsEnabled,
+                onEnabledChanged = onPersonalSuggestionsChanged,
+                onReset = onResetPersonalSuggestions,
+            )
+        }
+        item(key = "appearance") {
+            AppearanceSettingsSection(
+                appearanceMode = appearanceMode,
+                onOpenPicker = onOpenPicker,
+            )
+        }
+        item(key = "feedback") {
+            FeedbackSettingsSection(
+                hapticsEnabled = hapticsEnabled,
+                soundsEnabled = soundsEnabled,
+                onHapticsChanged = onHapticsChanged,
+                onSoundsChanged = onSoundsChanged,
+            )
+        }
+        item(key = "about") {
+            AboutSettingsSection(
+                versionName = versionName,
+                onOpenWebsite = onOpenWebsite,
+            )
+        }
+    }
+}

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/settings/components/PreferencePickerSheet.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/settings/components/PreferencePickerSheet.kt
@@ -23,6 +23,7 @@ import app.funput.funput.R
 internal data class PickerOption<T>(
     val value: T,
     val label: String,
+    val summary: String? = null,
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -52,11 +53,19 @@ internal fun <T> PreferencePickerSheet(
                         }
                         .padding(horizontal = 24.dp, vertical = 17.dp),
                 ) {
-                    Text(
-                        text = option.label,
-                        style = MaterialTheme.typography.bodyLarge,
-                        modifier = Modifier.weight(1f),
-                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = option.label,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        option.summary?.let { summary ->
+                            Text(
+                                text = summary,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        }
+                    }
                     if (option.value == selected) {
                         Icon(
                             painter = painterResource(R.drawable.ic_check),

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/settings/components/SettingsSwitchRow.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/settings/components/SettingsSwitchRow.kt
@@ -1,6 +1,7 @@
 package app.funput.funput.ui.settings.components
 
 import androidx.annotation.DrawableRes
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -26,6 +27,8 @@ internal fun SettingsSwitchRow(
     iconBackground: Color,
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    summary: String? = null,
+    enabled: Boolean = true,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -34,6 +37,7 @@ internal fun SettingsSwitchRow(
             .heightIn(min = 62.dp)
             .toggleable(
                 value = checked,
+                enabled = enabled,
                 onValueChange = onCheckedChange,
                 role = Role.Switch,
             )
@@ -41,14 +45,28 @@ internal fun SettingsSwitchRow(
     ) {
         SettingsIcon(iconRes, iconBackground)
         Spacer(modifier = Modifier.width(12.dp))
-        Text(
-            text = title,
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.weight(1f),
-        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (enabled) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                },
+            )
+            summary?.let { text ->
+                Text(
+                    text = text,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
         Switch(
             checked = checked,
             onCheckedChange = null,
+            enabled = enabled,
         )
     }
 }

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/settings/keyboard/KeyboardSettingsSection.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/settings/keyboard/KeyboardSettingsSection.kt
@@ -17,6 +17,7 @@ import app.funput.funput.ui.settings.components.SettingsDivider
 import app.funput.funput.ui.settings.components.SettingsGroup
 import app.funput.funput.ui.settings.components.SettingsRow
 import app.funput.funput.ui.settings.components.SettingsSectionHeader
+import app.funput.funput.ui.settings.components.SettingsSwitchRow
 import app.funput.funput.ui.settings.label
 import app.funput.funput.ui.settings.setup.KeyboardSetupStatus
 import app.funput.funput.ui.theme.BrandBlue
@@ -27,10 +28,12 @@ import app.funput.funput.ui.theme.BrandPurple
 internal fun KeyboardSettingsSection(
     setupStatus: KeyboardSetupStatus,
     inputMethod: KeyboardInputMethod,
+    showsNumberRow: Boolean,
     toneStyle: ToneStyle,
     keySizeProfile: KeyboardSizingProfile,
     keyboardThemeLabel: String,
     onOpenPicker: (SettingsPicker) -> Unit,
+    onShowsNumberRowChanged: (Boolean) -> Unit,
     onOpenThemeGallery: () -> Unit,
     onEnableKeyboard: () -> Unit,
     onSelectKeyboard: () -> Unit,
@@ -52,6 +55,16 @@ internal fun KeyboardSettingsSection(
                 iconRes = R.drawable.ic_keyboard,
                 iconBackground = BrandPurple,
                 onClick = { onOpenPicker(SettingsPicker.INPUT_METHOD) },
+            )
+            SettingsDivider()
+            SettingsSwitchRow(
+                title = stringResource(R.string.settings_number_row_title),
+                summary = stringResource(R.string.settings_number_row_summary),
+                checked = !inputMethod.isTelexFamily || showsNumberRow,
+                enabled = inputMethod.isTelexFamily,
+                iconRes = R.drawable.ic_key_size,
+                iconBackground = BrandOrange,
+                onCheckedChange = onShowsNumberRowChanged,
             )
             SettingsDivider()
             SettingsRow(

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/theme/KeyboardThemePreview.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/theme/KeyboardThemePreview.kt
@@ -23,6 +23,7 @@ internal data class KeyboardThemePreviewConfiguration(
     val shiftState: ShiftState = ShiftState.OFF,
     val sizingProfile: KeyboardSizingProfile = KeyboardSizingProfile.Normal,
     val suggestionBarEnabled: Boolean = true,
+    val showsNumberRow: Boolean = true,
     val suggestions: List<String> = emptyList(),
     val enterAction: KeyboardEnterAction = KeyboardEnterAction.Standard.NEW_LINE,
 )
@@ -71,6 +72,7 @@ private fun KeyboardSurfaceView.applyPreview(
     shiftState = configuration.shiftState
     sizingProfile = configuration.sizingProfile
     suggestionBarEnabled = configuration.suggestionBarEnabled
+    showsNumberRow = configuration.showsNumberRow
     suggestions = configuration.suggestions
     enterAction = configuration.enterAction
     systemInputMethodSwitcherVisible = false

--- a/platforms/android/app/src/main/res/values/strings.xml
+++ b/platforms/android/app/src/main/res/values/strings.xml
@@ -143,7 +143,11 @@
     <string name="custom_theme_save_hint">Nhập tên trong tab Thông tin để lưu theme.</string>
     <string name="custom_theme_back_description">Quay lại</string>
     <string name="input_method_telex">Telex</string>
+    <string name="input_method_telex_summary">Dùng tổ hợp chữ để nhập dấu.</string>
+    <string name="input_method_telex_advanced">Telex nâng cao</string>
+    <string name="input_method_telex_advanced_summary">Full Telex — [→ư, ]→ơ, w đầu từ→ư.</string>
     <string name="input_method_vni">VNI</string>
+    <string name="input_method_vni_summary">Dùng các phím số để nhập dấu.</string>
     <string name="settings_tone_style_title">Kiểu đặt dấu</string>
     <string name="tone_style_traditional">Truyền thống</string>
     <string name="tone_style_modern">Hiện đại</string>

--- a/platforms/android/app/src/main/res/values/strings.xml
+++ b/platforms/android/app/src/main/res/values/strings.xml
@@ -23,6 +23,8 @@
     <string name="settings_keyboard_setup_step_select">Chọn Funput khi gõ</string>
     <string name="settings_keyboard_setup_ready_hint">Gõ tiếng Việt ở bất kỳ đâu</string>
     <string name="settings_input_method_title">Kiểu gõ</string>
+    <string name="settings_number_row_title">Hàng phím số</string>
+    <string name="settings_number_row_summary">Hiển thị 0–9 với các kiểu Telex. VNI luôn cần hàng số để nhập dấu.</string>
     <string name="settings_key_size_title">Kích thước phím</string>
     <string name="settings_key_size_compact">Nhỏ gọn</string>
     <string name="settings_key_size_normal">Vừa</string>

--- a/platforms/android/ime/src/androidTest/java/app/funput/funput/ime/editing/ImeCompositionInstrumentedTest.kt
+++ b/platforms/android/ime/src/androidTest/java/app/funput/funput/ime/editing/ImeCompositionInstrumentedTest.kt
@@ -43,6 +43,47 @@ class ImeCompositionInstrumentedTest {
     }
 
     @Test
+    fun advancedTelexShortcutsComposeThroughJni() = onMainThread {
+        val cases = listOf(
+            "w" to "ư",
+            "wf" to "ừ",
+            "t[" to "tư",
+            "m]" to "mơ",
+            "tr[]ngf" to "trường",
+            "ng[]if" to "người",
+            "ww" to "w",
+            "Wf" to "Ừ",
+        )
+        cases.forEach { (keys, expected) ->
+            ImeEditingScenario.create(KeyboardInputMethod.TELEX_ADVANCED).use { scenario ->
+                scenario.handler.type(keys)
+
+                assertEquals("Failed input: $keys", expected, scenario.text)
+            }
+        }
+    }
+
+    @Test
+    fun bracketsStayLiteralOutsideAdvancedTelex() = onMainThread {
+        listOf(KeyboardInputMethod.TELEX, KeyboardInputMethod.VNI).forEach { method ->
+            ImeEditingScenario.create(method).use { scenario ->
+                scenario.handler.type("t[")
+
+                assertEquals("Failed method: $method", "t[", scenario.text)
+            }
+        }
+    }
+
+    @Test
+    fun bracesStayLiteralInAdvancedTelex() = onMainThread {
+        ImeEditingScenario.create(KeyboardInputMethod.TELEX_ADVANCED).use { scenario ->
+            scenario.handler.type("{}")
+
+            assertEquals("{}", scenario.text)
+        }
+    }
+
+    @Test
     fun backspaceEditsCompositionNotHostBuffer() = onMainThread {
         ImeEditingScenario.create().use { scenario ->
             scenario.handler.type("vieejt")

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/ImeKeyboardViewConfigurator.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/ImeKeyboardViewConfigurator.kt
@@ -34,6 +34,7 @@ internal fun FunputKeyboardView.applyImeState(
         sizingProfile = settings.sizingProfile,
         keyboardTheme = descriptor.theme,
         keyboardThemeBackgroundImage = descriptor.backgroundImage,
+        showsNumberRow = settings.showsNumberRow,
     )
 }
 
@@ -45,9 +46,11 @@ internal fun FunputKeyboardView.configureForEditor(
     sizingProfile: KeyboardSizingProfile,
     keyboardTheme: KeyboardTheme,
     keyboardThemeBackgroundImage: KeyboardThemeBackgroundImage?,
+    showsNumberRow: Boolean,
 ) {
     showLettersPanel()
     this.inputMethod = inputMethod
+    this.showsNumberRow = showsNumberRow
     this.sizingProfile = sizingProfile
     this.keyboardTheme = keyboardTheme
     this.keyboardThemeBackgroundImage = keyboardThemeBackgroundImage

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/ImeSettingsController.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/ImeSettingsController.kt
@@ -9,6 +9,7 @@ import app.funput.funput.ime.settings.KeyboardFeedbackSettings
 import app.funput.funput.ime.settings.KeyboardSizingSettings
 import app.funput.funput.ime.settings.KeyboardThemeSelection
 import app.funput.funput.ime.settings.KeyboardThemeSettings
+import app.funput.funput.ime.settings.NumberRowSettings
 import app.funput.funput.ime.settings.PersonalSuggestionPreferences
 import app.funput.funput.ime.settings.PersonalSuggestionSettings
 import app.funput.funput.ime.settings.SmartCompositionPreferences
@@ -17,7 +18,6 @@ import app.funput.funput.ime.settings.ToneStyle
 import app.funput.funput.ime.settings.ToneStyleSettings
 import app.funput.funput.keyboard.layout.KeyboardSizingProfile
 import app.funput.funput.keyboard.model.KeyboardInputMethod
-import app.funput.funput.theme.KeyboardThemeId
 import kotlinx.coroutines.CoroutineScope
 
 /** Keeps persisted IME settings synchronized with native and view state. */
@@ -34,6 +34,8 @@ internal class ImeSettingsController(
     var themeSelection = KeyboardThemeSettings.DefaultSelection
         private set
     var feedback = KeyboardFeedbackPreferences.Default
+        private set
+    var showsNumberRow = NumberRowSettings.DefaultShowsNumberRow
         private set
 
     // Seeded with the same defaults the settings flows fall back to, so the engine
@@ -62,6 +64,7 @@ internal class ImeSettingsController(
         KeyboardSizingSettings(context).profile.collectIn(scope, ::applySizingProfile)
         KeyboardThemeSettings(context).selection.collectIn(scope, ::applyThemeSelection)
         KeyboardFeedbackSettings(context).preferences.collectIn(scope, ::applyFeedback)
+        NumberRowSettings(context).showsNumberRow.collectIn(scope, ::applyShowsNumberRow)
         PersonalSuggestionSettings(context).preferences.collectIn(scope, onPersonalSuggestionsChanged)
     }
 
@@ -118,6 +121,12 @@ internal class ImeSettingsController(
     private fun applyFeedback(value: KeyboardFeedbackPreferences) {
         if (value == feedback) return
         feedback = value
+        onViewSettingsChanged()
+    }
+
+    private fun applyShowsNumberRow(value: Boolean) {
+        if (value == showsNumberRow) return
+        showsNumberRow = value
         onViewSettingsChanged()
     }
 }

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/AndroidCompositionSession.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/AndroidCompositionSession.kt
@@ -31,7 +31,7 @@ internal class AndroidCompositionSession(
         completedToken = null
         if (connection == null || text.isEmpty()) return false
         val codePoint = text.singleCodePointOrNull() ?: return commitRaw(connection, text)
-        return if (CompositionBoundary.isBoundary(codePoint)) {
+        return if (CompositionBoundary.isBoundary(codePoint, engine.inputMethod)) {
             commitBoundary(connection, text, codePoint)
         } else {
             recentCompletedToken = null

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/composition/CompositionBoundary.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/composition/CompositionBoundary.kt
@@ -1,9 +1,17 @@
 package app.funput.funput.ime.editing.composition
 
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+
 /** Mirrors the shared engine's current word-boundary contract. */
 internal object CompositionBoundary {
     fun isBoundary(codePoint: Int): Boolean =
         Character.isWhitespace(codePoint) || codePoint.isAsciiPunctuation()
+
+    fun isBoundary(codePoint: Int, inputMethod: KeyboardInputMethod): Boolean =
+        isBoundary(codePoint) && !codePoint.isAdvancedTelexShortcut(inputMethod)
+
+    private fun Int.isAdvancedTelexShortcut(inputMethod: KeyboardInputMethod): Boolean =
+        inputMethod == KeyboardInputMethod.TELEX_ADVANCED && (this == '['.code || this == ']'.code)
 
     private fun Int.isAsciiPunctuation(): Boolean =
         this in 0x21..0x2F ||

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/nativebridge/VietnameseEngine.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/nativebridge/VietnameseEngine.kt
@@ -21,6 +21,10 @@ internal data class EngineConfiguration(
 
 /** Platform-independent contract consumed by Android's composition adapter. */
 internal interface VietnameseEngine : AutoCloseable {
+    /** Method currently active in the engine, used by the Android boundary adapter. */
+    val inputMethod: KeyboardInputMethod
+        get() = KeyboardInputMethod.TELEX
+
     /** Single writer for durable configuration; see [EngineConfiguration]. */
     fun configure(configuration: EngineConfiguration)
     fun setEnabled(enabled: Boolean)
@@ -42,6 +46,8 @@ internal class NativeVietnameseEngine : VietnameseEngine {
     private var handle = FunputNative.nativeCreate().also {
         check(it != InvalidHandle) { "Unable to create Funput native engine" }
     }
+    override var inputMethod = KeyboardInputMethod.TELEX
+        private set
 
     override fun configure(configuration: EngineConfiguration) = withHandle { value ->
         FunputNative.nativeConfigure(
@@ -53,6 +59,7 @@ internal class NativeVietnameseEngine : VietnameseEngine {
             configuration.spellCheck,
             configuration.autoCapitalize,
         )
+        inputMethod = configuration.inputMethod
     }
 
     override fun setEnabled(enabled: Boolean) = withHandle { value ->
@@ -86,13 +93,14 @@ internal class NativeVietnameseEngine : VietnameseEngine {
         return operation(handle)
     }
 
-    private val KeyboardInputMethod.nativeValue: Int
-        get() = when (this) {
-            KeyboardInputMethod.TELEX -> 0
-            KeyboardInputMethod.VNI -> 1
-        }
-
     private companion object {
         const val InvalidHandle = 0L
     }
 }
+
+internal val KeyboardInputMethod.nativeValue: Int
+    get() = when (this) {
+        KeyboardInputMethod.TELEX -> 0
+        KeyboardInputMethod.VNI -> 1
+        KeyboardInputMethod.TELEX_ADVANCED -> 2
+    }

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/settings/InputMethodSettings.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/settings/InputMethodSettings.kt
@@ -36,9 +36,16 @@ class InputMethodSettings(context: Context) {
 }
 
 internal object InputMethodSettingCodec {
-    fun encode(method: KeyboardInputMethod): String = method.name
+    fun encode(method: KeyboardInputMethod): String = when (method) {
+        KeyboardInputMethod.TELEX -> "telex"
+        KeyboardInputMethod.TELEX_ADVANCED -> "telex_advanced"
+        KeyboardInputMethod.VNI -> "vni"
+    }
 
-    fun decode(value: String?): KeyboardInputMethod =
-        KeyboardInputMethod.entries.firstOrNull { it.name == value }
-            ?: InputMethodSettings.DefaultInputMethod
+    fun decode(value: String?): KeyboardInputMethod = when (value?.lowercase()) {
+        "telex" -> KeyboardInputMethod.TELEX
+        "telex_advanced" -> KeyboardInputMethod.TELEX_ADVANCED
+        "vni" -> KeyboardInputMethod.VNI
+        else -> InputMethodSettings.DefaultInputMethod
+    }
 }

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/settings/NumberRowSettings.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/settings/NumberRowSettings.kt
@@ -1,0 +1,39 @@
+package app.funput.funput.ime.settings
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import java.io.IOException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+/** Persists whether Telex-family layouts show the top digit row. */
+class NumberRowSettings(context: Context) {
+    private val dataStore = context.applicationContext.funputSettingsStore
+
+    val showsNumberRow: Flow<Boolean> = dataStore.data
+        .catch { error ->
+            if (error is IOException) emit(emptyPreferences()) else throw error
+        }
+        .map { preferences -> NumberRowSettingCodec.decode(preferences[ShowsNumberRowKey]) }
+        .distinctUntilChanged()
+
+    suspend fun setShowsNumberRow(enabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[ShowsNumberRowKey] = enabled
+        }
+    }
+
+    companion object {
+        const val DefaultShowsNumberRow = false
+
+        private val ShowsNumberRowKey = booleanPreferencesKey("shows_number_row")
+    }
+}
+
+internal object NumberRowSettingCodec {
+    fun decode(value: Boolean?): Boolean = value ?: NumberRowSettings.DefaultShowsNumberRow
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AndroidCompositionSessionTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AndroidCompositionSessionTest.kt
@@ -1,10 +1,6 @@
 package app.funput.funput.ime.editing
 
-import android.view.inputmethod.InputConnection
-import app.funput.funput.ime.editing.composition.CompositionBoundary
-import app.funput.funput.ime.nativebridge.EngineConfiguration
-import app.funput.funput.ime.nativebridge.VietnameseEngine
-import java.lang.reflect.Proxy
+import app.funput.funput.keyboard.model.KeyboardInputMethod
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -12,17 +8,32 @@ import org.junit.Test
 
 class AndroidCompositionSessionTest {
     @Test
-    fun `whitespace and ascii punctuation are boundaries`() {
-        listOf(' ', '\n', '\t', ',', '.', '!', '?', '-', '"').forEach { character ->
-            assertTrue(CompositionBoundary.isBoundary(character.code))
-        }
+    fun `advanced Telex bracket is routed through composition`() {
+        val connection = RecordingConnection()
+        val engine = ScriptedEngine(
+            processed = ArrayDeque(listOf("tư")),
+            inputMethod = KeyboardInputMethod.TELEX_ADVANCED,
+        )
+        val session = testSession(engine)
+
+        session.input(connection.proxy, "[")
+
+        assertEquals(listOf("tư"), connection.composingTexts)
+        assertEquals("tư", session.composingText)
     }
 
     @Test
-    fun `letters digits emoji and unicode punctuation are not boundaries`() {
-        listOf('a'.code, '1'.code, '9'.code, 'á'.code, '—'.code, 0x1F600).forEach { codePoint ->
-            assertFalse(CompositionBoundary.isBoundary(codePoint))
-        }
+    fun `Telex bracket stays a punctuation boundary`() {
+        val connection = RecordingConnection()
+        val engine = ScriptedEngine(processed = ArrayDeque(listOf("t")))
+        val session = testSession(engine)
+        session.input(connection.proxy, "t")
+
+        session.input(connection.proxy, "[")
+
+        assertEquals(1, connection.finishCount)
+        assertEquals(listOf("["), connection.committedTexts)
+        assertFalse(session.isComposing)
     }
 
     @Test
@@ -85,61 +96,4 @@ class AndroidCompositionSessionTest {
 
         assertEquals(false, engine.enabled)
     }
-}
-
-internal fun testSession(engine: VietnameseEngine) = AndroidCompositionSession(
-    engine = engine,
-    composingTextFactory = { text -> text },
-)
-
-internal class ScriptedEngine(
-    private val processed: ArrayDeque<String>,
-    private val boundaryOutput: String? = null,
-    private val backspaceOutput: String = "",
-) : VietnameseEngine {
-    var configuration: EngineConfiguration? = null
-        private set
-    var enabled: Boolean? = null
-        private set
-    /** Words this fake accepts for re-opening; mirrors the engine's syllable gate. */
-    var adoptable: Set<String> = emptySet()
-    var adopted: String? = null
-        private set
-
-    override fun process(codePoint: Int): String = processed.removeFirst()
-    override fun processBoundary(codePoint: Int): String? = boundaryOutput
-    override fun backspace(): String = backspaceOutput
-    override fun configure(configuration: EngineConfiguration) {
-        this.configuration = configuration
-    }
-    override fun adopt(word: String): Boolean = adoptable.contains(word).also {
-        if (it) adopted = word
-    }
-    override fun setEnabled(enabled: Boolean) {
-        this.enabled = enabled
-    }
-    override fun clear() = Unit
-    override fun close() = Unit
-}
-
-internal class RecordingConnection {
-    val composingTexts = mutableListOf<String>()
-    val committedTexts = mutableListOf<String>()
-    var finishCount = 0
-
-    val proxy: InputConnection = Proxy.newProxyInstance(
-        InputConnection::class.java.classLoader,
-        arrayOf(InputConnection::class.java),
-    ) { _, method, arguments ->
-        when (method.name) {
-            "setComposingText" -> true.also {
-                val value = arguments?.first() as CharSequence
-                composingTexts += value.toString()
-            }
-            "commitText" -> true.also { committedTexts += arguments?.first().toString() }
-            "finishComposingText" -> true.also { finishCount++ }
-            "toString" -> "RecordingInputConnection"
-            else -> false
-        }
-    } as InputConnection
 }

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CompositionSessionTestSupport.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CompositionSessionTestSupport.kt
@@ -1,0 +1,66 @@
+package app.funput.funput.ime.editing
+
+import android.view.inputmethod.InputConnection
+import app.funput.funput.ime.nativebridge.EngineConfiguration
+import app.funput.funput.ime.nativebridge.VietnameseEngine
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+import java.lang.reflect.Proxy
+
+internal fun testSession(engine: VietnameseEngine) = AndroidCompositionSession(
+    engine = engine,
+    composingTextFactory = { text -> text },
+)
+
+internal class ScriptedEngine(
+    private val processed: ArrayDeque<String>,
+    private val boundaryOutput: String? = null,
+    private val backspaceOutput: String = "",
+    override var inputMethod: KeyboardInputMethod = KeyboardInputMethod.TELEX,
+) : VietnameseEngine {
+    var configuration: EngineConfiguration? = null
+        private set
+    var enabled: Boolean? = null
+        private set
+    /** Words this fake accepts for re-opening; mirrors the engine's syllable gate. */
+    var adoptable: Set<String> = emptySet()
+    var adopted: String? = null
+        private set
+
+    override fun process(codePoint: Int): String = processed.removeFirst()
+    override fun processBoundary(codePoint: Int): String? = boundaryOutput
+    override fun backspace(): String = backspaceOutput
+    override fun configure(configuration: EngineConfiguration) {
+        this.configuration = configuration
+        inputMethod = configuration.inputMethod
+    }
+    override fun adopt(word: String): Boolean = adoptable.contains(word).also {
+        if (it) adopted = word
+    }
+    override fun setEnabled(enabled: Boolean) {
+        this.enabled = enabled
+    }
+    override fun clear() = Unit
+    override fun close() = Unit
+}
+
+internal class RecordingConnection {
+    val composingTexts = mutableListOf<String>()
+    val committedTexts = mutableListOf<String>()
+    var finishCount = 0
+
+    val proxy: InputConnection = Proxy.newProxyInstance(
+        InputConnection::class.java.classLoader,
+        arrayOf(InputConnection::class.java),
+    ) { _, method, arguments ->
+        when (method.name) {
+            "setComposingText" -> true.also {
+                val value = arguments?.first() as CharSequence
+                composingTexts += value.toString()
+            }
+            "commitText" -> true.also { committedTexts += arguments?.first().toString() }
+            "finishComposingText" -> true.also { finishCount++ }
+            "toString" -> "RecordingInputConnection"
+            else -> false
+        }
+    } as InputConnection
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/composition/CompositionBoundaryTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/composition/CompositionBoundaryTest.kt
@@ -1,0 +1,34 @@
+package app.funput.funput.ime.editing.composition
+
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CompositionBoundaryTest {
+    @Test
+    fun `whitespace and ascii punctuation are boundaries`() {
+        listOf(' ', '\n', '\t', ',', '.', '!', '?', '-', '"').forEach { character ->
+            assertTrue(CompositionBoundary.isBoundary(character.code, KeyboardInputMethod.TELEX))
+        }
+    }
+
+    @Test
+    fun `letters digits emoji and unicode punctuation are not boundaries`() {
+        listOf('a'.code, '1'.code, '9'.code, 'á'.code, '—'.code, 0x1F600).forEach { codePoint ->
+            assertFalse(CompositionBoundary.isBoundary(codePoint, KeyboardInputMethod.TELEX))
+        }
+    }
+
+    @Test
+    fun `brackets compose only in advanced Telex`() {
+        listOf(KeyboardInputMethod.TELEX, KeyboardInputMethod.VNI).forEach { method ->
+            assertTrue(CompositionBoundary.isBoundary('['.code, method))
+            assertTrue(CompositionBoundary.isBoundary(']'.code, method))
+        }
+        assertFalse(CompositionBoundary.isBoundary('['.code, KeyboardInputMethod.TELEX_ADVANCED))
+        assertFalse(CompositionBoundary.isBoundary(']'.code, KeyboardInputMethod.TELEX_ADVANCED))
+        assertTrue(CompositionBoundary.isBoundary('{'.code, KeyboardInputMethod.TELEX_ADVANCED))
+        assertTrue(CompositionBoundary.isBoundary('}'.code, KeyboardInputMethod.TELEX_ADVANCED))
+    }
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/nativebridge/KeyboardInputMethodNativeTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/nativebridge/KeyboardInputMethodNativeTest.kt
@@ -1,0 +1,14 @@
+package app.funput.funput.ime.nativebridge
+
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class KeyboardInputMethodNativeTest {
+    @Test
+    fun `input method wire values remain stable`() {
+        assertEquals(0, KeyboardInputMethod.TELEX.nativeValue)
+        assertEquals(1, KeyboardInputMethod.VNI.nativeValue)
+        assertEquals(2, KeyboardInputMethod.TELEX_ADVANCED.nativeValue)
+    }
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/settings/InputMethodSettingCodecTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/settings/InputMethodSettingCodecTest.kt
@@ -12,11 +12,21 @@ class InputMethodSettingCodecTest {
     }
 
     @Test
-    fun `both supported methods round trip`() {
+    fun `all supported methods use stable persisted values`() {
+        assertEquals("telex", InputMethodSettingCodec.encode(KeyboardInputMethod.TELEX))
+        assertEquals("telex_advanced", InputMethodSettingCodec.encode(KeyboardInputMethod.TELEX_ADVANCED))
+        assertEquals("vni", InputMethodSettingCodec.encode(KeyboardInputMethod.VNI))
+
         KeyboardInputMethod.entries.forEach { method ->
             val encoded = InputMethodSettingCodec.encode(method)
 
             assertEquals(method, InputMethodSettingCodec.decode(encoded))
         }
+    }
+
+    @Test
+    fun `legacy uppercase values remain readable`() {
+        assertEquals(KeyboardInputMethod.TELEX, InputMethodSettingCodec.decode("TELEX"))
+        assertEquals(KeyboardInputMethod.VNI, InputMethodSettingCodec.decode("VNI"))
     }
 }

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/settings/NumberRowSettingCodecTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/settings/NumberRowSettingCodecTest.kt
@@ -1,0 +1,20 @@
+package app.funput.funput.ime.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NumberRowSettingCodecTest {
+    @Test
+    fun `missing value falls back to compact Telex default`() {
+        assertFalse(NumberRowSettingCodec.decode(null))
+        assertEquals(NumberRowSettings.DefaultShowsNumberRow, NumberRowSettingCodec.decode(null))
+    }
+
+    @Test
+    fun `explicit values round trip`() {
+        assertTrue(NumberRowSettingCodec.decode(true))
+        assertFalse(NumberRowSettingCodec.decode(false))
+    }
+}

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/KeyboardDimensions.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/KeyboardDimensions.kt
@@ -16,16 +16,22 @@ object KeyboardDimensions {
         editorMode: KeyboardEditorMode = KeyboardEditorMode.TEXT,
         profile: KeyboardSizingProfile = KeyboardSizingProfile.Default,
         widthDp: Float = DefaultWidthDp,
-    ): Float = baseRecommendedHeightDp(editorMode, profile, widthDp)
+        showsNumberRow: Boolean = true,
+    ): Float = baseRecommendedHeightDp(editorMode, profile, widthDp, inputMethod, showsNumberRow)
 
     internal fun baseRecommendedHeightDp(
         editorMode: KeyboardEditorMode,
         profile: KeyboardSizingProfile = KeyboardSizingProfile.Default,
         widthDp: Float = DefaultWidthDp,
+        inputMethod: KeyboardInputMethod = KeyboardInputMethod.TELEX,
+        showsNumberRow: Boolean = true,
     ): Float = when {
         editorMode.usesKeypad -> heightForRowCount(4, false, profile, widthDp)
         editorMode.isPassword -> heightForRowCount(5, false, profile, widthDp)
-        else -> heightForRowCount(5, true, profile, widthDp)
+        else -> {
+            val compact = inputMethod.isTelexFamily && !showsNumberRow
+            heightForRowCount(if (compact) 4 else 5, true, profile, widthDp)
+        }
     }
 
     /**

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/KeyboardSurfaceSuggestionState.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/KeyboardSurfaceSuggestionState.kt
@@ -2,15 +2,32 @@ package app.funput.funput.keyboard
 
 import app.funput.funput.keyboard.layout.ResolvedKeyboard
 
+/**
+ * Normalizes suggestion candidates and refreshes visible capacity.
+ *
+ * When candidates flip between empty and non-empty, [onShowSettingsChanged] rebuilds
+ * toolbar geometry so Settings can yield space to suggestions.
+ */
 internal class KeyboardSurfaceSuggestionState(
     private val density: () -> Float,
     private val keyboard: () -> ResolvedKeyboard?,
     private val apply: (List<String>) -> Unit,
+    private val onShowSettingsChanged: (Boolean) -> Unit = {},
 ) {
     private var requested = emptyList<String>()
 
+    /** True when the toolbar should keep the Settings key (no suggestion candidates). */
+    var showSettings: Boolean = true
+        private set
+
     fun update(values: List<String>) {
         requested = SuggestionNormalizer.normalize(values)
+        val nextShowSettings = requested.isEmpty()
+        if (nextShowSettings != showSettings) {
+            showSettings = nextShowSettings
+            onShowSettingsChanged(nextShowSettings)
+            return
+        }
         refresh()
     }
 

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/KeyboardSurfaceView.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/KeyboardSurfaceView.kt
@@ -68,6 +68,7 @@ class KeyboardSurfaceView @JvmOverloads constructor(
         density = { resources.displayMetrics.density },
         keyboard = { resolvedKeyboard },
         apply = { values -> render.suggestions = values; accessibility.refresh() },
+        onShowSettingsChanged = { resolveGeometry() },
     )
     private val interaction: KeyboardSurfaceInteraction = createKeyboardSurfaceInteraction(
         host = this,
@@ -135,6 +136,7 @@ class KeyboardSurfaceView @JvmOverloads constructor(
             width = width, height = height,
             density = resources.displayMetrics.density,
             profile = sizingProfile,
+            showSettings = suggestionState.showSettings,
         )
         suggestionState.geometryChanged()
         accessibility.refresh()

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/KeyboardSurfaceView.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/KeyboardSurfaceView.kt
@@ -41,6 +41,7 @@ class KeyboardSurfaceView @JvmOverloads constructor(
     var layoutOverride: app.funput.funput.keyboard.model.KeyboardLayout? by layoutState::layoutOverride
     var suggestionBarEnabled: Boolean by layoutState::suggestionsEnabled
     var systemInputMethodSwitcherVisible: Boolean by layoutState::systemInputMethodSwitcherVisible
+    var showsNumberRow: Boolean by layoutState::showsNumberRow
     var keyboardTheme by render::keyboardTheme
     var keyboardThemeBackgroundImage by render::keyboardThemeBackgroundImage
     var sizingProfile: KeyboardSizingProfile by render::sizingProfile
@@ -96,7 +97,9 @@ class KeyboardSurfaceView @JvmOverloads constructor(
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         val density = resources.displayMetrics.density
         val width = resolveSize((KeyboardDimensions.DefaultWidthDp * density).roundToInt(), widthMeasureSpec)
-        val heightDp = KeyboardDimensions.recommendedHeightDp(inputMethod, editorMode, sizingProfile, width / density)
+        val heightDp = KeyboardDimensions.recommendedHeightDp(
+            inputMethod, editorMode, sizingProfile, width / density, showsNumberRow,
+        )
         val height = resolveSize((heightDp * density).roundToInt(), heightMeasureSpec)
         setMeasuredDimension(width, height)
     }

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/EditorKeyboardLayouts.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/EditorKeyboardLayouts.kt
@@ -10,9 +10,10 @@ internal object EditorKeyboardLayouts {
         inputMethod: KeyboardInputMethod,
         editorMode: KeyboardEditorMode,
         suggestionsEnabled: Boolean,
+        showsNumberRow: Boolean = true,
     ): KeyboardLayout {
         val layout = when (editorMode) {
-            KeyboardEditorMode.TEXT -> KeyboardLayouts.forInputMethod(inputMethod)
+            KeyboardEditorMode.TEXT -> KeyboardLayouts.forInputMethod(inputMethod, showsNumberRow)
             KeyboardEditorMode.SEARCH -> searchLayouts.getValue(inputMethod)
             KeyboardEditorMode.EMAIL -> emailLayouts.getValue(inputMethod)
             KeyboardEditorMode.URL -> urlLayouts.getValue(inputMethod)

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardGeometry.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardGeometry.kt
@@ -11,6 +11,7 @@ object KeyboardGeometry {
         width: Float,
         height: Float,
         spec: KeyboardGeometrySpec,
+        showSettings: Boolean = true,
     ): ResolvedKeyboard {
         require(width > 0f) { "Keyboard width must be positive" }
         require(height > 0f) { "Keyboard height must be positive" }
@@ -36,7 +37,7 @@ object KeyboardGeometry {
             verticalGap = verticalMetrics.verticalGap,
         )
 
-        val suggestionBar = ToolbarGeometry.resolve(layout, width, resolvedSpec)
+        val suggestionBar = ToolbarGeometry.resolve(layout, width, resolvedSpec, showSettings)
         val rowsTop = suggestionBar?.bounds?.bottom?.plus(resolvedSpec.suggestionBarGap)
             ?: spec.verticalPadding
         val rowsTopOffset = rowsTop

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardHitTargetResolver.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardHitTargetResolver.kt
@@ -8,36 +8,7 @@ package app.funput.funput.keyboard.layout
  */
 internal object KeyboardHitTargetResolver {
     fun resolve(keyboard: ResolvedKeyboard): ResolvedKeyboard {
-        val suggestionBar = keyboard.suggestionBar?.let { bar ->
-            val systemKey = bar.systemInputMethodKey?.let { key ->
-                resolveToolbarKey(
-                    keyboard = keyboard,
-                    key = key,
-                    left = if (bar.suggestionsEnabled) {
-                        midpoint(bar.suggestionsBounds.right, key.bounds.left)
-                    } else {
-                        key.bounds.left
-                    },
-                    right = midpoint(key.bounds.right, bar.settingsKey.bounds.left),
-                )
-            }
-            bar.copy(
-                systemInputMethodKey = systemKey,
-                settingsKey = resolveToolbarKey(
-                    keyboard = keyboard,
-                    key = bar.settingsKey,
-                    left = systemKey?.let { midpoint(it.bounds.right, bar.settingsKey.bounds.left) }
-                        ?: settingsHitLeft(bar),
-                    right = midpoint(bar.settingsKey.bounds.right, bar.emojiKey.bounds.left),
-                ),
-                emojiKey = resolveToolbarKey(
-                    keyboard = keyboard,
-                    key = bar.emojiKey,
-                    left = midpoint(bar.settingsKey.bounds.right, bar.emojiKey.bounds.left),
-                    right = keyboard.width,
-                ),
-            )
-        }
+        val suggestionBar = keyboard.suggestionBar?.let { bar -> resolveSuggestionBar(keyboard, bar) }
         val rows = keyboard.rows.mapIndexed { rowIndex, row ->
             val hitTop = rowHitTop(keyboard, rowIndex)
             val hitBottom = rowHitBottom(keyboard, rowIndex)
@@ -52,16 +23,66 @@ internal object KeyboardHitTargetResolver {
                 )
             }
         }
-        return keyboard.copy(
-            suggestionBar = suggestionBar,
-            rows = rows,
+        return keyboard.copy(suggestionBar = suggestionBar, rows = rows)
+    }
+
+    private fun resolveSuggestionBar(
+        keyboard: ResolvedKeyboard,
+        bar: ResolvedSuggestionBar,
+    ): ResolvedSuggestionBar {
+        val settings = bar.settingsKey
+        val systemKey = bar.systemInputMethodKey?.let { key ->
+            resolveToolbarKey(
+                keyboard = keyboard,
+                key = key,
+                left = if (bar.suggestionsEnabled) {
+                    midpoint(bar.suggestionsBounds.right, key.bounds.left)
+                } else {
+                    key.bounds.left
+                },
+                right = midpoint(
+                    key.bounds.right,
+                    settings?.bounds?.left ?: bar.emojiKey.bounds.left,
+                ),
+            )
+        }
+        val resolvedSettings = settings?.let { key ->
+            resolveToolbarKey(
+                keyboard = keyboard,
+                key = key,
+                left = systemKey?.let { midpoint(it.bounds.right, key.bounds.left) }
+                    ?: settingsHitLeft(bar, key),
+                right = midpoint(key.bounds.right, bar.emojiKey.bounds.left),
+            )
+        }
+        return bar.copy(
+            systemInputMethodKey = systemKey,
+            settingsKey = resolvedSettings,
+            emojiKey = resolveToolbarKey(
+                keyboard = keyboard,
+                key = bar.emojiKey,
+                left = emojiHitLeft(bar, systemKey, resolvedSettings),
+                right = keyboard.width,
+            ),
         )
     }
 
-    private fun settingsHitLeft(bar: ResolvedSuggestionBar): Float = if (bar.suggestionsEnabled) {
-        midpoint(bar.suggestionsBounds.right, bar.settingsKey.bounds.left)
-    } else {
-        midpoint(bar.logoBounds.right, bar.settingsKey.bounds.left)
+    private fun settingsHitLeft(bar: ResolvedSuggestionBar, settings: ResolvedKey): Float =
+        if (bar.suggestionsEnabled) {
+            midpoint(bar.suggestionsBounds.right, settings.bounds.left)
+        } else {
+            midpoint(bar.logoBounds.right, settings.bounds.left)
+        }
+
+    private fun emojiHitLeft(
+        bar: ResolvedSuggestionBar,
+        systemKey: ResolvedKey?,
+        settings: ResolvedKey?,
+    ): Float = when {
+        settings != null -> midpoint(settings.bounds.right, bar.emojiKey.bounds.left)
+        systemKey != null -> midpoint(systemKey.bounds.right, bar.emojiKey.bounds.left)
+        bar.suggestionsEnabled -> midpoint(bar.suggestionsBounds.right, bar.emojiKey.bounds.left)
+        else -> bar.emojiKey.bounds.left
     }
 
     private fun resolveToolbarKey(
@@ -69,16 +90,14 @@ internal object KeyboardHitTargetResolver {
         key: ResolvedKey,
         left: Float,
         right: Float,
-    ): ResolvedKey {
-        return key.copy(
-            hitBounds = KeyBounds(
-                left = left,
-                top = 0f,
-                right = right,
-                bottom = midpoint(key.bounds.bottom, keyboard.rows.first().first().bounds.top),
-            ),
-        )
-    }
+    ): ResolvedKey = key.copy(
+        hitBounds = KeyBounds(
+            left = left,
+            top = 0f,
+            right = right,
+            bottom = midpoint(key.bounds.bottom, keyboard.rows.first().first().bounds.top),
+        ),
+    )
 
     private fun rowHitTop(keyboard: ResolvedKeyboard, rowIndex: Int): Float {
         val row = keyboard.rows[rowIndex]

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayoutGeometry.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayoutGeometry.kt
@@ -7,6 +7,7 @@ internal fun KeyboardLayout.resolveGeometry(
     height: Int,
     density: Float,
     profile: KeyboardSizingProfile = KeyboardSizingProfile.Default,
+    showSettings: Boolean = true,
 ): ResolvedKeyboard? {
     if (width <= 0 || height <= 0) return null
     return KeyboardGeometry.resolve(
@@ -14,5 +15,6 @@ internal fun KeyboardLayout.resolveGeometry(
         width = width.toFloat(),
         height = height.toFloat(),
         spec = KeyboardGeometrySpec.fromProfile(density, profile),
+        showSettings = showSettings,
     )
 }

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayoutResolver.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayoutResolver.kt
@@ -1,6 +1,7 @@
 package app.funput.funput.keyboard.layout
 
 import app.funput.funput.keyboard.KeyboardFeatures
+import app.funput.funput.keyboard.layout.symbols.CompactSymbolLayouts
 import app.funput.funput.keyboard.model.KeyboardEditorMode
 import app.funput.funput.keyboard.model.KeyboardInputMethod
 import app.funput.funput.keyboard.model.KeyboardLayout
@@ -13,12 +14,29 @@ internal object KeyboardLayoutResolver {
         editorMode: KeyboardEditorMode = KeyboardEditorMode.TEXT,
         suggestionsEnabled: Boolean = KeyboardFeatures.SuggestionsEnabled,
         systemInputMethodSwitcherVisible: Boolean = false,
-    ): KeyboardLayout = when (mode) {
-        KeyboardLayoutMode.LETTERS ->
-            EditorKeyboardLayouts.resolve(inputMethod, editorMode, suggestionsEnabled)
-        KeyboardLayoutMode.SYMBOLS_PRIMARY ->
-            SymbolLayouts.primary(inputMethod, suggestionsEnabled, editorMode.isPassword)
-        KeyboardLayoutMode.SYMBOLS_SECONDARY ->
-            SymbolLayouts.secondary(inputMethod, suggestionsEnabled, editorMode.isPassword)
-    }.withSystemInputMethodSwitcher(systemInputMethodSwitcherVisible)
+        showsNumberRow: Boolean = true,
+    ): KeyboardLayout {
+        val usesCompact = editorMode == KeyboardEditorMode.TEXT &&
+            inputMethod.isTelexFamily &&
+            !showsNumberRow
+        val layout = when (mode) {
+            KeyboardLayoutMode.LETTERS -> EditorKeyboardLayouts.resolve(
+                inputMethod = inputMethod,
+                editorMode = editorMode,
+                suggestionsEnabled = suggestionsEnabled,
+                showsNumberRow = showsNumberRow,
+            )
+            KeyboardLayoutMode.SYMBOLS_PRIMARY -> if (usesCompact) {
+                CompactSymbolLayouts.primary(inputMethod, suggestionsEnabled)
+            } else {
+                SymbolLayouts.primary(inputMethod, suggestionsEnabled, editorMode.isPassword)
+            }
+            KeyboardLayoutMode.SYMBOLS_SECONDARY -> if (usesCompact) {
+                CompactSymbolLayouts.secondary(inputMethod, suggestionsEnabled)
+            } else {
+                SymbolLayouts.secondary(inputMethod, suggestionsEnabled, editorMode.isPassword)
+            }
+        }
+        return layout.withSystemInputMethodSwitcher(systemInputMethodSwitcherVisible)
+    }
 }

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayouts.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayouts.kt
@@ -41,6 +41,7 @@ object KeyboardLayouts {
             },
             actionKeys = standardActionKeys(),
             supportsVietnameseAlternates = true,
+            showsTelexHints = inputMethod.isTelexFamily,
         )
     }
 

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayouts.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayouts.kt
@@ -7,10 +7,12 @@ import app.funput.funput.keyboard.model.KeyboardLayout
 object KeyboardLayouts {
     fun forInputMethod(inputMethod: KeyboardInputMethod): KeyboardLayout = when (inputMethod) {
         KeyboardInputMethod.TELEX -> telex
+        KeyboardInputMethod.TELEX_ADVANCED -> telexAdvanced
         KeyboardInputMethod.VNI -> vni
     }
 
     val telex = create("qwerty-telex", KeyboardInputMethod.TELEX)
+    val telexAdvanced = create("qwerty-telex-advanced", KeyboardInputMethod.TELEX_ADVANCED)
     val vni = create("qwerty-vni", KeyboardInputMethod.VNI)
 
     private fun create(id: String, inputMethod: KeyboardInputMethod) = qwertyLayout(

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayouts.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayouts.kt
@@ -5,23 +5,44 @@ import app.funput.funput.keyboard.model.KeyboardInputMethod
 import app.funput.funput.keyboard.model.KeyboardLayout
 
 object KeyboardLayouts {
-    fun forInputMethod(inputMethod: KeyboardInputMethod): KeyboardLayout = when (inputMethod) {
-        KeyboardInputMethod.TELEX -> telex
-        KeyboardInputMethod.TELEX_ADVANCED -> telexAdvanced
-        KeyboardInputMethod.VNI -> vni
+    /**
+     * Builds the letters layout for [inputMethod].
+     *
+     * Factory default keeps the number row so existing geometry tests stay stable; the IME
+     * always passes the persisted preference (default off for Telex-family).
+     */
+    fun forInputMethod(
+        inputMethod: KeyboardInputMethod,
+        showsNumberRow: Boolean = true,
+    ): KeyboardLayout = when (inputMethod) {
+        KeyboardInputMethod.TELEX -> create("qwerty-telex", inputMethod, showsNumberRow)
+        KeyboardInputMethod.TELEX_ADVANCED ->
+            create("qwerty-telex-advanced", inputMethod, showsNumberRow)
+        KeyboardInputMethod.VNI -> create("qwerty-vni", inputMethod, showsNumberRow = true)
     }
 
-    val telex = create("qwerty-telex", KeyboardInputMethod.TELEX)
-    val telexAdvanced = create("qwerty-telex-advanced", KeyboardInputMethod.TELEX_ADVANCED)
-    val vni = create("qwerty-vni", KeyboardInputMethod.VNI)
+    val telex = forInputMethod(KeyboardInputMethod.TELEX, showsNumberRow = true)
+    val telexAdvanced = forInputMethod(KeyboardInputMethod.TELEX_ADVANCED, showsNumberRow = true)
+    val vni = forInputMethod(KeyboardInputMethod.VNI, showsNumberRow = true)
 
-    private fun create(id: String, inputMethod: KeyboardInputMethod) = qwertyLayout(
-        id = id,
-        inputMethod = inputMethod,
-        leadingRows = listOf(topNumberRowForLetters(inputMethod)),
-        actionKeys = standardActionKeys(),
-        supportsVietnameseAlternates = true,
-    )
+    private fun create(
+        id: String,
+        inputMethod: KeyboardInputMethod,
+        showsNumberRow: Boolean,
+    ): KeyboardLayout {
+        val hasNumberRow = inputMethod == KeyboardInputMethod.VNI || showsNumberRow
+        return qwertyLayout(
+            id = if (hasNumberRow) id else "$id-compact",
+            inputMethod = inputMethod,
+            leadingRows = if (hasNumberRow) {
+                listOf(topNumberRowForLetters(inputMethod))
+            } else {
+                emptyList()
+            },
+            actionKeys = standardActionKeys(),
+            supportsVietnameseAlternates = true,
+        )
+    }
 
     private fun standardActionKeys() = listOf(
         specialKey("symbols", "?123", KeyRole.SYMBOLS, 1.7f, "Symbols"),

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/QwertyLayoutFactory.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/QwertyLayoutFactory.kt
@@ -17,6 +17,7 @@ internal fun qwertyLayout(
     actionKeys: List<KeySpec>,
     showSuggestionBar: Boolean = KeyboardFeatures.EmojiToolbarEnabled,
     supportsVietnameseAlternates: Boolean = false,
+    showsTelexHints: Boolean = false,
 ): KeyboardLayout = KeyboardLayout(
     id = id,
     inputMethod = inputMethod,
@@ -27,9 +28,9 @@ internal fun qwertyLayout(
     },
     rows = buildList {
         addAll(leadingRows)
-        add(characterRow("qwertyuiop", supportsVietnameseAlternates = supportsVietnameseAlternates))
-        add(characterRow("asdfghjkl", 0.5f, supportsVietnameseAlternates))
-        add(bottomCharacterRow(supportsVietnameseAlternates))
+        add(characterRow("qwertyuiop", supportsVietnameseAlternates = supportsVietnameseAlternates, showsTelexHints = showsTelexHints))
+        add(characterRow("asdfghjkl", 0.5f, supportsVietnameseAlternates, showsTelexHints))
+        add(bottomCharacterRow(supportsVietnameseAlternates, showsTelexHints))
         add(KeyboardRow(actionKeys))
     },
 )
@@ -63,31 +64,44 @@ private fun characterRow(
     characters: String,
     horizontalInsetUnits: Float = 0f,
     supportsVietnameseAlternates: Boolean = false,
+    showsTelexHints: Boolean = false,
 ) = KeyboardRow(
-    keys = characters.map { characterKey(it, supportsVietnameseAlternates) },
+    keys = characters.map { characterKey(it, supportsVietnameseAlternates, showsTelexHints) },
     horizontalInsetUnits = horizontalInsetUnits,
 )
 
-private fun bottomCharacterRow(supportsVietnameseAlternates: Boolean) = KeyboardRow(
+private fun bottomCharacterRow(
+    supportsVietnameseAlternates: Boolean,
+    showsTelexHints: Boolean,
+) = KeyboardRow(
     keys = buildList {
         add(specialKey("shift", "", KeyRole.SHIFT, 1.5f, "Shift"))
-        addAll("zxcvbnm".map { characterKey(it, supportsVietnameseAlternates) })
+        addAll("zxcvbnm".map { characterKey(it, supportsVietnameseAlternates, showsTelexHints) })
         add(specialKey("backspace", "", KeyRole.BACKSPACE, 1.5f, "Backspace"))
     },
 )
 
-private fun characterKey(character: Char, supportsVietnameseAlternates: Boolean) = KeySpec(
-    id = "character-$character",
-    label = character.toString(),
-    role = KeyRole.CHARACTER,
-    shiftedLabel = character.uppercaseChar().toString(),
-    accessibilityLabel = character.toString(),
-    alternates = if (supportsVietnameseAlternates) {
-        VietnameseKeyAlternates.valuesFor(character)
-    } else {
-        emptyList()
-    },
-)
+private fun characterKey(
+    character: Char,
+    supportsVietnameseAlternates: Boolean,
+    showsTelexHints: Boolean,
+): KeySpec {
+    val hint = TelexKeyHints.hint(character).takeIf { showsTelexHints }
+    return KeySpec(
+        id = "character-$character",
+        label = character.toString(),
+        role = KeyRole.CHARACTER,
+        shiftedLabel = character.uppercaseChar().toString(),
+        secondaryLabel = hint?.glyph,
+        accessibilityLabel = hint?.let { TelexKeyHints.accessibilityLabel(character) }
+            ?: character.toString(),
+        alternates = if (supportsVietnameseAlternates) {
+            VietnameseKeyAlternates.valuesFor(character)
+        } else {
+            emptyList()
+        },
+    )
+}
 
 internal fun keyboardToolbarSpec() = SuggestionBarSpec(
     settingsKey = specialKey("settings", "", KeyRole.SETTINGS, accessibilityLabel = "Settings"),

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/ResolvedKeyboard.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/ResolvedKeyboard.kt
@@ -27,7 +27,7 @@ data class ResolvedSuggestionBar(
     val logoBounds: KeyBounds,
     val suggestionsBounds: KeyBounds,
     val systemInputMethodKey: ResolvedKey?,
-    val settingsKey: ResolvedKey,
+    val settingsKey: ResolvedKey?,
     val emojiKey: ResolvedKey,
     val suggestionsEnabled: Boolean,
 )

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/TelexKeyHints.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/TelexKeyHints.kt
@@ -1,0 +1,22 @@
+package app.funput.funput.keyboard.layout
+
+/** Tone and clear-key secondary hints for Telex-family letter keys (iOS parity). */
+internal object TelexKeyHints {
+    data class Hint(val glyph: String, val description: String)
+
+    private val ByCharacter = mapOf(
+        's' to Hint("´", "dấu sắc"),
+        'f' to Hint("`", "dấu huyền"),
+        'r' to Hint("̉", "dấu hỏi"),
+        'x' to Hint("˜", "dấu ngã"),
+        'j' to Hint("̣", "dấu nặng"),
+        'z' to Hint("×", "xóa dấu"),
+    )
+
+    fun hint(character: Char): Hint? = ByCharacter[character.lowercaseChar()]
+
+    fun accessibilityLabel(character: Char): String? {
+        val hint = hint(character) ?: return null
+        return "${character.uppercaseChar()}, ${hint.description}"
+    }
+}

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/ToolbarGeometry.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/ToolbarGeometry.kt
@@ -4,19 +4,27 @@ import app.funput.funput.keyboard.model.KeyboardLayout
 
 /** Places optional toolbar actions before the higher-priority Settings and Emoji keys. */
 internal object ToolbarGeometry {
+    /**
+     * Resolves toolbar bounds.
+     *
+     * When [showSettings] is false (suggestions present), Settings yields so the suggestion
+     * region can extend to the emoji key — matching iOS utility-key arbitration.
+     */
     fun resolve(
         layout: KeyboardLayout,
         width: Float,
         spec: KeyboardGeometrySpec,
+        showSettings: Boolean = true,
     ): ResolvedSuggestionBar? {
         val bar = layout.suggestionBar ?: return null
         val top = spec.verticalPadding
         val bottom = top + spec.suggestionBarHeight
         val right = width - spec.horizontalPadding
         val emoji = boundsBefore(right, top, bottom, spec, separated = false)
-        val settings = boundsBefore(emoji.left, top, bottom, spec)
-        val system = bar.systemInputMethodKey?.let { boundsBefore(settings.left, top, bottom, spec) }
-        val controlsLeft = system?.left ?: settings.left
+        val settings = if (showSettings) boundsBefore(emoji.left, top, bottom, spec) else null
+        val systemAnchor = settings?.left ?: emoji.left
+        val system = bar.systemInputMethodKey?.let { boundsBefore(systemAnchor, top, bottom, spec) }
+        val controlsLeft = system?.left ?: settings?.left ?: emoji.left
         val logoSize = spec.suggestionBarHeight * ToolbarBrandMetrics.LogoSizeRatio
         val logoTop = top + (spec.suggestionBarHeight - logoSize) / 2f
         val logo = KeyBounds(spec.horizontalPadding, logoTop, spec.horizontalPadding + logoSize, logoTop + logoSize)
@@ -27,7 +35,7 @@ internal object ToolbarGeometry {
             logoBounds = logo,
             suggestionsBounds = KeyBounds(suggestionsLeft, top, suggestionsRight, bottom),
             systemInputMethodKey = system?.let { ResolvedKey(requireNotNull(bar.systemInputMethodKey), it) },
-            settingsKey = ResolvedKey(bar.settingsKey, settings),
+            settingsKey = settings?.let { ResolvedKey(bar.settingsKey, it) },
             emojiKey = ResolvedKey(bar.emojiKey, emoji),
             suggestionsEnabled = bar.suggestionsEnabled,
         )

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/TopNumberRow.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/TopNumberRow.kt
@@ -12,9 +12,10 @@ internal enum class TopNumberRowMode {
 }
 
 internal fun topNumberRowForLetters(inputMethod: KeyboardInputMethod): KeyboardRow {
-    val mode = when (inputMethod) {
-        KeyboardInputMethod.VNI -> TopNumberRowMode.VNI_MODIFIERS
-        KeyboardInputMethod.TELEX -> TopNumberRowMode.PLAIN_CHARACTER
+    val mode = if (inputMethod.isTelexFamily) {
+        TopNumberRowMode.PLAIN_CHARACTER
+    } else {
+        TopNumberRowMode.VNI_MODIFIERS
     }
     return topNumberRow(mode, pageId = "letters-${inputMethod.name.lowercase()}")
 }

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/symbols/CompactSymbolLayouts.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/symbols/CompactSymbolLayouts.kt
@@ -1,0 +1,118 @@
+package app.funput.funput.keyboard.layout.symbols
+
+import app.funput.funput.keyboard.KeyboardFeatures
+import app.funput.funput.keyboard.layout.TopNumberRowMode
+import app.funput.funput.keyboard.layout.specialKey
+import app.funput.funput.keyboard.layout.standardSpaceKey
+import app.funput.funput.keyboard.layout.topNumberRow
+import app.funput.funput.keyboard.model.KeyRole
+import app.funput.funput.keyboard.model.KeySpec
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+import app.funput.funput.keyboard.model.KeyboardLayout
+import app.funput.funput.keyboard.model.KeyboardRow
+import app.funput.funput.keyboard.model.SuggestionBarSpec
+
+/** Four-row symbol pages used when Telex-family letters hide the number row. */
+internal object CompactSymbolLayouts {
+    fun primary(
+        inputMethod: KeyboardInputMethod,
+        suggestionsEnabled: Boolean = KeyboardFeatures.SuggestionsEnabled,
+    ): KeyboardLayout = create(
+        id = "symbols-primary-${inputMethod.name.lowercase()}-compact",
+        inputMethod = inputMethod,
+        suggestionsEnabled = suggestionsEnabled,
+        rows = listOf(
+            topNumberRow(TopNumberRowMode.PLAIN_PUNCTUATION, pageId = "compact-primary"),
+            symbolRow("compact-primary", CompactSymbolPageContent.primaryMiddle),
+            bottomRow(
+                page = "compact-primary",
+                switchRole = KeyRole.MORE_SYMBOLS,
+                switchLabel = "=\\<",
+                symbols = CompactSymbolPageContent.primaryBottom,
+            ),
+            actionRow("compact-primary"),
+        ),
+    )
+
+    fun secondary(
+        inputMethod: KeyboardInputMethod,
+        suggestionsEnabled: Boolean = KeyboardFeatures.SuggestionsEnabled,
+    ): KeyboardLayout = create(
+        id = "symbols-secondary-${inputMethod.name.lowercase()}-compact",
+        inputMethod = inputMethod,
+        suggestionsEnabled = suggestionsEnabled,
+        rows = listOf(
+            symbolRow("compact-secondary-top", CompactSymbolPageContent.secondaryTop),
+            symbolRow("compact-secondary-middle", CompactSymbolPageContent.secondaryMiddle),
+            bottomRow(
+                page = "compact-secondary",
+                switchRole = KeyRole.SYMBOLS,
+                switchLabel = "?123",
+                symbols = CompactSymbolPageContent.secondaryBottom,
+            ),
+            actionRow("compact-secondary"),
+        ),
+    )
+
+    private fun create(
+        id: String,
+        inputMethod: KeyboardInputMethod,
+        suggestionsEnabled: Boolean,
+        rows: List<KeyboardRow>,
+    ) = KeyboardLayout(
+        id = id + suggestionSuffix(suggestionsEnabled),
+        inputMethod = inputMethod,
+        suggestionBar = SuggestionBarSpec(
+            settingsKey = specialKey("settings-$id", "", KeyRole.SETTINGS, accessibilityLabel = "Settings"),
+            emojiKey = specialKey("emoji-$id", "", KeyRole.EMOJI, accessibilityLabel = "Emoji"),
+            suggestionsEnabled = KeyboardFeatures.SuggestionsEnabled && suggestionsEnabled,
+        ).takeIf { KeyboardFeatures.EmojiToolbarEnabled },
+        rows = rows,
+    )
+
+    private fun symbolRow(page: String, labels: List<String>) = KeyboardRow(
+        keys = labels.mapIndexed { index, label ->
+            KeySpec(
+                id = "symbol-$page-$index",
+                label = label,
+                role = KeyRole.PUNCTUATION,
+                accessibilityLabel = label,
+            )
+        },
+    )
+
+    private fun bottomRow(
+        page: String,
+        switchRole: KeyRole,
+        switchLabel: String,
+        symbols: List<String>,
+    ) = KeyboardRow(
+        keys = buildList {
+            add(specialKey("switch-$page", switchLabel, switchRole, 1.5f, "Switch symbol page"))
+            addAll(
+                symbols.mapIndexed { index, label ->
+                    KeySpec(
+                        id = "symbol-$page-bottom-$index",
+                        label = label,
+                        role = KeyRole.PUNCTUATION,
+                        accessibilityLabel = label,
+                    )
+                },
+            )
+            add(specialKey("backspace-$page", "", KeyRole.BACKSPACE, 1.5f, "Backspace"))
+        },
+    )
+
+    private fun actionRow(page: String) = KeyboardRow(
+        keys = listOf(
+            specialKey("letters-$page", "ABC", KeyRole.LETTERS, 1.7f, "Letters"),
+            specialKey("comma-$page", ",", KeyRole.PUNCTUATION),
+            standardSpaceKey(),
+            specialKey("period-$page", ".", KeyRole.PUNCTUATION),
+            specialKey("enter-$page", "", KeyRole.ENTER, 1.7f, "Enter"),
+        ),
+    )
+
+    private fun suggestionSuffix(suggestionsEnabled: Boolean): String =
+        if (!KeyboardFeatures.SuggestionsEnabled || !suggestionsEnabled) "-no-suggestions" else ""
+}

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/symbols/CompactSymbolPageContent.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/symbols/CompactSymbolPageContent.kt
@@ -1,0 +1,10 @@
+package app.funput.funput.keyboard.layout.symbols
+
+/** Symbol labels for Telex compact layouts, mirrored from iOS CompactSymbolPageContent. */
+internal object CompactSymbolPageContent {
+    val primaryMiddle = listOf("@", "#", "₫", "$", "%", "&", "*", "+", "=", "/")
+    val primaryBottom = listOf("(", ")", "-", "_", ":", "!", "?")
+    val secondaryTop = listOf(";", "'", "\"", "~", "•", "…", "°", "×", "÷", "^")
+    val secondaryMiddle = listOf("[", "]", "{", "}", "<", ">", "\\", "|", "`", "€")
+    val secondaryBottom = listOf("£", "¥", "©", "≠", "±", "≤", "≥")
+}

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/model/KeyboardInputMethod.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/model/KeyboardInputMethod.kt
@@ -2,5 +2,11 @@ package app.funput.funput.keyboard.model
 
 enum class KeyboardInputMethod {
     TELEX,
+    TELEX_ADVANCED,
     VNI,
+
+    ;
+
+    val isTelexFamily: Boolean
+        get() = this != VNI
 }

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/surface/KeyboardSurfaceLayoutState.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/surface/KeyboardSurfaceLayoutState.kt
@@ -45,6 +45,12 @@ internal class KeyboardSurfaceLayoutState(private val onLayoutChanged: () -> Uni
             field = value
             refresh()
         }
+    var showsNumberRow = true
+        set(value) {
+            if (field == value) return
+            field = value
+            refresh()
+        }
 
     var layout: KeyboardLayout = resolve()
         private set
@@ -60,5 +66,6 @@ internal class KeyboardSurfaceLayoutState(private val onLayoutChanged: () -> Uni
         editorMode = editorMode,
         suggestionsEnabled = suggestionsEnabled,
         systemInputMethodSwitcherVisible = systemInputMethodSwitcherVisible,
+        showsNumberRow = showsNumberRow,
     )
 }

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/KeyboardSurfaceSuggestionStateTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/KeyboardSurfaceSuggestionStateTest.kt
@@ -1,0 +1,105 @@
+package app.funput.funput.keyboard
+
+import app.funput.funput.keyboard.layout.KeyBounds
+import app.funput.funput.keyboard.layout.ResolvedKeyboard
+import app.funput.funput.keyboard.layout.ResolvedSuggestionBar
+import app.funput.funput.keyboard.layout.ResolvedKey
+import app.funput.funput.keyboard.model.KeyRole
+import app.funput.funput.keyboard.model.KeySpec
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KeyboardSurfaceSuggestionStateTest {
+    @Test
+    fun emptyToNonEmptyFlipsShowSettingsAndRebuildsGeometry() {
+        var geometryRebuilds = 0
+        var applied = emptyList<String>()
+        var keyboard = keyboardWithSuggestionsWidth(500f)
+        val state = KeyboardSurfaceSuggestionState(
+            density = { 1f },
+            keyboard = { keyboard },
+            apply = { applied = it },
+            onShowSettingsChanged = {
+                geometryRebuilds += 1
+                keyboard = keyboardWithSuggestionsWidth(700f)
+                // Mimic KeyboardSurfaceView.resolveGeometry -> geometryChanged.
+            },
+        )
+
+        assertTrue(state.showSettings)
+        state.update(listOf("xin", "chào"))
+        // Caller must invoke geometryChanged after rebuild, same as the surface view.
+        state.geometryChanged()
+
+        assertFalse(state.showSettings)
+        assertEquals(1, geometryRebuilds)
+        assertEquals(listOf("xin", "chào"), applied)
+    }
+
+    @Test
+    fun sameVisibilityOnlyRefreshesCandidates() {
+        var geometryRebuilds = 0
+        var applied = emptyList<String>()
+        val state = KeyboardSurfaceSuggestionState(
+            density = { 1f },
+            keyboard = { keyboardWithSuggestionsWidth(900f) },
+            apply = { applied = it },
+            onShowSettingsChanged = { geometryRebuilds += 1 },
+        )
+
+        state.update(listOf("a", "b"))
+        state.geometryChanged()
+        state.update(listOf("a", "b", "c"))
+
+        assertEquals(1, geometryRebuilds)
+        assertFalse(state.showSettings)
+        assertEquals(listOf("a", "b", "c"), applied)
+    }
+
+    @Test
+    fun clearingCandidatesShowsSettingsAgain() {
+        var geometryRebuilds = 0
+        val state = KeyboardSurfaceSuggestionState(
+            density = { 3f },
+            keyboard = { keyboardWithSuggestionsWidth(500f) },
+            apply = {},
+            onShowSettingsChanged = { geometryRebuilds += 1 },
+        )
+
+        state.update(listOf("xin"))
+        state.update(emptyList())
+
+        assertTrue(state.showSettings)
+        assertEquals(2, geometryRebuilds)
+    }
+
+    private fun keyboardWithSuggestionsWidth(width: Float): ResolvedKeyboard {
+        val emoji = ResolvedKey(
+            KeySpec("emoji", "", KeyRole.EMOJI, accessibilityLabel = "Emoji"),
+            KeyBounds(900f, 0f, 1000f, 100f),
+        )
+        return ResolvedKeyboard(
+            width = 1080f,
+            height = 700f,
+            suggestionBar = ResolvedSuggestionBar(
+                bounds = KeyBounds(0f, 0f, 1080f, 100f),
+                logoBounds = KeyBounds(0f, 0f, 80f, 80f),
+                suggestionsBounds = KeyBounds(90f, 0f, 90f + width, 100f),
+                systemInputMethodKey = null,
+                settingsKey = null,
+                emojiKey = emoji,
+                suggestionsEnabled = true,
+            ),
+            rows = listOf(
+                listOf(
+                    ResolvedKey(
+                        KeySpec("character-a", "a", KeyRole.CHARACTER),
+                        KeyBounds(0f, 120f, 100f, 220f),
+                    ),
+                ),
+            ),
+        )
+    }
+}

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/interaction/KeyboardInteractionTargetsTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/interaction/KeyboardInteractionTargetsTest.kt
@@ -8,6 +8,7 @@ import app.funput.funput.keyboard.model.KeyboardInputMethod
 import app.funput.funput.keyboard.model.SuggestionSelection
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class KeyboardInteractionTargetsTest {
@@ -71,11 +72,39 @@ class KeyboardInteractionTargetsTest {
 
     @Test
     fun settingsStillResolvesAsAKeyTarget() {
-        val settings = requireNotNull(keyboard.suggestionBar).settingsKey
+        val settings = requireNotNull(requireNotNull(keyboard.suggestionBar).settingsKey)
 
         assertEquals(
             settings.spec.id,
-            keyboard.interactionTargetAt(settings.bounds.centerX, settings.bounds.centerY, SuggestionCount),
+            keyboard.interactionTargetAt(settings.bounds.centerX, settings.bounds.centerY, suggestionCount = 0),
+        )
+    }
+
+    @Test
+    fun settingsYieldsWhenSuggestionsArePresent() {
+        val yielded = KeyboardGeometry.resolve(
+            layout = qwertyLayout(
+                id = "test-suggestions",
+                inputMethod = KeyboardInputMethod.TELEX,
+                actionKeys = KeyboardLayouts.telex.rows.last().keys,
+                showSuggestionBar = true,
+            ).copy(
+                suggestionBar = requireNotNull(KeyboardLayouts.telex.suggestionBar).copy(
+                    suggestionsEnabled = true,
+                ),
+            ),
+            width = 1080f,
+            height = 726f,
+            spec = spec,
+            showSettings = false,
+        )
+        val bar = requireNotNull(yielded.suggestionBar)
+
+        assertNull(bar.settingsKey)
+        assertTrue(bar.suggestionsBounds.right > requireNotNull(keyboard.suggestionBar).suggestionsBounds.right)
+        assertEquals(
+            bar.emojiKey.spec.id,
+            yielded.interactionTargetAt(bar.emojiKey.bounds.centerX, bar.emojiKey.bounds.centerY, SuggestionCount),
         )
     }
 

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/KeyboardGeometryTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/KeyboardGeometryTest.kt
@@ -93,16 +93,17 @@ class KeyboardGeometryTest {
             spec = spec,
         )
         val suggestionBar = requireNotNull(keyboard.suggestionBar)
+        val settings = requireNotNull(suggestionBar.settingsKey)
 
-        assertEquals("settings", suggestionBar.settingsKey.spec.id)
+        assertEquals("settings", settings.spec.id)
         assertEquals("emoji", suggestionBar.emojiKey.spec.id)
         assertTrue(suggestionBar.logoBounds.width > 0f)
         assertTrue(suggestionBar.suggestionsBounds.left > suggestionBar.logoBounds.right)
-        assertTrue(suggestionBar.suggestionsBounds.right < suggestionBar.settingsKey.bounds.left)
-        assertTrue(suggestionBar.settingsKey.bounds.right < suggestionBar.emojiKey.bounds.left)
+        assertTrue(suggestionBar.suggestionsBounds.right < settings.bounds.left)
+        assertTrue(settings.bounds.right < suggestionBar.emojiKey.bounds.left)
         assertEquals(
-            suggestionBar.settingsKey,
-            keyboard.keyAt(suggestionBar.settingsKey.bounds.centerX, suggestionBar.settingsKey.bounds.centerY),
+            settings,
+            keyboard.keyAt(settings.bounds.centerX, settings.bounds.centerY),
         )
         assertEquals(
             suggestionBar.emojiKey,

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/KeyboardHitTesterTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/KeyboardHitTesterTest.kt
@@ -82,11 +82,12 @@ class KeyboardHitTesterTest {
     @Test
     fun settingsTargetAbsorbsGapBetweenSuggestionsAndEmoji() {
         val bar = requireNotNull(keyboardWithSuggestions.suggestionBar)
-        val midpoint = (bar.suggestionsBounds.right + bar.settingsKey.bounds.left) / 2f
+        val settings = requireNotNull(bar.settingsKey)
+        val midpoint = (bar.suggestionsBounds.right + settings.bounds.left) / 2f
 
         assertNull(keyboardWithSuggestions.keyAt(midpoint - TestOffset, bar.bounds.centerY))
         assertEquals(
-            bar.settingsKey,
+            settings,
             keyboardWithSuggestions.keyAt(midpoint + TestOffset, bar.bounds.centerY),
         )
     }
@@ -94,10 +95,11 @@ class KeyboardHitTesterTest {
     @Test
     fun emojiTargetAbsorbsItsAdjacentGap() {
         val bar = requireNotNull(keyboardWithSuggestions.suggestionBar)
-        val midpoint = (bar.settingsKey.bounds.right + bar.emojiKey.bounds.left) / 2f
+        val settings = requireNotNull(bar.settingsKey)
+        val midpoint = (settings.bounds.right + bar.emojiKey.bounds.left) / 2f
 
         assertEquals(
-            bar.settingsKey,
+            settings,
             keyboardWithSuggestions.keyAt(midpoint - TestOffset, bar.bounds.centerY),
         )
         assertEquals(

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/KeyboardLayoutsTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/KeyboardLayoutsTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 
 class KeyboardLayoutsTest {
     @Test
-    fun bothInputMethodsUseFiveRows() {
+    fun allInputMethodsUseFiveRows() {
         KeyboardInputMethod.entries.forEach { inputMethod ->
             val layout = KeyboardLayouts.forInputMethod(inputMethod)
             assertEquals(5, layout.rows.size)
@@ -24,6 +24,16 @@ class KeyboardLayoutsTest {
         assertEquals("1234567890", topRow.keys.joinToString("") { key -> key.label })
         assertTrue(topRow.keys.all { key -> key.role == KeyRole.CHARACTER })
         assertTrue(topRow.keys.all { key -> key.secondaryLabel == null })
+    }
+
+    @Test
+    fun advancedTelexUsesItsOwnIdentityAndPlainDigits() {
+        val layout = KeyboardLayouts.forInputMethod(KeyboardInputMethod.TELEX_ADVANCED)
+
+        assertEquals("qwerty-telex-advanced", layout.id)
+        assertEquals(KeyboardInputMethod.TELEX_ADVANCED, layout.inputMethod)
+        assertEquals("1234567890", layout.rows.first().keys.joinToString("") { key -> key.label })
+        assertTrue(layout.rows.first().keys.all { key -> key.role == KeyRole.CHARACTER })
     }
 
     @Test

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/KeyboardLayoutsTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/KeyboardLayoutsTest.kt
@@ -53,16 +53,6 @@ class KeyboardLayoutsTest {
     }
 
     @Test
-    fun letterKeysDoNotShowSecondaryHints() {
-        val keys = KeyboardLayouts.forInputMethod(KeyboardInputMethod.TELEX)
-            .rows
-            .flatMap { row -> row.keys }
-            .filter { key -> key.role == KeyRole.CHARACTER && key.label.length == 1 && key.label[0].isLetter() }
-
-        assertTrue(keys.none { key -> key.secondaryLabel != null })
-    }
-
-    @Test
     fun everyLayoutUsesStableUniqueKeyIds() {
         KeyboardInputMethod.entries.forEach { inputMethod ->
             val layout = KeyboardLayouts.forInputMethod(inputMethod)

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/NumberRowLayoutTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/NumberRowLayoutTest.kt
@@ -1,0 +1,81 @@
+package app.funput.funput.keyboard.layout
+
+import app.funput.funput.keyboard.KeyboardDimensions
+import app.funput.funput.keyboard.model.KeyboardEditorMode
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+import app.funput.funput.keyboard.model.KeyboardLayoutMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NumberRowLayoutTest {
+    @Test
+    fun telexCompactLettersOmitNumberRow() {
+        val layout = KeyboardLayouts.forInputMethod(KeyboardInputMethod.TELEX, showsNumberRow = false)
+
+        assertEquals("qwerty-telex-compact", layout.id)
+        assertEquals(4, layout.rows.size)
+        assertFalse(layout.rows.first().keys.all { it.label.first().isDigit() })
+    }
+
+    @Test
+    fun advancedTelexCompactMatchesTelexShape() {
+        val layout = KeyboardLayouts.forInputMethod(
+            KeyboardInputMethod.TELEX_ADVANCED,
+            showsNumberRow = false,
+        )
+
+        assertEquals("qwerty-telex-advanced-compact", layout.id)
+        assertEquals(4, layout.rows.size)
+    }
+
+    @Test
+    fun vniAlwaysKeepsNumberRow() {
+        val layout = KeyboardLayouts.forInputMethod(KeyboardInputMethod.VNI, showsNumberRow = false)
+
+        assertEquals("qwerty-vni", layout.id)
+        assertEquals(5, layout.rows.size)
+        assertTrue(layout.rows.first().keys.all { it.label.first().isDigit() })
+    }
+
+    @Test
+    fun resolverUsesCompactSymbolsForTelexTextWithoutNumberRow() {
+        val layout = KeyboardLayoutResolver.resolve(
+            inputMethod = KeyboardInputMethod.TELEX,
+            mode = KeyboardLayoutMode.SYMBOLS_PRIMARY,
+            editorMode = KeyboardEditorMode.TEXT,
+            showsNumberRow = false,
+        )
+
+        assertTrue(layout.id.contains("compact"))
+        assertEquals(4, layout.rows.size)
+    }
+
+    @Test
+    fun resolverKeepsFullSymbolsWhenNumberRowShown() {
+        val layout = KeyboardLayoutResolver.resolve(
+            inputMethod = KeyboardInputMethod.TELEX,
+            mode = KeyboardLayoutMode.SYMBOLS_PRIMARY,
+            editorMode = KeyboardEditorMode.TEXT,
+            showsNumberRow = true,
+        )
+
+        assertFalse(layout.id.contains("compact"))
+        assertEquals(5, layout.rows.size)
+    }
+
+    @Test
+    fun compactHeightIsShorterThanFullTelexHeight() {
+        val compact = KeyboardDimensions.recommendedHeightDp(
+            KeyboardInputMethod.TELEX,
+            showsNumberRow = false,
+        )
+        val full = KeyboardDimensions.recommendedHeightDp(
+            KeyboardInputMethod.TELEX,
+            showsNumberRow = true,
+        )
+
+        assertTrue(compact < full)
+    }
+}

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/SystemInputMethodSwitcherTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/SystemInputMethodSwitcherTest.kt
@@ -64,8 +64,8 @@ class SystemInputMethodSwitcherTest {
         val bar = requireNotNull(keyboard.suggestionBar)
         val system = requireNotNull(bar.systemInputMethodKey)
 
-        assertTrue(system.bounds.right < bar.settingsKey.bounds.left)
-        assertTrue(bar.settingsKey.bounds.right < bar.emojiKey.bounds.left)
+        assertTrue(system.bounds.right < requireNotNull(bar.settingsKey).bounds.left)
+        assertTrue(requireNotNull(bar.settingsKey).bounds.right < bar.emojiKey.bounds.left)
     }
 
     private fun resolve(

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/TelexKeyHintsTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/TelexKeyHintsTest.kt
@@ -1,0 +1,32 @@
+package app.funput.funput.keyboard.layout
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TelexKeyHintsTest {
+    @Test
+    fun toneKeysExposeStableGlyphsAndAccessibility() {
+        val expected = mapOf(
+            's' to ("´" to "S, dấu sắc"),
+            'f' to ("`" to "F, dấu huyền"),
+            'r' to ("̉" to "R, dấu hỏi"),
+            'x' to ("˜" to "X, dấu ngã"),
+            'j' to ("̣" to "J, dấu nặng"),
+            'z' to ("×" to "Z, xóa dấu"),
+        )
+
+        expected.forEach { (character, glyphAndLabel) ->
+            val (glyph, label) = glyphAndLabel
+            assertEquals(glyph, TelexKeyHints.hint(character)?.glyph)
+            assertEquals(label, TelexKeyHints.accessibilityLabel(character))
+        }
+    }
+
+    @Test
+    fun nonToneLettersHaveNoHint() {
+        assertNull(TelexKeyHints.hint('a'))
+        assertNull(TelexKeyHints.hint('w'))
+        assertNull(TelexKeyHints.accessibilityLabel('d'))
+    }
+}

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/TelexToneHintsLayoutTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/TelexToneHintsLayoutTest.kt
@@ -1,0 +1,95 @@
+package app.funput.funput.keyboard.layout
+
+import app.funput.funput.keyboard.model.KeyRole
+import app.funput.funput.keyboard.model.KeyboardEditorMode
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+import app.funput.funput.keyboard.model.KeyboardLayoutMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TelexToneHintsLayoutTest {
+    private val expectedHints = mapOf(
+        "s" to "´",
+        "f" to "`",
+        "r" to "̉",
+        "x" to "˜",
+        "j" to "̣",
+        "z" to "×",
+    )
+
+    @Test
+    fun telexLettersExposeToneHintsWithoutChangingSemantics() {
+        assertToneHints(KeyboardLayouts.forInputMethod(KeyboardInputMethod.TELEX))
+    }
+
+    @Test
+    fun advancedTelexMatchesTelexToneHints() {
+        assertToneHints(KeyboardLayouts.forInputMethod(KeyboardInputMethod.TELEX_ADVANCED))
+    }
+
+    @Test
+    fun compactTelexStillShowsToneHints() {
+        assertToneHints(
+            KeyboardLayouts.forInputMethod(KeyboardInputMethod.TELEX, showsNumberRow = false),
+        )
+    }
+
+    @Test
+    fun vniLettersDoNotShowToneHints() {
+        val letterKeys = letterKeys(KeyboardLayouts.forInputMethod(KeyboardInputMethod.VNI))
+
+        assertTrue(letterKeys.none { it.secondaryLabel != null })
+        assertTrue(
+            KeyboardLayouts.forInputMethod(KeyboardInputMethod.VNI).rows.first()
+                .keys.all { it.secondaryLabel != null },
+        )
+    }
+
+    @Test
+    fun specializedEditorsHideTelexHints() {
+        listOf(
+            KeyboardEditorMode.SEARCH,
+            KeyboardEditorMode.EMAIL,
+            KeyboardEditorMode.URL,
+            KeyboardEditorMode.PASSWORD,
+        ).forEach { editorMode ->
+            val layout = KeyboardLayoutResolver.resolve(
+                inputMethod = KeyboardInputMethod.TELEX,
+                mode = KeyboardLayoutMode.LETTERS,
+                editorMode = editorMode,
+            )
+            assertTrue(
+                "$editorMode",
+                letterKeys(layout).none { it.secondaryLabel != null },
+            )
+        }
+    }
+
+    private fun assertToneHints(layout: app.funput.funput.keyboard.model.KeyboardLayout) {
+        val letterKeys = letterKeys(layout)
+        val hinted = letterKeys
+            .filter { it.secondaryLabel != null }
+            .associate { it.label to it.secondaryLabel }
+
+        assertEquals(expectedHints, hinted)
+        letterKeys.filter { it.label in expectedHints }.forEach { key ->
+            assertEquals(KeyRole.CHARACTER, key.role)
+            assertEquals(1f, key.widthWeight)
+            assertEquals("character-${key.label}", key.id)
+            assertEquals(
+                TelexKeyHints.accessibilityLabel(key.label.single()),
+                key.accessibilityLabel,
+            )
+        }
+        letterKeys.filter { it.label !in expectedHints }.forEach { key ->
+            assertNull(key.secondaryLabel)
+        }
+    }
+
+    private fun letterKeys(layout: app.funput.funput.keyboard.model.KeyboardLayout) =
+        layout.rows.flatMap { it.keys }.filter { key ->
+            key.role == KeyRole.CHARACTER && key.label.length == 1 && key.label[0].isLetter()
+        }
+}

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/ToolbarSettingsYieldTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/ToolbarSettingsYieldTest.kt
@@ -1,0 +1,53 @@
+package app.funput.funput.keyboard.layout
+
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ToolbarSettingsYieldTest {
+    private val spec = KeyboardGeometrySpec(
+        horizontalPadding = 21f,
+        verticalPadding = 24f,
+        horizontalGap = 0f,
+        verticalGap = 0f,
+        horizontalGapRatio = 0.11f,
+        verticalGapRatio = 0.16f,
+        keyAspectRatio = 0.75f,
+        suggestionBarHeight = 126f,
+        suggestionBarGap = 18f,
+    )
+
+    @Test
+    fun hidingSettingsWidensSuggestionRegionToEmoji() {
+        val withSettings = resolve(showSettings = true)
+        val withoutSettings = resolve(showSettings = false)
+        val shown = requireNotNull(withSettings.suggestionBar)
+        val yielded = requireNotNull(withoutSettings.suggestionBar)
+
+        assertNotNull(shown.settingsKey)
+        assertNull(yielded.settingsKey)
+        assertTrue(yielded.suggestionsBounds.width > shown.suggestionsBounds.width)
+        assertEquals(shown.emojiKey.bounds, yielded.emojiKey.bounds)
+        assertTrue(yielded.suggestionsBounds.right < yielded.emojiKey.bounds.left)
+    }
+
+    @Test
+    fun showingSettingsKeepsSettingsBeforeEmoji() {
+        val bar = requireNotNull(resolve(showSettings = true).suggestionBar)
+        val settings = requireNotNull(bar.settingsKey)
+
+        assertTrue(bar.suggestionsBounds.right < settings.bounds.left)
+        assertTrue(settings.bounds.right < bar.emojiKey.bounds.left)
+    }
+
+    private fun resolve(showSettings: Boolean) = KeyboardGeometry.resolve(
+        layout = KeyboardLayouts.forInputMethod(KeyboardInputMethod.TELEX),
+        width = 1080f,
+        height = 726f,
+        spec = spec,
+        showSettings = showSettings,
+    )
+}

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/model/KeyboardInputMethodTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/model/KeyboardInputMethodTest.kt
@@ -1,0 +1,27 @@
+package app.funput.funput.keyboard.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KeyboardInputMethodTest {
+    @Test
+    fun `methods keep stable settings order`() {
+        assertEquals(
+            listOf(
+                KeyboardInputMethod.TELEX,
+                KeyboardInputMethod.TELEX_ADVANCED,
+                KeyboardInputMethod.VNI,
+            ),
+            KeyboardInputMethod.entries,
+        )
+    }
+
+    @Test
+    fun `advanced and standard Telex share a family`() {
+        assertTrue(KeyboardInputMethod.TELEX.isTelexFamily)
+        assertTrue(KeyboardInputMethod.TELEX_ADVANCED.isTelexFamily)
+        assertFalse(KeyboardInputMethod.VNI.isTelexFamily)
+    }
+}

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/FunputKeyboardView.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/FunputKeyboardView.kt
@@ -33,6 +33,7 @@ class FunputKeyboardView @JvmOverloads constructor(
     var inputMethod: KeyboardInputMethod by keyboardSurface::inputMethod
     var editorMode: KeyboardEditorMode by keyboardSurface::editorMode
     var systemInputMethodSwitcherVisible: Boolean by keyboardSurface::systemInputMethodSwitcherVisible
+    var showsNumberRow: Boolean by keyboardSurface::showsNumberRow
     var suggestionBarEnabled: Boolean
         get() = keyboardSurface.suggestionBarEnabled
         set(value) {
@@ -102,11 +103,9 @@ class FunputKeyboardView @JvmOverloads constructor(
         val density = resources.displayMetrics.density
         val keyboardWidth = (KeyboardDimensions.DefaultWidthDp * density).roundToInt()
         val width = resolveSize(keyboardWidth + safeArea.horizontalInset, widthMeasureSpec)
+        val contentWidthDp = (width - safeArea.horizontalInset) / density
         val heightDp = KeyboardDimensions.recommendedHeightDp(
-            inputMethod = inputMethod,
-            editorMode = editorMode,
-            profile = sizingProfile,
-            widthDp = (width - safeArea.horizontalInset) / density,
+            inputMethod, editorMode, sizingProfile, contentWidthDp, showsNumberRow,
         )
         val height = resolveSize((heightDp * density).roundToInt() + safeArea.bottomInset, heightMeasureSpec)
         super.onMeasure(


### PR DESCRIPTION
- Introduced `TELEX_ADVANCED` as a new input method alongside existing Telex and VNI.
- Updated configuration and settings to accommodate the new input method, including UI changes for method selection.
- Enhanced composition handling to support advanced Telex shortcuts and boundaries.
- Added tests for advanced Telex functionality, ensuring correct behavior in various scenarios.
- Updated documentation to reflect changes in input method options and usage.