### PR TITLE
fix(windows): stop mid-line composing from destroying text, without an app list

### DIFF
--- a/crates/funput-desktop/src/shell/mod.rs
+++ b/crates/funput-desktop/src/shell/mod.rs
@@ -104,7 +104,7 @@ impl ShellState {
     }
 
     /// The app the user is in right now, or `None` before the first focus change.
-    /// The platform uses this for per-app injection quirks.
+    /// What a hotkey toggle binds its VI/EN choice to.
     pub fn foreground_id(&self) -> Option<&str> {
         self.foreground.as_deref()
     }

--- a/platforms/windows/src/background/hook/keyboard.rs
+++ b/platforms/windows/src/background/hook/keyboard.rs
@@ -67,11 +67,7 @@ fn fire(hit: Hit) -> bool {
             // The hotkey's own modifiers are still held on this keydown, so the
             // Backspaces must go out with them cleared — [`inject::send_plan_unmodified`].
             let plan = plan_inject(&shell::flip_composing());
-            inject::send_plan_unmodified(
-                &plan,
-                keymap::read_mods(),
-                shell::foreground_has_urlbar_autofill(),
-            );
+            inject::send_plan_unmodified(&plan, keymap::read_mods());
             true // swallow even on a no-op, so the hotkey never leaks to the app
         }
     }
@@ -114,7 +110,7 @@ fn handle_keydown(kbd: &KBDLLHOOKSTRUCT) -> bool {
             if plan.is_noop() {
                 false // Action::None — the literal key reaches the app
             } else {
-                inject::send_plan_auto(&plan); // delete + retype the composed text
+                inject::send_plan(&plan); // delete + retype the composed text
                 true
             }
         }

--- a/platforms/windows/src/background/inject.rs
+++ b/platforms/windows/src/background/inject.rs
@@ -2,137 +2,130 @@
 //! characters, via `SendInput`. Every synthesized event carries [`INJECT_TAG`] in
 //! `dwExtraInfo` so the hook ignores them (no re-entrancy).
 //!
-//! Backspace is the only deletion key that ever goes out, never `Delete`.
-//! Everything a plan replaces sits *behind* the caret, so an injection must be
-//! incapable of touching what is in front of it — see [`send_plan`].
+//! Backspace is the only deletion key that ever goes out, never `Delete`, and the
+//! caret is never steered with an arrow key. Everything a plan replaces sits
+//! *behind* the caret, so an injection is built to be incapable of reaching what is
+//! in front of it — including when the app holds a selection there, which
+//! [`send_plan`] neutralizes without having to know that it does.
 
+mod events;
 mod modifiers;
 
 use funput_desktop::InjectPlan;
-use windows::Win32::UI::Input::KeyboardAndMouse::{
-    SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
-    KEYEVENTF_UNICODE, VIRTUAL_KEY, VK_BACK,
-};
 
 pub use modifiers::send_plan_unmodified;
 
-use crate::shared::shell::INJECT_TAG;
+use events::{deletions, raw_send, text};
 
-fn vk_event(vk: VIRTUAL_KEY, up: bool) -> INPUT {
-    let dw_flags = if up {
-        KEYEVENTF_KEYUP
-    } else {
-        KEYBD_EVENT_FLAGS(0)
-    };
-    INPUT {
-        r#type: INPUT_KEYBOARD,
-        Anonymous: INPUT_0 {
-            ki: KEYBDINPUT {
-                wVk: vk,
-                wScan: 0,
-                dwFlags: dw_flags,
-                time: 0,
-                dwExtraInfo: INJECT_TAG,
-            },
-        },
-    }
+/// The leading UTF-16 units of `units`' first character — both halves of a surrogate
+/// pair, or the single unit of a BMP character. `None` for an empty plan.
+///
+/// Vietnamese NFC never leaves the BMP, but a gõ tắt expansion carries whatever the
+/// user typed into the table, so the pair must not be split: half a surrogate is not
+/// a character the app would delete with one Backspace.
+fn leading_char(units: &[u16]) -> Option<&[u16]> {
+    let first = *units.first()?;
+    let paired = (0xD800..=0xDBFF).contains(&first) && units.len() >= 2;
+    Some(&units[..if paired { 2 } else { 1 }])
 }
 
-fn unicode_event(unit: u16, up: bool) -> INPUT {
-    let mut dw_flags = KEYEVENTF_UNICODE;
-    if up {
-        dw_flags |= KEYEVENTF_KEYUP;
-    }
-    INPUT {
-        r#type: INPUT_KEYBOARD,
-        Anonymous: INPUT_0 {
-            ki: KEYBDINPUT {
-                wVk: VIRTUAL_KEY(0),
-                wScan: unit,
-                dwFlags: dw_flags,
-                time: 0,
-                dwExtraInfo: INJECT_TAG,
-            },
-        },
-    }
-}
-
-/// Backspace key presses (down+up) for `n` deletions.
-fn deletions(n: usize) -> Vec<INPUT> {
-    let mut v = Vec::with_capacity(n * 2);
-    for _ in 0..n {
-        v.push(vk_event(VK_BACK, false));
-        v.push(vk_event(VK_BACK, true));
-    }
-    v
-}
-
-/// Unicode key presses (down+up) for the composed `units`.
-fn text(units: &[u16]) -> Vec<INPUT> {
-    let mut v = Vec::with_capacity(units.len() * 2);
-    for &unit in units {
-        v.push(unicode_event(unit, false));
-        v.push(unicode_event(unit, true));
-    }
-    v
-}
-
-fn raw_send(inputs: &[INPUT]) {
-    if inputs.is_empty() {
-        return;
-    }
-    unsafe { SendInput(inputs, std::mem::size_of::<INPUT>() as i32) };
-}
-
-/// Send the deletions then the new text as one atomic `SendInput` batch. The only
-/// injection route there is: every app takes it, and it reaches no further than the
-/// `backspaces` characters behind the caret.
+/// Send a plan as one atomic `SendInput` batch. The only injection route there is —
+/// no app is special-cased, and none needs to be.
 ///
-/// # Why there is no `Delete` primer
+/// # The ambiguous first Backspace
 ///
-/// Chrome's omnibox and Firefox's address bar inline-autofill a *selected* suffix —
-/// "go" displays as "go[ogle.com]" — and a Backspace fired at that selection deletes
-/// the **selection** instead of the base character, so the new glyph piles on top:
-/// "go" + `w` gives "goơ" rather than "gơ".
+/// A plan says "delete the `backspaces` characters behind the caret, then type
+/// `units`". Backspace cannot express that on its own, because it means two
+/// different things: with a selection live it deletes the **selection**, otherwise a
+/// character. Apps put a selection in front of the caret without being asked —
+/// Chrome's omnibox and Firefox's address bar inline-autofill a selected suffix, so
+/// "exa" displays as "exa[mple.com]". The first Backspace then spends itself on that
+/// suffix, one stale character survives, and the new glyph piles on top: "go" + `w`
+/// gives "goơ" instead of "gơ".
 ///
-/// A leading `Delete` press dismisses that selection, and those browsers were once
-/// routed through one. It cannot stay: `Delete` is harmless only with the caret at
-/// end-of-text, and nothing here can tell an autofill selection apart from ordinary
-/// text in front of the caret — a hook shell cannot read the document. In a browser
-/// *page* field, where no omnibox autofill exists, the primer therefore ate the
-/// character to the right on every injected keystroke, so moving the caret back into
-/// a finished line to insert a word silently destroyed the text after it.
+/// A hook shell cannot read the document, so it cannot look for the selection, and
+/// Windows will not say where the caret is: Chrome draws its whole UI in one HWND,
+/// so `GetGUIThreadInfo` reports that same top-level window for the omnibox and for
+/// a page field alike, with no caret to inspect. Only UI Automation separates them,
+/// which a `WH_KEYBOARD_LL` callback cannot afford. An earlier fix guessed instead —
+/// a `Delete` primer for a hard-coded list of browsers — and guessed wrong in every
+/// page field of those browsers, eating the character to the right of the caret on
+/// every keystroke typed into the middle of a line.
 ///
-/// Narrowing the primer to the URL bar would need the focused *control*, which
-/// Windows will not give up: Chrome draws its whole UI in one HWND, so
-/// `GetGUIThreadInfo` reports that top-level window for the omnibox and for a page
-/// field alike, with no caret. Only UI Automation can tell them apart, and a
-/// `WH_KEYBOARD_LL` callback cannot afford a cross-process COM call.
+/// # Normalizing instead of guessing
 ///
-/// So the pile-on is left standing for now — it is one visibly wrong syllable in an
-/// address bar, where the primer was deleting text the user wrote and never typed
-/// over.
+/// There is one keystroke that does not care: **typing a character**. A selection in
+/// front of the caret is replaced by it; no selection and it is simply inserted.
+/// Both land on the same state, so leading with one erases the difference:
+///
+/// ```text
+///   selection live:  [keep][stale]|[sel][rest]  --type S[0]-->  [keep][stale][S0]|[rest]
+///   no selection:    [keep][stale]|[rest]       --type S[0]-->  [keep][stale][S0]|[rest]
+/// ```
+///
+/// From there `backspaces + 1` Backspaces bite `S[0]` and the stale characters, and
+/// the plan's text goes down on clean ground. The lead is the first character of
+/// that text, so a field that accepts the result accepts it too, and no arrow key is
+/// needed to get back. A pure insert (`backspaces == 0`) skips all this: its text is
+/// already the one keystroke that neutralizes a selection.
+///
+/// # What it does not cover
+///
+/// The lead only holds if it leaves the app with nothing to re-select, and a batch
+/// is not atomic against that. Measured in Chrome's omnibox: given "exa[mple.com]",
+/// a lead that *keeps* the URL matching brings the autofill straight back between
+/// the keystrokes of one `SendInput`, and the Backspaces are ambiguous again.
+///
+/// Reaching that needs `units[0]` to be the character the URL continues with, which
+/// a plan does not normally produce: `units[0]` *replaces* a character already on
+/// screen, so leading with it appends a letter the text just had rather than the one
+/// the match wants. A tone or shape leads with a Vietnamese glyph ("exa" + `à`
+/// measured correct); an English restore re-types the composing word's own first
+/// letter. Only a coincidence — a gõ tắt expansion whose first letter happens to be
+/// the URL's next one — lines up, and it costs one visibly wrong syllable in an
+/// address bar, not lost text.
+///
+/// The other cost: in a field sitting at its exact `maxlength` the lead is refused,
+/// and the extra Backspace then takes a real character. Rare, immediately visible,
+/// and confined to a field the user cannot type into anyway.
 pub fn send_plan(plan: &InjectPlan) {
     if plan.is_noop() {
         return;
     }
-    let mut inputs = deletions(plan.backspaces);
+    let lead = (plan.backspaces > 0)
+        .then(|| leading_char(&plan.units))
+        .flatten();
+    let mut inputs = Vec::new();
+    if let Some(lead) = lead {
+        inputs.extend(text(lead));
+        inputs.extend(deletions(plan.backspaces + 1));
+    } else {
+        inputs.extend(deletions(plan.backspaces));
+    }
     inputs.extend(text(&plan.units));
     raw_send(&inputs);
 }
 
 #[cfg(test)]
 mod tests {
-    use windows::Win32::UI::Input::KeyboardAndMouse::VK_DELETE;
+    use windows::Win32::UI::Input::KeyboardAndMouse::{KEYEVENTF_KEYUP, VK_BACK, VK_DELETE};
 
     use super::*;
 
     /// The batch [`send_plan`] would emit, as `(wVk, wScan, keyup)` per event.
-    /// Built from the same two halves rather than by calling `send_plan`, which
-    /// would `SendInput` into whatever window the test runner has focused.
+    /// Mirrors its assembly rather than calling it, since `send_plan` ends in
+    /// `SendInput` and would type into whatever window the test runner has focused.
     fn batch(backspaces: usize, output: &str) -> Vec<(u16, u16, bool)> {
         let units: Vec<u16> = output.encode_utf16().collect();
-        let mut inputs = deletions(backspaces);
+        let lead = (backspaces > 0).then(|| leading_char(&units)).flatten();
+        let mut inputs = Vec::new();
+        match lead {
+            Some(lead) => {
+                inputs.extend(text(lead));
+                inputs.extend(deletions(backspaces + 1));
+            }
+            None => inputs.extend(deletions(backspaces)),
+        }
         inputs.extend(text(&units));
         inputs
             .iter()
@@ -143,19 +136,77 @@ mod tests {
             .collect()
     }
 
+    /// How many characters the batch types, and how many it deletes.
+    fn typed_and_deleted(emitted: &[(u16, u16, bool)]) -> (usize, usize) {
+        let down = emitted.iter().filter(|&&(.., up)| !up);
+        let (mut typed, mut deleted) = (0, 0);
+        for &(vk, ..) in down {
+            if vk == VK_BACK.0 {
+                deleted += 1;
+            } else {
+                typed += 1;
+            }
+        }
+        (typed, deleted)
+    }
+
     #[test]
-    fn plan_is_backspaces_then_text() {
+    fn a_replacement_leads_with_one_character_and_pays_for_it() {
+        // "bo" + `j` -> "bộ": type the lead, delete it plus the stale vowel, then
+        // lay down the text. The lead is what makes the deletions unambiguous even
+        // when the app holds a selection in front of the caret.
         assert_eq!(
-            batch(2, "ơ"),
+            batch(1, "ộ"),
             vec![
+                (0, 'ộ' as u16, false),
+                (0, 'ộ' as u16, true),
                 (VK_BACK.0, 0, false),
                 (VK_BACK.0, 0, true),
                 (VK_BACK.0, 0, false),
                 (VK_BACK.0, 0, true),
-                (0, 'ơ' as u16, false),
-                (0, 'ơ' as u16, true),
+                (0, 'ộ' as u16, false),
+                (0, 'ộ' as u16, true),
             ]
         );
+    }
+
+    #[test]
+    fn the_lead_is_always_paid_back() {
+        // Whatever the plan, the batch deletes exactly the characters it typed on
+        // top of the ones the plan asked for — never a character more.
+        for (backspaces, output) in [(1, "ộ"), (3, "card "), (7, "Việt Nam ")] {
+            let (typed, deleted) = typed_and_deleted(&batch(backspaces, output));
+            assert_eq!(deleted, backspaces + 1, "plan ({backspaces}, {output:?})");
+            assert_eq!(typed, output.chars().count() + 1);
+        }
+    }
+
+    #[test]
+    fn a_pure_insert_needs_no_lead() {
+        // Its own text is already the keystroke that neutralizes a selection.
+        assert_eq!(
+            batch(0, "à"),
+            vec![(0, 'à' as u16, false), (0, 'à' as u16, true)]
+        );
+    }
+
+    #[test]
+    fn a_surrogate_pair_leads_with_both_halves() {
+        // One character, two units: splitting it would type half a code point and
+        // then spend one Backspace on something the app never rendered.
+        let emitted = batch(1, "😀x");
+        let units: Vec<u16> = "😀".encode_utf16().collect();
+        assert_eq!(units.len(), 2);
+        assert_eq!(
+            &emitted[..4],
+            &[
+                (0, units[0], false),
+                (0, units[0], true),
+                (0, units[1], false),
+                (0, units[1], true),
+            ]
+        );
+        assert_eq!(typed_and_deleted(&emitted).1, 2); // one lead char, one stale
     }
 
     #[test]
@@ -165,12 +216,12 @@ mod tests {
         // front of it. A `Delete` primer here once cost one character of existing
         // text per keystroke typed into the middle of a line — see [`send_plan`].
         for (backspaces, output) in [(0, "à"), (1, "ộ"), (3, "card ")] {
-            let emitted = batch(backspaces, output);
             assert!(
-                emitted.iter().all(|&(vk, ..)| vk != VK_DELETE.0),
+                batch(backspaces, output)
+                    .iter()
+                    .all(|&(vk, ..)| vk != VK_DELETE.0),
                 "forward delete in plan ({backspaces}, {output:?})"
             );
-            assert_eq!(emitted.len(), (backspaces + output.chars().count()) * 2);
         }
     }
 }

--- a/platforms/windows/src/background/inject.rs
+++ b/platforms/windows/src/background/inject.rs
@@ -1,31 +1,22 @@
 //! Emit an [`InjectPlan`] to the focused app: Backspace presses, then Unicode
 //! characters, via `SendInput`. Every synthesized event carries [`INJECT_TAG`] in
 //! `dwExtraInfo` so the hook ignores them (no re-entrancy).
+//!
+//! Backspace is the only deletion key that ever goes out, never `Delete`.
+//! Everything a plan replaces sits *behind* the caret, so an injection must be
+//! incapable of touching what is in front of it — see [`send_plan`].
 
 mod modifiers;
 
 use funput_desktop::InjectPlan;
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
-    KEYEVENTF_UNICODE, VIRTUAL_KEY, VK_BACK, VK_DELETE,
+    KEYEVENTF_UNICODE, VIRTUAL_KEY, VK_BACK,
 };
 
 pub use modifiers::send_plan_unmodified;
 
-use crate::shared::shell::{self, INJECT_TAG};
-
-/// Send a plan by whichever route the focused app needs.
-///
-/// Chrome's omnibox and Firefox's address bar eat a Backspace to clear their
-/// autofill selection, so those get a Delete primer first (see
-/// [`send_plan_primed`]); everything else takes the direct path.
-pub fn send_plan_auto(plan: &InjectPlan) {
-    if shell::foreground_has_urlbar_autofill() {
-        send_plan_primed(plan);
-    } else {
-        send_plan(plan);
-    }
-}
+use crate::shared::shell::INJECT_TAG;
 
 fn vk_event(vk: VIRTUAL_KEY, up: bool) -> INPUT {
     let dw_flags = if up {
@@ -93,9 +84,34 @@ fn raw_send(inputs: &[INPUT]) {
     unsafe { SendInput(inputs, std::mem::size_of::<INPUT>() as i32) };
 }
 
-/// Send the deletions then the new text as one atomic `SendInput` batch. This is
-/// the default path used for every app except browsers with URL-bar autofill
-/// (see [`send_plan_primed`]).
+/// Send the deletions then the new text as one atomic `SendInput` batch. The only
+/// injection route there is: every app takes it, and it reaches no further than the
+/// `backspaces` characters behind the caret.
+///
+/// # Why there is no `Delete` primer
+///
+/// Chrome's omnibox and Firefox's address bar inline-autofill a *selected* suffix —
+/// "go" displays as "go[ogle.com]" — and a Backspace fired at that selection deletes
+/// the **selection** instead of the base character, so the new glyph piles on top:
+/// "go" + `w` gives "goơ" rather than "gơ".
+///
+/// A leading `Delete` press dismisses that selection, and those browsers were once
+/// routed through one. It cannot stay: `Delete` is harmless only with the caret at
+/// end-of-text, and nothing here can tell an autofill selection apart from ordinary
+/// text in front of the caret — a hook shell cannot read the document. In a browser
+/// *page* field, where no omnibox autofill exists, the primer therefore ate the
+/// character to the right on every injected keystroke, so moving the caret back into
+/// a finished line to insert a word silently destroyed the text after it.
+///
+/// Narrowing the primer to the URL bar would need the focused *control*, which
+/// Windows will not give up: Chrome draws its whole UI in one HWND, so
+/// `GetGUIThreadInfo` reports that top-level window for the omnibox and for a page
+/// field alike, with no caret. Only UI Automation can tell them apart, and a
+/// `WH_KEYBOARD_LL` callback cannot afford a cross-process COM call.
+///
+/// So the pile-on is left standing for now — it is one visibly wrong syllable in an
+/// address bar, where the primer was deleting text the user wrote and never typed
+/// over.
 pub fn send_plan(plan: &InjectPlan) {
     if plan.is_noop() {
         return;
@@ -105,38 +121,56 @@ pub fn send_plan(plan: &InjectPlan) {
     raw_send(&inputs);
 }
 
-/// Like [`send_plan`] but prepends a single `Delete` press before the deletions,
-/// for URL bars with inline autofill (Chrome's omnibox, Firefox's address bar).
-///
-/// Those URL bars show an inline-autofill *suffix that is selected* (e.g. after
-/// "bo" it displays "bo[okmarks]"). A Backspace fired against that selection deletes
-/// the **selection**, not the base character, so the vowel we meant to replace
-/// survives and the new glyph piles on top: "bộ" → "boộ". The leading `Delete`
-/// dismisses that autofill selection first; the Backspaces then bite real
-/// characters. When there is no autofill and the caret sits at the end of the
-/// field (the normal case while typing), `Delete` is a no-op, so this stays safe.
-///
-/// Sent as one synchronous `SendInput` batch — autofill is recomputed
-/// asynchronously, so it will not re-appear between the `Delete` and the Backspaces
-/// within a single burst. Only used when `backspaces > 0` (a pure insert has no
-/// Backspace to lose).
-///
-/// Caveat: in a **web** field the URL-bar autofill does not exist, so the
-/// `Delete` is wanted only at end-of-text; if the caret is in the middle of existing
-/// text it will eat the following character. See
-/// `shell::foreground_has_urlbar_autofill`.
-pub fn send_plan_primed(plan: &InjectPlan) {
-    if plan.is_noop() {
-        return;
+#[cfg(test)]
+mod tests {
+    use windows::Win32::UI::Input::KeyboardAndMouse::VK_DELETE;
+
+    use super::*;
+
+    /// The batch [`send_plan`] would emit, as `(wVk, wScan, keyup)` per event.
+    /// Built from the same two halves rather than by calling `send_plan`, which
+    /// would `SendInput` into whatever window the test runner has focused.
+    fn batch(backspaces: usize, output: &str) -> Vec<(u16, u16, bool)> {
+        let units: Vec<u16> = output.encode_utf16().collect();
+        let mut inputs = deletions(backspaces);
+        inputs.extend(text(&units));
+        inputs
+            .iter()
+            .map(|i| {
+                let ki = unsafe { i.Anonymous.ki };
+                (ki.wVk.0, ki.wScan, (ki.dwFlags.0 & KEYEVENTF_KEYUP.0) != 0)
+            })
+            .collect()
     }
-    if plan.backspaces == 0 {
-        send_plan(plan); // nothing to lose to autocomplete; plain insert
-        return;
+
+    #[test]
+    fn plan_is_backspaces_then_text() {
+        assert_eq!(
+            batch(2, "ơ"),
+            vec![
+                (VK_BACK.0, 0, false),
+                (VK_BACK.0, 0, true),
+                (VK_BACK.0, 0, false),
+                (VK_BACK.0, 0, true),
+                (0, 'ơ' as u16, false),
+                (0, 'ơ' as u16, true),
+            ]
+        );
     }
-    let mut inputs = Vec::with_capacity(2 + plan.backspaces * 2 + plan.units.len() * 2);
-    inputs.push(vk_event(VK_DELETE, false)); // dismiss the inline-autocomplete selection
-    inputs.push(vk_event(VK_DELETE, true));
-    inputs.extend(deletions(plan.backspaces));
-    inputs.extend(text(&plan.units));
-    raw_send(&inputs);
+
+    #[test]
+    fn nothing_deletes_forward() {
+        // The regression this file guards: a plan only ever describes characters
+        // *behind* the caret, so no batch may carry a key that removes what is in
+        // front of it. A `Delete` primer here once cost one character of existing
+        // text per keystroke typed into the middle of a line — see [`send_plan`].
+        for (backspaces, output) in [(0, "à"), (1, "ộ"), (3, "card ")] {
+            let emitted = batch(backspaces, output);
+            assert!(
+                emitted.iter().all(|&(vk, ..)| vk != VK_DELETE.0),
+                "forward delete in plan ({backspaces}, {output:?})"
+            );
+            assert_eq!(emitted.len(), (backspaces + output.chars().count()) * 2);
+        }
+    }
 }

--- a/platforms/windows/src/background/inject/events.rs
+++ b/platforms/windows/src/background/inject/events.rs
@@ -1,0 +1,83 @@
+//! The Win32 side of injection: turning key presses into `INPUT` records and
+//! handing a batch to `SendInput`.
+//!
+//! Nothing here knows what a plan means — [`super::send_plan`] owns that. What this
+//! module guarantees is that every record carries [`INJECT_TAG`] in `dwExtraInfo`,
+//! which is what stops the keyboard hook from composing its own output.
+
+use windows::Win32::UI::Input::KeyboardAndMouse::{
+    SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
+    KEYEVENTF_UNICODE, VIRTUAL_KEY, VK_BACK,
+};
+
+use crate::shared::shell::INJECT_TAG;
+
+/// One virtual-key press or release.
+pub(super) fn vk_event(vk: VIRTUAL_KEY, up: bool) -> INPUT {
+    let dw_flags = if up {
+        KEYEVENTF_KEYUP
+    } else {
+        KEYBD_EVENT_FLAGS(0)
+    };
+    INPUT {
+        r#type: INPUT_KEYBOARD,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wVk: vk,
+                wScan: 0,
+                dwFlags: dw_flags,
+                time: 0,
+                dwExtraInfo: INJECT_TAG,
+            },
+        },
+    }
+}
+
+/// One UTF-16 code unit, delivered as text rather than as a key on some layout.
+fn unicode_event(unit: u16, up: bool) -> INPUT {
+    let mut dw_flags = KEYEVENTF_UNICODE;
+    if up {
+        dw_flags |= KEYEVENTF_KEYUP;
+    }
+    INPUT {
+        r#type: INPUT_KEYBOARD,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wVk: VIRTUAL_KEY(0),
+                wScan: unit,
+                dwFlags: dw_flags,
+                time: 0,
+                dwExtraInfo: INJECT_TAG,
+            },
+        },
+    }
+}
+
+/// Backspace key presses (down+up) for `n` deletions.
+pub(super) fn deletions(n: usize) -> Vec<INPUT> {
+    let mut v = Vec::with_capacity(n * 2);
+    for _ in 0..n {
+        v.push(vk_event(VK_BACK, false));
+        v.push(vk_event(VK_BACK, true));
+    }
+    v
+}
+
+/// Unicode key presses (down+up) for the composed `units`.
+pub(super) fn text(units: &[u16]) -> Vec<INPUT> {
+    let mut v = Vec::with_capacity(units.len() * 2);
+    for &unit in units {
+        v.push(unicode_event(unit, false));
+        v.push(unicode_event(unit, true));
+    }
+    v
+}
+
+/// Hand a batch to the OS. Empty batches are dropped rather than sent — `SendInput`
+/// treats a zero-length array as an error, and a no-op plan reaches here.
+pub(super) fn raw_send(inputs: &[INPUT]) {
+    if inputs.is_empty() {
+        return;
+    }
+    unsafe { SendInput(inputs, std::mem::size_of::<INPUT>() as i32) };
+}

--- a/platforms/windows/src/background/inject/modifiers.rs
+++ b/platforms/windows/src/background/inject/modifiers.rs
@@ -5,7 +5,7 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
     VIRTUAL_KEY, VK_CONTROL, VK_LWIN, VK_MENU, VK_SHIFT,
 };
 
-use super::{raw_send, send_plan, send_plan_primed, vk_event};
+use super::{raw_send, send_plan, vk_event};
 
 /// Send a plan with the currently-held modifiers momentarily released.
 ///
@@ -18,17 +18,10 @@ use super::{raw_send, send_plan, send_plan_primed, vk_event};
 /// them. Restoring matters: without it, a user holding Ctrl+Shift to flip a second
 /// time would find the chord no longer matches, because the OS would believe those
 /// keys had come up.
-pub fn send_plan_unmodified(plan: &InjectPlan, held: Mods, primed: bool) {
+pub fn send_plan_unmodified(plan: &InjectPlan, held: Mods) {
     if plan.is_noop() {
         return;
     }
-    let send = || {
-        if primed {
-            send_plan_primed(plan)
-        } else {
-            send_plan(plan)
-        }
-    };
     let down: Vec<VIRTUAL_KEY> = [
         held.ctrl.then_some(VK_CONTROL),
         held.alt.then_some(VK_MENU),
@@ -39,12 +32,12 @@ pub fn send_plan_unmodified(plan: &InjectPlan, held: Mods, primed: bool) {
     .flatten()
     .collect();
     if down.is_empty() {
-        send();
+        send_plan(plan);
         return;
     }
 
     let events = |up: bool| -> Vec<_> { down.iter().map(|&vk| vk_event(vk, up)).collect() };
     raw_send(&events(true));
-    send();
+    send_plan(plan);
     raw_send(&events(false));
 }

--- a/platforms/windows/src/background/inject/modifiers.rs
+++ b/platforms/windows/src/background/inject/modifiers.rs
@@ -5,7 +5,8 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
     VIRTUAL_KEY, VK_CONTROL, VK_LWIN, VK_MENU, VK_SHIFT,
 };
 
-use super::{raw_send, send_plan, vk_event};
+use super::events::{raw_send, vk_event};
+use super::send_plan;
 
 /// Send a plan with the currently-held modifiers momentarily released.
 ///

--- a/platforms/windows/src/shared/shell/mod.rs
+++ b/platforms/windows/src/shared/shell/mod.rs
@@ -7,8 +7,8 @@
 //! to be reachable from a static. Each function here is that static plus a lock.
 //!
 //! What the hook calls stays here; what the Settings window and tray call lives in
-//! [`settings`]. No Windows APIs in either — the two Windows *facts* this file
-//! does hold are the inject tag and the browser list, both explained below.
+//! [`settings`]. No Windows APIs in either — the one Windows *fact* this file does
+//! hold is the inject tag, explained below.
 
 mod settings;
 
@@ -24,14 +24,6 @@ pub use settings::*;
 /// the hook can recognize and ignore its own injected keystrokes (no re-entrancy).
 pub const INJECT_TAG: usize = 0x4655_4E50; // "FUNP"
 
-/// Browsers whose URL bar inline-autofills a *selected* suffix that eats a
-/// synthesized Backspace (Chrome's omnibox, Firefox's address bar). Chrome
-/// Beta/Dev/Canary also report `chrome.exe`; Firefox Developer Edition/Nightly
-/// also report `firefox.exe`. Zen (Firefox fork) reports `zen.exe`. Edge
-/// (`msedge.exe`) and Brave (`brave.exe`) deliberately do not match — they
-/// are unaffected.
-const URLBAR_AUTOFILL_BROWSERS: [&str; 3] = ["chrome.exe", "firefox.exe", "zen.exe"];
-
 static SHELL: OnceLock<Mutex<ShellState>> = OnceLock::new();
 
 fn shell() -> &'static Mutex<ShellState> {
@@ -41,16 +33,6 @@ fn shell() -> &'static Mutex<ShellState> {
 pub(super) fn with<R>(f: impl FnOnce(&mut ShellState) -> R) -> R {
     let mut guard = shell().lock().expect("shell mutex poisoned");
     f(&mut guard)
-}
-
-/// True when the focused app is a browser whose URL bar autofill swallows
-/// synthesized Backspaces. Used to route text injection through the Delete-primer
-/// path (see `inject::send_plan_primed`).
-pub fn foreground_has_urlbar_autofill() -> bool {
-    with(|s| {
-        s.foreground_id()
-            .is_some_and(|id| URLBAR_AUTOFILL_BROWSERS.contains(&id))
-    })
 }
 
 // --- called from the hook --------------------------------------------------


### PR DESCRIPTION
Two commits, reviewable separately.

## The reported bug (`e93f64a`)

Type a few Vietnamese words, move the caret back to insert another one, keep
typing — every injected keystroke deleted a character *after* the caret. Windows
only; macOS is a real IME and synthesizes nothing.

The cause was `send_plan_primed`, firing a `VK_DELETE` ahead of the Backspaces.
It exists for one field — Chrome's omnibox and Firefox's address bar
inline-autofill a *selected* suffix, so a Backspace aimed at it deletes the
selection rather than the base character and the glyph piles on ("go" + `w` →
"goơ"). The `Delete` clears the selection first.

The routing asked the wrong question. `foreground_has_urlbar_autofill` matched on
the **app** (chrome.exe, firefox.exe, zen.exe), while what decides whether
`Delete` is safe is the **field**: it is a no-op only with the caret at
end-of-text. Every page field in those browsers took the primer too, and there it
had a real character to eat — Gmail, chat boxes, comments: one character of the
user's own text per keystroke, silently.

Narrowing it to the URL bar needs the focused control, and Windows will not give
it up. Probed on Chrome 2026: focus in the omnibox and focus in a page `<input>`
both report the same top-level `Chrome_WidgetWin_1` from `GetGUIThreadInfo`, with
no caret — Chrome draws its whole UI in one HWND. Only UI Automation separates
them, which a `WH_KEYBOARD_LL` callback cannot afford.

So the primer, the browser list and the routing are gone. Backspace is now the
only deletion key injection emits.

## The bug the primer was covering (`b6ba6a9`)

Backspace is the wrong instrument: it means two different things depending on
state a hook shell cannot observe. Typing a character does not — a selection in
front of the caret is replaced by it, no selection and it is inserted. Both end
on the same state, so leading with one erases the difference:

```
type units[0]  →  Backspace × (backspaces + 1)  →  type units
```

The lead is the plan's own first character, so a field that accepts the result
accepts the lead; no arrow key is needed to get back. A pure insert skips it.
`leading_char` keeps a surrogate pair together.

**No app is named anywhere**, so this covers every inline-autocomplete field —
Edge and Brave included — instead of three exe names.

## Measurements

`SendInput` batches shaped exactly like `send_plan`, read back through UI
Automation, against a seeded typed-history entry so the autofill is live:

| case | before | after |
|---|---|---|
| omnibox `exa[mple.com]` + plan (1,`à`) | `exaà` | **`exà`** |
| omnibox `abc\|def` + plan (1,`X`) | — | **`abXdef`** |
| omnibox `aaa\| bbb` + plan (1,`à`) | — | **`aaà bbb`** |
| omnibox `xin chao\| ban` + plan (3,`card `) | — | **`xin ccard  ban`** |

## Known limits (documented on `send_plan`)

- A `SendInput` batch is **not** atomic against autofill — measured. A lead that
  keeps the URL matching brings the selection back mid-batch. Reaching that needs
  `units[0]` to be the character the URL continues with, which a plan does not
  normally produce (`units[0]` *replaces* a character already on screen). Only a
  gõ tắt expansion whose first letter coincides lines up; cost is one visible
  syllable, not lost text.
- A field at its exact `maxlength` refuses the lead, and the extra Backspace then
  takes a real character.
