### PR TITLE
fix(core): re-open a word still awaiting its vowel shape

### DIFF
--- a/crates/funput-core/src/validation/reachability.rs
+++ b/crates/funput-core/src/validation/reachability.rs
@@ -2,63 +2,21 @@
 //!
 //! Runs on every composed keystroke, so the check is allocation-free: the
 //! deshaped rhyme-so-far goes into a stack buffer and is prefix-matched against
-//! the cached deshaped rhyme inventory.
-
-use std::sync::LazyLock;
+//! the deshaped rhyme inventory ([`rhyme::has_deshaped_prefix`]).
 
 use crate::unicode::marks::{Tone, vowel_stem};
 use crate::validation::coda::{STOP_CODAS, coda_in, normalized_coda, nucleus_tone};
 use crate::validation::parse::{SyllableParts, parse_syllable};
-use crate::validation::rhyme;
+use crate::validation::rhyme::{self, plain_base};
 
 /// Longer than every deshaped rhyme (max is 4 chars, e.g. `uong`), so a query
 /// that overflows this buffer can never be a rhyme prefix.
 const MAX_QUERY: usize = 8;
 
-/// Plain base of a vowel — tone **and** shape stripped (`ớ`→`o`, `ẽ`→`e`,
-/// `ư`→`u`). Non-vowels pass through lowercased.
-fn plain_base(c: char) -> char {
-    let stem = vowel_stem(c).unwrap_or(c);
-    match char::to_lowercase(stem).next().unwrap_or(stem) {
-        'ă' | 'â' => 'a',
-        'ê' => 'e',
-        'ô' | 'ơ' => 'o',
-        'ư' => 'u',
-        other => other,
-    }
-}
-
 /// Stem with tone removed but vowel shape preserved (`ồ` → `ô`).
 fn shaped_base(c: char) -> char {
     let stem = vowel_stem(c).unwrap_or(c);
     char::to_lowercase(stem).next().unwrap_or(stem)
-}
-
-/// The rhyme inventory with tone/shape stripped, deshaped and sorted once.
-/// Lets [`is_definitely_invalid`] test reachability in O(log n) without
-/// re-deshaping all ~166 rhymes on every keystroke.
-static DESHAPED_RHYMES: LazyLock<Vec<String>> = LazyLock::new(|| {
-    let mut deshaped: Vec<String> = rhyme::all()
-        .iter()
-        .map(|r| r.chars().map(plain_base).collect())
-        .collect();
-    deshaped.sort_unstable();
-    deshaped
-});
-
-fn starts_with(rhyme: &str, prefix: &[char]) -> bool {
-    let mut chars = rhyme.chars();
-    prefix.iter().all(|&p| chars.next() == Some(p))
-}
-
-/// True if some rhyme starts with `prefix`. The inventory is sorted, so all
-/// candidates form a contiguous range beginning at the first entry ≥ `prefix`;
-/// checking that single entry suffices.
-fn any_rhyme_with_prefix(prefix: &[char]) -> bool {
-    let rhymes = &*DESHAPED_RHYMES;
-    let first = rhymes
-        .partition_point(|r| r.chars().cmp(prefix.iter().copied()) == std::cmp::Ordering::Less);
-    rhymes.get(first).is_some_and(|r| starts_with(r, prefix))
 }
 
 /// True when `buffer` can **no longer** become a valid Vietnamese syllable by
@@ -96,7 +54,7 @@ pub(crate) fn is_definitely_invalid_parts(parts: &SyllableParts<'_>) -> bool {
         len += 1;
     }
 
-    if !any_rhyme_with_prefix(&query[..len]) {
+    if !rhyme::has_deshaped_prefix(&query[..len]) {
         return true;
     }
 

--- a/crates/funput-core/src/validation/rhyme.rs
+++ b/crates/funput-core/src/validation/rhyme.rs
@@ -11,9 +11,18 @@
 //! `tests/spellcheck_corpus.rs`; rhymes for established loanwords and onomatopoeia
 //! (`buýt`, `xoong`, `soóc`, `tuýp`, `giếng`/`giêng`, `oăm`, `huých`…) are included
 //! so spell-check ("Kiểm tra chính tả") never blocks a real word.
+//!
+//! The inventory is queried three ways, all O(log n) over a sorted view built
+//! once: as written ([`is_valid_rhyme`], [`has_prefix`]) and **deshaped**
+//! ([`matches_deshaped`], [`has_deshaped_prefix`]) — the latter for the stretch
+//! of typing before the shape keys land, where `uoc` still stands for `ươc`.
+
+use std::sync::LazyLock;
+
+use crate::unicode::marks::vowel_stem;
 
 /// Valid toneless rhymes (lowercase, shaped vowels: `ươ`, `iê`, …).
-const VALID_RHYMES: &[&str] = &[
+pub(crate) const VALID_RHYMES: &[&str] = &[
     // Open (no coda)
     "a", "e", "ê", "i", "o", "ô", "ơ", "u", "ư", "y", "ia", "ya", "ai", "ao", "au", "ay", "âu",
     "ây", "eo", "êu", "iu", "oa", "oe", "oi", "ôi", "ơi", "ua", "ui", "uê", "uy", "uơ", "ưa", "ưi",
@@ -38,15 +47,69 @@ const VALID_RHYMES: &[&str] = &[
 /// The inventory sorted once for O(log n) membership checks. [`VALID_RHYMES`]
 /// itself stays grouped by coda — that grouping is the human-readable
 /// documentation of the inventory.
-static SORTED_RHYMES: std::sync::LazyLock<Vec<&'static str>> = std::sync::LazyLock::new(|| {
+static SORTED_RHYMES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
     let mut sorted = VALID_RHYMES.to_vec();
     sorted.sort_unstable();
     sorted
 });
 
+/// The same inventory with every vowel shape stripped (`ươc` → `uoc`), sorted.
+/// This is the inventory as the user's *keystrokes* spell it before the shape
+/// keys land, which is what [`has_deshaped_prefix`] and [`matches_deshaped`]
+/// answer questions about — computed once so neither re-deshapes ~166 rhymes.
+static DESHAPED_RHYMES: LazyLock<Vec<String>> = LazyLock::new(|| {
+    let mut deshaped: Vec<String> = VALID_RHYMES
+        .iter()
+        .map(|r| r.chars().map(plain_base).collect())
+        .collect();
+    deshaped.sort_unstable();
+    deshaped
+});
+
+/// Plain base of a vowel — tone **and** shape stripped (`ớ`→`o`, `ẽ`→`e`,
+/// `ư`→`u`). Non-vowels pass through lowercased.
+pub(crate) fn plain_base(c: char) -> char {
+    let stem = vowel_stem(c).unwrap_or(c);
+    match char::to_lowercase(stem).next().unwrap_or(stem) {
+        'ă' | 'â' => 'a',
+        'ê' => 'e',
+        'ô' | 'ơ' => 'o',
+        'ư' => 'u',
+        other => other,
+    }
+}
+
 /// True if `rhyme` (toneless, lowercase) is a valid Vietnamese rhyme.
 pub fn is_valid_rhyme(rhyme: &str) -> bool {
     SORTED_RHYMES.binary_search(&rhyme).is_ok()
+}
+
+/// True if `rhyme` (toneless, lowercase) *is* an inventory rhyme once both are
+/// deshaped: `ien` matches `iên`, `uoc` matches `uôc`/`ươc`, `uu` matches `ưu`.
+///
+/// A whole match, not a prefix: the caller is looking at a word the user already
+/// finished, so `ie` — which no rhyme spells — is English `die`, not a `diên` the
+/// user is halfway through.
+pub(crate) fn matches_deshaped(rhyme: &str) -> bool {
+    DESHAPED_RHYMES
+        .binary_search_by(|entry| entry.chars().cmp(rhyme.chars().map(plain_base)))
+        .is_ok()
+}
+
+/// Whether some deshaped rhyme starts with `prefix` (already deshaped). The
+/// inventory is sorted, so all candidates form a contiguous range beginning at
+/// the first entry ≥ `prefix`; checking that single entry suffices.
+pub(crate) fn has_deshaped_prefix(prefix: &[char]) -> bool {
+    let first = DESHAPED_RHYMES
+        .partition_point(|r| r.chars().cmp(prefix.iter().copied()) == std::cmp::Ordering::Less);
+    DESHAPED_RHYMES
+        .get(first)
+        .is_some_and(|r| starts_with(r, prefix))
+}
+
+fn starts_with(rhyme: &str, prefix: &[char]) -> bool {
+    let mut chars = rhyme.chars();
+    prefix.iter().all(|&p| chars.next() == Some(p))
 }
 
 /// Whether any valid shaped rhyme starts with `prefix`.
@@ -57,17 +120,9 @@ pub(crate) fn has_prefix(prefix: &[char]) -> bool {
     let first = SORTED_RHYMES.partition_point(|rhyme| {
         rhyme.chars().cmp(prefix.iter().copied()) == std::cmp::Ordering::Less
     });
-    SORTED_RHYMES.get(first).is_some_and(|rhyme| {
-        let mut chars = rhyme.chars();
-        prefix
-            .iter()
-            .all(|&expected| chars.next() == Some(expected))
-    })
-}
-
-/// The full toneless rhyme inventory (for prefix/reachability checks).
-pub fn all() -> &'static [&'static str] {
-    VALID_RHYMES
+    SORTED_RHYMES
+        .get(first)
+        .is_some_and(|rhyme| starts_with(rhyme, prefix))
 }
 
 #[cfg(test)]
@@ -95,9 +150,13 @@ mod tests {
 
     #[test]
     fn binary_search_covers_the_whole_inventory() {
-        // The sorted view must agree with the source table for every entry.
-        for rhyme in all() {
+        // Both sorted views must agree with the source table for every entry.
+        for rhyme in VALID_RHYMES {
             assert!(is_valid_rhyme(rhyme), "{rhyme} missing from sorted view");
+            assert!(
+                matches_deshaped(rhyme),
+                "{rhyme} missing from deshaped view"
+            );
         }
     }
 
@@ -106,5 +165,21 @@ mod tests {
         assert!(has_prefix(&['o', 'e']));
         assert!(!has_prefix(&['ô', 'e']));
         assert!(has_prefix(&['â', 't']));
+    }
+
+    #[test]
+    fn deshaped_match_is_whole_and_shape_blind() {
+        // A rhyme the user has typed without its shape keys: `iên` spelled `ien`.
+        for undiacriticked in ["ien", "uoc", "uong", "uu", "ue", "uyen", "ech", "yeu"] {
+            assert!(!is_valid_rhyme(undiacriticked));
+            assert!(matches_deshaped(undiacriticked), "{undiacriticked}");
+        }
+        // A *prefix* of one is not a match: `ie` is English `die`, not half a `diên`.
+        for bad in ["ie", "ye", "uye", "ae", "uuy", "eg"] {
+            assert!(!matches_deshaped(bad), "{bad}");
+        }
+        // Tone marks are stripped along with shape, so a toned rhyme still matches.
+        assert!(matches_deshaped("iên"));
+        assert!(matches_deshaped("ươc"));
     }
 }

--- a/crates/funput-core/src/validation/syllable/mod.rs
+++ b/crates/funput-core/src/validation/syllable/mod.rs
@@ -15,7 +15,7 @@ use crate::validation::coda::{
 };
 use crate::validation::parse::{is_valid_onset, parse_syllable};
 use crate::validation::reachability::{has_shaped_rhyme_prefix, is_definitely_invalid_parts};
-use crate::validation::rhyme::is_valid_rhyme;
+use crate::validation::rhyme::{is_valid_rhyme, matches_deshaped};
 
 use modifier::{ModifierKind, validate_parts};
 use spelling::violates_ckg_spelling;
@@ -47,22 +47,26 @@ pub fn is_valid(buffer: &str) -> bool {
 
 /// How a finished buffer sits against Vietnamese syllable structure.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum SyllableShape {
-    /// Not a Vietnamese syllable, and no tone can make it one: `cảd` (card),
+enum SyllableStatus {
+    /// Not a Vietnamese syllable, and no diacritic can make it one: `cảd` (card),
     /// `côl` (cool), `tẽt` (text).
     Invalid,
-    /// Structurally a syllable, but its **stop coda** (`p t c ch`) still carries
-    /// no tone, and Vietnamese requires sắc or nặng there: `chuc`, `tich`, `nuoc`.
-    /// Not a word yet — one tone key away from being one.
-    AwaitingTone,
+    /// Structurally a syllable, but still short of the **diacritics** the word
+    /// needs — which is exactly how a word looks when the user commits it before
+    /// finishing it. Three ways that happens:
+    /// - a **stop coda** (`p t c ch`) with no tone, where Vietnamese requires sắc
+    ///   or nặng: `chuc` → `chúc`, `tich` → `tích`;
+    /// - a rhyme that only exists shaped: `dien` → `diên`, `thuo` → `thuơ`;
+    /// - both at once: `nuoc` → `nước`.
+    AwaitingDiacritic,
     /// A real Vietnamese syllable as it stands: `chào`, `việt`, `ma`, `tét`.
     Complete,
 }
 
-fn classify(buffer: &str) -> SyllableShape {
+fn classify(buffer: &str) -> SyllableStatus {
     let parts = parse_syllable(buffer);
     let Some((coda, coda_len)) = normalized_coda(&parts) else {
-        return SyllableShape::Invalid;
+        return SyllableStatus::Invalid;
     };
     let coda = &coda[..coda_len];
 
@@ -75,26 +79,33 @@ fn classify(buffer: &str) -> SyllableShape {
         && !violates_ckg_spelling(parts.onset, &parts)
         && coda_in(VALID_CODAS, coda);
     if !structure_ok {
-        return SyllableShape::Invalid;
+        return SyllableStatus::Invalid;
     }
 
     // The nucleus+coda must be a real Vietnamese rhyme (Level 2): keeps `việt`,
-    // `trường` … but reverts structurally-ok-but-nonexistent rhymes.
-    if !is_valid_rhyme(&toneless_rhyme(&parts, coda)) {
-        return SyllableShape::Invalid;
-    }
+    // `trường` … but reverts structurally-ok-but-nonexistent rhymes. A rhyme that
+    // exists only *shaped* is that same rhyme with its shape keys still to come —
+    // `ien` is `iên` minus the circumflex — so it is unfinished, not wrong.
+    let rhyme = toneless_rhyme(&parts, coda);
+    let status = if is_valid_rhyme(&rhyme) {
+        SyllableStatus::Complete
+    } else if matches_deshaped(&rhyme) {
+        SyllableStatus::AwaitingDiacritic
+    } else {
+        return SyllableStatus::Invalid;
+    };
 
     // Phonotactics: a stop coda only allows sắc / nặng. A wrong tone (huyền / hỏi /
     // ngã) is what catches English `text` (→ `tẽt`) or `coot` (→ `côt`); no tone at
     // all is the un-toned form of a real word, which a tone key can still complete.
     if coda_in(STOP_CODAS, coda) {
         return match nucleus_tone(parts.nucleus_chars()) {
-            Some(Tone::Sac | Tone::Nang) => SyllableShape::Complete,
-            None => SyllableShape::AwaitingTone,
-            Some(_) => SyllableShape::Invalid,
+            Some(Tone::Sac | Tone::Nang) => status,
+            None => SyllableStatus::AwaitingDiacritic,
+            Some(_) => SyllableStatus::Invalid,
         };
     }
-    SyllableShape::Complete
+    status
 }
 
 /// Returns true if `buffer` is a *complete* valid Vietnamese syllable.
@@ -105,19 +116,20 @@ fn classify(buffer: &str) -> SyllableShape {
 /// the raw word when a finished word is *not* a complete syllable: `cảd` (card),
 /// `côl` (cool), `tẽt` (text).
 pub fn is_complete_syllable(buffer: &str) -> bool {
-    matches!(classify(buffer), SyllableShape::Complete)
+    matches!(classify(buffer), SyllableStatus::Complete)
 }
 
 /// Returns true if a committed `buffer` may be re-opened as a live composition
 /// (`Engine::adopt`, after Backspace puts the caret back on it).
 ///
-/// Looser than [`is_complete_syllable`] in exactly one place: a stop coda still
-/// **awaiting its tone** counts. Those words are the whole point of re-opening —
-/// `chuc` + `s` → `chúc`, `tich` + `s` → `tích` — and they are what the engine
-/// itself leaves on screen when the user commits before typing the tone. Still
-/// strict enough to keep English words and URLs literal (`hello`, `text`, `tẽt`).
+/// Looser than [`is_complete_syllable`] in exactly one place: a syllable still
+/// **awaiting a diacritic** counts — a missing tone (`chuc` + `s` → `chúc`), a
+/// missing vowel shape (`dien` + `e` → `diên`), or both (`nuoc` + `w` → `nươc`).
+/// Those words are the whole point of re-opening: they are what the engine itself
+/// leaves on screen when the user commits before finishing the word. Still strict
+/// enough to keep English words and URLs literal (`hello`, `text`, `tẽt`, `die`).
 pub fn is_reopenable_syllable(buffer: &str) -> bool {
-    !matches!(classify(buffer), SyllableShape::Invalid)
+    !matches!(classify(buffer), SyllableStatus::Invalid)
 }
 
 #[cfg(test)]

--- a/crates/funput-core/src/validation/syllable/tests.rs
+++ b/crates/funput-core/src/validation/syllable/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::validation::coda::{MAX_CODA, normalized_coda, toneless_rhyme};
 use crate::validation::reachability::is_definitely_invalid;
+use crate::validation::rhyme::{VALID_RHYMES, plain_base};
 
 #[test]
 fn validate_tone_cases() {
@@ -143,6 +144,48 @@ fn reopenable_accepts_a_stop_coda_awaiting_its_tone() {
     // Strictly looser than `is_complete_syllable`, never the other way round.
     for w in ["chuc", "tét", "tẽt", "ma", "text"] {
         assert!(!is_complete_syllable(w) || is_reopenable_syllable(w));
+    }
+}
+
+#[test]
+fn reopenable_accepts_a_rhyme_awaiting_its_vowel_shape() {
+    // Committed before the shape keys landed: the rhyme exists in Vietnamese only
+    // *shaped*, so the word is unfinished rather than foreign — `dien` + `e` →
+    // `diên`, `thuo` + `w` → `thuơ`, `nuoc` + `w` → `nươc`.
+    for ok in [
+        "dien", "vien", "thuo", "nuoc", "muon", "duong", "tuoi", "cuu", "tue", "chuyen", "diêu",
+        "nuóc",
+    ] {
+        assert!(is_reopenable_syllable(ok), "{ok} should be re-openable");
+    }
+    // Deshaping matches a *whole* rhyme, never a prefix of one: no Vietnamese rhyme
+    // is spelled `ie`, so English `die`/`lie`/`tie` stay literal.
+    for bad in ["die", "lie", "tie", "chuye", "nghie"] {
+        assert!(!is_reopenable_syllable(bad), "{bad} should be refused");
+    }
+    // Shape alone never excuses a stop coda carrying a tone it cannot have.
+    for bad in ["nuõc", "diẽt"] {
+        assert!(!is_reopenable_syllable(bad), "{bad} should be refused");
+    }
+    // And the loosened gate never loosens the word-boundary one: an unshaped rhyme
+    // is not a word, so English restore at Space is untouched.
+    for w in ["dien", "thuo", "nuoc", "tue"] {
+        assert!(!is_complete_syllable(w), "{w} is not a finished word");
+    }
+}
+
+/// The rule behind the two tests above, swept across the whole inventory rather than
+/// a handful of reported words: **every** Vietnamese rhyme, spelled the way the user's
+/// keystrokes leave it before any diacritic key lands, can be re-opened. Whatever the
+/// engine committed early, Backspace hands it back.
+#[test]
+fn every_rhyme_is_reopenable_before_its_diacritics_land() {
+    for rhyme in VALID_RHYMES {
+        let bare: String = rhyme.chars().map(plain_base).collect();
+        assert!(
+            is_reopenable_syllable(&bare),
+            "{rhyme} spelled {bare:?} should be re-openable"
+        );
     }
 }
 

--- a/crates/funput-desktop/tests/retone.rs
+++ b/crates/funput-desktop/tests/retone.rs
@@ -151,6 +151,53 @@ fn a_word_committed_before_its_tone_is_reopened() {
     }
 }
 
+/// The same bug one step earlier: a word committed before its *vowel shape*. `dien`
+/// is `diên` without the circumflex, so the shape, stroke and tone keys all have to
+/// reach it — `dien` + Space + ⌫ + `d` gives `đien`, not `diend`.
+#[test]
+fn a_word_committed_before_its_vowel_shape_is_reopened() {
+    for (keys, modifier, expected) in [
+        ("dien ", 'd', "đien"),
+        ("vien ", 'e', "viên"),
+        ("thuo ", 'w', "thuơ"),
+        ("nuoc ", 'w', "nươc"),
+        ("cuu ", 'w', "cưu"),
+    ] {
+        let mut shell = Shell::new(InputMethod::Telex);
+        shell.type_str(keys);
+        shell.backspace();
+        shell.key(modifier);
+        assert_eq!(
+            shell.app, expected,
+            "typing {keys:?} then ⌫ then {modifier:?}"
+        );
+    }
+}
+
+/// VNI reaches a re-opened word the same way — the gate is the engine's, not Telex's.
+#[test]
+fn a_word_awaiting_its_shape_is_reopened_in_vni_too() {
+    let mut shell = Shell::new(InputMethod::Vni);
+    shell.type_str("vien ");
+    shell.backspace();
+    shell.key('6'); // VNI circumflex
+    assert_eq!(shell.app, "viên");
+}
+
+/// The looser gate stops at the word boundary: an English word that happens to look
+/// like an unshaped rhyme is still restored when the next boundary arrives.
+#[test]
+fn an_english_word_that_looks_unshaped_is_restored_at_the_boundary() {
+    let mut shell = Shell::new(InputMethod::Telex);
+    shell.type_str("true ");
+    assert_eq!(shell.app, "true ");
+
+    shell.backspace();
+    shell.key('s');
+    shell.key(' ');
+    assert_eq!(shell.app, "trues ");
+}
+
 /// The engine only adopts real Vietnamese syllables, so an English word keeps
 /// taking literal letters after it.
 #[test]

--- a/crates/funput-engine/src/engine/editing.rs
+++ b/crates/funput-engine/src/engine/editing.rs
@@ -9,10 +9,11 @@ impl Engine {
     /// (Android: Backspace over the space after `chào`, then `s` gives `cháo`).
     ///
     /// Returns whether `text` was taken. Only a Vietnamese syllable is — including
-    /// one still missing the tone its stop coda requires (`chuc` + `s` → `chúc`),
-    /// which is how a word looks when the user commits it before typing the tone.
-    /// English words and URLs never become editable; the host should leave the
-    /// document untouched when this is `false`.
+    /// one still missing a diacritic, whether the tone its stop coda requires
+    /// (`chuc` + `s` → `chúc`) or its vowel shape (`dien` + `e` → `diên`), which is
+    /// how a word looks when the user commits it before finishing it. English words
+    /// and URLs never become editable; the host should leave the document untouched
+    /// when this is `false`.
     ///
     /// The raw keystrokes that produced `text` are gone, so they are seeded from the
     /// text itself — the same state `on_backspace` leaves behind. Composition only

--- a/crates/funput-engine/tests/adopt.rs
+++ b/crates/funput-engine/tests/adopt.rs
@@ -78,12 +78,58 @@ fn adopts_a_syllable_still_missing_its_stop_coda_tone() {
     }
 }
 
+/// The same story one step earlier: a word committed before its *vowel shape* — the
+/// rhyme only exists in Vietnamese shaped (`ien` is `iên` without its circumflex), so
+/// re-opening has to hand it back to the shape and stroke keys too.
+#[test]
+fn adopts_a_syllable_still_missing_its_vowel_shape() {
+    for (word, key, expected) in [
+        ("vien", 'e', "viên"),   // circumflex
+        ("thuo", 'w', "thuơ"),   // horn
+        ("dien", 'd', "đien"),   // stroke
+        ("nuoc", 'w', "nươc"),   // shape while the tone is still missing too
+        ("duong", 'w', "dương"), // ươ pair
+        ("cuu", 'w', "cưu"),
+    ] {
+        let mut engine = engine(InputMethod::Telex);
+        assert!(engine.adopt(word), "should adopt {word:?}");
+        engine.process_char(key);
+        assert_eq!(engine.buffer(), expected, "{word:?} + {key:?}");
+    }
+}
+
+/// The invariant behind every case above: re-opening a word puts the engine in the
+/// state it would have been in had the word never been committed. Whatever the next
+/// key does to a live composition, it does to a re-opened one.
+#[test]
+fn a_reopened_word_edits_exactly_like_a_live_one() {
+    for (word, key) in [
+        ("vien", 'e'),
+        ("thuo", 'w'),
+        ("dien", 'd'),
+        ("nuoc", 's'),
+        ("chuc", 's'),
+        ("tuoi", 'o'),
+    ] {
+        let mut adopted = engine(InputMethod::Telex);
+        assert!(adopted.adopt(word), "should adopt {word:?}");
+        adopted.process_char(key);
+
+        let mut typed = engine(InputMethod::Telex);
+        type_into(&mut typed, word);
+        typed.process_char(key);
+
+        assert_eq!(adopted.buffer(), typed.buffer(), "{word:?} + {key:?}");
+    }
+}
+
 /// Anything that is not a Vietnamese syllable is refused, so English words and URLs
-/// never silently become editable.
+/// never silently become editable. `die` is the near miss: no Vietnamese rhyme is
+/// spelled `ie`, however many diacritics you add.
 #[test]
 fn refuses_text_that_is_not_a_syllable() {
     let mut engine = engine(InputMethod::Telex);
-    for text in ["", "text", "tẽt", "hello", "funput.app", "chào bạn"] {
+    for text in ["", "text", "tẽt", "hello", "die", "funput.app", "chào bạn"] {
         assert!(!engine.adopt(text), "should not adopt {text:?}");
         assert_eq!(engine.buffer(), "", "buffer must stay empty after refusing");
     }

--- a/crates/funput-jni/src/engine/composition.rs
+++ b/crates/funput-jni/src/engine/composition.rs
@@ -12,7 +12,7 @@ use crate::abi::{JavaObject, neutral, safe, string_result};
 /// edits it (Backspace back onto `chào`, then `s` gives `cháo`).
 ///
 /// Returns whether the word was taken — only a Vietnamese syllable is, including one
-/// still missing the tone its stop coda needs (`chuc` → `chúc`), so the caller must
+/// still missing a diacritic (`chuc` → `chúc`, `dien` → `diên`), so the caller must
 /// leave the document untouched when this is `false`.
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_app_funput_funput_ime_nativebridge_FunputNative_nativeAdopt(

--- a/platforms/macos/Funput/IME/FunputComposer.swift
+++ b/platforms/macos/Funput/IME/FunputComposer.swift
@@ -82,8 +82,8 @@ final class FunputComposer {
 
     /// Re-open an already-committed word as the live composition, so the next keystroke
     /// edits it (`chào` + ⌫ then `s` gives `cháo`). Returns whether the engine took it:
-    /// only a Vietnamese syllable is — including one still missing the tone its stop coda
-    /// needs (`chuc` → `chúc`) — which keeps English words and URLs literal, so leave the
+    /// only a Vietnamese syllable is — including one still missing a diacritic (`chuc` →
+    /// `chúc`, `dien` → `diên`) — which keeps English words and URLs literal, so leave the
     /// document alone on `false`.
     func adopt(_ word: String) -> Bool {
         let scalars = word.unicodeScalars.map(\.value)


### PR DESCRIPTION
Follow-up to #fcf205e ("re-open a word still awaiting its stop-coda tone"), which
fixed one case of a general problem and left the rest.

## The bug

After Space, a committed word can no longer be edited unless it is already a real
syllable. Reported cases (Telex):

| typed | ⌫ then | before | after |
|---|---|---|---|
| `dien ` | `d` | `diend` | `đien` |
| `vien ` | `e` | `viene` | `viên` |
| `thuo ` | `w` | `thuow` | `thuơ` |
| `nuoc ` | `w` | `nuocw` | `nươc` |
| `cuu ` / `duong ` | `w` | not editable | `cưu` / `dương` |

## Why

The previous fix loosened `is_reopenable_syllable` in exactly one place — a stop
coda (`p t c ch`) still awaiting its tone — but the gate went on demanding an exact
hit in the rhyme inventory.

A word the user commits early is usually missing a **vowel shape**, not only a tone:
`dien` is `diên` without its circumflex, `thuo` is `thuơ` without its horn. Those
spellings are not in the inventory, so `classify` returned `Invalid` and `adopt`
refused. **35 of the 166 rhymes exist only shaped**, so the whole family was
affected: `ien uoc uong uoi uon uu ue uyen uyet iem iet ieu ech yeu`…

## The change

Generalized from *awaiting a tone* to **awaiting a diacritic**.

- `validation::rhyme` now owns the deshaped view of its own inventory (it was a
  private copy inside `reachability`) and answers both kinds of question over it.
  The new `matches_deshaped` is a **whole** match, never a prefix — that is the line
  that keeps English `die`/`lie`/`tie` literal, since no Vietnamese rhyme is
  spelled `ie`.
- `SyllableShape` → `SyllableStatus { Invalid, AwaitingDiacritic, Complete }`: a
  rhyme that only exists shaped is *unfinished*, not *wrong*.
- `is_complete_syllable` still means `Complete` alone, so **word-boundary English
  restore is untouched** — `true` + Space + ⌫ + `s` + Space still commits `trues`
  (covered by a test).

## Review notes

- **One gate, no platform code.** macOS, iOS, Android and Windows all defer to
  `Engine::adopt`; only three doc comments describing the gate were updated.
- **No allocation change** — still 1 alloc per `adopt`, confirmed by
  `tests/alloc_budget.rs` (`adopt: 64 allocs, 512 bytes over 64 calls`).
- **The move out of `reachability.rs`** (`plain_base`, `DESHAPED_RHYMES`,
  `any_rhyme_with_prefix` → `has_deshaped_prefix`) is a pure relocation with
  identical logic. It puts every query over the inventory in the file that owns the
  inventory, and keeps both files inside the 150-line budget (`rhyme.rs` 127,
  `reachability.rs` 94, `syllable/mod.rs` 134).
- **Wider adopt surface.** Words like `tech` and `true` become re-openable, as
  `cat`/`the` already were. That is deliberate and consistent: an adopted word now
  behaves exactly like a live one, and the boundary restore puts English back.

## Tests

The point is the sweep, not the six reported words:

- `every_rhyme_is_reopenable_before_its_diacritics_land` — all **166 rhymes**, each
  spelled the way the keystrokes leave it before any diacritic key lands, must be
  re-openable.
- `a_reopened_word_edits_exactly_like_a_live_one` — the invariant behind every case:
  `adopt(w)` + key == typing `w` + key.
- `reopenable_accepts_a_rhyme_awaiting_its_vowel_shape`, plus near-miss refusals
  (`die`, `nghie`, `nuõc`) and the stop-coda phonotactic guard.
- End-to-end through the hook+inject shell in Telex and VNI, and
  `an_english_word_that_looks_unshaped_is_restored_at_the_boundary`.

`cargo test --workspace`, `cargo clippy --workspace --all-targets`,
`cargo fmt --check` and `scripts/check-loc.sh` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
