### PR TITLE
feat(windows): implement CommittedTail for Backspace retoning functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,7 @@ dependencies = [
 name = "funput-desktop"
 version = "0.1.0"
 dependencies = [
+ "funput-core",
  "funput-engine",
 ]
 

--- a/crates/funput-desktop/Cargo.toml
+++ b/crates/funput-desktop/Cargo.toml
@@ -10,3 +10,8 @@ workspace = true
 
 [dependencies]
 funput-engine = { path = "../funput-engine" }
+
+[dev-dependencies]
+# The retone integration test drives a real engine, and selecting Telex/VNI needs
+# `InputMethod` — a core type the engine takes but does not re-export.
+funput-core = { path = "../funput-core" }

--- a/crates/funput-desktop/src/lib.rs
+++ b/crates/funput-desktop/src/lib.rs
@@ -9,10 +9,16 @@
 //!
 //! Two pure concerns: `key` (what a keystroke means — [`classify`] over a
 //! [`KeyEvent`]) and `inject` (what to emit — [`plan_inject`] into an [`InjectPlan`]).
+//!
+//! `retone` adds the one piece of state such a shell needs: a [`CommittedTail`]
+//! shadow of the text it has typed, which stands in for the document it cannot read
+//! when Backspace should re-open a finished word.
 
 mod inject;
 mod key;
+mod retone;
 
 pub use funput_engine::KeySource;
 pub use inject::{InjectPlan, plan_inject};
 pub use key::{KeyEvent, KeyKind, Mods, classify};
+pub use retone::CommittedTail;

--- a/crates/funput-desktop/src/retone.rs
+++ b/crates/funput-desktop/src/retone.rs
@@ -1,0 +1,140 @@
+//! Re-opening a finished word after Backspace, on a shell that cannot read the
+//! document.
+//!
+//! [`funput_engine::Engine::adopt`] takes the word the caret sits at the end of and
+//! makes it the live composition again, so `phủ` + Space + Backspace + `s` gives
+//! `phú`. Android asks the editor for that word (`getTextBeforeCursor`); a hook +
+//! inject shell has no editor to ask.
+//!
+//! It does not need one. While Vietnamese mode is on, every character that reaches
+//! the app is one this engine composed or waved through, so remembering the last
+//! few of them answers the only question `adopt` asks.
+//!
+//! # Invariant
+//!
+//! `tail` followed by the engine's composition buffer is always a **suffix** of the
+//! text before the caret. Remembering less than the truth is safe — the feature
+//! simply does not fire. Remembering more would hand `adopt` a word that is not
+//! there and let the next keystroke's diff delete characters Funput never wrote, so
+//! every event the shell cannot model — a click, a caret key, a focus change, an
+//! EN/VI toggle — must call [`CommittedTail::clear`].
+
+use funput_engine::{Action, ImeResult};
+
+/// How much committed text to keep, in bytes. Only the last word and whatever
+/// separates it from the caret is ever read, so this only has to outlast a word:
+/// the longest Vietnamese syllable (`nghiêng`) is 9 bytes in NFC.
+const CAPACITY: usize = 64;
+
+/// The tail of the text Funput has typed into the focused app, up to the live
+/// composition. Fed by the shell on every keystroke; queried on Backspace.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CommittedTail {
+    tail: String,
+    /// The composition as it stood before the current key — a word boundary wipes
+    /// it from the engine, and that is precisely the text that just got committed.
+    composing: String,
+    /// Where the word handed out by [`CommittedTail::backspace`] starts in `tail`.
+    word_start: usize,
+}
+
+impl CommittedTail {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Forget everything. Call whenever the caret may have moved on its own.
+    pub fn clear(&mut self) {
+        self.tail.clear();
+        self.composing.clear();
+        self.word_start = 0;
+    }
+
+    /// Snapshot the engine's composition *before* it processes the next key.
+    /// Pairs with [`CommittedTail::after_key`], once per composed keystroke.
+    pub fn before_key(&mut self, composing: &str) {
+        self.composing.clear();
+        self.composing.push_str(composing);
+    }
+
+    /// Fold what the app now shows into the shadow, *after* the engine ran `key`.
+    /// `composing` is the engine's buffer as it stands now.
+    pub fn after_key(&mut self, key: char, result: &ImeResult, composing: &str) {
+        if !composing.is_empty() {
+            return; // still inside a word — it joins the shadow when it commits
+        }
+        match result.action {
+            // The shell types `output` and swallows `key`: an English restore or a
+            // gõ tắt expansion, boundary character included. The deletions paired
+            // with it only ever remove the live composition, which is not in `tail`.
+            Action::Send | Action::Restore => self.tail.push_str(&result.output),
+            // Nothing injected: the app keeps the word already on screen (empty when
+            // the key composed nothing, e.g. a second space) and echoes `key` itself.
+            Action::None => {
+                self.tail.push_str(&self.composing);
+                self.tail.push(key);
+            }
+        }
+        self.trim();
+    }
+
+    /// One Backspace with nothing composing: the app is about to delete the last
+    /// committed character. Returns the finished word the caret then sits at the end
+    /// of — offer it to [`funput_engine::Engine::adopt`] and report back with
+    /// [`CommittedTail::resolve`].
+    pub fn backspace(&mut self) -> Option<&str> {
+        self.tail.pop()?;
+        let start = word_start(&self.tail);
+        if start == self.tail.len() {
+            return None; // the caret landed on a separator, not on a word
+        }
+        self.word_start = start;
+        Some(&self.tail[start..])
+    }
+
+    /// What the engine did with the word from [`CommittedTail::backspace`]. `true`:
+    /// it is the live composition now, so the shadow hands it over and the invariant
+    /// holds across the two. `false`: the word stays on screen with nothing tracking
+    /// it, which leaves the shadow unable to place the caret — so it starts over.
+    pub fn resolve(&mut self, adopted: bool) {
+        if adopted {
+            self.tail.truncate(self.word_start);
+        } else {
+            self.tail.clear();
+        }
+    }
+
+    /// Keep the shadow bounded. Drops from the front only as far as a separator, so
+    /// what remains never starts mid-word — and stays a suffix of the real text.
+    fn trim(&mut self) {
+        if self.tail.len() <= CAPACITY {
+            return;
+        }
+        let floor = self.tail.len() - CAPACITY;
+        let cut = self
+            .tail
+            .char_indices()
+            .find(|(i, c)| *i >= floor && is_separator(*c))
+            .map_or(self.tail.len(), |(i, c)| i + c.len_utf8());
+        self.tail.drain(..cut);
+    }
+}
+
+/// Byte index where the unbroken run of word characters at the end of `text`
+/// begins; `text.len()` when `text` ends on a separator.
+fn word_start(text: &str) -> usize {
+    text.char_indices()
+        .rev()
+        .find(|(_, c)| is_separator(*c))
+        .map_or(0, |(i, c)| i + c.len_utf8())
+}
+
+/// What ends a word on screen, mirroring the engine's own boundary rule. `[` and `]`
+/// compose in advanced Telex rather than separate, but they only ever reach the
+/// shadow inside a gõ tắt expansion, where separating is the right reading.
+fn is_separator(c: char) -> bool {
+    c.is_whitespace() || c.is_ascii_punctuation()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/funput-desktop/src/retone/tests.rs
+++ b/crates/funput-desktop/src/retone/tests.rs
@@ -1,0 +1,173 @@
+use funput_engine::{Action, ImeResult};
+
+use super::*;
+
+fn none() -> ImeResult {
+    ImeResult {
+        action: Action::None,
+        backspace: 0,
+        output: String::new(),
+    }
+}
+
+fn send(backspace: usize, output: &str) -> ImeResult {
+    ImeResult {
+        action: Action::Send,
+        backspace,
+        output: output.to_owned(),
+    }
+}
+
+/// Commit `word` with `key`, the way the engine does when nothing is injected:
+/// the word is already on screen and the app echoes the boundary key after it.
+fn commit(tail: &mut CommittedTail, word: &str, key: char) {
+    tail.before_key(word);
+    tail.after_key(key, &none(), "");
+}
+
+/// The reason this exists: `phủ` + Space, then Backspace, hands `phủ` back.
+#[test]
+fn backspace_over_the_space_reopens_the_word() {
+    let mut tail = CommittedTail::new();
+    commit(&mut tail, "phủ", ' ');
+
+    assert_eq!(tail.backspace(), Some("phủ"));
+    tail.resolve(true);
+    // The word belongs to the engine now, so the shadow no longer claims it.
+    assert_eq!(tail.backspace(), None);
+}
+
+#[test]
+fn a_key_that_is_still_composing_leaves_the_shadow_alone() {
+    let mut tail = CommittedTail::new();
+    commit(&mut tail, "phủ", ' ');
+
+    // Typing the next word must not push anything: it lives in the engine buffer
+    // until a boundary commits it.
+    tail.before_key("");
+    tail.after_key('c', &none(), "c");
+    tail.before_key("c");
+    tail.after_key('h', &none(), "ch");
+
+    assert_eq!(tail.backspace(), Some("phủ"));
+}
+
+#[test]
+fn every_separator_has_to_be_deleted_before_the_word_is_offered() {
+    let mut tail = CommittedTail::new();
+    commit(&mut tail, "phủ", ',');
+    tail.before_key("");
+    tail.after_key(' ', &none(), ""); // a space typed on an empty composition
+
+    assert_eq!(
+        tail.backspace(),
+        None,
+        "deleted the space, caret on the comma"
+    );
+    assert_eq!(
+        tail.backspace(),
+        Some("phủ"),
+        "deleted the comma, caret at the end of the word"
+    );
+}
+
+/// A digit at the start of a word passes through the engine untouched, so it stands
+/// between the word and the caret like any other character.
+#[test]
+fn a_passed_through_digit_counts_as_a_character() {
+    let mut tail = CommittedTail::new();
+    commit(&mut tail, "phủ", ' ');
+    tail.before_key("");
+    tail.after_key('1', &none(), "");
+
+    assert_eq!(tail.backspace(), None); // deleted the digit
+    assert_eq!(tail.backspace(), Some("phủ"));
+}
+
+/// English restore and gõ tắt expansion inject the finished text themselves; the
+/// boundary character is already part of `output`.
+#[test]
+fn injected_output_is_folded_in_whole() {
+    let mut tail = CommittedTail::new();
+    tail.before_key("tẽt");
+    tail.after_key(' ', &send(3, "text "), "");
+
+    assert_eq!(tail.backspace(), Some("text"));
+}
+
+#[test]
+fn an_expansion_offers_only_its_last_word() {
+    let mut tail = CommittedTail::new();
+    tail.before_key("vn");
+    tail.after_key(' ', &send(2, "Việt Nam "), "");
+
+    // `Nam` is what the caret is at the end of — `Việt` is two words back.
+    assert_eq!(tail.backspace(), Some("Nam"));
+}
+
+/// A refused word (the engine only adopts real syllables) is left on screen with
+/// nothing tracking it, so the shadow can no longer place the caret.
+#[test]
+fn a_refused_word_resets_the_shadow() {
+    let mut tail = CommittedTail::new();
+    commit(&mut tail, "chào", ' ');
+    commit(&mut tail, "hello", ' ');
+
+    assert_eq!(tail.backspace(), Some("hello"));
+    tail.resolve(false);
+    assert_eq!(tail.backspace(), None);
+}
+
+#[test]
+fn clear_forgets_everything() {
+    let mut tail = CommittedTail::new();
+    commit(&mut tail, "phủ", ' ');
+    tail.clear();
+    assert_eq!(tail.backspace(), None);
+}
+
+#[test]
+fn backspacing_an_empty_shadow_is_a_no_op() {
+    let mut tail = CommittedTail::new();
+    assert_eq!(tail.backspace(), None);
+    assert_eq!(tail.backspace(), None);
+}
+
+/// Over the cap, the shadow drops whole words off the front: what is left has to
+/// stay a suffix of the real text, and must never begin mid-word.
+#[test]
+fn trimming_drops_whole_words_and_keeps_the_last_one() {
+    let mut tail = CommittedTail::new();
+    for _ in 0..12 {
+        commit(&mut tail, "nghiêng", ' ');
+    }
+    commit(&mut tail, "phủ", ' ');
+
+    assert!(tail.tail.len() <= CAPACITY + "nghiêng ".len());
+    assert!(
+        !tail.tail.starts_with("iêng"),
+        "trimming cut a word in half: {:?}",
+        tail.tail
+    );
+    assert_eq!(tail.backspace(), Some("phủ"));
+}
+
+/// A single run longer than the cap has no separator to cut at, so the shadow gives
+/// up rather than offering a fragment from the middle of it.
+#[test]
+fn an_unbroken_run_longer_than_the_cap_is_dropped() {
+    let mut tail = CommittedTail::new();
+    let long = "a".repeat(CAPACITY * 2);
+    commit(&mut tail, &long, ' ');
+
+    assert!(tail.tail.len() <= CAPACITY);
+    assert_eq!(tail.backspace(), None);
+}
+
+#[test]
+fn word_start_finds_the_run_after_the_last_separator() {
+    assert_eq!(word_start(""), 0);
+    assert_eq!(word_start("phủ"), 0);
+    assert_eq!(word_start("chào phủ"), "chào ".len());
+    assert_eq!(word_start("phủ "), "phủ ".len()); // ends on a separator
+}

--- a/crates/funput-desktop/tests/retone.rs
+++ b/crates/funput-desktop/tests/retone.rs
@@ -1,0 +1,215 @@
+//! Retone after Backspace, driven the way a hook + inject shell drives it.
+//!
+//! The shell below is the Windows hook's `handle_keydown` with the OS taken out:
+//! same order of operations, same inject plan, plus a stand-in "app" that applies
+//! the plan to a string. What it asserts is the text the user ends up looking at.
+
+use funput_core::InputMethod;
+use funput_desktop::{CommittedTail, KeySource, plan_inject};
+use funput_engine::Engine;
+
+struct Shell {
+    engine: Engine,
+    tail: CommittedTail,
+    /// The focused app's document. The caret is always at the end.
+    app: String,
+}
+
+impl Shell {
+    fn new(method: InputMethod) -> Self {
+        let mut engine = Engine::new();
+        engine.set_method(method);
+        Self {
+            engine,
+            tail: CommittedTail::new(),
+            app: String::new(),
+        }
+    }
+
+    /// `KeyKind::Compose`: feed the engine, then either inject its plan or let the
+    /// literal key through to the app.
+    fn key(&mut self, c: char) {
+        self.tail.before_key(self.engine.buffer());
+        let result = self.engine.process_key(c, KeySource::Standard);
+        self.tail.after_key(c, &result, self.engine.buffer());
+
+        let plan = plan_inject(&result);
+        if plan.is_noop() {
+            self.app.push(c);
+            return;
+        }
+        self.delete(plan.backspaces);
+        self.app
+            .push_str(&String::from_utf16(&plan.units).expect("valid UTF-16"));
+    }
+
+    /// `KeyKind::Backspace`: sync Funput's state, then the physical key reaches the
+    /// app and deletes one character.
+    fn backspace(&mut self) {
+        self.sync_backspace();
+        self.delete(1);
+    }
+
+    /// The body of `shell::on_backspace` on Windows.
+    fn sync_backspace(&mut self) {
+        if !self.engine.buffer().is_empty() {
+            self.engine.on_backspace();
+            return;
+        }
+        let Some(word) = self.tail.backspace() else {
+            return;
+        };
+        let adopted = self.engine.adopt(word);
+        self.tail.resolve(adopted);
+    }
+
+    /// `KeyKind::Flush`: a caret key, Enter, a shortcut, or a mouse click.
+    fn flush(&mut self) {
+        self.engine.clear();
+        self.tail.clear();
+    }
+
+    fn type_str(&mut self, keys: &str) {
+        for key in keys.chars() {
+            self.key(key);
+        }
+    }
+
+    fn delete(&mut self, count: usize) {
+        for _ in 0..count {
+            self.app.pop();
+        }
+    }
+}
+
+/// The feature as the user asked for it: `phủ`, Space, Backspace, then a tone key
+/// edits the word instead of typing a letter after it.
+#[test]
+fn backspace_after_a_space_retones_the_word() {
+    let mut shell = Shell::new(InputMethod::Telex);
+    shell.type_str("phur ");
+    assert_eq!(shell.app, "phủ ");
+
+    shell.backspace();
+    assert_eq!(shell.app, "phủ", "the space is gone, the word is untouched");
+
+    shell.key('s');
+    assert_eq!(shell.app, "phú");
+}
+
+#[test]
+fn retoning_works_the_same_in_vni() {
+    let mut shell = Shell::new(InputMethod::Vni);
+    shell.type_str("phu3 ");
+    assert_eq!(shell.app, "phủ ");
+
+    shell.backspace();
+    shell.key('1'); // VNI sắc
+    assert_eq!(shell.app, "phú");
+}
+
+/// The retoned word is a normal composition again: the next boundary commits the
+/// edited form, and English restore does not fire on it.
+#[test]
+fn a_boundary_after_retoning_commits_the_edited_word() {
+    let mut shell = Shell::new(InputMethod::Telex);
+    shell.type_str("chaof ");
+    shell.backspace();
+    shell.key('s');
+    shell.key(' ');
+    assert_eq!(shell.app, "cháo ");
+}
+
+/// Two words: only the one the caret lands on is re-opened, and the text in front
+/// of it is left alone.
+#[test]
+fn only_the_word_at_the_caret_is_reopened() {
+    let mut shell = Shell::new(InputMethod::Telex);
+    shell.type_str("chaof phur ");
+    assert_eq!(shell.app, "chào phủ ");
+
+    shell.backspace();
+    shell.key('s');
+    assert_eq!(shell.app, "chào phú");
+}
+
+/// The engine only adopts real Vietnamese syllables, so an English word keeps
+/// taking literal letters after it.
+#[test]
+fn an_english_word_is_not_reopened() {
+    let mut shell = Shell::new(InputMethod::Telex);
+    shell.type_str("hello ");
+    assert_eq!(shell.app, "hello ");
+
+    shell.backspace();
+    shell.key('s');
+    assert_eq!(shell.app, "hellos");
+}
+
+/// Every character between the word and the caret has to be deleted first — the
+/// word is only re-opened once the caret actually reaches it.
+#[test]
+fn punctuation_between_the_word_and_the_caret_is_deleted_first() {
+    let mut shell = Shell::new(InputMethod::Telex);
+    shell.type_str("phur, ");
+    assert_eq!(shell.app, "phủ, ");
+
+    shell.backspace();
+    shell.key('s');
+    assert_eq!(
+        shell.app, "phủ,s",
+        "the caret was on the comma, not on the word"
+    );
+
+    shell.flush();
+    shell.type_str("phur, ");
+    shell.backspace();
+    shell.backspace();
+    shell.key('s');
+    assert_eq!(shell.app, "phủ,sphú");
+}
+
+/// Holding Backspace eats the live word and carries on into the one before it,
+/// which is re-opened in turn.
+#[test]
+fn backspace_carries_on_into_the_previous_word() {
+    let mut shell = Shell::new(InputMethod::Telex);
+    shell.type_str("chaof banj");
+    assert_eq!(shell.app, "chào bạn");
+
+    for _ in 0..4 {
+        shell.backspace(); // ba̱n, ba, b, then the space
+    }
+    assert_eq!(shell.app, "chào");
+
+    shell.key('s');
+    assert_eq!(shell.app, "cháo");
+}
+
+/// Anything that may have moved the caret without Funput seeing it — a click, an
+/// arrow key, a focus change — drops the shadow, and Backspace goes back to being
+/// a plain delete.
+#[test]
+fn a_flush_disables_retoning() {
+    let mut shell = Shell::new(InputMethod::Telex);
+    shell.type_str("phur ");
+    shell.flush(); // the user clicked somewhere; Funput no longer knows the caret
+
+    shell.backspace();
+    shell.key('s');
+    assert_eq!(shell.app, "phủs");
+}
+
+/// A gõ tắt expansion lands in the app as one injected string; the caret sits at
+/// the end of its last word, which is the one that re-opens.
+#[test]
+fn an_expansion_reopens_its_last_word() {
+    let mut shell = Shell::new(InputMethod::Telex);
+    shell.engine.add_shortcut("vn", "Việt Nam");
+    shell.type_str("vn ");
+    assert_eq!(shell.app, "Việt Nam ");
+
+    shell.backspace();
+    shell.key('f');
+    assert_eq!(shell.app, "Việt Nàm");
+}

--- a/platforms/windows/.gitignore
+++ b/platforms/windows/.gitignore
@@ -1,1 +1,2 @@
 /target
+/build

--- a/platforms/windows/src/hook.rs
+++ b/platforms/windows/src/hook.rs
@@ -128,6 +128,10 @@ unsafe extern "system" fn win_event_proc(
     };
     let is_funput = id == own_exe_id().as_str();
     FOREGROUND_IS_FUNPUT.store(is_funput, Ordering::Relaxed);
+    // The caret is somewhere else entirely now, so nothing Funput has typed sits in
+    // front of it any more (mirrors the mouse-click flush). Both directions: keys
+    // typed into Funput's own windows compose in-process and never reach the engine.
+    shell::clear();
     if is_funput {
         return;
     }
@@ -312,9 +316,10 @@ fn handle_keydown(kbd: &KBDLLHOOKSTRUCT) -> bool {
             }
         }
         KeyKind::Backspace => {
-            if shell::is_composing() {
-                shell::on_backspace(); // sync engine; app deletes its own char
-            }
+            // Sync Funput's model of the text; the app deletes its own char. When the
+            // deletion puts the caret back on a finished word, this re-opens it so the
+            // next keystroke retones it (`phủ` + Space + ⌫ + `s` → `phú`).
+            shell::on_backspace();
             false
         }
         KeyKind::Flush => {

--- a/platforms/windows/src/shell.rs
+++ b/platforms/windows/src/shell.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 
 use funput_core::{InputMethod, ToneStyle as CoreToneStyle};
+use funput_desktop::CommittedTail;
 use funput_engine::{Engine, EngineConfig, ImeResult, KeySource};
 
 use crate::settings::{
@@ -22,6 +23,12 @@ const RECENT_CAP: usize = 12;
 
 struct Shell {
     engine: Engine,
+    /// Shadow of the text Funput has typed into the focused app, up to the live
+    /// composition. A hook shell cannot read the document, so this stands in for it
+    /// when Backspace should re-open a finished word (see [`on_backspace`]). It only
+    /// ever holds text this process typed, and any event that may have moved the
+    /// caret behind our back drops it — see [`reset_composition`].
+    tail: CommittedTail,
     settings: Settings,
     /// Recently-focused apps (most recent first), fed by the foreground hook. Not
     /// persisted — it's just a convenience source for the Settings UI.
@@ -39,11 +46,21 @@ struct Shell {
 
 static SHELL: OnceLock<Mutex<Shell>> = OnceLock::new();
 
-fn apply_to_engine(engine: &mut Engine, s: &Settings) {
-    sync_engine_config(engine, s);
-    engine.set_enabled(s.enabled);
-    push_shortcuts(engine, &s.shortcuts);
-    engine.clear();
+/// Push everything in `s.settings` to the engine and start from a clean slate.
+fn apply_settings(s: &mut Shell) {
+    sync_engine_config(&mut s.engine, &s.settings);
+    s.engine.set_enabled(s.settings.enabled);
+    push_shortcuts(&mut s.engine, &s.settings.shortcuts);
+    reset_composition(s);
+}
+
+/// Drop the live composition *and* the committed-text shadow together. The two
+/// model one stretch of text around the caret, so one must never outlive the other:
+/// a shadow left standing after the engine forgot the word would let Backspace
+/// re-open text that is no longer where Funput thinks it is.
+fn reset_composition(s: &mut Shell) {
+    s.engine.clear();
+    s.tail.clear();
 }
 
 /// Push the six engine options from `settings` in one call. `settings` is the single
@@ -72,16 +89,16 @@ fn push_shortcuts(engine: &mut Engine, shortcuts: &[Shortcut]) {
 
 fn shell() -> &'static Mutex<Shell> {
     SHELL.get_or_init(|| {
-        let settings = Settings::load();
-        let mut engine = Engine::new();
-        apply_to_engine(&mut engine, &settings);
-        Mutex::new(Shell {
-            engine,
-            settings,
+        let mut shell = Shell {
+            engine: Engine::new(),
+            tail: CommittedTail::new(),
+            settings: Settings::load(),
             recent: Vec::new(),
             overrides: HashMap::new(),
             pending_override: None,
-        })
+        };
+        apply_settings(&mut shell);
+        Mutex::new(shell)
     })
 }
 
@@ -95,9 +112,9 @@ fn with<R>(f: impl FnOnce(&mut Shell) -> R) -> R {
 fn set_enabled_state(s: &mut Shell, on: bool) {
     s.settings.enabled = on;
     s.engine.set_enabled(on);
-    if !on {
-        s.engine.clear();
-    }
+    // Both directions: English-mode keystrokes never reach the engine, so whatever
+    // the shadow held before the switch no longer describes the text at the caret.
+    reset_composition(s);
 }
 
 // --- reads -----------------------------------------------------------------
@@ -137,9 +154,6 @@ pub fn toggle_combo() -> Option<KeyCombo> {
 pub fn flip_combo() -> Option<KeyCombo> {
     with(|s| s.settings.flip_combo.clone())
 }
-pub fn is_composing() -> bool {
-    with(|s| !s.engine.buffer().is_empty())
-}
 
 /// The user's current input method + tone style, for the in-process composer that the
 /// Settings window's gõ tắt field uses (it can't go through the global hook).
@@ -177,8 +191,8 @@ pub fn reload_settings() -> bool {
         if s.settings == loaded {
             return false;
         }
-        apply_to_engine(&mut s.engine, &loaded);
         s.settings = loaded;
+        apply_settings(s);
         true
     })
 }
@@ -188,8 +202,8 @@ pub fn reload_settings() -> bool {
 /// `reload_settings`, exactly as it does for any single-field edit.
 pub fn replace_settings(new: Settings) {
     with(|s| {
-        apply_to_engine(&mut s.engine, &new);
         s.settings = new;
+        apply_settings(s);
         s.settings.save();
     });
 }
@@ -248,7 +262,7 @@ pub fn set_method(method: InputMethod) {
     with(|s| {
         s.settings.method = Method::from_core(method);
         sync_engine_config(&mut s.engine, &s.settings);
-        s.engine.clear();
+        reset_composition(s);
         s.settings.save();
     });
 }
@@ -497,8 +511,17 @@ pub fn apply_for_app(id: &str) -> Option<bool> {
 
 /// Feed one character to the engine, tagged with its physical [`KeySource`] so a
 /// numpad digit stays a literal number instead of acting as a VNI modifier.
+///
+/// The two `tail` calls bracket the engine: the shadow needs the composition as it
+/// stood *before* the key (a word boundary wipes it, and that is exactly the text
+/// that just became committed) and the engine's verdict *after*.
 pub fn process_key(c: char, source: KeySource) -> ImeResult {
-    with(|s| s.engine.process_key(c, source))
+    with(|s| {
+        s.tail.before_key(s.engine.buffer());
+        let result = s.engine.process_key(c, source);
+        s.tail.after_key(c, &result, s.engine.buffer());
+        result
+    })
 }
 
 /// Flip the word being composed VN↔raw; returns the delete+inject to apply.
@@ -506,14 +529,30 @@ pub fn flip_composing() -> ImeResult {
     with(|s| s.engine.flip_composing())
 }
 
-/// Sync the engine after Backspace while composing; the physical Backspace then
-/// passes through so the app deletes its own visible char (like `funput-term`).
+/// Backspace while Vietnamese mode is on. The physical key always passes through, so
+/// the app deletes its own visible char (like `funput-term`); this only keeps Funput
+/// in step with it.
+///
+/// Mid-word that means shortening the composition. With nothing composing, the
+/// character about to disappear is a committed one, and when its removal leaves the
+/// caret at the end of a finished Vietnamese word the engine re-opens that word — so
+/// `phủ` + Space + Backspace + `s` gives `phú` instead of `phủs`. The engine refuses
+/// anything that is not a complete syllable, which keeps English words and URLs
+/// literal; a refusal costs the shadow its bearings, so it starts over.
 pub fn on_backspace() {
     with(|s| {
-        s.engine.on_backspace();
+        if !s.engine.buffer().is_empty() {
+            s.engine.on_backspace();
+            return;
+        }
+        let Some(word) = s.tail.backspace() else {
+            return;
+        };
+        let adopted = s.engine.adopt(word);
+        s.tail.resolve(adopted);
     });
 }
 
 pub fn clear() {
-    with(|s| s.engine.clear());
+    with(reset_composition);
 }


### PR DESCRIPTION
- Added CommittedTail struct to manage the shadow of typed text, enabling re-opening of finished words after Backspace.
- Updated the engine's process_key and on_backspace functions to integrate with CommittedTail, allowing for seamless text editing in Vietnamese mode.
- Introduced tests to validate the behavior of retoning and backspacing across various scenarios, ensuring correct word handling and state management.
- Enhanced the Cargo.toml and Cargo.lock files to include funput-core as a development dependency.