### PR TITLE
feat(macos): align input method Info.plist with IMKit conventions

### DIFF
--- a/platforms/macos/Funput.xcodeproj/project.pbxproj
+++ b/platforms/macos/Funput.xcodeproj/project.pbxproj
@@ -426,8 +426,6 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../crates/funput-ffi/include";
 				INFOPLIST_FILE = Funput/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Funput;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -466,8 +464,6 @@
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../crates/funput-ffi/include";
 				INFOPLIST_FILE = Funput/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Funput;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/platforms/macos/Funput/Info.plist
+++ b/platforms/macos/Funput/Info.plist
@@ -47,18 +47,29 @@
                 <string>app.funput.inputmethod.Funput.Vietnamese</string>
                 <key>TISIntendedLanguage</key>
                 <string>vi</string>
-                <key>tsInputModeAlternateMenuTitle</key>
-                <string>Funput (Tiếng Việt)</string>
+                <key>TISIconLabels</key>
+                <dict>
+                    <key>Primary</key>
+                    <string>VI</string>
+                </dict>
+                <key>tsInputModeCharacterRepertoireKey</key>
+                <array>
+                    <string>Latn</string>
+                </array>
+                <key>tsInputModeDefaultStateKey</key>
+                <true/>
                 <key>tsInputModeIsVisibleKey</key>
                 <true/>
                 <key>tsInputModeMenuIconFileKey</key>
                 <string>MenuIcon.tiff</string>
-                <key>tsInputModeKeyEquivalentKey</key>
-                <string></string>
-                <key>tsInputModeKeyEquivalentModifiersKey</key>
-                <integer>0</integer>
+                <key>tsInputModePaletteIconFileKey</key>
+                <string>MenuIcon.tiff</string>
                 <key>tsInputModePrimaryInScriptKey</key>
                 <true/>
+                <!-- smUnicodeScript is the traditional IMK script token (Ainu, Tamil).
+                     Roman/Latin key translation is declared via Latn repertoire below,
+                     not smRoman — claiming smRoman would compete with the system ABC
+                     keyboard as the primary Roman input source. -->
                 <key>tsInputModeScriptKey</key>
                 <string>smUnicodeScript</string>
             </dict>
@@ -74,14 +85,10 @@
     <string>FunputInputController</string>
     <key>InputMethodServerDelegateClass</key>
     <string>FunputInputController</string>
-    <key>LSApplicationCategoryType</key>
-    <string>public.app-category.productivity</string>
     <key>LSMinimumSystemVersion</key>
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
     <key>LSUIElement</key>
     <true/>
-    <key>NSHumanReadableCopyright</key>
-    <string></string>
     <!-- Sparkle auto-update. Feed is the appcast.xml asset attached to the latest
          GitHub Release. Checks are manual-only (no background polling). -->
     <key>SUFeedURL</key>
@@ -92,12 +99,22 @@
     <false/>
     <key>SUAllowsAutomaticUpdates</key>
     <false/>
-    <key>tsInputMethodCharacterRepertoireKey</key>
-    <array>
-        <string>vi</string>
-    </array>
     <key>TISIconIsTemplate</key>
     <true/>
+    <key>TISInputSourceID</key>
+    <string>app.funput.inputmethod.Funput</string>
+    <key>TISIntendedLanguage</key>
+    <string>vi</string>
+    <!-- ISO 15924 script code for the text this IME produces (cf. Taml for
+         Apple's Tamil IM, Hans for Simplified Chinese). Do not put the language
+         code `vi` here; language belongs in TISIntendedLanguage. Note this key
+         does not pick the physical layout: Funput ships no keyboard layout of its
+         own, so the system keeps the user's current ASCII-capable one (ABC, US,
+         AZERTY, …) — the layout Keyboard Viewer shows. -->
+    <key>tsInputMethodCharacterRepertoireKey</key>
+    <array>
+        <string>Latn</string>
+    </array>
     <key>tsInputMethodIconFileKey</key>
     <string>MenuIcon.tiff</string>
 </dict>


### PR DESCRIPTION
### Fixed
- `tsInputMethodCharacterRepertoireKey` was `vi` — a language code where an
  ISO 15924 *script* code belongs. Now `Latn` (cf. `Taml` for Apple's Tamil IM,
  `Hans` for Simplified Chinese). Language stays in `TISIntendedLanguage`.
- Added the top-level `TISInputSourceID` and `TISIntendedLanguage` that every
  Apple IME declares and Funput was missing.

### Added (parity with TamilIM/SCIM)
- `TISIconLabels/Primary = "VI"` — menu-bar fallback label when the icon is
  unavailable.
- `tsInputModePaletteIconFileKey` alongside the existing menu icon, so the
  Keyboard Viewer / palette shows an icon.
- Mode-level `tsInputModeCharacterRepertoireKey` and `tsInputModeDefaultStateKey`.

### Removed
- `tsInputModeAlternateMenuTitle` — the displayed name already comes from
  `InfoPlist.strings`, keyed by the input mode id, and is localized there.
- `tsInputModeKeyEquivalentKey = ""` / `tsInputModeKeyEquivalentModifiersKey = 0`
  — Apple only declares these when a real shortcut exists; empty values are noise.
- `LSApplicationCategoryType` and `NSHumanReadableCopyright`, from both the plist
  *and* the matching `INFOPLIST_KEY_*` build settings. They were injected from
  project.pbxproj, so removing them from the plist alone would have changed
  nothing — the shipping app carried an empty copyright string.

Also expanded the comments on `smUnicodeScript` and the `Latn` repertoire so the
reasoning survives the next edit.

### Verification
`plutil -lint` clean; `xcodebuild -showBuildSettings` confirms the two
`INFOPLIST_KEY_*` entries are no longer injected. Menu-bar label and palette icon
still need a visual check on a real install.