### PR TITLE
fix(android): type Vietnamese in ONLYOFFICE via key-event committed buffer

### DIFF
--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CommittedBufferWriter.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CommittedBufferWriter.kt
@@ -1,0 +1,61 @@
+package app.funput.funput.ime.editing
+
+import android.view.KeyEvent
+import android.view.inputmethod.InputConnection
+
+/**
+ * Writes the engine buffer into editors that cannot host composing spans.
+ *
+ * Prefer appending/shrinking the committed prefix so broken hosts that ignore
+ * [InputConnection.deleteSurroundingText] do not duplicate characters. Full
+ * replacements (tone transforms) still delete then commit.
+ */
+internal class CommittedBufferWriter {
+    fun replace(
+        connection: InputConnection,
+        previous: String,
+        replacement: String,
+        deleteWithKeyEvents: Boolean,
+    ): Boolean {
+        connection.beginBatchEdit()
+        return try {
+            when {
+                previous == replacement -> true
+                previous.isEmpty() -> commit(connection, replacement)
+                replacement.startsWith(previous) ->
+                    commit(connection, replacement.substring(previous.length))
+                previous.startsWith(replacement) ->
+                    deleteBefore(connection, previous.length - replacement.length, deleteWithKeyEvents)
+                else -> {
+                    deleteBefore(connection, previous.length, deleteWithKeyEvents) &&
+                        commit(connection, replacement)
+                }
+            }
+        } finally {
+            connection.endBatchEdit()
+        }
+    }
+
+    private fun commit(connection: InputConnection, text: String): Boolean =
+        text.isEmpty() || connection.commitText(text, CursorAfterText)
+
+    private fun deleteBefore(
+        connection: InputConnection,
+        count: Int,
+        deleteWithKeyEvents: Boolean,
+    ): Boolean {
+        if (count <= 0) return true
+        if (deleteWithKeyEvents) {
+            repeat(count) {
+                connection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL))
+                connection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_DEL))
+            }
+            return true
+        }
+        return connection.deleteSurroundingText(count, 0)
+    }
+
+    private companion object {
+        const val CursorAfterText = 1
+    }
+}

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CompositionCompatibilityPolicy.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CompositionCompatibilityPolicy.kt
@@ -4,7 +4,8 @@ package app.funput.funput.ime.editing
  * Selects editors that need committed buffer replacement instead of composing spans.
  *
  * Prefixes cover release variants such as Firefox Beta, Facebook Lite, Messenger, Instagram,
- * Threads, and Reddit builds without coupling the editing pipeline to individual product names.
+ * Threads, Reddit, and ONLYOFFICE Documents builds without coupling the editing pipeline to
+ * individual product names.
  */
 internal object CompositionCompatibilityPolicy {
     private val committedPackagePrefixes = listOf(
@@ -14,10 +15,15 @@ internal object CompositionCompatibilityPolicy {
         "com.reddit.",
     )
 
-    fun renderMode(packageName: String?): CompositionRenderMode =
-        if (committedPackagePrefixes.any { packageName?.startsWith(it) == true }) {
+    private val keyDeletePackagePrefixes = listOf(
+        "com.onlyoffice.",
+    )
+
+    fun renderMode(packageName: String?): CompositionRenderMode = when {
+        keyDeletePackagePrefixes.any { packageName?.startsWith(it) == true } ->
+            CompositionRenderMode.COMMITTED_KEY_DELETE
+        committedPackagePrefixes.any { packageName?.startsWith(it) == true } ->
             CompositionRenderMode.COMMITTED
-        } else {
-            CompositionRenderMode.COMPOSING
-        }
+        else -> CompositionRenderMode.COMPOSING
+    }
 }

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CompositionDocumentEditor.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CompositionDocumentEditor.kt
@@ -2,20 +2,16 @@ package app.funput.funput.ime.editing
 
 import android.view.inputmethod.InputConnection
 
-internal enum class CompositionRenderMode {
-    COMPOSING,
-    COMMITTED,
-}
-
 /**
  * Applies the engine buffer without exposing host-specific behavior to the engine session.
  *
- * Most editors get Android composing text. Gecko editors get committed replacements because they
- * decorate every composing region themselves, even when the supplied text has no underline span.
+ * Most editors get Android composing text. Broken hosts get committed replacements because they
+ * ignore or decorate composing regions incorrectly.
  */
 internal class CompositionDocumentEditor(
     private val composingTextFactory: (String) -> CharSequence,
 ) {
+    private val committedWriter = CommittedBufferWriter()
     private var committedSelection: Int? = null
     private var expectedCommittedSelection: Int? = null
 
@@ -27,7 +23,9 @@ internal class CompositionDocumentEditor(
     ): Boolean = when (mode) {
         CompositionRenderMode.COMPOSING ->
             connection.setComposingText(composingTextFactory(current), CursorAfterText)
-        CompositionRenderMode.COMMITTED -> replaceBeforeCursor(connection, previous, current)
+        CompositionRenderMode.COMMITTED,
+        CompositionRenderMode.COMMITTED_KEY_DELETE,
+        -> replaceBeforeCursor(connection, mode, previous, current)
     }
 
     fun finish(connection: InputConnection?, mode: CompositionRenderMode, active: Boolean) {
@@ -48,8 +46,10 @@ internal class CompositionDocumentEditor(
                 connection.commitText(boundary, CursorAfterText)
             }
         }
-        CompositionRenderMode.COMMITTED -> {
-            if (replacement != null) replaceBeforeCursor(connection, previous, replacement)
+        CompositionRenderMode.COMMITTED,
+        CompositionRenderMode.COMMITTED_KEY_DELETE,
+        -> {
+            if (replacement != null) replaceBeforeCursor(connection, mode, previous, replacement)
             else {
                 expectCommittedSelection(previousLength = 0, currentLength = boundary.length)
                 connection.commitText(boundary, CursorAfterText)
@@ -65,8 +65,9 @@ internal class CompositionDocumentEditor(
     ): Boolean = when (mode) {
         CompositionRenderMode.COMPOSING ->
             connection.commitText("$candidate ", CursorAfterText)
-        CompositionRenderMode.COMMITTED ->
-            replaceBeforeCursor(connection, prefix, "$candidate ")
+        CompositionRenderMode.COMMITTED,
+        CompositionRenderMode.COMMITTED_KEY_DELETE,
+        -> replaceBeforeCursor(connection, mode, prefix, "$candidate ")
     }
 
     fun reopenWord(
@@ -77,7 +78,9 @@ internal class CompositionDocumentEditor(
         CompositionRenderMode.COMPOSING ->
             connection.deleteSurroundingText(word.length, 0) &&
                 connection.setComposingText(composingTextFactory(word), CursorAfterText)
-        CompositionRenderMode.COMMITTED -> true.also {
+        CompositionRenderMode.COMMITTED,
+        CompositionRenderMode.COMMITTED_KEY_DELETE,
+        -> true.also {
             committedSelection = null
             expectedCommittedSelection = null
         }
@@ -93,27 +96,24 @@ internal class CompositionDocumentEditor(
     ): Boolean = when (mode) {
         CompositionRenderMode.COMPOSING ->
             selectionStart == composingEnd && selectionEnd == composingEnd
-        CompositionRenderMode.COMMITTED -> ownsCommittedSelection(
-            connection,
-            text,
-            selectionStart,
-            selectionEnd,
-        )
+        CompositionRenderMode.COMMITTED,
+        CompositionRenderMode.COMMITTED_KEY_DELETE,
+        -> ownsCommittedSelection(connection, text, selectionStart, selectionEnd)
     }
 
     private fun replaceBeforeCursor(
         connection: InputConnection,
+        mode: CompositionRenderMode,
         previous: String,
         replacement: String,
     ): Boolean {
         expectCommittedSelection(previous.length, replacement.length)
-        connection.beginBatchEdit()
-        return try {
-            val deleted = previous.isEmpty() || connection.deleteSurroundingText(previous.length, 0)
-            deleted && (replacement.isEmpty() || connection.commitText(replacement, CursorAfterText))
-        } finally {
-            connection.endBatchEdit()
-        }
+        return committedWriter.replace(
+            connection,
+            previous,
+            replacement,
+            deleteWithKeyEvents = mode.deleteWithKeyEvents,
+        )
     }
 
     private fun ownsCommittedSelection(

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CompositionRenderMode.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CompositionRenderMode.kt
@@ -1,0 +1,11 @@
+package app.funput.funput.ime.editing
+
+internal enum class CompositionRenderMode {
+    COMPOSING,
+    COMMITTED,
+    /** Like [COMMITTED], but shrink/replace via KEYCODE_DEL (ONLYOFFICE-style hosts). */
+    COMMITTED_KEY_DELETE,
+}
+
+internal val CompositionRenderMode.deleteWithKeyEvents: Boolean
+    get() = this == CompositionRenderMode.COMMITTED_KEY_DELETE

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CommittedBufferWriterTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CommittedBufferWriterTest.kt
@@ -1,0 +1,80 @@
+package app.funput.funput.ime.editing
+
+import android.view.inputmethod.InputConnection
+import java.lang.reflect.Proxy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CommittedBufferWriterTest {
+    @Test
+    fun `prefix growth commits only the suffix`() {
+        val editor = BrokenDeleteEditor()
+        val writer = CommittedBufferWriter()
+
+        assertTrue(writer.replace(editor.proxy, "", "p", deleteWithKeyEvents = false))
+        assertTrue(writer.replace(editor.proxy, "p", "ph", deleteWithKeyEvents = false))
+        assertTrue(writer.replace(editor.proxy, "ph", "phu", deleteWithKeyEvents = false))
+
+        assertEquals("phu", editor.text)
+        assertEquals(0, editor.deleteCalls)
+    }
+
+    @Test
+    fun `tone transform deletes with key events when surrounding delete is ignored`() {
+        val editor = BrokenDeleteEditor()
+        val writer = CommittedBufferWriter()
+
+        writer.replace(editor.proxy, "", "a", deleteWithKeyEvents = true)
+        writer.replace(editor.proxy, "a", "á", deleteWithKeyEvents = true)
+
+        assertEquals("á", editor.text)
+        assertEquals(0, editor.deleteCalls)
+        assertEquals(1, editor.keyDeleteCount)
+    }
+
+    @Test
+    fun `key-delete session types phu without duplication`() {
+        val editor = BrokenDeleteEditor()
+        val engine = ScriptedEngine(ArrayDeque(listOf("p", "ph", "phu")))
+        val session = testSession(engine).apply {
+            setRenderMode(CompositionRenderMode.COMMITTED_KEY_DELETE)
+        }
+
+        "phu".forEach { session.input(editor.proxy, it.toString()) }
+
+        assertEquals("phu", editor.text)
+        assertEquals("phu", session.composingText)
+    }
+}
+
+/** Mimics ONLYOFFICE: deleteSurroundingText returns true but does not remove text. */
+private class BrokenDeleteEditor(var text: String = "") {
+    var deleteCalls = 0
+    var keyDeleteCount = 0
+    private var keyEventCount = 0
+
+    val proxy: InputConnection = Proxy.newProxyInstance(
+        InputConnection::class.java.classLoader,
+        arrayOf(InputConnection::class.java),
+    ) { _, method, arguments ->
+        when (method.name) {
+            "beginBatchEdit", "endBatchEdit" -> true
+            "commitText" -> true.also { text += arguments?.first().toString() }
+            "deleteSurroundingText" -> true.also { deleteCalls += 1 }
+            "sendKeyEvent" -> true.also {
+                // Android stubs block KeyEvent getters; pair DOWN+UP as one delete.
+                keyEventCount += 1
+                if (keyEventCount % 2 == 0) {
+                    keyDeleteCount += 1
+                    if (text.isNotEmpty()) text = text.dropLast(1)
+                }
+            }
+            "getSelectedText" -> null
+            "getTextBeforeCursor" -> null
+            "setComposingText" -> true
+            "toString" -> "BrokenDeleteEditor"
+            else -> false
+        }
+    } as InputConnection
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CompositionCompatibilityPolicyTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CompositionCompatibilityPolicyTest.kt
@@ -28,6 +28,14 @@ class CompositionCompatibilityPolicyTest {
     }
 
     @Test
+    fun `OnlyOffice uses key-event committed composition`() {
+        assertEquals(
+            CompositionRenderMode.COMMITTED_KEY_DELETE,
+            CompositionCompatibilityPolicy.renderMode("com.onlyoffice.documents"),
+        )
+    }
+
+    @Test
     fun `unlisted and missing packages keep native composition`() {
         listOf(null, "com.android.chrome", "com.whatsapp").forEach { packageName ->
             assertEquals(


### PR DESCRIPTION
## Summary
- Route `com.onlyoffice.*` through `CompositionRenderMode.COMMITTED_KEY_DELETE` so Telex/VNI no longer relies on broken composing / `deleteSurroundingText` in the document editor.
- Commit only buffer suffixes when the word grows (avoids duplication like `phu` → `pphu`); shrink/replace with `KEYCODE_DEL` + `commitText` for tone transforms and backspace.
- Keep existing `COMMITTED` hosts (Firefox / Meta / Reddit) on surrounding-text deletes; other apps stay on native composing.
