### PR TITLE
fix(windows): open the tray UI without the busy pointer; drop the AppData settings migration

### DIFF
--- a/crates/funput-config/src/settings/path.rs
+++ b/crates/funput-config/src/settings/path.rs
@@ -31,8 +31,10 @@ pub fn dir_is_writable(dir: &Path) -> bool {
 /// 2. `<exe_dir>/settings.json` when `exe_writable`
 /// 3. else `appdata` (`%APPDATA%\Funput\settings.json`)
 ///
-/// When choosing the beside-exe path and the file is missing, copy from `appdata`
-/// once so an existing install keeps its settings (`appdata` is left in place).
+/// Picking a location is all this does — it never reads, writes or copies a file.
+/// A beside-exe path that does not exist yet simply starts from defaults; the
+/// `appdata` file is only ever *used in place*, when the exe directory refuses
+/// writes.
 pub fn resolve(
     env: Option<PathBuf>,
     exe_dir: Option<&Path>,
@@ -43,11 +45,7 @@ pub fn resolve(
         return Some(path);
     }
     if let Some(dir) = exe_dir.filter(|_| exe_writable) {
-        let path = dir.join(FILE);
-        if let Some(src) = appdata.filter(|p| p.is_file() && !path.exists()) {
-            let _ = fs::copy(src, &path);
-        }
-        return Some(path);
+        return Some(dir.join(FILE));
     }
     appdata.map(Path::to_path_buf)
 }

--- a/crates/funput-config/src/settings/path/tests.rs
+++ b/crates/funput-config/src/settings/path/tests.rs
@@ -44,8 +44,11 @@ fn falls_back_to_appdata_when_exe_not_writable() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// A beside-exe install ignores AppData completely — it is neither copied from nor
+/// touched, and a missing beside-exe file stays missing until something saves it.
+/// An AppData file left over from an older install is simply not this install's.
 #[test]
-fn migrates_appdata_once_when_beside_exe_is_missing() {
+fn an_appdata_file_is_never_read_or_copied() {
     let root = tmp();
     let exe = root.join("exe");
     let app_dir = root.join("app");
@@ -56,28 +59,14 @@ fn migrates_appdata_once_when_beside_exe_is_missing() {
 
     let path = resolve(None, Some(&exe), true, Some(&app)).unwrap();
     assert_eq!(path, exe.join(FILE));
-    assert_eq!(
-        fs::read_to_string(&path).unwrap(),
-        fs::read_to_string(&app).unwrap()
+    assert!(
+        !path.exists(),
+        "resolve must not create the beside-exe file"
     );
-    // AppData is left in place.
-    assert!(app.is_file());
-    let _ = fs::remove_dir_all(root);
-}
-
-#[test]
-fn does_not_overwrite_existing_beside_exe_file() {
-    let root = tmp();
-    let exe = root.join("exe");
-    let app_dir = root.join("app");
-    let app = app_dir.join(FILE);
-    let beside = exe.join(FILE);
-    fs::create_dir_all(&exe).unwrap();
-    fs::create_dir_all(&app_dir).unwrap();
-    fs::write(&beside, "beside").unwrap();
-    fs::write(&app, "appdata").unwrap();
-
-    let path = resolve(None, Some(&exe), true, Some(&app)).unwrap();
-    assert_eq!(fs::read_to_string(path).unwrap(), "beside");
+    assert_eq!(
+        fs::read_to_string(&app).unwrap(),
+        r#"{"method":"vni","enabled":true}"#,
+        "the AppData file must be left untouched"
+    );
     let _ = fs::remove_dir_all(root);
 }

--- a/platforms/windows/src/ui/lifecycle/child.rs
+++ b/platforms/windows/src/ui/lifecycle/child.rs
@@ -6,14 +6,15 @@
 //! rules live in [`super::flyout`].
 
 use std::cell::RefCell;
-use std::os::windows::io::AsRawHandle;
-use std::process::{Child, Command};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use windows::Win32::Foundation::HANDLE;
 
+use super::process::UiProcess;
+
 thread_local! {
-    pub(super) static UI_PROCESS: RefCell<Option<(UiKind, Child)>> = const { RefCell::new(None) };
+    pub(super) static UI_PROCESS: RefCell<Option<(UiKind, UiProcess)>> =
+        const { RefCell::new(None) };
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -52,35 +53,28 @@ pub(super) fn spawn_child(arg: &str, kind: UiKind, extra_env: &[(&str, &str)]) {
     let Some(exe) = std::env::current_exe().ok() else {
         return;
     };
-    let mut cmd = Command::new(exe);
-    cmd.arg(arg)
-        .env(PARENT_PID_ENV, std::process::id().to_string());
-    for (key, value) in extra_env {
-        cmd.env(*key, *value);
-    }
-    if let Some(child) = cmd.spawn().ok() {
+    let pid = std::process::id().to_string();
+    let mut env = vec![(PARENT_PID_ENV, pid.as_str())];
+    env.extend_from_slice(extra_env);
+    if let Some(child) = UiProcess::spawn(&exe, arg, &env) {
         UI_PROCESS.with(|cell| *cell.borrow_mut() = Some((kind, child)));
     }
 }
 
 /// Raw handle of the tracked UI child, for the hook thread's wait set.
 ///
-/// Borrowed, never owned: the `Child` in [`UI_PROCESS`] stays the only owner, so
-/// the caller must not close it. Only valid until that slot is cleared, which
-/// this thread alone does — see [`crate::background::instance::wait_activate_message_or_child`].
+/// Borrowed, never owned: the [`UiProcess`] in [`UI_PROCESS`] stays the only
+/// owner, so the caller must not close it. Only valid until that slot is cleared,
+/// which this thread alone does — see
+/// [`crate::background::instance::wait_activate_message_or_child`].
 pub(crate) fn current_child_handle() -> Option<HANDLE> {
-    UI_PROCESS.with(|cell| {
-        cell.borrow()
-            .as_ref()
-            .map(|(_, child)| HANDLE(child.as_raw_handle()))
-    })
+    UI_PROCESS.with(|cell| cell.borrow().as_ref().map(|(_, child)| child.handle()))
 }
 
 pub(crate) fn terminate_children() {
     UI_PROCESS.with(|cell| {
-        if let Some((_, mut child)) = cell.borrow_mut().take() {
-            let _ = child.kill();
-            let _ = child.wait();
+        if let Some((_, child)) = cell.borrow_mut().take() {
+            child.kill(); // dropping the slot then closes the handle
         }
     });
 }

--- a/platforms/windows/src/ui/lifecycle/flyout.rs
+++ b/platforms/windows/src/ui/lifecycle/flyout.rs
@@ -56,23 +56,10 @@ pub(crate) fn toggle_control_center(rect: Rect) {
 pub(crate) fn reap_ui_child() {
     let finished = UI_PROCESS.with(|cell| {
         let mut slot = cell.borrow_mut();
-        let Some((kind, child)) = slot.as_mut() else {
-            return None;
-        };
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                let out = (*kind, status.code().unwrap_or(0) as u8);
-                *slot = None;
-                Some(out)
-            }
-            Ok(None) => None,
-            // The handle is unusable, so it will never resolve. Drop it instead of
-            // leaving it in the pump's wait set, where it would spin the loop.
-            Err(_) => {
-                *slot = None;
-                None
-            }
-        }
+        let (kind, child) = slot.as_mut()?;
+        let out = (*kind, child.exit_code()? as u8);
+        *slot = None; // dropping it here is what closes the process handle
+        Some(out)
     });
     let Some((UiKind::ControlCenter, code)) = finished else {
         return;

--- a/platforms/windows/src/ui/lifecycle/mod.rs
+++ b/platforms/windows/src/ui/lifecycle/mod.rs
@@ -2,6 +2,7 @@
 
 mod child;
 mod flyout;
+mod process;
 
 use windows::Win32::Foundation::CloseHandle;
 use windows::Win32::System::Threading::{

--- a/platforms/windows/src/ui/lifecycle/process.rs
+++ b/platforms/windows/src/ui/lifecycle/process.rs
@@ -1,0 +1,178 @@
+//! Starting a UI child, and owning it afterwards.
+//!
+//! This exists instead of `std::process::Command` for one reason: the startup
+//! feedback cursor. `CreateProcess` makes the shell show the busy pointer until
+//! the new process goes idle, and for a Slint + Skia window that is long enough to
+//! read as "loading" on what is an ordinary tray click. Turning it off is a
+//! `STARTUPINFOW::dwFlags` bit, and `Command` only reaches `dwCreationFlags` —
+//! `startupinfo_force_feedback` is still unstable (rust-lang/rust#141010) and the
+//! toolchain is pinned to stable.
+//!
+//! So the spawn is done by hand, and [`UiProcess`] takes over what `Child` was
+//! holding: the process handle, closed on drop.
+
+mod buffers;
+
+use std::path::Path;
+
+use windows::core::PWSTR;
+use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_TIMEOUT};
+use windows::Win32::System::Threading::{
+    CreateProcessW, GetExitCodeProcess, TerminateProcess, WaitForSingleObject,
+    CREATE_UNICODE_ENVIRONMENT, INFINITE, PROCESS_INFORMATION, STARTF_FORCEOFFFEEDBACK,
+    STARTUPINFOW,
+};
+
+use buffers::{command_line, environment};
+
+/// A running UI child process. Owns the handle; closes it on drop.
+pub(super) struct UiProcess(HANDLE);
+
+impl UiProcess {
+    /// Launch `exe arg` with `extra` added to this process's environment, without
+    /// the startup feedback cursor.
+    ///
+    /// Handles are not inherited: the children are GUI processes that need none,
+    /// and a debug build's console reaches them by attachment rather than through
+    /// `STARTUPINFO`, so `eprintln!` still lands.
+    pub(super) fn spawn(exe: &Path, arg: &str, extra: &[(&str, &str)]) -> Option<Self> {
+        let mut line = command_line(exe, arg);
+        let mut env = environment(extra);
+        let startup = STARTUPINFOW {
+            cb: size_of::<STARTUPINFOW>() as u32,
+            dwFlags: STARTF_FORCEOFFFEEDBACK,
+            ..Default::default()
+        };
+        let mut info = PROCESS_INFORMATION::default();
+        unsafe {
+            CreateProcessW(
+                None,
+                Some(PWSTR(line.as_mut_ptr())),
+                None,
+                None,
+                false,
+                CREATE_UNICODE_ENVIRONMENT,
+                Some(env.as_mut_ptr().cast()),
+                None,
+                &startup,
+                &mut info,
+            )
+            .ok()?;
+            // Only the process is tracked; the initial thread's handle is dead weight.
+            let _ = CloseHandle(info.hThread);
+        }
+        Some(Self(info.hProcess))
+    }
+
+    /// Raw handle for the pump's wait set. Borrowed — this type stays the owner.
+    pub(super) fn handle(&self) -> HANDLE {
+        self.0
+    }
+
+    /// The exit code once it has finished, `None` while it is still running.
+    ///
+    /// The wait is what answers "finished", not `GetExitCodeProcess` alone: a
+    /// process that exits with `STILL_ACTIVE` would be indistinguishable from a
+    /// live one. A failed wait also reports finished — an unusable handle must not
+    /// stay in the pump's wait set, where it would spin the loop.
+    pub(super) fn exit_code(&self) -> Option<u32> {
+        if unsafe { WaitForSingleObject(self.0, 0) } == WAIT_TIMEOUT {
+            return None;
+        }
+        let mut code = 0u32;
+        let _ = unsafe { GetExitCodeProcess(self.0, &mut code) };
+        Some(code)
+    }
+
+    /// Kill it and wait for it to actually go, so the caller can drop the slot
+    /// knowing nothing is left half-dead in the wait set.
+    pub(super) fn kill(&self) {
+        unsafe {
+            let _ = TerminateProcess(self.0, 1);
+            WaitForSingleObject(self.0, INFINITE);
+        }
+    }
+}
+
+impl Drop for UiProcess {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::time::{Duration, Instant};
+
+    use super::*;
+
+    fn comspec() -> PathBuf {
+        std::env::var_os("COMSPEC")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| r"C:\Windows\System32\cmd.exe".into())
+    }
+
+    /// Block until the child is gone, so a hung spawn fails the test instead of
+    /// hanging the run.
+    fn wait(child: &UiProcess) -> u32 {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Some(code) = child.exit_code() {
+                return code;
+            }
+            assert!(Instant::now() < deadline, "child never exited");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn a_child_starts_and_reports_its_exit_code() {
+        // The Control Center answers through its exit code, so this round trip is
+        // the whole contract with the flyout.
+        let child = UiProcess::spawn(&comspec(), "/c exit 7", &[]).expect("spawn failed");
+        assert_eq!(wait(&child), 7);
+    }
+
+    #[test]
+    fn extra_variables_reach_the_child() {
+        // The hand-built environment block is the riskiest part of not using
+        // `Command`: get it subtly wrong and the child starts with no variables at
+        // all, which would strand the flyout with no tray rect and no parent pid.
+        let child = UiProcess::spawn(
+            &comspec(),
+            r#"/c if "%FUNPUT_SPAWN_TEST%"=="ok" (exit 5) else (exit 1)"#,
+            &[("FUNPUT_SPAWN_TEST", "ok")],
+        )
+        .expect("spawn failed");
+        assert_eq!(wait(&child), 5, "the child did not see FUNPUT_SPAWN_TEST");
+    }
+
+    #[test]
+    fn the_inherited_environment_survives_alongside_them() {
+        // `extra` is layered on top of this process's environment, not a
+        // replacement for it — the children still need PATH, TEMP and the rest.
+        let child = UiProcess::spawn(
+            &comspec(),
+            r#"/c if defined SystemRoot (exit 4) else (exit 1)"#,
+            &[("FUNPUT_SPAWN_TEST", "ok")],
+        )
+        .expect("spawn failed");
+        assert_eq!(wait(&child), 4, "the inherited environment was dropped");
+    }
+
+    #[test]
+    fn kill_ends_a_running_child() {
+        // Opening Settings kills the flyout first; that has to actually finish, or
+        // the pump keeps waiting on a handle that never signals.
+        let child = UiProcess::spawn(&comspec(), "/c ping -n 20 127.0.0.1 >nul", &[])
+            .expect("spawn failed");
+        child.kill();
+        assert!(
+            child.exit_code().is_some(),
+            "kill returned before the child was gone"
+        );
+    }
+}

--- a/platforms/windows/src/ui/lifecycle/process/buffers.rs
+++ b/platforms/windows/src/ui/lifecycle/process/buffers.rs
@@ -1,0 +1,107 @@
+//! The two UTF-16 buffers `CreateProcessW` is handed: the command line and the
+//! environment block. Split out because building them is string work with its own
+//! rules, and none of it has anything to say about process lifetime.
+
+use std::ffi::OsStr;
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
+
+/// `"<exe>" <arg>` as a mutable buffer — `CreateProcessW` is allowed to write into
+/// the command line it is given.
+///
+/// `argv[0]` has to be there, and the install path can contain spaces, so it is
+/// quoted. The arguments are fixed literals (`--control-center` and friends), so
+/// nothing beyond that needs escaping.
+pub(super) fn command_line(exe: &Path, arg: &str) -> Vec<u16> {
+    let quote = u16::from(b'"');
+    let mut line = vec![quote];
+    line.extend(exe.as_os_str().encode_wide());
+    line.extend([quote, u16::from(b' ')]);
+    line.extend(arg.encode_utf16());
+    line.push(0);
+    line
+}
+
+/// This process's environment with `extra` layered on top, in the
+/// `KEY=VALUE\0…\0\0` block `CREATE_UNICODE_ENVIRONMENT` expects.
+///
+/// Order is not significant — the child reads variables with
+/// `GetEnvironmentVariable`, which scans the block — but a name appearing twice
+/// would be, so anything `extra` overrides is dropped first. Windows compares
+/// names case-insensitively, hence the folded match.
+pub(super) fn environment(extra: &[(&str, &str)]) -> Vec<u16> {
+    let mut block = Vec::new();
+    for (key, value) in std::env::vars_os() {
+        if extra.iter().any(|(name, _)| key.eq_ignore_ascii_case(name)) {
+            continue;
+        }
+        push_var(&mut block, &key, &value);
+    }
+    for (key, value) in extra {
+        push_var(&mut block, OsStr::new(key), OsStr::new(value));
+    }
+    if block.is_empty() {
+        block.push(0); // an empty block is still two nulls, not one
+    }
+    block.push(0);
+    block
+}
+
+fn push_var(block: &mut Vec<u16>, key: &OsStr, value: &OsStr) {
+    block.extend(key.encode_wide());
+    block.push(u16::from(b'='));
+    block.extend(value.encode_wide());
+    block.push(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Read a block back as `KEY=VALUE` entries.
+    fn entries(block: &[u16]) -> Vec<String> {
+        String::from_utf16_lossy(block)
+            .split('\0')
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect()
+    }
+
+    #[test]
+    fn extra_vars_are_appended_and_the_block_is_double_terminated() {
+        let block = environment(&[("FUNPUT_TRAY_X", "12")]);
+        assert!(entries(&block).contains(&"FUNPUT_TRAY_X=12".to_string()));
+        assert_eq!(&block[block.len() - 2..], &[0, 0]);
+    }
+
+    #[test]
+    fn an_extra_var_never_appears_twice() {
+        // Whatever the parent holds, the child must see one value for a name —
+        // `GetEnvironmentVariable` takes the first hit and would shadow ours.
+        let name = std::env::vars_os()
+            .next()
+            .map(|(k, _)| k.to_string_lossy().into_owned())
+            .expect("the test process has an environment");
+        let block = environment(&[(name.as_str(), "ours")]);
+        let hits = entries(&block)
+            .into_iter()
+            .filter(|e| {
+                e.split_once('=')
+                    .is_some_and(|(k, _)| k.eq_ignore_ascii_case(&name))
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(hits, vec![format!("{name}=ours")]);
+    }
+
+    #[test]
+    fn the_exe_path_is_quoted_so_spaces_survive() {
+        let line = command_line(
+            Path::new(r"C:\Program Files\Funput.exe"),
+            "--control-center",
+        );
+        assert_eq!(
+            String::from_utf16_lossy(&line),
+            "\"C:\\Program Files\\Funput.exe\" --control-center\0"
+        );
+    }
+}


### PR DESCRIPTION
Two unrelated changes, one per commit.

### `e905609b` — stop migrating settings.json out of AppData

`resolve` used to copy `%APPDATA%\Funput\settings.json` next to the exe when it
found no file there. Gone: it now only picks a path, and reads/writes/copies
nothing.

The AppData **fallback** stays — that is not migration, it is where an install
that cannot write beside its exe (Program Files, read-only media) keeps
settings today.

Consequence, and the point: an install still holding settings in AppData starts
from defaults beside the exe. The old file is left on disk, unread.

### `389f05ee` — open the tray UI without the busy pointer

Left-clicking the tray showed the "working in background" cursor while the
Control Center opened. Nothing in the shell draws it — `CreateProcess` puts the
pointer in feedback mode until the new process goes idle, and the Control
Center is its own Slint + Skia process.

Measured with `GetCursorInfo` while spawning a GUI process both ways:

| spawn | cursor |
|---|---|
| default `STARTUPINFO` | `IDC_APPSTARTING` within ~40 ms |
| `STARTF_FORCEOFFFEEDBACK` | never appears |

`Command` cannot set that flag — it lives in `STARTUPINFOW::dwFlags`, and
`startupinfo_force_feedback` is still unstable (rust-lang/rust#141010) while the
toolchain is pinned to stable. So the spawn is by hand and `UiProcess` owns the
handle `Child` used to.

`exit_code` waits with a zero timeout rather than reading `GetExitCodeProcess`
alone, since a process exiting with `STILL_ACTIVE` (259) is otherwise
indistinguishable from a live one.

### Checks

`platforms/windows` 45 tests, `funput-config` 30, workspace green; fmt clean,
no new clippy warnings, `check-loc.sh` OK. Both commits verified independently,
so `e905609b` builds and tests on its own.

Four of the new tests spawn real processes — compiling proves nothing about a
hand-rolled `CreateProcessW`: exit-code round trip, extras reaching the child,
the inherited environment surviving, and `kill` finishing.
