### PR TITLE
fix(android): match Gboard key size, unsqueeze web editors, restore tone hints

### DIFF
--- a/platforms/android/app/build.gradle.kts
+++ b/platforms/android/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "app.funput.funput"
         minSdk = 26
         targetSdk = 37
-        versionCode = 24
-        versionName = "1.2026.68"
+        versionCode = 25
+        versionName = "1.2026.69"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/KeyboardDimensions.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/KeyboardDimensions.kt
@@ -1,6 +1,7 @@
 package app.funput.funput.keyboard
 
 import app.funput.funput.keyboard.layout.KeyboardSizingProfile
+import app.funput.funput.keyboard.layout.usesCompactLetterRows
 import app.funput.funput.keyboard.model.KeyboardEditorMode
 import app.funput.funput.keyboard.model.KeyboardInputMethod
 
@@ -30,7 +31,7 @@ object KeyboardDimensions {
         editorMode.usesKeypad -> heightForRowCount(4, true, profile, widthDp)
         editorMode.isPassword -> heightForRowCount(5, false, profile, widthDp)
         else -> {
-            val compact = inputMethod.isTelexFamily && !showsNumberRow
+            val compact = usesCompactLetterRows(inputMethod, editorMode, showsNumberRow)
             heightForRowCount(if (compact) 4 else 5, true, profile, widthDp)
         }
     }

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/CompactLetterRows.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/CompactLetterRows.kt
@@ -1,0 +1,20 @@
+package app.funput.funput.keyboard.layout
+
+import app.funput.funput.keyboard.model.KeyboardEditorMode
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+
+/**
+ * Single source of truth for "this keyboard drops its top number row".
+ *
+ * Only the plain-text letters layout honours the preference: the web/mail editors build their own
+ * leading number row unconditionally, and VNI needs the digits for its tone marks. Layout and
+ * measured height must agree on this, otherwise a five-row keyboard gets squeezed into a four-row
+ * panel.
+ */
+internal fun usesCompactLetterRows(
+    inputMethod: KeyboardInputMethod,
+    editorMode: KeyboardEditorMode,
+    showsNumberRow: Boolean,
+): Boolean = editorMode == KeyboardEditorMode.TEXT &&
+    inputMethod.isTelexFamily &&
+    !showsNumberRow

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/EditorKeyboardLayouts.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/EditorKeyboardLayouts.kt
@@ -74,7 +74,11 @@ internal object EditorKeyboardLayouts {
             id = "qwerty-$idPrefix-${inputMethod.name.lowercase()}",
             inputMethod = inputMethod,
             leadingRows = listOf(
-                topNumberRow(TopNumberRowMode.PLAIN_CHARACTER, pageId = "$idPrefix-${inputMethod.name.lowercase()}"),
+                topNumberRowFor(
+                    inputMethod,
+                    pageId = "$idPrefix-${inputMethod.name.lowercase()}",
+                    composesVietnamese = supportsVietnamese,
+                ),
             ),
             actionKeys = webActionKeys(
                 middleId = "slash",
@@ -83,6 +87,7 @@ internal object EditorKeyboardLayouts {
                 supportsVietnamese = supportsVietnamese,
             ),
             supportsVietnameseAlternates = supportsVietnamese,
+            showsTelexHints = supportsVietnamese && inputMethod.isTelexFamily,
         )
     }
 

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayoutResolver.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayoutResolver.kt
@@ -16,9 +16,7 @@ internal object KeyboardLayoutResolver {
         systemInputMethodSwitcherVisible: Boolean = false,
         showsNumberRow: Boolean = true,
     ): KeyboardLayout {
-        val usesCompact = editorMode == KeyboardEditorMode.TEXT &&
-            inputMethod.isTelexFamily &&
-            !showsNumberRow
+        val usesCompact = usesCompactLetterRows(inputMethod, editorMode, showsNumberRow)
         val layout = when (mode) {
             KeyboardLayoutMode.LETTERS -> EditorKeyboardLayouts.resolve(
                 inputMethod = inputMethod,

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardSizingProfile.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardSizingProfile.kt
@@ -6,7 +6,7 @@ data class KeyboardSizingProfile(
     val verticalPaddingDp: Float = 6f,
     val horizontalGapRatio: Float = 0.11f,
     val verticalGapRatio: Float = 0.16f,
-    val keyAspectRatio: Float = 0.75f,
+    val keyAspectRatio: Float = DefaultKeyAspectRatio,
     val heightScale: Float = 1f,
     val labelScale: Float = 0.96f,
 ) {
@@ -21,6 +21,16 @@ data class KeyboardSizingProfile(
     }
 
     companion object {
+        /**
+         * Key width over row pitch, calibrated so 100% lands on Gboard's untouched default.
+         *
+         * Measured on a 1440x3200 phone at density 3.75 (384dp wide): Gboard rows sit on a 189.5px
+         * pitch, and at the previous 0.75 this keyboard produced 184px — about 3% short, which read
+         * as Funput being the smaller keyboard at the same nominal size. The slider still spans
+         * [MinScale]..[MaxScale] around this baseline.
+         */
+        const val DefaultKeyAspectRatio = 0.73f
+
         /** The range Settings offers, matching the iOS slider so the two platforms agree. */
         const val MinScale = 0.85f
         const val MaxScale = 1.2f

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/TopNumberRow.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/TopNumberRow.kt
@@ -11,13 +11,27 @@ internal enum class TopNumberRowMode {
     PLAIN_PUNCTUATION,
 }
 
-internal fun topNumberRowForLetters(inputMethod: KeyboardInputMethod): KeyboardRow {
-    val mode = if (inputMethod.isTelexFamily) {
-        TopNumberRowMode.PLAIN_CHARACTER
-    } else {
+internal fun topNumberRowForLetters(inputMethod: KeyboardInputMethod): KeyboardRow =
+    topNumberRowFor(inputMethod, "letters-${inputMethod.name.lowercase()}", composesVietnamese = true)
+
+/**
+ * The digits row for [inputMethod], carrying VNI tone hints only where tones actually apply.
+ *
+ * VNI places tones with the digits, so the hints belong on any editor that composes Vietnamese —
+ * a browser address bar included. On an editor that does not compose (email, URL), the same hints
+ * would advertise an effect the keys no longer have, so the row stays plain.
+ */
+internal fun topNumberRowFor(
+    inputMethod: KeyboardInputMethod,
+    pageId: String,
+    composesVietnamese: Boolean,
+): KeyboardRow {
+    val mode = if (!inputMethod.isTelexFamily && composesVietnamese) {
         TopNumberRowMode.VNI_MODIFIERS
+    } else {
+        TopNumberRowMode.PLAIN_CHARACTER
     }
-    return topNumberRow(mode, pageId = "letters-${inputMethod.name.lowercase()}")
+    return topNumberRow(mode, pageId)
 }
 
 internal fun topNumberRow(mode: TopNumberRowMode, pageId: String): KeyboardRow {

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/KeyHeightConsistencyTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/KeyHeightConsistencyTest.kt
@@ -1,0 +1,106 @@
+package app.funput.funput.keyboard.layout
+
+import app.funput.funput.keyboard.KeyboardDimensions
+import app.funput.funput.keyboard.model.KeyRole
+import app.funput.funput.keyboard.model.KeyboardEditorMode
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+import app.funput.funput.keyboard.model.KeyboardLayoutMode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * A single key size for the whole app: at any one sizing profile every editor mode, layout page and
+ * number-row preference must resolve to the same key height. A panel measured for the wrong row
+ * count squeezes its rows instead, which reads as the size setting being ignored.
+ */
+class KeyHeightConsistencyTest {
+    @Test
+    fun everyModeResolvesTheSameKeyHeight() {
+        for (profile in listOf(
+            KeyboardSizingProfile.Normal,
+            KeyboardSizingProfile.Default,
+            KeyboardSizingProfile.scaled(KeyboardSizingProfile.MinScale),
+            KeyboardSizingProfile.scaled(KeyboardSizingProfile.MaxScale),
+        )) {
+            val spec = KeyboardGeometrySpec.fromProfile(1f, profile)
+            val expected = canonicalKeyHeight(spec)
+            forEachCombination { inputMethod, editorMode, layoutMode, showsNumberRow ->
+                if (!reachable(inputMethod, editorMode, layoutMode, showsNumberRow)) return@forEachCombination
+                val keyHeight = resolveKeyHeight(
+                    inputMethod, editorMode, layoutMode, showsNumberRow, profile, spec,
+                )
+
+                assertEquals(
+                    "$inputMethod/$editorMode/$layoutMode numberRow=$showsNumberRow " +
+                        "at scale ${profile.heightScale}",
+                    expected,
+                    keyHeight,
+                    0.5f,
+                )
+            }
+        }
+    }
+
+    /** The keypad editors ship no "?123" key, so their symbol pages are unreachable in the IME. */
+    private fun reachable(
+        inputMethod: KeyboardInputMethod,
+        editorMode: KeyboardEditorMode,
+        layoutMode: KeyboardLayoutMode,
+        showsNumberRow: Boolean,
+    ): Boolean = layoutMode == KeyboardLayoutMode.LETTERS ||
+        KeyboardLayoutResolver.resolve(
+            inputMethod = inputMethod,
+            mode = KeyboardLayoutMode.LETTERS,
+            editorMode = editorMode,
+            showsNumberRow = showsNumberRow,
+        ).rows.any { row -> row.keys.any { it.role == KeyRole.SYMBOLS } }
+
+    private fun canonicalKeyHeight(spec: KeyboardGeometrySpec): Float {
+        val contentWidth = KeyboardDimensions.DefaultWidthDp - spec.horizontalPadding * 2f
+        val canonicalUnit = contentWidth / (10 + 9 * spec.horizontalGapRatio)
+        return canonicalUnit / spec.keyAspectRatio * spec.heightScale
+    }
+
+    private fun resolveKeyHeight(
+        inputMethod: KeyboardInputMethod,
+        editorMode: KeyboardEditorMode,
+        layoutMode: KeyboardLayoutMode,
+        showsNumberRow: Boolean,
+        profile: KeyboardSizingProfile,
+        spec: KeyboardGeometrySpec,
+    ): Float {
+        val layout = KeyboardLayoutResolver.resolve(
+            inputMethod = inputMethod,
+            mode = layoutMode,
+            editorMode = editorMode,
+            showsNumberRow = showsNumberRow,
+        )
+        val keyboard = KeyboardGeometry.resolve(
+            layout = layout,
+            width = KeyboardDimensions.DefaultWidthDp,
+            height = KeyboardDimensions.recommendedHeightDp(
+                inputMethod = inputMethod,
+                editorMode = editorMode,
+                profile = profile,
+                showsNumberRow = showsNumberRow,
+            ),
+            spec = spec,
+        )
+        val key = keyboard.rows.first().first().bounds
+        return key.bottom - key.top
+    }
+
+    private fun forEachCombination(
+        block: (KeyboardInputMethod, KeyboardEditorMode, KeyboardLayoutMode, Boolean) -> Unit,
+    ) {
+        for (inputMethod in KeyboardInputMethod.entries) {
+            for (editorMode in KeyboardEditorMode.entries) {
+                for (layoutMode in KeyboardLayoutMode.entries) {
+                    for (showsNumberRow in listOf(true, false)) {
+                        block(inputMethod, editorMode, layoutMode, showsNumberRow)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/NumberRowLayoutTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/NumberRowLayoutTest.kt
@@ -78,4 +78,37 @@ class NumberRowLayoutTest {
 
         assertTrue(compact < full)
     }
+
+    @Test
+    fun webEditorsKeepFullHeightWhenNumberRowIsOff() {
+        for (editorMode in listOf(
+            KeyboardEditorMode.URL,
+            KeyboardEditorMode.SEARCH,
+            KeyboardEditorMode.EMAIL,
+        )) {
+            val layout = KeyboardLayoutResolver.resolve(
+                inputMethod = KeyboardInputMethod.TELEX,
+                mode = KeyboardLayoutMode.LETTERS,
+                editorMode = editorMode,
+                showsNumberRow = false,
+            )
+            val height = KeyboardDimensions.recommendedHeightDp(
+                KeyboardInputMethod.TELEX,
+                editorMode,
+                showsNumberRow = false,
+            )
+
+            assertEquals("$editorMode keeps its own number row", 5, layout.rows.size)
+            assertEquals(
+                "$editorMode height must fit $editorMode rows",
+                KeyboardDimensions.recommendedHeightDp(
+                    KeyboardInputMethod.TELEX,
+                    editorMode,
+                    showsNumberRow = true,
+                ),
+                height,
+                0.001f,
+            )
+        }
+    }
 }

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/TelexToneHintsLayoutTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/TelexToneHintsLayoutTest.kt
@@ -48,9 +48,20 @@ class TelexToneHintsLayoutTest {
     }
 
     @Test
-    fun specializedEditorsHideTelexHints() {
+    fun searchEditorsKeepTelexHints() {
+        // A browser address bar arrives as SEARCH and still composes Vietnamese, so the hints hold.
+        assertToneHints(
+            KeyboardLayoutResolver.resolve(
+                inputMethod = KeyboardInputMethod.TELEX,
+                mode = KeyboardLayoutMode.LETTERS,
+                editorMode = KeyboardEditorMode.SEARCH,
+            ),
+        )
+    }
+
+    @Test
+    fun nonComposingEditorsHideTelexHints() {
         listOf(
-            KeyboardEditorMode.SEARCH,
             KeyboardEditorMode.EMAIL,
             KeyboardEditorMode.URL,
             KeyboardEditorMode.PASSWORD,

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/ToneHintInvariantTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/ToneHintInvariantTest.kt
@@ -1,0 +1,81 @@
+package app.funput.funput.keyboard.layout
+
+import app.funput.funput.keyboard.model.KeyRole
+import app.funput.funput.keyboard.model.KeyboardEditorMode
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+import app.funput.funput.keyboard.model.KeyboardLayout
+import app.funput.funput.keyboard.model.KeyboardLayoutMode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tone hints promise an effect, so they must appear exactly where that effect exists: on every
+ * editor that composes Vietnamese, and on no editor that does not. A search field that composes but
+ * hides its hints is as wrong as an email field that advertises tones it will never apply.
+ */
+class ToneHintInvariantTest {
+    @Test
+    fun toneHintsAppearExactlyWhereCompositionDoes() {
+        forEachLettersLayout { inputMethod, editorMode, showsNumberRow, layout ->
+            val expected = editorMode.supportsVietnameseComposition
+            val label = "$inputMethod/$editorMode numberRow=$showsNumberRow"
+
+            if (inputMethod.isTelexFamily) {
+                assertEquals("$label telex hints", expected, layout.hasTelexHints())
+            } else {
+                assertEquals("$label VNI hints", expected, layout.hasVniModifiers())
+            }
+        }
+    }
+
+    @Test
+    fun theBrowserAddressBarKeepsItsHints() {
+        // A URI field resolves to SEARCH, which composes Vietnamese; regression guard for hints
+        // that were dropped because the web layouts are built apart from the text layout.
+        for (inputMethod in KeyboardInputMethod.entries) {
+            val layout = lettersLayout(inputMethod, KeyboardEditorMode.SEARCH, showsNumberRow = true)
+
+            assertEquals(
+                "$inputMethod search hints",
+                true,
+                if (inputMethod.isTelexFamily) layout.hasTelexHints() else layout.hasVniModifiers(),
+            )
+        }
+    }
+
+    private fun KeyboardLayout.hasTelexHints(): Boolean = rows.flatMap { it.keys }.any { key ->
+        key.role == KeyRole.CHARACTER && key.secondaryLabel != null
+    }
+
+    private fun KeyboardLayout.hasVniModifiers(): Boolean = rows.flatMap { it.keys }.any { key ->
+        key.role == KeyRole.VNI_MODIFIER && key.secondaryLabel != null
+    }
+
+    private fun lettersLayout(
+        inputMethod: KeyboardInputMethod,
+        editorMode: KeyboardEditorMode,
+        showsNumberRow: Boolean,
+    ): KeyboardLayout = KeyboardLayoutResolver.resolve(
+        inputMethod = inputMethod,
+        mode = KeyboardLayoutMode.LETTERS,
+        editorMode = editorMode,
+        showsNumberRow = showsNumberRow,
+    )
+
+    private fun forEachLettersLayout(
+        block: (KeyboardInputMethod, KeyboardEditorMode, Boolean, KeyboardLayout) -> Unit,
+    ) {
+        for (inputMethod in KeyboardInputMethod.entries) {
+            for (editorMode in KeyboardEditorMode.entries) {
+                for (showsNumberRow in listOf(true, false)) {
+                    block(
+                        inputMethod,
+                        editorMode,
+                        showsNumberRow,
+                        lettersLayout(inputMethod, editorMode, showsNumberRow),
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Three keyboard fixes on Android, each with a test that fails without its change.

## Key size at 100% now matches Gboard

`keyAspectRatio` 0.75 → 0.73. Measured on a 1440x3200 phone at density 3.75: Gboard's untouched default puts rows on a 189.5px pitch, Funput produced 184px — about 3% short, which read as Funput being the smaller keyboard at the same nominal size. Now 188.5px. The slider still spans 85–120% around the new baseline.

## Number row off no longer squeezed the web editors

`KeyboardDimensions` decided "compact" from the input method alone, while `KeyboardLayoutResolver` also required `editorMode == TEXT`. A browser address bar (which resolves to `SEARCH`) builds its own number row regardless of the preference, so with the preference off it got a panel measured for 4 rows and a layout of 5 — the rows were squeezed to fit. Both sites now share `usesCompactLetterRows`.

`KeyHeightConsistencyTest` covers the general invariant: every input method × editor mode × layout page × number-row preference × sizing profile must resolve to the same key height. It skips the symbol pages of keypad editors, which ship no `?123` key — reachability is read from the layout, so adding one turns the test red rather than shipping a squeezed page.

## Tone hints restored in the address bar

A URI field resolves to `SEARCH`, which composes Vietnamese — but the web layouts are built apart from the text layout and never passed `showsTelexHints`, and used a plain digits row instead of the VNI modifier row. Typing tones still worked; the hints were just invisible. Both now follow `supportsVietnameseComposition`, so `SEARCH` shows them and `EMAIL`/`URL` still don't.

`ToneHintInvariantTest` asserts hints appear exactly where composition does, across every editor mode. `TelexToneHintsLayoutTest` asserted the opposite for `SEARCH` and was split to match the new rule.

Also bumps versionCode 25 / versionName 1.2026.69.
