### PR TITLE
fix(ios): surface the drop counters in the typing harness

### DIFF
--- a/platforms/ios/Funput/App/TypingHarness/Presentation/MetricsSection.swift
+++ b/platforms/ios/Funput/App/TypingHarness/Presentation/MetricsSection.swift
@@ -8,6 +8,10 @@ struct MetricsSection: View {
     var body: some View {
         let value = report.metrics
         Section("Live metrics · #\(report.sequence)") {
+            // First, because it is the only one that means a keystroke the user made and the
+            // document never saw. Everything below is context for why.
+            metric("Abandoned contacts", value.contactsAbandoned)
+            metric("Stale UITouch identity", value.captureStaleIdentity)
             metric("Captured / committed", value.capturedContacts, value.committedContacts)
             metric("Cancelled / system", value.cancelledContacts, value.systemCancelled)
             metric("Recovered slop", value.recoveredTapSlop)


### PR DESCRIPTION
Theo sau [#156](https://github.com/Funput/Funput/pull/156).

`MetricsSection` liệt kê từng field bằng tay, nên `contactsAbandoned` và `captureStaleIdentity` **không hiện trên màn hình** dù `hasRegression` đã tính chúng.

Hậu quả nếu không sửa: chạy harness trên máy thật, thấy báo "regression" mà không có dòng nào giải thích vì sao. Counter tồn tại nhưng không đọc được.

`Abandoned contacts` đặt lên đầu vì nó là dòng duy nhất có nghĩa "người dùng đã gõ một phím mà document không hề nhận". Phần còn lại là bối cảnh.

Sửa 4 dòng, không đụng logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
