### PR TITLE
iOS: manual App Store Connect deploy workflow

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -1,0 +1,175 @@
+name: Deploy iOS
+
+# Manual only. Builds the App Store .ipa from whichever branch you run it on and
+# uploads it to App Store Connect, where it lands in TestFlight.
+#
+# Deliberately NOT wired into release.yml: every upload burns a build number
+# permanently at Apple, and iOS depends on Apple infrastructure that fails for
+# reasons unrelated to this repo (expired certificates, revoked profiles). Keeping
+# it separate means a bad day at Apple never blocks the macOS/Windows/Linux release.
+#
+# Uploading is not publishing: the build reaches TestFlight, but submitting it to
+# the App Store is still a deliberate act in App Store Connect.
+#
+# Required secrets:
+#   IOS_DIST_CERT_P12       base64 of an *Apple Distribution* .p12 (with private key).
+#                           The Developer ID cert used for macOS cannot sign this.
+#   IOS_DIST_CERT_PASSWORD  password set when exporting that .p12
+#   ASC_KEY_ID              App Store Connect API key id
+#   ASC_ISSUER_ID           App Store Connect API issuer id
+#   ASC_API_KEY_P8          base64 of the AuthKey_<ASC_KEY_ID>.p8 (downloadable once)
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version, e.g. 1.2026.66. Stamped as both the marketing version and the build number."
+        required: true
+        type: string
+      dry_run:
+        description: "Validate the .ipa with Apple but do not upload it."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# One upload at a time: two concurrent runs would race for the same build number.
+concurrency:
+  group: deploy-ios
+  cancel-in-progress: false
+
+env:
+  CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_NET_RETRY: "5"
+
+jobs:
+  ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Rust targets (device + simulator)
+        run: rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check Swift file size
+        working-directory: platforms/ios
+        run: sh ./Scripts/check-swift-loc.sh
+
+      # Builds FunputCore.xcframework and resolves packages; the tests below and the
+      # archive both need it. cargo caches, so later runs of build-ffi are cheap.
+      - name: Bootstrap native dependencies
+        working-directory: platforms/ios
+        run: sh ./Scripts/bootstrap-ios.sh
+
+      # Never ship a build the suite has not passed. The script picks whichever iOS
+      # simulator the runner image happens to provide.
+      - name: Run FunputKit tests
+        working-directory: platforms/ios
+        run: sh ./Scripts/test-funput-kit.sh
+
+      - name: Import Apple Distribution certificate
+        env:
+          CERT_P12: ${{ secrets.IOS_DIST_CERT_P12 }}
+          CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/funput-ios.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          echo "$CERT_P12" | base64 --decode > "$RUNNER_TEMP/ios-cert.p12"
+          security import "$RUNNER_TEMP/ios-cert.p12" -k "$KEYCHAIN" -P "$CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/xcodebuild
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN" \
+            $(security list-keychains -d user | sed 's/["[:space:]]//g')
+          security default-keychain -s "$KEYCHAIN"
+          rm -f "$RUNNER_TEMP/ios-cert.p12"
+
+      # Both xcodebuild (to create provisioning profiles) and altool (to upload) read
+      # the key from this directory, which is one of the locations altool searches.
+      - name: Install App Store Connect API key
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          echo "$ASC_API_KEY_P8" | base64 --decode \
+            > "$HOME/.appstoreconnect/private_keys/AuthKey_$ASC_KEY_ID.p8"
+          chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_$ASC_KEY_ID.p8"
+
+      - name: Archive and export .ipa
+        working-directory: platforms/ios
+        env:
+          VERSION: ${{ inputs.version }}
+        run: sh ./Scripts/release-ios.sh
+
+      # Validation catches the usual rejections — entitlements, icons, a build number
+      # Apple has already seen — in seconds, before pushing the whole binary.
+      - name: Validate with Apple
+        working-directory: platforms/ios
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: |
+          xcrun altool --validate-app -f build/release/export/Funput.ipa -t ios \
+            --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
+
+      - name: Upload to App Store Connect
+        if: ${{ !inputs.dry_run }}
+        working-directory: platforms/ios
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+        run: |
+          xcrun altool --upload-app -f build/release/export/Funput.ipa -t ios \
+            --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
+
+      # Kept so a rejected or failed upload can be inspected, or retried by hand from
+      # Transporter without rebuilding.
+      - name: Stage artifact
+        if: always()
+        run: |
+          OUT="$RUNNER_TEMP/out"; mkdir -p "$OUT"
+          cp platforms/ios/build/release/export/Funput.ipa \
+            "$OUT/Funput-${{ inputs.version }}.ipa" 2>/dev/null || exit 0
+          shasum -a 256 "$OUT/Funput-${{ inputs.version }}.ipa" \
+            | awk '{print $1}' > "$OUT/Funput-${{ inputs.version }}.ipa.sha256"
+
+      - uses: actions/upload-artifact@v5
+        if: always()
+        with:
+          name: ios
+          path: ${{ runner.temp }}/out
+          if-no-files-found: ignore
+
+      - name: Remove credentials from the runner
+        if: always()
+        run: |
+          rm -rf "$HOME/.appstoreconnect/private_keys"
+          security delete-keychain "$RUNNER_TEMP/funput-ios.keychain-db" || true
+
+      - name: Summary
+        if: success()
+        run: |
+          {
+            echo "### Funput iOS ${{ inputs.version }}"
+            if [ "${{ inputs.dry_run }}" = "true" ]; then
+              echo "Validated with Apple; **not** uploaded (dry run)."
+            else
+              echo "Uploaded to App Store Connect. Processing takes a few minutes,"
+              echo "then the build appears under TestFlight."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/platforms/ios/Scripts/release-ios.sh
+++ b/platforms/ios/Scripts/release-ios.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Archive Funput for iOS and export a signed App Store .ipa, ready to upload by
+# hand with Xcode Organizer or Transporter. The keyboard extension ships inside
+# the app, so this one archive covers both targets.
+#
+#   ./Scripts/release-ios.sh                  # versions come from the project
+#   VERSION=1.2026.66 ./Scripts/release-ios.sh  # stamp a version instead
+#
+# Without VERSION, bump the version in Xcode first — App Store Connect rejects a
+# build number it has already accepted.
+set -eu
+
+CONFIGURATION="${CONFIGURATION:-Release}"
+SCHEME="${SCHEME:-Funput}"
+TEAM_ID="${TEAM_ID:-RSARFZ5CD3}"
+VERSION="${VERSION:-}"
+# CFBundleVersion is what App Store Connect checks for uniqueness. The calver
+# doubles as one: it is three dot-separated integers and rises with every release.
+BUILD="${BUILD:-$VERSION}"
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+IOS_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+cd "$IOS_ROOT"
+
+OUT="$IOS_ROOT/build/release"
+ARCHIVE="$OUT/Funput.xcarchive"
+EXPORT="$OUT/export"
+EXPORT_OPTIONS="$OUT/ExportOptions.plist"
+
+rm -rf "$ARCHIVE" "$EXPORT"
+mkdir -p "$OUT"
+
+# The Release scheme pre-action builds this too, but doing it up front fails with
+# a readable error instead of a missing-framework link error. cargo caches, so the
+# pre-action's second run costs nothing.
+"$SCRIPT_DIR/build-ffi.sh"
+
+# Positional params so the version overrides stay single arguments. Setting them on
+# the command line applies them to every target, which is what keeps the keyboard
+# extension's CFBundleVersion identical to the app's — App Store Connect rejects the
+# upload when they differ.
+set -- -project Funput.xcodeproj -scheme "$SCHEME" \
+    -configuration "$CONFIGURATION" \
+    -destination "generic/platform=iOS" \
+    -archivePath "$ARCHIVE" \
+    -allowProvisioningUpdates
+if [ -n "$VERSION" ]; then
+    set -- "$@" "MARKETING_VERSION=$VERSION" "CURRENT_PROJECT_VERSION=$BUILD"
+fi
+xcodebuild archive "$@"
+
+# manageAppVersionAndBuildNumber stays false: left on, Xcode picks its own build
+# number at export time and the .ipa stops matching the project.
+cat >"$EXPORT_OPTIONS" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key><string>app-store-connect</string>
+    <key>teamID</key><string>$TEAM_ID</string>
+    <key>destination</key><string>export</string>
+    <key>uploadSymbols</key><true/>
+    <key>manageAppVersionAndBuildNumber</key><false/>
+</dict>
+</plist>
+EOF
+
+xcodebuild -exportArchive \
+    -archivePath "$ARCHIVE" \
+    -exportPath "$EXPORT" \
+    -exportOptionsPlist "$EXPORT_OPTIONS" \
+    -allowProvisioningUpdates
+
+echo "release-ios: wrote $EXPORT/Funput.ipa"


### PR DESCRIPTION
Adds a manual pipeline that builds the App Store `.ipa` and uploads it to App Store Connect (TestFlight).

**Actions → Deploy iOS → Run workflow** → pick a branch, enter a version like `1.2026.66`.

## Two files

- `platforms/ios/Scripts/release-ios.sh` — archive + export a signed App Store `.ipa`. Usable on its own for a manual upload via Transporter; takes an optional `VERSION` env override the same way the macOS release script does.
- `.github/workflows/deploy-ios.yml` — `workflow_dispatch` only: LOC gate → build FFI → run the FunputKit suite → import the signing certificate into a temporary keychain → build the `.ipa` → validate with Apple → upload.

## Why this is separate from `release.yml`

The other three platforms build from a tag, one tag → all platforms. iOS deliberately does not join them:

- Every upload burns a build number permanently at Apple. A mistyped tag on the shared pipeline would consume one with no way back.
- iOS depends on Apple infrastructure that fails for reasons unrelated to this repo — certificates expire yearly, profiles get revoked, App Store Connect has bad days. Wiring it into `release.yml` would let any of that block a macOS/Windows/Linux release.

`dry_run` validates with Apple without uploading. The first runs should use it: it exercises the whole signing and provisioning path without consuming a build number.

**Uploading is not publishing.** The build reaches TestFlight; submitting it to the App Store stays a deliberate act in App Store Connect. That last step is intentionally not automated — an upload mistake costs a build number, a submission mistake reaches real users through a review process that cannot be recalled.

## Details worth a look

- **Version stamping** goes on the `xcodebuild` command line, so it applies to *every* target. App Store Connect rejects the upload when the keyboard extension's `CFBundleVersion` differs from the app's, and that is only discoverable after waiting for a full upload.
- **The calver doubles as the build number** — three dot-separated integers that rise with every release — the same trick `platforms/macos/scripts/release.sh` already uses.
- **`manageAppVersionAndBuildNumber` is false** in the export options. Left on, Xcode picks its own build number at export and the `.ipa` silently stops matching the version you asked for.
- **Tests run before signing**, matching `build-macos.yml`. It reuses `Scripts/test-funput-kit.sh`, which discovers whatever simulator the runner image provides rather than hard-coding a device name that breaks when GitHub rotates images.
- **`concurrency: deploy-ios`** with `cancel-in-progress: false` — two runs would race for the same build number, and cancelling mid-upload is worse than queueing.
- **The `.ipa` is kept as an artifact even on failure**, so a rejected upload can be retried by hand from Transporter without rebuilding.
- Credentials are removed from the runner in an `always()` step.

## Before the first run

New repository secrets, documented in the workflow header:

| Secret | Notes |
|---|---|
| `IOS_DIST_CERT_P12` | base64 of an **Apple Distribution** `.p12`. The Developer ID certificate used for macOS **cannot** sign App Store builds — it is a different certificate type. |
| `IOS_DIST_CERT_PASSWORD` | password used when exporting that `.p12` |
| `ASC_KEY_ID`, `ASC_ISSUER_ID` | App Store Connect API key, role App Manager |
| `ASC_API_KEY_P8` | base64 of `AuthKey_*.p8` — downloadable only once |

Also required on Apple's side, and **not** something CI can verify: an app record for `app.funput.funput`, and App IDs for both the app and `app.funput.funput.Keyboard` with the App Groups capability enabled and `group.app.funput.funput` assigned to each. `-allowProvisioningUpdates` will happily produce a profile without the App Group — the build goes green, the upload succeeds, and the keyboard then cannot read its configuration on a real device.

## Verification

Syntax only: the workflow YAML parses, both shell scripts pass `sh -n`, the generated `ExportOptions.plist` passes `plutil -lint`, and the version-stamping argument construction was executed directly. **The signing, provisioning, validation and upload path has never been run** — it needs credentials that do not exist yet. Run once with `dry_run` enabled first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
