### PR TITLE
feat(core): convert Vietnamese text to and from VNI-Windows

### DIFF
--- a/crates/funput-core/src/charset/codecs/mod.rs
+++ b/crates/funput-core/src/charset/codecs/mod.rs
@@ -21,6 +21,7 @@
 //!   disappears in conversion.
 
 mod tcvn3;
+mod vni;
 
 use super::Charset;
 use super::pivot::Atom;
@@ -37,6 +38,7 @@ pub(super) fn decode(charset: Charset, cur: &Cursor<'_>) -> Decoded {
             recognized: true,
         },
         Charset::Tcvn3 => tcvn3::decode(cur),
+        Charset::VniWindows => vni::decode(cur),
     }
 }
 
@@ -49,6 +51,7 @@ pub(super) fn encode(charset: Charset, atom: Atom, out: &mut String) -> bool {
             true
         }
         Charset::Tcvn3 => tcvn3::encode(atom, out),
+        Charset::VniWindows => vni::encode(atom, out),
     }
 }
 
@@ -58,7 +61,7 @@ pub(super) fn encode(charset: Charset, atom: Atom, out: &mut String) -> bool {
 pub(super) fn is_byte_oriented(charset: Charset) -> bool {
     match charset {
         Charset::Unicode => false,
-        Charset::Tcvn3 => true,
+        Charset::Tcvn3 | Charset::VniWindows => true,
     }
 }
 

--- a/crates/funput-core/src/charset/codecs/vni/bytes.rs
+++ b/crates/funput-core/src/charset/codecs/vni/bytes.rs
@@ -1,0 +1,108 @@
+//! Byte-level queries over [`super::table`] — case folding and the two lookups.
+//!
+//! Everything here is a scan over seventy-two cells. `unicode::vowels` builds a
+//! dense table at compile time because it runs once per keystroke; conversion runs
+//! once per paste, where a scan costs nothing and keeps the data in one readable
+//! block next to its only reader.
+
+use super::table::{CASE_OFFSET, Cell, STROKE_LOWER, VNI_BYTES};
+
+/// Whether `byte` appears in the table as a base, as a mark, or as `đ`.
+fn is_lowercase_byte(byte: u8) -> bool {
+    byte == STROKE_LOWER
+        || VNI_BYTES
+            .iter()
+            .flatten()
+            .any(|&(base, mark)| base == byte || (mark != 0 && mark == byte))
+}
+
+/// Fold a byte to its lowercase table form, reporting whether it was uppercase.
+///
+/// Unambiguous because the lowercase bytes (`0x61 0x65 0x69 0x6F 0x75 0x79` and
+/// `0xE0..=0xFC`) and their uppercase counterparts (`0x41…` and `0xC0..=0xDC`)
+/// share no value — so testing lowercase first can never mistake one for the
+/// other. `None` for anything the charset does not use.
+pub(super) fn fold(byte: u8) -> Option<(u8, bool)> {
+    if is_lowercase_byte(byte) {
+        return Some((byte, false));
+    }
+    let lowered = byte.checked_add(CASE_OFFSET)?;
+    is_lowercase_byte(lowered).then_some((lowered, true))
+}
+
+/// A lowercase table byte written in the requested case.
+pub(super) fn cased(byte: u8, upper: bool) -> char {
+    char::from(if upper { byte - CASE_OFFSET } else { byte })
+}
+
+/// The inventory coordinates spelled by `base` plus `mark`, where `mark` is `0`
+/// for a one-byte letter.
+///
+/// A flat scan is sound here only because the seventy-two cells are pairwise
+/// distinct — `tests.rs` asserts that. TCVN3's reverse lookup searches for a
+/// single byte and would find the *first* family sharing it; the same shape over
+/// this table would read `ó` as `á`, since both spell their sắc with `0xF9`.
+pub(super) fn coords_for(base: u8, mark: u8) -> Option<(usize, usize)> {
+    VNI_BYTES.iter().enumerate().find_map(|(family, row)| {
+        row.iter()
+            .position(|&cell| cell == (base, mark))
+            .map(|tone| (family, tone))
+    })
+}
+
+/// How VNI spells the letter at these coordinates.
+pub(super) fn spelling(family: usize, tone: usize) -> Cell {
+    VNI_BYTES[family][tone]
+}
+
+/// The byte a char stands for in a legacy document, or `None` when the char is
+/// outside Latin-1 and so cannot be one.
+///
+/// `u8::try_from`, never `as u8`: truncation would read `U+02F9` as the sắc mark
+/// and quietly eat a character that was never VNI at all.
+pub(super) fn byte_of(c: char) -> Option<u8> {
+    u8::try_from(c as u32).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folding_recovers_the_case_of_every_table_byte() {
+        for &(base, mark) in VNI_BYTES.iter().flatten() {
+            assert_eq!(fold(base), Some((base, false)));
+            assert_eq!(fold(base - CASE_OFFSET), Some((base, true)));
+            if mark != 0 {
+                assert_eq!(fold(mark), Some((mark, false)));
+                assert_eq!(fold(mark - CASE_OFFSET), Some((mark, true)));
+            }
+        }
+        assert_eq!(fold(STROKE_LOWER), Some((STROKE_LOWER, false)));
+    }
+
+    #[test]
+    fn folding_refuses_bytes_the_charset_never_uses() {
+        // 0xE7 and 0xF0 sit in the gaps between the mark blocks; 'b' and '5' are
+        // ASCII that is not a vowel base.
+        for byte in [0xE7, 0xF0, 0xF7, b'b', b'5', b' '] {
+            assert_eq!(fold(byte), None, "{byte:#04X}");
+        }
+    }
+
+    #[test]
+    fn folding_an_uppercase_byte_near_the_top_does_not_overflow() {
+        assert_eq!(fold(0xFF), None);
+    }
+
+    #[test]
+    fn a_char_outside_latin1_has_no_byte() {
+        assert_eq!(byte_of('→'), None);
+        assert_eq!(
+            byte_of('\u{2F9}'),
+            None,
+            "must not truncate to the sắc mark"
+        );
+        assert_eq!(byte_of('\u{F9}'), Some(0xF9));
+    }
+}

--- a/crates/funput-core/src/charset/codecs/vni/mod.rs
+++ b/crates/funput-core/src/charset/codecs/vni/mod.rs
@@ -1,0 +1,133 @@
+//! VNI-Windows — the encoding drawn by the `VNI-Times` font family.
+//!
+//! A letter is a **base byte plus an optional mark byte**, so unlike TCVN3 one
+//! letter is not one char: `Ề` goes out as two, and conversion moves character
+//! boundaries. The spellings live in [`table`], the lookups in [`bytes`].
+//!
+//! # Reading is greedy, and that is provably safe
+//!
+//! Decoding takes the longest match: try the two-byte spelling first, then the
+//! one-byte one. It is safe because **no mark byte is ever a letter on its own** —
+//! the bases and the marks are disjoint sets. So a pair that matches could not have
+//! been two letters, and there is no ordering hazard to reason about. `tests.rs`
+//! asserts the disjointness rather than leaving it as a claim.
+//!
+//! The naive alternative — handle one-byte letters first — looks equivalent and is
+//! not: `0xF4` is both the letter `ơ` and the base of all five of its toned forms,
+//! so `ơ` would be taken alone and every `ớ ờ ở ỡ ợ` would break in half.
+//!
+//! # Two things it refuses to guess
+//!
+//! **A mark whose case disagrees with its base** (`a` + the uppercase sắc byte) is
+//! not something VNI emits, but sloppy converters do. It is read as the letter, in
+//! the base's case, and counted — the reading a person would give, without
+//! inventing a stray Latin-1 vowel that would then grow into two more bytes.
+//!
+//! **The `i` family is one byte per tone**, never base-plus-mark. Some converters
+//! in the wild write `í` as `i` plus the sắc mark; that is read here as `i`
+//! followed by an orphan, and counted. Accepting both would give one letter two
+//! spellings and cost the inventory sweep its power to catch a bad table.
+//!
+//! # What it cannot spell
+//!
+//! Nothing, within Vietnamese — including every uppercase toned vowel, where TCVN3
+//! gives up. `encode` returns false only for a non-ASCII character that was never
+//! Vietnamese to begin with.
+
+mod bytes;
+mod table;
+
+use crate::charset::pivot::Atom;
+use crate::charset::transcode::{Cursor, Decoded};
+
+use table::STROKE_LOWER;
+
+/// Read one VNI letter at the cursor, taking two chars where the spelling has two.
+pub(super) fn decode(cur: &Cursor<'_>) -> Decoded {
+    let first = cur.first();
+    let Some((base, base_upper)) = bytes::byte_of(first).and_then(bytes::fold) else {
+        return passthrough(first);
+    };
+
+    if base == STROKE_LOWER {
+        return Decoded {
+            atom: Atom::Stroke { upper: base_upper },
+            consumed: 1,
+            recognized: true,
+        };
+    }
+
+    // The mark, only if there is a second char *and* it is a byte at all. Folding
+    // a missing char to zero would match the one-byte spellings and swallow it.
+    let mark = cur.second().and_then(bytes::byte_of).and_then(bytes::fold);
+    if let Some((mark_byte, mark_upper)) = mark
+        && let Some((family, tone)) = bytes::coords_for(base, mark_byte)
+        && let Some(atom) = Atom::vowel(family, tone, base_upper)
+    {
+        return Decoded {
+            atom,
+            consumed: 2,
+            // VNI never writes a pair whose halves disagree on case.
+            recognized: base_upper == mark_upper,
+        };
+    }
+
+    match bytes::coords_for(base, 0).and_then(|(f, t)| Atom::vowel(f, t, base_upper)) {
+        Some(atom) => Decoded {
+            atom,
+            consumed: 1,
+            recognized: true,
+        },
+        None => passthrough(first),
+    }
+}
+
+/// A char VNI does not spell. ASCII is still classified, so an ASCII vowel keeps
+/// the family coordinates another charset would need to re-spell it.
+fn passthrough(c: char) -> Decoded {
+    match u8::try_from(c as u32) {
+        Ok(byte) if byte >= 0x80 => Decoded {
+            atom: Atom::Other(c),
+            consumed: 1,
+            recognized: false,
+        },
+        _ => Decoded {
+            atom: Atom::from_char(c),
+            consumed: 1,
+            recognized: true,
+        },
+    }
+}
+
+/// Write `atom` as VNI. `false` only for a non-ASCII character VNI has no code
+/// for — every Vietnamese letter is spellable, in either case.
+pub(super) fn encode(atom: Atom, out: &mut String) -> bool {
+    match atom {
+        Atom::Vowel {
+            family,
+            tone,
+            upper,
+        } => {
+            let (base, mark) = bytes::spelling(family.into(), tone.into());
+            out.push(bytes::cased(base, upper));
+            if mark != 0 {
+                out.push(bytes::cased(mark, upper));
+            }
+            true
+        }
+        Atom::Stroke { upper } => {
+            out.push(bytes::cased(STROKE_LOWER, upper));
+            true
+        }
+        // A passthrough whose code point happens to be a mark byte will fuse with
+        // the letter before it when the text is read back. `unmapped` counts it,
+        // so the module's "exact means reversible" contract still holds.
+        Atom::Other(c) => {
+            out.push(c);
+            c.is_ascii()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/funput-core/src/charset/codecs/vni/table.rs
+++ b/crates/funput-core/src/charset/codecs/vni/table.rs
@@ -1,0 +1,90 @@
+//! The VNI-Windows spelling of every letter in the Vietnamese inventory.
+//!
+//! # Where these numbers came from
+//!
+//! Read as raw bytes out of two converter implementations — `anhskohbo/u-convert`
+//! (PHP) and `vuthaihoc/py-unicode-convert` (Python) — and compared entry by entry:
+//! **134 of 134 agree, case-sensitively, with no cell differing.** Three
+//! independent anchors line up with them: vietunicode states `á = 97,249`
+//! (`61 F9`), and a separate gist gives `Ấ = 41 C1`, `Ằ = 41 C8`, `Ẳ = 41 DA`.
+//!
+//! Those two implementations share a lineage, so the comparison proves faithful
+//! transcription rather than two independent derivations. What actually proves the
+//! table is the structure below, which `tests.rs` asserts in full.
+//!
+//! # Structure
+//!
+//! A letter is **a base byte and an optional mark byte**, in that order — one
+//! model for all seventy-two, including the ones that come out a single byte
+//! (`(0xED, 0)` is `í`) and the two whose base is not ASCII (`(0xF4, …)` is the `ơ`
+//! family). Storing the base in full rather than "0 = derive it from the family"
+//! is what keeps the reverse lookup a flat scan and gives the distinctness check
+//! below something to bite on.
+//!
+//! Three mark sets do all the work: plain `F9 F8 FB F5 EF`, circumflex `E2` plus
+//! `E1 E0 E5 E3 E4` (shared by `â ê ô`, told apart by the base), and breve `EA`
+//! plus `E9 E8 FA FC EB` for `ă` alone.
+//!
+//! **Uppercase is every byte minus `0x20`**, without exception — so this table
+//! holds only lowercase and half the charset is derived rather than transcribed.
+
+use crate::unicode::vowels;
+
+/// A letter's spelling: base byte, then mark byte (`0` = the letter is one byte).
+pub(super) type Cell = (u8, u8);
+
+/// VNI-Windows spelling per (family, slot) of the vowel inventory.
+///
+/// Rows follow `VOWEL_FAMILIES`, so the index is shared with the inventory rather
+/// than re-derived. Columns follow it too: base, sắc, huyền, hỏi, ngã, nặng.
+///
+/// Two rows break the base-plus-mark rhythm, and both are VNI's doing rather than
+/// this table's: the `i` family spells every tone as **one** byte, and `ỵ` alone
+/// does the same in a family whose other tones do not.
+///
+/// `rustfmt` would put every tuple on its own line, turning twelve readable rows
+/// into a hundred and fifty. A charset table is read as a grid or not at all.
+#[rustfmt::skip]
+pub(super) const VNI_BYTES: [[Cell; 6]; 12] = [
+    /* a */ [(0x61, 0x00), (0x61, 0xF9), (0x61, 0xF8), (0x61, 0xFB), (0x61, 0xF5), (0x61, 0xEF)],
+    /* ă */ [(0x61, 0xEA), (0x61, 0xE9), (0x61, 0xE8), (0x61, 0xFA), (0x61, 0xFC), (0x61, 0xEB)],
+    /* â */ [(0x61, 0xE2), (0x61, 0xE1), (0x61, 0xE0), (0x61, 0xE5), (0x61, 0xE3), (0x61, 0xE4)],
+    /* e */ [(0x65, 0x00), (0x65, 0xF9), (0x65, 0xF8), (0x65, 0xFB), (0x65, 0xF5), (0x65, 0xEF)],
+    /* ê */ [(0x65, 0xE2), (0x65, 0xE1), (0x65, 0xE0), (0x65, 0xE5), (0x65, 0xE3), (0x65, 0xE4)],
+    /* i */ [(0x69, 0x00), (0xED, 0x00), (0xEC, 0x00), (0xE6, 0x00), (0xF3, 0x00), (0xF2, 0x00)],
+    /* o */ [(0x6F, 0x00), (0x6F, 0xF9), (0x6F, 0xF8), (0x6F, 0xFB), (0x6F, 0xF5), (0x6F, 0xEF)],
+    /* ô */ [(0x6F, 0xE2), (0x6F, 0xE1), (0x6F, 0xE0), (0x6F, 0xE5), (0x6F, 0xE3), (0x6F, 0xE4)],
+    /* ơ */ [(0xF4, 0x00), (0xF4, 0xF9), (0xF4, 0xF8), (0xF4, 0xFB), (0xF4, 0xF5), (0xF4, 0xEF)],
+    /* u */ [(0x75, 0x00), (0x75, 0xF9), (0x75, 0xF8), (0x75, 0xFB), (0x75, 0xF5), (0x75, 0xEF)],
+    /* ư */ [(0xF6, 0x00), (0xF6, 0xF9), (0xF6, 0xF8), (0xF6, 0xFB), (0xF6, 0xF5), (0xF6, 0xEF)],
+    /* y */ [(0x79, 0x00), (0x79, 0xF9), (0x79, 0xF8), (0x79, 0xFB), (0x79, 0xF5), (0xEE, 0x00)],
+];
+
+/// A thirteenth vowel family would leave this table silently short.
+const _: () = assert!(VNI_BYTES.len() == vowels::FAMILY_COUNT);
+
+/// Every letter has a base. `0` is the sentinel for a missing *mark*, and reusing
+/// it for a missing base would make "no base" and "ASCII base" the same value.
+/// The floor keeps `base - CASE_OFFSET` inside the printable range.
+const _: () = {
+    let mut family = 0;
+    while family < VNI_BYTES.len() {
+        let mut tone = 0;
+        while tone < 6 {
+            assert!(
+                VNI_BYTES[family][tone].0 >= 0x61,
+                "base byte missing or too low"
+            );
+            tone += 1;
+        }
+        family += 1;
+    }
+};
+
+/// `đ` — one byte, no mark, and no family to live in.
+pub(super) const STROKE_LOWER: u8 = 0xF1;
+
+/// How far above its uppercase counterpart every VNI byte sits. Holds for all
+/// sixty-six vowel spellings and for `đ` (`Đ` = `0xD1`), which is why no uppercase
+/// byte is written down anywhere in this file.
+pub(super) const CASE_OFFSET: u8 = 0x20;

--- a/crates/funput-core/src/charset/codecs/vni/tests.rs
+++ b/crates/funput-core/src/charset/codecs/vni/tests.rs
@@ -1,0 +1,290 @@
+use super::table::{CASE_OFFSET, STROKE_LOWER, VNI_BYTES};
+use crate::charset::Charset;
+use crate::charset::transcode::transcode;
+use crate::unicode::shapes::base_vowel;
+use crate::unicode::vowels;
+
+fn to_vni(text: &str) -> (String, usize) {
+    let out = transcode(text, Charset::Unicode, Charset::VniWindows);
+    (out.text, out.unmapped)
+}
+
+fn from_vni(text: &str) -> (String, usize) {
+    let out = transcode(text, Charset::VniWindows, Charset::Unicode);
+    (out.text, out.unmapped)
+}
+
+fn codepoints(text: &str) -> Vec<u32> {
+    text.chars().map(|c| c as u32).collect()
+}
+
+/// The sweep. Unlike TCVN3, whose uppercase toned vowels have no code, VNI spells
+/// the entire inventory — so the set that loses anything must be **empty**. That
+/// emptiness is the strongest single check on the table: a byte that collides with
+/// another cell shows up as a round-trip mismatch, and one that collides with
+/// nothing shows up as a non-zero `unmapped`.
+#[test]
+fn the_whole_inventory_round_trips_with_nothing_lost() {
+    for family in 0..vowels::FAMILY_COUNT {
+        for tone in 0..6 {
+            for upper in [false, true] {
+                let c = vowels::vowel_glyph(family, tone, upper).expect("in inventory");
+                let (encoded, unmapped) = to_vni(&c.to_string());
+                assert_eq!(unmapped, 0, "{c} should be spellable");
+                assert_eq!(from_vni(&encoded).0, c.to_string(), "{c} should round trip");
+            }
+        }
+    }
+}
+
+#[test]
+fn the_stroke_keeps_its_case_in_both_directions() {
+    for c in ['đ', 'Đ'] {
+        let (encoded, unmapped) = to_vni(&c.to_string());
+        assert_eq!(unmapped, 0);
+        assert_eq!(from_vni(&encoded).0, c.to_string());
+    }
+}
+
+/// A transposed byte is invisible to the eye, so assert structure instead. All
+/// seventy-three spellings distinct is what licenses the flat reverse scan in
+/// `bytes::coords_for` — two cells sharing a spelling would make it return
+/// whichever family came first.
+#[test]
+fn every_spelling_is_distinct() {
+    let mut spellings: Vec<(u8, u8)> = VNI_BYTES.iter().flatten().copied().collect();
+    spellings.push((STROKE_LOWER, 0));
+    assert_eq!(spellings.len(), 73, "12 families x 6 slots, plus đ");
+
+    let mut sorted = spellings.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(
+        sorted.len(),
+        spellings.len(),
+        "two letters share one spelling"
+    );
+}
+
+/// The invariant that makes greedy two-char matching safe: a mark byte is never a
+/// letter on its own, so a pair that matches could not have been two letters. The
+/// cross-case halves matter too, since decoding folds before it looks up.
+#[test]
+fn no_base_byte_is_ever_a_mark_byte() {
+    let bases: Vec<u8> = VNI_BYTES
+        .iter()
+        .flatten()
+        .map(|&(base, _)| base)
+        .chain([STROKE_LOWER])
+        .collect();
+    let marks: Vec<u8> = VNI_BYTES
+        .iter()
+        .flatten()
+        .map(|&(_, mark)| mark)
+        .filter(|&mark| mark != 0)
+        .collect();
+
+    for base in &bases {
+        assert!(
+            !marks.contains(base),
+            "{base:#04X} is both a base and a mark"
+        );
+        let raised = base - CASE_OFFSET;
+        assert!(
+            !marks.contains(&raised),
+            "{raised:#04X} collides across case"
+        );
+        assert!(
+            !bases.contains(&raised),
+            "{raised:#04X} is a base in both cases"
+        );
+    }
+}
+
+/// Half the charset is derived rather than transcribed, so prove the rule that
+/// derives it. Sixty-seven spellings, and not one uppercase byte written by hand.
+#[test]
+fn uppercase_is_every_byte_minus_the_case_offset() {
+    for family in 0..vowels::FAMILY_COUNT {
+        for tone in 0..6 {
+            let lower = vowels::vowel_glyph(family, tone, false).expect("in inventory");
+            let upper = vowels::vowel_glyph(family, tone, true).expect("in inventory");
+            let lowered = codepoints(&to_vni(&lower.to_string()).0);
+            let raised = codepoints(&to_vni(&upper.to_string()).0);
+            let expected: Vec<u32> = lowered.iter().map(|c| c - u32::from(CASE_OFFSET)).collect();
+            assert_eq!(raised, expected, "{upper} against {lower}");
+        }
+    }
+    assert_eq!(
+        codepoints(&to_vni("Đ").0),
+        vec![u32::from(STROKE_LOWER) - u32::from(CASE_OFFSET)]
+    );
+}
+
+/// The bases in the table have to stay the ones the inventory names, or a family
+/// would be spelled with another family's letter. Families 8 and 10 are the two
+/// deliberate exceptions: VNI gives `ơ` and `ư` bytes of their own rather than
+/// building them on `o` and `u`.
+#[test]
+fn every_ascii_base_matches_the_inventory() {
+    for (family, row) in VNI_BYTES.iter().enumerate() {
+        let stem = vowels::vowel_glyph(family, 0, false).expect("in inventory");
+        let ascii = base_vowel(stem).expect("a vowel has a base");
+        let (base, _) = row[0];
+        if base < 0x80 {
+            assert_eq!(char::from(base), ascii, "family {family} ({stem})");
+        } else {
+            assert!(
+                matches!(family, 8 | 10),
+                "family {family} ({stem}) has a non-ASCII base without being ơ or ư"
+            );
+        }
+    }
+}
+
+/// A base at the end of the text is a letter, not a truncated pair. Guards the
+/// sentinel trap: folding "no second char" to zero would match the one-byte
+/// spellings and consume a character that is not there.
+#[test]
+fn a_base_at_the_end_of_the_text_is_a_letter_on_its_own() {
+    for text in ["a", "\u{F4}", "\u{D4}", "\u{ED}", "\u{F1}"] {
+        let (out, unmapped) = from_vni(text);
+        assert_eq!(unmapped, 0, "{text:?}");
+        assert_eq!(out.chars().count(), 1, "{text:?} is one letter");
+    }
+}
+
+/// The two ways a second char can fail to be a mark byte, both of which a `0`
+/// sentinel or an `as u8` truncation would swallow silently. No property test in
+/// the suite generates either: one is outside Latin-1, the other truncates *into*
+/// the sắc mark.
+#[test]
+fn a_char_outside_latin1_after_a_base_is_not_eaten() {
+    for text in ["a\u{2192}", "a\u{2F9}"] {
+        let (out, _) = from_vni(text);
+        assert_eq!(out.chars().count(), 2, "{text:?} lost a character: {out:?}");
+        assert_eq!(out.chars().next(), Some('a'));
+    }
+}
+
+/// A mark with nothing to attach to is not a letter. It must take the `Other`
+/// path, not `Atom::from_char` — `ù` is a Vietnamese letter, and reading it as one
+/// would look confident when it is a guess.
+#[test]
+fn a_mark_with_no_base_passes_through_and_is_reported() {
+    let (out, unmapped) = from_vni("\u{F9}");
+    assert_eq!(out, "\u{F9}", "not read as a letter");
+    assert_eq!(unmapped, 1);
+
+    let (out, unmapped) = from_vni("b\u{F9}");
+    assert_eq!(out, "b\u{F9}");
+    assert_eq!(unmapped, 1);
+}
+
+/// The `i` family spells every tone in one byte, so `i` takes no marks at all. A
+/// converter that writes `í` as `i` plus sắc is not producing VNI, and saying so
+/// is what keeps one letter to one spelling.
+#[test]
+fn a_mark_on_a_base_that_cannot_take_it_is_reported() {
+    for text in ["i\u{F9}", "\u{F4}\u{E1}"] {
+        let (out, unmapped) = from_vni(text);
+        assert_eq!(out.chars().count(), 2, "{text:?} should stay two things");
+        assert_eq!(unmapped, 1, "{text:?}");
+    }
+}
+
+/// VNI never writes a pair whose halves disagree on case, but sloppy converters
+/// do. Read it as the letter, in the base's case, and count it.
+#[test]
+fn a_mixed_case_pair_reads_as_the_letter_and_is_reported() {
+    for (text, expected) in [("a\u{D9}", "á"), ("A\u{F9}", "Á"), ("a\u{C1}", "ấ")] {
+        let (out, unmapped) = from_vni(text);
+        assert_eq!(out, expected, "{text:?}");
+        assert_eq!(unmapped, 1, "{text:?} is malformed VNI");
+    }
+}
+
+/// A byte VNI does not assign comes through as itself. `0xE7` sits in the gap
+/// between the mark blocks.
+#[test]
+fn an_unassigned_high_byte_passes_through_and_is_reported() {
+    let (out, unmapped) = from_vni("\u{E7}");
+    assert_eq!(out, "\u{E7}");
+    assert_eq!(unmapped, 1);
+}
+
+/// TCVN3's `0xC2` trap, with a twist it cannot show. `0xFD` is unassigned in VNI
+/// and passes through as `ý`, which *is* Vietnamese — so re-encoding it spells it
+/// in two bytes and the text gets **longer**. And `0xD0` is `Ð`, Latin capital
+/// Eth: it looks like `Đ` but VNI's `Đ` is `0xD1`, so it must not be helpfully
+/// corrected.
+#[test]
+fn an_unassigned_byte_that_is_a_vietnamese_letter_changes_length_when_re_encoded() {
+    let (out, unmapped) = from_vni("\u{FD}");
+    assert_eq!(out, "ý");
+    assert_eq!(unmapped, 1, "the source never defined 0xFD");
+    assert_eq!(
+        codepoints(&to_vni(&out).0),
+        vec![0x79, 0xF9],
+        "one char to two"
+    );
+
+    let (out, unmapped) = from_vni("\u{D0}");
+    assert_eq!(out, "\u{D0}", "Ð is not Đ");
+    assert_eq!(unmapped, 1);
+}
+
+/// ASCII is untouched, and the ASCII vowels have to come back as bare ASCII rather
+/// than gaining a mark — they take the vowel path, not the passthrough one.
+#[test]
+fn ascii_survives_untouched() {
+    let text = "Ha Noi 1975 (bd) -- ok!";
+    let (encoded, unmapped) = to_vni(text);
+    assert_eq!(unmapped, 0);
+    assert_eq!(encoded, text);
+    assert_eq!(from_vni(&encoded).0, text);
+}
+
+/// Known and reported, rather than discovered in the field: a passthrough whose
+/// code point is a mark byte fuses with the letter before it. TCVN3 cannot do this,
+/// because nothing in it combines. `unmapped` is non-zero, so the module's "exact
+/// means reversible" contract survives.
+#[test]
+fn a_non_ascii_passthrough_can_fuse_with_the_letter_before_it() {
+    let (encoded, unmapped) = to_vni("a\u{F8}");
+    assert_eq!(unmapped, 1, "ø has no VNI code");
+    assert_eq!(from_vni(&encoded).0, "à", "the two fused on the way back");
+}
+
+/// Two real words with their bytes written out, so a table edit has to face a
+/// concrete example and not only a property. Both change length, and `đường`
+/// exercises the sequence that a non-greedy decoder breaks: `ư` alone, then `ơ`
+/// carrying a mark.
+#[test]
+fn a_real_word_encodes_to_the_bytes_a_vni_times_document_holds() {
+    let (encoded, unmapped) = to_vni("Việt Nam");
+    assert_eq!(unmapped, 0);
+    assert_eq!(
+        codepoints(&encoded),
+        vec![0x56, 0x69, 0x65, 0xE4, 0x74, 0x20, 0x4E, 0x61, 0x6D],
+        "V i ê+nặng t _ N a m"
+    );
+    assert_eq!(from_vni(&encoded).0, "Việt Nam");
+
+    let (encoded, unmapped) = to_vni("đường");
+    assert_eq!(unmapped, 0);
+    assert_eq!(
+        codepoints(&encoded),
+        vec![0xF1, 0xF6, 0xF4, 0xF8, 0x6E, 0x67],
+        "đ ư ơ+huyền n g"
+    );
+    assert_eq!(from_vni(&encoded).0, "đường");
+}
+
+/// One letter, two characters — the property TCVN3 does not have, stated plainly.
+#[test]
+fn a_letter_can_be_two_characters() {
+    assert_eq!(to_vni("Ề").0.chars().count(), 2);
+    assert_eq!(to_vni("ạ").0.chars().count(), 2);
+    assert_eq!(to_vni("í").0.chars().count(), 1, "the i family is one byte");
+}

--- a/crates/funput-core/src/charset/mod.rs
+++ b/crates/funput-core/src/charset/mod.rs
@@ -34,16 +34,22 @@ mod transcode;
 
 /// A Vietnamese character encoding.
 ///
-/// `#[non_exhaustive]`: VNI-Windows and Unicode tổ hợp are coming, and adding them
-/// should not break callers. Match with a wildcard arm.
+/// `#[non_exhaustive]`: Unicode tổ hợp is still to come, and adding it should not
+/// break callers. Match with a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum Charset {
     /// Precomposed Unicode (NFC) — the pivot, and what every modern system uses.
     Unicode,
     /// TCVN3, also called ABC: the `.VnTime` encoding of Vietnamese government
-    /// documents.
+    /// documents. One byte per letter, and no code for an uppercase toned vowel.
     Tcvn3,
+    /// VNI-Windows, the `VNI-Times` encoding. Spells most letters as a base byte
+    /// plus a mark byte, so a letter is not a character and conversion moves
+    /// character boundaries. Named for the encoding rather than `Vni`, which would
+    /// sit confusingly beside [`crate::InputMethod::Vni`] — a way of *typing*, not
+    /// a way of storing.
+    VniWindows,
 }
 
 /// Converted text, and how many characters did not survive it exactly.
@@ -53,8 +59,9 @@ pub enum Charset {
 /// much as the input did. What the number says is how many places need the user's
 /// eye. A character lands there for one of two reasons:
 ///
-/// - the **target** cannot spell it — an uppercase toned vowel, which TCVN3 leaves
-///   to the `.VnTimeH` font, or a `₫`, which no legacy charset has a code for;
+/// - the **target** cannot spell it — a `₫`, which no legacy charset has a code
+///   for, or an uppercase toned vowel, which is TCVN3's own gap rather than a
+///   general one: VNI-Windows spells those perfectly well;
 /// - the **source** never defined it, so reading it was a guess.
 ///
 /// The second is worth watching. Text converted from the wrong source charset is

--- a/crates/funput-core/src/charset/transcode.rs
+++ b/crates/funput-core/src/charset/transcode.rs
@@ -12,13 +12,13 @@ use super::{Charset, Conversion};
 /// A read window onto the source, positioned at a unit boundary.
 ///
 /// A codec reads as far ahead as its encoding needs and reports how much it took.
-/// TCVN3 only ever needs the first char; VNI's base-plus-mark pair will want a
-/// second, and adds the accessor for it then.
+/// TCVN3 spells every letter in one char and only ever reads [`Cursor::first`];
+/// VNI-Windows spells most of them as a base plus a mark and needs both.
 pub(super) struct Cursor<'a> {
     rest: &'a str,
 }
 
-impl<'a> Cursor<'a> {
+impl Cursor<'_> {
     /// The char at the cursor. Never fails: a cursor is only built on a non-empty
     /// remainder.
     pub(super) fn first(&self) -> char {
@@ -26,6 +26,15 @@ impl<'a> Cursor<'a> {
             .chars()
             .next()
             .expect("cursor built on non-empty text")
+    }
+
+    /// The char after it, or `None` at the end of the text.
+    ///
+    /// `None` must stay distinguishable from "some byte that happens to be zero":
+    /// a codec that folds the two together will match a one-char tail against a
+    /// two-char spelling and swallow whatever comes next.
+    pub(super) fn second(&self) -> Option<char> {
+        self.rest.chars().nth(1)
     }
 }
 

--- a/crates/funput-core/tests/charset/cases.rs
+++ b/crates/funput-core/tests/charset/cases.rs
@@ -1,34 +1,66 @@
 //! Fixture text for the conversion suite.
 //!
-//! The TCVN3 side is written with `\u{..}` escapes rather than literal characters
-//! on purpose: a `.VnTime` document's bytes render as Latin-1 punctuation in any
-//! editor, so `"Vi\u{D6}t"` says what is actually stored and `"Viքt"` would only
-//! confuse the next reader. The escapes are also what a reviewer can check against
-//! the table in `src/charset/codecs/tcvn3/table.rs` without running anything.
+//! The legacy sides are written with `\u{..}` escapes rather than literal
+//! characters on purpose: a legacy document's bytes render as Latin-1 punctuation
+//! in any editor, so `"Vi\u{D6}t"` says what is actually stored and `"Viքt"` would
+//! only confuse the next reader. The escapes are also what a reviewer can check
+//! against the tables in `src/charset/codecs/*/table.rs` without running anything.
+//!
+//! Both legacy spellings sit on one row so a reviewer sees them together, and so
+//! the tests loop over charsets instead of growing a parallel copy per charset.
+//! Note how the columns differ in length: TCVN3 spells every letter in one
+//! character, VNI-Windows spells most of them in two.
 
-/// Text that converts exactly both ways: `(Unicode, TCVN3)`.
-pub const EXACT: &[(&str, &str)] = &[
-    ("Việt Nam", "Vi\u{D6}t Nam"),
-    ("Chào bạn", "Ch\u{B5}o b\u{B9}n"),
-    ("đường", "\u{AE}\u{AD}\u{EA}ng"),
-    ("Nghị định", "Ngh\u{DE} \u{AE}\u{DE}nh"),
+/// Text that converts exactly in every direction: `(Unicode, TCVN3, VNI-Windows)`.
+pub const EXACT: &[(&str, &str, &str)] = &[
+    ("Việt Nam", "Vi\u{D6}t Nam", "Vi\u{65}\u{E4}t Nam"),
+    (
+        "Chào bạn",
+        "Ch\u{B5}o b\u{B9}n",
+        "Ch\u{61}\u{F8}o b\u{61}\u{EF}n",
+    ),
+    (
+        "đường",
+        "\u{AE}\u{AD}\u{EA}ng",
+        "\u{F1}\u{F6}\u{F4}\u{F8}ng",
+    ),
+    (
+        "Nghị định",
+        "Ngh\u{DE} \u{AE}\u{DE}nh",
+        "Ngh\u{F2} \u{F1}\u{F2}nh",
+    ),
     (
         "Cộng hòa Xã hội Chủ nghĩa Việt Nam",
         "C\u{E9}ng h\u{DF}a X\u{B7} h\u{E9}i Ch\u{F1} ngh\u{DC}a Vi\u{D6}t Nam",
+        "C\u{6F}\u{E4}ng h\u{6F}\u{F8}a X\u{61}\u{F5} h\u{6F}\u{E4}i Ch\u{75}\u{FB} \
+         ngh\u{F3}a Vi\u{65}\u{E4}t Nam",
     ),
-    // No Vietnamese at all: TCVN3 is ASCII below 0x80, so this is a no-op.
-    ("Ha Noi 1945", "Ha Noi 1945"),
+    // No Vietnamese at all: both charsets are ASCII below 0x80, so this is a no-op.
+    ("Ha Noi 1945", "Ha Noi 1945", "Ha Noi 1945"),
 ];
 
-/// Text TCVN3 cannot spell exactly: `(Unicode, TCVN3, unmapped, what it reads back
+/// What TCVN3 cannot spell exactly: `(Unicode, TCVN3, unmapped, what it reads back
 /// as)`.
 ///
-/// Both kinds of loss are here, and they are the only two kinds there are: an
-/// uppercase toned vowel, which TCVN3 leaves to the `.VnTimeH` font and so comes
-/// back lowercase, and a character with no TCVN3 code at all, which survives as
-/// itself.
-pub const LOSSY: &[(&str, &str, usize, &str)] = &[
+/// Both kinds of loss are here, and they are the only two TCVN3 has: an uppercase
+/// toned vowel, which it leaves to the `.VnTimeH` font and so comes back
+/// lowercase, and a character with no code at all, which survives as itself.
+pub const TCVN3_LOSSY: &[(&str, &str, usize, &str)] = &[
     ("ĐIỀU 5", "\u{A7}I\u{D2}U 5", 1, "ĐIềU 5"),
     ("GIÁ 5₫", "GI\u{B8} 5₫", 2, "GIá 5₫"),
     ("HÀ NỘI", "H\u{B5} N\u{E9}I", 2, "Hà NộI"),
+];
+
+/// What VNI-Windows cannot spell exactly — a much shorter list, and deliberately
+/// **not** merged with the one above.
+///
+/// The two charsets lose different things, so one table would be a lie: `ĐIỀU 5`
+/// is lossy in TCVN3 and exact in VNI, which is the whole point. VNI has no
+/// uppercase gap at all, so the only loss left is a character that was never
+/// Vietnamese.
+pub const VNI_LOSSY: &[(&str, &str, usize, &str)] = &[
+    ("GIÁ 5₫", "GI\u{41}\u{D9} 5₫", 1, "GIÁ 5₫"),
+    // `ø` is not Vietnamese, so it passes through — and its code point is VNI's
+    // huyền mark, so reading the result back fuses it onto the `a` before it.
+    ("a\u{F8}", "a\u{F8}", 1, "à"),
 ];

--- a/crates/funput-core/tests/charset/properties.rs
+++ b/crates/funput-core/tests/charset/properties.rs
@@ -1,5 +1,6 @@
 //! Properties that must hold for text no fixture would think to write down —
-//! arbitrary byte soup, half-words, unassigned codes.
+//! arbitrary byte soup, half-words, unassigned codes, marks with nothing to
+//! attach to.
 
 use funput_core::charset::{Charset, convert};
 use proptest::prelude::*;
@@ -7,14 +8,16 @@ use proptest::prelude::*;
 /// Anything a legacy document could hold: one char per byte, the whole range.
 const LEGACY_TEXT: &str = "[\\x{20}-\\x{FF}]{0,64}";
 
+const LEGACY: [Charset; 2] = [Charset::Tcvn3, Charset::VniWindows];
+
 proptest! {
     /// Conversion is total. Whatever the text is — and a user who picks the wrong
     /// source charset feeds it text that is *not* what it claims — it comes back
     /// as text, not as a panic.
     #[test]
     fn conversion_never_panics(text in LEGACY_TEXT) {
-        for from in [Charset::Unicode, Charset::Tcvn3] {
-            for to in [Charset::Unicode, Charset::Tcvn3] {
+        for from in [Charset::Unicode, Charset::Tcvn3, Charset::VniWindows] {
+            for to in [Charset::Unicode, Charset::Tcvn3, Charset::VniWindows] {
                 let _ = convert(&text, from, to);
             }
         }
@@ -24,21 +27,24 @@ proptest! {
     /// no character was approximated at either end, the conversion is exactly
     /// reversible. A table entry carrying two letters would break this.
     ///
-    /// Both counts have to be zero, and the first one is the interesting half —
-    /// arbitrary bytes are mostly *not* TCVN3, and an unrecognized byte re-encodes
-    /// to whatever its Latin-1 letter is worth, not to itself.
+    /// It is also the regression net for VNI's lenient mixed-case reading. A
+    /// decoder that took `61 D9` as `á` with `recognized = true` would re-encode
+    /// it as `61 F9` and fail here; counting it is what keeps the guard honest.
     #[test]
     fn an_exact_conversion_is_reversible(text in LEGACY_TEXT) {
-        let unicode = convert(&text, Charset::Tcvn3, Charset::Unicode);
-        let back = convert(&unicode.text, Charset::Unicode, Charset::Tcvn3);
-        if unicode.unmapped == 0 && back.unmapped == 0 {
-            prop_assert_eq!(&back.text, &text);
+        for charset in LEGACY {
+            let unicode = convert(&text, charset, Charset::Unicode);
+            let back = convert(&unicode.text, Charset::Unicode, charset);
+            if unicode.unmapped == 0 && back.unmapped == 0 {
+                prop_assert_eq!(&back.text, &text, "through {:?}", charset);
+            }
         }
     }
 
     /// TCVN3 spells every letter in one code, so a conversion to or from it moves
-    /// no character boundaries. (This is a property of TCVN3, not of the module:
-    /// VNI-Windows spells some letters in two, and will not have it.)
+    /// no character boundaries. This is a property of TCVN3, not of the module —
+    /// VNI-Windows spells most letters in two, and `a_letter_can_be_two_characters`
+    /// in its codec tests states the opposite for it.
     #[test]
     fn tcvn3_conversion_preserves_the_character_count(text in LEGACY_TEXT) {
         let decoded = convert(&text, Charset::Tcvn3, Charset::Unicode);
@@ -48,12 +54,42 @@ proptest! {
         prop_assert_eq!(encoded.text.chars().count(), text.chars().count());
     }
 
-    /// Nothing is ever dropped: `unmapped` counts characters that need attention,
-    /// never characters that went missing.
+    /// Nothing is ever dropped. `>=` rather than `==` is the honest statement of
+    /// that, and the one the module actually promises: encoding to VNI can make
+    /// text longer, and only TCVN3 keeps the count.
     #[test]
     fn no_character_is_ever_dropped(text in "\\PC{0,64}") {
-        let out = convert(&text, Charset::Unicode, Charset::Tcvn3);
-        prop_assert_eq!(out.text.chars().count(), text.chars().count());
-        prop_assert!(out.unmapped <= text.chars().count());
+        for charset in LEGACY {
+            let out = convert(&text, Charset::Unicode, charset);
+            prop_assert!(out.text.chars().count() >= text.chars().count());
+            prop_assert!(out.unmapped <= text.chars().count());
+        }
+    }
+
+    /// Decoding a legacy charset can only ever join characters, never invent them:
+    /// two bytes may become one letter, but one byte never becomes two. A decoder
+    /// that mistook a missing second char for a zero byte would break this by
+    /// consuming past the end.
+    #[test]
+    fn decoding_never_invents_characters(text in LEGACY_TEXT) {
+        for charset in LEGACY {
+            let out = convert(&text, charset, Charset::Unicode);
+            prop_assert!(
+                out.text.chars().count() <= text.chars().count(),
+                "{:?} grew {:?} into {:?}", charset, text, out.text
+            );
+        }
+    }
+
+    /// A legacy document has to be storable as bytes. Any character in the output
+    /// above `U+00FF` could not have come from the charset, so it must have been
+    /// counted — otherwise `decode_bytes` would hand back text a file cannot hold.
+    #[test]
+    fn a_legacy_charset_writes_only_bytes_or_reports_it(text in "\\PC{0,64}") {
+        for charset in LEGACY {
+            let out = convert(&text, Charset::Unicode, charset);
+            let wide = out.text.chars().filter(|c| *c > '\u{FF}').count();
+            prop_assert!(wide <= out.unmapped, "{:?} wrote {} unreported wide chars", charset, wide);
+        }
     }
 }

--- a/crates/funput-core/tests/charset/round_trip.rs
+++ b/crates/funput-core/tests/charset/round_trip.rs
@@ -2,37 +2,82 @@
 
 use funput_core::charset::{Charset, convert, decode_bytes};
 
-use crate::cases::{EXACT, LOSSY};
+use crate::cases::{EXACT, TCVN3_LOSSY, VNI_LOSSY};
+
+/// Every fixture row, once per legacy charset: `(charset, Unicode, its spelling)`.
+fn legacy_rows() -> impl Iterator<Item = (Charset, &'static str, &'static str)> {
+    EXACT.iter().flat_map(|&(unicode, tcvn3, vni)| {
+        [
+            (Charset::Tcvn3, unicode, tcvn3),
+            (Charset::VniWindows, unicode, vni),
+        ]
+    })
+}
 
 #[test]
-fn unicode_encodes_to_the_bytes_a_vntime_document_holds() {
-    for (unicode, tcvn3) in EXACT {
-        let out = convert(unicode, Charset::Unicode, Charset::Tcvn3);
-        assert_eq!(&out.text, tcvn3, "encoding {unicode:?}");
-        assert_eq!(out.unmapped, 0, "encoding {unicode:?}");
+fn unicode_encodes_to_the_bytes_a_legacy_document_holds() {
+    for (charset, unicode, legacy) in legacy_rows() {
+        let out = convert(unicode, Charset::Unicode, charset);
+        assert_eq!(out.text, legacy, "{charset:?} encoding {unicode:?}");
+        assert_eq!(out.unmapped, 0, "{charset:?} encoding {unicode:?}");
     }
 }
 
 #[test]
-fn a_vntime_document_decodes_back_to_unicode() {
-    for (unicode, tcvn3) in EXACT {
-        let out = convert(tcvn3, Charset::Tcvn3, Charset::Unicode);
-        assert_eq!(&out.text, unicode, "decoding {tcvn3:?}");
-        assert_eq!(out.unmapped, 0, "decoding {tcvn3:?}");
+fn a_legacy_document_decodes_back_to_unicode() {
+    for (charset, unicode, legacy) in legacy_rows() {
+        let out = convert(legacy, charset, Charset::Unicode);
+        assert_eq!(out.text, unicode, "{charset:?} decoding {legacy:?}");
+        assert_eq!(out.unmapped, 0, "{charset:?} decoding {legacy:?}");
     }
 }
 
-/// What TCVN3 cannot spell is reported and approximated, never dropped — and the
-/// approximation is the one the module documents, not whatever fell out.
+/// The claim the pivot exists to make: `TCVN3 ↔ VNI` works without either codec
+/// knowing the other exists. Nobody wrote a line of code for this pair.
 #[test]
-fn the_two_kinds_of_loss_are_reported_and_approximated() {
-    for (unicode, tcvn3, unmapped, reread) in LOSSY {
-        let out = convert(unicode, Charset::Unicode, Charset::Tcvn3);
-        assert_eq!(&out.text, tcvn3, "encoding {unicode:?}");
-        assert_eq!(out.unmapped, *unmapped, "encoding {unicode:?}");
+fn converting_between_two_legacy_charsets_needs_no_code_of_its_own() {
+    for row in EXACT {
+        let (unicode, tcvn3, vni) = *row;
 
-        let back = convert(&out.text, Charset::Tcvn3, Charset::Unicode);
-        assert_eq!(&back.text, reread, "reading {unicode:?} back");
+        let out = convert(tcvn3, Charset::Tcvn3, Charset::VniWindows);
+        assert_eq!(out.text, vni, "TCVN3 to VNI for {unicode:?}");
+        assert_eq!(out.unmapped, 0);
+
+        let out = convert(vni, Charset::VniWindows, Charset::Tcvn3);
+        assert_eq!(out.text, tcvn3, "VNI to TCVN3 for {unicode:?}");
+        assert_eq!(out.unmapped, 0);
+    }
+}
+
+/// The two charsets lose different things, and the loss lands wherever the gap is.
+/// `ĐIỀU 5` survives VNI intact and only degrades once it reaches TCVN3.
+#[test]
+fn loss_appears_only_at_the_end_that_cannot_spell_it() {
+    let vni = convert("ĐIỀU 5", Charset::Unicode, Charset::VniWindows);
+    assert_eq!(vni.unmapped, 0, "VNI spells uppercase toned vowels");
+
+    let tcvn3 = convert(&vni.text, Charset::VniWindows, Charset::Tcvn3);
+    assert_eq!(tcvn3.unmapped, 1, "TCVN3 is where Ề runs out of codes");
+    assert_eq!(
+        convert(&tcvn3.text, Charset::Tcvn3, Charset::Unicode).text,
+        "ĐIềU 5"
+    );
+}
+
+#[test]
+fn what_a_charset_cannot_spell_is_reported_and_approximated() {
+    for (charset, rows) in [
+        (Charset::Tcvn3, TCVN3_LOSSY),
+        (Charset::VniWindows, VNI_LOSSY),
+    ] {
+        for (unicode, legacy, unmapped, reread) in rows {
+            let out = convert(unicode, Charset::Unicode, charset);
+            assert_eq!(&out.text, legacy, "{charset:?} encoding {unicode:?}");
+            assert_eq!(out.unmapped, *unmapped, "{charset:?} encoding {unicode:?}");
+
+            let back = convert(&out.text, charset, Charset::Unicode);
+            assert_eq!(&back.text, reread, "{charset:?} reading {unicode:?} back");
+        }
     }
 }
 
@@ -41,23 +86,28 @@ fn the_two_kinds_of_loss_are_reported_and_approximated() {
 /// on both sides.
 #[test]
 fn converting_a_charset_to_itself_is_an_identity() {
-    for (unicode, tcvn3) in EXACT {
-        for (text, charset) in [(unicode, Charset::Unicode), (tcvn3, Charset::Tcvn3)] {
+    for row in EXACT {
+        let pairs = [
+            (row.0, Charset::Unicode),
+            (row.1, Charset::Tcvn3),
+            (row.2, Charset::VniWindows),
+        ];
+        for (text, charset) in pairs {
             let out = convert(text, charset, charset);
-            assert_eq!(&out.text, text, "{text:?} through {charset:?}");
+            assert_eq!(out.text, text, "{text:?} through {charset:?}");
             assert_eq!(out.unmapped, 0);
         }
     }
 }
 
-/// The file door. A `.VnTime` file's bytes are the code points the clipboard would
+/// The file door. A legacy file's bytes are the code points the clipboard would
 /// have carried, so both doors have to land on the same text.
 #[test]
 fn reading_a_file_agrees_with_reading_the_clipboard() {
-    for (unicode, tcvn3) in EXACT {
-        let bytes: Vec<u8> = tcvn3.chars().map(|c| c as u8).collect();
-        let out = decode_bytes(&bytes, Charset::Tcvn3);
-        assert_eq!(&out.text, unicode, "reading {tcvn3:?} as bytes");
+    for (charset, unicode, legacy) in legacy_rows() {
+        let bytes: Vec<u8> = legacy.chars().map(|c| c as u8).collect();
+        let out = decode_bytes(&bytes, charset);
+        assert_eq!(out.text, unicode, "{charset:?} reading {legacy:?}");
         assert_eq!(out.unmapped, 0);
     }
 }

--- a/docs/features/charset.md
+++ b/docs/features/charset.md
@@ -2,8 +2,11 @@
 
 ## Trạng thái
 
-Thiết kế. Tài liệu này chốt mô hình trước khi có code; nó là PR đầu tiên của tính
-năng và được review riêng.
+Đã có: khung core, **TCVN3**, **VNI-Windows**. Còn lại: Unicode tổ hợp, `detect()`,
+rồi các consumer (xem "Thứ tự hiện thực" ở cuối).
+
+Tài liệu này chốt mô hình *trước* khi có code và được review riêng; nó vẫn là nơi
+mọi quyết định thiết kế sống, nên mỗi bảng mã mới cập nhật lại nó trong cùng PR.
 
 Tên kỹ thuật là `funput_core::charset`, nằm sau cargo feature `charset` **mặc định
 tắt** — bản bàn phím iOS/Android không bao giờ biên dịch nó.
@@ -73,7 +76,7 @@ enum Atom {
     /// đ / Đ — phụ âm duy nhất mà cả ba bảng mã cũ đều gán mã riêng.
     Stroke { upper: bool },
     /// Mọi thứ khác: phụ âm ASCII, chữ số, dấu câu, ký tự nước ngoài.
-    Passthrough(char),
+    Other(char),
 }
 ```
 
@@ -86,26 +89,28 @@ Ba biến thể đó đủ cho cả bốn bảng mã. Kiểm chứng trên giấ
 |---|---|---|---|---|---|
 | `a` | `a` | `Vowel{0, 0}` | `a` | `a` | `a` |
 | `ầ` | `ầ` | `Vowel{2, 2}` | 1 byte vùng cao | `a` + 1 byte dấu | `â` + `U+0300` |
-| `ự` | `ự` | `Vowel{10, 5}` | 1 byte vùng cao | `u` + 1 byte dấu | `ư` + `U+0323` |
+| `ự` | `ự` | `Vowel{10, 5}` | 1 byte vùng cao | 1 byte nền `ư` + 1 byte dấu | `ư` + `U+0323` |
 | `Ề` | `Ề` | `Vowel{4, 2, upper}` | **không biểu diễn được** | `E` + 1 byte dấu | `Ê` + `U+0300` |
 | `đ` | `đ` | `Stroke{}` | 1 byte | 1 byte | `đ` |
-| `ng` | `ng` | 2× `Passthrough` | `ng` | `ng` | `ng` |
-| `₫` | `₫` | `Passthrough` | **không biểu diễn được** | **không biểu diễn được** | `₫` |
+| `ng` | `ng` | 2× `Other` | `ng` | `ng` | `ng` |
+| `₫` | `₫` | `Other` | **không biểu diễn được** | **không biểu diễn được** | `₫` |
 
 Nguyên âm ASCII thường (`a e i o u y`) đi qua nhánh `Vowel` với `tone = 0`, không
-qua `Passthrough` — vì VNI cần chúng làm chữ nền cho byte dấu đi sau, nên chúng phải
+qua `Other` — vì VNI cần chúng làm chữ nền cho byte dấu đi sau, nên chúng phải
 mang theo chỉ số họ.
 
 ## Bảng mã dùng chung chỉ số với `VOWEL_FAMILIES`
 
 Cả ba bảng mã cũ đều gán mã cho đúng một kho chữ: 12 họ nguyên âm × 6 ô, cộng `đ`.
-Nên mỗi bảng là `[[u8; 6]; 12]` — **12 dòng dữ liệu, không phải 67** — và chỉ số
-của nó trùng với `VOWEL_FAMILIES` ở `unicode/vowels/table.rs`.
+Nên mỗi bảng là **12 dòng dữ liệu, không phải 67**, và chỉ số của nó trùng với
+`VOWEL_FAMILIES` ở `unicode/vowels/table.rs`. Ô chứa gì thì tuỳ bảng mã: TCVN3 là
+`[[u8; 6]; 12]` (một mã một chữ), VNI-Windows là `[[(u8, u8); 6]; 12]` (byte nền
+cộng byte dấu tuỳ chọn).
 
 Điều đó cho một dòng canh trong mỗi tệp bảng:
 
 ```rust
-const _: () = assert!(TCVN3_BYTES.len() == vowels::VOWEL_FAMILY_COUNT);
+const _: () = assert!(TCVN3_BYTES.len() == vowels::FAMILY_COUNT);
 ```
 
 Ai đó thêm họ nguyên âm thứ 13 sẽ thành **lỗi build**, chứ không thành mã hoá sai
@@ -122,6 +127,12 @@ trong code — chỉ số dùng chung mới là thứ giữ hai bảng khỏi tr
 Tài liệu này cố tình **không liệt kê giá trị byte**. Chúng phải lấy từ nguồn tra cứu
 được và đối chiếu chéo lúc hiện thực, không lấy từ trí nhớ — một byte chép sai sẽ
 tạo ra mojibake mà mắt thường không bắt được trên văn bản dài.
+
+Một lưu ý thực hành, học được khi làm VNI: **đừng lấy dữ liệu qua công cụ tóm tắt
+văn bản.** Hai lần thử đầu cho ra bảng lệch hàng và hex bịa, tự mâu thuẫn ngay trong
+cùng một câu trả lời. Cách dùng được là kéo byte thô về (`gh api` + `base64 -d`) rồi
+tự ghép hai mảng bằng script — và **sinh luôn bảng Rust từ dữ liệu đó**, không chép
+tay. Chi tiết xuất xứ của từng bảng nằm trong doc của `table.rs` tương ứng.
 
 Thứ chứng minh bảng đúng là **test quét toàn bộ** trong `src/`: với mọi bộ ba
 `(family, index, upper)`, `encode` rồi `decode` phải là identity, **và** tập không
@@ -148,6 +159,54 @@ thuần, không phá API đã có.
 
 Đây là giới hạn của bảng mã, không phải lỗi của công cụ. UI phải nói thẳng điều đó,
 vì người dùng sẽ báo nó như một lỗi.
+
+## VNI-Windows: một chữ không phải một ký tự
+
+VNI viết hầu hết chữ bằng **byte nền cộng byte dấu**, nên chuyển mã làm **dịch
+ranh giới ký tự**: `Ề` đi ra thành hai. Đây là bảng mã đầu tiên phá tính chất
+"một chữ một ký tự" mà TCVN3 có, nên property test về số ký tự phải nói rõ nó chỉ
+đúng với TCVN3.
+
+Ba bộ dấu làm hết việc: *plain* `F9 F8 FB F5 EF`, *mũ* `E2` + `E1 E0 E5 E3 E4`
+(dùng chung cho `â ê ô`, phân biệt nhờ chữ nền), *trăng* `EA` + `E9 E8 FA FC EB`
+riêng cho `ă`. Hai họ `ơ`/`ư` có byte nền riêng (`F4`/`F6`) thay vì dựng trên `o`/`u`.
+
+**Hoa = mọi byte trừ `0x20`**, không ngoại lệ. Nên bảng chỉ lưu chữ thường, và
+**VNI không có khoảng trống hoa/thường nào** — nó viết được cả `Ề`, chỗ TCVN3 chịu
+thua. Tập mất mát của VNI trên kho chữ là **rỗng**.
+
+Hai ngoại lệ trong dữ liệu, là chuyện của VNI chứ không phải của bảng: họ `i` viết
+mọi thanh điệu bằng **một byte**, và riêng `ỵ` cũng vậy trong một họ mà các thanh
+khác thì không.
+
+### Đọc tham lam, và vì sao nó an toàn
+
+Giải mã lấy **khớp dài nhất**: thử cặp hai byte trước, rồi mới tới một byte. An toàn
+vì **byte dấu không bao giờ là một chữ đứng riêng** — tập nền và tập dấu rời nhau,
+nên một cặp đã khớp thì không thể vốn là hai chữ.
+
+Cách làm ngược lại — xử lý chữ một byte trước — trông tương đương nhưng **không**:
+`F4` vừa là chữ `ơ`, vừa là nền của cả năm dạng có dấu của nó, nên `ơ` sẽ bị lấy
+riêng và mọi `ớ ờ ở ỡ ợ` gãy làm đôi.
+
+### Hai chỗ nó từ chối đoán
+
+**Cặp lệch hoa/thường** (`a` kèm byte dấu hoa) không phải thứ VNI sinh ra, nhưng bộ
+chuyển đổi cẩu thả thì có. Đọc thành chữ, lấy case theo chữ nền, và **đếm vào
+`unmapped`** — cách đọc mà con người sẽ đọc, không sinh ra nguyên âm Latin-1 ma rồi
+nở thành hai byte nữa.
+
+**Họ `i` chỉ nhận byte đơn.** Vài bộ chuyển đổi ngoài đời viết `í` thành `i` + dấu
+sắc; ở đây nó đọc thành `i` rồi một dấu mồ côi, và bị đếm. Nhận cả hai cách viết sẽ
+cho một chữ hai cách viết, và bài test quét toàn kho chữ mất sức bắt lỗi bảng.
+
+### Một kiểu hỏng TCVN3 không có
+
+Ký tự đi xuyên qua (`Other`) mà code point của nó tình cờ là một byte dấu sẽ **dính
+vào chữ đứng trước** khi đọc lại: Unicode `"aø"` ra `61 F8`, đọc lại thành `à`.
+Không tránh được, vì `ø` phải đi qua nguyên vẹn theo đúng quy tắc "dạng gần nhất".
+`unmapped` khác 0 nên hợp đồng "chính xác thì đảo ngược được" vẫn đứng — và có một
+bài test ghim nó lại như hành vi **đã biết**, thay vì để ai đó phát hiện ngoài đời.
 
 ## Quy ước "Unicode tổ hợp"
 
@@ -231,7 +290,7 @@ match. Trục, driver và `detect` không đổi.
 ## API công khai
 
 ```rust
-#[non_exhaustive] pub enum Charset { Unicode, /* … */ }
+#[non_exhaustive] pub enum Charset { Unicode, Tcvn3, VniWindows, /* … */ }
 #[non_exhaustive] pub struct Conversion { pub text: String, pub unmapped: usize }
 
 pub fn convert(text: &str, from: Charset, to: Charset) -> Conversion;
@@ -256,6 +315,9 @@ Mỗi mục một PR:
 2. Khung core + **TCVN3**. Phải kèm một bảng mã thật, vì CI chạy `-D warnings` và một
    trục chỉ có codec identity là dead code. TCVN3 được chọn vì nó dùng tới cả adapter
    Latin-1 lẫn đường `unmapped`, tức kiểm chứng nhiều phần khung nhất.
-3. VNI-Windows → 4. Unicode tổ hợp → 5. `detect()`.
+3. **VNI-Windows**. Bảng mã đầu tiên có chữ dài hai ký tự, nên nó cũng là phép thử
+   thật đầu tiên cho mô hình trục: `TCVN3 ↔ VNI` chạy được mà không codec nào biết
+   codec kia.
+4. Unicode tổ hợp → 5. `detect()`.
 6. `funput-config` (sửa import UniKey) → 7. `funput convert` → 8. UI Windows →
    9. UI Linux GTK.


### PR DESCRIPTION
Stacked on #222 — land that first, and this diff is the VNI codec alone.

The second legacy charset, and the first real test of the pivot the design promised: **`TCVN3 ↔ VNI` works without either codec knowing the other exists.** Nobody wrote a line of code for that pair; `converting_between_two_legacy_charsets_needs_no_code_of_its_own` just passes.

### How VNI differs from TCVN3

- **A letter is not a character.** Most letters are a base byte plus a mark byte, so conversion moves character boundaries — `Ề` goes out as two. `Cursor` grew a `second()` for the lookahead.
- **No uppercase gap.** VNI spells `Ề` perfectly well, where TCVN3 leaves uppercase tones to the `.VnTimeH` font. Its lossy set over the inventory is **empty**, and the sweep asserts exactly that rather than a list.

### Reading is greedy, and that is proven rather than assumed

Try the two-byte spelling, then the one-byte one. Safe because **no mark byte is ever a letter on its own** — `no_base_byte_is_ever_a_mark_byte` asserts the disjointness, including across case.

The obvious alternative, handling one-byte letters first, looks equivalent and silently breaks **20 of the 132 spellings**: `0xF4` is both the letter `ơ` and the base of all five of its toned forms, so every `ớ ờ ở ỡ ợ` splits in half.

### Why cells store the base byte in full

`(0, mark)` with "0 = derive the base from the family" fails twice over, and both failures are quiet:

- `(0, 0xF9)` occurs in five families, so a flat reverse scan reads **`ó` as `á`**. This is the likeliest bug in the whole change, because the TCVN3 code it would be copied from looks correct — TCVN3's codes really are pairwise distinct.
- A missing second character folding to `0` matches the one-byte spellings, so `"a→"` **loses the arrow**. Same for `c as u8` truncation, where `U+02F9` becomes the sắc mark.

Storing the base keeps the reverse lookup a flat scan and gives the distinctness check something to bite on: 73 spellings, pairwise distinct. Both swallowing bugs have their own regression tests; no proptest in the suite would generate either.

### Two readings it refuses to guess

Both counted rather than silently accepted, per the policies now written into `docs/features/charset.md`:

- **A mark whose case disagrees with its base** is read as the letter, in the base's case. Lenient because the strict reading manufactures a phantom Latin-1 vowel that then grows into two more bytes.
- **The `i` family is one byte per tone**, so `i` plus a sắc mark is an orphan, not `í`. Accepting both spellings would cost the inventory sweep its power to catch a bad table.

`an_exact_conversion_is_reversible` is the regression net for the first one — a decoder that took the mixed-case pair as *recognized* would fail it.

### The bytes

Two implementations read as **raw bytes** (`gh api` + `base64 -d`, not through any summarizer — two earlier attempts returned misaligned tables and invented hex that contradicted itself) and compared entry by entry: **134 of 134 agree, case-sensitively**. The Rust table is generated from that data rather than typed. Three independent anchors line up with it.

They share a lineage, so that proves transcription, not independent derivation. What proves the table is structure: distinctness, base/mark disjointness, and `uppercase_is_every_byte_minus_the_case_offset`, which validates 67 spellings without a single uppercase byte written by hand.

`#[rustfmt::skip]` on the table is deliberate — rustfmt puts each tuple on its own line, turning 12 readable rows into 150 and blowing the line budget.

### Fixtures

`EXACT` went to three columns, one row per word with both legacy spellings side by side, so the tests loop over charsets instead of growing a parallel copy. `LOSSY` did **not** merge: `ĐIỀU 5` is lossy in TCVN3 and exact in VNI, and one table would say otherwise.

`no_character_is_ever_dropped` moved from `==` to `>=` — the honest statement, since encoding to VNI can lengthen text. `tcvn3_conversion_preserves_the_character_count` keeps its `==` and its TCVN3 scope.

### Verification

All four `rust` job commands clean with the feature **off**. Clippy and tests clean with it on: 133 lib tests, 13 integration, 6 proptests. `check-loc.sh` went 287 → 290, exactly the three new `src/` files. Largest file 135/150; no directory over 4 entries, leaving `codecs/` room for two more charsets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
