### PR TITLE
feat(ios): add compact digit alternates for keyboard layout

### DIFF
--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Alternates/CompactDigitAlternates.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Alternates/CompactDigitAlternates.swift
@@ -1,0 +1,47 @@
+/// Digit hints and long-press digits for the top character row.
+///
+/// The compact letters page hides the number row, which leaves the symbols page as the
+/// only way to reach a digit. Printing the digit on the keycap and offering it as the
+/// pre-selected long-press alternate restores that reach without spending a row.
+public enum CompactDigitAlternates {
+    private static let rowCharacters = "qwertyuiop"
+    private static let digits = "1234567890"
+
+    public static func decorate(_ layout: KeyboardLayout) -> KeyboardLayout {
+        KeyboardLayout(
+            id: layout.id,
+            inputMethod: layout.inputMethod,
+            toolbar: layout.toolbar,
+            rows: layout.rows.map(decorate)
+        )
+    }
+
+    /// Matches the row by its own labels rather than by index: the compact page has no
+    /// number row in front of it, so the top character row is not at a fixed position.
+    private static func decorate(_ row: KeyboardRow) -> KeyboardRow {
+        guard row.keys.map(\.label) == rowCharacters.map(String.init) else { return row }
+        return KeyboardRow(
+            keys: zip(row.keys, digits).map { key, digit in apply(String(digit), to: key) },
+            horizontalInsetUnits: row.horizontalInsetUnits
+        )
+    }
+
+    private static func apply(_ digit: String, to key: KeySpec) -> KeySpec {
+        KeySpec(
+            id: key.id,
+            label: key.label,
+            role: key.role,
+            widthWeight: key.widthWeight,
+            shiftedLabel: key.shiftedLabel,
+            // A Telex tone hint keeps the slot it already owns — `r` stays the hỏi key —
+            // and the digit joins it on the right, where every other key carries one.
+            secondaryLabel: key.secondaryLabel.map { "\($0) \(digit)" } ?? digit,
+            accessibilityLabel: "\(key.accessibilityLabel), số \(digit)",
+            horizontalSwipeAction: key.horizontalSwipeAction,
+            // First place wins the palette's default selection, which is what makes a
+            // plain hold-and-release type the digit.
+            alternates: [KeyAlternate(text: digit, accessibilityLabel: "Số \(digit)")]
+                + key.alternates
+        )
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/StandardKeyboardLayouts.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/StandardKeyboardLayouts.swift
@@ -4,7 +4,7 @@ public enum StandardKeyboardLayouts {
         showsNumberRow: Bool = true
     ) -> KeyboardLayout {
         let hasNumberRow = inputMethod == .vni || showsNumberRow
-        return qwertyLayout(
+        let layout = qwertyLayout(
             id: "qwerty-\(inputMethod.rawValue)\(hasNumberRow ? "" : "-compact")",
             inputMethod: inputMethod,
             leadingRows: hasNumberRow ? [topNumberRowForLetters(inputMethod)] : [],
@@ -12,6 +12,9 @@ public enum StandardKeyboardLayouts {
             showsTelexHints: inputMethod.isTelexFamily,
             supportsVietnameseAlternates: true
         )
+        // Digits move onto the top row only when no row of their own is on screen.
+        guard !hasNumberRow, inputMethod.isTelexFamily else { return layout }
+        return CompactDigitAlternates.decorate(layout)
     }
 }
 

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Controller/KeyboardSurfaceInteractionController+Tracking.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Controller/KeyboardSurfaceInteractionController+Tracking.swift
@@ -60,7 +60,7 @@ extension KeyboardSurfaceInteractionController {
         guard var state = touches[token] else { return }
         hapticsEnabled = presentation.isHapticFeedbackEnabled
         if let layout = state.alternateLayout {
-            let next = layout.index(at: point)
+            let next = layout.selection(at: point, from: state.startPoint)
             if next != state.selectedAlternateIndex, hapticsEnabled {
                 haptics.perform(.control)
             }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/Preview/KeyboardAlternatePaletteLayout.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/Preview/KeyboardAlternatePaletteLayout.swift
@@ -5,31 +5,42 @@ struct KeyboardAlternatePaletteLayout: Equatable {
     let frame: CGRect
     let itemFrames: [CGRect]
     let sourceFrame: CGRect
+    /// True when the palette had to be clamped over the key it came from, which happens
+    /// on the top row where there is no room above for every cell.
+    let overlapsSource: Bool
+
+    /// Preferred grid width. The palette stays narrow and wraps into more rows so it
+    /// reads as a block above the finger rather than a long strip across the keyboard.
+    private static let preferredColumns = 6
+    /// Past this the block would be taller than the keyboard, so wider rows win instead.
+    private static let maximumRows = 3
+    private static let preferredSpan: CGFloat = 40
+    /// Cells shrink no further than this, even to win a row.
+    private static let minimumSpan: CGFloat = 24
+    private static let cellHeight: CGFloat = 42
+    private static let padding: CGFloat = 6
+    private static let gap: CGFloat = 2
+    private static let sourceGap: CGFloat = 4
+    /// How far the finger must leave its starting point before it stops meaning
+    /// "the default cell", used only when the palette covers the source key.
+    private static let holdSlop: CGFloat = 16
 
     static func resolve(count: Int, sourceFrame: CGRect, bounds: CGRect) -> Self {
         let safe = bounds.insetBy(dx: 6, dy: 4)
-        let padding: CGFloat = 6
-        let gap: CGFloat = 2
-        let cellHeight: CGFloat = 42
         let available = max(1, safe.width - padding * 2)
-        let columns = min(count, max(1, min(9, Int((available + gap) / 40))))
+        let columns = columnCount(count: count, available: available)
         let rows = Int(ceil(Double(count) / Double(columns)))
-        let width = min(safe.width, CGFloat(columns) * 40 - gap + padding * 2)
+        let span = min(preferredSpan, (available + gap) / CGFloat(columns))
+        let width = min(safe.width, CGFloat(columns) * span - gap + padding * 2)
         let height = CGFloat(rows) * cellHeight + CGFloat(rows - 1) * gap + padding * 2
         let x = min(
             max(safe.minX, sourceFrame.midX - width / 2),
             safe.maxX - width
         )
-        let aboveY = sourceFrame.minY - height - 4
-        let belowY = sourceFrame.maxY + 4
-        let y: CGFloat
-        if aboveY >= safe.minY {
-            y = aboveY
-        } else if belowY + height <= safe.maxY {
-            y = belowY
-        } else {
-            y = max(safe.minY, min(aboveY, safe.maxY - height))
-        }
+        // The palette always rises from the key. Flipping it below would put it under the
+        // hand and away from the finger, so a palette too tall for the space above is
+        // clamped to the top edge instead.
+        let y = max(safe.minY, min(sourceFrame.minY - sourceGap - height, safe.maxY - height))
         let frame = CGRect(x: x, y: y, width: width, height: height)
         let contentWidth = width - padding * 2 - CGFloat(columns - 1) * gap
         let cellWidth = contentWidth / CGFloat(columns)
@@ -43,11 +54,39 @@ struct KeyboardAlternatePaletteLayout: Equatable {
                 height: cellHeight
             )
         }
-        return Self(frame: frame, itemFrames: items, sourceFrame: sourceFrame)
+        return Self(
+            frame: frame,
+            itemFrames: items,
+            sourceFrame: sourceFrame,
+            overlapsSource: frame.intersects(sourceFrame)
+        )
+    }
+
+    /// Wraps at ``preferredColumns`` and widens only when the set would otherwise need
+    /// more than ``maximumRows`` rows. The rows are then evened out, so thirteen cells
+    /// read as 5 + 5 + 3 rather than 6 + 6 + 1.
+    private static func columnCount(count: Int, available: CGFloat) -> Int {
+        let widthLimit = max(1, Int((available + gap) / minimumSpan))
+        let wrapped = Int(ceil(Double(count) / Double(preferredColumns)))
+        let rows = min(maximumRows, max(1, wrapped))
+        let balanced = Int(ceil(Double(count) / Double(rows)))
+        return min(count, min(widthLimit, max(1, balanced)))
+    }
+
+    /// The cell a moved finger is on. A palette clamped over its own key has no key
+    /// region left to stand for the default, so the touch's starting point holds it
+    /// until the finger travels away — otherwise a hand resting still would drift onto
+    /// whichever cell happens to cover it.
+    func selection(at point: CGPoint, from start: CGPoint) -> Int? {
+        guard overlapsSource else { return index(at: point) }
+        let dx = point.x - start.x
+        let dy = point.y - start.y
+        if dx * dx + dy * dy <= Self.holdSlop * Self.holdSlop { return 0 }
+        return index(at: point)
     }
 
     func index(at point: CGPoint) -> Int? {
-        if sourceFrame.insetBy(dx: -8, dy: -8).contains(point) { return 0 }
+        if !overlapsSource, sourceFrame.insetBy(dx: -8, dy: -8).contains(point) { return 0 }
         let local = CGPoint(x: point.x - frame.minX, y: point.y - frame.minY)
         return itemFrames.firstIndex { $0.insetBy(dx: -1, dy: -1).contains(local) }
     }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/Preview/KeyboardAlternatePaletteView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/Preview/KeyboardAlternatePaletteView.swift
@@ -62,6 +62,9 @@ final class KeyboardAlternatePaletteView: UIView {
             let label = UILabel()
             label.font = .systemFont(ofSize: 22)
             label.textAlignment = .center
+            // Cells narrow when the palette widens to fit above a top-row key.
+            label.adjustsFontSizeToFitWidth = true
+            label.minimumScaleFactor = 0.7
             label.layer.cornerCurve = .continuous
             label.layer.cornerRadius = 8
             addSubview(label)

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Alternates/KeyboardAlternateInputTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Alternates/KeyboardAlternateInputTests.swift
@@ -32,6 +32,18 @@ struct KeyboardAlternateInputTests {
         #expect(coordinator.composer.buffer().isEmpty)
     }
 
+    @Test("Digit alternate types the number without disturbing the word", arguments: [
+        KeyboardInputMethod.telex,
+        .telexAdvanced,
+    ])
+    func digit(method: KeyboardInputMethod) {
+        let coordinator = KeyboardInputCoordinator(inputMethod: method)
+        let document = TestKeyboardWriter()
+        for character in "nam " { type(String(character), with: coordinator, into: document) }
+        coordinator.handleAlternate(alternate("2"), from: sourceKey(), writer: document)
+        #expect(document.text == "nam 2")
+    }
+
     @Test("Alternate consumes one-shot Shift")
     func oneShotShift() {
         let coordinator = KeyboardInputCoordinator(inputMethod: .telex)

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardLayoutTests/Alternates/CompactDigitAlternatesTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardLayoutTests/Alternates/CompactDigitAlternatesTests.swift
@@ -1,0 +1,99 @@
+import KeyboardLayout
+import Testing
+
+@Suite("Compact digit hints")
+struct CompactDigitAlternatesTests {
+    @Test("Top row prints its digit, beside a Telex hint where there is one")
+    func hints() throws {
+        let compact = Self.compactRow(.telex)
+        let standard = Self.topRow(StandardKeyboardLayouts.letters(.telex))
+        for (index, key) in compact.keys.enumerated() {
+            let tone = standard.keys[index].secondaryLabel
+            #expect(key.secondaryLabel == tone.map { "\($0) \(Self.digits[index])" }
+                ?? Self.digits[index])
+        }
+        // `r` is the hỏi key: the tone hint leads and the digit follows it.
+        let hint = try #require(compact.keys[3].secondaryLabel)
+        let tone = try #require(standard.keys[3].secondaryLabel)
+        #expect(hint.hasPrefix(tone))
+        #expect(hint.hasSuffix("4"))
+    }
+
+    @Test("The digit leads every top-row palette", arguments: [
+        KeyboardInputMethod.telex,
+        .telexAdvanced,
+    ])
+    func digitLeadsPalette(method: KeyboardInputMethod) {
+        let row = Self.compactRow(method)
+        for (index, key) in row.keys.enumerated() {
+            #expect(key.alternates.first?.text == Self.digits[index])
+            #expect(key.alternates.first?.text(for: .uppercase) == Self.digits[index])
+            #expect(key.accessibilityLabel.hasSuffix(", số \(Self.digits[index])"))
+        }
+        #expect(row.keys[6].alternates.map(\.text)
+            == ["7"] + VietnameseKeyAlternates.values(for: "u").map(\.text))
+        #expect(row.keys[0].alternates.map(\.text) == ["1"])
+    }
+
+    @Test("Keys keep their identity so geometry and layout ids do not move")
+    func identity() {
+        let layout = StandardKeyboardLayouts.letters(.telex, showsNumberRow: false)
+        let row = Self.topRow(layout)
+        #expect(layout.id == "qwerty-telex-compact")
+        #expect(row.keys.map(\.id) == "qwertyuiop".map { "character-\($0)" })
+        #expect(row.keys.allSatisfy { $0.role == .character && $0.widthWeight == 1 })
+        #expect(row.keys.map(\.shiftedLabel) == "QWERTYUIOP".map(String.init))
+    }
+
+    @Test("Digits stay off whenever a number row is on screen")
+    func numberRowWins() {
+        for method in KeyboardInputMethod.allCases {
+            let row = Self.topRow(StandardKeyboardLayouts.letters(method))
+            #expect(row.keys[0].secondaryLabel == nil)
+            #expect(row.keys[0].alternates.isEmpty)
+            #expect(row.keys[6].alternates.first?.text == "u")
+        }
+        // VNI forces its own digit row, so the preference never reaches this page.
+        let vni = Self.topRow(StandardKeyboardLayouts.letters(.vni, showsNumberRow: false))
+        #expect(vni.keys[0].secondaryLabel == nil)
+        #expect(vni.keys[0].alternates.isEmpty)
+    }
+
+    @Test("Only the compact letters page changes")
+    func scope() throws {
+        let compact = StandardKeyboardLayouts.letters(.telex, showsNumberRow: false)
+        let standard = StandardKeyboardLayouts.letters(.telex)
+        for label in ["a", "s", "z"] {
+            let key = try #require(compact.rows.flatMap(\.keys).first { $0.label == label })
+            let reference = try #require(standard.rows.flatMap(\.keys).first { $0.label == label })
+            #expect(key.secondaryLabel == reference.secondaryLabel)
+            #expect(key.accessibilityLabel == reference.accessibilityLabel)
+            #expect(key.alternates == reference.alternates)
+        }
+        for mode in [KeyboardEditorMode.search, .email, .url] {
+            let row = Self.topRow(
+                EditorKeyboardLayouts.resolve(.telex, editorMode: mode, showsNumberRow: false)
+            )
+            #expect(row.keys[0].secondaryLabel == nil)
+            #expect(row.keys[0].alternates.isEmpty)
+        }
+        let system = KeyboardLayoutResolver.resolve(
+            inputMethod: .telex,
+            mode: .letters,
+            showsNumberRow: false,
+            preset: .system
+        )
+        #expect(Self.topRow(system).keys[0].secondaryLabel == nil)
+        #expect(Self.topRow(system).keys[0].alternates.isEmpty)
+    }
+
+    private static let digits = "1234567890".map(String.init)
+
+    private static func compactRow(_ method: KeyboardInputMethod) -> KeyboardRow {
+        topRow(StandardKeyboardLayouts.letters(method, showsNumberRow: false))
+    }
+
+    private static func topRow(_ layout: KeyboardLayout) -> KeyboardRow {
+        layout.rows.first { $0.keys.map(\.label) == "qwertyuiop".map(String.init) }!
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardLayoutTests/TelexHintGeometryTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardLayoutTests/TelexHintGeometryTests.swift
@@ -31,4 +31,53 @@ struct TelexHintGeometryTests {
             #expect(standardKey?.spec.widthWeight == 1)
         }
     }
+
+    @Test("Digit hints do not change compact character hit frames")
+    func compactHitFramesStayStable() {
+        let size = CGSize(width: 390, height: 240)
+        let compact = KeyboardGeometry.resolve(
+            layout: StandardKeyboardLayouts.letters(.telex, showsNumberRow: false),
+            size: size,
+            sizing: .default
+        )
+        let bare = KeyboardGeometry.resolve(
+            layout: undecoratedCompactLayout(),
+            size: size,
+            sizing: .default
+        )
+
+        for label in "qwertyuiop".map(String.init) {
+            let decorated = compact.keys.first { $0.spec.label == label }
+            let plain = bare.keys.first { $0.spec.label == label }
+            #expect(decorated?.frame == plain?.frame)
+            #expect(decorated?.spec.role == .character)
+            #expect(decorated?.spec.widthWeight == 1)
+        }
+    }
+
+    /// The same page with the decorator's contribution stripped back out, so the
+    /// comparison isolates hint and alternate metadata from every other difference.
+    private func undecoratedCompactLayout() -> KeyboardLayout {
+        let layout = StandardKeyboardLayouts.letters(.telex, showsNumberRow: false)
+        return KeyboardLayout(
+            id: layout.id,
+            inputMethod: layout.inputMethod,
+            toolbar: layout.toolbar,
+            rows: layout.rows.map { row in
+                KeyboardRow(
+                    keys: row.keys.map {
+                        KeySpec(
+                            id: $0.id,
+                            label: $0.label,
+                            role: $0.role,
+                            widthWeight: $0.widthWeight,
+                            shiftedLabel: $0.shiftedLabel,
+                            horizontalSwipeAction: $0.horizontalSwipeAction
+                        )
+                    },
+                    horizontalInsetUnits: row.horizontalInsetUnits
+                )
+            }
+        )
+    }
 }

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Alternates/KeyboardAlternateInteractionTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Alternates/KeyboardAlternateInteractionTests.swift
@@ -44,6 +44,21 @@ struct KeyboardAlternateInteractionTests {
         #expect(dragged.palette == nil)
     }
 
+    @Test("Holding a compact top-row key releases its pre-selected digit")
+    func selectDefaultDigit() {
+        let subject = Subject(key: Subject.digitKey)
+        subject.begin()
+        subject.scheduler.runNext()
+        subject.controller.endTouch(token: 1)
+
+        guard let phase = subject.events.last?.phase,
+              case let .alternateSelected(value) = phase else {
+            Issue.record("Expected alternate selection")
+            return
+        }
+        #expect(value.text == "7")
+    }
+
     @Test("Leaving the palette cancels the alternate release")
     func cancelOutside() {
         let subject = Subject()
@@ -66,13 +81,25 @@ private final class Subject {
         onAlternatePreview: { [weak self] _, layout, _ in self?.palette = layout },
         repeatScheduler: scheduler.schedule
     )
-    let key = KeySpec(
+    let key: KeySpec
+
+    init(key: KeySpec = Subject.toneKey) {
+        self.key = key
+    }
+
+    static let toneKey = KeySpec(
         id: "a",
         label: "a",
         role: .character,
         shiftedLabel: "A",
         alternates: VietnameseKeyAlternates.values(for: "a")
     )
+    /// The compact top row leads its palette with the digit, so a hold that never moves
+    /// resolves to the number rather than to the letter.
+    static let digitKey = StandardKeyboardLayouts
+        .letters(.telex, showsNumberRow: false)
+        .rows.flatMap(\.keys)
+        .first { $0.label == "u" }!
     var presentation: KeyboardPresentation {
         var value = KeyboardPresentation()
         value.isHapticFeedbackEnabled = false

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Alternates/KeyboardAlternatePaletteLayoutTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Alternates/KeyboardAlternatePaletteLayoutTests.swift
@@ -25,6 +25,72 @@ struct KeyboardAlternatePaletteLayoutTests {
         }
     }
 
+    @Test("The palette rises from the key instead of dropping below it")
+    func risesAbove() {
+        let bounds = CGRect(x: 0, y: 0, width: 390, height: 260)
+        for row in [CGFloat(62), 111, 160, 209] {
+            let source = CGRect(x: 156, y: row, width: 36, height: 40)
+            let layout = KeyboardAlternatePaletteLayout.resolve(
+                count: 13,
+                sourceFrame: source,
+                bounds: bounds
+            )
+            #expect(layout.frame.minY < source.minY)
+            #expect(bounds.contains(layout.frame))
+        }
+    }
+
+    @Test("The palette wraps into at most three rows instead of running wide")
+    func wrapsWithinThreeRows() {
+        let bounds = CGRect(x: 0, y: 0, width: 390, height: 260)
+        for row in [CGFloat(62), 209] {
+            let source = CGRect(x: 156, y: row, width: 36, height: 40)
+            for count in [13, 18, 19] {
+                let layout = KeyboardAlternatePaletteLayout.resolve(
+                    count: count,
+                    sourceFrame: source,
+                    bounds: bounds
+                )
+                let rows = Set(layout.itemFrames.map(\.minY)).count
+                #expect(rows > 1)
+                #expect(rows <= 3)
+                #expect(layout.frame.width <= bounds.width * 0.8)
+            }
+        }
+    }
+
+    @Test("Short sets stay on one row")
+    func shortSets() {
+        let layout = KeyboardAlternatePaletteLayout.resolve(
+            count: 2,
+            sourceFrame: CGRect(x: 156, y: 160, width: 36, height: 40),
+            bounds: CGRect(x: 0, y: 0, width: 390, height: 260)
+        )
+        #expect(Set(layout.itemFrames.map(\.minY)).count == 1)
+        #expect(layout.itemFrames.count == 2)
+    }
+
+    @Test("A palette clamped over its key keeps the default until the finger travels")
+    func clampedOverSource() {
+        // Nineteen alternates cannot fit above a top-row key, so the palette covers it.
+        let source = CGRect(x: 300, y: 62, width: 36, height: 40)
+        let layout = KeyboardAlternatePaletteLayout.resolve(
+            count: 19,
+            sourceFrame: source,
+            bounds: CGRect(x: 0, y: 0, width: 390, height: 260)
+        )
+        #expect(layout.overlapsSource)
+        let start = CGPoint(x: source.midX, y: source.midY)
+        #expect(layout.selection(at: start, from: start) == 0)
+        #expect(layout.selection(at: CGPoint(x: start.x + 6, y: start.y), from: start) == 0)
+        // The cell sitting over the key stays reachable once the finger has moved.
+        let covering = layout.index(at: start)
+        #expect(covering != nil)
+        #expect(covering != 0)
+        #expect(layout.selection(at: start, from: CGPoint(x: start.x, y: start.y + 60))
+            == covering)
+    }
+
     @Test("Source selects the base and cells select their own index")
     func hitTesting() {
         let source = CGRect(x: 120, y: 220, width: 36, height: 44)

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/RendererSemanticsTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/RendererSemanticsTests.swift
@@ -40,6 +40,16 @@ struct RendererSemanticsTests {
         }
     }
 
+    @Test("Compact top row renders its digit hints")
+    func compactDigitHints() throws {
+        let layout = StandardKeyboardLayouts.letters(.telex, showsNumberRow: false)
+        let key = try #require(layout.rows.flatMap(\.keys).first { $0.label == "u" })
+        let presentation = KeyboardPresentation(layout: layout)
+        let renderedLabels = labels(in: renderedControl(key: key, presentation: presentation))
+        #expect(renderedLabels.contains("7"))
+        #expect(renderedLabels.contains("u"))
+    }
+
     @Test("Language-aware Space shows swipe affordances")
     func languageSpace() {
         let layout = StandardKeyboardLayouts.letters(.telex)


### PR DESCRIPTION
- Introduced `CompactDigitAlternates` to display digit hints on the top character row when the number row is hidden.
- Updated `StandardKeyboardLayouts` to apply digit alternates when no number row is present.
- Enhanced keyboard rendering to ensure digit hints are correctly displayed and accessible.
- Added tests to verify the functionality of digit hints and their interaction with existing keyboard layouts.