### PR TITLE
chore(release): scope the notes to the five supported platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,11 +115,12 @@ jobs:
             echo
             echo "📖 **Hướng dẫn cài đặt & kích hoạt cho từng nền tảng:** https://docs.funput.app/docs/install/"
             echo
-            echo "### Tải về"
-            echo "- **macOS:** \`Funput-*.pkg\` (có quyền admin) hoặc \`Funput-*.app.zip\` (không cần admin)."
-            echo "- **Windows:** \`Funput-*.exe\` — portable, chạy ngay, tự cập nhật trong app."
-            echo "- **Funput Term (CLI, Windows):** \`scoop bucket add funput https://github.com/Funput/scoop-funput && scoop install funput\`, hoặc tải \`funput-term-*-x86_64-pc-windows-msvc.zip\`."
-            echo "- **Linux:** \`.deb\` (Debian/Ubuntu) hoặc \`.rpm\` (Fedora/openSUSE); mỗi loại có bản **IBus** (\`funput-ibus-*\`) và **Fcitx5** (\`funput-*\`). Chọn đúng kiến trúc CPU."
+            echo "### Cài đặt"
+            echo "- **iOS** — Tải trên [App Store](https://apps.apple.com/vn/app/id6788829996). Bản thử nghiệm sớm có trên [TestFlight](https://testflight.apple.com/join/E8YRd3sy)."
+            echo "- **macOS** — \`Funput-*.pkg\` cài cho toàn máy (cần quyền quản trị), hoặc \`Funput-*.app.zip\` dùng được mà không cần quyền đó."
+            echo "- **Windows** — \`Funput-*.exe\` chạy trực tiếp, không cần cài đặt, và tự cập nhật ngay trong ứng dụng."
+            echo "- **Linux** — \`.deb\` cho Debian/Ubuntu, \`.rpm\` cho Fedora/openSUSE. Mỗi định dạng có bản **IBus** (\`funput-ibus-*\`) và bản **Fcitx5** (\`funput-*\`); chọn đúng kiến trúc CPU của máy."
+            echo "- **Android** — Đang trong giai đoạn kiểm thử khép kín, chưa mở đăng ký công khai."
           } > notes.md
 
       # Create the release as a DRAFT with all assets attached. This repo has


### PR DESCRIPTION
Sửa phần "Tải về" trong release notes (`.github/workflows/release.yml`, bước *Assemble release notes*) để khớp với 5 nền tảng Funput đang hỗ trợ, đúng thứ tự bảng trong README.

## Thay đổi

- **Bỏ dòng Funput Term (CLI, Windows)** khỏi ghi chú.
- **Thêm iOS**: link App Store (cùng URL README đang dùng) kèm TestFlight công khai cho người muốn trải nghiệm sớm.
- **Thêm Android**: ghi rõ đang kiểm thử khép kín, chưa mở đăng ký công khai — sẽ sửa đúng dòng này khi có link.
- **Viết lại câu chữ** cho cùng một giọng: mỗi nền tảng một câu hoàn chỉnh theo khuôn `**Nền tảng** — …`, bỏ giọng mời chào và từ mượn không cần thiết (`portable` → "chạy trực tiếp, không cần cài đặt"; "trong app" → "trong ứng dụng"; "quyền admin" → "quyền quản trị").
- **Đổi tiêu đề `### Tải về` → `### Cài đặt`**, vì trong 5 mục thì iOS đi qua App Store và Android chưa có gì để tải.

## Kết quả render

```
### Cài đặt
- **iOS** — Tải trên [App Store](https://apps.apple.com/vn/app/id6788829996). Bản thử nghiệm sớm có trên [TestFlight](https://testflight.apple.com/join/E8YRd3sy).
- **macOS** — `Funput-*.pkg` cài cho toàn máy (cần quyền quản trị), hoặc `Funput-*.app.zip` dùng được mà không cần quyền đó.
- **Windows** — `Funput-*.exe` chạy trực tiếp, không cần cài đặt, và tự cập nhật ngay trong ứng dụng.
- **Linux** — `.deb` cho Debian/Ubuntu, `.rpm` cho Fedora/openSUSE. Mỗi định dạng có bản **IBus** (`funput-ibus-*`) và bản **Fcitx5** (`funput-*`); chọn đúng kiến trúc CPU của máy.
- **Android** — Đang trong giai đoạn kiểm thử khép kín, chưa mở đăng ký công khai.
```

## Kiểm chứng

Chạy thật khối shell đó với version giả để kiểm escaping backtick trong `run:` — output đúng như trên. `yaml.safe_load` trên workflow: hợp lệ.

## Lưu ý khi review

PR này **chỉ bỏ phần chữ** về Funput Term. File `funput-term-*-x86_64-pc-windows-msvc.zip` vẫn được build và đính kèm release (`cp artifacts/windows-cli/*`), vì bucket Scoop `Funput/scoop-funput` trỏ vào chính asset đó — gỡ ra là cài qua Scoop hỏng. Nếu ý là ngưng phát hành luôn bản CLI thì cần một PR riêng xử lý cả build lẫn bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)