### PR TITLE
CI: run the iOS deploy scripts through their own shebangs

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -62,19 +62,19 @@ jobs:
 
       - name: Check Swift file size
         working-directory: platforms/ios
-        run: sh ./Scripts/check-swift-loc.sh
+        run: ./Scripts/check-swift-loc.sh
 
       # Builds FunputCore.xcframework and resolves packages; the tests below and the
       # archive both need it. cargo caches, so later runs of build-ffi are cheap.
       - name: Bootstrap native dependencies
         working-directory: platforms/ios
-        run: sh ./Scripts/bootstrap-ios.sh
+        run: ./Scripts/bootstrap-ios.sh
 
       # Never ship a build the suite has not passed. The script picks whichever iOS
       # simulator the runner image happens to provide.
       - name: Run FunputKit tests
         working-directory: platforms/ios
-        run: sh ./Scripts/test-funput-kit.sh
+        run: ./Scripts/test-funput-kit.sh
 
       - name: Import Apple Distribution certificate
         env:
@@ -114,7 +114,7 @@ jobs:
         working-directory: platforms/ios
         env:
           VERSION: ${{ inputs.version }}
-        run: sh ./Scripts/release-ios.sh
+        run: ./Scripts/release-ios.sh
 
       # Validation catches the usual rejections — entitlements, icons, a build number
       # Apple has already seen — in seconds, before pushing the whole binary.


### PR DESCRIPTION
Fixes the first failing step of the `Deploy iOS` workflow added in #172:

```
Run sh ./Scripts/check-swift-loc.sh
./Scripts/check-swift-loc.sh: line 16: syntax error near unexpected token `<'
```

`check-swift-loc.sh` declares `#!/usr/bin/env bash` and uses process substitution:

```bash
done < <(
    find "$ios_root" -type f \( -name '*.swift' ... \) -print0
)
```

`< <(...)` is bash-only, and `sh ./Scripts/...` forced a POSIX shell onto it. `build-macos.yml` invokes the same script as `bash ./scripts/check-swift-loc.sh` for precisely this reason — I read that line while writing the workflow and still used `sh`.

Calling each script directly is the fix that keeps working. Everything in `Scripts/` is mode 755, so the shebang picks the interpreter: bash for `check-swift-loc.sh`, sh for the other three. A script that later switches between the two needs no change here.

Applied to all four call sites, not just the one that failed.

This missed review because `sh -n` only checks the syntax of the file handed to it — it says nothing about how the workflow invokes it.

Note this is a re-open: the same fix was pushed to `ci/ios-deploy-workflow` after #172 had already merged, so it never reached `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
