### PR TITLE
feat(macos): retone after Backspace

### DIFF
--- a/platforms/macos/Funput/IME/FunputComposer.swift
+++ b/platforms/macos/Funput/IME/FunputComposer.swift
@@ -80,6 +80,15 @@ final class FunputComposer {
         funput_backspace(handle)
     }
 
+    /// Re-open an already-committed word as the live composition, so the next keystroke
+    /// edits it (`chào` + ⌫ then `s` gives `cháo`). Returns whether the engine took it:
+    /// only a complete Vietnamese syllable is, which keeps English words and URLs literal,
+    /// so leave the document alone on `false`.
+    func adopt(_ word: String) -> Bool {
+        let scalars = word.unicodeScalars.map(\.value)
+        return funput_adopt(handle, scalars, UInt(scalars.count))
+    }
+
     /// Flip the word being composed between its Vietnamese form and its raw
     /// keystrokes (`card` ⇄ `cải`), and back on a second call. Returns the engine
     /// result; the caller re-renders the marked text from `buffer()` when its

--- a/platforms/macos/Funput/IME/FunputInputController+Retone.swift
+++ b/platforms/macos/Funput/IME/FunputInputController+Retone.swift
@@ -1,0 +1,28 @@
+import AppKit
+import InputMethodKit
+
+extension FunputInputController {
+    /// Backspace with nothing composing: give the word the caret is about to land on back
+    /// to the engine, so the next keystroke retones it instead of typing a literal letter
+    /// (`chào` + Space + ⌫ + `s` → `cháo`) — the behaviour the Windows and Android shells
+    /// already have.
+    ///
+    /// Returns whether Funput handled the key. `false` is the safe answer, and the common
+    /// one: the app then deletes its own character exactly as it did before, with nothing
+    /// here having touched the document. `true` means the word *and* the character being
+    /// deleted were replaced in a single `setMarkedText`, so the app must not delete again.
+    ///
+    /// Auto-repeat is left alone. Holding Backspace to wipe a phrase would otherwise
+    /// re-open a word per repeat — an underline flickering through text on its way out —
+    /// and would put a cross-process document read on every one of them. A deliberate
+    /// single press never repeats, so the feature itself loses nothing.
+    func reopenPreviousWord(_ client: IMKTextInput, event: NSEvent) -> Bool {
+        guard AppSettings.shared.retoneAfterBackspace, !event.isARepeat else { return false }
+        let document = IMKRetoneDocument(client: client)
+        guard let plan = Retone.plan(document: document, adopt: composer.adopt) else {
+            return false
+        }
+        setMarked(plan.word, client, replacementRange: plan.replacement)
+        return true
+    }
+}

--- a/platforms/macos/Funput/IME/FunputInputController+Settings.swift
+++ b/platforms/macos/Funput/IME/FunputInputController+Settings.swift
@@ -14,7 +14,14 @@ extension FunputInputController {
         lastSyncedShortcutsRevision = settings.shortcutsRevision
     }
 
-    func setMarked(_ text: String, _ client: IMKTextInput) {
+    /// Show `text` as the marked (underlined) composition. `replacementRange` defaults to
+    /// "wherever the caret is"; retoning passes a real range to swallow the committed word
+    /// it is re-opening, along with the character Backspace was deleting.
+    func setMarked(
+        _ text: String,
+        _ client: IMKTextInput,
+        replacementRange: NSRange = FunputInputController.notFound
+    ) {
         let marked = NSAttributedString(string: text, attributes: [
             .underlineStyle: NSUnderlineStyle.single.rawValue,
             .underlineColor: NSColor.labelColor,
@@ -22,7 +29,7 @@ extension FunputInputController {
         client.setMarkedText(
             marked,
             selectionRange: NSRange(location: text.utf16.count, length: 0),
-            replacementRange: Self.notFound
+            replacementRange: replacementRange
         )
     }
 

--- a/platforms/macos/Funput/IME/FunputInputController.swift
+++ b/platforms/macos/Funput/IME/FunputInputController.swift
@@ -63,7 +63,9 @@ final class FunputInputController: IMKInputController {
         }
 
         if event.keyCode == KeyCode.backspace {
-            guard !composer.buffer().isEmpty else { return false }
+            // Nothing composing: the character about to disappear is a committed one, and
+            // its removal may leave the caret at the end of a finished word to re-open.
+            guard !composer.buffer().isEmpty else { return reopenPreviousWord(client, event: event) }
             composer.backspace()
             setMarked(composer.buffer(), client)
             return true

--- a/platforms/macos/Funput/IME/RetoneDocument.swift
+++ b/platforms/macos/Funput/IME/RetoneDocument.swift
@@ -1,0 +1,47 @@
+import InputMethodKit
+
+/// The focused app's text, as retoning needs to see it: where the caret is, and what sits
+/// just before it.
+///
+/// Reading is the part that varies by app — a client is free to answer with nothing — so it
+/// sits behind this protocol, which also lets `Retone` be exercised against a plain string
+/// in tests. Writing needs no seam: it is one `setMarkedText` back in the controller.
+protocol RetoneDocument {
+    /// Where the caret is, in UTF-16 units, or nil when the client cannot place it.
+    func caret() -> Int?
+
+    /// The text in `range`, or nil when the client will not hand it over. Implementations
+    /// pass on whatever they are given; `Retone` checks it covers the range it asked for.
+    func text(in range: NSRange) -> String?
+}
+
+/// An `IMKTextInput` client seen through that lens — the only place in Funput that reads
+/// the focused app's document.
+///
+/// Every call here is a synchronous round trip to another process, which is why the only
+/// caller is the Backspace path: on macOS 26/27 those round trips are exactly what
+/// Chromium's text-input bridge deadlocks on (see `docs/KNOWN_ISSUES.md`), so they must
+/// never reach the per-keystroke path.
+struct IMKRetoneDocument: RetoneDocument {
+    let client: IMKTextInput
+
+    func caret() -> Int? {
+        // A selection is not a caret: there Backspace deletes the selection, and no word
+        // ends up under the caret at all. Some clients report a caret this way too — Cursor
+        // answers (0,1) for an empty document — which lands on the same safe refusal.
+        let selected = client.selectedRange()
+        guard selected.location != NSNotFound, selected.length == 0 else { return nil }
+
+        // Marked text of our own would mean the indices below describe a document that is
+        // still mid-edit. Callers only get here with an empty composition, so this is a
+        // stray composition left by something else — leave it alone.
+        let marked = client.markedRange()
+        guard marked.location == NSNotFound || marked.length == 0 else { return nil }
+
+        return selected.location
+    }
+
+    func text(in range: NSRange) -> String? {
+        client.attributedSubstring(from: range)?.string
+    }
+}

--- a/platforms/macos/Funput/IME/RetoneDocument.swift
+++ b/platforms/macos/Funput/IME/RetoneDocument.swift
@@ -26,19 +26,7 @@ struct IMKRetoneDocument: RetoneDocument {
     let client: IMKTextInput
 
     func caret() -> Int? {
-        // A selection is not a caret: there Backspace deletes the selection, and no word
-        // ends up under the caret at all. Some clients report a caret this way too — Cursor
-        // answers (0,1) for an empty document — which lands on the same safe refusal.
-        let selected = client.selectedRange()
-        guard selected.location != NSNotFound, selected.length == 0 else { return nil }
-
-        // Marked text of our own would mean the indices below describe a document that is
-        // still mid-edit. Callers only get here with an empty composition, so this is a
-        // stray composition left by something else — leave it alone.
-        let marked = client.markedRange()
-        guard marked.location == NSNotFound || marked.length == 0 else { return nil }
-
-        return selected.location
+        Retone.caret(selected: client.selectedRange(), marked: client.markedRange())
     }
 
     func text(in range: NSRange) -> String? {

--- a/platforms/macos/Funput/IME/RetoneScan.swift
+++ b/platforms/macos/Funput/IME/RetoneScan.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Re-opening a finished word after Backspace: `chào` + Space + ⌫ then `s` gives `cháo`.
+///
+/// The engine decides *whether* — `FunputComposer.adopt` refuses anything that is not a
+/// complete Vietnamese syllable, which keeps English words and URLs literal. This type only
+/// works out *which* word the caret is about to land on, and which stretch of the document
+/// has to be handed over for it.
+///
+/// Windows answers the same question from a shadow copy of everything Funput typed
+/// (`funput_desktop::CommittedTail`), because a hook shell has no document to ask. macOS
+/// does, so there is no shadow here to keep in step with the caret — and no invariant to
+/// break when the user clicks somewhere else.
+enum Retone {
+    /// How far back to look for the start of the word. The longest Vietnamese syllable
+    /// (`nghiêng`) is 7 characters; the slack matches Android's `WordLookback`.
+    static let lookback = 12
+
+    /// The single edit that turns a committed word back into a live composition.
+    struct Plan: Equatable {
+        /// The word to compose, precomposed (NFC) the way the engine hands text back.
+        let word: String
+        /// The stretch of document it replaces: the word *plus* the character Backspace
+        /// was about to delete, so one edit does both and nothing can land in between.
+        let replacement: NSRange
+    }
+
+    /// What Backspace should do, or nil to let the app delete a character the ordinary way.
+    ///
+    /// `adopt` is the engine, and it is asked last — only ever about a word that is really
+    /// there — so a refusal leaves the document exactly as it was.
+    static func plan(document: RetoneDocument, adopt: (String) -> Bool) -> Plan? {
+        // `end` is the character Backspace removes; with nothing in front of it there is no
+        // word to re-open, and asking the client to prove that costs a round trip.
+        guard let caret = document.caret(), caret > 1 else { return nil }
+        let end = caret - 1
+        let start = max(0, end - lookback)
+        // Everything below is anchored on the window ending exactly at `end`. A client that
+        // answers with some other stretch of text gives no way to tell which end it trimmed,
+        // and a range built on the wrong guess would replace text Funput never wrote.
+        guard let window = document.text(in: NSRange(location: start, length: end - start)),
+            window.utf16.count == end - start,
+            let raw = trailingWord(of: window, clipped: start > 0)
+        else { return nil }
+
+        let word = raw.precomposedStringWithCanonicalMapping
+        guard adopt(word) else { return nil }
+        // The range is measured on `raw`, not on `word`: a document is free to hold the
+        // syllable decomposed, where it spans more UTF-16 units than the precomposed form
+        // about to replace it.
+        let length = raw.utf16.count
+        return Plan(word: word, replacement: NSRange(location: end - length, length: length + 1))
+    }
+
+    /// The unbroken run of word characters at the end of `text`, or nil when there is no
+    /// whole word to re-open.
+    ///
+    /// Two ways that happens: `text` ends on a separator, where the caret lands between
+    /// words; or the run reaches the front of a `clipped` window, where the word carries on
+    /// out of sight and only a fragment of it would be handed over.
+    private static func trailingWord(of text: String, clipped: Bool) -> String? {
+        var start = text.endIndex
+        while start > text.startIndex {
+            let previous = text.index(before: start)
+            if let scalar = text[previous].unicodeScalars.first, isSeparator(scalar) { break }
+            start = previous
+        }
+        if start == text.startIndex, clipped { return nil }
+        return start == text.endIndex ? nil : String(text[start...])
+    }
+
+    /// Mirrors the engine's own word-boundary rule via `InputEventPolicy`. `.telex` is
+    /// passed deliberately: Telex-advanced's `[` and `]` compose while *typing*, but text
+    /// already sitting in the document is just text, and there a bracket ends a word — the
+    /// same reading `funput_desktop`'s `is_separator` settled on.
+    private static func isSeparator(_ scalar: Unicode.Scalar) -> Bool {
+        InputEventPolicy.isBoundary(scalar, method: .telex)
+    }
+}

--- a/platforms/macos/Funput/IME/RetoneScan.swift
+++ b/platforms/macos/Funput/IME/RetoneScan.swift
@@ -25,6 +25,28 @@ enum Retone {
         let replacement: NSRange
     }
 
+    /// Where the caret is, given what a client says about its selection and its marked
+    /// text, or nil when those answers are no basis for an edit.
+    ///
+    /// Split out from `IMKRetoneDocument` so the refusals are testable rather than only
+    /// reachable through a live app. Note this is the first of two filters a bad client
+    /// meets, not the whole defence: Cursor's `(0, 1)` — a selection where the user sees a
+    /// caret — is turned away here, while its `(1, 0)` passes and is turned away by `plan`,
+    /// which finds nothing in front of the character being deleted.
+    static func caret(selected: NSRange, marked: NSRange) -> Int? {
+        // A selection is not a caret: there Backspace deletes the selection, and no word
+        // ends up under the caret at all.
+        guard selected.location != NSNotFound, selected.length == 0 else { return nil }
+
+        // Marked text means the document is mid-edit. Callers only reach this with an empty
+        // composition of their own, so it belongs to something else — leave it alone. An
+        // empty range counts as none: clients differ on whether they say so with
+        // `NSNotFound` or with a zero length.
+        guard marked.location == NSNotFound || marked.length == 0 else { return nil }
+
+        return selected.location
+    }
+
     /// What Backspace should do, or nil to let the app delete a character the ordinary way.
     ///
     /// `adopt` is the engine, and it is asked last — only ever about a word that is really

--- a/platforms/macos/Funput/Model/AppSettings.swift
+++ b/platforms/macos/Funput/Model/AppSettings.swift
@@ -39,6 +39,14 @@ final class AppSettings {
     var autoCapitalizeEnabled: Bool {
         didSet { defaults.set(autoCapitalizeEnabled, forKey: Keys.autoCapitalizeEnabled) }
     }
+    /// Re-open the previous word on Backspace so the next keystroke retones it
+    /// (`chào` + Space + ⌫ + `s` → `cháo`). On by default and deliberately without UI —
+    /// Windows and Android just do it too. It exists as an escape hatch for an app whose
+    /// text-input bridge misreports the document:
+    /// `defaults write app.funput.inputmethod.Funput retoneAfterBackspace -bool false`.
+    var retoneAfterBackspace: Bool {
+        didSet { defaults.set(retoneAfterBackspace, forKey: Keys.retoneAfterBackspace) }
+    }
     /// User-recorded VI/EN toggle hotkey. Defaults to `⌃\`. Read live by
     /// `FunputInputController`.
     var toggleShortcut: KeyCombo {
@@ -105,6 +113,7 @@ final class AppSettings {
             Keys.eagerRestore: true,
             Keys.showMenuBarIcon: true,
             Keys.vietnameseEnabled: true,
+            Keys.retoneAfterBackspace: true,
         ])
         inputMethod = InputMethod.persisted(defaults.object(forKey: Keys.inputMethod))
         toneStyle = ToneStyle(rawValue: defaults.integer(forKey: Keys.toneStyle)) ?? .traditional
@@ -113,6 +122,7 @@ final class AppSettings {
         eagerRestore = defaults.bool(forKey: Keys.eagerRestore)
         spellCheckEnabled = defaults.bool(forKey: Keys.spellCheckEnabled)
         autoCapitalizeEnabled = defaults.bool(forKey: Keys.autoCapitalizeEnabled)
+        retoneAfterBackspace = defaults.bool(forKey: Keys.retoneAfterBackspace)
         toggleShortcut = defaults.data(forKey: Keys.toggleShortcut)
             .flatMap { try? JSONDecoder().decode(KeyCombo.self, from: $0) } ?? .defaultToggle
         flipShortcut = defaults.data(forKey: Keys.flipShortcut)

--- a/platforms/macos/Funput/Model/AppSettingsKeys.swift
+++ b/platforms/macos/Funput/Model/AppSettingsKeys.swift
@@ -7,6 +7,7 @@ extension AppSettings {
         static let eagerRestore = "eagerRestore"
         static let spellCheckEnabled = "spellCheckEnabled"
         static let autoCapitalizeEnabled = "autoCapitalizeEnabled"
+        static let retoneAfterBackspace = "retoneAfterBackspace"
         static let toggleShortcut = "toggleShortcut"
         static let flipShortcut = "flipShortcut"
         static let launchAtLogin = "launchAtLogin"

--- a/platforms/macos/FunputTests/RetoneCaretTests.swift
+++ b/platforms/macos/FunputTests/RetoneCaretTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Funput
+
+/// The first filter every client's answers meet, and the one that decides whether an edit
+/// gets placed on invented indices. Kept apart from `RetoneTests` because it is the half
+/// `IMKRetoneDocument` used to hold, where nothing could reach it but a live app.
+@MainActor
+final class RetoneCaretTests: XCTestCase {
+    private let noMarkedText = NSRange(location: NSNotFound, length: 0)
+
+    func testACollapsedCaretIsWhereItSaysItIs() {
+        XCTAssertEqual(Retone.caret(selected: NSRange(location: 5, length: 0), marked: noMarkedText), 5)
+    }
+
+    func testTheStartOfTheDocumentIsStillACaret() {
+        // Refusing this one is `plan`'s job, not this function's: there is a caret here, it
+        // simply has nothing in front of it.
+        XCTAssertEqual(Retone.caret(selected: NSRange(location: 0, length: 0), marked: noMarkedText), 0)
+    }
+
+    func testASelectionIsNotACaret() {
+        // Cursor's answer with `chào ` on screen and no selection at all. Backspace deletes
+        // a selection outright, so there is no word for the caret to land on either way.
+        XCTAssertNil(Retone.caret(selected: NSRange(location: 0, length: 1), marked: noMarkedText))
+    }
+
+    func testAClientThatCannotPlaceTheCaretIsRefused() {
+        let unplaced = NSRange(location: NSNotFound, length: 0)
+
+        XCTAssertNil(Retone.caret(selected: unplaced, marked: noMarkedText))
+    }
+
+    func testStrayMarkedTextIsLeftAlone() {
+        let marked = NSRange(location: 2, length: 3)
+
+        XCTAssertNil(Retone.caret(selected: NSRange(location: 5, length: 0), marked: marked))
+    }
+
+    func testAnEmptyMarkedRangeCountsAsNoMarkedText() {
+        // Clients differ on how they say "nothing is marked" — some send `NSNotFound`,
+        // others a zero-length range. Neither is a composition to keep clear of.
+        let empty = NSRange(location: 2, length: 0)
+
+        XCTAssertEqual(Retone.caret(selected: NSRange(location: 5, length: 0), marked: empty), 5)
+    }
+}

--- a/platforms/macos/FunputTests/RetoneTests.swift
+++ b/platforms/macos/FunputTests/RetoneTests.swift
@@ -88,6 +88,10 @@ final class RetoneTests: XCTestCase {
 
     func testThereIsNothingBeforeTheStartOfTheDocument() {
         XCTAssertNil(Retone.plan(document: FakeDocument("a", caret: 0), adopt: takeAnything))
+        // Caret 1 is also the second of Cursor's two answers (see `RetoneCaretTests`): a
+        // caret that passes the first filter, on a document whose contents it misreports.
+        // Only the character Backspace deletes lies before it, so there is no word — and
+        // the client is never asked to prove it.
         XCTAssertNil(Retone.plan(document: FakeDocument("a", caret: 1), adopt: takeAnything))
     }
 

--- a/platforms/macos/FunputTests/RetoneTests.swift
+++ b/platforms/macos/FunputTests/RetoneTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+@testable import Funput
+
+/// A document that answers from a plain string, standing in for the focused app.
+private struct FakeDocument: RetoneDocument {
+    var content: String
+    var caretLocation: Int?
+    /// Hand back less than was asked for, the way a client with a partial text-input
+    /// bridge does. The scan has to read that as "cannot be read", not guess at offsets.
+    var truncateReads = false
+
+    init(_ content: String, caret: Int? = nil, truncateReads: Bool = false) {
+        self.content = content
+        self.caretLocation = caret ?? content.utf16.count
+        self.truncateReads = truncateReads
+    }
+
+    func caret() -> Int? { caretLocation }
+
+    func text(in range: NSRange) -> String? {
+        let units = Array(content.utf16)
+        guard range.location >= 0, range.location + range.length <= units.count else { return nil }
+        let end = range.location + (truncateReads ? max(0, range.length - 1) : range.length)
+        return String(decoding: units[range.location..<end], as: UTF16.self)
+    }
+}
+
+private func takeAnything(_: String) -> Bool { true }
+private func takeNothing(_: String) -> Bool { false }
+
+@MainActor
+final class RetoneTests: XCTestCase {
+    func testBackspaceOverASpaceReopensTheWordBeforeIt() {
+        var asked: [String] = []
+        let plan = Retone.plan(document: FakeDocument("chào ")) {
+            asked.append($0)
+            return true
+        }
+
+        // The range covers the word *and* the space: one edit, no gap in between.
+        XCTAssertEqual(plan, Retone.Plan(word: "chào", replacement: NSRange(location: 0, length: 5)))
+        XCTAssertEqual(asked, ["chào"])
+    }
+
+    func testBackspaceInsideAWordReopensWhatIsLeftOfIt() {
+        let plan = Retone.plan(document: FakeDocument("chào"), adopt: takeAnything)
+
+        XCTAssertEqual(plan, Retone.Plan(word: "chà", replacement: NSRange(location: 0, length: 4)))
+    }
+
+    func testOnlyTheWordAtTheCaretIsReopened() {
+        let plan = Retone.plan(document: FakeDocument("xin chào "), adopt: takeAnything)
+
+        XCTAssertEqual(plan, Retone.Plan(word: "chào", replacement: NSRange(location: 4, length: 5)))
+    }
+
+    func testARefusedWordLeavesTheDocumentAlone() {
+        XCTAssertNil(Retone.plan(document: FakeDocument("hello "), adopt: takeNothing))
+    }
+
+    func testACaretOnASeparatorHasNoWordToReopen() {
+        // Backspace here deletes the second space and lands the caret on the first.
+        XCTAssertNil(Retone.plan(document: FakeDocument("chào  "), adopt: takeAnything))
+    }
+
+    func testDecomposedTextIsMeasuredAsItSitsInTheDocument() {
+        let plan = Retone.plan(document: FakeDocument("cha\u{0300}o "), adopt: takeAnything)
+
+        // Five UTF-16 units of word in the document, four in the composition that replaces
+        // it: measuring the range on the precomposed form would eat the `c`.
+        XCTAssertEqual(plan?.replacement, NSRange(location: 0, length: 6))
+        XCTAssertEqual(plan?.word, "chào")
+        XCTAssertEqual(plan?.word.utf16.count, 4)
+    }
+
+    func testAPartialReadIsNotGuessedAt() {
+        let document = FakeDocument("chào ", truncateReads: true)
+
+        XCTAssertNil(Retone.plan(document: document, adopt: takeAnything))
+    }
+
+    func testAClientThatCannotPlaceTheCaretIsLeftAlone() {
+        var document = FakeDocument("chào ")
+        document.caretLocation = nil
+
+        XCTAssertNil(Retone.plan(document: document, adopt: takeAnything))
+    }
+
+    func testThereIsNothingBeforeTheStartOfTheDocument() {
+        XCTAssertNil(Retone.plan(document: FakeDocument("a", caret: 0), adopt: takeAnything))
+        XCTAssertNil(Retone.plan(document: FakeDocument("a", caret: 1), adopt: takeAnything))
+    }
+
+    func testAWordThatOverrunsTheLookbackIsLeftAlone() {
+        let long = String(repeating: "a", count: Retone.lookback + 1)
+
+        // The window starts mid-word, so its front is a fragment, not a word — taking it
+        // would replace the wrong stretch of document.
+        XCTAssertNil(Retone.plan(document: FakeDocument(long + " "), adopt: takeAnything))
+    }
+
+    /// End to end through the real engine: the word goes back in, the next key retones it.
+    func testAdoptedWordIsRetonedByTheNextKeystroke() {
+        let composer = FunputComposer()
+        composer.apply(ComposerConfiguration())
+
+        let plan = Retone.plan(document: FakeDocument("chào "), adopt: composer.adopt)
+
+        XCTAssertEqual(plan?.word, "chào")
+        composer.process("s")
+        XCTAssertEqual(composer.buffer(), "cháo")
+    }
+
+    func testTheEngineRefusesAWordThatIsNotVietnamese() {
+        let composer = FunputComposer()
+        composer.apply(ComposerConfiguration())
+
+        XCTAssertNil(Retone.plan(document: FakeDocument("hello "), adopt: composer.adopt))
+        XCTAssertEqual(composer.buffer(), "")
+    }
+}

--- a/platforms/macos/docs/KNOWN_ISSUES.md
+++ b/platforms/macos/docs/KNOWN_ISSUES.md
@@ -1,5 +1,34 @@
 # Known Issues
 
+## Backspace does not retone in Cursor
+
+**Symptom:** `chào` + Space + ⌫ + `s` gives `cháo` in TextEdit, Notes, Mail, Safari,
+Pages, Chrome, VS Code and Slack, but stays `chàos` in Cursor. Nothing else changes:
+Backspace still deletes normally and no text is mangled.
+
+Retoning needs to know where the caret is and what word sits in front of it, which it
+asks the focused app for through `IMKTextInput` (see `Funput/IME/RetoneDocument.swift`).
+Cursor's Chromium does not expose a real document to input methods. Measured with
+`chào ` on screen and the caret at the end (temporary `os_log` in `IMKRetoneDocument`,
+read back with `log show --predicate 'category == "retone"'`):
+
+| | Cursor reports | Reality |
+|---|---|---|
+| `selectedRange()` | `(1, 0)`, and `(0, 1)` before that | `(5, 0)` |
+| `length()` | `0` | `5` |
+
+A caret at 1 in a document of length 0 is already self-contradictory, so nothing built on
+those indices can be trusted. The scan therefore refuses and the key passes through
+untouched, which is the intended failure direction.
+
+**Not fixable from Funput's side**, and not worth an app-specific workaround either: the
+committed-text shadow that the Windows shell uses (`funput_desktop::CommittedTail`) would
+still need a truthful caret index to place its replacement, so it fails here for the same
+reason. Cursor 3.15.6 ships Electron 40; VS Code 1.132 ships Electron 42 and works, so
+this should resolve itself when Cursor moves up. `defaults write
+app.funput.inputmethod.Funput retoneAfterBackspace -bool false` turns the feature off
+globally if some other app misbehaves worse than this.
+
 ## Typing silently stops working in Chromium/Electron apps on macOS 26/27 beta
 
 **Symptom:** after switching the input source to Funput (or back to it) while a


### PR DESCRIPTION
Backspace with nothing composing now hands the word the caret lands on back to the engine, so the next keystroke edits it: `chào` + Space + ⌫ + `s` gives `cháo`. This is the macOS half of a feature Android (#104), iOS (#105) and Windows (513a930) already have — all four platforms driven by the same `Engine::adopt`, no engine change here.

## Why macOS needs no shadow

Windows reconstructs that word from `funput_desktop::CommittedTail`, a shadow copy of everything it typed, because a hook shell has no document to ask. `IMKTextInput` does have one: it reports the caret, hands over the text in front of it, and replaces committed text with marked text in a single call.

So one `setMarkedText` whose replacement range spans the word **plus** the character Backspace was deleting does both edits at once. Nothing can land in between (the equivalent of Android's `beginBatchEdit`), and there is no shadow to keep in step with the caret — none of the "every unmodelled caret move must call `clear()`" invariant that the Windows version carries.

## Shape

| File | Role |
|---|---|
| `RetoneDocument.swift` | The two reads, behind a protocol + an `IMKTextInput` adapter. The only place that touches IMK, and the only place that generates IPC |
| `RetoneScan.swift` | `Retone.plan` — word scan and range arithmetic, no InputMethodKit import, returns a value rather than writing |
| `FunputInputController+Retone.swift` | Guards, then one `setMarked` |

Every uncertainty resolves to "let the app delete a character the ordinary way": no caret, a selection instead of a caret, a stray composition, a short read, a word running past the lookback window, or an engine that refuses the syllable. `false` from `reopenPreviousWord` means the document was never touched.

Two details worth a reviewer's eye:

- The replacement range is measured on the text **as it sits in the document**, which may be decomposed, while the engine and the marked text get the NFC form. Measuring on the precomposed form would eat a character.
- The window read must come back exactly as long as it was asked for. A short answer gives no way to tell which end was trimmed, and a range built on the wrong guess would replace text Funput never wrote.

Word boundaries reuse `InputEventPolicy.isBoundary`, called with `.telex` on purpose: Telex-advanced's `[` and `]` compose while *typing*, but text already in the document is just text — the same reading `funput_desktop`'s `is_separator` settled on. Lookback matches Android's `WordLookback`.

Auto-repeat is skipped deliberately. Holding Backspace would otherwise re-open a word per repeat — an underline flickering through text on its way out — and put a cross-process read on every one of them, which is the exact traffic Chromium's macOS 26/27 IME bridge deadlocks on. A deliberate single press never repeats.

## Behaviour note

Backspace **inside** a word re-opens it too (`chào` + ⌫ leaves `chà` composing). That is intentional parity: Windows' `CommittedTail::backspace` pops a character and returns the word at the end, and Android deletes backward then calls `reopenPreviousWord`.

## Testing

`RetoneTests.swift` — 12 cases against a fake document built on a plain string, covering the range arithmetic, the decomposed-text case, partial reads, separators, over-long words, and both engine outcomes. Two of them drive the real `FunputComposer` through the FFI, so `adopt("chào")` → `process("s")` → `cháo` is proven end to end. Full suite 21/21, Swift LOC gate green.

Verified by hand: works in TextEdit, Notes, Mail, Safari, Pages, Chrome, VS Code, Slack. **Cursor does not** — it reports a stub document to input methods (`selectedRange` `(1,0)` and `length` `0` with `chào ` on screen), so the scan refuses and Backspace behaves exactly as before. Measured with temporary `os_log`, written up in `KNOWN_ISSUES.md`; not fixable from Funput's side, and it also rules out a committed-text fallback for that app, since that would need a truthful caret index too. Cursor ships Electron 40, VS Code ships 42.

`retoneAfterBackspace` (UserDefaults, on by default, no UI) turns it off if some app misbehaves worse than Cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
