### PR TITLE
ci: gate pull requests on fmt, clippy, tests and the LOC budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+# The pull-request gate. Nothing here builds or ships — the release workflows own
+# that. This only checks that the Rust workspace stays formatted, lint-clean,
+# tested and inside the per-file line budget.
+#
+# The toolchain comes from rust-toolchain.toml (1.97.1 + rustfmt + clippy), so
+# bumping the pin moves CI with it. The two excluded shells
+# (platforms/windows, platforms/linux/settings-gtk) need system libraries and are
+# covered by the release builds instead.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Test
+        run: cargo test --workspace
+
+      - name: Line budget
+        run: bash scripts/check-loc.sh


### PR DESCRIPTION
Closes **R1** from the crate-hygiene review — the biggest remaining gap.

Every workflow in the repo today is release-driven (`push: tags v*`, `workflow_call`, `workflow_dispatch`, `release`). Nothing runs on a pull request, and nothing runs `cargo test`, `clippy` or `fmt` anywhere. That is how `shell/tests.rs` drifted out of rustfmt unnoticed, and why `scripts/check-loc.sh` has never actually run since it was written.

One job, four steps, all already green locally:

| Step | Command |
|---|---|
| Format | `cargo fmt --all -- --check` |
| Clippy | `cargo clippy --workspace --all-targets -- -D warnings` |
| Test | `cargo test --workspace` |
| Line budget | `bash scripts/check-loc.sh` |

Notes:

- The toolchain is **not** pinned in the workflow — rustup picks it up from `rust-toolchain.toml` (1.97.1 + rustfmt + clippy), so bumping that file moves CI with it and there is no second place to keep in sync.
- `ubuntu-latest` is enough: every workspace member is pure Rust with no system libraries. The two shells that do need them (`platforms/windows`, `platforms/linux/settings-gtk`) are excluded from the workspace by design and stay covered by the release builds.
- `Swatinem/rust-cache@v2` and `actions/checkout@v5` match what the existing workflows already use.

> **Based on #181, not main** — the fmt step goes red against current main until that one-file rustfmt PR lands. Merge #181 first and GitHub retargets this to main automatically. After both land, #180 gets a real CI run instead of my word for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
