### PR TITLE
feat(android): implement compact digit alternates

### DIFF
--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/popover/AlternateCompositionTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/popover/AlternateCompositionTest.kt
@@ -25,6 +25,24 @@ class AlternateCompositionTest {
     }
 
     @Test
+    fun `digit alternate goes through composition like the number row`() {
+        // The compact top row offers its digit as the first alternate. It must take the same
+        // path a real digit key takes — through the engine — not a literal commit.
+        val connection = RecordingConnection()
+        val handler = ImeKeyActionHandler(
+            composition = testSession(ScriptedEngine(ArrayDeque(listOf("2")))),
+            editor = InputConnectionEditor(),
+            connection = { connection.proxy },
+            enterCommand = { ImeEditCommand.CommitText("\n") },
+        )
+        handler.start()
+        handler.onKeyAction(KeyAction.Input("character-w", "2"))
+
+        assertEquals(listOf("2"), connection.composingTexts)
+        assertEquals(emptyList<String>(), connection.committedTexts)
+    }
+
+    @Test
     fun `English mode commits precomposed alternate directly`() {
         val connection = RecordingConnection()
         val handler = ImeKeyActionHandler(

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/CompactDigitAlternates.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/CompactDigitAlternates.kt
@@ -1,0 +1,42 @@
+package app.funput.funput.keyboard.layout
+
+import app.funput.funput.keyboard.model.KeySpec
+import app.funput.funput.keyboard.model.KeyboardLayout
+import app.funput.funput.keyboard.model.KeyboardRow
+import app.funput.funput.keyboard.popover.model.KeyAlternate
+
+/**
+ * Digit hints and long-press digits for the top character row.
+ *
+ * The compact letters page hides the number row, which leaves the symbols page as the only
+ * way to reach a digit. Printing the digit on the keycap and offering it as the pre-selected
+ * long-press alternate restores that reach without spending a row.
+ */
+internal object CompactDigitAlternates {
+    private const val RowCharacters = "qwertyuiop"
+    private const val Digits = "1234567890"
+
+    fun decorate(layout: KeyboardLayout): KeyboardLayout =
+        layout.copy(rows = layout.rows.map(::decorate))
+
+    /**
+     * Matches the row by its own labels rather than by index: the compact page has no number
+     * row in front of it, so the top character row is not at a fixed position.
+     */
+    private fun decorate(row: KeyboardRow): KeyboardRow {
+        if (row.keys.map { it.label } != RowCharacters.map(Char::toString)) return row
+        return row.copy(keys = row.keys.mapIndexed { index, key -> apply(Digits[index], key) })
+    }
+
+    private fun apply(digit: Char, key: KeySpec): KeySpec = key.copy(
+        // A Telex tone hint keeps the slot it already owns — `r` stays the hỏi key — and the
+        // digit joins it on the right, where every other key carries one.
+        secondaryLabel = key.secondaryLabel?.let { "$it $digit" } ?: digit.toString(),
+        accessibilityLabel = "${key.accessibilityLabel}, số $digit",
+        // First place wins the palette's default selection, which is what makes a plain
+        // hold-and-release type the digit.
+        alternates = listOf(
+            KeyAlternate(digit.toString(), accessibilityLabel = "Số $digit"),
+        ) + key.alternates,
+    )
+}

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayouts.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayouts.kt
@@ -31,7 +31,7 @@ object KeyboardLayouts {
         showsNumberRow: Boolean,
     ): KeyboardLayout {
         val hasNumberRow = inputMethod == KeyboardInputMethod.VNI || showsNumberRow
-        return qwertyLayout(
+        val layout = qwertyLayout(
             id = if (hasNumberRow) id else "$id-compact",
             inputMethod = inputMethod,
             leadingRows = if (hasNumberRow) {
@@ -43,6 +43,9 @@ object KeyboardLayouts {
             supportsVietnameseAlternates = true,
             showsTelexHints = inputMethod.isTelexFamily,
         )
+        // Digits move onto the top row only when no row of their own is on screen.
+        if (hasNumberRow || !inputMethod.isTelexFamily) return layout
+        return CompactDigitAlternates.decorate(layout)
     }
 
     private fun standardActionKeys() = listOf(

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/popover/interaction/AlternateSelectionController.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/popover/interaction/AlternateSelectionController.kt
@@ -55,7 +55,7 @@ internal class AlternateSelectionController(
             }
             return
         }
-        val next = layout.indexAt(x, y, density)
+        val next = layout.selectionAt(x, y, session.startX, session.startY, density)
         if (next != session.selectedIndex) {
             session.selectedIndex = next
             onFeedback()
@@ -67,7 +67,7 @@ internal class AlternateSelectionController(
         val session = sessions.remove(pointerId) ?: return false
         cancel(session.task)
         val layout = session.layout ?: return false
-        val index = layout.indexAt(x, y, density)
+        val index = layout.selectionAt(x, y, session.startX, session.startY, density)
         index?.let { session.key.alternates.getOrNull(it) }?.let {
             onSelected(session.key, it)
         }

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/popover/rendering/AlternatePaletteLayout.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/popover/rendering/AlternatePaletteLayout.kt
@@ -7,13 +7,55 @@ internal data class AlternatePaletteLayout(
     val bounds: KeyBounds,
     val itemBounds: List<KeyBounds>,
     val sourceBounds: KeyBounds,
+    /**
+     * True when the palette had to be clamped over the key it came from, which happens on the
+     * top row where there is no room above for every cell.
+     */
+    val overlapsSource: Boolean,
 ) {
+    /**
+     * The cell a moved finger is on. A palette clamped over its own key has no key region left
+     * to stand for the default, so the touch's starting point holds it until the finger travels
+     * away — otherwise a hand resting still would drift onto whichever cell happens to cover it.
+     */
+    fun selectionAt(x: Float, y: Float, startX: Float, startY: Float, density: Float): Int? {
+        if (!overlapsSource) return indexAt(x, y, density)
+        val dx = x - startX
+        val dy = y - startY
+        val slop = HoldSlop * density
+        if (dx * dx + dy * dy <= slop * slop) return 0
+        return indexAt(x, y, density)
+    }
+
     fun indexAt(x: Float, y: Float, density: Float): Int? {
-        if (sourceBounds.expanded(8f * density).contains(x, y)) return 0
+        if (!overlapsSource && sourceBounds.expanded(8f * density).contains(x, y)) return 0
         return itemBounds.indexOfFirst { it.expanded(density).contains(x, y) }.takeIf { it >= 0 }
     }
 
     companion object {
+        /**
+         * Preferred grid width. The palette stays narrow and wraps into more rows so it reads as
+         * a block above the finger rather than a long strip across the keyboard.
+         */
+        private const val PreferredColumns = 6
+
+        /** Past this the block would be taller than the keyboard, so wider rows win instead. */
+        private const val MaximumRows = 3
+        private const val PreferredSpan = 40f
+
+        /** Cells shrink no further than this, even to win a row. */
+        private const val MinimumSpan = 24f
+        private const val CellHeight = 42f
+        private const val Padding = 6f
+        private const val Gap = 2f
+        private const val SourceGap = 4f
+
+        /**
+         * How far the finger must leave its starting point before it stops meaning "the default
+         * cell", used only when the palette covers the source key.
+         */
+        private const val HoldSlop = 16f
+
         fun resolve(
             count: Int,
             source: KeyBounds,
@@ -21,25 +63,44 @@ internal data class AlternatePaletteLayout(
             density: Float,
         ): AlternatePaletteLayout {
             val safe = surface.inset(6f * density, 4f * density)
-            val padding = 6f * density
-            val gap = 2f * density
-            val targetWidth = 40f * density
-            val cellHeight = 42f * density
+            val padding = Padding * density
+            val gap = Gap * density
+            val cellHeight = CellHeight * density
             val available = (safe.width - padding * 2f).coerceAtLeast(1f)
-            val columns = minOf(count, 9, ((available + gap) / targetWidth).toInt().coerceAtLeast(1))
+            val columns = columnCount(count, available, density)
             val rows = ceil(count.toDouble() / columns).toInt()
-            val width = minOf(safe.width, columns * targetWidth - gap + padding * 2f)
+            val span = minOf(PreferredSpan * density, (available + gap) / columns)
+            val width = minOf(safe.width, columns * span - gap + padding * 2f)
             val height = rows * cellHeight + (rows - 1) * gap + padding * 2f
             val left = (source.centerX - width / 2f).coerceIn(safe.left, safe.right - width)
-            val above = source.top - height - 4f * density
-            val below = source.bottom + 4f * density
-            val top = when {
-                above >= safe.top -> above
-                below + height <= safe.bottom -> below
-                else -> maxOf(safe.top, minOf(above, safe.bottom - height))
-            }
+            // The palette always rises from the key. Flipping it below would put it under the
+            // hand and away from the finger, so a palette too tall for the space above is
+            // clamped to the top edge instead.
+            val top = maxOf(
+                safe.top,
+                minOf(source.top - SourceGap * density - height, safe.bottom - height),
+            )
             val bounds = KeyBounds(left, top, left + width, top + height)
-            return AlternatePaletteLayout(bounds, itemBounds(count, bounds, columns, padding, gap, cellHeight), source)
+            return AlternatePaletteLayout(
+                bounds = bounds,
+                itemBounds = itemBounds(count, bounds, columns, padding, gap, cellHeight),
+                sourceBounds = source,
+                overlapsSource = bounds.intersects(source),
+            )
+        }
+
+        /**
+         * Wraps at [PreferredColumns] and widens only when the set would otherwise need more than
+         * [MaximumRows] rows. The rows are then evened out, so thirteen cells read as 5 + 5 + 3
+         * rather than 6 + 6 + 1.
+         */
+        private fun columnCount(count: Int, available: Float, density: Float): Int {
+            val widthLimit = ((available + Gap * density) / (MinimumSpan * density))
+                .toInt().coerceAtLeast(1)
+            val wrapped = ceil(count.toDouble() / PreferredColumns).toInt()
+            val rows = minOf(MaximumRows, wrapped.coerceAtLeast(1))
+            val balanced = ceil(count.toDouble() / rows).toInt()
+            return minOf(count, minOf(widthLimit, balanced.coerceAtLeast(1)))
         }
 
         private fun itemBounds(
@@ -67,3 +128,6 @@ private fun KeyBounds.inset(dx: Float, dy: Float) =
 
 private fun KeyBounds.expanded(value: Float) =
     KeyBounds(left - value, top - value, right + value, bottom + value)
+
+private fun KeyBounds.intersects(other: KeyBounds) =
+    left < other.right && other.left < right && top < other.bottom && other.top < bottom

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/CompactDigitAlternatesTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/CompactDigitAlternatesTest.kt
@@ -1,0 +1,116 @@
+package app.funput.funput.keyboard.layout
+
+import app.funput.funput.keyboard.model.KeyRole
+import app.funput.funput.keyboard.model.KeyboardEditorMode
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+import app.funput.funput.keyboard.model.KeyboardLayout
+import app.funput.funput.keyboard.model.KeyboardLayoutMode
+import app.funput.funput.keyboard.model.KeyboardRow
+import app.funput.funput.keyboard.popover.model.VietnameseKeyAlternates
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CompactDigitAlternatesTest {
+    @Test
+    fun `top row prints its digit, beside a Telex hint where there is one`() {
+        val compact = compactRow(KeyboardInputMethod.TELEX)
+        val standard = topRow(KeyboardLayouts.forInputMethod(KeyboardInputMethod.TELEX))
+
+        compact.keys.forEachIndexed { index, key ->
+            val tone = standard.keys[index].secondaryLabel
+            assertEquals(
+                tone?.let { "$it ${Digits[index]}" } ?: Digits[index],
+                key.secondaryLabel,
+            )
+        }
+        // `r` is the hỏi key: the tone hint leads and the digit follows it.
+        val hint = requireNotNull(compact.keys[3].secondaryLabel)
+        assertTrue(hint.startsWith(requireNotNull(standard.keys[3].secondaryLabel)))
+        assertTrue(hint.endsWith("4"))
+    }
+
+    @Test
+    fun `the digit leads every top-row palette`() {
+        listOf(KeyboardInputMethod.TELEX, KeyboardInputMethod.TELEX_ADVANCED).forEach { method ->
+            val row = compactRow(method)
+            row.keys.forEachIndexed { index, key ->
+                assertEquals(Digits[index], key.alternates.first().text)
+                assertEquals(Digits[index], key.alternates.first().shiftedText)
+                assertTrue(key.accessibilityLabel.endsWith(", số ${Digits[index]}"))
+            }
+            assertEquals(
+                listOf("7") + VietnameseKeyAlternates.valuesFor('u').map { it.text },
+                row.keys[6].alternates.map { it.text },
+            )
+            assertEquals(listOf("1"), row.keys[0].alternates.map { it.text })
+        }
+    }
+
+    @Test
+    fun `keys keep their identity so geometry and layout ids do not move`() {
+        val layout = KeyboardLayouts.forInputMethod(KeyboardInputMethod.TELEX, showsNumberRow = false)
+        val row = topRow(layout)
+
+        assertEquals("qwerty-telex-compact", layout.id)
+        assertEquals(TopRow.map { "character-$it" }, row.keys.map { it.id })
+        assertTrue(row.keys.all { it.role == KeyRole.CHARACTER && it.widthWeight == 1f })
+        assertEquals(TopRow.uppercase().map(Char::toString), row.keys.map { it.shiftedLabel })
+    }
+
+    @Test
+    fun `digits stay off whenever a number row is on screen`() {
+        KeyboardInputMethod.entries.forEach { method ->
+            val row = topRow(KeyboardLayouts.forInputMethod(method))
+            assertEquals(null, row.keys[0].secondaryLabel)
+            assertTrue(row.keys[0].alternates.isEmpty())
+            assertEquals("u", row.keys[6].alternates.first().text)
+        }
+        // VNI forces its own digit row, so the preference never reaches this page.
+        val vni = topRow(
+            KeyboardLayouts.forInputMethod(KeyboardInputMethod.VNI, showsNumberRow = false),
+        )
+        assertEquals(null, vni.keys[0].secondaryLabel)
+        assertTrue(vni.keys[0].alternates.isEmpty())
+    }
+
+    @Test
+    fun `only the compact letters page changes`() {
+        val compact = KeyboardLayouts.forInputMethod(KeyboardInputMethod.TELEX, showsNumberRow = false)
+        val standard = KeyboardLayouts.forInputMethod(KeyboardInputMethod.TELEX)
+        listOf("a", "s", "z").forEach { label ->
+            val key = compact.rows.flatMap { it.keys }.first { it.label == label }
+            val reference = standard.rows.flatMap { it.keys }.first { it.label == label }
+            assertEquals(reference.secondaryLabel, key.secondaryLabel)
+            assertEquals(reference.accessibilityLabel, key.accessibilityLabel)
+            assertEquals(reference.alternates, key.alternates)
+        }
+        listOf(
+            KeyboardEditorMode.SEARCH,
+            KeyboardEditorMode.EMAIL,
+            KeyboardEditorMode.URL,
+        ).forEach { editorMode ->
+            val row = topRow(
+                KeyboardLayoutResolver.resolve(
+                    inputMethod = KeyboardInputMethod.TELEX,
+                    mode = KeyboardLayoutMode.LETTERS,
+                    editorMode = editorMode,
+                    showsNumberRow = false,
+                ),
+            )
+            assertEquals("$editorMode", null, row.keys[0].secondaryLabel)
+            assertTrue("$editorMode", row.keys[0].alternates.isEmpty())
+        }
+    }
+
+    private fun compactRow(method: KeyboardInputMethod): KeyboardRow =
+        topRow(KeyboardLayouts.forInputMethod(method, showsNumberRow = false))
+
+    private fun topRow(layout: KeyboardLayout): KeyboardRow =
+        layout.rows.first { row -> row.keys.map { it.label } == TopRow.map(Char::toString) }
+
+    private companion object {
+        const val TopRow = "qwertyuiop"
+        val Digits = "1234567890".map(Char::toString)
+    }
+}

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/TelexToneHintsLayoutTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/TelexToneHintsLayoutTest.kt
@@ -30,9 +30,25 @@ class TelexToneHintsLayoutTest {
     }
 
     @Test
-    fun compactTelexStillShowsToneHints() {
-        assertToneHints(
-            KeyboardLayouts.forInputMethod(KeyboardInputMethod.TELEX, showsNumberRow = false),
+    fun compactTelexKeepsToneHintsBesideItsDigitHints() {
+        // With the number row hidden the top row also carries digits, so `r` reads "hỏi 4"
+        // and its nine neighbours gain a hint they do not have on the full layout.
+        val layout = KeyboardLayouts.forInputMethod(KeyboardInputMethod.TELEX, showsNumberRow = false)
+        val hinted = letterKeys(layout)
+            .filter { it.secondaryLabel != null }
+            .associate { it.label to it.secondaryLabel }
+
+        expectedHints.forEach { (label, glyph) ->
+            val hint = requireNotNull(hinted[label]) { label }
+            assertTrue(label, hint.startsWith(glyph))
+        }
+        assertEquals("̉ 4", hinted["r"])
+        assertEquals("´", hinted["s"])
+        // Only the top row and the tone keys are hinted; the rest stay bare.
+        assertTrue(
+            letterKeys(layout)
+                .filter { it.label !in expectedHints && it.label !in TopRowLabels }
+                .all { it.secondaryLabel == null },
         )
     }
 
@@ -97,6 +113,10 @@ class TelexToneHintsLayoutTest {
         letterKeys.filter { it.label !in expectedHints }.forEach { key ->
             assertNull(key.secondaryLabel)
         }
+    }
+
+    private companion object {
+        val TopRowLabels = "qwertyuiop".map(Char::toString)
     }
 
     private fun letterKeys(layout: app.funput.funput.keyboard.model.KeyboardLayout) =

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/popover/interaction/AlternateDispatchTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/popover/interaction/AlternateDispatchTest.kt
@@ -29,6 +29,14 @@ class AlternateDispatchTest {
     }
 
     @Test
+    fun `a digit alternate stays a digit under shift`() {
+        dispatcher.setShiftState(ShiftState.CAPS_LOCK)
+        dispatcher.dispatchAlternate(key, KeyAlternate("7", accessibilityLabel = "Số 7"))
+
+        assertEquals(KeyAction.Input(key.id, "7"), actions.single())
+    }
+
+    @Test
     fun `caps lock remains active after alternate`() {
         dispatcher.setShiftState(ShiftState.CAPS_LOCK)
         dispatcher.dispatchAlternate(key, KeyAlternate("ư"))

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/popover/interaction/AlternateSelectionControllerTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/popover/interaction/AlternateSelectionControllerTest.kt
@@ -3,6 +3,7 @@ package app.funput.funput.keyboard.popover.interaction
 import app.funput.funput.keyboard.layout.KeyBounds
 import app.funput.funput.keyboard.model.KeyRole
 import app.funput.funput.keyboard.model.KeySpec
+import app.funput.funput.keyboard.popover.model.KeyAlternate
 import app.funput.funput.keyboard.popover.model.VietnameseKeyAlternates
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -37,6 +38,21 @@ class AlternateSelectionControllerTest {
         startAndActivate()
         assertTrue(controller.finish(1, 120f, 220f))
         assertEquals(listOf("a"), selected)
+    }
+
+    @Test
+    fun `hold release on a compact top-row key selects its digit`() {
+        val digitKey = key.copy(
+            id = "character-u",
+            label = "u",
+            alternates = listOf(KeyAlternate("7", accessibilityLabel = "Số 7")) +
+                VietnameseKeyAlternates.valuesFor('u'),
+        )
+        controller.start(1, digitKey, 120f, 220f)
+        scheduler.run()
+
+        assertTrue(controller.finish(1, 120f, 220f))
+        assertEquals(listOf("7"), selected)
     }
 
     @Test

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/popover/rendering/AlternatePaletteLayoutTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/popover/rendering/AlternatePaletteLayoutTest.kt
@@ -2,6 +2,7 @@ package app.funput.funput.keyboard.popover.rendering
 
 import app.funput.funput.keyboard.layout.KeyBounds
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -14,18 +15,60 @@ class AlternatePaletteLayoutTest {
         val layout = resolve(18, KeyBounds(102f, 198f, 138f, 242f))
 
         assertEquals(18, layout.itemBounds.size)
-        assertEquals(9, layout.itemBounds.count { it.top == layout.itemBounds.first().top })
         assertTrue(layout.bounds.left >= 6f)
         assertTrue(layout.bounds.right <= 384f)
         assertTrue(layout.bounds.top >= 4f)
     }
 
     @Test
-    fun `palette uses below placement when top has no room`() {
-        val source = KeyBounds(60f, 8f, 100f, 48f)
-        val layout = resolve(12, source)
+    fun `the palette rises from the key instead of dropping below it`() {
+        listOf(62f, 111f, 160f, 209f).forEach { top ->
+            val source = KeyBounds(156f, top, 192f, top + 40f)
+            val layout = resolve(13, source)
 
-        assertTrue(layout.bounds.top > source.bottom)
+            assertTrue("$top", layout.bounds.top < source.top)
+            assertTrue("$top", layout.bounds.left >= 6f && layout.bounds.right <= 384f)
+        }
+    }
+
+    @Test
+    fun `the palette wraps into at most three rows instead of running wide`() {
+        listOf(62f, 209f).forEach { top ->
+            val source = KeyBounds(156f, top, 192f, top + 40f)
+            listOf(13, 18, 19).forEach { count ->
+                val layout = resolve(count, source)
+                val rows = layout.itemBounds.map { it.top }.distinct().size
+
+                assertTrue("$count", rows in 2..3)
+                assertTrue("$count", layout.bounds.width <= surface.width * 0.8f)
+            }
+        }
+    }
+
+    @Test
+    fun `short sets stay on one row`() {
+        val layout = resolve(2, KeyBounds(156f, 160f, 192f, 200f))
+
+        assertEquals(1, layout.itemBounds.map { it.top }.distinct().size)
+        assertEquals(2, layout.itemBounds.size)
+    }
+
+    @Test
+    fun `a palette clamped over its key keeps the default until the finger travels`() {
+        // Nineteen alternates cannot fit above a top-row key, so the palette covers it.
+        val source = KeyBounds(300f, 62f, 336f, 102f)
+        val layout = resolve(19, source)
+        val startX = source.centerX
+        val startY = source.centerY
+
+        assertTrue(layout.overlapsSource)
+        assertEquals(0, layout.selectionAt(startX, startY, startX, startY, 1f))
+        assertEquals(0, layout.selectionAt(startX + 6f, startY, startX, startY, 1f))
+        // The cell sitting over the key stays reachable once the finger has moved.
+        val covering = layout.indexAt(startX, startY, 1f)
+        assertNotEquals(null, covering)
+        assertNotEquals(0, covering)
+        assertEquals(covering, layout.selectionAt(startX, startY, startX, startY + 60f, 1f))
     }
 
     @Test


### PR DESCRIPTION
- Added `CompactDigitAlternates` to provide digit hints on the top character row when the number row is hidden.
- Updated `KeyboardLayouts` to apply digit alternates based on input method conditions.
- Enhanced `AlternateSelectionController` and `AlternatePaletteLayout` to improve interaction with digit alternates.
- Introduced tests for `CompactDigitAlternates` and updated existing tests to ensure correct behavior of digit hints and selection.