### PR TITLE
enhance(shortcuts): implement smart-case matching for text expansions

### DIFF
--- a/crates/funput-engine/README.en.md
+++ b/crates/funput-engine/README.en.md
@@ -139,8 +139,13 @@ buffer to raw keys, so a flip can recover it even after a restore.
 
 ## Shortcuts / Text expansion (macro)
 
-A user-defined trigger → expansion table (`vn` → `Việt Nam`, `kg` → `không`). At a **word boundary**
-the engine matches the **raw keystrokes** (`keys`) — **case-sensitively** — against the table:
+A user-defined trigger → expansion table (`vn` → `việt nam`, `kg` → `không`). At a **word boundary**
+the engine matches the **raw keystrokes** (`keys`) against the table using **smart-case** matching:
+typing `vn`/`Vn`/`VN` all resolve to the same trigger, and the expansion is re-cased to match —
+`vn` → `việt nam`, `Vn` → `Việt Nam` (capitalize every word), `VN` → `VIỆT NAM` (all uppercase). Keys
+with a mixed case that don't fit one of those three patterns (e.g. `vNa`) fall back to an **exact**
+match only, so a deliberately mixed-case trigger (e.g. `iOS`) still works exactly as defined. See
+`classify_case`/`apply_shortcut_case` in `compose/boundary.rs`.
 
 - Hit → `Send`: delete what is displayed (`backspace = buffer.chars().count()`), insert `expansion +
   boundary key`, then `clear()`. Backspace counts the displayed buffer, so `as` → `á` (one char) is

--- a/crates/funput-engine/README.md
+++ b/crates/funput-engine/README.md
@@ -134,8 +134,13 @@ phục được ngay cả sau khi đã restore.
 
 ## Gõ tắt / Text expansion (macro)
 
-Bảng trigger → expansion do người dùng định nghĩa (`vn` → `Việt Nam`, `kg` → `không`). Tại **ranh
-giới từ**, engine khớp **chuỗi phím thô** (`keys`) — **phân biệt hoa/thường** — với bảng gõ tắt:
+Bảng trigger → expansion do người dùng định nghĩa (`vn` → `việt nam`, `kg` → `không`). Tại **ranh
+giới từ**, engine khớp **chuỗi phím thô** (`keys`) với bảng gõ tắt theo kiểu **smart-case**: gõ
+`vn`/`Vn`/`VN` đều khớp cùng một trigger, và expansion được viết lại hoa/thường tương ứng —
+`vn` → `việt nam`, `Vn` → `Việt Nam` (hoa chữ đầu mỗi từ), `VN` → `VIỆT NAM` (hoa toàn bộ). Kiểu gõ
+hoa/thường "lộn xộn" không khớp 1 trong 3 mẫu trên (ví dụ `vNa`) chỉ được khớp **chính xác** — nhờ
+vậy trigger cố ý viết hoa/thường tuỳ ý (ví dụ `iOS`) vẫn hoạt động đúng như định nghĩa. Xem
+`classify_case`/`apply_shortcut_case` trong `compose/boundary.rs`.
 
 - Trúng → `Send`: xoá phần đang hiển thị (`backspace = buffer.chars().count()`), chèn `expansion +
   phím ranh giới`, rồi `clear()`. Backspace đếm theo buffer hiển thị nên `as` → `á` (1 ký tự) vẫn xoá

--- a/crates/funput-engine/src/compose/boundary/mod.rs
+++ b/crates/funput-engine/src/compose/boundary/mod.rs
@@ -35,12 +35,79 @@ fn english_restore_result(session: &Session, boundary_key: char) -> ImeResult {
     ImeResult::send(backspace, output)
 }
 
+/// The letter-casing pattern of typed keys, used to mirror the expansion's case
+/// (`vn` → lowercase, `Vn` → Title Case, `VN` → UPPERCASE) — the same "propagate
+/// case" convention used by common text expanders like Espanso.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ShortcutCase {
+    Lower,
+    Upper,
+    Title,
+}
+
+/// Classify the case pattern of `keys` from its cased characters (letters), ignoring
+/// digits and punctuation. Returns `None` when the keys don't fit a clean pattern
+/// (e.g. `vNa`), so the caller falls back to an exact, unmodified lookup — this keeps
+/// deliberately mixed-case triggers (like `iOS`) working exactly as defined.
+fn classify_case(keys: &str) -> Option<ShortcutCase> {
+    let mut letters = keys.chars().filter(|c| c.is_alphabetic());
+    let first = letters.next()?;
+    let rest: Vec<char> = letters.collect();
+    if first.is_lowercase() {
+        rest.iter()
+            .all(|c| c.is_lowercase())
+            .then_some(ShortcutCase::Lower)
+    } else if !rest.is_empty() && rest.iter().all(|c| c.is_uppercase()) {
+        Some(ShortcutCase::Upper)
+    } else if rest.iter().all(|c| c.is_lowercase()) {
+        // A single uppercase letter (`rest` empty) also lands here: capitalizing one
+        // word reads more naturally than shouting the whole expansion.
+        Some(ShortcutCase::Title)
+    } else {
+        None
+    }
+}
+
+/// Re-case `expansion` to match `case`, using Unicode-aware `to_uppercase`/
+/// `to_lowercase` so accented Vietnamese letters (`đ` → `Đ`, `ệ` → `Ệ`) come out right.
+fn apply_shortcut_case(expansion: &str, case: ShortcutCase) -> String {
+    match case {
+        ShortcutCase::Lower => expansion.to_string(),
+        ShortcutCase::Upper => expansion.to_uppercase(),
+        ShortcutCase::Title => {
+            let mut result = String::with_capacity(expansion.len());
+            let mut start_of_word = true;
+            for ch in expansion.chars() {
+                if ch.is_whitespace() {
+                    start_of_word = true;
+                    result.push(ch);
+                } else if start_of_word {
+                    result.extend(ch.to_uppercase());
+                    start_of_word = false;
+                } else {
+                    result.extend(ch.to_lowercase());
+                }
+            }
+            result
+        }
+    }
+}
+
 fn shortcut_expansion(session: &Session, boundary_key: char) -> Option<ImeResult> {
     if session.keys.is_empty() {
         return None;
     }
-    let expansion = session.shortcuts.get(&session.keys)?;
-    let output = format!("{expansion}{boundary_key}");
+    let case = classify_case(&session.keys);
+    let lookup_key = match case {
+        Some(_) => session.keys.to_lowercase(),
+        None => session.keys.clone(),
+    };
+    let expansion = session.shortcuts.get(&lookup_key)?;
+    let cased = match case {
+        Some(case) => apply_shortcut_case(expansion, case),
+        None => expansion.clone(),
+    };
+    let output = format!("{cased}{boundary_key}");
     Some(ImeResult::send(session.buffer.chars().count(), output))
 }
 

--- a/crates/funput-engine/src/compose/boundary/tests/commit.rs
+++ b/crates/funput-engine/src/compose/boundary/tests/commit.rs
@@ -45,11 +45,25 @@ fn shortcut_wins_and_counts_the_displayed_buffer() {
 }
 
 #[test]
-fn shortcuts_are_case_sensitive_and_keep_punctuation() {
+fn uppercase_trigger_expands_to_uppercase_expansion() {
     let mut upper = session(InputMethod::Telex, "VN", "VN");
-    upper.shortcuts.insert("vn".into(), "Việt Nam".into());
-    assert_eq!(on_word_boundary(&mut upper, ' ').action, Action::None);
+    upper.shortcuts.insert("vn".into(), "việt nam".into());
+    let result = on_word_boundary(&mut upper, ' ');
+    assert_eq!(result.action, Action::Send);
+    assert_eq!(result.output, "VIỆT NAM ");
+}
 
+#[test]
+fn mixed_case_trigger_without_clean_pattern_does_not_expand() {
+    // `vNa` doesn't fit lowercase/Title/UPPERCASE, so it isn't smart-case matched —
+    // and there's no exact `vNa` entry either.
+    let mut mixed = session(InputMethod::Telex, "vNa", "vNa");
+    mixed.shortcuts.insert("vn".into(), "Việt Nam".into());
+    assert_eq!(on_word_boundary(&mut mixed, ' ').action, Action::None);
+}
+
+#[test]
+fn shortcuts_keep_punctuation() {
     let mut punctuated = session(InputMethod::Telex, "kg", "kg");
     punctuated.shortcuts.insert("kg".into(), "không".into());
     assert_eq!(on_word_boundary(&mut punctuated, ',').output, "không,");

--- a/crates/funput-engine/src/model/session.rs
+++ b/crates/funput-engine/src/model/session.rs
@@ -26,8 +26,10 @@ pub(crate) struct Session {
     /// when a word begins. Survives `clear()`.
     pub(crate) cap_armed: bool,
     /// Text-expansion table (gõ tắt): raw-keystroke trigger → expansion. Matched
-    /// case-sensitively against `keys` at a word boundary, before English restore.
-    /// Config that lives for the whole session — `clear()` does not touch it.
+    /// smart-case against `keys` at a word boundary, before English restore — a
+    /// trigger typed lowercase, Title Case, or UPPERCASE all resolve to the same
+    /// entry, re-casing the expansion to match. Config that lives for the whole
+    /// session — `clear()` does not touch it.
     pub(crate) shortcuts: HashMap<String, String>,
     /// The composed Vietnamese form of the current word, captured each keystroke
     /// *before* an eager English-restore can collapse `buffer` to the raw keys. Lets

--- a/crates/funput-engine/tests/words/shortcut.rs
+++ b/crates/funput-engine/tests/words/shortcut.rs
@@ -1,8 +1,11 @@
 //! Text-expansion (gõ tắt) integration tests at the [`Engine`] level.
 //!
-//! A trigger matches the raw keystrokes since the last word boundary,
-//! case-sensitively, and expands at the boundary — taking priority over English
-//! restore. See `src/boundary.rs` for the matching logic.
+//! A trigger matches the raw keystrokes since the last word boundary and expands at
+//! the boundary — taking priority over English restore. Matching is smart-case: a
+//! trigger typed as lowercase, Title Case, or UPPERCASE all resolve to the same
+//! entry, and the expansion is re-cased to match. Keystrokes with a mixed case that
+//! doesn't fit one of those three patterns fall back to an exact match only. See
+//! `src/compose/boundary/mod.rs` for the matching logic.
 
 use funput_core::InputMethod;
 use funput_engine::{Action, Engine};
@@ -59,10 +62,45 @@ fn expansion_wins_over_english_restore() {
 }
 
 #[test]
-fn trigger_is_case_sensitive() {
-    // Only lowercase `vn` is defined — `VN` falls through to normal handling.
-    let text = app_text_with_shortcuts(InputMethod::Telex, &[("vn", "Việt Nam")], "VN ");
-    assert_eq!(text, "VN ");
+fn uppercase_trigger_expands_to_uppercase() {
+    let text = app_text_with_shortcuts(InputMethod::Telex, &[("vn", "việt nam")], "VN ");
+    assert_eq!(text, "VIỆT NAM ");
+}
+
+#[test]
+fn title_case_trigger_expands_to_title_case() {
+    let text = app_text_with_shortcuts(InputMethod::Telex, &[("vn", "việt nam")], "Vn ");
+    assert_eq!(text, "Việt Nam ");
+}
+
+#[test]
+fn title_case_capitalizes_every_word_in_a_multi_word_expansion() {
+    let text = app_text_with_shortcuts(InputMethod::Telex, &[("kg", "không có gì")], "Kg ");
+    assert_eq!(text, "Không Có Gì ");
+}
+
+#[test]
+fn single_uppercase_letter_trigger_capitalizes_rather_than_shouts() {
+    // A lone capital reads as "capitalize" (Title Case), not "shout the whole
+    // expansion in uppercase" — that requires 2+ uppercase letters (`VN`, not `V`).
+    let text = app_text_with_shortcuts(InputMethod::Telex, &[("v", "việt nam")], "V ");
+    assert_eq!(text, "Việt Nam ");
+}
+
+#[test]
+fn mixed_case_trigger_without_clean_pattern_falls_back_to_exact_match() {
+    // `vNa` doesn't fit lowercase/Title/UPPERCASE, so no smart-case lookup applies;
+    // since no exact `vNa` entry exists either, it falls through unchanged.
+    let text = app_text_with_shortcuts(InputMethod::Telex, &[("vn", "việt nam")], "vNa ");
+    assert_eq!(text, "vNa ");
+}
+
+#[test]
+fn deliberately_mixed_case_trigger_still_matches_exactly() {
+    // A trigger defined with intentional mixed case (e.g. a brand name) keeps working
+    // via the exact-match fallback.
+    let text = app_text_with_shortcuts(InputMethod::Telex, &[("iOS", "iPhone OS")], "iOS ");
+    assert_eq!(text, "iPhone OS ");
 }
 
 #[test]

--- a/platforms/linux/settings-gtk/src/settings_window/shortcuts.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/shortcuts.rs
@@ -1,4 +1,5 @@
-//! "Gõ tắt" page: manage text-expansion shortcuts (`vn` → `Việt Nam`). Each shortcut
+//! "Gõ tắt" page: manage text-expansion shortcuts (`vn` → `việt nam`, smart-cased to
+//! `Vn` → `Việt Nam` / `VN` → `VIỆT NAM` at expansion time). Each shortcut
 //! is an expander with two editable fields; edits persist by index and update the
 //! header live, while add/delete rebuild the list.
 
@@ -21,7 +22,10 @@ pub(super) fn page() -> PreferencesPage {
 
     let group = PreferencesGroup::builder()
         .title("Gõ tắt")
-        .description("Gõ chữ tắt rồi dấu cách để bung — ví dụ vn → Việt Nam. Phân biệt hoa/thường.")
+        .description(
+            "Gõ chữ tắt rồi dấu cách để bung — ví dụ vn → việt nam. Tự nhận diện hoa/thường: \
+             Vn → Việt Nam, VN → VIỆT NAM.",
+        )
         .build();
     page.add(&group);
 

--- a/platforms/macos/Funput/Settings/Panes/ShortcutsPane.swift
+++ b/platforms/macos/Funput/Settings/Panes/ShortcutsPane.swift
@@ -45,7 +45,7 @@ struct ShortcutsPane: View {
 
             Section("Mẹo") {
                 VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-                    Text("Trigger khớp đúng chuỗi phím bạn gõ và **phân biệt hoa/thường** — `vn` khác `VN`. Gõ tắt được ưu tiên hơn tự động khôi phục tiếng Anh.")
+                    Text("Trigger tự nhận diện hoa/thường — gõ `vn`, `Vn` hay `VN` đều bung, expansion tự viết hoa tương ứng. Gõ tắt được ưu tiên hơn tự động khôi phục tiếng Anh.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/platforms/windows/ui/pages/shortcuts/page.slint
+++ b/platforms/windows/ui/pages/shortcuts/page.slint
@@ -17,7 +17,7 @@ export component ShortcutsPage inherits VerticalLayout {
 
     PageHeader {
         title: "Gõ tắt";
-        subtitle: "Bung chữ tắt khi gõ khoảng trắng hoặc dấu câu.";
+        subtitle: "Bung chữ tắt khi gõ khoảng trắng hoặc dấu câu — tự nhận diện hoa/thường: vn → việt nam, Vn → Việt Nam, VN → VIỆT NAM.";
     }
 
     Section {


### PR DESCRIPTION
- Updated the text expansion logic to support smart-case matching, allowing triggers typed in lowercase, Title Case, or UPPERCASE to resolve to the same expansion.
- Introduced functions to classify the case of typed keys and apply the corresponding case to the expansion.
- Updated documentation and tests to reflect the new behavior, ensuring mixed-case triggers fall back to exact matches when necessary.