### PR TITLE
test(suggestions): charge the alloc budget to the measured thread only

### DIFF
--- a/crates/funput-suggestions/tests/alloc_budget.rs
+++ b/crates/funput-suggestions/tests/alloc_budget.rs
@@ -1,15 +1,29 @@
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::cell::Cell;
 
 use funput_suggestions::{SuggestionConfig, SuggestionEngine};
 
 struct CountingAllocator;
 
-static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+// A global allocator sees every thread: the test harness and any sibling test
+// allocate while this one runs, and a shared counter would charge those to the
+// lookup. Count per thread instead, so the budget measures the lookup path and
+// nothing else. Both cells are const-init with no destructor, so reading them
+// from inside the allocator never allocates or re-enters.
+thread_local! {
+    static MEASURING: Cell<bool> = const { Cell::new(false) };
+    static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+}
+
+fn record() {
+    if MEASURING.get() {
+        ALLOCATIONS.set(ALLOCATIONS.get() + 1);
+    }
+}
 
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        record();
         unsafe { System.alloc(layout) }
     }
 
@@ -18,7 +32,7 @@ unsafe impl GlobalAlloc for CountingAllocator {
     }
 
     unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, size: usize) -> *mut u8 {
-        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        record();
         unsafe { System.realloc(pointer, layout, size) }
     }
 }
@@ -33,10 +47,14 @@ fn warm_lookup_does_not_allocate() {
         engine.learn(word);
         engine.learn(word);
     }
-    let before = ALLOCATIONS.load(Ordering::Relaxed);
+
+    MEASURING.set(true);
+    let before = ALLOCATIONS.get();
     for _ in 0..100_000 {
         std::hint::black_box(engine.suggest(std::hint::black_box("kh")));
     }
-    let allocations = ALLOCATIONS.load(Ordering::Relaxed) - before;
+    let allocations = ALLOCATIONS.get() - before;
+    MEASURING.set(false);
+
     assert_eq!(allocations, 0, "warm lookup allocated {allocations} times");
 }


### PR DESCRIPTION
## Vấn đề

CI đỏ trên `main`: `warm_lookup_does_not_allocate` báo `warm lookup allocated 4 times`.

Đây là test flaky, không phải hồi quy trong đường tra cứu:

- Cùng commit `81b9804` **pass** ở lần chạy PR nhưng **fail** ở lần chạy push (run `31408432549`).
- 4 lần cấp phát trên 100.000 lượt tra cứu không tỉ lệ với vòng lặp. Nếu `suggest()` thật sự cấp phát thì con số phải ~100.000.
- `#[global_allocator]` thấy mọi luồng trong tiến trình, nhưng bộ đếm là một `AtomicUsize` toàn cục. Luồng của libtest harness cấp phát trong cửa sổ đo cũng bị tính vào ngân sách của phép tra cứu; trên máy CI đang tải nặng thì rơi trúng.

## Cách sửa

Đếm theo từng luồng: hai `thread_local!` const-init, không destructor (đọc từ trong allocator không tự cấp phát, không đệ quy) — cờ `MEASURING` và bộ đếm `ALLOCATIONS`. Chỉ luồng đang đo mới cộng số.

Ngân sách vẫn giữ nguyên mức **0** — không nới lỏng để test dễ pass.

## Kiểm chứng

Chạy trong container Linux `rust:1.97.1` (đúng pin `rust-toolchain.toml`):

- `cargo fmt --all -- --check` — sạch
- `cargo clippy --workspace --all-targets -- -D warnings` — không cảnh báo
- `cargo test --workspace` — không failure
- `scripts/check-loc.sh` — 236 file trong budget

Thiết kế bộ đếm được kiểm chứng bằng một file probe tạm (đã xoá trước khi commit), và probe lộ thêm một nguồn nhiễu thứ hai: với bộ đếm toàn cục, **một test chạy song song trong cùng binary** cũng lẫn vào — 983 trong 1.000 lần cấp phát của test anh em bị tính nhầm. Bộ đếm thread-local chặn cả hai nguồn, đồng thời vẫn bắt đủ 1.000/1.000 lần cấp phát thật trên luồng đo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)