### PR TITLE
feat(core): convert Vietnamese text to and from TCVN3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,19 @@ jobs:
       - name: Test
         run: cargo test --workspace
 
+      # Optional features are invisible to the three steps above: with `charset`
+      # off, nothing lints or runs `funput-core/src/charset/**` and it would rot
+      # unnoticed. Same runner, so the cache is already warm and this costs one
+      # incremental build.
+      #
+      # Format and the line budget need no second pass: `cargo fmt` walks `mod`
+      # items whatever their `cfg`, and check-loc.sh walks the filesystem.
+      - name: Clippy (charset)
+        run: cargo clippy -p funput-core --all-targets --features charset -- -D warnings
+
+      - name: Test (charset)
+        run: cargo test -p funput-core --features charset
+
       - name: Line budget
         run: bash scripts/check-loc.sh
 

--- a/crates/funput-core/Cargo.toml
+++ b/crates/funput-core/Cargo.toml
@@ -7,6 +7,15 @@ license.workspace = true
 [lints]
 workspace = true
 
+# The charset tables are dead weight in a keyboard: iOS and Android have no
+# converter UI and never call this. Off by default so their builds compile
+# byte-identically to before. Enabled by the desktop consumers that need it.
+# Adds no dependencies — the zero-runtime-dependency invariant below holds either
+# way, and `cargo tree --features charset` is the one-line proof.
+[features]
+default = []
+charset = []
+
 [dependencies]
 
 [dev-dependencies]

--- a/crates/funput-core/src/charset/codecs/mod.rs
+++ b/crates/funput-core/src/charset/codecs/mod.rs
@@ -1,0 +1,86 @@
+//! Where a charset says how it spells an [`Atom`] — the extension point.
+//!
+//! Adding a charset means adding a codec module here plus a [`Charset`] variant.
+//! The pivot, the driver, and every consumer stay as they are, and the compiler
+//! points at the match arms you owe: these three matches are exhaustive over
+//! `Charset`, so a new variant cannot be forgotten halfway.
+//!
+//! No trait, deliberately. `funput-core` dispatches on enums throughout (see
+//! [`crate::input_method`]) and defines no traits at all; a `dyn` codec would add
+//! a vtable and take away exactly the exhaustiveness that makes this safe to
+//! extend. `#[non_exhaustive]` on `Charset` does not weaken it — it only affects
+//! callers outside the crate.
+//!
+//! Each codec provides two functions:
+//!
+//! - `decode(&Cursor) -> Decoded` — read one unit at the cursor. Total: anything
+//!   the charset does not define comes back as [`Atom::Other`] with `recognized`
+//!   false, never as an error.
+//! - `encode(Atom, &mut String) -> bool` — write the atom, returning `false` when
+//!   what it wrote is not exact. It always writes *something*; a character never
+//!   disappears in conversion.
+
+mod tcvn3;
+
+use super::Charset;
+use super::pivot::Atom;
+use super::transcode::{Cursor, Decoded};
+
+/// Read one unit of `charset` at the cursor.
+pub(super) fn decode(charset: Charset, cur: &Cursor<'_>) -> Decoded {
+    match charset {
+        // The pivot is already the atom's own spelling — nothing to undo, and no
+        // char it fails to define.
+        Charset::Unicode => Decoded {
+            atom: Atom::from_char(cur.first()),
+            consumed: 1,
+            recognized: true,
+        },
+        Charset::Tcvn3 => tcvn3::decode(cur),
+    }
+}
+
+/// Write `atom` as `charset` spells it. `false` means the spelling is not exact —
+/// see the module doc.
+pub(super) fn encode(charset: Charset, atom: Atom, out: &mut String) -> bool {
+    match charset {
+        Charset::Unicode => {
+            out.push(atom.to_char());
+            true
+        }
+        Charset::Tcvn3 => tcvn3::encode(atom, out),
+    }
+}
+
+/// Whether a charset spells text in single bytes drawn by a legacy font, so bytes
+/// read from a file are Latin-1 rather than UTF-8. Used only by
+/// [`crate::charset::decode_bytes`].
+pub(super) fn is_byte_oriented(charset: Charset) -> bool {
+    match charset {
+        Charset::Unicode => false,
+        Charset::Tcvn3 => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_pivot_encodes_every_atom_exactly() {
+        let mut out = String::new();
+        for c in ['a', 'ệ', 'Ự', 'đ', 'Đ', 'b', '₫'] {
+            assert!(
+                encode(Charset::Unicode, Atom::from_char(c), &mut out),
+                "{c} should be exact in Unicode"
+            );
+        }
+        assert_eq!(out, "aệỰđĐb₫");
+    }
+
+    #[test]
+    fn only_the_legacy_charsets_are_byte_oriented() {
+        assert!(!is_byte_oriented(Charset::Unicode));
+        assert!(is_byte_oriented(Charset::Tcvn3));
+    }
+}

--- a/crates/funput-core/src/charset/codecs/tcvn3/mod.rs
+++ b/crates/funput-core/src/charset/codecs/tcvn3/mod.rs
@@ -1,0 +1,137 @@
+//! TCVN3 (ABC) — the encoding of Vietnamese government documents, drawn by the
+//! `.VnTime` font family.
+//!
+//! One byte per letter, Vietnamese letters in `0xA1..=0xFE`, ASCII below `0x80`
+//! untouched. The codes themselves live in [`table`].
+//!
+//! # The one thing it cannot do
+//!
+//! TCVN3 encodes no uppercase toned vowel. `.VnTimeH` draws those from the very
+//! codes this table gives their lowercase forms, so the byte carries the letter
+//! and the *font* carries the case.
+//!
+//! Both directions lose by it. Encoding `Ề` writes `ề`'s code and reports the loss;
+//! decoding can only ever produce lowercase, and no amount of cleverness recovers
+//! what was never written down. Writing the nearest code beats refusing: the output
+//! is going into a `.VnTime` document, where a correct letter in the wrong case is
+//! something the user can fix and a raw `Ề` is silent garbage.
+
+mod table;
+
+use crate::charset::pivot::Atom;
+use crate::charset::transcode::{Cursor, Decoded};
+
+/// Read one TCVN3 byte at the cursor.
+///
+/// A high byte TCVN3 does not assign is carried through as itself, but reported
+/// unrecognized. That matters more than it looks: the same code point is also a
+/// perfectly good Latin-1 letter, so re-encoding it later can quietly land on a
+/// *different* TCVN3 code (`0xC2` is unassigned, but reads back as `Â`, whose code
+/// is `0xA2`). Flagging it is what turns that silent shift into a number the user
+/// can see — and a high count is usually them having picked the wrong source
+/// charset.
+pub(super) fn decode(cur: &Cursor<'_>) -> Decoded {
+    let c = cur.first();
+    let (atom, recognized) = match u8::try_from(c as u32) {
+        Ok(byte) if byte >= 0x80 => match atom_for_byte(byte) {
+            Some(atom) => (atom, true),
+            None => (Atom::Other(c), false),
+        },
+        // Below 0x80 TCVN3 is ASCII — but an ASCII vowel still has to pick up its
+        // family coordinates, or the target charset could not re-spell it.
+        _ => (Atom::from_char(c), true),
+    };
+    Decoded {
+        atom,
+        consumed: 1,
+        recognized,
+    }
+}
+
+/// Write `atom` as TCVN3. `false` when the code written is not exact — which for
+/// this charset means an uppercase toned vowel, or a character it has no code for.
+pub(super) fn encode(atom: Atom, out: &mut String) -> bool {
+    match atom {
+        Atom::Vowel {
+            family,
+            tone,
+            upper,
+        } => encode_vowel(atom, family.into(), tone.into(), upper, out),
+        Atom::Stroke { upper } => {
+            out.push(byte_char(if upper {
+                table::STROKE_UPPER
+            } else {
+                table::STROKE_LOWER
+            }));
+            true
+        }
+        // ASCII survives unchanged. Anything else has no TCVN3 code at all, so it
+        // goes through as itself and is reported.
+        Atom::Other(c) => {
+            out.push(c);
+            c.is_ascii()
+        }
+    }
+}
+
+fn encode_vowel(atom: Atom, family: usize, tone: usize, upper: bool, out: &mut String) -> bool {
+    let byte = table::TCVN3_BYTES[family][tone];
+    if byte == 0 {
+        // A plain ASCII vowel; TCVN3 spells it as ASCII in either case.
+        out.push(atom.to_char());
+        return true;
+    }
+    if !upper {
+        out.push(byte_char(byte));
+        return true;
+    }
+    match upper_base(family).filter(|_| tone == 0) {
+        // Ă Â Ê Ô Ơ Ư — the uppercase vowels TCVN3 does encode.
+        Some(code) => {
+            out.push(byte_char(code));
+            true
+        }
+        // Uppercase and toned: the code is right, the case is lost with the font.
+        None => {
+            out.push(byte_char(byte));
+            false
+        }
+    }
+}
+
+/// The uppercase code for a family's shaped base, for the six families that have
+/// one. `None` for the ASCII-base families, whose uppercase is ASCII anyway.
+fn upper_base(family: usize) -> Option<u8> {
+    table::UPPER_BASES
+        .iter()
+        .find(|(shaped, _)| *shaped == family)
+        .map(|&(_, code)| code)
+}
+
+/// The letter a TCVN3 byte stands for, or `None` when the byte is not one of the
+/// 74 the charset assigns to Vietnamese.
+fn atom_for_byte(byte: u8) -> Option<Atom> {
+    match byte {
+        table::STROKE_LOWER => return Some(Atom::Stroke { upper: false }),
+        table::STROKE_UPPER => return Some(Atom::Stroke { upper: true }),
+        _ => {}
+    }
+    if let Some(&(family, _)) = table::UPPER_BASES.iter().find(|(_, code)| *code == byte) {
+        return Atom::vowel(family, 0, true);
+    }
+    let (family, row) = table::TCVN3_BYTES
+        .iter()
+        .enumerate()
+        .find(|(_, row)| row.contains(&byte))?;
+    let tone = row.iter().position(|&code| code == byte)?;
+    Atom::vowel(family, tone, false)
+}
+
+/// A TCVN3 byte as the char a legacy document stores it as — see
+/// [`crate::charset::decode_bytes`] for why the two are the same thing.
+fn byte_char(byte: u8) -> char {
+    char::from(byte)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/funput-core/src/charset/codecs/tcvn3/table.rs
+++ b/crates/funput-core/src/charset/codecs/tcvn3/table.rs
@@ -1,0 +1,72 @@
+//! The TCVN3 code for every letter in the Vietnamese inventory.
+//!
+//! # Where these numbers came from
+//!
+//! Transcribed from three independent converter implementations and cross-checked
+//! cell by cell — a Python one (`gist.github.com/congkhoa/bcd46eea…`, which lists
+//! the pairs in its own order) and two PHP ones (`gist.github.com/ducviet1696/
+//! 7a94421951532edc60cdc008ca989c41` and `github.com/anhskohbo/u-convert`). All
+//! three agree on all 74 assignments.
+//!
+//! Two structural checks back that up, because a transposed byte is invisible to
+//! the eye and produces mojibake only on real text: the 74 codes are pairwise
+//! distinct, and they fill exactly twelve families of five tones plus the fourteen
+//! shaped bases. `tests.rs` asserts both, and sweeps the whole inventory.
+//!
+//! # Lookup direction
+//!
+//! Reverse lookup (code → letter) is a linear scan of these 72 cells, not a dense
+//! compile-time table like the one in [`crate::unicode::vowels`]. That one is
+//! built because it runs once per keystroke; conversion runs once per paste, where
+//! scanning is free — and keeping the data in one readable block next to its only
+//! reader is worth more than the nanoseconds. Please do not "optimize" it back.
+
+use crate::unicode::vowels;
+
+/// TCVN3 code per (family, slot) of the vowel inventory; `0` where the letter is
+/// plain ASCII and TCVN3 spells it as ASCII too.
+///
+/// Rows follow `VOWEL_FAMILIES`, so the index is shared with the inventory rather
+/// than re-derived. Columns follow it too: base, sắc, huyền, hỏi, ngã, nặng.
+/// TCVN3's own codes run in a different order inside each family — huyền, hỏi,
+/// ngã, sắc, nặng, visible as `B5..B9` on the `a` row. That reordering lives here,
+/// in the data, and nowhere in the code.
+pub(super) const TCVN3_BYTES: [[u8; 6]; 12] = [
+    /* a */ [0x00, 0xB8, 0xB5, 0xB6, 0xB7, 0xB9],
+    /* ă */ [0xA8, 0xBE, 0xBB, 0xBC, 0xBD, 0xC6],
+    /* â */ [0xA9, 0xCA, 0xC7, 0xC8, 0xC9, 0xCB],
+    /* e */ [0x00, 0xD0, 0xCC, 0xCE, 0xCF, 0xD1],
+    /* ê */ [0xAA, 0xD5, 0xD2, 0xD3, 0xD4, 0xD6],
+    /* i */ [0x00, 0xDD, 0xD7, 0xD8, 0xDC, 0xDE],
+    /* o */ [0x00, 0xE3, 0xDF, 0xE1, 0xE2, 0xE4],
+    /* ô */ [0xAB, 0xE8, 0xE5, 0xE6, 0xE7, 0xE9],
+    /* ơ */ [0xAC, 0xED, 0xEA, 0xEB, 0xEC, 0xEE],
+    /* u */ [0x00, 0xF3, 0xEF, 0xF1, 0xF2, 0xF4],
+    /* ư */ [0xAD, 0xF8, 0xF5, 0xF6, 0xF7, 0xF9],
+    /* y */ [0x00, 0xFD, 0xFA, 0xFB, 0xFC, 0xFE],
+];
+
+/// A thirteenth vowel family would leave this table silently short. Make it a
+/// build failure instead.
+const _: () = assert!(TCVN3_BYTES.len() == vowels::FAMILY_COUNT);
+
+/// Uppercase codes for the six shaped bases, by family index.
+///
+/// These are the *only* uppercase vowels TCVN3 encodes. Every toned uppercase
+/// vowel — `Ầ`, `Ế`, `Ự` — has no code at all: a TCVN3 document draws those by
+/// switching to the `.VnTimeH` font, which maps these same lowercase codes to
+/// uppercase glyphs. The charset carries no case information, and no
+/// implementation can invent it.
+pub(super) const UPPER_BASES: [(usize, u8); 6] = [
+    (1, 0xA1),  // Ă
+    (2, 0xA2),  // Â
+    (4, 0xA3),  // Ê
+    (7, 0xA4),  // Ô
+    (8, 0xA5),  // Ơ
+    (10, 0xA6), // Ư
+];
+
+/// `đ` — the one consonant TCVN3 gives a code of its own.
+pub(super) const STROKE_LOWER: u8 = 0xAE;
+/// `Đ`, which unlike the toned vowels does have its own code.
+pub(super) const STROKE_UPPER: u8 = 0xA7;

--- a/crates/funput-core/src/charset/codecs/tcvn3/tests.rs
+++ b/crates/funput-core/src/charset/codecs/tcvn3/tests.rs
@@ -1,0 +1,165 @@
+use super::*;
+use crate::charset::Charset;
+use crate::charset::transcode::transcode;
+use crate::unicode::vowels;
+
+fn to_tcvn3(text: &str) -> (String, usize) {
+    let out = transcode(text, Charset::Unicode, Charset::Tcvn3);
+    (out.text, out.unmapped)
+}
+
+fn to_unicode(text: &str) -> String {
+    transcode(text, Charset::Tcvn3, Charset::Unicode).text
+}
+
+/// The sweep: every letter the inventory has, encoded and read back.
+///
+/// The round trip alone would pass on a table with two codes swapped between
+/// families, because the error cancels. What catches that is the second half —
+/// the set of letters that lose something has to be *exactly* the uppercase toned
+/// vowels, no more and no fewer.
+#[test]
+fn the_whole_inventory_round_trips_except_uppercase_tones() {
+    let mut lossy = Vec::new();
+
+    for family in 0..vowels::FAMILY_COUNT {
+        for tone in 0..6 {
+            for upper in [false, true] {
+                let c = vowels::vowel_glyph(family, tone, upper).expect("in inventory");
+                let (encoded, unmapped) = to_tcvn3(&c.to_string());
+
+                if unmapped == 0 {
+                    assert_eq!(to_unicode(&encoded), c.to_string(), "{c} should round trip");
+                    continue;
+                }
+                lossy.push(c);
+                let lower = vowels::vowel_glyph(family, tone, false).expect("in inventory");
+                assert_eq!(
+                    to_unicode(&encoded),
+                    lower.to_string(),
+                    "{c} has no code; it should come back as {lower}"
+                );
+            }
+        }
+    }
+
+    let uppercase_toned: Vec<char> = (0..vowels::FAMILY_COUNT)
+        .flat_map(|family| (1..6).map(move |tone| (family, tone)))
+        .filter_map(|(family, tone)| vowels::vowel_glyph(family, tone, true))
+        .collect();
+    assert_eq!(
+        lossy, uppercase_toned,
+        "only the uppercase toned vowels may lose anything"
+    );
+}
+
+/// `đ` and `Đ` both have codes, so unlike the vowels they keep their case.
+#[test]
+fn the_stroke_keeps_its_case_in_both_directions() {
+    for c in ['đ', 'Đ'] {
+        let (encoded, unmapped) = to_tcvn3(&c.to_string());
+        assert_eq!(unmapped, 0, "{c} has a code of its own");
+        assert_eq!(to_unicode(&encoded), c.to_string());
+    }
+}
+
+/// A transposed code is invisible to the eye. Two structural facts make one
+/// visible to the build instead: no code is shared, and every code sits in the
+/// high range where a legacy font draws Vietnamese.
+#[test]
+fn every_code_is_distinct_and_in_the_vietnamese_range() {
+    let codes: Vec<u8> = table::TCVN3_BYTES
+        .iter()
+        .flatten()
+        .copied()
+        .filter(|&code| code != 0)
+        .chain(table::UPPER_BASES.iter().map(|&(_, code)| code))
+        .chain([table::STROKE_LOWER, table::STROKE_UPPER])
+        .collect();
+
+    // 12 families x 5 tones, + 6 lowercase shaped bases, + their 6 uppercase, + đĐ.
+    assert_eq!(codes.len(), 74);
+    for code in &codes {
+        assert!(
+            (0xA1..=0xFE).contains(code),
+            "{code:#04X} is outside the range TCVN3 uses"
+        );
+    }
+
+    let mut sorted = codes.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(sorted.len(), codes.len(), "two letters share one code");
+}
+
+/// TCVN3 is ASCII below 0x80, so anything that is not Vietnamese survives a
+/// round trip untouched — including the ASCII vowels, which take the vowel path
+/// rather than the passthrough one.
+#[test]
+fn ascii_survives_untouched() {
+    let text = "Ho Chi Minh 1975 (bd) -- ok!";
+    let (encoded, unmapped) = to_tcvn3(text);
+    assert_eq!(unmapped, 0);
+    assert_eq!(encoded, text);
+    assert_eq!(to_unicode(&encoded), text);
+}
+
+/// A character TCVN3 has no code for is reported, but never dropped.
+#[test]
+fn a_character_outside_the_charset_is_reported_and_kept() {
+    let (encoded, unmapped) = to_tcvn3("giá 5₫");
+    assert_eq!(unmapped, 1, "only ₫ is outside TCVN3");
+    assert!(
+        encoded.ends_with('₫'),
+        "it must still be there: {encoded:?}"
+    );
+}
+
+/// A high byte TCVN3 does not assign comes through as itself rather than being
+/// forced onto the nearest letter — and is reported, because the same code point
+/// is a Latin-1 letter too and re-encoding it can land on a different TCVN3 code.
+#[test]
+fn an_unassigned_high_byte_passes_through_and_is_reported() {
+    let unassigned = char::from(0xB0); // between the đ block and the `a` family
+    let out = transcode(&unassigned.to_string(), Charset::Tcvn3, Charset::Unicode);
+    assert_eq!(out.text, unassigned.to_string());
+    assert_eq!(out.unmapped, 1);
+}
+
+/// The case the property test found. `0xC2` is not a TCVN3 code, but the code
+/// point it passes through as is `Â`, which *is* Vietnamese and whose TCVN3 code
+/// is `0xA2`. Round-tripping therefore moves the byte — silently, unless the
+/// unrecognized reading is counted. It is.
+#[test]
+fn an_unassigned_byte_that_is_a_latin1_letter_is_reported_not_normalized_silently() {
+    let out = transcode("\u{C2}", Charset::Tcvn3, Charset::Unicode);
+    assert_eq!(out.text, "Â");
+    assert_eq!(out.unmapped, 1, "the source never defined 0xC2");
+
+    let back = to_tcvn3(&out.text);
+    assert_eq!(back.0, "\u{A2}", "re-encoding lands on Â's real code");
+    assert_eq!(back.1, 0, "and that spelling is exact");
+}
+
+/// The word this whole feature exists for, spelled the way a `.VnTime` document
+/// spells it. Fixed bytes, so a table edit has to face a concrete example and not
+/// just a property.
+#[test]
+fn a_real_word_encodes_to_the_bytes_a_vntime_document_holds() {
+    let (encoded, unmapped) = to_tcvn3("Việt Nam");
+    assert_eq!(unmapped, 0);
+    assert_eq!(
+        encoded.chars().map(|c| c as u32).collect::<Vec<_>>(),
+        vec![
+            0x56, // V
+            0x69, // i
+            0xD6, // ệ
+            0x74, // t
+            0x20, // space
+            0x4E, // N
+            0x61, // a
+            0x6D, // m
+        ]
+    );
+    assert_eq!(to_unicode(&encoded), "Việt Nam");
+}

--- a/crates/funput-core/src/charset/mod.rs
+++ b/crates/funput-core/src/charset/mod.rs
@@ -1,0 +1,146 @@
+//! Converting Vietnamese text between Unicode and the legacy encodings.
+//!
+//! Vietnamese government documents still circulate in TCVN3, drawn by the
+//! `.VnTime` fonts. This turns them into Unicode, and back.
+//!
+//! # Text in, text out
+//!
+//! [`convert`] takes a `&str`, not bytes, and that is not a convenience — it is
+//! what the input actually is. Word stores a TCVN3 document as Unicode code points
+//! `U+0020..=U+00FF` and leaves the *font* to draw the Vietnamese glyphs, so text
+//! arriving from the clipboard is already "bytes as chars". Converting it means
+//! reading those code points back as TCVN3 codes. [`decode_bytes`] is the other
+//! door, for text that really is bytes because it came from a file.
+//!
+//! # How it is put together
+//!
+//! Everything pivots through precomposed Unicode: `source → Atom → target`. A
+//! charset therefore never has to know about any other charset, and adding one
+//! costs two mappings rather than one per charset already present. See
+//! [`codecs`](self::codecs) for what a new charset owes, and
+//! `docs/features/charset.md` for the design in full.
+//!
+//! ```
+//! use funput_core::charset::{Charset, convert};
+//!
+//! let out = convert("Việt Nam", Charset::Unicode, Charset::Tcvn3);
+//! assert_eq!(convert(&out.text, Charset::Tcvn3, Charset::Unicode).text, "Việt Nam");
+//! assert_eq!(out.unmapped, 0);
+//! ```
+
+mod codecs;
+mod pivot;
+mod transcode;
+
+/// A Vietnamese character encoding.
+///
+/// `#[non_exhaustive]`: VNI-Windows and Unicode tổ hợp are coming, and adding them
+/// should not break callers. Match with a wildcard arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Charset {
+    /// Precomposed Unicode (NFC) — the pivot, and what every modern system uses.
+    Unicode,
+    /// TCVN3, also called ABC: the `.VnTime` encoding of Vietnamese government
+    /// documents.
+    Tcvn3,
+}
+
+/// Converted text, and how many characters did not survive it exactly.
+///
+/// `unmapped` counts characters, not bytes, and never counts *lost* text:
+/// conversion always writes something for every character, so the output holds as
+/// much as the input did. What the number says is how many places need the user's
+/// eye. A character lands there for one of two reasons:
+///
+/// - the **target** cannot spell it — an uppercase toned vowel, which TCVN3 leaves
+///   to the `.VnTimeH` font, or a `₫`, which no legacy charset has a code for;
+/// - the **source** never defined it, so reading it was a guess.
+///
+/// The second is worth watching. Text converted from the wrong source charset is
+/// mostly unrecognized units, so a count near the length of the input is the
+/// clearest signal there is that the user picked the wrong bảng mã.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Conversion {
+    pub text: String,
+    pub unmapped: usize,
+}
+
+/// Convert text from one charset to another.
+///
+/// `from` must be what the text actually is; guessing it is a separate job, and
+/// not one this function does.
+pub fn convert(text: &str, from: Charset, to: Charset) -> Conversion {
+    transcode::transcode(text, from, to)
+}
+
+/// Read raw bytes in `from` and return them as Unicode.
+///
+/// For a legacy charset the bytes are read one-to-one as code points, which is
+/// exactly how the document that produced them was stored. For [`Charset::Unicode`]
+/// they are decoded as UTF-8, and any invalid sequence becomes `U+FFFD` and counts
+/// toward `unmapped` — a caller reading a file it merely *believes* is UTF-8 gets
+/// told when it was wrong instead of silently receiving replacement characters.
+pub fn decode_bytes(bytes: &[u8], from: Charset) -> Conversion {
+    if codecs::is_byte_oriented(from) {
+        let text: String = bytes.iter().copied().map(char::from).collect();
+        return convert(&text, from, Charset::Unicode);
+    }
+    let Err(_) = std::str::from_utf8(bytes) else {
+        return Conversion {
+            text: String::from_utf8_lossy(bytes).into_owned(),
+            unmapped: 0,
+        };
+    };
+    let text = String::from_utf8_lossy(bytes).into_owned();
+    let unmapped = text
+        .matches(char::REPLACEMENT_CHARACTER)
+        .count()
+        .saturating_sub(genuine_replacements(bytes));
+    Conversion { text, unmapped }
+}
+
+/// How many `U+FFFD` the bytes genuinely encode. Subtracting these is what keeps a
+/// source that legitimately contains a replacement character from being reported
+/// as damaged.
+fn genuine_replacements(bytes: &[u8]) -> usize {
+    bytes
+        .windows(3)
+        .filter(|window| *window == [0xEF, 0xBF, 0xBD])
+        .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_bytes_are_read_one_to_one_as_code_points() {
+        // 0xD6 is `ệ`; the rest is ASCII. This is what a .VnTime file holds.
+        let bytes = [0x56, 0x69, 0xD6, 0x74];
+        let out = decode_bytes(&bytes, Charset::Tcvn3);
+        assert_eq!(out.text, "Việt");
+        assert_eq!(out.unmapped, 0);
+    }
+
+    #[test]
+    fn utf8_bytes_are_decoded_as_utf8() {
+        let out = decode_bytes("Việt".as_bytes(), Charset::Unicode);
+        assert_eq!(out.text, "Việt");
+        assert_eq!(out.unmapped, 0);
+    }
+
+    #[test]
+    fn broken_utf8_is_reported_rather_than_silently_replaced() {
+        let out = decode_bytes(&[0x56, 0xFF, 0x69], Charset::Unicode);
+        assert_eq!(out.unmapped, 1);
+    }
+
+    #[test]
+    fn a_replacement_character_in_the_source_is_not_counted_as_damage() {
+        let out = decode_bytes("a\u{FFFD}b".as_bytes(), Charset::Unicode);
+        assert_eq!(out.text, "a\u{FFFD}b");
+        assert_eq!(out.unmapped, 0);
+    }
+}

--- a/crates/funput-core/src/charset/pivot.rs
+++ b/crates/funput-core/src/charset/pivot.rs
@@ -1,0 +1,121 @@
+//! The pivot: one unit of text with its encoding stripped off.
+//!
+//! Every conversion runs `source → Atom → target`, so a charset only ever has to
+//! know how to spell an [`Atom`] — never how any *other* charset spells one. That
+//! is what keeps the cost of charset N+1 at two mappings instead of N.
+//!
+//! Three variants cover all four charsets Funput targets. The worked mapping table
+//! in `docs/features/charset.md` is where that claim is checked letter by letter.
+
+use crate::unicode::vowels;
+
+/// One unit of text, independent of how a charset spells it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Atom {
+    /// A vowel by its inventory coordinates: `family` indexes the vowel families
+    /// of [`crate::unicode::vowels`], and `tone` is 0 for the toneless base and
+    /// 1–5 for sắc, huyền, hỏi, ngã, nặng.
+    ///
+    /// Build one with [`Atom::vowel`], never by writing the fields — that is what
+    /// lets [`Atom::to_char`] be infallible.
+    Vowel { family: u8, tone: u8, upper: bool },
+    /// `đ`/`Đ`. The one consonant every legacy Vietnamese encoding gives a code of
+    /// its own, so it cannot ride along in [`Atom::Other`].
+    Stroke { upper: bool },
+    /// Everything else: consonants, digits, punctuation, foreign letters. Carried
+    /// through untouched — a charset that cannot spell it says so when it encodes.
+    Other(char),
+}
+
+impl Atom {
+    /// Classify one precomposed Unicode char. Total: anything outside the
+    /// Vietnamese inventory becomes [`Atom::Other`], which is why decoding never
+    /// has to report failure.
+    pub(super) fn from_char(c: char) -> Self {
+        if let Some((family, tone, upper)) = vowels::vowel_coords(c) {
+            return Self::Vowel {
+                family: family as u8,
+                tone: tone as u8,
+                upper,
+            };
+        }
+        match c {
+            'đ' => Self::Stroke { upper: false },
+            'Đ' => Self::Stroke { upper: true },
+            other => Self::Other(other),
+        }
+    }
+
+    /// Build a vowel atom from inventory coordinates, or `None` when the inventory
+    /// has no such letter. The only constructor for [`Atom::Vowel`], so a codec
+    /// cannot hand [`Atom::to_char`] coordinates that do not exist.
+    pub(super) fn vowel(family: usize, tone: usize, upper: bool) -> Option<Self> {
+        vowels::vowel_glyph(family, tone, upper)?;
+        Some(Self::Vowel {
+            family: family as u8,
+            tone: tone as u8,
+            upper,
+        })
+    }
+
+    /// The precomposed Unicode char this atom stands for.
+    pub(super) fn to_char(self) -> char {
+        match self {
+            Self::Vowel {
+                family,
+                tone,
+                upper,
+            } => vowels::vowel_glyph(family.into(), tone.into(), upper)
+                .expect("Atom::vowel checks its coordinates against the inventory"),
+            Self::Stroke { upper } => {
+                if upper {
+                    'Đ'
+                } else {
+                    'đ'
+                }
+            }
+            Self::Other(c) => c,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_vietnamese_letter_round_trips_through_an_atom() {
+        for family in 0..vowels::FAMILY_COUNT {
+            for tone in 0..6 {
+                for upper in [false, true] {
+                    let c = vowels::vowel_glyph(family, tone, upper).expect("in inventory");
+                    assert_eq!(Atom::from_char(c).to_char(), c, "{c}");
+                }
+            }
+        }
+        for c in ['đ', 'Đ'] {
+            assert_eq!(Atom::from_char(c).to_char(), c, "{c}");
+        }
+    }
+
+    #[test]
+    fn a_stroke_is_not_an_other() {
+        assert_eq!(Atom::from_char('đ'), Atom::Stroke { upper: false });
+        assert_eq!(Atom::from_char('Đ'), Atom::Stroke { upper: true });
+    }
+
+    #[test]
+    fn anything_outside_the_inventory_passes_through() {
+        for c in ['b', 'Z', '7', ' ', '₫', '日'] {
+            assert_eq!(Atom::from_char(c), Atom::Other(c), "{c}");
+            assert_eq!(Atom::from_char(c).to_char(), c, "{c}");
+        }
+    }
+
+    #[test]
+    fn coordinates_outside_the_inventory_are_refused() {
+        assert!(Atom::vowel(vowels::FAMILY_COUNT, 0, false).is_none());
+        assert!(Atom::vowel(0, 6, false).is_none());
+        assert!(Atom::vowel(0, 0, false).is_some());
+    }
+}

--- a/crates/funput-core/src/charset/transcode.rs
+++ b/crates/funput-core/src/charset/transcode.rs
@@ -1,0 +1,117 @@
+//! The conversion driver, and the window a codec reads the source through.
+//!
+//! The loop is deliberately dull: decode one unit, encode it, advance. All the
+//! charset knowledge sits in [`crate::charset::codecs`], and all the letter
+//! knowledge in [`crate::charset::pivot`], so this file stays the same shape no
+//! matter how many charsets exist.
+
+use super::codecs;
+use super::pivot::Atom;
+use super::{Charset, Conversion};
+
+/// A read window onto the source, positioned at a unit boundary.
+///
+/// A codec reads as far ahead as its encoding needs and reports how much it took.
+/// TCVN3 only ever needs the first char; VNI's base-plus-mark pair will want a
+/// second, and adds the accessor for it then.
+pub(super) struct Cursor<'a> {
+    rest: &'a str,
+}
+
+impl<'a> Cursor<'a> {
+    /// The char at the cursor. Never fails: a cursor is only built on a non-empty
+    /// remainder.
+    pub(super) fn first(&self) -> char {
+        self.rest
+            .chars()
+            .next()
+            .expect("cursor built on non-empty text")
+    }
+}
+
+/// What a codec made of the text at the cursor.
+pub(super) struct Decoded {
+    pub(super) atom: Atom,
+    /// How many chars this reading consumed. Must be at least 1, or the driver
+    /// would not advance.
+    pub(super) consumed: usize,
+    /// False when the source charset does not define this unit at all. The atom is
+    /// still usable — it carries the character through untouched — but the reading
+    /// is a guess, and the caller deserves to know.
+    pub(super) recognized: bool,
+}
+
+/// Convert `text` from one charset to another, counting every character that did
+/// not survive exactly.
+///
+/// A character is counted once, whichever end failed it: the source charset does
+/// not define it, or the target cannot spell it. Both are things the user has to
+/// look at, and the commonest cause of the first one is picking the wrong source
+/// charset — which makes a high count the signal that they did.
+pub(super) fn transcode(text: &str, from: Charset, to: Charset) -> Conversion {
+    let mut out = String::with_capacity(text.len());
+    let mut unmapped = 0;
+    let mut rest = text;
+
+    while !rest.is_empty() {
+        let decoded = codecs::decode(from, &Cursor { rest });
+        let written_exactly = codecs::encode(to, decoded.atom, &mut out);
+        if !decoded.recognized || !written_exactly {
+            unmapped += 1;
+        }
+        rest = advance(rest, decoded.consumed);
+    }
+
+    Conversion {
+        text: out,
+        unmapped,
+    }
+}
+
+/// Step `count` chars forward, clamping at the end. A codec that reports more than
+/// it could see leaves the loop finishing early rather than panicking.
+fn advance(rest: &str, count: usize) -> &str {
+    match rest.char_indices().nth(count.max(1)) {
+        Some((offset, _)) => &rest[offset..],
+        None => "",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advance_steps_over_whole_chars() {
+        assert_eq!(advance("phủ", 1), "hủ");
+        assert_eq!(advance("phủ", 2), "ủ"); // multi-byte char, single step
+        assert_eq!(advance("phủ", 3), "");
+        assert_eq!(
+            advance("phủ", 99),
+            "",
+            "over-reporting clamps, never panics"
+        );
+    }
+
+    /// A codec reporting zero would spin the driver forever; the floor is what
+    /// makes the loop's termination a property of this file rather than of every
+    /// codec that will ever be written.
+    #[test]
+    fn advance_never_stands_still() {
+        assert_eq!(advance("ab", 0), "b");
+    }
+
+    #[test]
+    fn unicode_to_unicode_is_an_exact_identity() {
+        let result = transcode("Chào bạn — 42₫", Charset::Unicode, Charset::Unicode);
+        assert_eq!(result.text, "Chào bạn — 42₫");
+        assert_eq!(result.unmapped, 0);
+    }
+
+    #[test]
+    fn empty_text_converts_to_empty_text() {
+        let result = transcode("", Charset::Unicode, Charset::Tcvn3);
+        assert!(result.text.is_empty());
+        assert_eq!(result.unmapped, 0);
+    }
+}

--- a/crates/funput-core/src/lib.rs
+++ b/crates/funput-core/src/lib.rs
@@ -1,7 +1,14 @@
-//! Pure Vietnamese input transform — one keystroke at a time.
+//! Pure Vietnamese orthography, in two surfaces.
 //!
-//! `funput-core` answers: given the current syllable buffer and a key, what is the
-//! new text according to VNI or Telex?
+//! **Input transform** — one keystroke at a time — is what the crate is for and
+//! what everything below the fold serves: given the current syllable buffer and a
+//! key, what is the new text according to VNI or Telex?
+//!
+//! **Charset mapping** ([`charset`], off by default) converts whole text between
+//! Unicode and the legacy Vietnamese encodings. It is here rather than in a crate
+//! of its own because it maps the same letter inventory the transform already
+//! owns — `unicode::vowels` is the single source of truth for both, and a second
+//! copy of it would drift.
 //!
 //! # API FROZEN (Phase 8)
 //!
@@ -12,6 +19,10 @@
 //! committed word for editing).
 //! Breaking changes require semver coordination with the engine.
 //!
+//! That list stays complete for the default build. [`charset`] is additive, keeps
+//! to its own namespace, and re-exports nothing here, so the engine's view of this
+//! crate is the same with the feature on or off.
+//!
 //! # Contract
 //!
 //! - **Stateless:** no session, no backspace count — the engine diffs `buffer` vs
@@ -20,6 +31,8 @@
 //!   split words on spaces.
 //! - **No I/O:** no platform hooks, config files, or English auto-restore (engine).
 
+#[cfg(feature = "charset")]
+pub mod charset;
 mod composition;
 mod input_method;
 mod options;

--- a/crates/funput-core/src/unicode/mod.rs
+++ b/crates/funput-core/src/unicode/mod.rs
@@ -1,3 +1,5 @@
 pub mod marks;
 pub mod shapes;
-mod vowels;
+// `charset` reads the vowel inventory through the accessors in `vowels` rather
+// than keeping its own copy, so the module has to reach past `unicode`.
+pub(crate) mod vowels;

--- a/crates/funput-core/src/unicode/vowels.rs
+++ b/crates/funput-core/src/unicode/vowels.rs
@@ -35,6 +35,32 @@ pub fn tone_index_on_vowel(c: char) -> Option<usize> {
     entry(c)?.index.checked_sub(1)
 }
 
+/// How many families the inventory holds, derived from the table rather than
+/// written down twice. Charset tables index by family, so each one asserts its
+/// own row count against this — adding a 13th family becomes a build error
+/// instead of a silent mis-encoding.
+#[cfg(feature = "charset")]
+pub(crate) const FAMILY_COUNT: usize = table::VOWEL_FAMILIES.len();
+
+/// A vowel's coordinates: family, slot within it (0 = toneless base, 1–5 = sắc,
+/// huyền, hỏi, ngã, nặng), and case.
+///
+/// This and [`vowel_glyph`] are the whole of what charset mapping needs from the
+/// inventory. Every legacy Vietnamese encoding assigns its codes to exactly these
+/// coordinates, which is what lets a charset table be twelve rows of six rather
+/// than a list of sixty-seven glyphs.
+#[cfg(feature = "charset")]
+pub(crate) fn vowel_coords(c: char) -> Option<(usize, usize, bool)> {
+    let e = entry(c)?;
+    Some((e.family, e.index, e.upper))
+}
+
+/// The glyph at a set of coordinates — the inverse of [`vowel_coords`].
+#[cfg(feature = "charset")]
+pub(crate) fn vowel_glyph(family: usize, index: usize, upper: bool) -> Option<char> {
+    (family < FAMILY_COUNT && index < 6).then(|| glyph(family, index, upper))
+}
+
 #[cfg(test)]
 mod tests {
     use super::table::VOWEL_FAMILIES;

--- a/crates/funput-core/tests/charset.rs
+++ b/crates/funput-core/tests/charset.rs
@@ -1,0 +1,25 @@
+// The whole suite is gated here, as an inner attribute on the crate root, rather
+// than on each `mod` below. That is what makes `cargo test --workspace` compile
+// this to an empty binary when the feature is off — a per-`mod` gate would still
+// let the crate root reference `funput_core::charset` and fail. Please do not
+// "fix" it into per-module attributes.
+#![cfg(feature = "charset")]
+
+//! Charset conversion integration suite — one binary, modules under
+//! `tests/charset/`. `#[path]` is required because a `tests/*.rs` crate root looks
+//! up plain `mod` in `tests/`, not a subdirectory.
+//!
+//! The split from the tests inside `src/` is deliberate: those sweep the letter
+//! inventory and need the crate's private accessors to enumerate it, while these
+//! only ever touch the public API — which means they also check that the public
+//! API is enough to do the job.
+
+// Fixture data (shared by the test modules below).
+#[path = "charset/cases.rs"]
+mod cases;
+
+// Test modules.
+#[path = "charset/properties.rs"]
+mod properties;
+#[path = "charset/round_trip.rs"]
+mod round_trip;

--- a/crates/funput-core/tests/charset/cases.rs
+++ b/crates/funput-core/tests/charset/cases.rs
@@ -1,0 +1,34 @@
+//! Fixture text for the conversion suite.
+//!
+//! The TCVN3 side is written with `\u{..}` escapes rather than literal characters
+//! on purpose: a `.VnTime` document's bytes render as Latin-1 punctuation in any
+//! editor, so `"Vi\u{D6}t"` says what is actually stored and `"Viքt"` would only
+//! confuse the next reader. The escapes are also what a reviewer can check against
+//! the table in `src/charset/codecs/tcvn3/table.rs` without running anything.
+
+/// Text that converts exactly both ways: `(Unicode, TCVN3)`.
+pub const EXACT: &[(&str, &str)] = &[
+    ("Việt Nam", "Vi\u{D6}t Nam"),
+    ("Chào bạn", "Ch\u{B5}o b\u{B9}n"),
+    ("đường", "\u{AE}\u{AD}\u{EA}ng"),
+    ("Nghị định", "Ngh\u{DE} \u{AE}\u{DE}nh"),
+    (
+        "Cộng hòa Xã hội Chủ nghĩa Việt Nam",
+        "C\u{E9}ng h\u{DF}a X\u{B7} h\u{E9}i Ch\u{F1} ngh\u{DC}a Vi\u{D6}t Nam",
+    ),
+    // No Vietnamese at all: TCVN3 is ASCII below 0x80, so this is a no-op.
+    ("Ha Noi 1945", "Ha Noi 1945"),
+];
+
+/// Text TCVN3 cannot spell exactly: `(Unicode, TCVN3, unmapped, what it reads back
+/// as)`.
+///
+/// Both kinds of loss are here, and they are the only two kinds there are: an
+/// uppercase toned vowel, which TCVN3 leaves to the `.VnTimeH` font and so comes
+/// back lowercase, and a character with no TCVN3 code at all, which survives as
+/// itself.
+pub const LOSSY: &[(&str, &str, usize, &str)] = &[
+    ("ĐIỀU 5", "\u{A7}I\u{D2}U 5", 1, "ĐIềU 5"),
+    ("GIÁ 5₫", "GI\u{B8} 5₫", 2, "GIá 5₫"),
+    ("HÀ NỘI", "H\u{B5} N\u{E9}I", 2, "Hà NộI"),
+];

--- a/crates/funput-core/tests/charset/properties.rs
+++ b/crates/funput-core/tests/charset/properties.rs
@@ -1,0 +1,59 @@
+//! Properties that must hold for text no fixture would think to write down —
+//! arbitrary byte soup, half-words, unassigned codes.
+
+use funput_core::charset::{Charset, convert};
+use proptest::prelude::*;
+
+/// Anything a legacy document could hold: one char per byte, the whole range.
+const LEGACY_TEXT: &str = "[\\x{20}-\\x{FF}]{0,64}";
+
+proptest! {
+    /// Conversion is total. Whatever the text is — and a user who picks the wrong
+    /// source charset feeds it text that is *not* what it claims — it comes back
+    /// as text, not as a panic.
+    #[test]
+    fn conversion_never_panics(text in LEGACY_TEXT) {
+        for from in [Charset::Unicode, Charset::Tcvn3] {
+            for to in [Charset::Unicode, Charset::Tcvn3] {
+                let _ = convert(&text, from, to);
+            }
+        }
+    }
+
+    /// The contract `unmapped` states, checked rather than asserted in prose: when
+    /// no character was approximated at either end, the conversion is exactly
+    /// reversible. A table entry carrying two letters would break this.
+    ///
+    /// Both counts have to be zero, and the first one is the interesting half —
+    /// arbitrary bytes are mostly *not* TCVN3, and an unrecognized byte re-encodes
+    /// to whatever its Latin-1 letter is worth, not to itself.
+    #[test]
+    fn an_exact_conversion_is_reversible(text in LEGACY_TEXT) {
+        let unicode = convert(&text, Charset::Tcvn3, Charset::Unicode);
+        let back = convert(&unicode.text, Charset::Unicode, Charset::Tcvn3);
+        if unicode.unmapped == 0 && back.unmapped == 0 {
+            prop_assert_eq!(&back.text, &text);
+        }
+    }
+
+    /// TCVN3 spells every letter in one code, so a conversion to or from it moves
+    /// no character boundaries. (This is a property of TCVN3, not of the module:
+    /// VNI-Windows spells some letters in two, and will not have it.)
+    #[test]
+    fn tcvn3_conversion_preserves_the_character_count(text in LEGACY_TEXT) {
+        let decoded = convert(&text, Charset::Tcvn3, Charset::Unicode);
+        prop_assert_eq!(decoded.text.chars().count(), text.chars().count());
+
+        let encoded = convert(&text, Charset::Unicode, Charset::Tcvn3);
+        prop_assert_eq!(encoded.text.chars().count(), text.chars().count());
+    }
+
+    /// Nothing is ever dropped: `unmapped` counts characters that need attention,
+    /// never characters that went missing.
+    #[test]
+    fn no_character_is_ever_dropped(text in "\\PC{0,64}") {
+        let out = convert(&text, Charset::Unicode, Charset::Tcvn3);
+        prop_assert_eq!(out.text.chars().count(), text.chars().count());
+        prop_assert!(out.unmapped <= text.chars().count());
+    }
+}

--- a/crates/funput-core/tests/charset/round_trip.rs
+++ b/crates/funput-core/tests/charset/round_trip.rs
@@ -1,0 +1,63 @@
+//! Fixed cases, through the public API only.
+
+use funput_core::charset::{Charset, convert, decode_bytes};
+
+use crate::cases::{EXACT, LOSSY};
+
+#[test]
+fn unicode_encodes_to_the_bytes_a_vntime_document_holds() {
+    for (unicode, tcvn3) in EXACT {
+        let out = convert(unicode, Charset::Unicode, Charset::Tcvn3);
+        assert_eq!(&out.text, tcvn3, "encoding {unicode:?}");
+        assert_eq!(out.unmapped, 0, "encoding {unicode:?}");
+    }
+}
+
+#[test]
+fn a_vntime_document_decodes_back_to_unicode() {
+    for (unicode, tcvn3) in EXACT {
+        let out = convert(tcvn3, Charset::Tcvn3, Charset::Unicode);
+        assert_eq!(&out.text, unicode, "decoding {tcvn3:?}");
+        assert_eq!(out.unmapped, 0, "decoding {tcvn3:?}");
+    }
+}
+
+/// What TCVN3 cannot spell is reported and approximated, never dropped — and the
+/// approximation is the one the module documents, not whatever fell out.
+#[test]
+fn the_two_kinds_of_loss_are_reported_and_approximated() {
+    for (unicode, tcvn3, unmapped, reread) in LOSSY {
+        let out = convert(unicode, Charset::Unicode, Charset::Tcvn3);
+        assert_eq!(&out.text, tcvn3, "encoding {unicode:?}");
+        assert_eq!(out.unmapped, *unmapped, "encoding {unicode:?}");
+
+        let back = convert(&out.text, Charset::Tcvn3, Charset::Unicode);
+        assert_eq!(&back.text, reread, "reading {unicode:?} back");
+    }
+}
+
+/// Converting to the charset the text is already in changes nothing. Worth its own
+/// test because the UI will do exactly this whenever a user picks the same charset
+/// on both sides.
+#[test]
+fn converting_a_charset_to_itself_is_an_identity() {
+    for (unicode, tcvn3) in EXACT {
+        for (text, charset) in [(unicode, Charset::Unicode), (tcvn3, Charset::Tcvn3)] {
+            let out = convert(text, charset, charset);
+            assert_eq!(&out.text, text, "{text:?} through {charset:?}");
+            assert_eq!(out.unmapped, 0);
+        }
+    }
+}
+
+/// The file door. A `.VnTime` file's bytes are the code points the clipboard would
+/// have carried, so both doors have to land on the same text.
+#[test]
+fn reading_a_file_agrees_with_reading_the_clipboard() {
+    for (unicode, tcvn3) in EXACT {
+        let bytes: Vec<u8> = tcvn3.chars().map(|c| c as u8).collect();
+        let out = decode_bytes(&bytes, Charset::Tcvn3);
+        assert_eq!(&out.text, unicode, "reading {tcvn3:?} as bytes");
+        assert_eq!(out.unmapped, 0);
+    }
+}


### PR DESCRIPTION
Stacked on #221 — base that PR first, and this diff is code only.

Vietnamese government documents still circulate in TCVN3, drawn by the `.VnTime` fonts, and Funput could not read a word of them. This builds the conversion module #221 designed, and runs the first charset through it.

Nothing reaches users yet: the module sits behind a default-off `charset` feature and no consumer enables it. The consumers come next, starting with the UniKey macro import that currently tells people to go install UniKey.

### Why it is in `funput-core`

Because it maps the same letter inventory the input transform already owns. The tables index by `VOWEL_FAMILIES` rather than restating which letters Vietnamese has, and a `const _: () = assert!` ties their row count to it — a thirteenth vowel family fails the build instead of encoding wrongly. A separate crate would have meant a second copy of that inventory, and two copies of one truth drift.

The feature flag is what keeps it out of the iOS and Android keyboards, which have no converter and no reason to carry tables.

### Shape

Conversion pivots through precomposed Unicode, so a codec only has to know how to spell an `Atom` — never how another charset spells one. Charset N+1 costs two mappings, not N.

Dispatch is a `match`, not a trait. The crate defines no traits and dispatches on enums throughout (`input_method/mod.rs` is the precedent), and the match is the point: adding a `Charset` variant becomes a compile error naming the arms still owed.

### The byte table, and why you can trust it

Transcribed from three independent converter implementations and cross-checked cell by cell — one Python, two PHP, different authors. All three agree on all 74 assignments, and the third independently confirms the design's central claim that uppercase toned vowels have no code at all.

Reading cannot catch a transposed byte, so the tests assert structure instead:

- the 74 codes are pairwise distinct and all sit in the range TCVN3 uses;
- they fill exactly twelve families of five tones plus the fourteen shaped bases;
- a sweep round-trips every letter in the inventory, and asserts the set that loses anything is **exactly** the uppercase toned vowels. That negative half is the one that catches a code swapped between families, where a round trip alone would cancel the error out.

### What the property tests changed

`unmapped` now counts a character the **source** charset never defined, not only one the target cannot spell.

An unrecognized byte re-encodes as whatever Latin-1 letter its code point happens to be: TCVN3 `0xC2` is unassigned, passes through as `Â` — which *is* Vietnamese — and re-encodes to `0xA2`. The round trip moves the byte. That cannot be avoided, since one code point is both a stray byte and a real letter, but counting it turns a silent shift into a visible number. It also gives the converter UI its best signal: a count near the length of the input means the wrong source charset was picked.

`Decoded` grew a `recognized` flag to carry this, and #221's `unmapped` section was updated to match.

### CI

Two steps added. With the feature off, nothing lints or runs the new module and it would rot unnoticed.

Format and the line budget need no second pass, and I verified both rather than assuming: `cargo fmt --all -- --check` found diffs inside the cfg-gated module with the feature off, and `check-loc.sh` went from 281 to 287 files — exactly the six new `src/` files.

### Verification

`cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` and `check-loc.sh` all clean with the feature **off**, which is the proof the mobile keyboard build is unchanged. Then `clippy` and `test` clean with it on: 21 charset tests, largest file 135/150 lines, no directory over 5 entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
