### PR TITLE
feat(android): add Kaomoji keyboard

### DIFF
--- a/platforms/android/ime/src/androidTest/java/app/funput/funput/ime/editing/ImeCompositionInstrumentedTest.kt
+++ b/platforms/android/ime/src/androidTest/java/app/funput/funput/ime/editing/ImeCompositionInstrumentedTest.kt
@@ -84,6 +84,18 @@ class ImeCompositionInstrumentedTest {
     }
 
     @Test
+    fun kaomojiCommitsWholeAndVietnameseCompositionContinues() = onMainThread {
+        ImeEditingScenario.create().use { scenario ->
+            scenario.handler.type("vieejt")
+            scenario.handler.onEmojiSelected(" ¯\\_(ツ)_/¯ ")
+            scenario.handler.type("as")
+
+            assertEquals("việt ¯\\_(ツ)_/¯ á", scenario.text)
+            assertTrue(scenario.composition.isComposing)
+        }
+    }
+
+    @Test
     fun backspaceEditsCompositionNotHostBuffer() = onMainThread {
         ImeEditingScenario.create().use { scenario ->
             scenario.handler.type("vieejt")

--- a/platforms/android/keyboard-ui/build.gradle.kts
+++ b/platforms/android/keyboard-ui/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
@@ -10,30 +10,33 @@ plugins {
     alias(libs.plugins.kotlin.compose)
 }
 
-abstract class GenerateEmojiCatalog : DefaultTask() {
-    @get:InputFile abstract val sourceFile: RegularFileProperty
+abstract class GeneratePanelCatalogs : DefaultTask() {
+    @get:InputFiles abstract val sourceFiles: ConfigurableFileCollection
     @get:OutputDirectory abstract val outputDirectory: DirectoryProperty
 
     @TaskAction
     fun generate() {
-        val target = outputDirectory.file("EmojiCatalog.json").get().asFile
-        target.parentFile.mkdirs()
-        sourceFile.get().asFile.copyTo(target, overwrite = true)
-        check(sourceFile.get().asFile.readBytes().contentEquals(target.readBytes())) {
-            "Android and iOS emoji catalogs differ"
+        sourceFiles.files.forEach { source ->
+            val target = outputDirectory.file(source.name).get().asFile
+            target.parentFile.mkdirs()
+            source.copyTo(target, overwrite = true)
+            check(source.readBytes().contentEquals(target.readBytes())) {
+                "Android and iOS ${source.name} catalogs differ"
+            }
         }
     }
 }
 
-val canonicalEmojiCatalog =
-    layout.projectDirectory.file("../../ios/Packages/FunputKit/Sources/KeyboardRenderer/Resources/EmojiCatalog.json")
-val generatedEmojiAssets = layout.buildDirectory.dir("generated/funputEmojiAssets")
-val syncEmojiCatalog by tasks.registering(GenerateEmojiCatalog::class) {
-    sourceFile.set(canonicalEmojiCatalog)
-    outputDirectory.set(generatedEmojiAssets)
+val canonicalCatalogs = listOf("EmojiCatalog.json", "KaomojiCatalog.json").map {
+    layout.projectDirectory.file("../../ios/Packages/FunputKit/Sources/KeyboardRenderer/Resources/$it")
 }
-val verifyEmojiCatalogParity by tasks.registering {
-    dependsOn(syncEmojiCatalog)
+val generatedPanelAssets = layout.buildDirectory.dir("generated/funputPanelAssets")
+val syncPanelCatalogs by tasks.registering(GeneratePanelCatalogs::class) {
+    sourceFiles.from(canonicalCatalogs)
+    outputDirectory.set(generatedPanelAssets)
+}
+val verifyPanelCatalogParity by tasks.registering {
+    dependsOn(syncPanelCatalogs)
 }
 
 android {
@@ -59,10 +62,10 @@ android {
 
 androidComponents.onVariants { variant ->
     variant.sources.assets?.addGeneratedSourceDirectory(
-        syncEmojiCatalog,
-        GenerateEmojiCatalog::outputDirectory,
+        syncPanelCatalogs,
+        GeneratePanelCatalogs::outputDirectory,
     )
-    tasks.named("preBuild").configure { dependsOn(verifyEmojiCatalogParity) }
+    tasks.named("preBuild").configure { dependsOn(verifyPanelCatalogParity) }
 }
 
 dependencies {

--- a/platforms/android/keyboard-ui/src/androidTest/java/app/funput/funput/keyboard/ui/EmojiPanelInstrumentedTest.kt
+++ b/platforms/android/keyboard-ui/src/androidTest/java/app/funput/funput/keyboard/ui/EmojiPanelInstrumentedTest.kt
@@ -5,7 +5,7 @@ import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import app.funput.funput.keyboard.ui.emoji.EmojiPanelPalette
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelPalette
 import app.funput.funput.keyboard.ui.emoji.EmojiSearchContentView
 import app.funput.funput.keyboard.ui.emoji.EmojiSearchMode
 import app.funput.funput.keyboard.ui.emoji.EmojiSearchState
@@ -13,6 +13,8 @@ import app.funput.funput.theme.KeyboardThemeDescriptor
 import app.funput.funput.theme.KeyboardThemes
 import app.funput.funput.theme.LocalKeyboardThemeCatalog
 import org.junit.Test
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
@@ -44,11 +46,27 @@ class EmojiPanelInstrumentedTest {
                     render(
                         EmojiSearchState(EmojiSearchMode.EDITING, "smile"),
                         emptyList(),
-                        EmojiPanelPalette.from(theme),
+                        KeyboardPanelPalette.from(theme),
                     )
                 }
                 root.addView(search, FrameLayout.LayoutParams(-1, -1))
                 activity.setContentView(root)
+            }
+        }
+    }
+
+    @Test
+    fun panelNavigatesBetweenEmojiAndKaomojiWithoutChangingHostPanel() {
+        ActivityScenario.launch(EmojiTestActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val panel = EmojiPanelView(activity).apply { updateTheme(KeyboardThemes.GlassDark) }
+                activity.setContentView(panel)
+
+                assertFalse(panel.isShowingKaomoji)
+                panel.showKaomojiPanel()
+                assertTrue(panel.isShowingKaomoji)
+                panel.showEmojiPanel()
+                assertFalse(panel.isShowingKaomoji)
             }
         }
     }

--- a/platforms/android/keyboard-ui/src/androidTest/java/app/funput/funput/keyboard/ui/kaomoji/catalog/KaomojiGlyphSupportInstrumentedTest.kt
+++ b/platforms/android/keyboard-ui/src/androidTest/java/app/funput/funput/keyboard/ui/kaomoji/catalog/KaomojiGlyphSupportInstrumentedTest.kt
@@ -1,0 +1,39 @@
+package app.funput.funput.keyboard.ui.kaomoji.catalog
+
+import android.content.Context
+import android.graphics.Paint
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class KaomojiGlyphSupportInstrumentedTest {
+    @Test
+    fun visibleCatalogContainsOnlyCharactersSupportedByTheDevice() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        context.getSharedPreferences("funput_kaomoji_glyph_support", 0).edit().clear().commit()
+        val catalog = context.assets.open("KaomojiCatalog.json").bufferedReader().use {
+            KaomojiCatalogDecoder.decode(it.readText())
+        }
+        val paint = Paint()
+
+        val visible = KaomojiGlyphSupport(context).filter(catalog, paint::hasGlyph)
+
+        assertFalse(visible.items.isEmpty())
+        assertTrue(visible.items.all { item -> supports(item.text, paint) })
+    }
+
+    private fun supports(text: String, paint: Paint): Boolean = text.codePoints().allMatch {
+        Character.isWhitespace(it) || ignored(it) || paint.hasGlyph(String(Character.toChars(it)))
+    }
+
+    private fun ignored(codePoint: Int): Boolean = Character.getType(codePoint) in setOf(
+        Character.FORMAT.toInt(),
+        Character.NON_SPACING_MARK.toInt(),
+        Character.COMBINING_SPACING_MARK.toInt(),
+        Character.ENCLOSING_MARK.toInt(),
+    )
+}

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/EmojiPanelView.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/EmojiPanelView.kt
@@ -1,144 +1,81 @@
 package app.funput.funput.keyboard.ui
 
 import android.content.Context
-import android.graphics.drawable.GradientDrawable
 import android.util.AttributeSet
 import android.view.View
 import android.widget.FrameLayout
-import android.widget.LinearLayout
-import app.funput.funput.keyboard.KeyboardHapticType
-import app.funput.funput.keyboard.KeyboardHaptics
-import app.funput.funput.keyboard.KeyboardSounds
+import androidx.core.view.isVisible
 import app.funput.funput.keyboard.model.KeyAction
-import app.funput.funput.keyboard.ui.emoji.EmojiBottomBarView
-import app.funput.funput.keyboard.ui.emoji.EmojiBrowserView
-import app.funput.funput.keyboard.ui.emoji.EmojiCatalog
-import app.funput.funput.keyboard.ui.emoji.EmojiCatalogLoader
-import app.funput.funput.keyboard.ui.emoji.EmojiItem
-import app.funput.funput.keyboard.ui.emoji.EmojiLoadingView
-import app.funput.funput.keyboard.ui.emoji.EmojiPanelPalette
-import app.funput.funput.keyboard.ui.emoji.EmojiRecentsStore
-import app.funput.funput.keyboard.ui.emoji.EmojiSearchContentView
-import app.funput.funput.keyboard.ui.emoji.EmojiSearchController
-import app.funput.funput.keyboard.ui.emoji.EmojiSearchHeaderView
-import app.funput.funput.keyboard.ui.emoji.EmojiSearchIndex
-import app.funput.funput.keyboard.ui.emoji.EmojiSearchMode
-import app.funput.funput.keyboard.ui.emoji.EmojiSearchState
+import app.funput.funput.keyboard.ui.emoji.panel.EmojiBrowserPanelView
+import app.funput.funput.keyboard.ui.kaomoji.panel.KaomojiPanelView
 import app.funput.funput.theme.KeyboardTheme
 
 internal class EmojiPanelView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-) : LinearLayout(context, attrs) {
+) : FrameLayout(context, attrs) {
     var onEmojiSelected: (String) -> Unit = {}
     var onLettersRequested: () -> Unit = {}
     var onBackspaceRequested: (KeyAction) -> Unit = {}
     var hapticsEnabled: Boolean
-        get() = isHapticFeedbackEnabled
+        get() = emoji.hapticsEnabled
         set(value) {
-            isHapticFeedbackEnabled = value
-            search.updateFeedback(value, soundsEnabled)
+            emoji.hapticsEnabled = value
+            kaomoji.hapticsEnabled = value
         }
     var soundsEnabled: Boolean
-        get() = isSoundEffectsEnabled
+        get() = emoji.soundsEnabled
         set(value) {
-            isSoundEffectsEnabled = value
-            search.updateFeedback(hapticsEnabled, value)
+            emoji.soundsEnabled = value
+            kaomoji.soundsEnabled = value
         }
-    private val header = EmojiSearchHeaderView(context)
-    private val browser = EmojiBrowserView(context)
-    private val search = EmojiSearchContentView(context)
-    private val bottom = EmojiBottomBarView(context)
-    private val loading = EmojiLoadingView(context)
-    private val content = FrameLayout(context)
-    private val divider = View(context)
-    private val recents = EmojiRecentsStore(context)
-    private var catalog = EmojiCatalog.Empty
-    private var index = EmojiSearchIndex(emptyList())
-    private lateinit var palette: EmojiPanelPalette
-    private val controller = EmojiSearchController(::renderSearch)
+    private val emoji = EmojiBrowserPanelView(context)
+    private val kaomoji = KaomojiPanelView(context)
 
-    init { KeyboardComposeLifecycle.install(this)
-        orientation = VERTICAL
-        content.addView(browser, matchParent())
-        content.addView(search, matchParent())
-        content.addView(loading, matchParent())
-        addView(header, LayoutParams(LayoutParams.MATCH_PARENT, dp(46)))
-        addView(content, LayoutParams(LayoutParams.MATCH_PARENT, 0, 1f))
-        addView(divider, LayoutParams(LayoutParams.MATCH_PARENT, dp(1)))
-        addView(bottom, LayoutParams(LayoutParams.MATCH_PARENT, dp(46)))
+    init {
+        KeyboardComposeLifecycle.install(this)
+        addView(emoji, matchParent())
+        addView(kaomoji, matchParent())
         wireActions()
-        EmojiCatalogLoader.load(context) { content ->
-            catalog = content.catalog
-            index = content.searchIndex
-            if (catalog.emojis.isEmpty()) loading.showEmpty()
-            loading.visibility = if (catalog.emojis.isEmpty()) VISIBLE else GONE
-            refreshBrowser()
-            renderSearch(controller.state)
-        }
+        showEmojiPanel()
     }
 
     fun updateTheme(theme: KeyboardTheme) {
-        palette = EmojiPanelPalette.from(theme)
-        background = GradientDrawable(
-            GradientDrawable.Orientation.TL_BR,
-            intArrayOf(palette.backgroundStart, palette.backgroundEnd),
-        )
-        divider.setBackgroundColor(palette.divider)
-        loading.updatePalette(palette)
-        header.render(controller.state, palette)
-        browser.updatePalette(palette)
-        bottom.updatePalette(palette)
-        search.updateTheme(theme)
-        renderSearch(controller.state)
+        emoji.updateTheme(theme)
+        kaomoji.updateTheme(theme)
     }
 
     override fun onVisibilityChanged(changedView: View, visibility: Int) {
         super.onVisibilityChanged(changedView, visibility)
-        if (changedView === this && visibility != VISIBLE) controller.reset()
+        if (changedView === this && visibility != VISIBLE) {
+            emoji.reset()
+            kaomoji.reset()
+            showEmojiPanel()
+        }
     }
 
     private fun wireActions() {
-        header.onSearchRequested = controller::begin
-        header.onClearRequested = controller::clear
-        header.onCancelRequested = controller::cancel
-        browser.onEmojiSelected = ::select
-        browser.onCategoryChanged = bottom::setSelected
-        bottom.onCategoryRequested = browser::scrollTo
-        bottom.onLettersRequested = onLetters@{ feedback(KeyboardHapticType.CONTROL); onLettersRequested() }
-        bottom.onBackspaceRequested = { feedback(KeyboardHapticType.DELETE); onBackspaceRequested(KeyAction.Backspace) }
-        search.onEmojiSelected = ::select
-        search.onInput = controller::input
-        search.onSpace = controller::space
-        search.onBackspace = controller::backspace
-        search.onDone = controller::done
-        search.onCancel = controller::cancel
+        emoji.onEmojiSelected = { onEmojiSelected(it) }
+        emoji.onLettersRequested = { onLettersRequested() }
+        emoji.onBackspaceRequested = { onBackspaceRequested(it) }
+        emoji.onKaomojiRequested = ::showKaomojiPanel
+        kaomoji.onKaomojiSelected = { onEmojiSelected(it) }
+        kaomoji.onLettersRequested = { onLettersRequested() }
+        kaomoji.onBackspaceRequested = { onBackspaceRequested(it) }
+        kaomoji.onEmojiRequested = ::showEmojiPanel
     }
 
-    private fun select(item: EmojiItem) {
-        feedback(KeyboardHapticType.KEY_PRESS)
-        recents.record(item.glyph)
-        onEmojiSelected(item.glyph)
-        refreshBrowser()
+    internal fun showEmojiPanel() {
+        kaomoji.visibility = GONE
+        emoji.visibility = VISIBLE
     }
 
-    private fun refreshBrowser() = browser.submit(catalog, recents.glyphs())
-
-    private fun renderSearch(state: EmojiSearchState) {
-        if (!::palette.isInitialized) return
-        val browsing = state.mode == EmojiSearchMode.BROWSING
-        browser.visibility = if (browsing) VISIBLE else GONE
-        search.visibility = if (browsing) GONE else VISIBLE
-        bottom.visibility = if (browsing) VISIBLE else GONE
-        divider.visibility = bottom.visibility
-        header.render(state, palette)
-        search.render(state, index.search(state.query), palette)
+    internal fun showKaomojiPanel() {
+        emoji.visibility = GONE
+        kaomoji.visibility = VISIBLE
     }
 
-    private fun feedback(type: KeyboardHapticType) {
-        KeyboardHaptics.perform(this, type)
-        KeyboardSounds.perform(this, type)
-    }
-    private fun dp(value: Int) = (value * resources.displayMetrics.density).toInt()
-    private fun matchParent() = FrameLayout.LayoutParams(-1, -1)
+    internal val isShowingKaomoji: Boolean get() = kaomoji.isVisible
+
+    private fun matchParent() = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
 }

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/emoji/EmojiBottomBarView.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/emoji/EmojiBottomBarView.kt
@@ -27,17 +27,20 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelComposeView
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelPalette
 
-internal class EmojiBottomBarView(context: Context) : EmojiComposeView(context) {
+internal class EmojiBottomBarView(context: Context) : KeyboardPanelComposeView(context) {
     var onLettersRequested: () -> Unit = {}
+    var onKaomojiRequested: () -> Unit = {}
     var onBackspaceRequested: () -> Unit = {}
     var onCategoryRequested: (EmojiCategory) -> Unit = {}
-    private var palette by mutableStateOf<EmojiPanelPalette?>(null)
+    private var palette by mutableStateOf<KeyboardPanelPalette?>(null)
     private var selectedCategory by mutableStateOf(EmojiCategory.SMILEYS_PEOPLE)
 
     init { setContent { Content() } }
 
-    fun updatePalette(value: EmojiPanelPalette) { palette = value }
+    fun updatePalette(value: KeyboardPanelPalette) { palette = value }
     fun setSelected(value: EmojiCategory) { selectedCategory = value }
 
     @Composable
@@ -46,6 +49,9 @@ internal class EmojiBottomBarView(context: Context) : EmojiComposeView(context) 
         Row(Modifier.fillMaxSize(), verticalAlignment = Alignment.CenterVertically) {
             Action("ABC", "Về bàn phím", colors.label, Modifier.width(52.dp)) {
                 onLettersRequested()
+            }
+            Action("(^_^)", "Biểu tượng kaomoji", colors.label, Modifier.width(46.dp)) {
+                onKaomojiRequested()
             }
             LazyRow(Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
                 items(EmojiCategory.entries, key = EmojiCategory::name) { category ->

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/emoji/EmojiBrowserView.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/emoji/EmojiBrowserView.kt
@@ -24,13 +24,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelComposeView
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelPalette
 import kotlinx.coroutines.flow.distinctUntilChanged
 
-internal class EmojiBrowserView(context: Context) : EmojiComposeView(context) {
+internal class EmojiBrowserView(context: Context) : KeyboardPanelComposeView(context) {
     var onEmojiSelected: (EmojiItem) -> Unit = {}
     var onCategoryChanged: (EmojiCategory) -> Unit = {}
     private var sections by mutableStateOf(EmojiSections(emptyList()))
-    private var palette by mutableStateOf<EmojiPanelPalette?>(null)
+    private var palette by mutableStateOf<KeyboardPanelPalette?>(null)
     private var requestedCategory by mutableStateOf<EmojiCategory?>(null)
     private var requestId by mutableIntStateOf(0)
 
@@ -40,11 +42,15 @@ internal class EmojiBrowserView(context: Context) : EmojiComposeView(context) {
         sections = EmojiSections.from(catalog, recents)
     }
 
-    fun updatePalette(value: EmojiPanelPalette) { palette = value }
+    fun updatePalette(value: KeyboardPanelPalette) { palette = value }
 
     fun scrollTo(category: EmojiCategory) {
         requestedCategory = category
         requestId++
+    }
+
+    fun reset() {
+        scrollTo(sections.values.firstOrNull()?.category ?: EmojiCategory.SMILEYS_PEOPLE)
     }
 
     @androidx.compose.runtime.Composable

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/emoji/EmojiLoadingView.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/emoji/EmojiLoadingView.kt
@@ -6,6 +6,7 @@ import android.view.Gravity
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelPalette
 import app.funput.funput.keyboard.ui.R
 
 internal class EmojiLoadingView(context: Context) : LinearLayout(context) {
@@ -29,7 +30,7 @@ internal class EmojiLoadingView(context: Context) : LinearLayout(context) {
         label.setText(R.string.emoji_panel_empty)
     }
 
-    fun updatePalette(palette: EmojiPanelPalette) {
+    fun updatePalette(palette: KeyboardPanelPalette) {
         progress.indeterminateTintList = ColorStateList.valueOf(palette.accent)
         label.setTextColor(palette.secondaryLabel)
     }

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/emoji/EmojiResultsView.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/emoji/EmojiResultsView.kt
@@ -16,8 +16,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelComposeView
 
-internal class EmojiResultsView(context: Context) : EmojiComposeView(context) {
+internal class EmojiResultsView(context: Context) : KeyboardPanelComposeView(context) {
     var onEmojiSelected: (EmojiItem) -> Unit = {}
     private var items by mutableStateOf(emptyList<EmojiItem>())
     private var vertical by mutableStateOf(false)

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/emoji/EmojiSearchContentView.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/emoji/EmojiSearchContentView.kt
@@ -15,11 +15,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import app.funput.funput.keyboard.KeyboardSurfaceView
 import app.funput.funput.keyboard.model.KeyAction
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelComposeView
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelPalette
 import app.funput.funput.keyboard.model.KeyboardEnterAction
 import app.funput.funput.keyboard.ui.R
 import app.funput.funput.theme.KeyboardTheme
 
-internal class EmojiSearchContentView(context: Context) : EmojiComposeView(context) {
+internal class EmojiSearchContentView(context: Context) : KeyboardPanelComposeView(context) {
     var onEmojiSelected: (EmojiItem) -> Unit = {}
     var onInput: (String) -> Unit = {}
     var onSpace: () -> Unit = {}
@@ -28,7 +30,7 @@ internal class EmojiSearchContentView(context: Context) : EmojiComposeView(conte
     var onCancel: () -> Unit = {}
     private var state by mutableStateOf(EmojiSearchState())
     private var items by mutableStateOf(emptyList<EmojiItem>())
-    private var palette by mutableStateOf<EmojiPanelPalette?>(null)
+    private var palette by mutableStateOf<KeyboardPanelPalette?>(null)
     private var theme by mutableStateOf<KeyboardTheme?>(null)
     private var haptics by mutableStateOf(true)
     private var sounds by mutableStateOf(true)
@@ -53,7 +55,7 @@ internal class EmojiSearchContentView(context: Context) : EmojiComposeView(conte
     fun render(
         state: EmojiSearchState,
         items: List<EmojiItem>,
-        palette: EmojiPanelPalette,
+        palette: KeyboardPanelPalette,
     ) {
         this.state = state
         this.items = items

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/emoji/EmojiSearchHeaderView.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/emoji/EmojiSearchHeaderView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.Gravity
 import android.widget.FrameLayout
 import android.widget.TextView
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelPalette
 
 internal class EmojiSearchHeaderView(context: Context) : FrameLayout(context) {
     var onSearchRequested: () -> Unit = {}
@@ -40,7 +41,7 @@ internal class EmojiSearchHeaderView(context: Context) : FrameLayout(context) {
         addView(cancel, LayoutParams(dp(54), dp(46), Gravity.END))
     }
 
-    fun render(state: EmojiSearchState, palette: EmojiPanelPalette) {
+    fun render(state: EmojiSearchState, palette: KeyboardPanelPalette) {
         val browsing = state.mode == EmojiSearchMode.BROWSING
         cancel.visibility = if (browsing) GONE else VISIBLE
         clear.visibility = if (!browsing && state.query.isNotEmpty()) VISIBLE else GONE

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/emoji/panel/EmojiBrowserPanelView.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/emoji/panel/EmojiBrowserPanelView.kt
@@ -1,0 +1,143 @@
+package app.funput.funput.keyboard.ui.emoji.panel
+
+import android.content.Context
+import android.graphics.drawable.GradientDrawable
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import app.funput.funput.keyboard.KeyboardHapticType
+import app.funput.funput.keyboard.KeyboardHaptics
+import app.funput.funput.keyboard.KeyboardSounds
+import app.funput.funput.keyboard.model.KeyAction
+import app.funput.funput.keyboard.ui.emoji.EmojiBottomBarView
+import app.funput.funput.keyboard.ui.emoji.EmojiBrowserView
+import app.funput.funput.keyboard.ui.emoji.EmojiCatalog
+import app.funput.funput.keyboard.ui.emoji.EmojiCatalogLoader
+import app.funput.funput.keyboard.ui.emoji.EmojiItem
+import app.funput.funput.keyboard.ui.emoji.EmojiLoadingView
+import app.funput.funput.keyboard.ui.emoji.EmojiRecentsStore
+import app.funput.funput.keyboard.ui.emoji.EmojiSearchContentView
+import app.funput.funput.keyboard.ui.emoji.EmojiSearchController
+import app.funput.funput.keyboard.ui.emoji.EmojiSearchHeaderView
+import app.funput.funput.keyboard.ui.emoji.EmojiSearchIndex
+import app.funput.funput.keyboard.ui.emoji.EmojiSearchMode
+import app.funput.funput.keyboard.ui.emoji.EmojiSearchState
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelPalette
+import app.funput.funput.theme.KeyboardTheme
+
+internal class EmojiBrowserPanelView(context: Context) : LinearLayout(context) {
+    var onEmojiSelected: (String) -> Unit = {}
+    var onLettersRequested: () -> Unit = {}
+    var onKaomojiRequested: () -> Unit = {}
+    var onBackspaceRequested: (KeyAction) -> Unit = {}
+    var hapticsEnabled: Boolean
+        get() = isHapticFeedbackEnabled
+        set(value) {
+            isHapticFeedbackEnabled = value
+            search.updateFeedback(value, soundsEnabled)
+        }
+    var soundsEnabled: Boolean
+        get() = isSoundEffectsEnabled
+        set(value) {
+            isSoundEffectsEnabled = value
+            search.updateFeedback(hapticsEnabled, value)
+        }
+    private val header = EmojiSearchHeaderView(context)
+    private val browser = EmojiBrowserView(context)
+    private val search = EmojiSearchContentView(context)
+    private val bottom = EmojiBottomBarView(context)
+    private val loading = EmojiLoadingView(context)
+    private val content = FrameLayout(context)
+    private val divider = View(context)
+    private val recents = EmojiRecentsStore(context)
+    private var catalog = EmojiCatalog.Empty
+    private var index = EmojiSearchIndex(emptyList())
+    private lateinit var palette: KeyboardPanelPalette
+    private val controller = EmojiSearchController(::renderSearch)
+
+    init {
+        orientation = VERTICAL
+        content.addView(browser, matchParent())
+        content.addView(search, matchParent())
+        content.addView(loading, matchParent())
+        addView(header, LayoutParams(LayoutParams.MATCH_PARENT, dp(46)))
+        addView(content, LayoutParams(LayoutParams.MATCH_PARENT, 0, 1f))
+        addView(divider, LayoutParams(LayoutParams.MATCH_PARENT, dp(1)))
+        addView(bottom, LayoutParams(LayoutParams.MATCH_PARENT, dp(46)))
+        wireActions()
+        EmojiCatalogLoader.load(context) { loaded ->
+            catalog = loaded.catalog
+            index = loaded.searchIndex
+            if (catalog.emojis.isEmpty()) loading.showEmpty()
+            loading.visibility = if (catalog.emojis.isEmpty()) VISIBLE else GONE
+            refreshBrowser()
+            renderSearch(controller.state)
+        }
+    }
+
+    fun updateTheme(theme: KeyboardTheme) {
+        palette = KeyboardPanelPalette.from(theme)
+        background = GradientDrawable(
+            GradientDrawable.Orientation.TL_BR,
+            intArrayOf(palette.backgroundStart, palette.backgroundEnd),
+        )
+        divider.setBackgroundColor(palette.divider)
+        loading.updatePalette(palette)
+        header.render(controller.state, palette)
+        browser.updatePalette(palette)
+        bottom.updatePalette(palette)
+        search.updateTheme(theme)
+        renderSearch(controller.state)
+    }
+
+    fun reset() {
+        controller.reset()
+        browser.reset()
+    }
+
+    private fun wireActions() {
+        header.onSearchRequested = controller::begin
+        header.onClearRequested = controller::clear
+        header.onCancelRequested = controller::cancel
+        browser.onEmojiSelected = ::select
+        browser.onCategoryChanged = bottom::setSelected
+        bottom.onCategoryRequested = browser::scrollTo
+        bottom.onLettersRequested = { feedback(KeyboardHapticType.CONTROL); onLettersRequested() }
+        bottom.onKaomojiRequested = { feedback(KeyboardHapticType.CONTROL); onKaomojiRequested() }
+        bottom.onBackspaceRequested = { feedback(KeyboardHapticType.DELETE); onBackspaceRequested(KeyAction.Backspace) }
+        search.onEmojiSelected = ::select
+        search.onInput = controller::input
+        search.onSpace = controller::space
+        search.onBackspace = controller::backspace
+        search.onDone = controller::done
+        search.onCancel = controller::cancel
+    }
+
+    private fun select(item: EmojiItem) {
+        feedback(KeyboardHapticType.KEY_PRESS)
+        recents.record(item.glyph)
+        onEmojiSelected(item.glyph)
+        refreshBrowser()
+    }
+
+    private fun refreshBrowser() = browser.submit(catalog, recents.glyphs())
+
+    private fun renderSearch(state: EmojiSearchState) {
+        if (!::palette.isInitialized) return
+        val browsing = state.mode == EmojiSearchMode.BROWSING
+        browser.visibility = if (browsing) VISIBLE else GONE
+        search.visibility = if (browsing) GONE else VISIBLE
+        bottom.visibility = if (browsing) VISIBLE else GONE
+        divider.visibility = bottom.visibility
+        header.render(state, palette)
+        search.render(state, index.search(state.query), palette)
+    }
+
+    private fun feedback(type: KeyboardHapticType) {
+        KeyboardHaptics.perform(this, type)
+        KeyboardSounds.perform(this, type)
+    }
+
+    private fun dp(value: Int) = (value * resources.displayMetrics.density).toInt()
+    private fun matchParent() = FrameLayout.LayoutParams(-1, -1)
+}

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/browser/KaomojiBrowserView.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/browser/KaomojiBrowserView.kt
@@ -1,0 +1,145 @@
+package app.funput.funput.keyboard.ui.kaomoji.browser
+
+import android.content.Context
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.TextAutoSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.funput.funput.keyboard.ui.kaomoji.catalog.KaomojiCatalog
+import app.funput.funput.keyboard.ui.kaomoji.catalog.KaomojiCategory
+import app.funput.funput.keyboard.ui.kaomoji.catalog.KaomojiItem
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelComposeView
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelPalette
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+internal class KaomojiBrowserView(context: Context) : KeyboardPanelComposeView(context) {
+    var onKaomojiSelected: (KaomojiItem) -> Unit = {}
+    var onCategoryChanged: (KaomojiCategory) -> Unit = {}
+    private var sections by mutableStateOf(KaomojiSections(emptyList()))
+    private var palette by mutableStateOf<KeyboardPanelPalette?>(null)
+    private var loaded by mutableStateOf(false)
+    private var requestedCategory by mutableStateOf<KaomojiCategory?>(null)
+    private var requestId by mutableIntStateOf(0)
+
+    init { setContent { Content() } }
+
+    fun submit(catalog: KaomojiCatalog, recent: List<String>) {
+        sections = KaomojiSections.from(catalog, recent)
+        loaded = true
+    }
+
+    fun updatePalette(value: KeyboardPanelPalette) { palette = value }
+
+    fun scrollTo(category: KaomojiCategory) { requestedCategory = category; requestId++ }
+
+    fun reset() { scrollTo(sections.values.firstOrNull()?.category ?: KaomojiCategory.HAPPY) }
+
+    @Composable
+    private fun Content() {
+        val colors = palette ?: return
+        if (sections.values.isEmpty()) return EmptyState(colors)
+        val state = rememberLazyListState()
+        LaunchedEffect(requestId) {
+            sections.position(requestedCategory ?: return@LaunchedEffect)
+                .takeIf { it >= 0 }?.let { state.scrollToItem(it) }
+        }
+        LaunchedEffect(state, sections) {
+            snapshotFlow { state.firstVisibleItemIndex }.distinctUntilChanged()
+                .collect { sections.categoryAt(it)?.let(onCategoryChanged) }
+        }
+        LazyColumn(
+            state = state,
+            contentPadding = PaddingValues(top = 8.dp, bottom = 10.dp),
+        ) {
+            sections.values.forEach { section ->
+                item(key = section.category.name) { Section(section, colors) }
+            }
+        }
+    }
+
+    @Composable
+    private fun Section(section: KaomojiSection, colors: KeyboardPanelPalette) {
+        BasicText(
+            section.category.label,
+            Modifier.fillMaxWidth().height(28.dp).padding(horizontal = 16.dp),
+            TextStyle(Color(colors.secondaryLabel), fontSize = 13.sp),
+        )
+        BoxWithConstraints(Modifier.fillMaxWidth()) {
+            val availableWidth = maxWidth - 16.dp
+            FlowRow(
+                Modifier.padding(horizontal = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(14.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                section.items.forEach { item -> KaomojiCell(item, availableWidth, colors) }
+            }
+        }
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    @Composable
+    private fun KaomojiCell(item: KaomojiItem, maximumWidth: androidx.compose.ui.unit.Dp, colors: KeyboardPanelPalette) {
+        val style = TextStyle(Color(colors.label), fontSize = 17.sp)
+        val measurer = rememberTextMeasurer()
+        val measured = remember(item.text, measurer) { measurer.measure(item.text, style).size.width }
+        val density = LocalDensity.current
+        val width = with(density) {
+            KaomojiCellMetrics.widthFor(measured.toDp().value, maximumWidth.value).dp
+        }
+        Box(
+            Modifier.height(44.dp).width(width)
+                .semantics { contentDescription = item.name }
+                .clickable { onKaomojiSelected(item) }.padding(horizontal = 8.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            BasicText(
+                item.text,
+                style = style,
+                maxLines = 1,
+                overflow = TextOverflow.Clip,
+                autoSize = TextAutoSize.StepBased(10.sp, 17.sp, 1.sp),
+            )
+        }
+    }
+
+    @Composable
+    private fun EmptyState(colors: KeyboardPanelPalette) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            BasicText(
+                if (loaded) "Không có kaomoji" else "Đang tải kaomoji…",
+                style = TextStyle(Color(colors.secondaryLabel), fontSize = 15.sp),
+            )
+        }
+    }
+}

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/browser/KaomojiCellMetrics.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/browser/KaomojiCellMetrics.kt
@@ -1,0 +1,12 @@
+package app.funput.funput.keyboard.ui.kaomoji.browser
+
+internal object KaomojiCellMetrics {
+    const val MinimumWidth = 44f
+    const val HorizontalPadding = 16f
+
+    fun widthFor(measuredTextWidth: Float, availableWidth: Float): Float =
+        (measuredTextWidth + HorizontalPadding).coerceIn(
+            MinimumWidth,
+            availableWidth.coerceAtLeast(MinimumWidth),
+        )
+}

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/browser/KaomojiSections.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/browser/KaomojiSections.kt
@@ -1,0 +1,34 @@
+package app.funput.funput.keyboard.ui.kaomoji.browser
+
+import app.funput.funput.keyboard.ui.kaomoji.catalog.KaomojiCatalog
+import app.funput.funput.keyboard.ui.kaomoji.catalog.KaomojiCategory
+import app.funput.funput.keyboard.ui.kaomoji.catalog.KaomojiItem
+
+internal data class KaomojiSection(
+    val category: KaomojiCategory,
+    val items: List<KaomojiItem>,
+)
+
+internal class KaomojiSections(val values: List<KaomojiSection>) {
+    fun position(category: KaomojiCategory): Int =
+        values.indexOfFirst { it.category == category }
+
+    fun categoryAt(position: Int): KaomojiCategory? =
+        values.getOrNull(position)?.category ?: values.lastOrNull()?.category
+
+    companion object {
+        fun from(catalog: KaomojiCatalog, recentTexts: List<String>): KaomojiSections {
+            val lookup = catalog.items.associateBy(KaomojiItem::text)
+            return KaomojiSections(buildList {
+                recentTexts.mapNotNull(lookup::get).takeIf(List<KaomojiItem>::isNotEmpty)?.let {
+                    add(KaomojiSection(KaomojiCategory.RECENT, it))
+                }
+                KaomojiCategory.entries.drop(1).forEach { category ->
+                    catalog.items(category).takeIf(List<KaomojiItem>::isNotEmpty)?.let {
+                        add(KaomojiSection(category, it))
+                    }
+                }
+            })
+        }
+    }
+}

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/catalog/KaomojiCatalog.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/catalog/KaomojiCatalog.kt
@@ -1,0 +1,37 @@
+package app.funput.funput.keyboard.ui.kaomoji.catalog
+
+internal enum class KaomojiCategory(val wireName: String, val label: String) {
+    RECENT("recent", "Dùng gần đây"),
+    HAPPY("happy", "Vui vẻ"),
+    LOVE("love", "Yêu thương"),
+    SAD("sad", "Buồn bã"),
+    ANGRY("angry", "Giận dữ"),
+    SURPRISED("surprised", "Ngạc nhiên"),
+    CONFUSED("confused", "Bối rối"),
+    ACTION("action", "Hành động"),
+    ANIMAL("animal", "Động vật"),
+    GREETING("greeting", "Chào hỏi");
+
+    companion object {
+        fun fromWireName(value: String): KaomojiCategory? =
+            entries.firstOrNull { it.wireName == value }
+    }
+}
+
+internal data class KaomojiItem(
+    val text: String,
+    val name: String,
+    val category: KaomojiCategory,
+)
+
+internal data class KaomojiCatalog(
+    val version: String,
+    val items: List<KaomojiItem>,
+) {
+    fun items(category: KaomojiCategory): List<KaomojiItem> =
+        items.filter { it.category == category }
+
+    companion object {
+        val Empty = KaomojiCatalog("", emptyList())
+    }
+}

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/catalog/KaomojiCatalogDecoder.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/catalog/KaomojiCatalogDecoder.kt
@@ -1,0 +1,25 @@
+package app.funput.funput.keyboard.ui.kaomoji.catalog
+
+import org.json.JSONObject
+
+internal object KaomojiCatalogDecoder {
+    fun decode(json: String): KaomojiCatalog = runCatching {
+        val root = JSONObject(json)
+        val values = root.getJSONArray("items")
+        val items = buildList(values.length()) {
+            repeat(values.length()) { index ->
+                decodeItem(values.getJSONObject(index))?.let(::add)
+            }
+        }
+        KaomojiCatalog(root.optString("version"), items)
+    }.getOrDefault(KaomojiCatalog.Empty)
+
+    private fun decodeItem(value: JSONObject): KaomojiItem? {
+        val category = KaomojiCategory.fromWireName(value.optString("category")) ?: return null
+        if (category == KaomojiCategory.RECENT) return null
+        val text = value.optString("text")
+        val name = value.optString("name")
+        if (text.isBlank() || name.isBlank()) return null
+        return KaomojiItem(text, name, category)
+    }
+}

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/catalog/KaomojiCatalogLoader.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/catalog/KaomojiCatalogLoader.kt
@@ -1,0 +1,50 @@
+package app.funput.funput.keyboard.ui.kaomoji.catalog
+
+import android.content.Context
+import android.graphics.Paint
+import android.os.Handler
+import android.os.Looper
+import java.util.concurrent.Executors
+
+internal object KaomojiCatalogLoader {
+    private const val AssetName = "KaomojiCatalog.json"
+    private val executor = Executors.newSingleThreadExecutor { task ->
+        Thread(task, "FunputKaomojiCatalog").apply {
+            priority = Thread.MIN_PRIORITY
+            isDaemon = true
+        }
+    }
+    private val main = Handler(Looper.getMainLooper())
+    @Volatile private var cached: KaomojiCatalog? = null
+    private var loading = false
+    private val callbacks = mutableListOf<(KaomojiCatalog) -> Unit>()
+
+    fun load(context: Context, completion: (KaomojiCatalog) -> Unit) {
+        cached?.let(completion) ?: enqueue(context.applicationContext, completion)
+    }
+
+    private fun enqueue(context: Context, completion: (KaomojiCatalog) -> Unit) {
+        synchronized(this) {
+            cached?.let { ready -> main.post { completion(ready) }; return }
+            callbacks += completion
+            if (loading) return
+            loading = true
+            executor.execute { decode(context) }
+        }
+    }
+
+    private fun decode(context: Context) {
+        val decoded = runCatching {
+            context.assets.open(AssetName).bufferedReader().use { KaomojiCatalogDecoder.decode(it.readText()) }
+        }.getOrDefault(KaomojiCatalog.Empty)
+        val paint = Paint()
+        val supported = KaomojiGlyphSupport(context).filter(decoded, paint::hasGlyph)
+        synchronized(this) {
+            cached = supported
+            loading = false
+            val pending = callbacks.toList()
+            callbacks.clear()
+            main.post { pending.forEach { it(supported) } }
+        }
+    }
+}

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/catalog/KaomojiGlyphSupport.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/catalog/KaomojiGlyphSupport.kt
@@ -1,0 +1,50 @@
+package app.funput.funput.keyboard.ui.kaomoji.catalog
+
+import android.content.Context
+import android.graphics.Paint
+import android.os.Build
+import androidx.core.content.edit
+
+internal class KaomojiGlyphSupport(context: Context) {
+    private val preferences = context.getSharedPreferences(FileName, Context.MODE_PRIVATE)
+
+    fun filter(catalog: KaomojiCatalog, hasGlyph: (String) -> Boolean): KaomojiCatalog {
+        if (catalog.items.isEmpty()) return catalog
+        val signature = "${Build.FINGERPRINT}|${Build.VERSION.SDK_INT}|${catalog.version}"
+        val cached = preferences.getStringSet(UnsupportedKey, null)
+            ?.takeIf { preferences.getString(SignatureKey, null) == signature }
+        val unsupported = cached ?: catalog.items.asSequence()
+            .filterNot { item -> supports(item.text, hasGlyph) }
+            .map(KaomojiItem::text)
+            .toSet()
+            .also {
+                preferences.edit {
+                    putString(SignatureKey, signature)
+                    putStringSet(UnsupportedKey, it)
+                }
+            }
+        return catalog.copy(items = catalog.items.filterNot { it.text in unsupported })
+    }
+
+    private fun supports(text: String, hasGlyph: (String) -> Boolean): Boolean =
+        text.codePoints().allMatch { codePoint ->
+            ignorable(codePoint) || hasGlyph(String(Character.toChars(codePoint)))
+        }
+
+    private fun ignorable(codePoint: Int): Boolean {
+        if (Character.isWhitespace(codePoint)) return true
+        return Character.getType(codePoint) in IgnorableTypes
+    }
+
+    private companion object {
+        const val FileName = "funput_kaomoji_glyph_support"
+        const val SignatureKey = "catalog_device_signature"
+        const val UnsupportedKey = "unsupported_kaomoji"
+        val IgnorableTypes = setOf(
+            Character.FORMAT.toInt(),
+            Character.NON_SPACING_MARK.toInt(),
+            Character.COMBINING_SPACING_MARK.toInt(),
+            Character.ENCLOSING_MARK.toInt(),
+        )
+    }
+}

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/panel/KaomojiBottomBarView.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/panel/KaomojiBottomBarView.kt
@@ -1,0 +1,112 @@
+package app.funput.funput.keyboard.ui.kaomoji.panel
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.funput.funput.keyboard.ui.emoji.EmojiCategory
+import app.funput.funput.keyboard.ui.emoji.EmojiCategoryIcon
+import app.funput.funput.keyboard.ui.kaomoji.catalog.KaomojiCategory
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelComposeView
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelPalette
+
+internal class KaomojiBottomBarView(context: Context) : KeyboardPanelComposeView(context) {
+    var onLettersRequested: () -> Unit = {}
+    var onEmojiRequested: () -> Unit = {}
+    var onBackspaceRequested: () -> Unit = {}
+    var onCategoryRequested: (KaomojiCategory) -> Unit = {}
+    private var palette by mutableStateOf<KeyboardPanelPalette?>(null)
+    private var selectedCategory by mutableStateOf(KaomojiCategory.HAPPY)
+
+    init { setContent { Content() } }
+
+    fun updatePalette(value: KeyboardPanelPalette) { palette = value }
+    fun setSelected(value: KaomojiCategory) { selectedCategory = value }
+
+    @Composable
+    private fun Content() {
+        val colors = palette ?: return
+        Row(Modifier.fillMaxSize(), verticalAlignment = Alignment.CenterVertically) {
+            Action("ABC", "Về bàn phím", colors.label, Modifier.width(52.dp), onLettersRequested)
+            Action("😀", "Biểu tượng cảm xúc", colors.label, Modifier.width(46.dp), onEmojiRequested)
+            LazyRow(Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
+                items(KaomojiCategory.entries, key = KaomojiCategory::name) { category ->
+                    val active = category == selectedCategory
+                    CategoryAction(category, colors, active)
+                }
+            }
+            Action("⌫", "Xóa", colors.label, Modifier.width(52.dp), onBackspaceRequested)
+        }
+    }
+
+    @Composable
+    private fun CategoryAction(category: KaomojiCategory, colors: KeyboardPanelPalette, active: Boolean) {
+        Box(
+            Modifier.width(40.dp).height(46.dp)
+                .then(if (active) Modifier.background(Color(colors.buttonSurface), RoundedCornerShape(8.dp)) else Modifier)
+                .semantics { contentDescription = category.label; selected = active }
+                .clickable { onCategoryRequested(category) },
+            contentAlignment = Alignment.Center,
+        ) {
+            val tint = Color(if (active) colors.accent else colors.secondaryLabel)
+            if (category == KaomojiCategory.RECENT) {
+                EmojiCategoryIcon(EmojiCategory.RECENT, tint)
+            } else {
+                BasicText(
+                    category.symbol,
+                    style = TextStyle(color = tint, fontSize = 18.sp, textAlign = TextAlign.Center),
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun Action(label: String, description: String, color: Int, modifier: Modifier, clicked: () -> Unit) {
+        Box(
+            modifier.height(46.dp).semantics { contentDescription = description }.clickable(onClick = clicked),
+            contentAlignment = Alignment.Center,
+        ) {
+            BasicText(
+                label,
+                style = TextStyle(Color(color), 15.sp, fontWeight = FontWeight.Medium, textAlign = TextAlign.Center),
+            )
+        }
+    }
+}
+
+private val KaomojiCategory.symbol: String
+    get() = when (this) {
+        KaomojiCategory.RECENT -> "◷"
+        KaomojiCategory.HAPPY -> "☺"
+        KaomojiCategory.LOVE -> "♥"
+        KaomojiCategory.SAD -> "☂"
+        KaomojiCategory.ANGRY -> "♨"
+        KaomojiCategory.SURPRISED -> "!"
+        KaomojiCategory.CONFUSED -> "?"
+        KaomojiCategory.ACTION -> "↗"
+        KaomojiCategory.ANIMAL -> "♧"
+        KaomojiCategory.GREETING -> "✋"
+    }

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/panel/KaomojiPanelView.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/panel/KaomojiPanelView.kt
@@ -1,0 +1,89 @@
+package app.funput.funput.keyboard.ui.kaomoji.panel
+
+import android.content.Context
+import android.graphics.drawable.GradientDrawable
+import android.util.AttributeSet
+import android.view.View
+import android.widget.LinearLayout
+import app.funput.funput.keyboard.KeyboardHapticType
+import app.funput.funput.keyboard.KeyboardHaptics
+import app.funput.funput.keyboard.KeyboardSounds
+import app.funput.funput.keyboard.model.KeyAction
+import app.funput.funput.keyboard.ui.kaomoji.browser.KaomojiBrowserView
+import app.funput.funput.keyboard.ui.kaomoji.catalog.KaomojiCatalog
+import app.funput.funput.keyboard.ui.kaomoji.catalog.KaomojiCatalogLoader
+import app.funput.funput.keyboard.ui.kaomoji.catalog.KaomojiItem
+import app.funput.funput.keyboard.ui.kaomoji.persistence.KaomojiRecentsStore
+import app.funput.funput.keyboard.ui.panel.KeyboardPanelPalette
+import app.funput.funput.theme.KeyboardTheme
+
+internal class KaomojiPanelView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : LinearLayout(context, attrs) {
+    var onKaomojiSelected: (String) -> Unit = {}
+    var onLettersRequested: () -> Unit = {}
+    var onEmojiRequested: () -> Unit = {}
+    var onBackspaceRequested: (KeyAction) -> Unit = {}
+    var hapticsEnabled: Boolean
+        get() = isHapticFeedbackEnabled
+        set(value) { isHapticFeedbackEnabled = value }
+    var soundsEnabled: Boolean
+        get() = isSoundEffectsEnabled
+        set(value) { isSoundEffectsEnabled = value }
+    private val browser = KaomojiBrowserView(context)
+    private val bottom = KaomojiBottomBarView(context)
+    private val divider = View(context)
+    private val recents = KaomojiRecentsStore(context)
+    private var catalog = KaomojiCatalog.Empty
+
+    init {
+        orientation = VERTICAL
+        addView(browser, LayoutParams(LayoutParams.MATCH_PARENT, 0, 1f))
+        addView(divider, LayoutParams(LayoutParams.MATCH_PARENT, dp(1)))
+        addView(bottom, LayoutParams(LayoutParams.MATCH_PARENT, dp(46)))
+        wireActions()
+        KaomojiCatalogLoader.load(context) {
+            catalog = it
+            refreshBrowser()
+        }
+    }
+
+    fun updateTheme(theme: KeyboardTheme) {
+        val palette = KeyboardPanelPalette.from(theme)
+        background = GradientDrawable(
+            GradientDrawable.Orientation.TL_BR,
+            intArrayOf(palette.backgroundStart, palette.backgroundEnd),
+        )
+        divider.setBackgroundColor(palette.divider)
+        browser.updatePalette(palette)
+        bottom.updatePalette(palette)
+    }
+
+    fun reset() = browser.reset()
+
+    private fun wireActions() {
+        browser.onKaomojiSelected = ::select
+        browser.onCategoryChanged = bottom::setSelected
+        bottom.onCategoryRequested = browser::scrollTo
+        bottom.onLettersRequested = { feedback(KeyboardHapticType.CONTROL); onLettersRequested() }
+        bottom.onEmojiRequested = { feedback(KeyboardHapticType.CONTROL); onEmojiRequested() }
+        bottom.onBackspaceRequested = { feedback(KeyboardHapticType.DELETE); onBackspaceRequested(KeyAction.Backspace) }
+    }
+
+    private fun select(item: KaomojiItem) {
+        feedback(KeyboardHapticType.KEY_PRESS)
+        recents.record(item.text)
+        onKaomojiSelected(item.text)
+        refreshBrowser()
+    }
+
+    private fun refreshBrowser() = browser.submit(catalog, recents.texts())
+
+    private fun feedback(type: KeyboardHapticType) {
+        KeyboardHaptics.perform(this, type)
+        KeyboardSounds.perform(this, type)
+    }
+
+    private fun dp(value: Int) = (value * resources.displayMetrics.density).toInt()
+}

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/persistence/KaomojiRecentsStore.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/kaomoji/persistence/KaomojiRecentsStore.kt
@@ -1,0 +1,33 @@
+package app.funput.funput.keyboard.ui.kaomoji.persistence
+
+import android.content.Context
+import androidx.core.content.edit
+import org.json.JSONArray
+
+internal class KaomojiRecentsStore(context: Context) {
+    private val preferences = context.getSharedPreferences(FileName, Context.MODE_PRIVATE)
+
+    fun texts(): List<String> = decode(preferences.getString(Key, null))
+
+    fun record(text: String) {
+        val updated = (listOf(text) + texts()).distinct().take(Limit)
+        preferences.edit { putString(Key, encode(updated)) }
+    }
+
+    companion object {
+        const val Limit = 30
+        private const val FileName = "funput_kaomoji_recents"
+        private const val Key = "recent_kaomoji"
+
+        internal fun decode(value: String?): List<String> = runCatching {
+            val array = JSONArray(value ?: "[]")
+            buildList(array.length()) {
+                repeat(array.length()) { index ->
+                    array.optString(index).takeIf(String::isNotBlank)?.let(::add)
+                }
+            }.distinct().take(Limit)
+        }.getOrDefault(emptyList())
+
+        internal fun encode(values: List<String>): String = JSONArray(values).toString()
+    }
+}

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/panel/KeyboardPanelComposeView.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/panel/KeyboardPanelComposeView.kt
@@ -1,4 +1,4 @@
-package app.funput.funput.keyboard.ui.emoji
+package app.funput.funput.keyboard.ui.panel
 
 import android.content.Context
 import android.widget.FrameLayout
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 
-internal open class EmojiComposeView(context: Context) : FrameLayout(context) {
+internal open class KeyboardPanelComposeView(context: Context) : FrameLayout(context) {
     private val composeView = ComposeView(context)
 
     init {

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/panel/KeyboardPanelPalette.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/panel/KeyboardPanelPalette.kt
@@ -1,8 +1,8 @@
-package app.funput.funput.keyboard.ui.emoji
+package app.funput.funput.keyboard.ui.panel
 
 import app.funput.funput.theme.KeyboardTheme
 
-internal data class EmojiPanelPalette(
+internal data class KeyboardPanelPalette(
     val backgroundStart: Int,
     val backgroundEnd: Int,
     val label: Int,
@@ -13,7 +13,7 @@ internal data class EmojiPanelPalette(
     val buttonSurface: Int,
 ) {
     companion object {
-        fun from(theme: KeyboardTheme) = EmojiPanelPalette(
+        fun from(theme: KeyboardTheme) = KeyboardPanelPalette(
             backgroundStart = theme.backgroundStartColor,
             backgroundEnd = theme.backgroundEndColor,
             label = theme.labelColor,

--- a/platforms/android/keyboard-ui/src/test/java/app/funput/funput/keyboard/ui/kaomoji/browser/KaomojiCellMetricsTest.kt
+++ b/platforms/android/keyboard-ui/src/test/java/app/funput/funput/keyboard/ui/kaomoji/browser/KaomojiCellMetricsTest.kt
@@ -1,0 +1,21 @@
+package app.funput.funput.keyboard.ui.kaomoji.browser
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KaomojiCellMetricsTest {
+    @Test
+    fun `cells grow with text and keep the minimum width`() {
+        val narrow = KaomojiCellMetrics.widthFor(12f, 320f)
+        val wide = KaomojiCellMetrics.widthFor(120f, 320f)
+
+        assertEquals(44f, narrow)
+        assertTrue(wide > narrow)
+    }
+
+    @Test
+    fun `long text is clamped to the available row`() {
+        assertEquals(304f, KaomojiCellMetrics.widthFor(1_000f, 304f))
+    }
+}

--- a/platforms/android/keyboard-ui/src/test/java/app/funput/funput/keyboard/ui/kaomoji/browser/KaomojiSectionsTest.kt
+++ b/platforms/android/keyboard-ui/src/test/java/app/funput/funput/keyboard/ui/kaomoji/browser/KaomojiSectionsTest.kt
@@ -1,0 +1,31 @@
+package app.funput.funput.keyboard.ui.kaomoji.browser
+
+import app.funput.funput.keyboard.ui.kaomoji.catalog.KaomojiCatalog
+import app.funput.funput.keyboard.ui.kaomoji.catalog.KaomojiCategory
+import app.funput.funput.keyboard.ui.kaomoji.catalog.KaomojiItem
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class KaomojiSectionsTest {
+    private val happy = KaomojiItem("(^_^)", "cười", KaomojiCategory.HAPPY)
+    private val love = KaomojiItem("(♡‿♡)", "yêu", KaomojiCategory.LOVE)
+    private val catalog = KaomojiCatalog("test", listOf(happy, love))
+
+    @Test
+    fun `recents lead when present and disappear when empty`() {
+        val recent = KaomojiSections.from(catalog, listOf(love.text))
+        val empty = KaomojiSections.from(catalog, emptyList())
+
+        assertEquals(KaomojiCategory.RECENT, recent.values.first().category)
+        assertEquals(listOf(love), recent.values.first().items)
+        assertEquals(KaomojiCategory.HAPPY, empty.values.first().category)
+    }
+
+    @Test
+    fun `positions map to the visible category`() {
+        val sections = KaomojiSections.from(catalog, emptyList())
+
+        assertEquals(1, sections.position(KaomojiCategory.LOVE))
+        assertEquals(KaomojiCategory.LOVE, sections.categoryAt(1))
+    }
+}

--- a/platforms/android/keyboard-ui/src/test/java/app/funput/funput/keyboard/ui/kaomoji/catalog/KaomojiCatalogDecoderTest.kt
+++ b/platforms/android/keyboard-ui/src/test/java/app/funput/funput/keyboard/ui/kaomoji/catalog/KaomojiCatalogDecoderTest.kt
@@ -1,0 +1,38 @@
+package app.funput.funput.keyboard.ui.kaomoji.catalog
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KaomojiCatalogDecoderTest {
+    private val canonical = File(
+        "../../ios/Packages/FunputKit/Sources/KeyboardRenderer/Resources/KaomojiCatalog.json",
+    )
+
+    @Test
+    fun `canonical catalog matches the iOS product contract`() {
+        val catalog = KaomojiCatalogDecoder.decode(canonical.readText())
+
+        assertEquals("1", catalog.version)
+        assertEquals(161, catalog.items.size)
+        assertEquals(161, catalog.items.map(KaomojiItem::text).distinct().size)
+        assertTrue(catalog.items.all { it.text.isNotBlank() && it.name.isNotBlank() })
+        assertFalse(catalog.items.any { it.category == KaomojiCategory.RECENT })
+        KaomojiCategory.entries.drop(1).forEach { assertTrue(catalog.items(it).isNotEmpty()) }
+    }
+
+    @Test
+    fun `category order keeps recents first and love beside happy`() {
+        assertEquals(
+            listOf(KaomojiCategory.RECENT, KaomojiCategory.HAPPY, KaomojiCategory.LOVE),
+            KaomojiCategory.entries.take(3),
+        )
+    }
+
+    @Test
+    fun `malformed json returns an empty catalog`() {
+        assertEquals(KaomojiCatalog.Empty, KaomojiCatalogDecoder.decode("{broken"))
+    }
+}

--- a/platforms/android/keyboard-ui/src/test/java/app/funput/funput/keyboard/ui/kaomoji/persistence/KaomojiRecentsStoreTest.kt
+++ b/platforms/android/keyboard-ui/src/test/java/app/funput/funput/keyboard/ui/kaomoji/persistence/KaomojiRecentsStoreTest.kt
@@ -1,0 +1,31 @@
+package app.funput.funput.keyboard.ui.kaomoji.persistence
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KaomojiRecentsStoreTest {
+    @Test
+    fun `json preserves punctuation whitespace slashes and unicode`() {
+        val values = listOf("¯\\_(ツ)_/¯", "(づ｡◕‿‿◕｡)づ", "hello, world", "  (^-^)  ")
+
+        assertEquals(values, KaomojiRecentsStore.decode(KaomojiRecentsStore.encode(values)))
+    }
+
+    @Test
+    fun `decode keeps newest unique values and caps history`() {
+        val values = (0..35).map { "kaomoji-$it" } + listOf("kaomoji-0")
+
+        val decoded = KaomojiRecentsStore.decode(KaomojiRecentsStore.encode(values))
+
+        assertEquals(KaomojiRecentsStore.Limit, decoded.size)
+        assertEquals("kaomoji-0", decoded.first())
+        assertEquals(decoded.distinct(), decoded)
+    }
+
+    @Test
+    fun `corrupt values fall back safely`() {
+        assertTrue(KaomojiRecentsStore.decode(null).isEmpty())
+        assertTrue(KaomojiRecentsStore.decode("not-json").isEmpty())
+    }
+}

--- a/platforms/android/keyboard-ui/src/test/java/app/funput/funput/keyboard/ui/panel/KeyboardPanelPaletteTest.kt
+++ b/platforms/android/keyboard-ui/src/test/java/app/funput/funput/keyboard/ui/panel/KeyboardPanelPaletteTest.kt
@@ -1,4 +1,4 @@
-package app.funput.funput.keyboard.ui.emoji
+package app.funput.funput.keyboard.ui.panel
 
 import app.funput.funput.theme.KeyboardThemeDescriptor
 import app.funput.funput.theme.LocalKeyboardThemeCatalog
@@ -6,11 +6,11 @@ import app.funput.funput.theme.validation.ContrastRatio
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class EmojiPanelPaletteTest {
+class KeyboardPanelPaletteTest {
     @Test fun `all presets keep panel text readable`() {
         val themes = LocalKeyboardThemeCatalog.themes.map(KeyboardThemeDescriptor::theme)
         themes.forEach { theme ->
-            val palette = EmojiPanelPalette.from(theme)
+            val palette = KeyboardPanelPalette.from(theme)
             assertTrue(ContrastRatio.between(palette.label, palette.searchSurface, palette.backgroundEnd) >= 3.0)
             assertTrue(
                 ContrastRatio.between(


### PR DESCRIPTION
## Tổng quan

Bổ sung bàn phím Kaomoji cho Android, bám sát implementation hiện có trên iOS và giữ trải nghiệm thống nhất giữa các nền tảng.

## Thay đổi chính

- Đồng bộ `KaomojiCatalog.json` trực tiếp từ iOS để dùng chung 161 Kaomoji.
- Thêm các danh mục và lịch sử “Dùng gần đây” riêng, tối đa 30 mục.
- Hỗ trợ chuyển đổi Emoji ↔ Kaomoji ngay trên thanh điều hướng.
- Hiển thị Kaomoji theo độ rộng nội dung, tự co chữ với chuỗi dài.
- Đồng bộ theme, haptic, sound và accessibility với panel Emoji.
- Lọc Kaomoji chứa glyph không được thiết bị hỗ trợ.
- Chèn Kaomoji nguyên chuỗi mà không làm gián đoạn composition tiếng Việt.
- Tách palette và Compose host dùng chung cho các keyboard panel.
- Không thay đổi public API hoặc logical `EMOJI` panel hiện có.