### PR TITLE
CI: derive the iOS build number from the run number

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version, e.g. 1.2026.66. Stamped as both the marketing version and the build number."
+        description: "Marketing version, e.g. 1.2026.66 — what users see. The build number is derived from the run number."
         required: true
         type: string
       dry_run:
@@ -42,6 +42,12 @@ concurrency:
 env:
   CARGO_HTTP_MULTIPLEXING: "false"
   CARGO_NET_RETRY: "5"
+  # CFBundleVersion is derived from the run number, so re-deploying the same
+  # marketing version never collides. The offset leaves room below the first build
+  # for a future move to some other scheme; set the repository variable to raise it.
+  # Careful: renaming this workflow file resets the run counter to 1, which would
+  # push the build number *backwards* — Apple rejects that.
+  IOS_BUILD_OFFSET: ${{ vars.IOS_BUILD_OFFSET || '100' }}
 
 jobs:
   ios:
@@ -110,11 +116,17 @@ jobs:
             > "$HOME/.appstoreconnect/private_keys/AuthKey_$ASC_KEY_ID.p8"
           chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_$ASC_KEY_ID.p8"
 
+      # A re-run keeps the same run number, which is what we want: a failed upload
+      # never consumed a build number, so reusing it is correct.
       - name: Archive and export .ipa
         working-directory: platforms/ios
         env:
           VERSION: ${{ inputs.version }}
-        run: ./Scripts/release-ios.sh
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          BUILD=$(( IOS_BUILD_OFFSET + RUN_NUMBER ))
+          echo "Marketing version $VERSION, build $BUILD"
+          BUILD="$BUILD" ./Scripts/release-ios.sh
 
       # Validation catches the usual rejections — entitlements, icons, a build number
       # Apple has already seen — in seconds, before pushing the whole binary.
@@ -165,7 +177,7 @@ jobs:
         if: success()
         run: |
           {
-            echo "### Funput iOS ${{ inputs.version }}"
+            echo "### Funput iOS ${{ inputs.version }} (build $(( IOS_BUILD_OFFSET + ${{ github.run_number }} )))"
             if [ "${{ inputs.dry_run }}" = "true" ]; then
               echo "Validated with Apple; **not** uploaded (dry run)."
             else

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -123,6 +123,8 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           RUN_NUMBER: ${{ github.run_number }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
         run: |
           BUILD=$(( IOS_BUILD_OFFSET + RUN_NUMBER ))
           echo "Marketing version $VERSION, build $BUILD"

--- a/platforms/ios/Scripts/release-ios.sh
+++ b/platforms/ios/Scripts/release-ios.sh
@@ -17,6 +17,13 @@ CONFIGURATION="${CONFIGURATION:-Release}"
 SCHEME="${SCHEME:-Funput}"
 TEAM_ID="${TEAM_ID:-RSARFZ5CD3}"
 VERSION="${VERSION:-}"
+# App Store Connect API key, for `-allowProvisioningUpdates` to fetch or create the
+# signing assets. Unlike altool, xcodebuild does not look in
+# ~/.appstoreconnect/private_keys on its own — the flags have to be passed. Left
+# unset (a Mac with Xcode signed in), it uses the logged-in account instead.
+ASC_KEY_ID="${ASC_KEY_ID:-}"
+ASC_ISSUER_ID="${ASC_ISSUER_ID:-}"
+ASC_KEY_PATH="${ASC_KEY_PATH:-$HOME/.appstoreconnect/private_keys/AuthKey_$ASC_KEY_ID.p8}"
 # Defaulting to VERSION keeps a bare `VERSION=... ./release-ios.sh` self-consistent;
 # CI passes both separately.
 BUILD="${BUILD:-$VERSION}"
@@ -32,6 +39,17 @@ EXPORT_OPTIONS="$OUT/ExportOptions.plist"
 
 rm -rf "$ARCHIVE" "$EXPORT"
 mkdir -p "$OUT"
+
+run_xcodebuild() {
+    if [ -n "$ASC_KEY_ID" ] && [ -n "$ASC_ISSUER_ID" ] && [ -f "$ASC_KEY_PATH" ]; then
+        xcodebuild "$@" \
+            -authenticationKeyPath "$ASC_KEY_PATH" \
+            -authenticationKeyID "$ASC_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+    else
+        xcodebuild "$@"
+    fi
+}
 
 # The Release scheme pre-action builds this too, but doing it up front fails with
 # a readable error instead of a missing-framework link error. cargo caches, so the
@@ -53,7 +71,7 @@ fi
 if [ -n "$BUILD" ]; then
     set -- "$@" "CURRENT_PROJECT_VERSION=$BUILD"
 fi
-xcodebuild archive "$@"
+run_xcodebuild archive "$@"
 
 # manageAppVersionAndBuildNumber stays false: left on, Xcode picks its own build
 # number at export time and the .ipa stops matching the project.
@@ -71,7 +89,7 @@ cat >"$EXPORT_OPTIONS" <<EOF
 </plist>
 EOF
 
-xcodebuild -exportArchive \
+run_xcodebuild -exportArchive \
     -archivePath "$ARCHIVE" \
     -exportPath "$EXPORT" \
     -exportOptionsPlist "$EXPORT_OPTIONS" \

--- a/platforms/ios/Scripts/release-ios.sh
+++ b/platforms/ios/Scripts/release-ios.sh
@@ -3,19 +3,22 @@
 # hand with Xcode Organizer or Transporter. The keyboard extension ships inside
 # the app, so this one archive covers both targets.
 #
-#   ./Scripts/release-ios.sh                  # versions come from the project
-#   VERSION=1.2026.66 ./Scripts/release-ios.sh  # stamp a version instead
+#   ./Scripts/release-ios.sh                            # versions come from the project
+#   VERSION=1.2026.66 ./Scripts/release-ios.sh          # stamp a marketing version
+#   VERSION=1.2026.66 BUILD=101 ./Scripts/release-ios.sh  # ...and a build number
 #
-# Without VERSION, bump the version in Xcode first — App Store Connect rejects a
-# build number it has already accepted.
+# VERSION is CFBundleShortVersionString, what users see. BUILD is CFBundleVersion,
+# which only Apple reads: it must be unique per upload and must never go backwards.
+# Overriding neither takes both from the project, in which case bump the version in
+# Xcode first — App Store Connect rejects a build number it has already accepted.
 set -eu
 
 CONFIGURATION="${CONFIGURATION:-Release}"
 SCHEME="${SCHEME:-Funput}"
 TEAM_ID="${TEAM_ID:-RSARFZ5CD3}"
 VERSION="${VERSION:-}"
-# CFBundleVersion is what App Store Connect checks for uniqueness. The calver
-# doubles as one: it is three dot-separated integers and rises with every release.
+# Defaulting to VERSION keeps a bare `VERSION=... ./release-ios.sh` self-consistent;
+# CI passes both separately.
 BUILD="${BUILD:-$VERSION}"
 
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
@@ -45,7 +48,10 @@ set -- -project Funput.xcodeproj -scheme "$SCHEME" \
     -archivePath "$ARCHIVE" \
     -allowProvisioningUpdates
 if [ -n "$VERSION" ]; then
-    set -- "$@" "MARKETING_VERSION=$VERSION" "CURRENT_PROJECT_VERSION=$BUILD"
+    set -- "$@" "MARKETING_VERSION=$VERSION"
+fi
+if [ -n "$BUILD" ]; then
+    set -- "$@" "CURRENT_PROJECT_VERSION=$BUILD"
 fi
 xcodebuild archive "$@"
 


### PR DESCRIPTION
Splits the two version fields that #172 conflated.

Until now the `version` input was stamped as **both** `CFBundleShortVersionString` and `CFBundleVersion`. That works exactly once per version string: re-deploying `1.2026.66` after a bad build, or after an upload that died halfway, meant inventing a version number Apple had not seen — for a reason that has nothing to do with what changed in the app.

The two fields answer different questions. One is what users read on the App Store page; the other is what Apple uses to tell uploads apart. So:

| | Source | Example |
|---|---|---|
| `CFBundleShortVersionString` | the `version` input | `1.2026.66` |
| `CFBundleVersion` | `IOS_BUILD_OFFSET + github.run_number` | `101`, `102`, … |

`IOS_BUILD_OFFSET` is a repository variable defaulting to `100`, so the number can be raised from Settings without touching the workflow, and there is room below the first build if the scheme ever changes again.

## Details

- **A re-run keeps its run number** — `run_number` does not change when you re-run a run, only `run_attempt` does. That is the behaviour we want: a failed upload never consumed a build number, so reusing it is correct.
- **Renaming the workflow file resets the counter to 1**, which would push the build number *backwards* — Apple rejects that. Called out in a comment right next to the offset, since the failure would appear months later and look unrelated.
- `release-ios.sh` now takes `VERSION` and `BUILD` **independently** rather than deriving one from the other, so either can be set alone. Passing only `VERSION` still stamps both, which keeps a by-hand `VERSION=1.2026.66 ./Scripts/release-ios.sh` self-consistent.

## Timing

This is safe to land now and awkward later: no build has been uploaded yet, so the build-number format is still free to choose. Once a build with `CFBundleVersion = 1.2026.66` has been accepted, switching to `101` would be a *decrease* and Apple would refuse it.

## Verification

Syntax only, as with the rest of this pipeline — the workflow YAML parses, `release-ios.sh` passes `sh -n`, and both the offset arithmetic and the `xcodebuild` argument construction were executed directly (`MARKETING_VERSION=1.2026.66`, `CURRENT_PROJECT_VERSION=101`). The signing and upload path still has not been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
