### PR TITLE
fix(core): re-open a word still awaiting its stop-coda tone

### DIFF
--- a/crates/funput-core/src/lib.rs
+++ b/crates/funput-core/src/lib.rs
@@ -8,7 +8,8 @@
 //! The public surface is intentionally minimal for `funput-engine`:
 //! [`InputMethod`], [`TransformKind`], [`TransformResult`], [`apply`], and the
 //! syllable-structure checks [`is_valid`] (lenient) / [`is_complete_syllable`]
-//! (strict, for word boundaries).
+//! (strict, for word boundaries) / [`is_reopenable_syllable`] (re-opening a
+//! committed word for editing).
 //! Breaking changes require semver coordination with the engine.
 //!
 //! # Contract
@@ -69,7 +70,7 @@ pub struct TransformResult {
 /// );
 /// ```
 pub use validation::reachability::is_definitely_invalid;
-pub use validation::syllable::{is_complete_syllable, is_valid};
+pub use validation::syllable::{is_complete_syllable, is_reopenable_syllable, is_valid};
 
 #[inline]
 pub fn apply(

--- a/crates/funput-core/src/validation/syllable/mod.rs
+++ b/crates/funput-core/src/validation/syllable/mod.rs
@@ -45,17 +45,24 @@ pub fn is_valid(buffer: &str) -> bool {
     )
 }
 
-/// Returns true if `buffer` is a *complete* valid Vietnamese syllable.
-///
-/// **Strict**: the coda must be a real Vietnamese final (`c ch m n ng nh p t`),
-/// and a **stop coda** (`p t c ch`) only with the sắc or nặng tone (phonotactics).
-/// No "still typing" leniency. Use this at a word boundary — the engine restores
-/// the raw word when a finished word is *not* a complete syllable: `cảd` (card),
-/// `côl` (cool), `tẽt` (text).
-pub fn is_complete_syllable(buffer: &str) -> bool {
+/// How a finished buffer sits against Vietnamese syllable structure.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum SyllableShape {
+    /// Not a Vietnamese syllable, and no tone can make it one: `cảd` (card),
+    /// `côl` (cool), `tẽt` (text).
+    Invalid,
+    /// Structurally a syllable, but its **stop coda** (`p t c ch`) still carries
+    /// no tone, and Vietnamese requires sắc or nặng there: `chuc`, `tich`, `nuoc`.
+    /// Not a word yet — one tone key away from being one.
+    AwaitingTone,
+    /// A real Vietnamese syllable as it stands: `chào`, `việt`, `ma`, `tét`.
+    Complete,
+}
+
+fn classify(buffer: &str) -> SyllableShape {
     let parts = parse_syllable(buffer);
     let Some((coda, coda_len)) = normalized_coda(&parts) else {
-        return false;
+        return SyllableShape::Invalid;
     };
     let coda = &coda[..coda_len];
 
@@ -68,24 +75,49 @@ pub fn is_complete_syllable(buffer: &str) -> bool {
         && !violates_ckg_spelling(parts.onset, &parts)
         && coda_in(VALID_CODAS, coda);
     if !structure_ok {
-        return false;
+        return SyllableShape::Invalid;
     }
 
     // The nucleus+coda must be a real Vietnamese rhyme (Level 2): keeps `việt`,
     // `trường` … but reverts structurally-ok-but-nonexistent rhymes.
     if !is_valid_rhyme(&toneless_rhyme(&parts, coda)) {
-        return false;
+        return SyllableShape::Invalid;
     }
 
-    // Phonotactics: a stop coda only allows sắc / nặng. Flags `tẽt` (English
-    // "text"), `bèct`, etc. as not-a-syllable so the engine restores the raw word.
+    // Phonotactics: a stop coda only allows sắc / nặng. A wrong tone (huyền / hỏi /
+    // ngã) is what catches English `text` (→ `tẽt`) or `coot` (→ `côt`); no tone at
+    // all is the un-toned form of a real word, which a tone key can still complete.
     if coda_in(STOP_CODAS, coda) {
-        return matches!(
-            nucleus_tone(parts.nucleus_chars()),
-            Some(Tone::Sac | Tone::Nang)
-        );
+        return match nucleus_tone(parts.nucleus_chars()) {
+            Some(Tone::Sac | Tone::Nang) => SyllableShape::Complete,
+            None => SyllableShape::AwaitingTone,
+            Some(_) => SyllableShape::Invalid,
+        };
     }
-    true
+    SyllableShape::Complete
+}
+
+/// Returns true if `buffer` is a *complete* valid Vietnamese syllable.
+///
+/// **Strict**: the coda must be a real Vietnamese final (`c ch m n ng nh p t`),
+/// and a **stop coda** (`p t c ch`) only with the sắc or nặng tone (phonotactics).
+/// No "still typing" leniency. Use this at a word boundary — the engine restores
+/// the raw word when a finished word is *not* a complete syllable: `cảd` (card),
+/// `côl` (cool), `tẽt` (text).
+pub fn is_complete_syllable(buffer: &str) -> bool {
+    matches!(classify(buffer), SyllableShape::Complete)
+}
+
+/// Returns true if a committed `buffer` may be re-opened as a live composition
+/// (`Engine::adopt`, after Backspace puts the caret back on it).
+///
+/// Looser than [`is_complete_syllable`] in exactly one place: a stop coda still
+/// **awaiting its tone** counts. Those words are the whole point of re-opening —
+/// `chuc` + `s` → `chúc`, `tich` + `s` → `tích` — and they are what the engine
+/// itself leaves on screen when the user commits before typing the tone. Still
+/// strict enough to keep English words and URLs literal (`hello`, `text`, `tẽt`).
+pub fn is_reopenable_syllable(buffer: &str) -> bool {
+    !matches!(classify(buffer), SyllableShape::Invalid)
 }
 
 #[cfg(test)]

--- a/crates/funput-core/src/validation/syllable/tests.rs
+++ b/crates/funput-core/src/validation/syllable/tests.rs
@@ -127,6 +127,26 @@ fn stop_coda_only_allows_sac_or_nang() {
 }
 
 #[test]
+fn reopenable_accepts_a_stop_coda_awaiting_its_tone() {
+    // The words this exists for: committed without a tone, re-opened so the next
+    // tone key finishes them (`chuc` + `s` → `chúc`).
+    for ok in [
+        "chuc", "tich", "hoc", "dat", "viêt", "nươc", "chào", "phủ", "ma",
+    ] {
+        assert!(is_reopenable_syllable(ok), "{ok} should be re-openable");
+    }
+    // A wrong tone on a stop coda, or no syllable at all, stays refused — those are
+    // the English words the gate is there to protect.
+    for bad in ["", "tẽt", "tèt", "côl", "cảd", "text", "hello", "chào bạn"] {
+        assert!(!is_reopenable_syllable(bad), "{bad} should be refused");
+    }
+    // Strictly looser than `is_complete_syllable`, never the other way round.
+    for w in ["chuc", "tét", "tẽt", "ma", "text"] {
+        assert!(!is_complete_syllable(w) || is_reopenable_syllable(w));
+    }
+}
+
+#[test]
 fn ckg_spelling() {
     assert_eq!(validate_tone("ke"), ModifierValidation::Allow);
     // `k` is exempt from the pairing rule for loanwords/toponyms (Kông, Kenya).

--- a/crates/funput-desktop/src/shell/compose.rs
+++ b/crates/funput-desktop/src/shell/compose.rs
@@ -30,7 +30,7 @@ impl ShellState {
     /// character about to disappear is a committed one, and when its removal leaves
     /// the caret at the end of a finished Vietnamese word the engine re-opens that
     /// word — so `phủ` + Space + Backspace + `s` gives `phú` instead of `phủs`. The
-    /// engine refuses anything that is not a complete syllable, which keeps English
+    /// engine refuses anything that is not a Vietnamese syllable, which keeps English
     /// words and URLs literal; a refusal costs the shadow its bearings, so it
     /// starts over.
     pub fn on_backspace(&mut self) {

--- a/crates/funput-desktop/tests/retone.rs
+++ b/crates/funput-desktop/tests/retone.rs
@@ -133,6 +133,24 @@ fn only_the_word_at_the_caret_is_reopened() {
     assert_eq!(shell.app, "chào phú");
 }
 
+/// The reported bug: a word whose stop coda (`c`, `ch`, `p`, `t`) never got its tone
+/// is committed exactly as typed, so re-opening it has to work too.
+#[test]
+fn a_word_committed_before_its_tone_is_reopened() {
+    for (keys, tone, expected) in [
+        ("chuc ", 's', "chúc"),
+        ("tich ", 's', "tích"),
+        ("hoc ", 'j', "học"),
+        ("dat ", 'j', "dạt"),
+    ] {
+        let mut shell = Shell::new(InputMethod::Telex);
+        shell.type_str(keys);
+        shell.backspace();
+        shell.key(tone);
+        assert_eq!(shell.app, expected, "typing {keys:?} then ⌫ then {tone:?}");
+    }
+}
+
 /// The engine only adopts real Vietnamese syllables, so an English word keeps
 /// taking literal letters after it.
 #[test]

--- a/crates/funput-engine/src/engine/editing.rs
+++ b/crates/funput-engine/src/engine/editing.rs
@@ -1,4 +1,4 @@
-use funput_core::is_complete_syllable;
+use funput_core::is_reopenable_syllable;
 
 use crate::compose::{diff, flip};
 use crate::{Engine, ImeResult};
@@ -8,16 +8,18 @@ impl Engine {
     /// keystroke edits it — the host uses this when the caret lands back on a word
     /// (Android: Backspace over the space after `chào`, then `s` gives `cháo`).
     ///
-    /// Returns whether `text` was taken. Only a complete Vietnamese syllable is,
-    /// which keeps English words and URLs from silently becoming editable; the host
-    /// should leave the document untouched when this is `false`.
+    /// Returns whether `text` was taken. Only a Vietnamese syllable is — including
+    /// one still missing the tone its stop coda requires (`chuc` + `s` → `chúc`),
+    /// which is how a word looks when the user commits it before typing the tone.
+    /// English words and URLs never become editable; the host should leave the
+    /// document untouched when this is `false`.
     ///
     /// The raw keystrokes that produced `text` are gone, so they are seeded from the
     /// text itself — the same state `on_backspace` leaves behind. Composition only
     /// ever reads the buffer, so tone and shape edits work from here; there is no raw
     /// form to flip back to, which makes the flip hotkey a no-op on an adopted word.
     pub fn adopt(&mut self, text: &str) -> bool {
-        if !self.session.enabled || text.is_empty() || !is_complete_syllable(text) {
+        if !self.session.enabled || text.is_empty() || !is_reopenable_syllable(text) {
             return false;
         }
         // clear() + push_str refills the session strings in place, so seeding them

--- a/crates/funput-engine/tests/adopt.rs
+++ b/crates/funput-engine/tests/adopt.rs
@@ -61,6 +61,23 @@ fn adopts_a_toneless_syllable_and_adds_a_tone() {
     assert_eq!(engine.buffer(), "chào");
 }
 
+/// A stop coda (`p t c ch`) with no tone yet is not a *complete* syllable, but it is
+/// exactly what a committed word looks like before its tone: `chuc` + Space + ⌫ + `s`
+/// has to give `chúc`, not `chucs`.
+#[test]
+fn adopts_a_syllable_still_missing_its_stop_coda_tone() {
+    for (word, key, expected) in [
+        ("chuc", 's', "chúc"),
+        ("tich", 's', "tích"),
+        ("hoc", 'j', "học"),
+    ] {
+        let mut engine = engine(InputMethod::Telex);
+        assert!(engine.adopt(word), "should adopt {word:?}");
+        engine.process_char(key);
+        assert_eq!(engine.buffer(), expected);
+    }
+}
+
 /// Anything that is not a Vietnamese syllable is refused, so English words and URLs
 /// never silently become editable.
 #[test]

--- a/crates/funput-ffi/src/engine/compose.rs
+++ b/crates/funput-ffi/src/engine/compose.rs
@@ -131,8 +131,8 @@ pub unsafe extern "C" fn funput_flip_composing(engine: *mut FunputEngine) -> Fun
 
 /// Re-open an already-committed word as the live composition, so the next keystroke
 /// edits it (Backspace back onto `chào`, then `s` gives `cháo`). `word` is UTF-32, as in
-/// [`funput_add_shortcut`](crate::funput_add_shortcut). Returns whether it was taken —
-/// only a complete Vietnamese syllable is, so leave the document alone on `false`.
+/// [`funput_add_shortcut`](crate::funput_add_shortcut). Returns whether it was taken — only
+/// a Vietnamese syllable is, so leave the document alone on `false`.
 ///
 /// # Safety
 /// `engine` must be a valid handle or null; `word` must point to `len` `u32` values or

--- a/crates/funput-jni/src/engine/composition.rs
+++ b/crates/funput-jni/src/engine/composition.rs
@@ -11,8 +11,9 @@ use crate::abi::{JavaObject, neutral, safe, string_result};
 /// Re-open an already-committed word as the live composition, so the next keystroke
 /// edits it (Backspace back onto `chào`, then `s` gives `cháo`).
 ///
-/// Returns whether the word was taken — only a complete Vietnamese syllable is, so the
-/// caller must leave the document untouched when this is `false`.
+/// Returns whether the word was taken — only a Vietnamese syllable is, including one
+/// still missing the tone its stop coda needs (`chuc` → `chúc`), so the caller must
+/// leave the document untouched when this is `false`.
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_app_funput_funput_ime_nativebridge_FunputNative_nativeAdopt(
     mut env: EnvUnowned<'_>,

--- a/platforms/macos/Funput/IME/FunputComposer.swift
+++ b/platforms/macos/Funput/IME/FunputComposer.swift
@@ -82,8 +82,9 @@ final class FunputComposer {
 
     /// Re-open an already-committed word as the live composition, so the next keystroke
     /// edits it (`chào` + ⌫ then `s` gives `cháo`). Returns whether the engine took it:
-    /// only a complete Vietnamese syllable is, which keeps English words and URLs literal,
-    /// so leave the document alone on `false`.
+    /// only a Vietnamese syllable is — including one still missing the tone its stop coda
+    /// needs (`chuc` → `chúc`) — which keeps English words and URLs literal, so leave the
+    /// document alone on `false`.
     func adopt(_ word: String) -> Bool {
         let scalars = word.unicodeScalars.map(\.value)
         return funput_adopt(handle, scalars, UInt(scalars.count))

--- a/platforms/macos/Funput/IME/RetoneScan.swift
+++ b/platforms/macos/Funput/IME/RetoneScan.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Re-opening a finished word after Backspace: `chào` + Space + ⌫ then `s` gives `cháo`.
 ///
 /// The engine decides *whether* — `FunputComposer.adopt` refuses anything that is not a
-/// complete Vietnamese syllable, which keeps English words and URLs literal. This type only
+/// Vietnamese syllable, which keeps English words and URLs literal. This type only
 /// works out *which* word the caret is about to land on, and which stretch of the document
 /// has to be handed over for it.
 ///


### PR DESCRIPTION
## The bug

On Windows, Telex:

```
chuc + Space + Backspace + s  →  chucs   (expected chúc)
tich + Space + Backspace + s  →  tichs   (expected tích)
```

## Why

Retone-after-Backspace calls `Engine::adopt`, which was gated by `is_complete_syllable`. That predicate enforces the phonotactic rule that a **stop coda** (`p t c ch`) only carries sắc or nặng — the signal that tells English `text` (→ `tẽt`) apart from a real syllable.

It also refuses the *toneless* form:

```
chuc → false    tich → false    hoc → false    dat → false
chào → true     phủ  → true
```

So `adopt` said no, and the tone key fell through as a literal letter. Those words are precisely the ones worth re-opening: a toneless stop-coda syllable is what the engine itself leaves on screen when the user commits before typing the tone.

## The fix

`funput-core` now classifies a finished buffer once, into three states:

| | Examples | `is_complete_syllable` | `is_reopenable_syllable` (new) |
|---|---|---|---|
| `Complete` | `chào`, `tét`, `ma` | ✅ | ✅ |
| `AwaitingTone` | `chuc`, `tich`, `hoc` | ❌ | ✅ |
| `Invalid` | `tẽt`, `text`, `cảd` | ❌ | ❌ |

- `is_complete_syllable` is still exactly `Complete` — **word-boundary English restore is unchanged**.
- `adopt` moves to `is_reopenable_syllable`. A *wrong* tone on a stop coda (`tẽt`, `tèt`) stays `Invalid`; that is the English-word signal, and it keeps `hello` / `text` / URLs literal.

No allocation change (still 1 per `adopt`, the rhyme string), and no platform code was touched beyond doc comments.

## Platform reach

All four platforms that have this feature call the same engine gate with no pre-filter of their own, so one change covers them — **after each rebuilds the native library**:

- macOS — `RetoneScan` → `FunputComposer.adopt` → `funput_adopt`
- iOS — `KeyboardInputCoordinator.reopenPreviousWord` → `funput_adopt`
- Android — `AndroidCompositionSession` → JNI `nativeAdopt`
- Windows — `funput_desktop::ShellState::on_backspace` → `Engine::adopt`

Linux (fcitx5/ibus) never wired retone-after-Backspace at all, so it is unaffected — still a separate task.

## Tests

- `funput-core`: `reopenable_accepts_a_stop_coda_awaiting_its_tone` — the new gate, both directions, plus an assertion that it is strictly looser than `is_complete_syllable`.
- `funput-engine`: `adopts_a_syllable_still_missing_its_stop_coda_tone` — `chuc`+`s`→`chúc`, `tich`+`s`→`tích`, `hoc`+`j`→`học`.
- `funput-desktop`: `a_word_committed_before_its_tone_is_reopened` — the reported sequence driven through the hook-and-inject shell, asserting the text the user ends up looking at.

Whole workspace green, `clippy` clean, `check-loc.sh` OK.

**Not yet verified on a live Windows machine** — the desktop test simulates the hook + inject shell, it does not run on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
