### PR TITLE
fix(windows): retone a word once Backspace makes it a syllable

### DIFF
--- a/crates/funput-desktop/src/retone.rs
+++ b/crates/funput-desktop/src/retone.rs
@@ -94,13 +94,14 @@ impl CommittedTail {
 
     /// What the engine did with the word from [`CommittedTail::backspace`]. `true`:
     /// it is the live composition now, so the shadow hands it over and the invariant
-    /// holds across the two. `false`: the word stays on screen with nothing tracking
-    /// it, which leaves the shadow unable to place the caret — so it starts over.
+    /// holds across the two. `false`: the word stays on screen and the shadow keeps
+    /// describing it — the deleted character was folded in by `backspace` itself, so
+    /// what remains is still a suffix of the text before the caret. Holding on is
+    /// what lets a *later* Backspace re-open the word: `dungh` + Space + ⌫⌫ leaves
+    /// the caret on `dung`, which the engine does take.
     pub fn resolve(&mut self, adopted: bool) {
         if adopted {
             self.tail.truncate(self.word_start);
-        } else {
-            self.tail.clear();
         }
     }
 

--- a/crates/funput-desktop/src/retone/tests.rs
+++ b/crates/funput-desktop/src/retone/tests.rs
@@ -105,17 +105,20 @@ fn an_expansion_offers_only_its_last_word() {
     assert_eq!(tail.backspace(), Some("Nam"));
 }
 
-/// A refused word (the engine only adopts real syllables) is left on screen with
-/// nothing tracking it, so the shadow can no longer place the caret.
+/// A refused word (the engine only adopts real syllables) stays on screen, and so
+/// does the shadow describing it: `backspace` already folded the deletion in, so
+/// the next one keeps walking back through the word — and hands over whatever
+/// shorter form the engine will take.
 #[test]
-fn a_refused_word_resets_the_shadow() {
+fn a_refused_word_keeps_the_shadow() {
     let mut tail = CommittedTail::new();
     commit(&mut tail, "chào", ' ');
-    commit(&mut tail, "hello", ' ');
+    commit(&mut tail, "dungh", ' ');
 
-    assert_eq!(tail.backspace(), Some("hello"));
-    tail.resolve(false);
-    assert_eq!(tail.backspace(), None);
+    assert_eq!(tail.backspace(), Some("dungh"));
+    tail.resolve(false); // not a syllable
+    assert_eq!(tail.backspace(), Some("dung"));
+    tail.resolve(true); // `dung` is the live composition now
 }
 
 #[test]

--- a/crates/funput-desktop/src/shell/compose.rs
+++ b/crates/funput-desktop/src/shell/compose.rs
@@ -31,8 +31,9 @@ impl ShellState {
     /// the caret at the end of a finished Vietnamese word the engine re-opens that
     /// word — so `phủ` + Space + Backspace + `s` gives `phú` instead of `phủs`. The
     /// engine refuses anything that is not a Vietnamese syllable, which keeps English
-    /// words and URLs literal; a refusal costs the shadow its bearings, so it
-    /// starts over.
+    /// words and URLs literal. A refusal keeps the shadow, so Backspace goes on
+    /// eating the word and re-opens it as soon as what is left *is* a syllable —
+    /// `dungh` + Space + ⌫⌫ lands on `dung`, and the next tone key reaches it.
     pub fn on_backspace(&mut self) {
         if !self.engine.buffer().is_empty() {
             self.engine.on_backspace();

--- a/crates/funput-desktop/tests/retone.rs
+++ b/crates/funput-desktop/tests/retone.rs
@@ -278,3 +278,19 @@ fn an_expansion_reopens_its_last_word() {
     shell.key('f');
     assert_eq!(shell.app, "Việt Nàm");
 }
+
+/// Reported: `dungh` + Space, then Backspace twice to drop the space and the stray
+/// `h`. The caret now sits at the end of `dung`, so the tone key has to reach it.
+#[test]
+fn a_refused_word_is_reopened_once_backspace_makes_it_a_syllable() {
+    let mut shell = Shell::new(InputMethod::Telex);
+    shell.type_str("dungh ");
+    assert_eq!(shell.app, "dungh ");
+
+    shell.backspace(); // the space
+    shell.backspace(); // the stray `h`
+    assert_eq!(shell.app, "dung");
+
+    shell.key('s');
+    assert_eq!(shell.app, "dúng");
+}


### PR DESCRIPTION
Gõ sai một chữ, xoá bớt cho đúng, rồi bỏ dấu — trên Windows bước cuối không ăn.

### Fixed

- `dungh` + Space, rồi Backspace hai lần để xoá dấu cách và chữ `h` thừa: con
  trỏ nằm cuối `dung`, nhưng phím dấu lại ra `dungs` thay vì `dúng`.

Windows không đọc được nội dung ô nhập, nên nó tự nhớ phần chữ vừa gõ để biết
Backspace đang lùi về từ nào. Lần Backspace đầu đưa `dungh` cho engine, engine
từ chối vì không phải âm tiết — và phần ghi nhớ tự xoá sạch theo. Lần Backspace
thứ hai vì thế không còn gì để đưa.

Việc xoá đó không cần thiết: ký tự vừa mất đã được trừ trước khi đưa từ đi, nên
phần còn lại vẫn mô tả đúng đoạn chữ trước con trỏ. Giữ nó lại thì Backspace đi
tiếp vào trong từ và mở lại ngay khi phần còn lại là một âm tiết hợp lệ. Chuyển
VI/EN vẫn xoá sạch như cũ qua `reset_composition()`.

Chỉ Windows. macOS, Linux, iOS và Android đọc thẳng nội dung ô nhập nên không
dính.

Một hệ quả có chủ ý: từ tiếng Anh cũng được nhớ lâu hơn, nên xoá lùi vào một
đoạn tình cờ hợp lệ tiếng Việt sẽ mở lại được — đúng như các nền tảng kia vẫn
làm.

### Verification

Test tái hiện trong `crates/funput-desktop/tests/retone.rs` (ra `dungs` trước
khi sửa), và `a_refused_word_resets_the_shadow` → `a_refused_word_keeps_the_shadow`.
`cargo test --workspace` và `cargo clippy --workspace --all-targets` sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
