### PR TITLE
iOS deploy: manual signing, and guards for everything that went wrong getting there

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -160,6 +160,11 @@ jobs:
           ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
         run: |
           set -euo pipefail
+          # A secret pasted with a stray newline or space produces a bearer token Apple
+          # rejects, and the only symptom is a flat 401. Trim before anything uses the
+          # values — the key file is named after the key id.
+          ASC_KEY_ID="$(printf '%s' "$ASC_KEY_ID" | tr -d '[:space:]')"
+          ASC_ISSUER_ID="$(printf '%s' "$ASC_ISSUER_ID" | tr -d '[:space:]')"
           mkdir -p "$HOME/.appstoreconnect/private_keys"
           KEY="$HOME/.appstoreconnect/private_keys/AuthKey_$ASC_KEY_ID.p8"
           # Take the secret either way: base64 of the .p8, or the .p8 text pasted
@@ -185,9 +190,22 @@ jobs:
             echo "::error::ASC_API_KEY_P8 decoded to something that is not a usable private key — most likely its line breaks were lost on the way into the secret. Re-add it with: base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy"
             exit 1
           fi
-          # Lengths only — a key id is 10 characters and an issuer id is a 36-character
-          # UUID. Anything else is the 401, and this says so without printing either.
-          echo "API key parses. Key id: ${#ASC_KEY_ID} chars (expect 10). Issuer id: ${#ASC_ISSUER_ID} chars (expect 36)."
+          # Hand the trimmed values to the later steps rather than re-reading the raw
+          # secrets there.
+          echo "ASC_KEY_ID=$ASC_KEY_ID" >> "$GITHUB_ENV"
+          echo "ASC_ISSUER_ID=$ASC_ISSUER_ID" >> "$GITHUB_ENV"
+          # Shapes, not values: a key id is 10 characters, an issuer id a 36-character
+          # UUID. Checking them here turns the most common cause of that 401 into a
+          # message that names it, and costs nothing when they are right.
+          if [ "${#ASC_KEY_ID}" -ne 10 ]; then
+            echo "::error::ASC_KEY_ID is ${#ASC_KEY_ID} characters; a key id is 10. It is the XXXXXXXXXX in AuthKey_XXXXXXXXXX.p8."
+            exit 1
+          fi
+          if [ "${#ASC_ISSUER_ID}" -ne 36 ]; then
+            echo "::error::ASC_ISSUER_ID is ${#ASC_ISSUER_ID} characters; an issuer id is a 36-character UUID shown above the key table in App Store Connect -> Users and Access -> Integrations. It is not the key id and not the team id."
+            exit 1
+          fi
+          echo "API key parses; key id and issuer id are the right shape."
 
       # A re-run keeps the same run number, which is what we want: a failed upload
       # never consumed a build number, so reusing it is correct.
@@ -196,8 +214,6 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           RUN_NUMBER: ${{ github.run_number }}
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
         run: |
           BUILD=$(( IOS_BUILD_OFFSET + RUN_NUMBER ))
           echo "Marketing version $VERSION, build $BUILD"
@@ -207,9 +223,6 @@ jobs:
       # Apple has already seen — in seconds, before pushing the whole binary.
       - name: Validate with Apple
         working-directory: platforms/ios
-        env:
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
         run: |
           xcrun altool --validate-app -f build/release/export/Funput.ipa -t ios \
             --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
@@ -217,9 +230,6 @@ jobs:
       - name: Upload to App Store Connect
         if: ${{ !inputs.dry_run }}
         working-directory: platforms/ios
-        env:
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
         run: |
           xcrun altool --upload-app -f build/release/export/Funput.ipa -t ios \
             --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -112,9 +112,22 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$HOME/.appstoreconnect/private_keys"
-          echo "$ASC_API_KEY_P8" | base64 --decode \
-            > "$HOME/.appstoreconnect/private_keys/AuthKey_$ASC_KEY_ID.p8"
-          chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_$ASC_KEY_ID.p8"
+          KEY="$HOME/.appstoreconnect/private_keys/AuthKey_$ASC_KEY_ID.p8"
+          # Take the secret either way: base64 of the .p8, or the .p8 text pasted
+          # straight in. Both are things a person reasonably ends up with.
+          if printf '%s' "$ASC_API_KEY_P8" | grep -q "BEGIN PRIVATE KEY"; then
+            printf '%s\n' "$ASC_API_KEY_P8" > "$KEY"
+          else
+            printf '%s' "$ASC_API_KEY_P8" | base64 --decode > "$KEY"
+          fi
+          chmod 600 "$KEY"
+          # macOS base64 drops characters it does not recognise and still exits 0, so
+          # a wrong secret decodes to garbage and only surfaces later as xcodebuild's
+          # "Invalid authentication key credential". Check the shape here instead.
+          if ! head -n 1 "$KEY" | grep -q "BEGIN PRIVATE KEY"; then
+            echo "::error::ASC_API_KEY_P8 is not an App Store Connect .p8 key. Set it to the file's contents, or to its base64: base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy"
+            exit 1
+          fi
 
       # A re-run keeps the same run number, which is what we want: a failed upload
       # never consumed a build number, so reusing it is correct.

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -108,6 +108,7 @@ jobs:
       - name: Install App Store Connect API key
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
         run: |
           set -euo pipefail
@@ -128,6 +129,17 @@ jobs:
             echo "::error::ASC_API_KEY_P8 is not an App Store Connect .p8 key. Set it to the file's contents, or to its base64: base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy"
             exit 1
           fi
+          # A PEM whose line breaks were lost still starts with BEGIN PRIVATE KEY but
+          # signs nothing, and Apple answers 401 — a long way from the cause. Parsing
+          # it here separates "the key is malformed" from "the key id, issuer or team
+          # is wrong", which are the two things a 401 can mean.
+          if ! /usr/bin/openssl pkey -in "$KEY" -noout >/dev/null 2>&1; then
+            echo "::error::ASC_API_KEY_P8 decoded to something that is not a usable private key — most likely its line breaks were lost on the way into the secret. Re-add it with: base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy"
+            exit 1
+          fi
+          # Lengths only — a key id is 10 characters and an issuer id is a 36-character
+          # UUID. Anything else is the 401, and this says so without printing either.
+          echo "API key parses. Key id: ${#ASC_KEY_ID} chars (expect 10). Issuer id: ${#ASC_ISSUER_ID} chars (expect 36)."
 
       # A re-run keeps the same run number, which is what we want: a failed upload
       # never consumed a build number, so reusing it is correct.

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -103,8 +103,48 @@ jobs:
           security default-keychain -s "$KEYCHAIN"
           rm -f "$RUNNER_TEMP/ios-cert.p12"
 
-      # Both xcodebuild (to create provisioning profiles) and altool (to upload) read
-      # the key from this directory, which is one of the locations altool searches.
+      # Xcode has read profiles from ~/Library/MobileDevice/Provisioning Profiles for
+      # years and from ~/Library/Developer/Xcode/UserData/Provisioning Profiles more
+      # recently; installing into both costs nothing and removes the question.
+      - name: Install provisioning profiles
+        env:
+          IOS_PROFILE_APP: ${{ secrets.IOS_PROFILE_APP }}
+          IOS_PROFILE_KEYBOARD: ${{ secrets.IOS_PROFILE_KEYBOARD }}
+        run: |
+          set -euo pipefail
+          OLD="$HOME/Library/MobileDevice/Provisioning Profiles"
+          NEW="$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles"
+          mkdir -p "$OLD" "$NEW"
+          install_profile() {
+            label="$1"; value="$2"; out_var="$3"
+            tmp="$RUNNER_TEMP/$label.mobileprovision"
+            if printf '%s' "$value" | grep -q "BEGIN PROVISIONING"; then
+              printf '%s' "$value" > "$tmp"
+            else
+              printf '%s' "$value" | base64 --decode > "$tmp"
+            fi
+            # A .mobileprovision is CMS-signed; if this fails the secret is not one.
+            if ! plist=$(security cms -D -i "$tmp" 2>/dev/null); then
+              echo "::error::$label is not a .mobileprovision. Re-add it with: base64 -i <file>.mobileprovision | pbcopy"
+              exit 1
+            fi
+            uuid=$(printf '%s' "$plist" | plutil -extract UUID raw -)
+            # An App Store profile provisions no devices. A development one does, and
+            # would sail through here only to be rejected by Apple at upload.
+            if printf '%s' "$plist" | plutil -extract ProvisionedDevices raw - >/dev/null 2>&1; then
+              echo "::error::$label is a development/ad-hoc profile, not an App Store one."
+              exit 1
+            fi
+            cp "$tmp" "$OLD/$uuid.mobileprovision"
+            cp "$tmp" "$NEW/$uuid.mobileprovision"
+            echo "$out_var=$uuid" >> "$GITHUB_ENV"
+            echo "$label: $(printf '%s' "$plist" | plutil -extract Name raw -) ($uuid), expires $(printf '%s' "$plist" | plutil -extract ExpirationDate raw -)"
+          }
+          install_profile app "$IOS_PROFILE_APP" PROFILE_APP
+          install_profile keyboard "$IOS_PROFILE_KEYBOARD" PROFILE_KEYBOARD
+
+      # With manual signing the archive needs no account at all; the key is only for
+      # altool's upload, which searches this directory.
       - name: Install App Store Connect API key
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -191,7 +191,12 @@ jobs:
             exit 1
           fi
           # Hand the trimmed values to the later steps rather than re-reading the raw
-          # secrets there.
+          # secrets there — but mask them first. GitHub redacts the exact secret string
+          # it was given; a trimmed value is a different string, so without this it
+          # would appear in clear text in the environment block every later step
+          # prints. On a public repository those logs are readable by anyone.
+          echo "::add-mask::$ASC_KEY_ID"
+          echo "::add-mask::$ASC_ISSUER_ID"
           echo "ASC_KEY_ID=$ASC_KEY_ID" >> "$GITHUB_ENV"
           echo "ASC_ISSUER_ID=$ASC_ISSUER_ID" >> "$GITHUB_ENV"
           # Shapes, not values: a key id is 10 characters, an issuer id a 36-character
@@ -256,6 +261,7 @@ jobs:
         if: always()
         run: |
           rm -rf "$HOME/.appstoreconnect/private_keys"
+          rm -f "$RUNNER_TEMP"/*.mobileprovision "$RUNNER_TEMP/ios-cert.p12"
           security delete-keychain "$RUNNER_TEMP/funput-ios.keychain-db" || true
 
       - name: Summary

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -135,6 +135,14 @@ jobs:
               echo "::error::$label is a development/ad-hoc profile, not an App Store one."
               exit 1
             fi
+            # Xcode-managed profiles are the ones Xcode creates and regenerates for
+            # itself; exportArchive refuses them under manual signing. The fix is a
+            # profile created by hand in the portal, so say that here rather than
+            # letting the export fail several minutes later.
+            if [ "$(printf '%s' "$plist" | plutil -extract IsXcodeManaged raw - 2>/dev/null || echo false)" = "true" ]; then
+              echo "::error::$label is an Xcode-managed profile, which manual signing cannot use. Create an explicit one: developer.apple.com -> Profiles -> + -> App Store Connect -> pick the App ID and the Apple Distribution certificate -> Download, then update the secret."
+              exit 1
+            fi
             cp "$tmp" "$OLD/$uuid.mobileprovision"
             cp "$tmp" "$NEW/$uuid.mobileprovision"
             echo "$out_var=$uuid" >> "$GITHUB_ENV"

--- a/platforms/ios/Scripts/release-ios.sh
+++ b/platforms/ios/Scripts/release-ios.sh
@@ -24,6 +24,20 @@ VERSION="${VERSION:-}"
 ASC_KEY_ID="${ASC_KEY_ID:-}"
 ASC_ISSUER_ID="${ASC_ISSUER_ID:-}"
 ASC_KEY_PATH="${ASC_KEY_PATH:-$HOME/.appstoreconnect/private_keys/AuthKey_$ASC_KEY_ID.p8}"
+
+# Manual signing. Set both profiles (UUID or name) and the archive stops talking to
+# Apple entirely: nothing is fetched, nothing is created, the assets are already on
+# disk. Leave them unset and the script keeps its automatic-signing behaviour, which
+# is what a Mac with Xcode signed in wants.
+PROFILE_APP="${PROFILE_APP:-}"
+PROFILE_KEYBOARD="${PROFILE_KEYBOARD:-}"
+SIGN_IDENTITY="${SIGN_IDENTITY:-Apple Distribution}"
+APP_BUNDLE_ID="${APP_BUNDLE_ID:-app.funput.funput}"
+KEYBOARD_BUNDLE_ID="${KEYBOARD_BUNDLE_ID:-app.funput.funput.Keyboard}"
+MANUAL_SIGNING=
+if [ -n "$PROFILE_APP" ] && [ -n "$PROFILE_KEYBOARD" ]; then
+    MANUAL_SIGNING=1
+fi
 # Defaulting to VERSION keeps a bare `VERSION=... ./release-ios.sh` self-consistent;
 # CI passes both separately.
 BUILD="${BUILD:-$VERSION}"
@@ -41,7 +55,11 @@ rm -rf "$ARCHIVE" "$EXPORT"
 mkdir -p "$OUT"
 
 run_xcodebuild() {
-    if [ -n "$ASC_KEY_ID" ] && [ -n "$ASC_ISSUER_ID" ] && [ -f "$ASC_KEY_PATH" ]; then
+    # Only automatic signing needs to reach Apple. Under manual signing the flags are
+    # dead weight, and leaving them off makes "the archive talks to nobody" true
+    # rather than merely intended.
+    if [ -z "$MANUAL_SIGNING" ] \
+        && [ -n "$ASC_KEY_ID" ] && [ -n "$ASC_ISSUER_ID" ] && [ -f "$ASC_KEY_PATH" ]; then
         xcodebuild "$@" \
             -authenticationKeyPath "$ASC_KEY_PATH" \
             -authenticationKeyID "$ASC_KEY_ID" \
@@ -63,8 +81,17 @@ run_xcodebuild() {
 set -- -project Funput.xcodeproj -scheme "$SCHEME" \
     -configuration "$CONFIGURATION" \
     -destination "generic/platform=iOS" \
-    -archivePath "$ARCHIVE" \
-    -allowProvisioningUpdates
+    -archivePath "$ARCHIVE"
+if [ -n "$MANUAL_SIGNING" ]; then
+    # A build setting given on the command line reaches every target, so there is no
+    # way to hand the app and the extension different profiles here. Archive without
+    # signing and let the export step do it: -exportArchive re-signs everything and
+    # takes a per-bundle-id profile map, which is the only place that distinction can
+    # be expressed.
+    set -- "$@" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
+else
+    set -- "$@" -allowProvisioningUpdates
+fi
 if [ -n "$VERSION" ]; then
     set -- "$@" "MARKETING_VERSION=$VERSION"
 fi
@@ -75,7 +102,8 @@ run_xcodebuild archive "$@"
 
 # manageAppVersionAndBuildNumber stays false: left on, Xcode picks its own build
 # number at export time and the .ipa stops matching the project.
-cat >"$EXPORT_OPTIONS" <<EOF
+{
+    cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -85,14 +113,26 @@ cat >"$EXPORT_OPTIONS" <<EOF
     <key>destination</key><string>export</string>
     <key>uploadSymbols</key><true/>
     <key>manageAppVersionAndBuildNumber</key><false/>
-</dict>
-</plist>
 EOF
+    if [ -n "$MANUAL_SIGNING" ]; then
+        cat <<EOF
+    <key>signingStyle</key><string>manual</string>
+    <key>signingCertificate</key><string>$SIGN_IDENTITY</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>$APP_BUNDLE_ID</key><string>$PROFILE_APP</string>
+        <key>$KEYBOARD_BUNDLE_ID</key><string>$PROFILE_KEYBOARD</string>
+    </dict>
+EOF
+    fi
+    printf '</dict>\n</plist>\n'
+} >"$EXPORT_OPTIONS"
 
-run_xcodebuild -exportArchive \
-    -archivePath "$ARCHIVE" \
-    -exportPath "$EXPORT" \
-    -exportOptionsPlist "$EXPORT_OPTIONS" \
-    -allowProvisioningUpdates
+set -- -exportArchive -archivePath "$ARCHIVE" -exportPath "$EXPORT" \
+    -exportOptionsPlist "$EXPORT_OPTIONS"
+if [ -z "$MANUAL_SIGNING" ]; then
+    set -- "$@" -allowProvisioningUpdates
+fi
+run_xcodebuild "$@"
 
 echo "release-ios: wrote $EXPORT/Funput.ipa"


### PR DESCRIPTION
The six commits that landed on this branch after #174 was merged. Together they take the iOS deploy pipeline from "fails at the first signing step" to a run that archives, signs, exports and uploads.

## The change that mattered

**The archive signs manually instead of asking Apple.** Automatic signing made every run depend on reaching Apple at build time — through an endpoint that answered 401, and which wanted an *iOS App Development* profile, something an App Store archive has no use for. The signing assets already exist; there was no reason to negotiate for them on each run.

A build setting passed on the command line reaches every target, so the app and the keyboard extension cannot be handed different profiles there. The archive is therefore built unsigned and `-exportArchive` does the signing, which is the one place a per-bundle-id profile map can be expressed.

With this the archive contacts nobody. The API key is left to altool's upload, which authenticates by a different route than the one that was failing.

Setting no profiles keeps the previous automatic-signing behaviour, so running `release-ios.sh` by hand on a Mac with Xcode signed in is unchanged.

## One security fix

GitHub redacts the exact string it was given as a secret. The trimming step produced a *different* string, so writing the trimmed key id and issuer id to `GITHUB_ENV` published them in clear text in the environment block every later step prints — and this repository is public.

They only stayed hidden because the secrets happened to have no stray whitespace, which made the trimmed value identical to the original. That is luck, not a design. Both are now masked before being exported, and the decoded profiles and the `.p12` are cleared out of `RUNNER_TEMP` alongside the API key at the end of a run.

## Guards, one per failure we hit

Each of these cost ten minutes to diagnose once. They now cost five seconds and name the fix:

| Check | What it caught |
|---|---|
| `.p8` decodes to a PEM | macOS `base64 --decode` drops characters it does not recognise and still exits 0, so a wrong secret became 72 bytes of garbage and surfaced minutes later as xcodebuild's "Invalid authentication key credential" |
| `.p8` parses as a key | A PEM whose line breaks were lost still starts with `BEGIN PRIVATE KEY` but signs nothing, and Apple answers a flat 401 |
| Key id is 10 chars, issuer id 36 | An issuer id that is really a key id or a team id — the most common cause of that same 401 |
| Profile is CMS-signed | The secret is not a `.mobileprovision` at all |
| Profile provisions no devices | A development profile, which passes archive and is rejected at upload |
| Profile is not Xcode-managed | `exportArchive` refuses those under manual signing, and says so only after a full archive has been built |

The API key secret is also accepted either as base64 or as the key text pasted straight in, both being things a person reasonably ends up with.

Nothing secret is logged: the checks report lengths and shapes, never values.

## Verified

The pipeline now archives, exports and uploads successfully — the remaining failure was a misconfigured key on the Apple side, since corrected.

Tests still run before signing. Worth knowing: this workflow is currently the **only** place iOS tests run automatically — no workflow triggers on `pull_request`. Moving that gate to PRs is the obvious next step, and would make the copy here a redundant safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
