### PR TITLE
fix(windows): flyout→Settings handoff, Win10 backdrop, flip hotkey; tighten Control Center

### DIFF
--- a/platforms/windows/src/background/hook/keyboard.rs
+++ b/platforms/windows/src/background/hook/keyboard.rs
@@ -64,10 +64,14 @@ fn fire(hit: Hit) -> bool {
             if !shell::enabled() || FOREGROUND_IS_FUNPUT.load(Ordering::Relaxed) {
                 return false;
             }
+            // The hotkey's own modifiers are still held on this keydown, so the
+            // Backspaces must go out with them cleared — [`inject::send_plan_unmodified`].
             let plan = plan_inject(&shell::flip_composing());
-            if !plan.is_noop() {
-                send(&plan);
-            }
+            inject::send_plan_unmodified(
+                &plan,
+                keymap::read_mods(),
+                shell::foreground_has_urlbar_autofill(),
+            );
             true // swallow even on a no-op, so the hotkey never leaks to the app
         }
     }
@@ -95,13 +99,22 @@ fn handle_keydown(kbd: &KBDLLHOOKSTRUCT) -> bool {
         return false;
     }
 
+    // A modifier going *down* is not a shortcut being run; which shortcut it is
+    // only becomes known when the main key lands. `classify` saw the already-held
+    // Ctrl and flushed, so Ctrl+Shift+Z destroyed the composing word on its own
+    // Shift keydown — one event before flip could act on it. Only the low-level
+    // hook reaches here: macOS sends modifier changes as `flagsChanged`, not keys.
+    if hotkey::is_modifier_key(vk) {
+        return false;
+    }
+
     match classify(&keymap::to_key_event(kbd)) {
         KeyKind::Compose(c, source) => {
             let plan = plan_inject(&shell::process_key(c, source));
             if plan.is_noop() {
                 false // Action::None — the literal key reaches the app
             } else {
-                send(&plan); // delete + retype the composed text
+                inject::send_plan_auto(&plan); // delete + retype the composed text
                 true
             }
         }
@@ -122,18 +135,5 @@ fn handle_keydown(kbd: &KBDLLHOOKSTRUCT) -> bool {
             false
         }
         KeyKind::PassThrough => false,
-    }
-}
-
-/// Emit an inject plan to the focused app.
-///
-/// Chrome's omnibox and Firefox's address bar eat a Backspace to clear their
-/// autofill selection, so those get a Delete primer first (see
-/// [`inject::send_plan_primed`]); everything else takes the direct path.
-fn send(plan: &funput_desktop::InjectPlan) {
-    if shell::foreground_has_urlbar_autofill() {
-        inject::send_plan_primed(plan);
-    } else {
-        inject::send_plan(plan);
     }
 }

--- a/platforms/windows/src/background/hook/mod.rs
+++ b/platforms/windows/src/background/hook/mod.rs
@@ -90,13 +90,21 @@ pub fn run() {
         // the same pump and its events can be drained right after each dispatch.
         tray::install();
 
-        // Wait on the activate Event and the thread queue together so a second
-        // Funput.exe launch can open Settings even while the pump is idle.
+        // Wait on the activate Event, the current UI child, and the thread queue
+        // together: a second Funput.exe launch must open Settings while the pump is
+        // idle, and the Control Center reports the button the user pressed through
+        // its exit code, which reaches us only by waiting on its handle.
         let mut msg = MSG::default();
         loop {
-            match instance::wait_activate_or_message() {
+            // Re-read every turn: reaping one child can spawn the next (flyout →
+            // Settings), so the handle to wait on changes as we go.
+            let child = ui::current_child_handle();
+            match instance::wait_activate_message_or_child(child) {
                 WaitKind::Activate => {
                     ui::launch_settings(false);
+                }
+                WaitKind::ChildExited => {
+                    ui::reap_ui_child();
                 }
                 WaitKind::Message => {
                     while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {

--- a/platforms/windows/src/background/hotkey.rs
+++ b/platforms/windows/src/background/hotkey.rs
@@ -66,6 +66,11 @@ pub fn on_key_event(vk: VIRTUAL_KEY, mods: Mods, down: bool) -> Option<Hit> {
     (flip_mods() == Some(gesture)).then_some(Hit::Flip)
 }
 
+/// Whether this virtual-key is a modifier (either side, generic or specific).
+pub fn is_modifier_key(vk: VIRTUAL_KEY) -> bool {
+    rules::is_modifier(vk)
+}
+
 /// Abandon the gesture in progress. Clicking or scrolling with modifiers down is
 /// a Ctrl+click or a Ctrl+wheel zoom, never a bare modifier tap.
 pub fn note_other_input() {

--- a/platforms/windows/src/background/inject.rs
+++ b/platforms/windows/src/background/inject.rs
@@ -2,13 +2,30 @@
 //! characters, via `SendInput`. Every synthesized event carries [`INJECT_TAG`] in
 //! `dwExtraInfo` so the hook ignores them (no re-entrancy).
 
+mod modifiers;
+
 use funput_desktop::InjectPlan;
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
     KEYEVENTF_UNICODE, VIRTUAL_KEY, VK_BACK, VK_DELETE,
 };
 
-use crate::shared::shell::INJECT_TAG;
+pub use modifiers::send_plan_unmodified;
+
+use crate::shared::shell::{self, INJECT_TAG};
+
+/// Send a plan by whichever route the focused app needs.
+///
+/// Chrome's omnibox and Firefox's address bar eat a Backspace to clear their
+/// autofill selection, so those get a Delete primer first (see
+/// [`send_plan_primed`]); everything else takes the direct path.
+pub fn send_plan_auto(plan: &InjectPlan) {
+    if shell::foreground_has_urlbar_autofill() {
+        send_plan_primed(plan);
+    } else {
+        send_plan(plan);
+    }
+}
 
 fn vk_event(vk: VIRTUAL_KEY, up: bool) -> INPUT {
     let dw_flags = if up {

--- a/platforms/windows/src/background/inject/modifiers.rs
+++ b/platforms/windows/src/background/inject/modifiers.rs
@@ -1,0 +1,50 @@
+//! Injecting while the user still holds the hotkey's modifier keys.
+
+use funput_desktop::{InjectPlan, Mods};
+use windows::Win32::UI::Input::KeyboardAndMouse::{
+    VIRTUAL_KEY, VK_CONTROL, VK_LWIN, VK_MENU, VK_SHIFT,
+};
+
+use super::{raw_send, send_plan, send_plan_primed, vk_event};
+
+/// Send a plan with the currently-held modifiers momentarily released.
+///
+/// The flip hotkey fires on its main key's *keydown*, so Ctrl (and Shift) are
+/// still down when the plan goes out — and `VK_BACK` under Ctrl is
+/// delete-previous-*word*, not delete-character. A correct 3-character plan then
+/// wiped the whole word: "tiếng" flipped to "eengs" instead of "tieengs".
+///
+/// The releases and the restores both carry `INJECT_TAG`, so the hook ignores
+/// them. Restoring matters: without it, a user holding Ctrl+Shift to flip a second
+/// time would find the chord no longer matches, because the OS would believe those
+/// keys had come up.
+pub fn send_plan_unmodified(plan: &InjectPlan, held: Mods, primed: bool) {
+    if plan.is_noop() {
+        return;
+    }
+    let send = || {
+        if primed {
+            send_plan_primed(plan)
+        } else {
+            send_plan(plan)
+        }
+    };
+    let down: Vec<VIRTUAL_KEY> = [
+        held.ctrl.then_some(VK_CONTROL),
+        held.alt.then_some(VK_MENU),
+        held.shift.then_some(VK_SHIFT),
+        held.win.then_some(VK_LWIN),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    if down.is_empty() {
+        send();
+        return;
+    }
+
+    let events = |up: bool| -> Vec<_> { down.iter().map(|&vk| vk_event(vk, up)).collect() };
+    raw_send(&events(true));
+    send();
+    raw_send(&events(false));
+}

--- a/platforms/windows/src/background/instance.rs
+++ b/platforms/windows/src/background/instance.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use windows::core::w;
 use windows::Win32::Foundation::{
-    CloseHandle, GetLastError, ERROR_ALREADY_EXISTS, HANDLE, WAIT_EVENT, WAIT_OBJECT_0,
+    CloseHandle, GetLastError, ERROR_ALREADY_EXISTS, HANDLE, WAIT_OBJECT_0,
 };
 use windows::Win32::System::Threading::{
     CreateEventW, CreateMutexW, OpenEventW, ResetEvent, SetEvent, WaitForSingleObject,
@@ -95,27 +95,45 @@ pub fn poll_activate() -> bool {
     }
 }
 
-/// Block until the activate event or a thread message arrives.
-pub fn wait_activate_or_message() -> WaitKind {
+/// Block until the activate event fires, the UI child exits, or a thread message
+/// arrives.
+///
+/// Waiting on `child` is what makes the flyout → Settings handoff prompt: the
+/// child reports the button pressed through its *exit code*, and a process
+/// exiting posts no window message, so without its handle the pump would sleep
+/// until unrelated input happened to wake it.
+///
+/// The handle is borrowed from the caller's `Child`. Both live on this thread and
+/// the thread parks inside this call, so it cannot be closed mid-wait.
+pub fn wait_activate_message_or_child(child: Option<HANDLE>) -> WaitKind {
     let Some(event) = activate_handle() else {
         return WaitKind::Failed;
     };
     unsafe {
-        let handles = [event];
+        // Index 0 is the activate event, index 1 the child when present, and the
+        // message queue always sits one past the last handle.
+        let mut handles = [event, HANDLE::default()];
+        let count = child.map_or(1, |handle| {
+            handles[1] = handle;
+            2
+        });
         let result = windows::Win32::UI::WindowsAndMessaging::MsgWaitForMultipleObjects(
-            Some(&handles),
+            Some(&handles[..count]),
             false,
             INFINITE,
             windows::Win32::UI::WindowsAndMessaging::QS_ALLINPUT,
         );
-        // nCount=1 → index 0 is the event; index 1 means the thread message queue.
-        if result == WAIT_OBJECT_0 {
-            let _ = ResetEvent(event);
-            WaitKind::Activate
-        } else if result == WAIT_EVENT(WAIT_OBJECT_0.0 + 1) {
-            WaitKind::Message
-        } else {
-            WaitKind::Failed
+        let Some(index) = result.0.checked_sub(WAIT_OBJECT_0.0) else {
+            return WaitKind::Failed;
+        };
+        match index as usize {
+            0 => {
+                let _ = ResetEvent(event);
+                WaitKind::Activate
+            }
+            1 if count == 2 => WaitKind::ChildExited,
+            i if i == count => WaitKind::Message,
+            _ => WaitKind::Failed,
         }
     }
 }
@@ -123,6 +141,8 @@ pub fn wait_activate_or_message() -> WaitKind {
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum WaitKind {
     Activate,
+    /// The tracked UI child process ended; its exit code is ready to be reaped.
+    ChildExited,
     Message,
     Failed,
 }

--- a/platforms/windows/src/background/tray/events.rs
+++ b/platforms/windows/src/background/tray/events.rs
@@ -8,9 +8,11 @@ use crate::background::hook;
 use crate::ui;
 
 /// Drain pending tray + menu events. Call after each `DispatchMessageW`.
+///
+/// Child reaping is deliberately not done here: the pump waits on the child's
+/// handle directly, so polling it once per dispatched message would only add a
+/// `try_wait` syscall to every mouse move the low-level hook delivers.
 pub(super) fn drain() {
-    ui::reap_ui_child();
-
     while let Ok(ev) = TrayIconEvent::receiver().try_recv() {
         if let TrayIconEvent::Click {
             button: MouseButton::Left,

--- a/platforms/windows/src/ui/control_center/mod.rs
+++ b/platforms/windows/src/ui/control_center/mod.rs
@@ -16,7 +16,9 @@ use funput_config::{Method, ToneStyle};
 /// Process exit codes parent reaps to open Settings on a given tab.
 pub(super) const EXIT_DISMISS: u8 = 0;
 pub(super) const EXIT_SETTINGS: u8 = 10;
-pub(super) const EXIT_SHORTCUTS: u8 = 11;
+// 11 was EXIT_SHORTCUTS, dropped when the flyout's shortcut tile became the
+// smart-restore toggle. Codes stay stable so an older parent reaping a newer
+// child never mistakes one destination for another.
 pub(super) const EXIT_KEYBOARD: u8 = 12;
 
 static EXIT_CODE: AtomicU8 = AtomicU8::new(EXIT_DISMISS);
@@ -49,7 +51,7 @@ fn populate(window: &ControlCenterWindow) {
     window.set_method_label(method_label(s.method).into());
     window.set_spell_check(s.spell_check);
     window.set_auto_capitalize(s.auto_capitalize);
-    window.set_shortcut_count(shell::shortcuts().len() as i32);
+    window.set_smart_restore(s.smart_restore);
     window.set_hotkey_label(hotkey_label(&s).into());
     window.set_tone_label(tone_label(s.tone_style).into());
 }

--- a/platforms/windows/src/ui/control_center/wire.rs
+++ b/platforms/windows/src/ui/control_center/wire.rs
@@ -8,7 +8,7 @@ use funput_config::ToneStyle;
 
 use super::{
     cycle_method, method_label, request_exit, status_line, tone_label, EXIT_DISMISS, EXIT_KEYBOARD,
-    EXIT_SETTINGS, EXIT_SHORTCUTS,
+    EXIT_SETTINGS,
 };
 
 pub(super) fn attach(window: &ControlCenterWindow) {
@@ -50,6 +50,15 @@ pub(super) fn attach(window: &ControlCenterWindow) {
     });
 
     let weak = window.as_weak();
+    window.on_toggle_restore(move || {
+        let on = !shell::snapshot().smart_restore;
+        commands::set_smart_restore(on);
+        if let Some(w) = weak.upgrade() {
+            w.set_smart_restore(on);
+        }
+    });
+
+    let weak = window.as_weak();
     window.on_cycle_tone(move || {
         let next = match shell::snapshot().tone_style {
             ToneStyle::Traditional => ToneStyle::Modern,
@@ -61,7 +70,6 @@ pub(super) fn attach(window: &ControlCenterWindow) {
         }
     });
 
-    window.on_open_shortcuts(|| request_exit(EXIT_SHORTCUTS));
     window.on_open_keyboard(|| request_exit(EXIT_KEYBOARD));
     window.on_open_settings(|| request_exit(EXIT_SETTINGS));
     window.on_dismiss(|| request_exit(EXIT_DISMISS));

--- a/platforms/windows/src/ui/lifecycle/child.rs
+++ b/platforms/windows/src/ui/lifecycle/child.rs
@@ -6,8 +6,11 @@
 //! rules live in [`super::flyout`].
 
 use std::cell::RefCell;
+use std::os::windows::io::AsRawHandle;
 use std::process::{Child, Command};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+use windows::Win32::Foundation::HANDLE;
 
 use crate::shared::shell;
 
@@ -63,6 +66,19 @@ pub(super) fn spawn_child(arg: &str, kind: UiKind, extra_env: &[(&str, &str)]) {
     if let Some(child) = cmd.spawn().ok() {
         UI_PROCESS.with(|cell| *cell.borrow_mut() = Some((kind, child)));
     }
+}
+
+/// Raw handle of the tracked UI child, for the hook thread's wait set.
+///
+/// Borrowed, never owned: the `Child` in [`UI_PROCESS`] stays the only owner, so
+/// the caller must not close it. Only valid until that slot is cleared, which
+/// this thread alone does — see [`crate::background::instance::wait_activate_message_or_child`].
+pub(crate) fn current_child_handle() -> Option<HANDLE> {
+    UI_PROCESS.with(|cell| {
+        cell.borrow()
+            .as_ref()
+            .map(|(_, child)| HANDLE(child.as_raw_handle()))
+    })
 }
 
 pub(crate) fn terminate_children() {

--- a/platforms/windows/src/ui/lifecycle/flyout.rs
+++ b/platforms/windows/src/ui/lifecycle/flyout.rs
@@ -86,7 +86,6 @@ pub(crate) fn reap_ui_child() {
     }
     match code {
         control_center::EXIT_SETTINGS => launch_settings_tab("overview", false),
-        control_center::EXIT_SHORTCUTS => launch_settings_tab("shortcuts", false),
         control_center::EXIT_KEYBOARD => launch_settings_tab("keyboard", false),
         _ => {}
     }

--- a/platforms/windows/src/ui/lifecycle/flyout.rs
+++ b/platforms/windows/src/ui/lifecycle/flyout.rs
@@ -65,7 +65,13 @@ pub(crate) fn reap_ui_child() {
                 *slot = None;
                 Some(out)
             }
-            _ => None,
+            Ok(None) => None,
+            // The handle is unusable, so it will never resolve. Drop it instead of
+            // leaving it in the pump's wait set, where it would spin the loop.
+            Err(_) => {
+                *slot = None;
+                None
+            }
         }
     });
     let Some((UiKind::ControlCenter, code)) = finished else {

--- a/platforms/windows/src/ui/lifecycle/mod.rs
+++ b/platforms/windows/src/ui/lifecycle/mod.rs
@@ -11,7 +11,9 @@ use windows::Win32::System::Threading::{
 use super::{control_center, onboarding, settings_window};
 use crate::shared::shell;
 
-pub(crate) use child::{launch_onboarding, launch_settings, terminate_children};
+pub(crate) use child::{
+    current_child_handle, launch_onboarding, launch_settings, terminate_children,
+};
 pub(crate) use flyout::{reap_ui_child, toggle_control_center};
 
 use child::{PARENT_PID_ENV, RECENT_APPS_ENV};

--- a/platforms/windows/src/ui/mica.rs
+++ b/platforms/windows/src/ui/mica.rs
@@ -15,16 +15,28 @@
 //!     is applied. Hence apply runs from the event loop, and the caller flips
 //!     the transparent background afterwards.
 
-/// Long-lived window backdrop: Mica first, Acrylic fallback.
+/// Long-lived window backdrop (Settings, Onboarding): Mica, or nothing.
+///
+/// There is deliberately no Acrylic fallback here. `apply_mica` is Win11-only, but
+/// below it `apply_acrylic` still *succeeds*, through the undocumented
+/// `SetWindowCompositionAttribute` path — and that path is wrong for a window the
+/// user drags and resizes:
+///   * `window-vibrancy` documents it as making the window "lag when resizing or
+///     dragging" on Windows 10 v1903+, and DWM re-blurs the desktop behind every
+///     frame, so the whole window feels sluggish and not just while moving.
+///   * It is handed no tint (alpha is forced to 1/255), so it blurs without
+///     covering anything.
+///
+/// Reporting success would then flip `Theme.mica`, and the UI paints `transparent`
+/// and drops its own `Backdrop` — leaving a see-through, laggy window. Returning
+/// false is exactly what routes Windows 10 to the opaque fallback the shells
+/// already carry.
+///
+/// The flyout is a different case and keeps its Acrylic — see [`apply_flyout`].
 pub fn apply(window: &slint::Window) -> bool {
     #[cfg(windows)]
     {
-        use window_vibrancy::{apply_acrylic, apply_mica};
-        let handle = window.window_handle();
-        if apply_mica(&handle, None).is_ok() {
-            return true;
-        }
-        if apply_acrylic(&handle, None).is_ok() {
+        if window_vibrancy::apply_mica(window.window_handle(), None).is_ok() {
             return true;
         }
     }
@@ -34,6 +46,11 @@ pub fn apply(window: &slint::Window) -> bool {
 
 /// Transient flyout backdrop (Control Center): Acrylic first, then Mica, plus
 /// the small Win11 corner radius menus and flyouts use.
+///
+/// Acrylic stays here even on Windows 10, where [`apply`] refuses it: the flyout
+/// is `no-frame` and fixed-size, so the resize/drag lag has nothing to act on, and
+/// its own layer (`Theme.flyout-base`) is ~92% opaque, so an untinted blur behind
+/// it cannot make it see-through.
 #[cfg(windows)]
 pub fn apply_flyout(window: &slint::Window) -> bool {
     use window_vibrancy::{apply_acrylic, apply_mica};

--- a/platforms/windows/src/ui/mod.rs
+++ b/platforms/windows/src/ui/mod.rs
@@ -27,7 +27,8 @@ pub mod recorder;
 pub mod system_accent;
 
 pub(crate) use lifecycle::{
-    launch_onboarding, launch_settings, reap_ui_child, run_control_center, run_onboarding,
-    run_settings, terminate_children, terminate_parent_for_update, toggle_control_center,
+    current_child_handle, launch_onboarding, launch_settings, reap_ui_child, run_control_center,
+    run_onboarding, run_settings, terminate_children, terminate_parent_for_update,
+    toggle_control_center,
 };
 pub(crate) use settings_window::set_update_state;

--- a/platforms/windows/ui/control_center/header.slint
+++ b/platforms/windows/ui/control_center/header.slint
@@ -9,61 +9,58 @@ export component CcHeader {
     callback toggle-enabled(bool);
 
     width: 100%;
-    VerticalLayout {
-        spacing: 6px;
+    // Single row: the old VerticalLayout wrapper held one child, so its spacing
+    // was dead weight and the extra nesting bought nothing.
+    HorizontalLayout {
+        spacing: Theme.sp-ms;
         width: 100%;
-        HorizontalLayout {
-            spacing: 10px;
-            width: 100%;
-            VerticalLayout {
-                alignment: center;
-                Image {
-                    // Sized to span the name + status lines beside it.
-                    source: @image-url("../../../../assets/logo.png");
-                    width: 38px;
-                    height: 38px;
-                }
+        VerticalLayout {
+            alignment: center;
+            Image {
+                // Sized to span the name + status lines beside it.
+                source: @image-url("../../../../assets/logo.png");
+                width: 32px;
+                height: 32px;
             }
-            VerticalLayout {
-                horizontal-stretch: 1;
-                alignment: center;
-                spacing: 2px;
-                Text {
-                    text: "Funput";
-                    font-size: 16px;
-                    font-weight: 700;
-                    color: Palette.foreground;
-                }
-                Text {
-                    text: root.status;
-                    font-size: Theme.font-caption;
-                    color: root.enabled ? Theme.accent-legible : Theme.subtle;
-                    overflow: elide;
-                }
+        }
+        VerticalLayout {
+            horizontal-stretch: 1;
+            alignment: center;
+            Text {
+                text: "Funput";
+                font-size: 15px;
+                font-weight: 700;
+                color: Palette.foreground;
             }
-            // Large VI toggle.
+            Text {
+                text: root.status;
+                font-size: Theme.font-caption;
+                color: root.enabled ? Theme.accent-legible : Theme.subtle;
+                overflow: elide;
+            }
+        }
+        // Large VI toggle.
+        Rectangle {
+            width: 44px;
+            height: 26px;
+            border-radius: 13px;
+            // No fill animation: the flyout is created fresh on every open, and
+            // an animated background renders its first frame transparent.
+            background: root.enabled ? Theme.accent : Theme.track;
+            border-width: root.enabled ? 0px : 1px;
+            border-color: Theme.flyout-border;
             Rectangle {
-                width: 48px;
-                height: 28px;
-                border-radius: 14px;
-                // No fill animation: the flyout is created fresh on every open, and
-                // an animated background renders its first frame transparent.
-                background: root.enabled ? Theme.accent : Theme.track;
-                border-width: root.enabled ? 0px : 1px;
-                border-color: Theme.flyout-border;
-                Rectangle {
-                    x: root.enabled ? parent.width - 25px : 3px;
-                    y: 3px;
-                    width: 22px;
-                    height: 22px;
-                    border-radius: 11px;
-                    background: #ffffff;
-                    animate x { duration: 120ms; easing: ease-out; }
-                }
-                TouchArea {
-                    mouse-cursor: pointer;
-                    clicked => { root.toggle-enabled(!root.enabled); }
-                }
+                x: root.enabled ? parent.width - 23px : 3px;
+                y: 3px;
+                width: 20px;
+                height: 20px;
+                border-radius: 10px;
+                background: #ffffff;
+                animate x { duration: 120ms; easing: ease-out; }
+            }
+            TouchArea {
+                mouse-cursor: pointer;
+                clicked => { root.toggle-enabled(!root.enabled); }
             }
         }
     }

--- a/platforms/windows/ui/control_center/list.slint
+++ b/platforms/windows/ui/control_center/list.slint
@@ -7,9 +7,9 @@ component LinkRow inherits Rectangle {
     in property <string> label;
     in property <string> value;
     callback clicked;
-    height: 40px;
+    height: 34px;
     HorizontalLayout {
-        spacing: 10px;
+        spacing: Theme.sp-sm;
         Text {
             text: root.label;
             horizontal-stretch: 1;
@@ -46,7 +46,7 @@ export component CcList {
 
     width: 100%;
     VerticalLayout {
-        spacing: 10px;
+        spacing: Theme.sp-sm;
         width: 100%;
         Rectangle {
             width: 100%;
@@ -55,10 +55,10 @@ export component CcList {
             border-width: 1px;
             border-color: Theme.flyout-border;
             VerticalLayout {
-                padding-left: 14px;
-                padding-right: 14px;
-                padding-top: 4px;
-                padding-bottom: 4px;
+                padding-left: Theme.sp-ms;
+                padding-right: Theme.sp-ms;
+                padding-top: Theme.sp-xs;
+                padding-bottom: Theme.sp-xs;
                 LinkRow {
                     label: "Phím chuyển";
                     value: root.hotkey-label;

--- a/platforms/windows/ui/control_center/tiles.slint
+++ b/platforms/windows/ui/control_center/tiles.slint
@@ -12,7 +12,6 @@ export component BigTile inherits Rectangle {
 
     horizontal-stretch: 1;
     min-width: 0px;
-    height: 88px;
     border-radius: Theme.r-shell;
     background: root.emphasized
         ? (touch.has-hover ? Theme.accent-hover : Theme.accent)
@@ -20,29 +19,37 @@ export component BigTile inherits Rectangle {
     border-width: 1px;
     border-color: root.emphasized ? transparent : Theme.flyout-border;
 
+    // Height follows the content: the old fixed 88px left a dead band that the
+    // stretch spacer absorbed, which is what made the flyout read as too airy.
+    // Vertical padding is tighter than horizontal on purpose — the tile is wide
+    // and short, so side breathing room matters more than top/bottom.
     VerticalLayout {
-        padding: 14px;
+        padding-left: Theme.sp-ms;
+        padding-right: Theme.sp-ms;
+        padding-top: Theme.sp-sm;
+        padding-bottom: Theme.sp-sm;
         spacing: 0px;
         width: 100%;
-        height: 100%;
         Image {
             source: root.icon;
-            width: 18px;
-            height: 18px;
+            width: 16px;
+            height: 16px;
             colorize: root.emphasized ? Theme.accent-text : Palette.foreground;
             horizontal-alignment: left;
         }
-        Rectangle { vertical-stretch: 1; }
+        // Fixed gap instead of a stretched spacer, so the icon-to-label distance
+        // no longer grows with the tile.
+        Rectangle { height: Theme.sp-xs; }
         Text {
             text: root.title;
-            font-size: 14px;
+            font-size: 13px;
             font-weight: 600;
             color: root.emphasized ? Theme.accent-text : Palette.foreground;
             overflow: elide;
         }
         Text {
             text: root.subtitle;
-            font-size: 12px;
+            font-size: Theme.font-caption;
             // Opaque on the accent fill: any transparency drops it under 4.5:1.
             color: root.emphasized ? Theme.accent-text : Theme.subtle;
             overflow: elide;
@@ -66,15 +73,18 @@ export component CcTiles {
     callback toggle-cap();
     callback open-shortcuts();
 
+    // One gap value drives both the layout spacing and the half-width maths, so
+    // the columns cannot drift out of sync when the rhythm is retuned.
+    private property <length> gap: Theme.sp-sm;
     // Explicit half-width: HorizontalLayout stretch was shrink-wrapping to text.
-    private property <length> tile-w: (root.width - 12px) / 2;
+    private property <length> tile-w: (root.width - root.gap) / 2;
 
     width: 100%;
     VerticalLayout {
-        spacing: 12px;
+        spacing: root.gap;
         width: 100%;
         HorizontalLayout {
-            spacing: 12px;
+            spacing: root.gap;
             BigTile {
                 width: root.tile-w;
                 icon: @image-url("../icons/nav/primary/keyboard.svg");
@@ -93,7 +103,7 @@ export component CcTiles {
             }
         }
         HorizontalLayout {
-            spacing: 12px;
+            spacing: root.gap;
             BigTile {
                 width: root.tile-w;
                 icon: @image-url("../icons/nav/primary/shortcut.svg");

--- a/platforms/windows/ui/control_center/tiles.slint
+++ b/platforms/windows/ui/control_center/tiles.slint
@@ -67,11 +67,11 @@ export component CcTiles {
     in property <string> method-label;
     in property <bool> spell-check;
     in property <bool> auto-capitalize;
-    in property <int> shortcut-count;
+    in property <bool> smart-restore;
     callback cycle-method();
     callback toggle-spell();
     callback toggle-cap();
-    callback open-shortcuts();
+    callback toggle-restore();
 
     // One gap value drives both the layout spacing and the half-width maths, so
     // the columns cannot drift out of sync when the rhythm is retuned.
@@ -106,11 +106,11 @@ export component CcTiles {
             spacing: root.gap;
             BigTile {
                 width: root.tile-w;
-                icon: @image-url("../icons/nav/primary/shortcut.svg");
-                title: "Gõ tắt";
-                subtitle: root.shortcut-count + " mục";
-                emphasized: root.shortcut-count > 0;
-                clicked => { root.open-shortcuts(); }
+                icon: @image-url("../icons/row/restore.svg");
+                title: "Khôi phục tiếng Anh";
+                subtitle: root.smart-restore ? "Đang bật" : "Đang tắt";
+                emphasized: root.smart-restore;
+                clicked => { root.toggle-restore(); }
             }
             BigTile {
                 width: root.tile-w;

--- a/platforms/windows/ui/control_center/window.slint
+++ b/platforms/windows/ui/control_center/window.slint
@@ -21,7 +21,7 @@ export component ControlCenterWindow inherits Window {
     in property <string> method-label: "Telex";
     in-out property <bool> spell-check: true;
     in-out property <bool> auto-capitalize: false;
-    in property <int> shortcut-count: 0;
+    in-out property <bool> smart-restore: true;
     in property <string> hotkey-label: "Ctrl+`";
     in property <string> tone-label: "Truyền thống";
 
@@ -29,7 +29,7 @@ export component ControlCenterWindow inherits Window {
     callback cycle-method();
     callback toggle-spell();
     callback toggle-cap();
-    callback open-shortcuts();
+    callback toggle-restore();
     callback open-keyboard();
     callback cycle-tone();
     callback open-settings();
@@ -64,11 +64,11 @@ export component ControlCenterWindow inherits Window {
                 method-label: root.method-label;
                 spell-check: root.spell-check;
                 auto-capitalize: root.auto-capitalize;
-                shortcut-count: root.shortcut-count;
+                smart-restore: root.smart-restore;
                 cycle-method() => { root.cycle-method(); }
                 toggle-spell() => { root.toggle-spell(); }
                 toggle-cap() => { root.toggle-cap(); }
-                open-shortcuts() => { root.open-shortcuts(); }
+                toggle-restore() => { root.toggle-restore(); }
             }
             CcList {
                 hotkey-label: root.hotkey-label;

--- a/platforms/windows/ui/control_center/window.slint
+++ b/platforms/windows/ui/control_center/window.slint
@@ -48,9 +48,12 @@ export component ControlCenterWindow inherits Window {
             }
         }
 
+        // One rhythm for the whole flyout: 12px between sections, 12px inset.
+        // Sections carry their own card padding, so a wider gutter here only
+        // compounds it.
         VerticalLayout {
-            padding: 16px;
-            spacing: 14px;
+            padding: Theme.sp-ms;
+            spacing: Theme.sp-ms;
             width: 100%;
             CcHeader {
                 enabled: root.enabled;

--- a/platforms/windows/ui/theme/tokens.slint
+++ b/platforms/windows/ui/theme/tokens.slint
@@ -66,6 +66,8 @@ export global Theme {
 
     out property <length> sp-xs: 4px;
     out property <length> sp-sm: 8px;
+    // Fills the 8→16 gap in the 4px scale; the dense flyout rhythm needs it.
+    out property <length> sp-ms: 12px;
     out property <length> sp-md: 16px;
     out property <length> sp-lg: 20px;
     out property <length> sp-xl: 28px;


### PR DESCRIPTION
Windows shell only. Four user-reported bugs, each traced to a root cause and verified by measurement, plus a density pass on the tray Control Center.

## Bugs fixed

### 1. Settings took a long, variable time to open from the flyout

Clicking "Mở cài đặt đầy đủ" does not open Settings — the flyout exits with a code and the tray process reads it. But the pump waited on `MsgWaitForMultipleObjects([activate_event], INFINITE, QS_ALLINPUT)`, and **the child's handle was not in that set**. `reap_ui_child()` also only ran *inside* the `while PeekMessageW` body, so a wake with no message skipped it. With no timer anywhere, the delay had no upper bound: Settings appeared only when some unrelated input (a mouse move via the low-level hook) happened to wake the pump.

Fix: wait on the tracked child handle alongside the activate event, and reap on `WaitKind::ChildExited`.

Measured, with the desktop deliberately idle after the child exits:

| | result |
|---|---|
| before | **never reaped** in a 6 s window |
| after | **reaped in 7–10 ms** (3 runs) |

Settings itself was never slow — it paints in ~110 ms warm; the wait was the whole delay.

### 2. Windows 10: Settings laggy and see-through

`mica::apply()` tried Mica, then fell back to Acrylic. Below Win11 `apply_mica` fails but `apply_acrylic` **succeeds**, via the undocumented `SetWindowCompositionAttribute` path — which `window-vibrancy` documents as making the window *"lag when resizing or dragging"* on Win10 v1903+, and which it hands a zero-alpha tint (alpha forced to 1/255). Reporting success then set `Theme.mica`, so the UI painted `transparent` and dropped its own `Backdrop`.

The opaque fallback already existed in both shells (`Theme.window-base` + `Backdrop`); it was simply unreachable. Making `apply()` Mica-only routes Win10 to it. No version-detection code needed — `apply_mica` is already the Win11 gate.

The flyout keeps Acrylic on purpose: it is `no-frame` and fixed-size, so the resize/drag lag has nothing to act on, and its own layer is ~92% opaque.

Verified: Win11 still reports `true` (Mica unchanged, checked on a live run); the Win10 path renders fully opaque.

### 3. "Lật từ vừa gõ" did nothing

Two independent faults, both required:

**a. The chord destroyed its own target.** When Shift goes down, Ctrl is already held, so `mods.is_shortcut()` is true → `classify()` returns `Flush` → `shell::clear()` ends the composing session. By the time Z arrived the hotkey matched correctly but had nothing to act on. Both presets are Ctrl+Shift+‹key›, so flip had never worked through a preset.

```
DBG_FLUSH vk=0xA0 clears composing     <- Shift keydown
DBG_FLIP reached
DBG_FLIP plan_is_noop=true             <- nothing left to flip
```

Fix: a bare modifier keydown is not a shortcut being run — skip it before `classify()`.

**b. Injected Backspaces became Ctrl+Backspace.** Flip fires on the main key's keydown, so Ctrl is still physically held; `VK_BACK` under Ctrl deletes a *word*. A correct 3-character plan wiped the whole word — `tiếng` flipped to `eengs` instead of `tieengs` (reproducible 3/3, while the plan itself logged `backspaces=3 units="eengs"`, i.e. correct).

Fix: release the held modifiers around the batch and press them back. Restoring matters — without it a user holding Ctrl+Shift to flip twice would find the chord no longer matches.

Fix (a) alone would have been **worse than the bug**: it turns "nothing happens" into "the word is deleted". They ship together.

Verified end-to-end in Notepad: telex `tieengs` → `tiếng` → Ctrl+Shift+Z → `tieengs`.

### 4. Per-message syscall on the hook hot path

`reap_ui_child()` ran a `try_wait()` after every dispatched message — including every mouse move the low-level hook delivers. Now redundant, and removed.

## Improvements

**Control Center density.** The flyout was 421 px tall for seven controls. `BigTile` was pinned to 88 px with a `vertical-stretch` spacer absorbing the slack, so the icon-to-label gap grew with the tile. Height now follows content, spacing is on one 4 px scale (a `sp-ms: 12px` token fills the 8→16 gap), and the header lost a `VerticalLayout` wrapper that held a single child. **421 px → 351 px (−17%)**, verified at 100% and 150% DPI, light and dark, plus a long-label stress case.

**"Gõ tắt" tile replaced by a "Khôi phục tiếng Anh" toggle**, matching the other quick toggles. `EXIT_SHORTCUTS` and its handler became dead code and were removed; exit code 11 is left unused on purpose so an older parent reaping a newer child cannot mistake one destination for another.

**Robustness.** `reap_ui_child` now clears the slot when `try_wait` errors — a dead handle left in the pump's wait set would spin the loop.

## Verification

`cargo build`, `cargo fmt --check`, `cargo test --workspace` (296 tests) all pass. `cargo clippy --all-targets` reports 4 findings — **the same set already on `main`**, none added.

Every file touched stays under the 150-line limit from `check-loc.sh`; `inject/modifiers.rs` was split out and `send()` moved from the hook into `inject::send_plan_auto` to keep it that way.

Behavioural checks were run against a real build with synthetic input and an isolated `$FUNPUT_CONFIG` — the toggle matrix (7 press patterns × 5 presses) still passes, confirming no regression from the modifier change.

## Known, not addressed

- **Ctrl+Shift as the VI/EN toggle, reported as needing several presses.** Not reproduced: 7 realistic press patterns each toggled 5/5. The leading suspicion is that Ctrl+Shift is also the Windows layout-switch shortcut, and `recorder::system_conflict()` cannot flag it — every branch there compares `c.vk`, which is `0` for a modifier-only combo, so Ctrl+Shift and Alt+Shift are never warned about. The test machine has one keyboard layout, the one configuration where that conflict cannot occur.
- **Linux (fcitx5) likely shares bug 3a**: a bare Shift press while Ctrl is held falls into `commitBuffer()`. Unverified — no Linux machine, and the ibus path was not read. macOS is unaffected: it delivers modifier changes as `flagsChanged`, never as a key down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)