### PR TITLE
fix(windows): keep the Ctrl+Shift style VI/EN toggle working

### DIFF
--- a/crates/funput-desktop/src/shell/apps.rs
+++ b/crates/funput-desktop/src/shell/apps.rs
@@ -27,6 +27,11 @@ impl ShellState {
     /// Flip VI/EN from the keyboard hotkey; returns the new state. Unlike the tray,
     /// the hotkey fires while the target app is focused, so the choice binds to
     /// that app immediately and clears any stale pending override.
+    ///
+    /// In memory only. The caller persists with [`Self::save_settings`] once it is
+    /// somewhere it can afford to block: on Windows this runs inside the low-level
+    /// keyboard hook, and a hook callback that overruns `LowLevelHooksTimeout` is
+    /// silently unhooked by the OS — a file write cannot promise to beat it.
     pub fn toggle_enabled_hotkey(&mut self) -> bool {
         let on = !self.settings.enabled;
         self.set_enabled_state(on);
@@ -34,8 +39,14 @@ impl ShellState {
             self.remember(&id, on);
         }
         self.pending_override = None;
-        self.save();
         on
+    }
+
+    /// Write down what [`Self::toggle_enabled_hotkey`] changed. Split out because
+    /// it is the one write in this file whose caller may have to postpone it; the
+    /// rest happen where blocking is free.
+    pub fn save_settings(&self) {
+        self.save();
     }
 
     /// Record the app that just took focus, so a hotkey toggle knows what to bind

--- a/crates/funput-desktop/src/shell/tests.rs
+++ b/crates/funput-desktop/src/shell/tests.rs
@@ -150,7 +150,8 @@ fn a_remembered_choice_survives_a_restart() {
 
     let mut state = ShellState::new(Some(path.clone()));
     state.note_foreground("code.exe".into());
-    state.toggle_enabled_hotkey(); // code.exe → English
+    state.toggle_enabled_hotkey(); // code.exe → English, in memory…
+    state.save_settings(); // …and on disk, the step the hook defers
 
     let mut reopened = ShellState::new(Some(path));
     assert_eq!(

--- a/platforms/windows/src/background/hook/foreground.rs
+++ b/platforms/windows/src/background/hook/foreground.rs
@@ -15,7 +15,7 @@ use windows::Win32::System::Threading::{
 use windows::Win32::UI::Accessibility::HWINEVENTHOOK;
 use windows::Win32::UI::WindowsAndMessaging::{GetWindowThreadProcessId, EVENT_SYSTEM_FOREGROUND};
 
-use super::{FOREGROUND_IS_FUNPUT, ON_TOGGLE};
+use super::{toggle, FOREGROUND_IS_FUNPUT};
 use crate::background::tray;
 use crate::shared::shell;
 
@@ -57,9 +57,7 @@ pub(super) unsafe extern "system" fn win_event_proc(
     // Focus on a new app is the start of input: arm so the first letter is capitalized.
     shell::arm_capitalization();
     if let Some(on) = shell::apply_for_app(&id) {
-        if let Some(cb) = ON_TOGGLE.get() {
-            cb(on); // keep tray checkmark / tooltip in sync with the auto-switch
-        }
+        toggle::notify(on); // keep tray checkmark / tooltip in sync with the auto-switch
     }
 }
 

--- a/platforms/windows/src/background/hook/keyboard.rs
+++ b/platforms/windows/src/background/hook/keyboard.rs
@@ -12,7 +12,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
     CallNextHookEx, HC_ACTION, KBDLLHOOKSTRUCT, WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN, WM_SYSKEYUP,
 };
 
-use super::{FOREGROUND_IS_FUNPUT, ON_TOGGLE};
+use super::{toggle, FOREGROUND_IS_FUNPUT};
 use crate::background::hotkey::{self, Hit};
 use crate::background::{inject, keymap};
 use crate::shared::shell;
@@ -51,11 +51,11 @@ pub(super) unsafe extern "system" fn keyboard_proc(
 /// after all, so the key carries on to the engine (and then to the app).
 fn fire(hit: Hit) -> bool {
     match hit {
+        // The flip must land before the next keystroke; writing it down and
+        // repainting the tray must not happen here at all — see [`toggle`].
         Hit::Toggle => {
-            let on = shell::toggle_enabled_hotkey();
-            if let Some(cb) = ON_TOGGLE.get() {
-                cb(on);
-            }
+            shell::toggle_enabled_hotkey();
+            toggle::defer();
             true
         }
         // Flip the word being composed VN↔raw. There is nothing to flip in

--- a/platforms/windows/src/background/hook/mod.rs
+++ b/platforms/windows/src/background/hook/mod.rs
@@ -12,9 +12,9 @@
 mod foreground;
 mod keyboard;
 mod mouse;
+mod toggle;
 
 use std::sync::atomic::AtomicBool;
-use std::sync::OnceLock;
 
 use windows::Win32::Foundation::HINSTANCE;
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
@@ -29,18 +29,12 @@ use crate::background::instance::{self, WaitKind};
 use crate::background::tray;
 use crate::ui;
 
-/// Called after a Ctrl+` toggle so the tray can refresh its checkmark/icon.
-type ToggleCb = Box<dyn Fn(bool) + Send + Sync>;
-static ON_TOGGLE: OnceLock<ToggleCb> = OnceLock::new();
+pub use toggle::set_on_toggle;
 
 /// Whether the focused window belongs to Funput itself. Written by [`foreground`],
 /// read by [`keyboard`]: our own Settings fields compose in-process, so the global
 /// hook must leave their keystrokes alone.
 static FOREGROUND_IS_FUNPUT: AtomicBool = AtomicBool::new(false);
-
-pub fn set_on_toggle(f: impl Fn(bool) + Send + Sync + 'static) {
-    let _ = ON_TOGGLE.set(Box::new(f));
-}
 
 /// Install the hooks and tray on the current thread, then run their Win32 message
 /// pump until the tray's Quit command posts `WM_QUIT`.
@@ -110,6 +104,14 @@ pub fn run() {
                     while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
                         if msg.message == WM_QUIT {
                             return;
+                        }
+                        // The toggle work the hook refused to do itself. Posted to
+                        // the thread, so it has no window and dispatching would
+                        // drop it — and the null `hwnd` is what tells it apart
+                        // from a window message that happens to share the number.
+                        if msg.message == toggle::WM_TOGGLED && msg.hwnd.0.is_null() {
+                            toggle::run_pending();
+                            continue;
                         }
                         let _ = TranslateMessage(&msg);
                         DispatchMessageW(&msg);

--- a/platforms/windows/src/background/hook/toggle.rs
+++ b/platforms/windows/src/background/hook/toggle.rs
@@ -1,0 +1,62 @@
+//! The slow half of a VI/EN hotkey toggle, kept out of the keyboard hook.
+//!
+//! Persisting the settings is a file write, and refreshing the tray is two
+//! cross-process calls into Explorer; neither has an upper bound on how long it
+//! takes. Windows silently removes a `WH_KEYBOARD_LL` hook whose callback
+//! overruns `LowLevelHooksTimeout` (300 ms by default), and nothing reinstalls
+//! it — Funput would go deaf mid-session with no hotkey, no composition, and no
+//! error anywhere. So the hook flips the in-memory state and posts here; the
+//! pump in [`super::run`] does the rest one message later, with the user's
+//! keystroke already delivered.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+
+use windows::Win32::Foundation::{LPARAM, WPARAM};
+use windows::Win32::System::Threading::GetCurrentThreadId;
+use windows::Win32::UI::WindowsAndMessaging::{PostThreadMessageW, WM_APP};
+
+use crate::shared::shell;
+
+/// Posted by [`defer`] to the hook thread, recognized by [`super::run`]'s pump.
+pub(super) const WM_TOGGLED: u32 = WM_APP + 1;
+
+/// Called after a toggle so the tray can refresh its icon and tooltip.
+type ToggleCb = Box<dyn Fn(bool) + Send + Sync>;
+static ON_TOGGLE: OnceLock<ToggleCb> = OnceLock::new();
+
+/// Whether a toggle is still waiting to be written down. A flag rather than a
+/// count: holding Ctrl and tapping Shift ten times leaves one write to do, not
+/// ten, and the last state is the only one worth saving.
+static PENDING: AtomicBool = AtomicBool::new(false);
+
+pub fn set_on_toggle(f: impl Fn(bool) + Send + Sync + 'static) {
+    let _ = ON_TOGGLE.set(Box::new(f));
+}
+
+/// Hand the toggle's side effects to the pump. Called from inside the hook, so
+/// it must not block — posting a message never waits on the receiver.
+pub(super) fn defer() {
+    PENDING.store(true, Ordering::Relaxed);
+    unsafe {
+        let _ = PostThreadMessageW(GetCurrentThreadId(), WM_TOGGLED, WPARAM(0), LPARAM(0));
+    }
+}
+
+/// Run those side effects, on the pump thread and off the hook.
+pub(super) fn run_pending() {
+    if !PENDING.swap(false, Ordering::Relaxed) {
+        return; // a burst of toggles: an earlier message already covered this one
+    }
+    shell::save_settings();
+    notify(shell::enabled());
+}
+
+/// Tell the tray about a VI/EN change that did not come from the hotkey — the
+/// per-app auto-switch, or a config reload. Callable directly because those all
+/// arrive on the pump, where taking a moment costs nobody a keystroke.
+pub(super) fn notify(on: bool) {
+    if let Some(cb) = ON_TOGGLE.get() {
+        cb(on);
+    }
+}

--- a/platforms/windows/src/background/hotkey.rs
+++ b/platforms/windows/src/background/hotkey.rs
@@ -51,11 +51,10 @@ pub fn on_keydown(vk: VIRTUAL_KEY, mods: Mods) -> Option<Hit> {
 /// the engine goes on to swallow — a swallowed keystroke still means the user
 /// was typing a shortcut, not tapping a bare modifier pair.
 pub fn on_key_event(vk: VIRTUAL_KEY, mods: Mods, down: bool) -> Option<Hit> {
-    let event = match (rules::is_modifier(vk), down) {
-        (true, true) => Event::ModifierDown,
-        (true, false) => Event::ModifierUp,
-        (false, true) => Event::OtherDown,
-        (false, false) => return None, // an ordinary key coming up changes nothing
+    let event = match (rules::mod_bit(vk), down) {
+        (Some(bit), down) => Event::Modifier { bit, down },
+        (None, true) => Event::OtherDown,
+        (None, false) => return None, // an ordinary key coming up changes nothing
     };
     let held = rules::mods_with(vk, mods, down);
     let gesture = WATCHER.with(|w| w.borrow_mut().feed(event, held))?;

--- a/platforms/windows/src/background/hotkey/rules.rs
+++ b/platforms/windows/src/background/hotkey/rules.rs
@@ -27,7 +27,21 @@ fn normalize_vk(vk: VIRTUAL_KEY) -> VIRTUAL_KEY {
 /// Whether the key is a modifier, i.e. one that can only ever be part of a
 /// gesture resolved on release.
 pub fn is_modifier(vk: VIRTUAL_KEY) -> bool {
-    matches!(normalize_vk(vk), VK_CONTROL | VK_MENU | VK_SHIFT | VK_LWIN)
+    mod_bit(vk).is_some()
+}
+
+/// This key's own modifier bit, or `None` when it is not a modifier. Both sides
+/// fold to the same bit, so Left Ctrl down + Right Ctrl up is still one Ctrl.
+pub fn mod_bit(vk: VIRTUAL_KEY) -> Option<Mods> {
+    let mut bit = Mods::default();
+    match normalize_vk(vk) {
+        VK_CONTROL => bit.ctrl = true,
+        VK_MENU => bit.alt = true,
+        VK_SHIFT => bit.shift = true,
+        VK_LWIN => bit.win = true,
+        _ => return None,
+    }
+    Some(bit)
 }
 
 /// `mods` with this event's own key forced to `down`. `GetAsyncKeyState` lags

--- a/platforms/windows/src/background/hotkey/watcher.rs
+++ b/platforms/windows/src/background/hotkey/watcher.rs
@@ -5,26 +5,50 @@
 //! input-language switcher instead waits for a modifier to come back up, and
 //! abandons the gesture if any other key was pressed while they were held. This
 //! reproduces that rule, so Alt+Shift+Tab still reaches the focused app.
+//!
+//! It also reproduces the repeat: keeping Ctrl down and tapping Shift over and
+//! over toggles once per tap, the way holding Alt and tapping Shift cycles
+//! Windows' input languages. A gesture that was *interrupted* does not repeat —
+//! releasing and re-pressing Shift in the middle of a Ctrl+Shift+arrow selection
+//! is still that selection, not a hotkey.
 
 use funput_desktop::Mods;
 
 /// The only three shapes of key event this cares about.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Event {
-    ModifierDown,
-    ModifierUp,
+    /// A modifier key going down or up, carrying *which* modifier it is.
+    Modifier { bit: Mods, down: bool },
     /// Any non-modifier keydown — it turns the gesture into a real shortcut.
     OtherDown,
 }
 
 #[derive(Debug, Default)]
 pub struct Watcher {
+    /// The modifiers still down, counted from the hook's own events.
+    ///
+    /// Deliberately *not* read back from `GetAsyncKeyState`: that snapshot lags
+    /// the hook by an event (see [`super::rules::mods_with`]), so releasing
+    /// Ctrl+Shift together could hand the second keyup a snapshot in which the
+    /// first key is still down. The gesture then never saw "everything is up",
+    /// stayed `spent`, and every later press was swallowed — the toggle worked
+    /// once or twice and then went dead until Funput was restarted.
+    down: Mods,
     /// Every modifier seen down since the gesture began. The live state at the
     /// moment of a release is already missing the key being released, so the
     /// gesture has to be remembered rather than read back.
     peak: Mods,
-    /// The gesture can no longer fire: another key intervened, or it fired.
-    spent: bool,
+    /// Why the gesture can no longer fire, while it cannot.
+    spent: Option<Spent>,
+}
+
+/// What ended the gesture. The two are not interchangeable: one re-arms while the
+/// remaining modifiers stay down, the other does not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Spent {
+    Fired,
+    /// A non-modifier key or a mouse action turned it into a real shortcut.
+    Interrupted,
 }
 
 impl Watcher {
@@ -37,19 +61,43 @@ impl Watcher {
                 self.interrupt();
                 None
             }
-            Event::ModifierDown => {
-                if !any(self.peak) {
-                    self.spent = false; // a fresh gesture starts clean
+            Event::Modifier { bit, down: true } => {
+                let others = without(held, bit);
+                // A fresh gesture: either we saw everything come up, or the OS
+                // says nothing else is down. The second test is the recovery
+                // path — a keyup the hook never got (focus stolen by an elevated
+                // window, a locked session) would otherwise leave `down` stuck
+                // forever, and with it the gesture.
+                if !any(self.down) || !any(others) {
+                    *self = Self::default();
+                    // Modifiers already held when this gesture began still count
+                    // towards it, so Ctrl+Shift is rejected as Ctrl+Alt+Shift.
+                    self.down = others;
+                    self.peak = others;
+                } else if self.spent == Some(Spent::Fired) {
+                    // Ctrl is still down and Shift has just been pressed again:
+                    // that is the next toggle, not a leftover of the last one.
+                    // The new gesture is whatever is held right now, so a tap
+                    // that adds a third modifier is still judged on its own.
+                    self.spent = None;
+                    self.peak = self.down;
                 }
-                self.peak = union(self.peak, held);
+                self.down = union(self.down, bit);
+                self.peak = union(self.peak, bit);
                 None
             }
-            Event::ModifierUp => {
-                let fired = (!self.spent && any(self.peak)).then_some(self.peak);
+            Event::Modifier { bit, down: false } => {
+                self.down = without(self.down, bit);
+                let fired = (self.spent.is_none() && any(self.peak)).then_some(self.peak);
                 // A gesture fires once, on the first release; the remaining
                 // modifiers coming up must not repeat it.
-                self.spent = true;
-                if !any(held) {
+                self.spent = Some(match fired {
+                    Some(_) => Spent::Fired,
+                    // Not `Fired`: an interrupted gesture stays interrupted, so
+                    // re-pressing a modifier inside a shortcut cannot revive it.
+                    None => self.spent.unwrap_or(Spent::Interrupted),
+                });
+                if !any(self.down) {
                     *self = Self::default();
                 }
                 fired
@@ -60,7 +108,7 @@ impl Watcher {
     /// Something other than a modifier key happened while they were held, so the
     /// user was performing a shortcut rather than tapping a bare pair.
     pub fn interrupt(&mut self) {
-        self.spent = true;
+        self.spent = Some(Spent::Interrupted);
     }
 }
 
@@ -74,6 +122,16 @@ fn union(a: Mods, b: Mods) -> Mods {
         alt: a.alt || b.alt,
         win: a.win || b.win,
         shift: a.shift || b.shift,
+    }
+}
+
+/// `a` with everything set in `b` cleared.
+fn without(a: Mods, b: Mods) -> Mods {
+    Mods {
+        ctrl: a.ctrl && !b.ctrl,
+        alt: a.alt && !b.alt,
+        win: a.win && !b.win,
+        shift: a.shift && !b.shift,
     }
 }
 

--- a/platforms/windows/src/background/hotkey/watcher/tests.rs
+++ b/platforms/windows/src/background/hotkey/watcher/tests.rs
@@ -1,4 +1,4 @@
-use super::Event::{ModifierDown, ModifierUp, OtherDown};
+use super::Event::OtherDown;
 use super::*;
 
 fn mods(ctrl: bool, alt: bool, shift: bool, win: bool) -> Mods {
@@ -17,40 +17,67 @@ const NONE: Mods = Mods {
     shift: false,
 };
 
+const CTRL: Mods = Mods {
+    ctrl: true,
+    alt: false,
+    win: false,
+    shift: false,
+};
+const ALT: Mods = Mods {
+    ctrl: false,
+    alt: true,
+    win: false,
+    shift: false,
+};
+const SHIFT: Mods = Mods {
+    ctrl: false,
+    alt: false,
+    win: false,
+    shift: true,
+};
+
+fn down(bit: Mods) -> Event {
+    Event::Modifier { bit, down: true }
+}
+
+fn up(bit: Mods) -> Event {
+    Event::Modifier { bit, down: false }
+}
+
 #[test]
 fn bare_pair_fires_on_the_first_release() {
     let mut w = Watcher::default();
-    assert_eq!(w.feed(ModifierDown, mods(false, true, false, false)), None);
-    assert_eq!(w.feed(ModifierDown, mods(false, true, true, false)), None);
+    assert_eq!(w.feed(down(ALT), mods(false, true, false, false)), None);
+    assert_eq!(w.feed(down(SHIFT), mods(false, true, true, false)), None);
     // Shift comes up first: the pair is already known from the peak.
     assert_eq!(
-        w.feed(ModifierUp, mods(false, true, false, false)),
+        w.feed(up(SHIFT), mods(false, true, false, false)),
         Some(mods(false, true, true, false))
     );
     // Alt following it must not fire a second time.
-    assert_eq!(w.feed(ModifierUp, NONE), None);
+    assert_eq!(w.feed(up(ALT), NONE), None);
 }
 
 #[test]
 fn a_key_pressed_in_between_cancels_the_gesture() {
     // Alt+Shift+Tab belongs to the app, not to us.
     let mut w = Watcher::default();
-    w.feed(ModifierDown, mods(false, true, false, false));
-    w.feed(ModifierDown, mods(false, true, true, false));
+    w.feed(down(ALT), mods(false, true, false, false));
+    w.feed(down(SHIFT), mods(false, true, true, false));
     w.feed(OtherDown, mods(false, true, true, false));
-    assert_eq!(w.feed(ModifierUp, mods(false, true, false, false)), None);
-    assert_eq!(w.feed(ModifierUp, NONE), None);
+    assert_eq!(w.feed(up(SHIFT), mods(false, true, false, false)), None);
+    assert_eq!(w.feed(up(ALT), NONE), None);
 }
 
 #[test]
 fn a_third_modifier_is_reported_so_the_caller_can_reject_it() {
     // Ctrl+Alt+Shift is a different gesture from Alt+Shift and must not match it.
     let mut w = Watcher::default();
-    w.feed(ModifierDown, mods(false, true, false, false));
-    w.feed(ModifierDown, mods(false, true, true, false));
-    w.feed(ModifierDown, mods(true, true, true, false));
+    w.feed(down(ALT), mods(false, true, false, false));
+    w.feed(down(SHIFT), mods(false, true, true, false));
+    w.feed(down(CTRL), mods(true, true, true, false));
     assert_eq!(
-        w.feed(ModifierUp, mods(true, true, false, false)),
+        w.feed(up(CTRL), mods(true, true, false, false)),
         Some(mods(true, true, true, false))
     );
 }
@@ -59,10 +86,10 @@ fn a_third_modifier_is_reported_so_the_caller_can_reject_it() {
 fn typing_before_the_modifiers_does_not_poison_the_next_gesture() {
     let mut w = Watcher::default();
     w.feed(OtherDown, NONE); // a plain letter, no modifier held
-    w.feed(ModifierDown, mods(false, true, false, false));
-    w.feed(ModifierDown, mods(false, true, true, false));
+    w.feed(down(ALT), mods(false, true, false, false));
+    w.feed(down(SHIFT), mods(false, true, true, false));
     assert_eq!(
-        w.feed(ModifierUp, mods(false, true, false, false)),
+        w.feed(up(SHIFT), mods(false, true, false, false)),
         Some(mods(false, true, true, false))
     );
 }
@@ -71,16 +98,138 @@ fn typing_before_the_modifiers_does_not_poison_the_next_gesture() {
 fn each_gesture_is_independent() {
     let mut w = Watcher::default();
     for _ in 0..2 {
-        w.feed(ModifierDown, mods(true, false, false, false));
-        w.feed(ModifierDown, mods(true, false, true, false));
-        w.feed(ModifierUp, mods(true, false, false, false));
-        assert_eq!(w.feed(ModifierUp, NONE), None); // gesture already spent
+        w.feed(down(CTRL), mods(true, false, false, false));
+        w.feed(down(SHIFT), mods(true, false, true, false));
+        w.feed(up(CTRL), mods(false, false, true, false));
+        assert_eq!(w.feed(up(SHIFT), NONE), None); // gesture already spent
     }
     // A third run still reports the pair, i.e. state was reset each time.
-    w.feed(ModifierDown, mods(true, false, false, false));
-    w.feed(ModifierDown, mods(true, false, true, false));
+    w.feed(down(CTRL), mods(true, false, false, false));
+    w.feed(down(SHIFT), mods(true, false, true, false));
     assert_eq!(
-        w.feed(ModifierUp, mods(true, false, false, false)),
+        w.feed(up(CTRL), mods(false, false, true, false)),
+        Some(mods(true, false, true, false))
+    );
+}
+
+#[test]
+fn tapping_the_second_modifier_again_toggles_again() {
+    // Ctrl stays down while Shift is tapped over and over — one toggle per tap,
+    // like holding Alt and tapping Shift through Windows' input languages.
+    let mut w = Watcher::default();
+    w.feed(down(CTRL), mods(true, false, false, false));
+    for _ in 0..3 {
+        w.feed(down(SHIFT), mods(true, false, true, false));
+        assert_eq!(
+            w.feed(up(SHIFT), mods(true, false, false, false)),
+            Some(mods(true, false, true, false))
+        );
+    }
+    // Ctrl finally coming up is not a fourth toggle.
+    assert_eq!(w.feed(up(CTRL), NONE), None);
+}
+
+#[test]
+fn a_repeat_tap_is_judged_on_what_is_held_now() {
+    // Ctrl+Shift fires, then Alt joins and Shift is tapped again: that tap is
+    // Ctrl+Alt+Shift, which the caller must be able to tell apart from the pair.
+    let mut w = Watcher::default();
+    w.feed(down(CTRL), mods(true, false, false, false));
+    w.feed(down(SHIFT), mods(true, false, true, false));
+    w.feed(up(SHIFT), mods(true, false, false, false));
+
+    w.feed(down(ALT), mods(true, true, false, false));
+    w.feed(down(SHIFT), mods(true, true, true, false));
+    assert_eq!(
+        w.feed(up(SHIFT), mods(true, true, false, false)),
+        Some(mods(true, true, true, false))
+    );
+}
+
+#[test]
+fn an_interrupted_gesture_does_not_repeat() {
+    // Ctrl+Shift+Right is a selection. Letting go of Shift and pressing it again
+    // to carry on selecting must not be read as a toggle.
+    let mut w = Watcher::default();
+    w.feed(down(CTRL), mods(true, false, false, false));
+    w.feed(down(SHIFT), mods(true, false, true, false));
+    w.feed(OtherDown, mods(true, false, true, false)); // Right arrow
+    assert_eq!(w.feed(up(SHIFT), mods(true, false, false, false)), None);
+
+    w.feed(down(SHIFT), mods(true, false, true, false));
+    assert_eq!(w.feed(up(SHIFT), mods(true, false, false, false)), None);
+    assert_eq!(w.feed(up(CTRL), NONE), None);
+}
+
+#[test]
+fn a_lagging_snapshot_on_the_last_release_does_not_latch_the_gesture() {
+    // Releasing Ctrl+Shift together: `GetAsyncKeyState` still reports Ctrl down
+    // on Shift's keyup, one event behind. The gesture must end on its own event
+    // stream anyway, or every later press is swallowed (the "toggle stops
+    // working after a press or two" bug).
+    let mut w = Watcher::default();
+    w.feed(down(CTRL), mods(true, false, false, false));
+    w.feed(down(SHIFT), mods(true, false, true, false));
+    assert_eq!(
+        w.feed(up(CTRL), mods(true, false, true, false)), // stale: ctrl still set
+        Some(mods(true, false, true, false))
+    );
+    assert_eq!(w.feed(up(SHIFT), mods(true, false, false, false)), None); // stale again
+
+    // The next press must fire, exactly as the first one did.
+    w.feed(down(CTRL), mods(true, false, false, false));
+    w.feed(down(SHIFT), mods(true, false, true, false));
+    assert_eq!(
+        w.feed(up(CTRL), mods(false, false, true, false)),
+        Some(mods(true, false, true, false))
+    );
+}
+
+#[test]
+fn a_release_the_hook_never_saw_is_recovered_from() {
+    // A keyup lost while an elevated window had focus leaves Shift stuck in the
+    // tracker. The next press starts from a snapshot saying nothing is down, so
+    // the gesture restarts clean instead of staying spent forever.
+    let mut w = Watcher::default();
+    w.feed(down(CTRL), mods(true, false, false, false));
+    w.feed(down(SHIFT), mods(true, false, true, false));
+    w.feed(up(CTRL), mods(false, false, true, false)); // fires; Shift's keyup is lost
+
+    w.feed(down(CTRL), mods(true, false, false, false));
+    w.feed(down(SHIFT), mods(true, false, true, false));
+    assert_eq!(
+        w.feed(up(CTRL), mods(false, false, true, false)),
+        Some(mods(true, false, true, false))
+    );
+}
+
+#[test]
+fn a_modifier_already_held_when_the_gesture_starts_still_counts() {
+    // Ctrl was down before the tracker saw anything (its keydown was lost). The
+    // snapshot carries it, so Ctrl+Shift is reported rather than a bare Shift.
+    let mut w = Watcher::default();
+    w.feed(down(SHIFT), mods(true, false, true, false));
+    assert_eq!(
+        w.feed(up(SHIFT), mods(true, false, false, false)),
+        Some(mods(true, false, true, false))
+    );
+}
+
+#[test]
+fn a_click_ends_the_gesture_without_stranding_it() {
+    // Ctrl+Shift+click is multi-select. The click cancels this gesture, and the
+    // next press is unaffected.
+    let mut w = Watcher::default();
+    w.feed(down(CTRL), mods(true, false, false, false));
+    w.feed(down(SHIFT), mods(true, false, true, false));
+    w.interrupt();
+    assert_eq!(w.feed(up(CTRL), mods(false, false, true, false)), None);
+    w.feed(up(SHIFT), NONE);
+
+    w.feed(down(CTRL), mods(true, false, false, false));
+    w.feed(down(SHIFT), mods(true, false, true, false));
+    assert_eq!(
+        w.feed(up(CTRL), mods(false, false, true, false)),
         Some(mods(true, false, true, false))
     );
 }

--- a/platforms/windows/src/background/tray/icon.rs
+++ b/platforms/windows/src/background/tray/icon.rs
@@ -1,13 +1,34 @@
 //! Tray icon assets and hover tooltip text.
 
+use std::cell::RefCell;
+
 use funput_core::InputMethod;
 use tray_icon::Icon;
 
 const TRAY_PNG: &[u8] = include_bytes!("../../../icons/tray.png"); // VI: brand colour
 const TRAY_MONO_PNG: &[u8] = include_bytes!("../../../icons/tray-mono.png"); // EN: high-contrast white
 
-/// Load the enabled (colour) or disabled (mono) 32×32 tray glyph.
+thread_local! {
+    /// The two glyphs, decoded on first use and kept: they never change, and
+    /// every VI/EN switch asks for one. Indexed by `on`. `Icon` owns a refcounted
+    /// handle, so handing out a clone costs nothing. Thread-local like the tray
+    /// itself — both belong to the hook thread that built them.
+    static ICONS: RefCell<[Option<Icon>; 2]> = const { RefCell::new([None, None]) };
+}
+
+/// The enabled (colour) or disabled (mono) 32×32 tray glyph.
 pub(super) fn make_icon(on: bool) -> Option<Icon> {
+    ICONS.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        let slot = &mut cache[usize::from(on)];
+        if slot.is_none() {
+            *slot = decode(on);
+        }
+        slot.clone()
+    })
+}
+
+fn decode(on: bool) -> Option<Icon> {
     let bytes = if on { TRAY_PNG } else { TRAY_MONO_PNG };
     let img = image::load_from_memory(bytes).ok()?.into_rgba8();
     let (w, h) = img.dimensions();

--- a/platforms/windows/src/shared/shell/mod.rs
+++ b/platforms/windows/src/shared/shell/mod.rs
@@ -76,7 +76,13 @@ pub fn note_foreground(id: String) {
 pub fn apply_for_app(id: &str) -> Option<bool> {
     with(|s| s.apply_for_app(id))
 }
-/// Flip VI/EN from the keyboard hotkey; returns the new state.
+/// Flip VI/EN from the keyboard hotkey; returns the new state. In memory only —
+/// [`save_settings`] finishes the job off the hook.
 pub fn toggle_enabled_hotkey() -> bool {
     with(|s| s.toggle_enabled_hotkey())
+}
+/// Persist what a hotkey toggle changed. Runs on the message pump, never in the
+/// hook: see [`crate::background::hook`]'s `toggle` module.
+pub fn save_settings() {
+    with(|s| s.save_settings());
 }


### PR DESCRIPTION
Two bugs reported against the modifier-only VI/EN toggle on Windows, plus
the hazard found underneath them.

## 1. The toggle died after a press or two

A hotkey made only of modifiers cannot fire on keydown (Ctrl+Shift would
steal Ctrl+Shift+T), so it resolves on release. The gesture tracker
decided a gesture was over by reading `GetAsyncKeyState` back — a
snapshot that lags the hook by an event, as `rules::mods_with` already
documented. Releasing Ctrl and Shift together therefore handed the
second keyup a state in which the first key still looked down: the
tracker never saw "everything is up", stayed `spent`, and swallowed
every later press. It worked once or twice, then went dead until Funput
was restarted.

It now counts modifiers from the hook's own event stream, which is
ordered and complete, and reads the snapshot only at the start of a
fresh press — which doubles as the recovery path for a keyup the hook
genuinely never received (elevated window steals focus, session locks).

## 2. Holding Ctrl and tapping Shift only toggled once

Now one toggle per tap, matching how holding Alt and tapping Shift
cycles Windows' own input languages. `spent` gained a reason
(`Fired` vs `Interrupted`) so a gesture that a real key or a mouse
action cut short does not repeat: letting go of Shift and pressing it
again mid Ctrl+Shift+arrow selection is still that selection.

## 3. The toggle path was blocking the keyboard hook

Found while fixing the above, fixed separately in the second commit.
Every toggle serialized the settings, wrote them, decoded a PNG and made
two cross-process calls into Explorer, all inside the `WH_KEYBOARD_LL`
callback. Windows silently removes a low-level hook that overruns
`LowLevelHooksTimeout` (300 ms by default) and nothing reinstalls it —
one slow write and Funput goes deaf mid-session with no error anywhere.
Fixing #2 made that path hotter, one write per tap.

The hook now flips the in-memory state (that must land before the next
keystroke) and posts a thread message; the pump does the write and the
tray repaint one message later, coalescing a burst of taps into a single
write.

## Review notes

- `ShellState::toggle_enabled_hotkey` no longer persists on its own —
  `save_settings()` is the second half. Windows is the only caller;
  both halves document the split.
- `hook/` reaches 5 files with `toggle.rs`; every touched file stays
  under 140 lines.
- CI does not build `platforms/windows`, so that half was verified
  locally: `cargo build`, `cargo test --bin funput` (33 pass),
  `cargo fmt --check`, `cargo clippy --all-targets` (no new warnings —
  the 4 remaining are pre-existing, in `update/mod.rs`,
  `instance.rs`, `ui/lifecycle/{child,flyout}.rs`).
- Both commits build and test green on their own.

## Testing

15 tracker tests, 8 of them new, covering the lagging snapshot, a lost
keyup, repeat taps, a repeat that adds a third modifier, and an
interrupted gesture refusing to repeat. The reporter has confirmed both
behaviours by hand on Windows 11; the deferral in commit 2 is verified
by build and test only and would benefit from a real-machine pass —
toggle rapidly, then confirm the tray icon follows and `settings.json`
holds the final state.
