### PR TITLE
feat(ios): smart gestures — double-space period, spacebar caret pan, swipe-to-delete-word

### DIFF
--- a/platforms/ios/Funput.xcodeproj/project.pbxproj
+++ b/platforms/ios/Funput.xcodeproj/project.pbxproj
@@ -566,7 +566,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Funput/Funput.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = RSARFZ5CD3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -582,7 +582,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2026.67;
+				MARKETING_VERSION = 1.2026.69;
 				PRODUCT_BUNDLE_IDENTIFIER = app.funput.funput;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -602,7 +602,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Funput/Funput.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = RSARFZ5CD3;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_TESTABILITY = YES;
@@ -619,7 +619,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2026.67;
+				MARKETING_VERSION = 1.2026.69;
 				PRODUCT_BUNDLE_IDENTIFIER = app.funput.funput;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -723,7 +723,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Keyboard/Keyboard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = RSARFZ5CD3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Keyboard/Info.plist;
@@ -736,7 +736,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2026.67;
+				MARKETING_VERSION = 1.2026.69;
 				PRODUCT_BUNDLE_IDENTIFIER = app.funput.funput.Keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -754,7 +754,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Keyboard/Keyboard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 35;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = RSARFZ5CD3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Keyboard/Info.plist;
@@ -767,7 +767,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2026.67;
+				MARKETING_VERSION = 1.2026.69;
 				PRODUCT_BUNDLE_IDENTIFIER = app.funput.funput.Keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/platforms/ios/Funput/Settings/FeedbackSettingsCard.swift
+++ b/platforms/ios/Funput/Settings/FeedbackSettingsCard.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// The "Phản hồi" card: how the keyboard answers a touch.
+///
+/// Haptics and sound need Full Access, so their bindings arrive already wrapped by
+/// ``SettingsModel/fullAccessBinding(_:onDenied:)`` — this view only lays them out.
+struct FeedbackSettingsCard: View {
+    @Binding var haptics: Bool
+    @Binding var sound: Bool
+    @Binding var keyPreviews: Bool
+
+    var body: some View {
+        SettingsSectionCard(title: "Phản hồi", systemImage: "hand.tap") {
+            SettingsToggleRow(
+                title: "Rung khi gõ",
+                summary: "Yêu cầu Cho phép truy cập đầy đủ khi bật.",
+                isOn: $haptics
+            )
+            SettingsToggleRow(
+                title: "Âm thanh khi gõ",
+                summary: "Phát tiếng click bàn phím khi chạm phím.",
+                isOn: $sound
+            )
+            SettingsToggleRow(
+                title: "Xem trước phím",
+                summary: "Hiện ký tự phóng lớn khi bạn chạm phím.",
+                isOn: $keyPreviews
+            )
+        }
+    }
+}

--- a/platforms/ios/Funput/Settings/GestureSettingsCard.swift
+++ b/platforms/ios/Funput/Settings/GestureSettingsCard.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+/// One switch for every gesture that reads intent from movement rather than from a tap.
+///
+/// They ship as a group because they share a failure mode: a gesture that fires when the
+/// user only meant to type is worse than not having it, and someone who dislikes one of
+/// them almost always wants all three gone.
+struct GestureSettingsCard: View {
+    @Binding var isEnabled: Bool
+
+    var body: some View {
+        SettingsSectionCard(title: "Cử chỉ", systemImage: "hand.draw") {
+            SettingsToggleRow(
+                title: "Cử chỉ thông minh",
+                summary: "Gõ đúp phím cách để chấm câu, giữ phím cách rồi kéo để di chuyển "
+                    + "con trỏ, vuốt trái phím xóa để xóa cả từ.",
+                isOn: $isEnabled
+            )
+        }
+    }
+}

--- a/platforms/ios/Funput/Settings/SettingsScreen.swift
+++ b/platforms/ios/Funput/Settings/SettingsScreen.swift
@@ -73,27 +73,16 @@ struct SettingsScreen: View {
                 selectExpiry: { picker = .clipboardExpiry },
                 clear: { model.clearClipboardHistory() }
             )
-            SettingsSectionCard(title: "Phản hồi", systemImage: "hand.tap") {
-                SettingsToggleRow(
-                    title: "Rung khi gõ",
-                    summary: "Yêu cầu Cho phép truy cập đầy đủ khi bật.",
-                    isOn: model.fullAccessBinding(\.isHapticFeedbackEnabled) {
-                        requestsHapticAccess = true
-                    }
-                )
-                SettingsToggleRow(
-                    title: "Âm thanh khi gõ",
-                    summary: "Phát tiếng click bàn phím khi chạm phím.",
-                    isOn: model.fullAccessBinding(\.isKeySoundEnabled) {
-                        requestsSoundAccess = true
-                    }
-                )
-                SettingsToggleRow(
-                    title: "Xem trước phím",
-                    summary: "Hiện ký tự phóng lớn khi bạn chạm phím.",
-                    isOn: model.boolBinding(\.showsKeyPreviews)
-                )
-            }
+            FeedbackSettingsCard(
+                haptics: model.fullAccessBinding(\.isHapticFeedbackEnabled) {
+                    requestsHapticAccess = true
+                },
+                sound: model.fullAccessBinding(\.isKeySoundEnabled) {
+                    requestsSoundAccess = true
+                },
+                keyPreviews: model.boolBinding(\.showsKeyPreviews)
+            )
+            GestureSettingsCard(isEnabled: model.boolBinding(\.smartGesturesEnabled))
             SettingsResetCard { model.reset() }
         }
         .navigationTitle("Cài đặt")

--- a/platforms/ios/FunputTests/Support/TouchSynthesis.swift
+++ b/platforms/ios/FunputTests/Support/TouchSynthesis.swift
@@ -22,6 +22,9 @@ func accessibleControls(in view: UIView) -> [UIControl] {
 @MainActor
 final class ScriptedWriter: KeyboardDocumentWriting {
     private(set) var text = ""
+    /// Character index of the caret; the trackpad gesture is the only thing that moves it
+    /// away from the end of the text.
+    private(set) var caret = 0
     let documentIdentifier = UUID()
     /// When set, `contextBeforeInput` reports this instead of `text`,
     /// simulating a stale host callback. Cleared by the test after delivery.
@@ -30,22 +33,41 @@ final class ScriptedWriter: KeyboardDocumentWriting {
     var snapshot: KeyboardDocumentSnapshot {
         .init(
             documentIdentifier: documentIdentifier,
-            contextBeforeInput: reportedContext ?? text,
+            contextBeforeInput: reportedContext
+                ?? (caret == text.count ? text : String(text.prefix(caret))),
             hasSelection: false
         )
     }
 
     func replaceTextExternally(with text: String) {
         self.text = text
+        caret = text.count
     }
 
     func apply(_ transaction: InputTransaction) {
         for mutation in transaction.mutations {
             switch mutation {
             case let .deleteBackward(count):
-                for _ in 0..<count where !text.isEmpty { text.removeLast() }
+                for _ in 0..<count where caret > 0 {
+                    if caret == text.count {
+                        text.removeLast()
+                    } else {
+                        text.remove(at: text.index(text.startIndex, offsetBy: caret - 1))
+                    }
+                    caret -= 1
+                }
             case let .insert(inserted):
-                text += inserted
+                if caret == text.count {
+                    text += inserted
+                } else {
+                    text.insert(
+                        contentsOf: inserted,
+                        at: text.index(text.startIndex, offsetBy: caret)
+                    )
+                }
+                caret += inserted.count
+            case let .moveCursor(offset):
+                caret = min(max(0, caret + offset), text.count)
             }
         }
     }

--- a/platforms/ios/FunputTests/Support/TouchSynthesis.swift
+++ b/platforms/ios/FunputTests/Support/TouchSynthesis.swift
@@ -25,6 +25,9 @@ final class ScriptedWriter: KeyboardDocumentWriting {
     /// Character index of the caret; the trackpad gesture is the only thing that moves it
     /// away from the end of the text.
     private(set) var caret = 0
+    /// `text.count` walks the whole string, and the hundred-thousand-key stress tests ask
+    /// for it on every keystroke. Maintained alongside every mutation instead.
+    private var textCount = 0
     let documentIdentifier = UUID()
     /// When set, `contextBeforeInput` reports this instead of `text`,
     /// simulating a stale host callback. Cleared by the test after delivery.
@@ -34,14 +37,15 @@ final class ScriptedWriter: KeyboardDocumentWriting {
         .init(
             documentIdentifier: documentIdentifier,
             contextBeforeInput: reportedContext
-                ?? (caret == text.count ? text : String(text.prefix(caret))),
+                ?? (caret == textCount ? text : String(text.prefix(caret))),
             hasSelection: false
         )
     }
 
     func replaceTextExternally(with text: String) {
         self.text = text
-        caret = text.count
+        textCount = text.count
+        caret = textCount
     }
 
     func apply(_ transaction: InputTransaction) {
@@ -49,15 +53,16 @@ final class ScriptedWriter: KeyboardDocumentWriting {
             switch mutation {
             case let .deleteBackward(count):
                 for _ in 0..<count where caret > 0 {
-                    if caret == text.count {
+                    if caret == textCount {
                         text.removeLast()
                     } else {
                         text.remove(at: text.index(text.startIndex, offsetBy: caret - 1))
                     }
                     caret -= 1
+                    textCount -= 1
                 }
             case let .insert(inserted):
-                if caret == text.count {
+                if caret == textCount {
                     text += inserted
                 } else {
                     text.insert(
@@ -65,9 +70,11 @@ final class ScriptedWriter: KeyboardDocumentWriting {
                         at: text.index(text.startIndex, offsetBy: caret)
                     )
                 }
-                caret += inserted.count
+                let insertedCount = inserted.count
+                caret += insertedCount
+                textCount += insertedCount
             case let .moveCursor(offset):
-                caret = min(max(0, caret + offset), text.count)
+                caret = min(max(0, caret + offset), textCount)
             }
         }
     }

--- a/platforms/ios/FunputUITests/FunputKeyboardDriver.swift
+++ b/platforms/ios/FunputUITests/FunputKeyboardDriver.swift
@@ -74,6 +74,16 @@ enum FunputKeyboardDriver {
         }
     }
 
+    /// Frame of one keycap addressed by its accessibility label, for keys the
+    /// character-based lookup cannot name (Backspace, Shift, …).
+    static func keyFrame(
+        _ app: XCUIApplication, labeled label: String, exact: Bool = true
+    ) -> CGRect? {
+        let element = keyElement(app, labeled: label, exact: exact)
+        guard element.waitForExistence(timeout: 3) else { return nil }
+        return element.frame
+    }
+
     /// A keycap in the keyboard area. Prefers real `.key` elements; falls back
     /// to any labeled element in the lower half of the screen so the query can
     /// never land on the harness text content.

--- a/platforms/ios/FunputUITests/SmartGestureUITests.swift
+++ b/platforms/ios/FunputUITests/SmartGestureUITests.swift
@@ -1,0 +1,116 @@
+import XCTest
+
+/// The three smart gestures driven through the real keyboard extension.
+///
+/// Only a real touch sequence exercises the whole stack — hold timers, the
+/// gesture claim, and the document writes — so these live here rather than in
+/// the unit targets, which stop at the controller boundary.
+///
+/// Prerequisites are the same as `VietnameseTypingUITests`: the extension must
+/// already be enabled (simulator → `Scripts/uitest-enable-keyboard.sh`, device →
+/// Settings › General › Keyboard › Keyboards).
+final class SmartGestureUITests: XCTestCase {
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    override func tearDownWithError() throws {
+        app?.terminate()
+        let cleanupApp = XCUIApplication()
+        cleanupApp.launchArguments = ["-uitest-clear-configuration-override"]
+        cleanupApp.launch()
+        cleanupApp.terminate()
+        app = nil
+    }
+
+    @MainActor
+    func testDoubleTappingSpaceWritesAFullStop() throws {
+        let field = try startTyping()
+        let taps = FunputKeyboardDriver.resolveKeyCoordinates(app, for: "xin chao")
+        type("xin chao", taps: taps)
+
+        taps[" "]!.doubleTap()
+
+        Thread.sleep(forTimeInterval: 1)
+        XCTAssertEqual(field.value as? String, "xin chao. ")
+    }
+
+    @MainActor
+    func testHoldingSpaceAndDraggingMovesTheCaret() throws {
+        let field = try startTyping()
+        let taps = FunputKeyboardDriver.resolveKeyCoordinates(app, for: "abcdefx")
+        type("abcdef", taps: taps)
+
+        let space = try key(labeled: "Dấu cách", exact: false)
+        space.press(
+            forDuration: 0.45,
+            thenDragTo: space.withOffset(CGVector(dx: -40, dy: 0)),
+            withVelocity: .slow,
+            thenHoldForDuration: 0.2
+        )
+        taps["x"]!.tap()
+
+        Thread.sleep(forTimeInterval: 1)
+        let actual = (field.value as? String) ?? ""
+        XCTAssertTrue(actual.contains("x"), "nothing was typed: \(actual)")
+        XCTAssertFalse(
+            actual.hasSuffix("x"),
+            "the caret never moved — dragging the spacebar typed at the end: \(actual)"
+        )
+        XCTAssertEqual(actual.count, 7, "the drag inserted or ate characters: \(actual)")
+    }
+
+    @MainActor
+    func testSwipingLeftOnBackspaceDeletesAWholeWord() throws {
+        let field = try startTyping()
+        type("xin chao", taps: FunputKeyboardDriver.resolveKeyCoordinates(app, for: "xin chao"))
+
+        let backspace = try key(labeled: "Xóa")
+        backspace.press(
+            forDuration: 0.05,
+            thenDragTo: backspace.withOffset(CGVector(dx: -70, dy: 0)),
+            withVelocity: .slow,
+            thenHoldForDuration: 0.2
+        )
+
+        Thread.sleep(forTimeInterval: 1)
+        XCTAssertEqual(field.value as? String, "xin ")
+    }
+
+    @MainActor
+    private func startTyping() throws -> XCUIElement {
+        app = XCUIApplication()
+        app.launchArguments += ["-uitest-typing-harness"]
+        app.launch()
+
+        let field = app.textViews["typingHarness.field"]
+        XCTAssertTrue(field.waitForExistence(timeout: 10), "typing harness field missing")
+        field.tap()
+        XCTAssertTrue(FunputKeyboardDriver.switchToFunputKeyboard(app), """
+        Funput keyboard never appeared. Enable the extension first: \
+        simulator → Scripts/uitest-enable-keyboard.sh, device → Settings › \
+        General › Keyboard › Keyboards.
+        """)
+        return field
+    }
+
+    @MainActor
+    private func key(labeled label: String, exact: Bool = true) throws -> XCUICoordinate {
+        let frame = try XCTUnwrap(
+            FunputKeyboardDriver.keyFrame(app, labeled: label, exact: exact),
+            "key \"\(label)\" not found on the Funput keyboard"
+        )
+        return app.coordinate(withNormalizedOffset: .zero)
+            .withOffset(CGVector(dx: frame.midX, dy: frame.midY))
+    }
+
+    @MainActor
+    private func type(_ text: String, taps: [Character: XCUICoordinate]) {
+        for character in text {
+            taps[character]!.tap()
+            usleep(80_000)
+        }
+    }
+}

--- a/platforms/ios/Keyboard/Controller/KeyboardViewController+Gestures.swift
+++ b/platforms/ios/Keyboard/Controller/KeyboardViewController+Gestures.swift
@@ -1,0 +1,31 @@
+import KeyboardInput
+import KeyboardLayout
+import KeyboardRenderer
+import UIKit
+
+extension KeyboardViewController {
+    /// Handles the phases the gesture lane writes to the document itself.
+    ///
+    /// Returns whether the event was fully handled, so `handleKeyEvent` can leave the
+    /// ordinary key path untouched.
+    func handleGesturePhase(_ phase: KeyboardKeyEvent.Phase) -> Bool {
+        switch phase {
+        case .swiped(.toggleLanguage):
+            inputCoordinator.toggleLanguage()
+            applyPostCommitEffects(
+                .init(presentationChanged: true, suggestionsChanged: true)
+            )
+        case let .cursorMoved(offset):
+            applyPostCommitEffects(
+                inputCoordinator.moveCursor(by: offset, writer: makeDocumentWriter())
+            )
+        case .deletedWord:
+            applyPostCommitEffects(
+                inputCoordinator.deleteWordBackward(writer: makeDocumentWriter())
+            )
+        default:
+            return false
+        }
+        return true
+    }
+}

--- a/platforms/ios/Keyboard/Controller/KeyboardViewController+Input.swift
+++ b/platforms/ios/Keyboard/Controller/KeyboardViewController+Input.swift
@@ -111,6 +111,8 @@ extension KeyboardViewController {
         presentation.enterAction = state.enterAction
         presentation.showsKeyPreviews = !state.editorMode.isPassword
             && configuration.showsKeyPreviews
+        presentation.areSmartGesturesEnabled = !state.editorMode.isPassword
+            && configuration.smartGesturesEnabled
         return presentation
     }
 

--- a/platforms/ios/Keyboard/Controller/KeyboardViewController+Input.swift
+++ b/platforms/ios/Keyboard/Controller/KeyboardViewController+Input.swift
@@ -7,22 +7,14 @@ import UIKit
 
 extension KeyboardViewController {
     func handleKeyEvent(_ event: KeyboardKeyEvent) {
+        if handleGesturePhase(event.phase) { return }
         let alternate: KeyAlternate?
         switch event.phase {
         case .released, .repeated:
             alternate = nil
         case let .alternateSelected(value):
             alternate = value
-        case .pressed, .cancelled:
-            return
-        case .swiped(.toggleLanguage):
-            inputCoordinator.toggleLanguage()
-            applyPostCommitEffects(
-                .init(
-                    presentationChanged: true,
-                    suggestionsChanged: true
-                )
-            )
+        case .pressed, .cancelled, .swiped, .cursorMoved, .deletedWord:
             return
         }
 

--- a/platforms/ios/Keyboard/Document/KeyboardDocumentWriter.swift
+++ b/platforms/ios/Keyboard/Document/KeyboardDocumentWriter.swift
@@ -60,6 +60,10 @@ final class KeyboardDocumentWriter: KeyboardDocumentWriting {
             case let .insert(text):
                 guard !text.isEmpty else { continue }
                 proxy.insertText(text)
+            case let .moveCursor(offset):
+                // The proxy clamps at both ends of the document and reports nothing back,
+                // so the caret position is never inferred here — it is re-read from the host.
+                proxy.adjustTextPosition(byCharacterOffset: offset)
             }
         }
         os_signpost(

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Configuration/FunputConfiguration+Codable.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Configuration/FunputConfiguration+Codable.swift
@@ -18,6 +18,7 @@ extension FunputConfiguration {
         config.isHapticFeedbackEnabled = try container.decodeIfPresent(Bool.self, forKey: .isHapticFeedbackEnabled) ?? config.isHapticFeedbackEnabled
         config.isKeySoundEnabled = try container.decodeIfPresent(Bool.self, forKey: .isKeySoundEnabled) ?? config.isKeySoundEnabled
         config.showsKeyPreviews = try container.decodeIfPresent(Bool.self, forKey: .showsKeyPreviews) ?? config.showsKeyPreviews
+        config.smartGesturesEnabled = try container.decodeIfPresent(Bool.self, forKey: .smartGesturesEnabled) ?? config.smartGesturesEnabled
         config.showsNumberRow = try container.decodeIfPresent(Bool.self, forKey: .showsNumberRow) ?? config.showsNumberRow
         config.layoutPreset = try container.decodeIfPresent(KeyboardLayoutPreset.self, forKey: .layoutPreset) ?? config.layoutPreset
         config.heightScale = try container.decodeIfPresent(Double.self, forKey: .heightScale) ?? config.heightScale
@@ -61,6 +62,11 @@ extension FunputConfiguration {
         // which stomps a value because that field's default flipped.
         if config.schemaVersion < 10 {
             config.schemaVersion = 10
+        }
+        // v11 added `smartGesturesEnabled`, defaulting to on for everyone: the gestures
+        // it covers are what iOS users already expect from the system keyboard.
+        if config.schemaVersion < 11 {
+            config.schemaVersion = 11
         }
         self = config
     }

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Configuration/FunputConfiguration.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Configuration/FunputConfiguration.swift
@@ -19,6 +19,8 @@ public struct FunputConfiguration: Codable, Hashable, Sendable {
     public var isHapticFeedbackEnabled: Bool
     public var isKeySoundEnabled: Bool
     public var showsKeyPreviews: Bool
+    /// Double-tap space, spacebar cursor panning and swipe-to-delete-word, as one switch.
+    public var smartGesturesEnabled: Bool
     public var showsNumberRow: Bool
     public var layoutPreset: KeyboardLayoutPreset
     public var heightScale: Double
@@ -32,6 +34,7 @@ public struct FunputConfiguration: Codable, Hashable, Sendable {
         case inputMethod, language, toneStyle, spellCheck, smartRestore
         case eagerRestore, autoCapitalize, selectedThemeID
         case isHapticFeedbackEnabled, isKeySoundEnabled, showsKeyPreviews
+        case smartGesturesEnabled
         case showsNumberRow, layoutPreset, heightScale
         case personalSuggestionsEnabled, personalSuggestionResetToken
         case clipboardEnabled, clipboardExpiry, schemaVersion
@@ -49,6 +52,7 @@ public struct FunputConfiguration: Codable, Hashable, Sendable {
         isHapticFeedbackEnabled: Bool = false,
         isKeySoundEnabled: Bool = false,
         showsKeyPreviews: Bool = true,
+        smartGesturesEnabled: Bool = true,
         showsNumberRow: Bool = false,
         layoutPreset: KeyboardLayoutPreset = .funput,
         heightScale: Double = 1.1,
@@ -69,6 +73,7 @@ public struct FunputConfiguration: Codable, Hashable, Sendable {
         self.isHapticFeedbackEnabled = isHapticFeedbackEnabled
         self.isKeySoundEnabled = isKeySoundEnabled
         self.showsKeyPreviews = showsKeyPreviews
+        self.smartGesturesEnabled = smartGesturesEnabled
         self.showsNumberRow = showsNumberRow
         self.layoutPreset = layoutPreset
         self.heightScale = heightScale
@@ -84,5 +89,5 @@ public struct FunputConfiguration: Codable, Hashable, Sendable {
     public static let defaultThemeID = "app.funput.theme.glass"
 
     /// Schema version emitted by this build. Bump when the stored shape changes.
-    public static let currentSchemaVersion = 10
+    public static let currentSchemaVersion = 11
 }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardConfiguration/Presentation/KeyboardPresentationFactory.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardConfiguration/Presentation/KeyboardPresentationFactory.swift
@@ -36,7 +36,8 @@ public enum KeyboardPresentationFactory {
             language: configuration.language,
             isHapticFeedbackEnabled: configuration.isHapticFeedbackEnabled,
             isKeySoundEnabled: configuration.isKeySoundEnabled,
-            showsKeyPreviews: configuration.showsKeyPreviews
+            showsKeyPreviews: configuration.showsKeyPreviews,
+            areSmartGesturesEnabled: configuration.smartGesturesEnabled
         )
     }
 

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Configuration/KeyboardInputCoordinator+Configuration.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Configuration/KeyboardInputCoordinator+Configuration.swift
@@ -26,6 +26,8 @@ public extension KeyboardInputCoordinator {
             )
         )
         shiftController.resetTapSequence()
+        spaceTapTracker.reset()
+        smartGesturesEnabled = configuration.smartGesturesEnabled
         documentSynchronizer.invalidate()
         personalSuggestionsEnabled = configuration.personalSuggestionsEnabled
         resetPersonalSuggestionTracking()

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/Gestures/KeyboardInputCoordinator+Cursor.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/Gestures/KeyboardInputCoordinator+Cursor.swift
@@ -1,0 +1,26 @@
+#if os(iOS) && canImport(FunputCore)
+extension KeyboardInputCoordinator {
+    /// Moves the caret by whole characters for the spacebar trackpad.
+    ///
+    /// Composition cannot survive the caret leaving the buffer it mirrors, so every step
+    /// ends it. Deliberately not routed through ``commit(writer:closesEpoch:preservesOneShotShift:reopensPreviousWord:build:)``:
+    /// that path re-resolves capitalization from a shadow this mutation has just dropped.
+    /// Shift is resolved instead from the host's own selection callback.
+    @discardableResult
+    public func moveCursor(
+        by offset: Int,
+        writer: any KeyboardDocumentWriting
+    ) -> KeyboardPostCommitEffects {
+        guard offset != 0 else { return .none }
+        prepareForLiteralInput()
+        let transaction = InputTransaction(
+            sequence: nextTransactionSequence,
+            mutations: [.moveCursor(offset: offset)],
+            resultingState: state
+        )
+        nextTransactionSequence += 1
+        writer.apply(transaction)
+        return .init(suggestionsChanged: true)
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/Gestures/KeyboardInputCoordinator+SmartSpace.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/Gestures/KeyboardInputCoordinator+SmartSpace.swift
@@ -1,0 +1,27 @@
+#if os(iOS) && canImport(FunputCore)
+extension KeyboardInputCoordinator {
+    /// Turns the second of two quick spaces into `". "`, the way the system keyboard does.
+    ///
+    /// Staged into the same transaction as an ordinary space so the document shadow, the
+    /// echo ledger and the suggestion tracker all see one coherent mutation. Returns
+    /// whether the substitution was made; the caller inserts a plain space otherwise.
+    func applySmartSpace(builder: inout InputTransactionBuilder) -> Bool {
+        guard smartGesturesEnabled else { return false }
+        guard spaceTapTracker.registerSpace() else { return false }
+        // Read the shadow rather than the proxy: `commit` has already synchronized it, and
+        // it is the copy that stays correct when the host reports stale context.
+        guard let snapshot = documentSynchronizer.snapshot,
+              !snapshot.hasSelection,
+              SentencePunctuationRule.appliesTo(
+                  contextBeforeInput: snapshot.contextBeforeInput
+              )
+        else { return false }
+        // The trailing space is literal text, never part of a syllable, so the composer is
+        // cleared instead of being asked to delete through it.
+        composer.clear()
+        builder.deleteBackward()
+        builder.insert(". ")
+        return true
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/Gestures/KeyboardInputCoordinator+WordDelete.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/Gestures/KeyboardInputCoordinator+WordDelete.swift
@@ -1,0 +1,50 @@
+#if os(iOS) && canImport(FunputCore)
+extension KeyboardInputCoordinator {
+    /// Deletes the word behind the caret, plus any spaces between it and the caret.
+    ///
+    /// Falls back to a single backspace whenever the span cannot be measured — a
+    /// selection is pending, or the host reports no context — because deleting a guessed
+    /// number of characters is far worse than deleting one too few.
+    @discardableResult
+    public func deleteWordBackward(
+        writer: any KeyboardDocumentWriting
+    ) -> KeyboardPostCommitEffects {
+        synchronizeBeforeInput(writer)
+        guard let snapshot = documentSynchronizer.snapshot,
+              !snapshot.hasSelection,
+              let count = KeyboardWordDeletion.spanBeforeCursor(snapshot.contextBeforeInput)
+        else { return deleteBackward(writer: writer) }
+        return commit(
+            writer: writer,
+            closesEpoch: true,
+            preservesOneShotShift: true
+        ) { builder in
+            // Literal deletion: the span covers committed text, so the composer is ended
+            // rather than walked back character by character.
+            composer.clear()
+            builder.deleteBackward(count: count)
+        }
+    }
+}
+
+enum KeyboardWordDeletion {
+    /// The number of characters a word-delete should remove, or nil when there is nothing
+    /// measurable behind the caret.
+    ///
+    /// Trailing whitespace goes first, so a swipe after `"xin chao "` takes the word too
+    /// rather than only the space the caret visually sits behind. What follows is either a
+    /// word or a run of punctuation — `"a!!!"` loses all three marks, not one.
+    static func spanBeforeCursor(_ context: String?) -> Int? {
+        guard let context, !context.isEmpty else { return nil }
+        let spaces = context.reversed().prefix { $0.isWhitespace && !$0.isNewline }.count
+        let trimmed = String(context.dropLast(spaces))
+        guard let last = trimmed.last else { return spaces > 0 ? spaces : nil }
+        let run = last.isCompositionBoundary
+            ? trimmed.reversed().prefix { $0.isCompositionBoundary && !$0.isWhitespace }.count
+            : (trimmed.wordBeforeCursor()?.count ?? 0)
+        let span = spaces + run
+        return span > 0 ? span : nil
+    }
+}
+
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/KeyboardInputCoordinator+Actions.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/KeyboardInputCoordinator+Actions.swift
@@ -57,13 +57,15 @@ extension KeyboardInputCoordinator {
         _ key: KeySpec,
         builder: inout InputTransactionBuilder
     ) {
+        if key.role != .space { spaceTapTracker.reset() }
         switch key.role {
         case .character:
             input(characterText(for: key), builder: &builder)
             consumeOneShotShift()
         case .vniModifier, .punctuation:
             input(key.label, builder: &builder)
-        case .space: input(" ", builder: &builder)
+        case .space:
+            if !applySmartSpace(builder: &builder) { input(" ", builder: &builder) }
         case .enter: input("\n", builder: &builder)
         // Re-opening the previous word is deferred to `commit`, which runs it once the
         // shadow reflects this deletion.

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/KeyboardInputCoordinator+Document.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/KeyboardInputCoordinator+Document.swift
@@ -113,6 +113,8 @@ extension KeyboardInputCoordinator {
     private func resetCompositionState() {
         composer.clear()
         shiftController.resetTapSequence()
+        // A focus change must not carry a half-finished double tap into the next field.
+        spaceTapTracker.reset()
     }
 
     private func synchronizeCapitalization(

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/KeyboardInputCoordinator.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/KeyboardInputCoordinator.swift
@@ -9,6 +9,10 @@ public final class KeyboardInputCoordinator {
 
     let composer: FunputComposer
     var shiftController: ShiftStateController
+    var spaceTapTracker: SpaceTapTracker
+    /// Mirrors ``FunputConfiguration/smartGesturesEnabled`` for the gestures the engine
+    /// owns; the touch-side gestures read it from ``KeyboardPresentation`` instead.
+    public internal(set) var smartGesturesEnabled = true
     var documentSynchronizer = KeyboardDocumentSynchronizer()
     var suggestionTracker = AuthoredTokenTracker()
     var personalSuggestionsEnabled = true
@@ -20,6 +24,9 @@ public final class KeyboardInputCoordinator {
         inputMethod: KeyboardInputMethod = .vni,
         shiftDoubleTapInterval: TimeInterval = 0.3,
         shiftClock: @escaping () -> TimeInterval = {
+            ProcessInfo.processInfo.systemUptime
+        },
+        gestureClock: @escaping () -> TimeInterval = {
             ProcessInfo.processInfo.systemUptime
         },
         echoClock: @escaping () -> TimeInterval = {
@@ -37,6 +44,9 @@ public final class KeyboardInputCoordinator {
             doubleTapInterval: shiftDoubleTapInterval,
             clock: shiftClock
         )
+        // Its own clock, not `shiftClock`: a test that freezes shift's clock would
+        // otherwise turn every second space into a full stop.
+        spaceTapTracker = SpaceTapTracker(clock: gestureClock)
         documentSynchronizer.clock = echoClock
         composer.setInputMethod(inputMethod.engineMethod)
     }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Document/KeyboardDocumentSynchronizer.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Document/KeyboardDocumentSynchronizer.swift
@@ -76,6 +76,11 @@ struct KeyboardDocumentSynchronizer {
                 for _ in 0..<count { recordDeletion() }
             case let .insert(text):
                 recordInsertion(text)
+            case .moveCursor:
+                // The shadow holds only the text before the caret, so a move to the right
+                // would need `documentContextAfterInput`, which no snapshot carries. Drop
+                // the shadow and let the host's next change callback re-seed it.
+                invalidate()
             }
         }
     }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/PersonalSuggestions/AuthoredTokenTracker.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/PersonalSuggestions/AuthoredTokenTracker.swift
@@ -42,6 +42,10 @@ struct AuthoredTokenTracker {
                 for _ in 0..<count { recordDeletion() }
             case let .insert(text):
                 recordInsertion(text)
+            case .moveCursor:
+                // The caret left the token being tracked; nothing typed here is a word any
+                // more, so the prefix is abandoned rather than continued.
+                reset()
             }
         }
     }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/State/Gestures/SentencePunctuationRule.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/State/Gestures/SentencePunctuationRule.swift
@@ -1,0 +1,13 @@
+/// Decides whether a second space should become a full stop.
+///
+/// Mirrors the system keyboard: the substitution only applies when the caret sits behind
+/// a single space that closes a word, so `"xin chao "` qualifies while `"xin chao. "`,
+/// `"(  "` and the start of a document do not. A newline or tab before the caret is not a
+/// word ending anyone means to punctuate, which the letter-or-number test also rejects.
+enum SentencePunctuationRule {
+    static func appliesTo(contextBeforeInput: String?) -> Bool {
+        guard let context = contextBeforeInput, context.hasSuffix(" ") else { return false }
+        guard let preceding = context.dropLast().last else { return false }
+        return preceding.isLetter || preceding.isNumber
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/State/Gestures/SpaceTapTracker.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/State/Gestures/SpaceTapTracker.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Recognizes two space presses in quick succession.
+///
+/// Deliberately shaped like ``ShiftStateController``: a value type over an injected
+/// clock, so the double-tap window is testable without waiting on wall time.
+@MainActor
+struct SpaceTapTracker {
+    private let doubleTapInterval: TimeInterval
+    private let clock: () -> TimeInterval
+    private var lastTapTime: TimeInterval?
+
+    init(
+        doubleTapInterval: TimeInterval = 0.3,
+        clock: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
+    ) {
+        self.doubleTapInterval = doubleTapInterval
+        self.clock = clock
+    }
+
+    /// Records a space press and reports whether it completes a double tap.
+    ///
+    /// A firing press clears the sequence, so three spaces produce one substitution
+    /// and a plain space rather than a second one.
+    mutating func registerSpace() -> Bool {
+        let tapTime = clock()
+        if let lastTapTime, tapTime - lastTapTime <= doubleTapInterval {
+            reset()
+            return true
+        }
+        lastTapTime = tapTime
+        return false
+    }
+
+    /// Called for every non-space key: two spaces separated by other input are not a
+    /// double tap, however fast they arrive.
+    mutating func reset() {
+        lastTapTime = nil
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Transactions/InputTransaction.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Transactions/InputTransaction.swift
@@ -3,6 +3,9 @@ import Foundation
 public enum DocumentMutation: Equatable, Sendable {
     case deleteBackward(count: Int)
     case insert(String)
+    /// Moves the caret without changing the text. Kept in the same channel as the text
+    /// mutations so the document shadow is never advanced behind the synchronizer's back.
+    case moveCursor(offset: Int)
 }
 
 public struct InputTransaction: Equatable, Sendable {

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/Factory/KeyboardKeyFactory.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/Factory/KeyboardKeyFactory.swift
@@ -84,7 +84,8 @@ func standardSpaceKey(weight: CGFloat = 5.8) -> KeySpec {
         label: "Tiếng Việt",
         role: .space,
         widthWeight: weight,
-        accessibilityLabel: "Dấu cách. Vuốt để đổi Tiếng Việt và Tiếng Anh",
+        accessibilityLabel: "Dấu cách. Vuốt để đổi Tiếng Việt và Tiếng Anh. "
+            + "Giữ rồi kéo để di chuyển con trỏ",
         horizontalSwipeAction: .toggleLanguage
     )
 }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Alternates/KeyHoldController.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Alternates/KeyHoldController.swift
@@ -1,8 +1,12 @@
 #if canImport(UIKit)
 import Foundation
 
+/// Fires once a single contact has stayed down past `delay`.
+///
+/// Shared by the alternates palette and the spacebar trackpad: both are "the finger has
+/// stopped being a tap" timers, differing only in how long they wait and what they do.
 @MainActor
-final class AlternateHoldController {
+final class KeyHoldController {
     typealias TouchToken = UInt64
     typealias Scheduler = BackspaceRepeatController.Scheduler
 

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Controller/Gestures/KeyboardSurfaceInteractionController+SpaceTrackpad.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Controller/Gestures/KeyboardSurfaceInteractionController+SpaceTrackpad.swift
@@ -1,0 +1,64 @@
+#if canImport(UIKit)
+import KeyboardLayout
+import UIKit
+
+extension KeyboardSurfaceInteractionController {
+    /// Hold timer callback: the press is now old enough to become a trackpad, but nothing
+    /// is claimed until the finger actually moves — a resting thumb must still type a space.
+    func armSpaceTrackpad(for token: TouchToken) {
+        touches[token]?.holdArmed = true
+    }
+
+    /// Promotes an armed space press into a caret pan once the finger travels sideways.
+    ///
+    /// A refused claim means the pipeline already committed the press; the caller falls
+    /// through to the ordinary swipe handling rather than emitting anyway.
+    func activateSpaceTrackpad(token: TouchToken, translation: CGPoint) -> Bool {
+        guard var state = touches[token],
+              state.holdArmed,
+              state.trackpad == nil,
+              abs(translation.x) >= KeyboardSurfaceInteractionController.trackpadActivation,
+              // A repeat that already fired inserted spaces; switching to a caret pan on
+              // top of that would leave the user unsure what the gesture did.
+              !(repeatTouch == token && repeatController.hasRepeated),
+              onClaimGesture(token, .trackpad)
+        else { return false }
+        clearKeyRepeat()
+        if let key = state.currentKey { setHighlighted(key, false) }
+        state.currentKey = nil
+        state.claimedGesture = .trackpad
+        state.trackpad = SpaceCursorPanTracker()
+        touches[token] = state
+        if hapticsEnabled { haptics.perform(.control) }
+        refreshPreview()
+        return true
+    }
+
+    func updateSpaceTrackpad(token: TouchToken, translation: CGPoint) {
+        guard var state = touches[token], var tracker = state.trackpad else { return }
+        let offset = tracker.update(translationX: translation.x)
+        state.trackpad = tracker
+        touches[token] = state
+        guard offset != 0 else { return }
+        onContactEvent(
+            token,
+            KeyboardKeyEvent(key: state.initialKey, phase: .cursorMoved(offset: offset))
+        )
+        if hapticsEnabled { haptics.perform(.deleteRepeat) }
+    }
+
+    func completeGestureTouch(token: TouchToken, state: TouchState) {
+        touches.removeValue(forKey: token)
+        if let key = state.currentKey { setHighlighted(key, false) }
+        if repeatTouch == token { clearKeyRepeat() }
+        // One `.cancelled` closes the contact's bookkeeping without producing a key: the
+        // gesture already wrote whatever the user asked for.
+        onContactEvent(
+            token,
+            KeyboardKeyEvent(key: state.initialKey, phase: .cancelled)
+        )
+        endSignpost(state, token: token, phase: 3)
+        refreshPreview()
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Controller/Gestures/KeyboardSurfaceInteractionController+WordDelete.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Controller/Gestures/KeyboardSurfaceInteractionController+WordDelete.swift
@@ -1,0 +1,55 @@
+#if canImport(UIKit)
+import KeyboardLayout
+import UIKit
+
+extension KeyboardSurfaceInteractionController {
+    /// Takes ownership of a leftward rub on Backspace while the finger is still on the
+    /// keycap, so it can never drift onto a neighbour and commit that key instead.
+    func activateWordRatchet(token: TouchToken, translation: CGPoint) -> Bool {
+        guard var state = touches[token],
+              state.smartGestures,
+              state.initialKey.role == .backspace,
+              state.ratchet == nil,
+              // Once Backspace has begun repeating, the user is watching characters
+              // disappear one by one; switching to whole words mid-press is a surprise.
+              !(repeatTouch == token && repeatController.hasRepeated)
+        else { return false }
+        let ratchet = BackspaceWordRatchet()
+        guard ratchet.shouldClaim(translation), onClaimGesture(token, .wordDelete) else {
+            return false
+        }
+        clearKeyRepeat()
+        state.claimedGesture = .wordDelete
+        state.ratchet = ratchet
+        touches[token] = state
+        return true
+    }
+
+    func updateWordRatchet(token: TouchToken, translation: CGPoint) {
+        guard var state = touches[token], var ratchet = state.ratchet else { return }
+        let words = ratchet.update(translation)
+        state.ratchet = ratchet
+        touches[token] = state
+        guard words > 0 else { return }
+        for _ in 0..<words {
+            onContactEvent(
+                token,
+                KeyboardKeyEvent(key: state.initialKey, phase: .deletedWord)
+            )
+        }
+        if hapticsEnabled { haptics.perform(.delete) }
+    }
+
+    /// A rub that claimed but never crossed a full step still deletes one character, so a
+    /// short flick reads as a backspace rather than as a dropped touch.
+    func finishWordRatchet(token: TouchToken, state: TouchState) {
+        if state.ratchet?.hasDeleted == false {
+            onContactEvent(
+                token,
+                KeyboardKeyEvent(key: state.initialKey, phase: .repeated)
+            )
+        }
+        completeGestureTouch(token: token, state: state)
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Controller/KeyboardSurfaceInteractionController+Lifecycle.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Controller/KeyboardSurfaceInteractionController+Lifecycle.swift
@@ -17,6 +17,7 @@ extension KeyboardSurfaceInteractionController {
     /// rather than routed through `cancelTouch`, which would honour them.
     func cancelAll() {
         alternateHoldController.cancelAll()
+        spaceHoldController.cancelAll()
         for (token, state) in touches {
             if let key = state.currentKey { setHighlighted(key, false) }
             endSignpost(state, token: token, phase: 2)

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Controller/KeyboardSurfaceInteractionController+Touch.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Controller/KeyboardSurfaceInteractionController+Touch.swift
@@ -4,6 +4,15 @@ import KeyboardLayout
 extension KeyboardSurfaceInteractionController {
     func finishTrackedTouch(token: TouchToken, state: TouchState) {
         alternateHoldController.cancel(for: token)
+        spaceHoldController.cancel(for: token)
+        if state.ratchet != nil {
+            finishWordRatchet(token: token, state: state)
+            return
+        }
+        if state.claimedGesture?.detachesContact == true {
+            completeGestureTouch(token: token, state: state)
+            return
+        }
         if let key = state.currentKey { setHighlighted(key, false) }
         let wasRepeating = repeatTouch == token && repeatController.finish()
         if repeatTouch == token { repeatTouch = nil }
@@ -29,6 +38,7 @@ extension KeyboardSurfaceInteractionController {
 
     func cancelTrackedTouch(token: TouchToken, state: TouchState) {
         alternateHoldController.cancel(for: token)
+        spaceHoldController.cancel(for: token)
         if let key = state.currentKey { setHighlighted(key, false) }
         _ = repeatTouch == token && repeatController.finish()
         if repeatTouch == token { repeatTouch = nil }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Controller/KeyboardSurfaceInteractionController+Tracking.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Controller/KeyboardSurfaceInteractionController+Tracking.swift
@@ -23,6 +23,7 @@ extension KeyboardSurfaceInteractionController {
             containerBounds: containerBounds,
             alternateLayout: nil,
             selectedAlternateIndex: nil,
+            smartGestures: presentation.areSmartGesturesEnabled,
             signpostID: signpostID
         )
         os_signpost(
@@ -41,7 +42,13 @@ extension KeyboardSurfaceInteractionController {
         if presentation.isKeySoundEnabled { UIDevice.current.playInputClick() }
         if repeatTouch == nil, key.role == .backspace || key.role == .space {
             repeatTouch = token
-            repeatController.start()
+            let holdsForTrackpad = presentation.areSmartGesturesEnabled && key.role == .space
+            repeatController.start(
+                initialDelay: holdsForTrackpad
+                    ? KeyboardSurfaceInteractionController.smartSpaceRepeatDelay
+                    : nil
+            )
+            if holdsForTrackpad { spaceHoldController.start(for: token) }
         }
         if !key.alternates.isEmpty, sourceFrame != nil, !containerBounds.isEmpty {
             alternateHoldController.start(for: token)
@@ -59,6 +66,14 @@ extension KeyboardSurfaceInteractionController {
     ) {
         guard var state = touches[token] else { return }
         hapticsEnabled = presentation.isHapticFeedbackEnabled
+        if state.trackpad != nil {
+            updateSpaceTrackpad(token: token, translation: translation(for: state, at: point))
+            return
+        }
+        if state.ratchet != nil {
+            updateWordRatchet(token: token, translation: translation(for: state, at: point))
+            return
+        }
         if let layout = state.alternateLayout {
             let next = layout.selection(at: point, from: state.startPoint)
             if next != state.selectedAlternateIndex, hapticsEnabled {
@@ -74,10 +89,25 @@ extension KeyboardSurfaceInteractionController {
             let dy = point.y - state.startPoint.y
             let slop = KeyboardSurfaceInteractionController.tapSlop
             state.hasWandered = dx * dx + dy * dy > slop * slop
-            if state.hasWandered { alternateHoldController.cancel(for: token) }
+            if state.hasWandered {
+                alternateHoldController.cancel(for: token)
+                // A finger that travels this far before the hold fires is swiping, not
+                // holding: cancelling here is what keeps a quick swipe on the spacebar a
+                // language toggle rather than a caret pan.
+                if !state.holdArmed { spaceHoldController.cancel(for: token) }
+            }
+        }
+        let travel = translation(for: state, at: point)
+        if activateSpaceTrackpad(token: token, translation: travel) {
+            updateSpaceTrackpad(token: token, translation: travel)
+            return
+        }
+        if activateWordRatchet(token: token, translation: travel) {
+            updateWordRatchet(token: token, translation: travel)
+            return
         }
         if let action = state.swipeTracker.update(
-            translation: CGPoint(x: point.x - state.startPoint.x, y: point.y - state.startPoint.y),
+            translation: travel,
             action: state.initialKey.horizontalSwipeAction
         ) {
             touches[token] = state
@@ -109,6 +139,10 @@ extension KeyboardSurfaceInteractionController {
         if target?.id != state.initialKey.id { alternateHoldController.cancel(for: token) }
         touches[token] = state
         if presentation.showsKeyPreviews { refreshPreview() }
+    }
+
+    func translation(for state: TouchState, at point: CGPoint) -> CGPoint {
+        CGPoint(x: point.x - state.startPoint.x, y: point.y - state.startPoint.y)
     }
 }
 #endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Controller/KeyboardSurfaceInteractionController.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Controller/KeyboardSurfaceInteractionController.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import Foundation
 import KeyboardLayout
 import os
 import UIKit
@@ -23,6 +24,18 @@ final class KeyboardSurfaceInteractionController {
         case alternate
         case repeatKey
         case swipe
+        case trackpad
+        case wordDelete
+
+        /// Whether winning this claim takes the contact out of the pipeline entirely.
+        /// Detached contacts produce no key on release, which is what a gesture that has
+        /// already written to the document needs.
+        var detachesContact: Bool {
+            switch self {
+            case .repeatKey, .trackpad, .wordDelete: true
+            case .alternate, .swipe: false
+            }
+        }
     }
 
     struct TouchState {
@@ -34,6 +47,15 @@ final class KeyboardSurfaceInteractionController {
         var alternateLayout: KeyboardAlternatePaletteLayout?
         var selectedAlternateIndex: Int?
         var swipeTracker = KeySwipeGestureTracker()
+        /// Snapshotted at touch-down so a configuration change mid-press cannot flip the
+        /// state machine under a finger that is already moving.
+        var smartGestures = false
+        /// Set by the hold timer. Arming is not claiming: a resting thumb must still be
+        /// able to lift and type a space.
+        var holdArmed = false
+        var trackpad: SpaceCursorPanTracker?
+        var ratchet: BackspaceWordRatchet?
+        var claimedGesture: GestureClaim?
         /// Set once the finger travels past `tapSlop`, which separates a tap from a
         /// gesture that merely started on a keycap.
         var hasWandered = false
@@ -42,6 +64,11 @@ final class KeyboardSurfaceInteractionController {
 
     /// Half the swipe threshold: past this a touch is no longer a tap.
     static let tapSlop: CGFloat = 16
+    /// Sideways travel that turns an armed space hold into a caret pan.
+    static let trackpadActivation: CGFloat = 10
+    /// Space repeat waits this long when smart gestures are on, leaving a usable window
+    /// between the hold arming and the first inserted space.
+    static let smartSpaceRepeatDelay: TimeInterval = 0.7
 
     let haptics: KeyboardHaptics
     let onEvent: (KeyboardKeyEvent) -> Void
@@ -58,10 +85,15 @@ final class KeyboardSurfaceInteractionController {
     ) { [weak self] in
         self?.repeatActiveKey()
     }
-    lazy var alternateHoldController = AlternateHoldController(
+    lazy var alternateHoldController = KeyHoldController(
         schedule: repeatScheduler
     ) { [weak self] token in
         self?.activateAlternates(for: token)
+    }
+    lazy var spaceHoldController = KeyHoldController(
+        schedule: repeatScheduler
+    ) { [weak self] token in
+        self?.armSpaceTrackpad(for: token)
     }
     var touches: [TouchToken: TouchState] = [:]
     var highlightCounts: [String: Int] = [:]

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Gestures/BackspaceRepeatController.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Gestures/BackspaceRepeatController.swift
@@ -28,7 +28,7 @@ final class BackspaceRepeatController {
     private let repeatInterval: TimeInterval
     private var scheduledAction: KeyboardScheduledAction?
     private var isActive = false
-    private var hasRepeated = false
+    private(set) var hasRepeated = false
 
     init(
         initialDelay: TimeInterval = 0.4,
@@ -44,10 +44,13 @@ final class BackspaceRepeatController {
         self.onRepeat = onRepeat
     }
 
-    func start() {
+    /// - Parameter initialDelay: overrides the configured delay for this press only.
+    ///   The spacebar pushes it out so a trackpad drag has room to start before the key
+    ///   begins inserting spaces.
+    func start(initialDelay override: TimeInterval? = nil) {
         cancel()
         isActive = true
-        scheduleNext(after: initialDelay)
+        scheduleNext(after: override ?? initialDelay)
     }
 
     func finish() -> Bool {

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Gestures/BackspaceWordRatchet.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Gestures/BackspaceWordRatchet.swift
@@ -1,0 +1,44 @@
+#if canImport(UIKit)
+import CoreGraphics
+
+/// Recognizes a leftward rub on the Backspace key and meters it into whole words.
+///
+/// Claims as early as `activation` — inside the keycap — rather than at a swipe-sized
+/// threshold. The contact has to be detached before the finger can drift onto a
+/// neighbouring key, otherwise the touch pipeline commits that key on release.
+struct BackspaceWordRatchet {
+    private let activation: CGFloat
+    private let dominance: CGFloat
+    private let step: CGFloat
+    private var emittedSteps = 0
+
+    init(activation: CGFloat = 16, dominance: CGFloat = 1.25, step: CGFloat = 40) {
+        precondition(activation > 0)
+        precondition(step > 0)
+        self.activation = activation
+        self.dominance = dominance
+        self.step = step
+    }
+
+    /// Whether this contact has become a word-delete rub.
+    func shouldClaim(_ translation: CGPoint) -> Bool {
+        translation.x <= -activation
+            && abs(translation.x) > abs(translation.y) * dominance
+    }
+
+    /// How many further words the finger has asked to delete since the last call.
+    ///
+    /// Rightward travel never rewinds the anchor and never returns a count, which is how
+    /// "swiping right does nothing" falls out without a special case.
+    mutating func update(_ translation: CGPoint) -> Int {
+        let steps = Int(max(0, -translation.x) / step)
+        let delta = steps - emittedSteps
+        guard delta > 0 else { return 0 }
+        emittedSteps = steps
+        return delta
+    }
+
+    /// True once the rub has deleted at least one word.
+    var hasDeleted: Bool { emittedSteps > 0 }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Gestures/SpaceCursorPanTracker.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Gestures/SpaceCursorPanTracker.swift
@@ -1,0 +1,28 @@
+#if canImport(UIKit)
+import CoreGraphics
+
+/// Converts horizontal travel on the spacebar into whole-character caret steps.
+///
+/// Keeps the sub-step remainder so a slow drag advances exactly once per `stepWidth`
+/// instead of drifting, and so reversing direction costs nothing.
+struct SpaceCursorPanTracker {
+    private let stepWidth: CGFloat
+    private var emittedSteps = 0
+
+    init(stepWidth: CGFloat = 10) {
+        precondition(stepWidth > 0)
+        self.stepWidth = stepWidth
+    }
+
+    /// - Parameter translationX: total travel since the pan began, not since the last call.
+    /// - Returns: signed character offset to apply now; zero when the finger has not
+    ///   crossed into a new step.
+    mutating func update(translationX: CGFloat) -> Int {
+        let steps = Int((translationX / stepWidth).rounded(.towardZero))
+        let delta = steps - emittedSteps
+        guard delta != 0 else { return 0 }
+        emittedSteps = steps
+        return delta
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Touch/KeyboardTouchCoordinator+Policy.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Touch/KeyboardTouchCoordinator+Policy.swift
@@ -52,8 +52,14 @@ extension KeyboardTouchCoordinator {
         kind: KeyboardSurfaceInteractionController.GestureClaim
     ) -> Bool {
         let id = ContactID(rawValue: token)
-        if let existing = claims[id] { return existing == kind }
-        let accepted = kind == .repeatKey
+        if let existing = claims[id] {
+            // A repeating press may still be upgraded to a word rub: both are already
+            // detached, so the pipeline transition is done and only the label changes.
+            guard existing.detachesContact, kind.detachesContact else { return existing == kind }
+            claims[id] = kind
+            return true
+        }
+        let accepted = kind.detachesContact
             ? pipeline.detach(id, at: clock())
             : pipeline.claimForGesture(id)
         guard accepted else {
@@ -83,6 +89,16 @@ extension KeyboardTouchCoordinator {
             resolve(id, action: hits[id].map { .alternate($0, value) })
         case let .swiped(action):
             resolve(id, action: hits[id].map { .swiped($0, action) })
+        case .cursorMoved, .deletedWord:
+            // Written straight to the document by the gesture lane; the arbiter never
+            // produces these, so they only pass through once the contact is detached.
+            guard claims[id]?.detachesContact == true else {
+                registry.metrics.gestureConflict += 1
+                notify()
+                return nil
+            }
+            notify()
+            return event
         case .cancelled:
             cancelClaim(id)
         case .released:
@@ -114,7 +130,7 @@ extension KeyboardTouchCoordinator {
     private func cancelClaim(_ id: ContactID) {
         guard let claim = claims[id] else { return }
         _ = pipeline.detach(id, at: clock())
-        if claim == .repeatKey {
+        if claim.detachesContact {
             registry.finish(id)
         } else {
             cancel(id, emit: true)

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/Accessibility/KeyboardKeyAccessibilityActions.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/Accessibility/KeyboardKeyAccessibilityActions.swift
@@ -28,7 +28,39 @@ enum KeyboardKeyAccessibilityActions {
                 }
             )
         }
+        // VoiceOver consumes drags for its own navigation, so the three smart gestures are
+        // unreachable by touch there. Custom actions are the only way to keep the
+        // functionality available rather than merely the polish.
+        if presentation.areSmartGesturesEnabled {
+            actions.append(contentsOf: smartGestureActions(role: spec.role, emit: emit))
+        }
         return actions.isEmpty ? nil : actions
+    }
+
+    private static func smartGestureActions(
+        role: KeyRole,
+        emit: @escaping (KeyboardKeyEvent.Phase) -> Void
+    ) -> [UIAccessibilityCustomAction] {
+        switch role {
+        case .backspace:
+            [UIAccessibilityCustomAction(name: "Xóa cả từ") { _ in
+                emit(.deletedWord)
+                return true
+            }]
+        case .space:
+            [
+                UIAccessibilityCustomAction(name: "Con trỏ sang trái") { _ in
+                    emit(.cursorMoved(offset: -1))
+                    return true
+                },
+                UIAccessibilityCustomAction(name: "Con trỏ sang phải") { _ in
+                    emit(.cursorMoved(offset: 1))
+                    return true
+                },
+            ]
+        default:
+            []
+        }
     }
 }
 #endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Presentation/KeyboardPresentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Presentation/KeyboardPresentation.swift
@@ -14,6 +14,8 @@ public struct KeyboardPresentation: Hashable, Sendable {
     public var isHapticFeedbackEnabled: Bool
     public var isKeySoundEnabled: Bool
     public var showsKeyPreviews: Bool
+    /// Double-tap space, spacebar cursor panning and swipe-to-delete-word.
+    public var areSmartGesturesEnabled: Bool
 
     public init(
         layout: KeyboardLayout = .funputQWERTY,
@@ -25,7 +27,8 @@ public struct KeyboardPresentation: Hashable, Sendable {
         enterAction: KeyboardEnterAction = .newLine,
         isHapticFeedbackEnabled: Bool = true,
         isKeySoundEnabled: Bool = false,
-        showsKeyPreviews: Bool = true
+        showsKeyPreviews: Bool = true,
+        areSmartGesturesEnabled: Bool = true
     ) {
         self.layout = layout
         self.sizing = sizing
@@ -37,6 +40,7 @@ public struct KeyboardPresentation: Hashable, Sendable {
         self.isHapticFeedbackEnabled = isHapticFeedbackEnabled
         self.isKeySoundEnabled = isKeySoundEnabled
         self.showsKeyPreviews = showsKeyPreviews
+        self.areSmartGesturesEnabled = areSmartGesturesEnabled
     }
 }
 

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Presentation/KeyboardPresentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Presentation/KeyboardPresentation.swift
@@ -49,6 +49,10 @@ public struct KeyboardKeyEvent: Sendable {
         case pressed
         case repeated
         case swiped(KeySwipeAction)
+        /// Caret movement from the spacebar trackpad, in characters.
+        case cursorMoved(offset: Int)
+        /// One word rubbed away by a leftward drag on Backspace.
+        case deletedWord
         case alternateSelected(KeyAlternate)
         case released
         case cancelled

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/AdvancedTelex/AdvancedTelexConfigurationTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/AdvancedTelex/AdvancedTelexConfigurationTests.swift
@@ -19,7 +19,7 @@ struct AdvancedTelexConfigurationTests {
         let decoded = try JSONDecoder().decode(FunputConfiguration.self, from: data)
 
         #expect(decoded.inputMethod == .telexAdvanced)
-        #expect(decoded.schemaVersion == 10)
+        #expect(decoded.schemaVersion == 11)
     }
 
     @Test("Legacy schema preserves its input method while migrating")
@@ -30,6 +30,6 @@ struct AdvancedTelexConfigurationTests {
         let decoded = try JSONDecoder().decode(FunputConfiguration.self, from: data)
 
         #expect(decoded.inputMethod == .telex)
-        #expect(decoded.schemaVersion == 10)
+        #expect(decoded.schemaVersion == 11)
     }
 }

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/FunputConfigurationTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/FunputConfigurationTests.swift
@@ -24,7 +24,7 @@ struct FunputConfigurationTests {
         #expect(config.clipboardEnabled)
         #expect(config.clipboardExpiry == .hour)
         #expect(config.layoutPreset == .funput)
-        #expect(config.schemaVersion == 10)
+        #expect(config.schemaVersion == 11)
     }
 
     @Test("Configuration survives a JSON round-trip")
@@ -61,7 +61,7 @@ struct FunputConfigurationTests {
         #expect(!decoded.isHapticFeedbackEnabled)
         #expect(!decoded.isKeySoundEnabled)
         #expect(!decoded.showsNumberRow)
-        #expect(decoded.schemaVersion == 10)
+        #expect(decoded.schemaVersion == 11)
     }
 
     @Test("Schema 3 migrates to the compact Telex default")
@@ -69,7 +69,7 @@ struct FunputConfigurationTests {
         let data = Data(#"{"showsNumberRow":true,"schemaVersion":3}"#.utf8)
         let decoded = try JSONDecoder().decode(FunputConfiguration.self, from: data)
         #expect(!decoded.showsNumberRow)
-        #expect(decoded.schemaVersion == 10)
+        #expect(decoded.schemaVersion == 11)
     }
 
     /// v8 dropped `showsGlobeKey` entirely. A stored payload still carrying it must
@@ -79,7 +79,7 @@ struct FunputConfigurationTests {
         let data = Data(#"{"showsGlobeKey":true,"showsNumberRow":true,"schemaVersion":4}"#.utf8)
         let decoded = try JSONDecoder().decode(FunputConfiguration.self, from: data)
         #expect(decoded.showsNumberRow)
-        #expect(decoded.schemaVersion == 10)
+        #expect(decoded.schemaVersion == 11)
     }
 
     /// v10 added `layoutPreset`. Unlike the `< 4` rung it must not touch stored values:
@@ -92,6 +92,6 @@ struct FunputConfigurationTests {
         #expect(decoded.layoutPreset == .funput)
         #expect(decoded.inputMethod == .telex)
         #expect(decoded.showsNumberRow)
-        #expect(decoded.schemaVersion == 10)
+        #expect(decoded.schemaVersion == 11)
     }
 }

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Gestures/CursorMoveTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Gestures/CursorMoveTests.swift
@@ -1,0 +1,65 @@
+#if os(iOS) && canImport(FunputCore)
+import Foundation
+@testable import KeyboardInput
+import KeyboardLayout
+import Testing
+
+@MainActor
+struct CursorMoveTests {
+    @Test("A move produces one caret mutation and no text change")
+    func emitsMoveMutation() {
+        let (coordinator, document) = makeCoordinator(context: "xin chao")
+
+        coordinator.moveCursor(by: -3, writer: document)
+
+        #expect(document.transactions.count == 1)
+        #expect(document.transactions[0].mutations == [.moveCursor(offset: -3)])
+        #expect(document.text == "xin chao")
+        #expect(document.caret == 5)
+    }
+
+    @Test("A zero move writes nothing")
+    func zeroIsNoOp() {
+        let (coordinator, document) = makeCoordinator(context: "xin chao")
+
+        let effects = coordinator.moveCursor(by: 0, writer: document)
+
+        #expect(effects == .none)
+        #expect(document.transactions.isEmpty)
+    }
+
+    @Test("Moving the caret drops the document shadow")
+    func invalidatesShadow() {
+        let (coordinator, document) = makeCoordinator(context: "xin chao")
+
+        coordinator.moveCursor(by: -2, writer: document)
+
+        #expect(coordinator.documentSynchronizer.snapshot == nil)
+    }
+
+    @Test("Typing after a move composes at the new caret, not the old one")
+    func typesAtNewCaret() {
+        let (coordinator, document) = makeCoordinator(context: "xin chao")
+
+        coordinator.moveCursor(by: -4, writer: document)
+        coordinator.synchronizeDocument(document, event: .selectionChanged)
+        type("Z", with: coordinator, into: document)
+
+        #expect(document.text == "xin Zchao")
+    }
+
+    private func makeCoordinator(
+        context: String
+    ) -> (KeyboardInputCoordinator, TestKeyboardWriter) {
+        let coordinator = KeyboardInputCoordinator()
+        let document = TestKeyboardWriter()
+        document.replaceTextExternally(with: context)
+        coordinator.updateContext(inputContext(
+            editorMode: .text,
+            enterAction: .newLine
+        ))
+        coordinator.synchronizeDocument(document, event: .activated)
+        return (coordinator, document)
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Gestures/SentencePunctuationRuleTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Gestures/SentencePunctuationRuleTests.swift
@@ -1,0 +1,30 @@
+#if os(iOS) && canImport(FunputCore)
+@testable import KeyboardInput
+import Testing
+
+struct SentencePunctuationRuleTests {
+    @Test(
+        "A trailing space after a word or a digit is punctuable",
+        arguments: [
+            ("xin chao ", true),
+            ("chào ", true),
+            ("3 ", true),
+            ("xin chao", false),
+            ("xin chao  ", false),
+            ("xin chao. ", false),
+            ("xin chao, ", false),
+            ("( ", false),
+            ("\n", false),
+            ("", false),
+        ]
+    )
+    func rule(context: String, expected: Bool) {
+        #expect(SentencePunctuationRule.appliesTo(contextBeforeInput: context) == expected)
+    }
+
+    @Test("An unknown context never punctuates")
+    func nilContext() {
+        #expect(!SentencePunctuationRule.appliesTo(contextBeforeInput: nil))
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Gestures/SmartSpaceTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Gestures/SmartSpaceTests.swift
@@ -1,0 +1,109 @@
+#if os(iOS) && canImport(FunputCore)
+import Foundation
+import FunputShared
+import KeyboardInput
+import KeyboardLayout
+import Testing
+
+@MainActor
+struct SmartSpaceTests {
+    @Test("A second quick space becomes a full stop")
+    func punctuates() {
+        let (coordinator, document) = makeCoordinator(context: "xin chao")
+
+        space(coordinator, document)
+        space(coordinator, document)
+
+        #expect(document.text == "xin chao. ")
+    }
+
+    @Test("The next character after the substitution is capitalized")
+    func capitalizes() {
+        let (coordinator, document) = makeCoordinator(
+            context: "xin chao",
+            mode: .sentences
+        )
+
+        space(coordinator, document)
+        space(coordinator, document)
+
+        #expect(coordinator.state.shiftState == .uppercase)
+        type("t", with: coordinator, into: document)
+        #expect(document.text == "xin chao. T")
+    }
+
+    @Test("Two slow spaces stay two spaces")
+    func slowTapsAreSpaces() {
+        var now: Double = 0
+        let (coordinator, document) = makeCoordinator(context: "xin chao") { now }
+
+        space(coordinator, document)
+        now = 1
+        space(coordinator, document)
+
+        #expect(document.text == "xin chao  ")
+    }
+
+    @Test("A key between the spaces breaks the sequence")
+    func interveningKeyBreaksSequence() {
+        let (coordinator, document) = makeCoordinator(context: "xin")
+
+        space(coordinator, document)
+        type("a", with: coordinator, into: document)
+        space(coordinator, document)
+        space(coordinator, document)
+
+        #expect(document.text == "xin a. ")
+    }
+
+    @Test("Nothing is substituted when the gesture setting is off")
+    func disabled() {
+        let (coordinator, document) = makeCoordinator(context: "xin chao")
+        var configuration = FunputConfiguration.default
+        configuration.smartGesturesEnabled = false
+        coordinator.apply(configuration)
+        coordinator.synchronizeDocument(document, event: .activated)
+
+        space(coordinator, document)
+        space(coordinator, document)
+
+        #expect(document.text == "xin chao  ")
+    }
+
+    @Test("A pending selection is never replaced by a full stop")
+    func selectionSuppresses() {
+        let (coordinator, document) = makeCoordinator(context: "xin chao ")
+        document.hasSelection = true
+        coordinator.synchronizeDocument(document, event: .selectionChanged)
+
+        space(coordinator, document)
+        space(coordinator, document)
+
+        #expect(document.text.hasSuffix("  "))
+    }
+
+    private func space(
+        _ coordinator: KeyboardInputCoordinator,
+        _ document: TestKeyboardWriter
+    ) {
+        coordinator.handle(testKey(.space, label: " "), writer: document)
+    }
+
+    private func makeCoordinator(
+        context: String,
+        mode: KeyboardAutocapitalizationMode = .none,
+        clock: @escaping () -> TimeInterval = { 0 }
+    ) -> (KeyboardInputCoordinator, TestKeyboardWriter) {
+        let coordinator = KeyboardInputCoordinator(gestureClock: clock)
+        let document = TestKeyboardWriter()
+        document.replaceTextExternally(with: context)
+        coordinator.updateContext(inputContext(
+            editorMode: .text,
+            enterAction: .newLine,
+            autocapitalization: mode
+        ))
+        coordinator.synchronizeDocument(document, event: .activated)
+        return (coordinator, document)
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Gestures/SpaceTapTrackerTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Gestures/SpaceTapTrackerTests.swift
@@ -1,0 +1,52 @@
+#if os(iOS) && canImport(FunputCore)
+@testable import KeyboardInput
+import Testing
+
+@MainActor
+struct SpaceTapTrackerTests {
+    @Test("Two spaces inside the window are a double tap")
+    func withinWindow() {
+        var now: Double = 0
+        var tracker = SpaceTapTracker(doubleTapInterval: 0.3) { now }
+        let first = tracker.registerSpace()
+        now = 0.2
+        let second = tracker.registerSpace()
+        #expect(!first)
+        #expect(second)
+    }
+
+    @Test("Two spaces outside the window are two spaces")
+    func outsideWindow() {
+        var now: Double = 0
+        var tracker = SpaceTapTracker(doubleTapInterval: 0.3) { now }
+        _ = tracker.registerSpace()
+        now = 0.4
+        let second = tracker.registerSpace()
+        #expect(!second)
+    }
+
+    @Test("A firing tap is consumed, so three spaces punctuate once")
+    func consumesSequence() {
+        var now: Double = 0
+        var tracker = SpaceTapTracker(doubleTapInterval: 0.3) { now }
+        _ = tracker.registerSpace()
+        now = 0.1
+        let second = tracker.registerSpace()
+        now = 0.2
+        let third = tracker.registerSpace()
+        #expect(second)
+        #expect(!third)
+    }
+
+    @Test("Another key between the spaces breaks the sequence")
+    func resetBreaksSequence() {
+        var now: Double = 0
+        var tracker = SpaceTapTracker(doubleTapInterval: 0.3) { now }
+        _ = tracker.registerSpace()
+        tracker.reset()
+        now = 0.1
+        let second = tracker.registerSpace()
+        #expect(!second)
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Gestures/WordDeleteTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Gestures/WordDeleteTests.swift
@@ -1,0 +1,81 @@
+#if os(iOS) && canImport(FunputCore)
+import Foundation
+@testable import KeyboardInput
+import KeyboardLayout
+import Testing
+
+@MainActor
+struct WordDeleteTests {
+    @Test(
+        "The span behind the caret covers trailing spaces and the whole word",
+        arguments: [
+            ("xin chào", 4),
+            ("xin chào ", 5),
+            ("xin   ", 6),
+            ("a!!!", 3),
+        ]
+    )
+    func span(context: String, expected: Int) {
+        #expect(KeyboardWordDeletion.spanBeforeCursor(context) == expected)
+    }
+
+    @Test("An empty or unknown context has no measurable span")
+    func unmeasurable() {
+        #expect(KeyboardWordDeletion.spanBeforeCursor("") == nil)
+        #expect(KeyboardWordDeletion.spanBeforeCursor(nil) == nil)
+    }
+
+    @Test("Deleting a word removes it together with the space before the caret")
+    func deletesWordAndSpace() {
+        let (coordinator, document) = makeCoordinator(context: "xin chào ")
+
+        coordinator.deleteWordBackward(writer: document)
+
+        #expect(document.text == "xin ")
+    }
+
+    @Test("A Vietnamese word with diacritics is removed whole")
+    func deletesDiacritics() {
+        let (coordinator, document) = makeCoordinator(context: "xin chào")
+
+        coordinator.deleteWordBackward(writer: document)
+
+        #expect(document.text == "xin ")
+    }
+
+    @Test("Without context the gesture degrades to one backspace")
+    func unknownContextDeletesOne() {
+        let (coordinator, document) = makeCoordinator(context: "xin chao")
+        document.exposesContext = false
+        coordinator.synchronizeDocument(document, event: .activated)
+
+        coordinator.deleteWordBackward(writer: document)
+
+        #expect(document.text == "xin cha")
+    }
+
+    @Test("Deleting a word does not reopen it for retoning")
+    func doesNotReopenWord() {
+        let (coordinator, document) = makeCoordinator(context: "xin chào")
+
+        coordinator.deleteWordBackward(writer: document)
+        type("s", with: coordinator, into: document)
+
+        #expect(document.text == "xin s")
+    }
+
+    private func makeCoordinator(
+        context: String
+    ) -> (KeyboardInputCoordinator, TestKeyboardWriter) {
+        let coordinator = KeyboardInputCoordinator()
+        let document = TestKeyboardWriter()
+        document.replaceTextExternally(with: context)
+        coordinator.updateContext(inputContext(
+            editorMode: .text,
+            enterAction: .newLine
+        ))
+        coordinator.synchronizeDocument(document, event: .activated)
+        return (coordinator, document)
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Support/KeyboardInputTestSupport.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Support/KeyboardInputTestSupport.swift
@@ -9,6 +9,9 @@ final class TestKeyboardWriter: KeyboardDocumentWriting {
     /// Character index of the caret. Defaults to the end of the text on every external
     /// replacement, which is where the pre-trackpad model implicitly kept it.
     private(set) var caret = 0
+    /// `text.count` walks the whole string, and the hundred-thousand-key stress test
+    /// asks for it on every keystroke. Maintained alongside every mutation instead.
+    private var textCount = 0
     private(set) var transactions: [InputTransaction] = []
     /// Optional so tests can reproduce a host that has not bound a document yet.
     var documentIdentifier: UUID? = UUID()
@@ -28,7 +31,7 @@ final class TestKeyboardWriter: KeyboardDocumentWriting {
     }
 
     var textBeforeCaret: String {
-        caret == text.count ? text : String(text.prefix(caret))
+        caret == textCount ? text : String(text.prefix(caret))
     }
 
     func apply(_ transaction: InputTransaction) {
@@ -37,17 +40,18 @@ final class TestKeyboardWriter: KeyboardDocumentWriting {
             switch mutation {
             case let .deleteBackward(count):
                 for _ in 0..<count where caret > 0 {
-                    if caret == text.count {
+                    if caret == textCount {
                         text.removeLast()
                     } else {
                         text.remove(at: text.index(text.startIndex, offsetBy: caret - 1))
                     }
                     caret -= 1
+                    textCount -= 1
                 }
             case let .insert(inserted):
                 // Appending is the overwhelmingly common case and the only one the
                 // hundred-thousand-key stress test can afford; indexing is O(n).
-                if caret == text.count {
+                if caret == textCount {
                     text.append(inserted)
                 } else {
                     text.insert(
@@ -55,16 +59,19 @@ final class TestKeyboardWriter: KeyboardDocumentWriting {
                         at: text.index(text.startIndex, offsetBy: caret)
                     )
                 }
-                caret += inserted.count
+                let insertedCount = inserted.count
+                caret += insertedCount
+                textCount += insertedCount
             case let .moveCursor(offset):
-                caret = min(max(0, caret + offset), text.count)
+                caret = min(max(0, caret + offset), textCount)
             }
         }
     }
 
     func replaceTextExternally(with text: String) {
         self.text = text
-        caret = text.count
+        textCount = text.count
+        caret = textCount
         reportedText = text
     }
 

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Support/KeyboardInputTestSupport.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Support/KeyboardInputTestSupport.swift
@@ -6,6 +6,9 @@ import KeyboardLayout
 @MainActor
 final class TestKeyboardWriter: KeyboardDocumentWriting {
     private(set) var text = ""
+    /// Character index of the caret. Defaults to the end of the text on every external
+    /// replacement, which is where the pre-trackpad model implicitly kept it.
+    private(set) var caret = 0
     private(set) var transactions: [InputTransaction] = []
     /// Optional so tests can reproduce a host that has not bound a document yet.
     var documentIdentifier: UUID? = UUID()
@@ -18,10 +21,14 @@ final class TestKeyboardWriter: KeyboardDocumentWriting {
         KeyboardDocumentSnapshot(
             documentIdentifier: documentIdentifier,
             contextBeforeInput: exposesContext
-                ? (delaysContextUpdates ? reportedText : text)
+                ? (delaysContextUpdates ? reportedText : textBeforeCaret)
                 : nil,
             hasSelection: hasSelection
         )
+    }
+
+    var textBeforeCaret: String {
+        caret == text.count ? text : String(text.prefix(caret))
     }
 
     func apply(_ transaction: InputTransaction) {
@@ -29,20 +36,40 @@ final class TestKeyboardWriter: KeyboardDocumentWriting {
         for mutation in transaction.mutations {
             switch mutation {
             case let .deleteBackward(count):
-                for _ in 0..<count where !text.isEmpty { text.removeLast() }
+                for _ in 0..<count where caret > 0 {
+                    if caret == text.count {
+                        text.removeLast()
+                    } else {
+                        text.remove(at: text.index(text.startIndex, offsetBy: caret - 1))
+                    }
+                    caret -= 1
+                }
             case let .insert(inserted):
-                text.append(inserted)
+                // Appending is the overwhelmingly common case and the only one the
+                // hundred-thousand-key stress test can afford; indexing is O(n).
+                if caret == text.count {
+                    text.append(inserted)
+                } else {
+                    text.insert(
+                        contentsOf: inserted,
+                        at: text.index(text.startIndex, offsetBy: caret)
+                    )
+                }
+                caret += inserted.count
+            case let .moveCursor(offset):
+                caret = min(max(0, caret + offset), text.count)
             }
         }
     }
 
     func replaceTextExternally(with text: String) {
         self.text = text
+        caret = text.count
         reportedText = text
     }
 
     func publishContext() {
-        reportedText = text
+        reportedText = textBeforeCaret
     }
 }
 

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Gestures/BackspaceWordSwipeTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Gestures/BackspaceWordSwipeTests.swift
@@ -1,0 +1,88 @@
+#if canImport(UIKit)
+@testable import KeyboardRenderer
+import CoreGraphics
+import KeyboardLayout
+import Testing
+
+@MainActor
+struct BackspaceWordSwipeTests {
+    private static let backspaceKey = KeySpec(id: "backspace", label: "", role: .backspace)
+
+    @Test("Rubbing left one step deletes one word")
+    func oneStepDeletesOneWord() {
+        let subject = subject()
+        subject.begin()
+        subject.move(to: 75)
+
+        #expect(subject.claims == [.wordDelete])
+        #expect(subject.phases == [.pressed, .deletedWord])
+    }
+
+    @Test("Rubbing further deletes further words")
+    func ratchetsPerStep() {
+        let subject = subject()
+        subject.begin()
+        subject.move(to: 75)
+        subject.move(to: 35)
+        subject.move(to: 20)
+
+        #expect(subject.phases == [.pressed, .deletedWord, .deletedWord])
+    }
+
+    @Test("Rubbing right does nothing")
+    func rightwardIsInert() {
+        let subject = subject()
+        subject.begin()
+        subject.move(to: 220)
+
+        #expect(subject.claims.isEmpty)
+        #expect(subject.phases == [.pressed])
+    }
+
+    @Test("A claimed rub too short to delete a word still deletes one character")
+    func shortRubDegradesToBackspace() {
+        let subject = subject()
+        subject.begin()
+        subject.move(to: 100)
+        subject.controller.endTouch(token: 1)
+
+        #expect(subject.phases == [.pressed, .repeated, .cancelled])
+    }
+
+    @Test("A claimed rub that deleted words commits no extra backspace")
+    func longRubEndsClean() {
+        let subject = subject()
+        subject.begin()
+        subject.move(to: 75)
+        subject.controller.endTouch(token: 1)
+
+        #expect(subject.phases == [.pressed, .deletedWord, .cancelled])
+    }
+
+    @Test("Once Backspace has repeated, rubbing left keeps repeating characters")
+    func repeatWinsOverRatchet() {
+        let subject = subject()
+        subject.begin()
+        subject.scheduler.fire(after: 0.4)
+        subject.move(to: 75)
+
+        #expect(subject.claims == [.repeatKey])
+        #expect(subject.phases == [.pressed, .repeated])
+    }
+
+    @Test("With smart gestures off a leftward drag is not a word delete")
+    func disabledKeepsOldBehaviour() {
+        let subject = subject()
+        subject.smartGestures = false
+        subject.begin()
+        subject.move(to: 75)
+
+        #expect(subject.claims.isEmpty)
+        #expect(subject.phases == [.pressed])
+    }
+
+    private func subject() -> GestureTestSubject {
+        GestureTestSubject(key: Self.backspaceKey)
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Gestures/GestureTestSubject.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Gestures/GestureTestSubject.swift
@@ -1,0 +1,95 @@
+#if canImport(UIKit)
+@testable import KeyboardRenderer
+import Foundation
+import KeyboardLayout
+import UIKit
+
+/// Scheduler that keeps every pending timer, not just the last one.
+///
+/// The spacebar arms two at once — the trackpad hold and the repeat — so the single-slot
+/// `TestRepeatScheduler` cannot drive it.
+@MainActor
+final class TestGestureScheduler {
+    private var pending: [(delay: TimeInterval, action: @MainActor () -> Void)] = []
+
+    func schedule(
+        delay: TimeInterval,
+        action: @escaping @MainActor () -> Void
+    ) -> KeyboardScheduledAction {
+        let entry = (delay: delay, action: action)
+        pending.append(entry)
+        let index = pending.count - 1
+        return KeyboardScheduledAction { [weak self] in
+            guard let self, pending.indices.contains(index) else { return }
+            pending[index].action = {}
+        }
+    }
+
+    /// Runs the earliest pending timer with the given delay, if any.
+    func fire(after delay: TimeInterval) {
+        guard let index = pending.firstIndex(where: { $0.delay == delay }) else { return }
+        let action = pending[index].action
+        pending.remove(at: index)
+        action()
+    }
+}
+
+/// One interaction controller over a single key, driven by explicit touch points.
+@MainActor
+final class GestureTestSubject {
+    let scheduler = TestGestureScheduler()
+    var events: [(token: UInt64, event: KeyboardKeyEvent)] = []
+    var claims: [KeyboardSurfaceInteractionController.GestureClaim] = []
+    var grantsClaims = true
+    let key: KeySpec
+    var smartGestures = true
+
+    lazy var controller = KeyboardSurfaceInteractionController(
+        onEvent: { _ in },
+        onContactEvent: { [weak self] token, event in
+            self?.events.append((token, event))
+        },
+        onClaimGesture: { [weak self] _, kind in
+            guard let self else { return false }
+            claims.append(kind)
+            return grantsClaims
+        },
+        onPreview: { _, _ in },
+        repeatScheduler: scheduler.schedule
+    )
+
+    init(key: KeySpec) {
+        self.key = key
+    }
+
+    var phases: [KeyboardKeyEvent.Phase] { events.map(\.event.phase) }
+
+    var presentation: KeyboardPresentation {
+        var value = KeyboardPresentation()
+        value.isHapticFeedbackEnabled = false
+        value.areSmartGesturesEnabled = smartGestures
+        return value
+    }
+
+    func begin(at x: CGFloat = 120) {
+        controller.beginTouch(
+            token: 1,
+            key: key,
+            point: CGPoint(x: x, y: 220),
+            sourceFrame: CGRect(x: 102, y: 198, width: 36, height: 44),
+            containerBounds: CGRect(x: 0, y: 0, width: 390, height: 304),
+            presentation: presentation
+        )
+    }
+
+    func move(to x: CGFloat, y: CGFloat = 220) {
+        controller.moveTouch(
+            token: 1,
+            key: key,
+            point: CGPoint(x: x, y: y),
+            sourceFrame: CGRect(x: 102, y: 198, width: 36, height: 44),
+            presentation: presentation
+        )
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Gestures/SpaceTrackpadGestureTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Gestures/SpaceTrackpadGestureTests.swift
@@ -1,0 +1,104 @@
+#if canImport(UIKit)
+@testable import KeyboardRenderer
+import KeyboardLayout
+import Testing
+
+@MainActor
+struct SpaceTrackpadGestureTests {
+    private static let spaceKey = KeySpec(
+        id: "space",
+        label: "Tiếng Việt",
+        role: .space,
+        horizontalSwipeAction: .toggleLanguage
+    )
+    private static let hold = 0.35
+    private static let smartRepeat = 0.7
+
+    @Test("A quick swipe still toggles the language")
+    func quickSwipeTogglesLanguage() {
+        let subject = subject()
+        subject.begin()
+        subject.move(to: 180)
+
+        #expect(subject.phases.contains(.swiped(.toggleLanguage)))
+        #expect(!subject.phases.contains { if case .cursorMoved = $0 { true } else { false } })
+    }
+
+    @Test("Holding then dragging moves the caret instead")
+    func holdThenDragMovesCaret() {
+        let subject = subject()
+        subject.begin()
+        subject.scheduler.fire(after: Self.hold)
+        subject.move(to: 145)
+
+        #expect(subject.claims == [.trackpad])
+        #expect(subject.phases == [.pressed, .cursorMoved(offset: 2)])
+        #expect(!subject.phases.contains(.swiped(.toggleLanguage)))
+    }
+
+    @Test("The caret follows the finger back and forth")
+    func trackpadFollowsFinger() {
+        let subject = subject()
+        subject.begin()
+        subject.scheduler.fire(after: Self.hold)
+        subject.move(to: 150)
+        subject.move(to: 130)
+
+        #expect(subject.phases == [
+            .pressed,
+            .cursorMoved(offset: 3),
+            .cursorMoved(offset: -2),
+        ])
+    }
+
+    @Test("Once the space has repeated, dragging no longer starts the trackpad")
+    func repeatWinsOverTrackpad() {
+        let subject = subject()
+        subject.begin()
+        subject.scheduler.fire(after: Self.hold)
+        subject.scheduler.fire(after: Self.smartRepeat)
+        subject.move(to: 145)
+
+        #expect(subject.claims == [.repeatKey])
+        #expect(subject.phases == [.pressed, .repeated])
+    }
+
+    @Test("A refused claim leaves the press with the touch pipeline")
+    func refusedClaimFallsThrough() {
+        let subject = subject()
+        subject.grantsClaims = false
+        subject.begin()
+        subject.scheduler.fire(after: Self.hold)
+        subject.move(to: 145)
+
+        #expect(subject.phases == [.pressed])
+    }
+
+    @Test("With smart gestures off the spacebar behaves exactly as before")
+    func disabledKeepsOldBehaviour() {
+        let subject = subject()
+        subject.smartGestures = false
+        subject.begin()
+        subject.scheduler.fire(after: 0.4)
+        subject.move(to: 145)
+
+        #expect(subject.claims == [.repeatKey])
+        #expect(subject.phases == [.pressed, .repeated])
+    }
+
+    @Test("Releasing a trackpad drag commits no space")
+    func releaseCommitsNothing() {
+        let subject = subject()
+        subject.begin()
+        subject.scheduler.fire(after: Self.hold)
+        subject.move(to: 150)
+        subject.controller.endTouch(token: 1)
+
+        #expect(subject.phases.last == .cancelled)
+    }
+
+    private func subject() -> GestureTestSubject {
+        GestureTestSubject(key: Self.spaceKey)
+    }
+}
+#endif


### PR DESCRIPTION
Three gestures iOS users expect from the system keyboard, now on Funput.

### What you get

- **Double-tap the spacebar** to end a sentence: the trailing space becomes ". "
  and the next letter is capitalized. Only after a word or a number, so it never
  turns "xin chao. " into "xin chao.. ".
- **Hold the spacebar and slide** to move the caret left and right, character by
  character — no more tapping at the exact spot in the middle of a word. A quick
  swipe on the spacebar still switches between Vietnamese and English, and
  holding it still still repeats spaces.
- **Swipe left on Backspace** to erase a whole word. Keep sliding to erase more,
  one word per step; lift and it stops. Holding Backspace still deletes
  character by character as before.

All three are under one switch, **Settings › Cử chỉ › Cử chỉ thông minh**, on by
default. Turning it off restores exactly the previous behaviour. They stay off in
password fields, and each one is also available as a VoiceOver action, since
VoiceOver consumes drags for its own navigation.