### PR TITLE
feat(windows): import UniKey's gõ tắt table, and a switch to turn expansion off

### DIFF
--- a/crates/funput-config/src/lib.rs
+++ b/crates/funput-config/src/lib.rs
@@ -12,6 +12,9 @@
 //!   made of, where the file lives ([`settings::path`]), and reading/writing it.
 //! - `transfer` — the versioned interchange document behind Export/Import,
 //!   specified in `platforms/CONFIG_FORMAT.md`.
+//! - `unikey` — reading UniKey's gõ tắt table, so a user switching over does not
+//!   retype it. Its rows come out as `transfer`'s own shape, which lets the import
+//!   reuse that module's merge rule instead of restating it.
 //!
 //! # Two things that stay with the platform
 //!
@@ -22,6 +25,7 @@
 
 pub mod settings;
 pub mod transfer;
+pub mod unikey;
 
 #[cfg(test)]
 mod test_support;

--- a/crates/funput-config/src/settings/model.rs
+++ b/crates/funput-config/src/settings/model.rs
@@ -61,6 +61,15 @@ pub struct Settings {
     pub excluded_apps: Vec<ExcludedApp>,
     #[serde(default)]
     pub shortcuts: Vec<Shortcut>,
+    /// Whether the gõ tắt table expands. Defaults to **on**, including for a file
+    /// written before this field existed — those users have a working table and
+    /// would otherwise find it silently dead after an update.
+    #[serde(default = "shortcuts_enabled_default")]
+    pub shortcuts_enabled: bool,
+}
+
+fn shortcuts_enabled_default() -> bool {
+    true
 }
 
 impl Settings {
@@ -96,6 +105,7 @@ impl Default for Settings {
             app_language_memory: BTreeMap::new(),
             excluded_apps: Vec::new(),
             shortcuts: Vec::new(),
+            shortcuts_enabled: true,
         }
     }
 }

--- a/crates/funput-config/src/settings/model/tests.rs
+++ b/crates/funput-config/src/settings/model/tests.rs
@@ -105,3 +105,35 @@ fn a_minimal_legacy_file_falls_back_to_defaults() {
     assert!(s.app_language_memory.is_empty());
     assert!(s.shortcuts.is_empty());
 }
+
+/// The gõ tắt switch is the one added field whose absent value must not be `false`:
+/// a file written before it existed belongs to someone with a working table, and
+/// defaulting off would leave them wondering why their shortcuts died.
+#[test]
+fn a_file_without_the_shortcut_switch_still_expands() {
+    let legacy = r#"{
+      "method": "vni",
+      "enabled": true,
+      "smartRestore": true,
+      "eagerRestore": true,
+      "toggleHotkey": "ctrl_backtick",
+      "launchAtLogin": false,
+      "hasCompletedOnboarding": false,
+      "shortcuts": [{ "trigger": "vn", "expansion": "Việt Nam" }]
+    }"#;
+    let s: Settings = serde_json::from_str(legacy).expect("legacy settings.json must decode");
+
+    assert!(s.shortcuts_enabled);
+    assert_eq!(s.shortcuts.len(), 1);
+}
+
+#[test]
+fn the_shortcut_switch_round_trips_when_turned_off() {
+    let s = Settings {
+        shortcuts_enabled: false,
+        ..Settings::default()
+    };
+    let text = serde_json::to_string(&s).expect("serialize");
+    let back: Settings = serde_json::from_str(&text).expect("deserialize");
+    assert!(!back.shortcuts_enabled);
+}

--- a/crates/funput-config/src/transfer/apply.rs
+++ b/crates/funput-config/src/transfer/apply.rs
@@ -29,6 +29,7 @@ pub fn to_document(s: &Settings, source: Source) -> ConfigDocument {
             eager_restore: Some(s.eager_restore),
             spell_check: Some(s.spell_check),
             auto_capitalize: Some(s.auto_capitalize),
+            shortcuts_enabled: Some(s.shortcuts_enabled),
         }),
         shortcuts: Some(
             s.shortcuts
@@ -91,6 +92,9 @@ fn apply_preferences(s: &mut Settings, prefs: &Preferences) {
     }
     if let Some(v) = prefs.auto_capitalize {
         s.auto_capitalize = v;
+    }
+    if let Some(v) = prefs.shortcuts_enabled {
+        s.shortcuts_enabled = v;
     }
 }
 

--- a/crates/funput-config/src/transfer/document.rs
+++ b/crates/funput-config/src/transfer/document.rs
@@ -64,6 +64,10 @@ pub struct Preferences {
     pub spell_check: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_capitalize: Option<bool>,
+    /// Whether the gõ tắt rows carried in `shortcuts` actually expand. Portable
+    /// because it is a typing preference, not a per-OS one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shortcuts_enabled: Option<bool>,
 }
 
 /// Comparable and printable because it is also what [`crate::unikey`] parses a

--- a/crates/funput-config/src/transfer/document.rs
+++ b/crates/funput-config/src/transfer/document.rs
@@ -66,7 +66,9 @@ pub struct Preferences {
     pub auto_capitalize: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize)]
+/// Comparable and printable because it is also what [`crate::unikey`] parses a
+/// UniKey macro table into, and those rows are asserted on directly in tests.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PortableShortcut {
     pub trigger: String,
     pub expansion: String,

--- a/crates/funput-config/src/unikey.rs
+++ b/crates/funput-config/src/unikey.rs
@@ -1,0 +1,148 @@
+//! Reading UniKey's gõ tắt table into Funput's shortcut rows.
+//!
+//! UniKey keeps its macros in `ukmacro.txt` beside the executable. The format is
+//! not documented anywhere; this is what a real file from UniKey 4.6 RC2 contains,
+//! byte for byte:
+//!
+//! ```text
+//! EF BB BF                                   UTF-8 BOM
+//! ;DO NOT DELETE THIS LINE*** version=1 ***  header, CRLF
+//! vn:việt nam                                one pair, split at the first colon
+//! ```
+//!
+//! Only the pair lines matter. The header is not required — a hand-edited file or
+//! another UniKey build should still import — so anything starting with `;` is
+//! simply skipped as a comment.
+//!
+//! What comes out is [`PortableShortcut`], the same shape Export/Import already
+//! carries, so the caller can hand it to [`crate::transfer::apply`] and inherit the
+//! merge rule and the counters instead of restating them.
+
+mod encoding;
+
+use std::fmt;
+use std::path::Path;
+
+use crate::transfer::PortableShortcut;
+
+/// Why a macro table could not be turned into shortcut rows.
+///
+/// Separate from [`crate::transfer::ConfigError`] because that one's messages name
+/// "cấu hình", which would read wrong for a gõ tắt file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MacroError {
+    /// The file could not be opened or read at all.
+    Unreadable,
+    /// Read, but the bytes are not text this can decode — most likely a legacy
+    /// 8-bit Vietnamese encoding (TCVN3, VNI-Windows).
+    UnknownEncoding,
+    /// Decoded, but held no usable `trigger:expansion` line.
+    NoEntries,
+}
+
+impl fmt::Display for MacroError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let text = match self {
+            Self::Unreadable => "Không đọc được tệp bảng gõ tắt.",
+            Self::UnknownEncoding => {
+                "Bảng mã của tệp này không đọc được. Hãy mở lại bằng UniKey và ghi \
+                 bảng gõ tắt ra tệp mới (Unicode)."
+            }
+            Self::NoEntries => "Tệp không có mục gõ tắt nào.",
+        };
+        f.write_str(text)
+    }
+}
+
+impl std::error::Error for MacroError {}
+
+/// Read a UniKey macro file and turn it into shortcut rows.
+pub fn read_macro_file(path: &Path) -> Result<Vec<PortableShortcut>, MacroError> {
+    let bytes = std::fs::read(path).map_err(|_| MacroError::Unreadable)?;
+    let text = encoding::decode(&bytes).ok_or(MacroError::UnknownEncoding)?;
+    let rows = parse_macros(&text);
+    if rows.is_empty() {
+        return Err(MacroError::NoEntries);
+    }
+    Ok(rows)
+}
+
+/// Parse the text of a macro table. Unusable lines are dropped, not reported: a
+/// table is a list of independent pairs, and one odd line is no reason to refuse
+/// the rest.
+///
+/// A trigger repeated inside one file keeps its last value, matching the
+/// "incoming wins" rule the merge downstream applies between files.
+pub fn parse_macros(text: &str) -> Vec<PortableShortcut> {
+    let mut rows: Vec<PortableShortcut> = Vec::new();
+    for line in text.trim_start_matches('\u{feff}').lines() {
+        let Some(row) = parse_line(line) else {
+            continue;
+        };
+        match rows.iter_mut().find(|kept| kept.trigger == row.trigger) {
+            Some(kept) => kept.expansion = row.expansion,
+            None => rows.push(row),
+        }
+    }
+    rows
+}
+
+/// One `trigger:expansion` line, or `None` for a blank line, a `;` comment, a line
+/// with no colon, or one whose sides are blank.
+///
+/// Dropping blank sides here is load-bearing, not tidiness: import writes straight
+/// through `replace_settings` and never passes `ShellState`'s `is_complete` filter,
+/// so an empty row would reach `settings.json` and the engine's table.
+fn parse_line(line: &str) -> Option<PortableShortcut> {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with(';') {
+        return None;
+    }
+    // The first colon only: an expansion is free to contain more of them, which is
+    // how `url:https://funput.app` keeps its scheme.
+    let (trigger, expansion) = line.split_once(':')?;
+    let trigger = normalize_trigger(trigger.trim());
+    let expansion = expansion.trim();
+    if trigger.is_empty() || expansion.is_empty() {
+        return None;
+    }
+    Some(PortableShortcut {
+        trigger,
+        expansion: expansion.to_string(),
+    })
+}
+
+/// Store the trigger the way the engine expects to find it.
+///
+/// `funput_engine`'s `classify_case` folds a typed word to lowercase before looking
+/// it up whenever its letters form a clean pattern, so `vn`, `Vn` and `VN` all reach
+/// a trigger stored as `vn` and re-case the expansion to match. A trigger stored in
+/// any other casing is only ever found by an exact match — so folding is what makes
+/// an imported `VN` usable, and *not* folding is what keeps a deliberate `iOS` from
+/// becoming unreachable.
+fn normalize_trigger(trigger: &str) -> String {
+    if folds_to_lowercase(trigger) {
+        trigger.to_lowercase()
+    } else {
+        trigger.to_string()
+    }
+}
+
+/// Mirrors `classify_case` returning `Some`: letters only, digits and punctuation
+/// ignored; first letter lowercase with the rest lowercase, or first letter
+/// uppercase with the rest all one case. A trigger with no letters folds to itself.
+fn folds_to_lowercase(trigger: &str) -> bool {
+    let mut letters = trigger.chars().filter(|c| c.is_alphabetic());
+    let Some(first) = letters.next() else {
+        return true;
+    };
+    let rest: Vec<char> = letters.collect();
+    if first.is_lowercase() {
+        rest.iter().all(|c| c.is_lowercase())
+    } else {
+        rest.iter().all(|c| c.is_uppercase()) || rest.iter().all(|c| c.is_lowercase())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/funput-config/src/unikey/encoding.rs
+++ b/crates/funput-config/src/unikey/encoding.rs
@@ -1,0 +1,76 @@
+//! Turning a macro file's bytes into text.
+//!
+//! Reading bytes rather than `fs::read_to_string` is deliberate: that helper hard-
+//! fails on anything that is not UTF-8 and cannot tell "this is UTF-16" from "this
+//! is corrupt". A legacy 8-bit Vietnamese encoding (TCVN3, VNI-Windows) still fails
+//! here, but as its own answer, so the caller can say what to do about it — guessing
+//! at one of those would silently import mojibake the user then has to hunt down row
+//! by row.
+
+/// Decode by byte-order mark, falling back to plain UTF-8. `None` when the bytes are
+/// none of those.
+pub(super) fn decode(bytes: &[u8]) -> Option<String> {
+    if let Some(rest) = bytes.strip_prefix(&[0xEF, 0xBB, 0xBF]) {
+        return String::from_utf8(rest.to_vec()).ok();
+    }
+    if let Some(rest) = bytes.strip_prefix(&[0xFF, 0xFE]) {
+        return utf16(rest, u16::from_le_bytes);
+    }
+    if let Some(rest) = bytes.strip_prefix(&[0xFE, 0xFF]) {
+        return utf16(rest, u16::from_be_bytes);
+    }
+    String::from_utf8(bytes.to_vec()).ok()
+}
+
+fn utf16(bytes: &[u8], unit: fn([u8; 2]) -> u16) -> Option<String> {
+    if !bytes.len().is_multiple_of(2) {
+        return None;
+    }
+    let units: Vec<u16> = bytes
+        .chunks_exact(2)
+        .map(|pair| unit([pair[0], pair[1]]))
+        .collect();
+    String::from_utf16(&units).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_utf8_bom_is_stripped_rather_than_decoded_into_the_text() {
+        assert_eq!(decode(b"\xEF\xBB\xBFvn").as_deref(), Some("vn"));
+    }
+
+    #[test]
+    fn plain_utf8_without_a_bom_still_decodes() {
+        assert_eq!(
+            decode("vn:việt nam".as_bytes()).as_deref(),
+            Some("vn:việt nam")
+        );
+    }
+
+    #[test]
+    fn both_utf16_byte_orders_decode() {
+        let text = "vn:việt nam";
+        let mut le = vec![0xFF, 0xFE];
+        let mut be = vec![0xFE, 0xFF];
+        for unit in text.encode_utf16() {
+            le.extend_from_slice(&unit.to_le_bytes());
+            be.extend_from_slice(&unit.to_be_bytes());
+        }
+        assert_eq!(decode(&le).as_deref(), Some(text));
+        assert_eq!(decode(&be).as_deref(), Some(text));
+    }
+
+    #[test]
+    fn a_truncated_utf16_file_is_refused_rather_than_half_read() {
+        assert_eq!(decode(&[0xFF, 0xFE, 0x76]), None);
+    }
+
+    #[test]
+    fn a_legacy_eight_bit_encoding_is_refused() {
+        // 0xFF mid-stream: not valid UTF-8, no BOM to explain it.
+        assert_eq!(decode(b"vn:vi\xFFt nam"), None);
+    }
+}

--- a/crates/funput-config/src/unikey/tests.rs
+++ b/crates/funput-config/src/unikey/tests.rs
@@ -1,0 +1,146 @@
+use std::fs;
+
+use super::*;
+use crate::test_support::unique_dir;
+
+/// Write `bytes` to a scratch file and read it back through the real entry point,
+/// so BOM handling and decoding are exercised rather than bypassed.
+fn read_bytes(bytes: &[u8]) -> Result<Vec<PortableShortcut>, MacroError> {
+    let dir = unique_dir("unikey");
+    let path = dir.join("ukmacro.txt");
+    fs::write(&path, bytes).expect("write scratch macro file");
+    let result = read_macro_file(&path);
+    let _ = fs::remove_dir_all(&dir);
+    result
+}
+
+fn pairs(rows: &[PortableShortcut]) -> Vec<(&str, &str)> {
+    rows.iter()
+        .map(|r| (r.trigger.as_str(), r.expansion.as_str()))
+        .collect()
+}
+
+/// The 59 bytes of a stock UniKey 4.6 RC2 `ukmacro.txt`, exactly as measured.
+const SAMPLE: &[u8] =
+    b"\xEF\xBB\xBF;DO NOT DELETE THIS LINE*** version=1 ***\r\nvn:vi\xE1\xBB\x87t nam";
+
+#[test]
+fn the_stock_unikey_file_yields_its_one_pair() {
+    let rows = read_bytes(SAMPLE);
+    let rows = rows.expect("the stock file must import");
+    assert_eq!(pairs(&rows), vec![("vn", "việt nam")]);
+}
+
+#[test]
+fn the_bom_never_leaks_into_the_first_trigger() {
+    // A stray U+FEFF on the trigger would make it unmatchable while looking right
+    // in the settings list — the kind of bug that costs an afternoon.
+    let rows = read_bytes(b"\xEF\xBB\xBFvn:viet nam");
+    let rows = rows.expect("import");
+    assert_eq!(rows[0].trigger, "vn");
+}
+
+#[test]
+fn comments_and_blank_lines_are_skipped() {
+    let rows = parse_macros(";header\n\nvn:việt nam\n   \n; another comment\nct:công ty\n");
+    assert_eq!(pairs(&rows), vec![("vn", "việt nam"), ("ct", "công ty")]);
+}
+
+#[test]
+fn an_expansion_may_contain_colons() {
+    // Split on the first colon only, or every URL in the table loses its scheme.
+    let rows = parse_macros("url:https://funput.app\n");
+    assert_eq!(pairs(&rows), vec![("url", "https://funput.app")]);
+}
+
+#[test]
+fn lines_with_a_blank_side_are_dropped() {
+    // The only guard there is: import writes through `replace_settings` and never
+    // meets `ShellState::is_complete`, so a blank row would reach settings.json.
+    let rows = parse_macros(":nothing\nvn:\n   :   \nno colon here\nok:fine\n");
+    assert_eq!(pairs(&rows), vec![("ok", "fine")]);
+}
+
+#[test]
+fn whitespace_around_the_separator_is_trimmed() {
+    let rows = parse_macros("  vn  :  việt nam  \n");
+    assert_eq!(pairs(&rows), vec![("vn", "việt nam")]);
+}
+
+#[test]
+fn a_clean_case_pattern_folds_so_the_engine_can_smart_case_it() {
+    let rows = parse_macros("VN:việt nam\nCt:công ty\nhn:hà nội\n");
+    assert_eq!(
+        pairs(&rows),
+        vec![("vn", "việt nam"), ("ct", "công ty"), ("hn", "hà nội")]
+    );
+}
+
+#[test]
+fn a_deliberately_mixed_trigger_is_left_alone() {
+    // `classify_case` gives up on these and looks them up verbatim, so folding
+    // would store a row nothing can ever match.
+    let rows = parse_macros("iOS:hệ điều hành iOS\nvNa:gì đó\n");
+    assert_eq!(
+        pairs(&rows),
+        vec![("iOS", "hệ điều hành iOS"), ("vNa", "gì đó")]
+    );
+}
+
+#[test]
+fn digits_do_not_stop_a_trigger_from_folding() {
+    let rows = parse_macros("K1:kho một\n");
+    assert_eq!(pairs(&rows), vec![("k1", "kho một")]);
+}
+
+#[test]
+fn a_repeated_trigger_keeps_its_last_value() {
+    // Same rule the cross-file merge uses, applied within one file.
+    let rows = parse_macros("vn:cũ\nvn:mới\n");
+    assert_eq!(pairs(&rows), vec![("vn", "mới")]);
+}
+
+#[test]
+fn folding_makes_two_spellings_of_one_trigger_collide() {
+    let rows = parse_macros("vn:thường\nVN:hoa\n");
+    assert_eq!(pairs(&rows), vec![("vn", "hoa")]);
+}
+
+#[test]
+fn crlf_and_lf_parse_the_same() {
+    let crlf = parse_macros("vn:việt nam\r\nct:công ty\r\n");
+    let lf = parse_macros("vn:việt nam\nct:công ty\n");
+    assert_eq!(pairs(&crlf), pairs(&lf));
+}
+
+#[test]
+fn a_utf16_file_decodes_through_its_bom() {
+    let mut bytes = vec![0xFF, 0xFE];
+    for unit in "vn:việt nam".encode_utf16() {
+        bytes.extend_from_slice(&unit.to_le_bytes());
+    }
+    let rows = read_bytes(&bytes);
+    assert_eq!(pairs(&rows.expect("import")), vec![("vn", "việt nam")]);
+}
+
+#[test]
+fn a_file_with_nothing_usable_is_an_error() {
+    let rows = read_bytes(b"\xEF\xBB\xBF;DO NOT DELETE THIS LINE*** version=1 ***\r\n");
+    assert_eq!(rows, Err(MacroError::NoEntries));
+}
+
+#[test]
+fn a_legacy_encoding_is_named_rather_than_guessed_at() {
+    // 0xFF is not valid UTF-8 and carries no BOM: report it instead of importing
+    // mojibake the user would have to hunt down row by row.
+    let rows = read_bytes(b"vn:vi\xFFt nam");
+    assert_eq!(rows, Err(MacroError::UnknownEncoding));
+}
+
+#[test]
+fn a_missing_file_is_unreadable() {
+    let dir = unique_dir("unikey-missing");
+    let result = read_macro_file(&dir.join("nope.txt"));
+    let _ = fs::remove_dir_all(&dir);
+    assert_eq!(result, Err(MacroError::Unreadable));
+}

--- a/crates/funput-desktop/src/shell/config.rs
+++ b/crates/funput-desktop/src/shell/config.rs
@@ -18,8 +18,9 @@ impl ShellState {
         self.reset_composition();
     }
 
-    /// Push the six engine options in one call. `enabled` and the gõ tắt table are
-    /// separate (see [`ShellState::set_enabled_state`] and [`push_shortcuts`]).
+    /// Push the engine options in one call. `enabled` and the gõ tắt *rows* are
+    /// separate (see [`ShellState::set_enabled_state`] and [`push_shortcuts`]); the
+    /// switch that decides whether those rows expand is an option and rides here.
     pub(super) fn sync_engine_config(&mut self) {
         self.engine.configure(EngineConfig {
             method: self.settings.method.core(),
@@ -28,6 +29,7 @@ impl ShellState {
             eager_restore: self.settings.eager_restore,
             spell_check: self.settings.spell_check,
             auto_capitalize: self.settings.auto_capitalize,
+            shortcuts_enabled: self.settings.shortcuts_enabled,
         });
     }
 

--- a/crates/funput-desktop/src/shell/options.rs
+++ b/crates/funput-desktop/src/shell/options.rs
@@ -37,6 +37,12 @@ impl ShellState {
         self.update_config(|s| s.auto_capitalize = on);
     }
 
+    /// Turn gõ tắt expansion on or off. The table itself is left alone, so the rows
+    /// are still there — and still editable — while it is off.
+    pub fn set_shortcuts_enabled(&mut self, on: bool) {
+        self.update_config(|s| s.shortcuts_enabled = on);
+    }
+
     /// Picking a preset also clears any recorded custom combo — the two are
     /// alternatives, and the combo (when present) always wins in the hook.
     pub fn set_toggle_hotkey(&mut self, hotkey: Hotkey) {

--- a/crates/funput-engine/src/compose/boundary/mod.rs
+++ b/crates/funput-engine/src/compose/boundary/mod.rs
@@ -94,7 +94,9 @@ fn apply_shortcut_case(expansion: &str, case: ShortcutCase) -> String {
 }
 
 fn shortcut_expansion(session: &Session, boundary_key: char) -> Option<ImeResult> {
-    if session.keys.is_empty() {
+    // Gated here rather than by clearing the table: the rows stay loaded, so the
+    // switch is instant in both directions and nothing has to be re-pushed.
+    if !session.config.shortcuts_enabled || session.keys.is_empty() {
         return None;
     }
     let case = classify_case(&session.keys);

--- a/crates/funput-engine/src/compose/boundary/tests/mod.rs
+++ b/crates/funput-engine/src/compose/boundary/tests/mod.rs
@@ -14,6 +14,7 @@ fn session(method: InputMethod, buffer: &str, keys: &str) -> Session {
             eager_restore: true,
             spell_check: false,
             auto_capitalize: false,
+            shortcuts_enabled: true,
         },
         buffer: buffer.into(),
         keys: keys.into(),

--- a/crates/funput-engine/src/model/config.rs
+++ b/crates/funput-engine/src/model/config.rs
@@ -26,6 +26,12 @@ pub struct EngineConfig {
     /// Auto-capitalize ("Tự động viết hoa"): uppercase the first letter of a word at
     /// the start of a sentence. Off by default.
     pub auto_capitalize: bool,
+    /// Whether the gõ tắt table expands at all ("Bật gõ tắt"). On by default.
+    ///
+    /// A switch rather than an empty table, so turning the feature off for a moment
+    /// — to type a word that collides with a trigger — costs nothing and gives the
+    /// rows back untouched.
+    pub shortcuts_enabled: bool,
 }
 
 impl Default for EngineConfig {
@@ -37,6 +43,7 @@ impl Default for EngineConfig {
             eager_restore: true,
             spell_check: false,
             auto_capitalize: false,
+            shortcuts_enabled: true,
         }
     }
 }

--- a/crates/funput-engine/tests/engine_api.rs
+++ b/crates/funput-engine/tests/engine_api.rs
@@ -469,6 +469,7 @@ fn configure_applies_all_options() {
         eager_restore: false,
         spell_check: true,
         auto_capitalize: true,
+        shortcuts_enabled: false,
     });
     assert_eq!(engine.method(), InputMethod::Vni);
     assert_eq!(engine.tone_style(), ToneStyle::Modern);
@@ -476,6 +477,7 @@ fn configure_applies_all_options() {
     assert_eq!(config.method, InputMethod::Vni);
     assert!(config.spell_check && config.auto_capitalize);
     assert!(!config.smart_restore && !config.eager_restore);
+    assert!(!config.shortcuts_enabled);
 }
 
 /// `configure` keeps the `set_*` side effect: switching method mid-word clears the

--- a/crates/funput-engine/tests/words/shortcut.rs
+++ b/crates/funput-engine/tests/words/shortcut.rs
@@ -149,3 +149,58 @@ fn re_adding_trigger_overwrites() {
         Some("Vietnam")
     );
 }
+
+/// Drive `keys` with gõ tắt switched off, otherwise identical to
+/// [`app_text_with_shortcuts`].
+fn app_text_with_shortcuts_off(shortcuts: &[(&str, &str)], keys: &str) -> String {
+    let mut engine = Engine::new();
+    engine.update_config(|config| config.shortcuts_enabled = false);
+    for (trigger, expansion) in shortcuts {
+        engine.add_shortcut(*trigger, *expansion);
+    }
+    let mut app = String::new();
+    for key in keys.chars() {
+        let r = engine.process_char(key);
+        match r.action {
+            Action::None => app.push(key),
+            Action::Send => {
+                for _ in 0..r.backspace {
+                    app.pop();
+                }
+                app.push_str(&r.output);
+            }
+            Action::Restore => unreachable!("Restore not implemented yet"),
+        }
+    }
+    app
+}
+
+#[test]
+fn the_switch_stops_expansion_without_touching_the_table() {
+    let text = app_text_with_shortcuts_off(&[("vn", "Việt Nam")], "vn ");
+    assert_eq!(text, "vn ", "the trigger must stay as typed");
+}
+
+#[test]
+fn a_word_that_is_not_a_trigger_still_composes_with_the_switch_off() {
+    // Turning gõ tắt off must not disturb ordinary Vietnamese composition.
+    let text = app_text_with_shortcuts_off(&[("vn", "Việt Nam")], "chaof ");
+    assert_eq!(text, "chào ");
+}
+
+#[test]
+fn the_table_survives_the_switch_so_flipping_back_costs_nothing() {
+    let mut engine = Engine::new();
+    engine.add_shortcut("vn", "Việt Nam");
+    engine.update_config(|config| config.shortcuts_enabled = false);
+    assert_eq!(
+        engine.shortcuts().get("vn").map(String::as_str),
+        Some("Việt Nam"),
+        "the rows must outlive the switch"
+    );
+    engine.update_config(|config| config.shortcuts_enabled = true);
+    for key in "vn ".chars() {
+        engine.process_char(key);
+    }
+    assert_eq!(engine.shortcuts().len(), 1);
+}

--- a/crates/funput-ffi/src/engine/config.rs
+++ b/crates/funput-ffi/src/engine/config.rs
@@ -75,6 +75,12 @@ pub unsafe extern "C" fn funput_configure(engine: *mut FunputEngine, config: Fun
         eager_restore: config.eager_restore,
         spell_check: config.spell_check,
         auto_capitalize: config.auto_capitalize,
+        // Not in `FunputConfig`: this struct crosses the C ABI by value, and the
+        // Swift side declaring it is built separately, so growing it here would
+        // mismatch silently until every consumer is rebuilt. The hosts on this ABI
+        // have no gõ tắt switch yet, and `true` is what they behaved as before —
+        // give them a dedicated setter when one of them grows the feature.
+        shortcuts_enabled: true,
     };
     unsafe { abi::with_engine_mut(engine, |e| e.configure(cfg)) }
 }

--- a/crates/funput-jni/src/engine/settings.rs
+++ b/crates/funput-jni/src/engine/settings.rs
@@ -34,6 +34,11 @@ pub extern "system" fn Java_app_funput_funput_ime_nativebridge_FunputNative_nati
         eager_restore,
         spell_check,
         auto_capitalize,
+        // Not a parameter: the JNI symbol name encodes the Java signature, so an
+        // extra argument would stop Kotlin finding this function at all until the
+        // `external fun` is changed to match. Android has no gõ tắt switch yet, and
+        // `true` is how it behaved before there was one.
+        shortcuts_enabled: true,
     };
     update(handle, |engine| engine.configure(config));
 }

--- a/crates/funput-term/src/config/mod.rs
+++ b/crates/funput-term/src/config/mod.rs
@@ -44,6 +44,9 @@ pub struct TermConfig {
     pub spell_check: bool,
     pub auto_capitalize: bool,
     pub shortcuts: Vec<(String, String)>,
+    /// Whether those shortcuts expand. Read from the same `settings.json` the GUI
+    /// writes, so turning gõ tắt off there turns it off here too.
+    pub shortcuts_enabled: bool,
     /// The byte that toggles VI/EN.
     pub toggle: u8,
     /// The byte that cycles Telex↔VNI at runtime, or `None` to disable.
@@ -75,6 +78,7 @@ impl From<FileSettings> for TermConfig {
                 .into_iter()
                 .map(|s| (s.trigger, s.expansion))
                 .collect(),
+            shortcuts_enabled: f.shortcuts_enabled,
             toggle: DEFAULT_TOGGLE,
             cycle_method: DEFAULT_CYCLE_METHOD,
             vi_cursor_color: DEFAULT_VI_CURSOR_COLOR.to_string(),
@@ -102,6 +106,7 @@ impl TermConfig {
             eager_restore: self.eager_restore,
             spell_check: self.spell_check,
             auto_capitalize: self.auto_capitalize,
+            shortcuts_enabled: self.shortcuts_enabled,
         });
         engine.clear_shortcuts();
         for (trigger, expansion) in &self.shortcuts {

--- a/crates/funput-term/src/config/schema.rs
+++ b/crates/funput-term/src/config/schema.rs
@@ -73,6 +73,8 @@ pub(super) struct FileSettings {
     pub(super) auto_capitalize: bool,
     #[serde(default)]
     pub(super) shortcuts: Vec<Shortcut>,
+    #[serde(default = "default_true")]
+    pub(super) shortcuts_enabled: bool,
 }
 
 fn default_true() -> bool {

--- a/platforms/CONFIG_FORMAT.md
+++ b/platforms/CONFIG_FORMAT.md
@@ -40,7 +40,8 @@ one machine imports on another. macOS is the first implementation
     "smartEnglishRestore": true,
     "eagerRestore": true,
     "spellCheck": false,
-    "autoCapitalize": false
+    "autoCapitalize": false,
+    "shortcutsEnabled": true
   },
 
   "shortcuts": [
@@ -67,7 +68,7 @@ one machine imports on another. macOS is the first implementation
 | `source` | — | `platform` + `appVersion` that produced the file. Metadata only. |
 | `preferences.inputMethod` | ✅ | `telex`, `telex_advanced`, or `vni`. Exposed on macOS, Windows, Linux, iOS, and Android; unsupported consumers keep their current selection. |
 | `preferences.*` | ✅ | Other typing options; each is optional and applied only if present. |
-| `shortcuts[]` | ✅ | `{ trigger, expansion }`. Local UUIDs are dropped; recreated on import. |
+| `shortcuts[]` | ✅ | `{ trigger, expansion }`. Local UUIDs are dropped; recreated on import. Whether they expand is `preferences.shortcutsEnabled`, which defaults to `true` when absent — an older file carries a working table and must not arrive switched off. |
 | `platform.macos.toggleShortcut` | ❌ | `KeyCombo` (`keyCode` is AppKit-specific). Applied only on macOS, only if present. |
 | `platform.macos.flipShortcut` | ❌ | `KeyCombo` or `null`. Applied only on macOS, only if present. |
 | `platform.macos.appLanguageMemory` | ❌ | `{ bundleId: rememberedIsVietnamese }`. macOS-only per-app VI/EN memory; merged by key, existing entries win. |

--- a/platforms/windows/src/shared/commands/config.rs
+++ b/platforms/windows/src/shared/commands/config.rs
@@ -1,8 +1,12 @@
-//! Export and import of the shared config document.
+//! Export and import of the shared config document, and importing a UniKey
+//! gõ tắt table.
 
 use std::path::Path;
 
-use funput_config::transfer::{self, ConfigError, ImportSummary, Source};
+use funput_config::transfer::{
+    self, ConfigDocument, ConfigError, ImportSummary, Source, SCHEMA_ID,
+};
+use funput_config::unikey::{self, MacroError};
 
 use crate::shared::shell;
 
@@ -22,6 +26,30 @@ pub fn export_config(path: &Path) -> std::io::Result<()> {
 pub fn import_config(path: &Path) -> Result<ImportSummary, ConfigError> {
     let mut settings = shell::snapshot();
     let summary = transfer::import_file(path, &mut settings)?;
+    shell::replace_settings(settings);
+    Ok(summary)
+}
+
+/// Merge a UniKey `ukmacro.txt` into the live gõ tắt table.
+///
+/// The parsed rows are wrapped in a document carrying nothing else, so
+/// [`transfer::apply`] does the merging — same rule as importing a Funput config
+/// (a repeated trigger takes the incoming expansion, rows absent from the file
+/// survive) and the same counters back. Restating that here would be a second copy
+/// of a rule that has to stay identical in both places.
+pub fn import_unikey_macros(path: &Path) -> Result<ImportSummary, MacroError> {
+    let shortcuts = unikey::read_macro_file(path)?;
+    let document = ConfigDocument {
+        schema: SCHEMA_ID.to_string(),
+        version: transfer::CURRENT_VERSION,
+        exported_at: None,
+        source: None,
+        preferences: None,
+        shortcuts: Some(shortcuts),
+        platform: None,
+    };
+    let mut settings = shell::snapshot();
+    let summary = transfer::apply(&mut settings, &document);
     shell::replace_settings(settings);
     Ok(summary)
 }

--- a/platforms/windows/src/shared/commands/mod.rs
+++ b/platforms/windows/src/shared/commands/mod.rs
@@ -10,7 +10,7 @@ mod settings;
 mod system;
 mod updates;
 
-pub use config::{export_config, import_config};
+pub use config::{export_config, import_config, import_unikey_macros};
 pub use settings::*;
 pub use system::{open_url, set_launch_at_login, sync_autostart};
 pub use updates::{check_for_updates, install_update, relaunch_after_update};

--- a/platforms/windows/src/shared/commands/settings.rs
+++ b/platforms/windows/src/shared/commands/settings.rs
@@ -31,6 +31,10 @@ pub fn set_auto_capitalize(on: bool) {
     shell::set_auto_capitalize(on);
 }
 
+pub fn set_shortcuts_enabled(on: bool) {
+    shell::set_shortcuts_enabled(on);
+}
+
 pub fn set_enabled(on: bool) {
     shell::set_enabled(on);
 }

--- a/platforms/windows/src/shared/shell/settings.rs
+++ b/platforms/windows/src/shared/shell/settings.rs
@@ -75,6 +75,9 @@ pub fn set_spell_check(on: bool) {
 pub fn set_auto_capitalize(on: bool) {
     with(|s| s.set_auto_capitalize(on));
 }
+pub fn set_shortcuts_enabled(on: bool) {
+    with(|s| s.set_shortcuts_enabled(on));
+}
 pub fn set_toggle_hotkey(hotkey: Hotkey) {
     with(|s| s.set_toggle_hotkey(hotkey));
 }

--- a/platforms/windows/src/ui/settings_callbacks.rs
+++ b/platforms/windows/src/ui/settings_callbacks.rs
@@ -88,6 +88,7 @@ pub(super) fn wire(window: &SettingsWindow) {
     window.on_set_eager(commands::set_eager_restore);
     window.on_set_spell(commands::set_spell_check);
     window.on_set_auto_cap(commands::set_auto_capitalize);
+    window.on_set_shortcuts_enabled(commands::set_shortcuts_enabled);
     window.on_set_launch(commands::set_launch_at_login);
 
     let weak = window.as_weak();

--- a/platforms/windows/src/ui/settings_callbacks/config.rs
+++ b/platforms/windows/src/ui/settings_callbacks/config.rs
@@ -1,3 +1,10 @@
+//! The Dữ liệu page: export, import, and bringing a UniKey table over.
+//!
+//! The file pickers stay native — that is the one dialog Windows should own — but
+//! results are reported through the window's own [`Notice`](../../../ui/shell/notice.slint)
+//! overlay rather than `rfd::MessageDialog`, which draws a system message box with
+//! none of this window's Fluent tokens and no idea about the Mica backdrop.
+
 use slint::ComponentHandle;
 
 use crate::shared::commands;
@@ -7,7 +14,8 @@ use funput_config::transfer::{self, ImportSummary};
 use super::super::settings_window;
 
 pub(super) fn wire(window: &SettingsWindow) {
-    window.on_export_config(|| {
+    let weak = window.as_weak();
+    window.on_export_config(move || {
         let Some(path) = rfd::FileDialog::new()
             .set_file_name(format!("Funput-config-{}.json", transfer::today_stamp()))
             .add_filter("JSON", &["json"])
@@ -15,8 +23,12 @@ pub(super) fn wire(window: &SettingsWindow) {
         else {
             return;
         };
-        if let Err(err) = commands::export_config(&path) {
-            message(&format!("Không xuất được cấu hình: {err}"));
+        let Some(window) = weak.upgrade() else {
+            return;
+        };
+        match commands::export_config(&path) {
+            Ok(()) => notice(&window, "Đã xuất cấu hình", &shown_path(&path), false),
+            Err(err) => notice(&window, "Không xuất được cấu hình", &err.to_string(), true),
         }
     });
 
@@ -28,26 +40,82 @@ pub(super) fn wire(window: &SettingsWindow) {
         else {
             return;
         };
-        match commands::import_config(&path) {
+        let result = commands::import_config(&path);
+        let Some(window) = weak.upgrade() else {
+            return;
+        };
+        match result {
             Ok(summary) => {
-                if let Some(window) = weak.upgrade() {
-                    settings_window::populate(&window);
-                }
-                message(&import_message(&summary));
+                settings_window::populate(&window);
+                notice(&window, "Đã nhập cấu hình", &import_body(&summary), false);
             }
-            Err(err) => message(&err.to_string()),
+            Err(err) => notice(&window, "Không nhập được cấu hình", &err.to_string(), true),
+        }
+    });
+
+    let weak = window.as_weak();
+    window.on_import_unikey(move || {
+        // UniKey writes `ukmacro.txt`, so `.txt` is the filter — but the file can
+        // be named anything once the user has copied it somewhere, hence the
+        // second, unrestricted entry.
+        let Some(path) = rfd::FileDialog::new()
+            .set_file_name("ukmacro.txt")
+            .add_filter("Bảng gõ tắt UniKey", &["txt"])
+            .add_filter("Tất cả tệp", &["*"])
+            .pick_file()
+        else {
+            return;
+        };
+        let result = commands::import_unikey_macros(&path);
+        let Some(window) = weak.upgrade() else {
+            return;
+        };
+        match result {
+            Ok(summary) => {
+                settings_window::populate(&window);
+                notice(&window, "Đã nhập từ UniKey", &unikey_body(&summary), false);
+            }
+            Err(err) => notice(
+                &window,
+                "Không nhập được bảng gõ tắt",
+                &err.to_string(),
+                true,
+            ),
         }
     });
 }
 
-fn message(text: &str) {
-    rfd::MessageDialog::new()
-        .set_title("Cấu hình")
-        .set_description(text)
-        .show();
+/// Raise the in-window notice. `danger` is for a failure the user has to read, not
+/// a summary they can wave away.
+fn notice(window: &SettingsWindow, title: &str, body: &str, danger: bool) {
+    window.set_notice_title(title.into());
+    window.set_notice_body(body.into());
+    window.set_notice_danger(danger);
+    window.set_notice_open(true);
 }
 
-fn import_message(summary: &ImportSummary) -> String {
+/// Just the file name: the full path is the user's own choice from a dialog they
+/// just dismissed, and spelling it out crowds the notice for no new information.
+fn shown_path(path: &std::path::Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+/// A macro file carries only gõ tắt, so this says nothing about typing options —
+/// unlike [`import_body`], which reports a whole config document. Zero of both
+/// means every row was already present with the same text.
+fn unikey_body(summary: &ImportSummary) -> String {
+    if summary.shortcuts_added == 0 && summary.shortcuts_updated == 0 {
+        return "Bảng gõ tắt đã có sẵn các mục này, không có gì thay đổi.".to_string();
+    }
+    format!(
+        "Gõ tắt: thêm {}, cập nhật {}.",
+        summary.shortcuts_added, summary.shortcuts_updated
+    )
+}
+
+fn import_body(summary: &ImportSummary) -> String {
     let mut lines = vec!["Đã áp các tuỳ chọn gõ.".to_string()];
     if summary.shortcuts_added > 0 || summary.shortcuts_updated > 0 {
         lines.push(format!(

--- a/platforms/windows/src/ui/settings_window.rs
+++ b/platforms/windows/src/ui/settings_window.rs
@@ -102,6 +102,7 @@ pub(super) fn populate(window: &SettingsWindow) {
     window.set_update_version("".into());
     window.set_update_message("".into());
     window.set_shortcuts(models::shortcuts(&shell::shortcuts()));
+    window.set_shortcuts_enabled(settings.shortcuts_enabled);
     window.set_can_add_shortcut(commands::can_add_shortcut());
 }
 

--- a/platforms/windows/ui/pages/data/page.slint
+++ b/platforms/windows/ui/pages/data/page.slint
@@ -1,10 +1,11 @@
-// Settings → "Dữ liệu": export/import config (room to grow later).
+// Settings → "Dữ liệu": export/import config, and bringing a UniKey table over.
 
 import { Theme, PageHeader, Section, Row, PrimaryButton, GhostButton } from "../../theme/mod.slint";
 
 export component DataPage inherits VerticalLayout {
     callback export-config();
     callback import-config();
+    callback import-unikey();
 
     spacing: Theme.sp-lg;
     width: 100%;
@@ -12,7 +13,7 @@ export component DataPage inherits VerticalLayout {
 
     PageHeader {
         title: "Dữ liệu";
-        subtitle: "Xuất và nhập cấu hình Funput.";
+        subtitle: "Xuất, nhập cấu hình Funput và chuyển gõ tắt từ UniKey.";
     }
 
     Section {
@@ -34,6 +35,19 @@ export component DataPage inherits VerticalLayout {
             PrimaryButton {
                 text: "Nhập…";
                 clicked => { root.import-config(); }
+            }
+        }
+    }
+
+    Section {
+        title: "Chuyển từ UniKey";
+        Row {
+            title: "Nhập bảng gõ tắt UniKey";
+            subtitle: "Đọc ukmacro.txt và gộp vào bảng gõ tắt hiện có.";
+            icon: @image-url("../../icons/status/backup.svg");
+            GhostButton {
+                text: "Chọn tệp…";
+                clicked => { root.import-unikey(); }
             }
         }
     }

--- a/platforms/windows/ui/pages/shortcuts/page.slint
+++ b/platforms/windows/ui/pages/shortcuts/page.slint
@@ -1,15 +1,17 @@
 // Settings → "Gõ tắt": manage text-expansion shortcuts.
 
-import { Theme, PageHeader, Section, PrimaryButton, ShortcutEntry } from "../../theme/mod.slint";
+import { Theme, PageHeader, Section, Row, AccentSwitch, PrimaryButton, ShortcutEntry } from "../../theme/mod.slint";
 import { ShortcutRow } from "row.slint";
 
 export component ShortcutsPage inherits VerticalLayout {
     in property <[ShortcutEntry]> shortcuts;
     in property <bool> can-add: true;
+    in-out property <bool> shortcuts-enabled;
     callback add-shortcut();
     callback remove-shortcut(int);
     callback edit-trigger(int, string);
     callback edit-expansion(int, string);
+    callback set-shortcuts-enabled(bool);
 
     spacing: Theme.sp-lg;
     width: 100%;
@@ -18,6 +20,20 @@ export component ShortcutsPage inherits VerticalLayout {
     PageHeader {
         title: "Gõ tắt";
         subtitle: "Bung chữ tắt khi gõ khoảng trắng hoặc dấu câu — tự nhận diện hoa/thường: vn → việt nam, Vn → Việt Nam, VN → VIỆT NAM.";
+    }
+
+    Section {
+        Row {
+            // The page's own sidebar mark, so the switch reads as governing the
+            // whole feature rather than one option among several.
+            icon: @image-url("../../icons/nav/primary/shortcut.svg");
+            title: "Bật gõ tắt";
+            subtitle: "Tắt để tạm gõ nguyên chữ tắt — bảng bên dưới vẫn giữ nguyên.";
+            AccentSwitch {
+                checked <=> root.shortcuts-enabled;
+                toggled => { root.set-shortcuts-enabled(root.shortcuts-enabled); }
+            }
+        }
     }
 
     Section {

--- a/platforms/windows/ui/shell/content.slint
+++ b/platforms/windows/ui/shell/content.slint
@@ -27,6 +27,7 @@ export component SettingsContent inherits ScrollView {
     in-out property <bool> launch-at-login;
     in property <[ShortcutEntry]> shortcuts;
     in property <bool> can-add-shortcut: true;
+    in-out property <bool> shortcuts-enabled;
     in property <string> version;
     in property <string> update-state: "idle";
     in property <string> update-version;
@@ -44,6 +45,7 @@ export component SettingsContent inherits ScrollView {
     callback set-auto-cap(bool);
     callback set-launch(bool);
     callback add-shortcut();
+    callback set-shortcuts-enabled(bool);
     callback remove-shortcut(int);
     callback edit-trigger(int, string);
     callback edit-expansion(int, string);
@@ -104,7 +106,9 @@ export component SettingsContent inherits ScrollView {
             if root.active == "shortcuts": ShortcutsPage {
                 shortcuts: root.shortcuts;
                 can-add: root.can-add-shortcut;
+                shortcuts-enabled <=> root.shortcuts-enabled;
                 add-shortcut() => { root.add-shortcut(); }
+                set-shortcuts-enabled(v) => { root.set-shortcuts-enabled(v); }
                 remove-shortcut(i) => { root.remove-shortcut(i); }
                 edit-trigger(i, t) => { root.edit-trigger(i, t); }
                 edit-expansion(i, t) => { root.edit-expansion(i, t); }

--- a/platforms/windows/ui/shell/content.slint
+++ b/platforms/windows/ui/shell/content.slint
@@ -53,6 +53,7 @@ export component SettingsContent inherits ScrollView {
     callback relaunch-now();
     callback export-config();
     callback import-config();
+    callback import-unikey();
 
     HorizontalLayout {
         padding-top: Theme.sp-lg;
@@ -111,6 +112,7 @@ export component SettingsContent inherits ScrollView {
             if root.active == "data": DataPage {
                 export-config() => { root.export-config(); }
                 import-config() => { root.import-config(); }
+                import-unikey() => { root.import-unikey(); }
             }
             if root.active == "about": AboutPage {
                 version: root.version;

--- a/platforms/windows/ui/shell/notice.slint
+++ b/platforms/windows/ui/shell/notice.slint
@@ -1,0 +1,97 @@
+// A result notice drawn inside the window, replacing the Win32 message box the
+// config actions used to raise. A `rfd::MessageDialog` is a system dialog: square
+// corners, system font, its own grey — none of the Fluent tokens the rest of this
+// window is built from, and it ignores the Mica backdrop entirely.
+//
+// Sits directly under `Window` so it covers the sidebar too, gated by `if` at the
+// call site rather than `visible` so it costs nothing and takes no hits when closed.
+
+import { Palette } from "std-widgets.slint";
+import { Theme, PrimaryButton } from "../theme/mod.slint";
+
+export component Notice inherits Rectangle {
+    in property <string> title;
+    in property <string> body;
+    /// Paints the title in the danger colour — a failure the user has to read,
+    /// rather than a summary they can wave away.
+    in property <bool> danger;
+    callback dismissed();
+
+    // Scrim: dims the page and, with the TouchArea below, is what makes this modal
+    // rather than merely on top.
+    background: Theme.dark ? #0000008c : #00000040;
+
+    TouchArea {
+        clicked => {
+            root.dismissed();
+        }
+    }
+
+    // A modal that only closes by mouse is a trap for anyone who just typed a path
+    // into the file dialog. Focus is taken on `init` because the notice appears
+    // without the user aiming at it, so there is nothing else to hand focus over.
+    keys := FocusScope {
+        init => {
+            self.focus();
+        }
+        key-pressed(event) => {
+            if event.text == Key.Escape || event.text == Key.Return {
+                root.dismissed();
+                return accept;
+            }
+            reject
+        }
+    }
+
+    Rectangle {
+        // Clamped so a long summary wraps instead of stretching edge to edge, and
+        // still fits when the window is narrow.
+        width: min(400px, root.width - 2 * Theme.sp-xl);
+        height: card.preferred-height;
+        x: (root.width - self.width) / 2;
+        y: (root.height - self.height) / 2;
+
+        // `popup-base` is opaque on purpose: this floats over a Mica-transparent
+        // window, where a translucent fill would show the desktop through the text.
+        background: Theme.popup-base;
+        border-radius: Theme.r-card;
+        border-width: 1px;
+        border-color: Theme.card-border;
+        drop-shadow-color: Theme.shadow;
+        drop-shadow-blur: 24px;
+        drop-shadow-offset-y: 8px;
+
+        // Swallows clicks on the card so they do not reach the scrim and dismiss it.
+        TouchArea { }
+
+        card := VerticalLayout {
+            padding: Theme.sp-lg;
+            spacing: Theme.sp-ms;
+
+            Text {
+                // Title size, not body size: at the same 14px as the line below it
+                // the two read as one paragraph and the notice has no shape.
+                text: root.title;
+                font-size: Theme.font-title;
+                font-weight: 700;
+                color: root.danger ? Theme.danger : Palette.foreground;
+                wrap: word-wrap;
+            }
+            Text {
+                text: root.body;
+                font-size: Theme.font-body;
+                color: Theme.subtle;
+                wrap: word-wrap;
+            }
+            HorizontalLayout {
+                alignment: end;
+                PrimaryButton {
+                    text: "OK";
+                    clicked => {
+                        root.dismissed();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/platforms/windows/ui/shell/settings.slint
+++ b/platforms/windows/ui/shell/settings.slint
@@ -5,6 +5,7 @@ import { Theme, ShortcutEntry } from "../theme/mod.slint";
 import { Backdrop } from "backdrop.slint";
 import { Sidebar } from "sidebar.slint";
 import { SettingsContent } from "content.slint";
+import { Notice } from "notice.slint";
 
 export component SettingsWindow inherits Window {
     title: "Funput — Cài đặt";
@@ -34,6 +35,10 @@ export component SettingsWindow inherits Window {
     in property <string> update-state: "idle";
     in property <string> update-version;
     in property <string> update-message;
+    in-out property <bool> notice-open;
+    in property <string> notice-title;
+    in property <string> notice-body;
+    in property <bool> notice-danger;
 
     callback pick-method(string);
     callback pick-tone(string);
@@ -57,6 +62,7 @@ export component SettingsWindow inherits Window {
     callback relaunch-now();
     callback export-config();
     callback import-config();
+    callback import-unikey();
 
     in-out property <string> active: "overview";
     private property <string> previous-active: "overview";
@@ -117,6 +123,17 @@ export component SettingsWindow inherits Window {
             relaunch-now() => { root.relaunch-now(); }
             export-config() => { root.export-config(); }
             import-config() => { root.import-config(); }
+            import-unikey() => { root.import-unikey(); }
+        }
+    }
+
+    // Last child, so it draws over the sidebar as well as the page.
+    if root.notice-open: Notice {
+        title: root.notice-title;
+        body: root.notice-body;
+        danger: root.notice-danger;
+        dismissed => {
+            root.notice-open = false;
         }
     }
 }

--- a/platforms/windows/ui/shell/settings.slint
+++ b/platforms/windows/ui/shell/settings.slint
@@ -31,6 +31,7 @@ export component SettingsWindow inherits Window {
     in-out property <bool> launch-at-login;
     in property <[ShortcutEntry]> shortcuts;
     in property <bool> can-add-shortcut: true;
+    in-out property <bool> shortcuts-enabled;
     in property <string> version;
     in property <string> update-state: "idle";
     in property <string> update-version;
@@ -52,6 +53,7 @@ export component SettingsWindow inherits Window {
     callback set-auto-cap(bool);
     callback set-launch(bool);
     callback add-shortcut();
+    callback set-shortcuts-enabled(bool);
     callback remove-shortcut(int);
     callback edit-trigger(int, string);
     callback edit-expansion(int, string);
@@ -98,6 +100,7 @@ export component SettingsWindow inherits Window {
             launch-at-login <=> root.launch-at-login;
             shortcuts: root.shortcuts;
             can-add-shortcut: root.can-add-shortcut;
+            shortcuts-enabled <=> root.shortcuts-enabled;
             version: root.version;
             update-state: root.update-state;
             update-version: root.update-version;
@@ -114,6 +117,7 @@ export component SettingsWindow inherits Window {
             set-auto-cap(v) => { root.set-auto-cap(v); }
             set-launch(v) => { root.set-launch(v); }
             add-shortcut() => { root.add-shortcut(); }
+            set-shortcuts-enabled(v) => { root.set-shortcuts-enabled(v); }
             remove-shortcut(i) => { root.remove-shortcut(i); }
             edit-trigger(i, t) => { root.edit-trigger(i, t); }
             edit-expansion(i, t) => { root.edit-expansion(i, t); }


### PR DESCRIPTION
## 1. Import a UniKey gõ tắt table (`71408c0`)

Someone moving from UniKey had to retype their whole macro table by hand. Settings →
Dữ liệu now reads UniKey's `ukmacro.txt` and merges it in.

The format is undocumented, so it was established by reading a real file's bytes
(UniKey 4.6 RC2):

    EF BB BF                                   UTF-8 BOM
    ;DO NOT DELETE THIS LINE*** version=1 ***  header, CRLF
    vn:việt nam                                split at the first colon

`crates/funput-config/src/unikey.rs` parses that: BOM stripped, `;` comments and
blank lines skipped, split on the **first** colon so `url:https://…` keeps its
scheme, both sides trimmed, a repeated trigger keeps its last value. The header is
not required — a hand-edited file still imports. Encoding is decided by BOM
(UTF-8/UTF-16LE/BE, else plain UTF-8); a legacy 8-bit encoding gets its own error
telling the user to re-save, because guessing at TCVN3 would import mojibake
silently.

## 2. A switch to turn gõ tắt off (`2764277`)