### PR TITLE
feat(core): convert Vietnamese text to and from Unicode tổ hợp

### DIFF
--- a/crates/funput-core/src/charset/codecs/combining/compose.rs
+++ b/crates/funput-core/src/charset/codecs/combining/compose.rs
@@ -1,0 +1,114 @@
+//! Building one letter out of a base and the marks that follow it.
+//!
+//! # Why this is not a fold
+//!
+//! The obvious implementation applies each mark to a `char` in turn. It is wrong,
+//! and quietly: [`crate::unicode::shapes::apply_shape_to_vowel`] goes through
+//! `base_vowel`, which strips the **tone** as well as the shape — the crate's own
+//! test for it is called `apply_shape_to_vowel_strips_tone`.
+//!
+//! Canonical NFD puts the tone first whenever it is nặng, because `U+0323` has a
+//! lower combining class than the circumflex and breve: `ậ` is `a` `U+0323`
+//! `U+0302`. Folding that would produce `ạ`, then throw the tone away and hand
+//! back `â`. It would hit `ặ ậ ệ ộ` — that is `Việt`, `một`, `cộng`, `nặng`.
+//!
+//! So marks go into slots and the letter is composed **once**, at the end. Order
+//! stops mattering, which is the right answer anyway: NFD's own order flips
+//! depending on which tone is involved.
+//!
+//! # A full slot ends the letter
+//!
+//! A second mark of the same kind is *not* absorbed. `apply_tone` replaces rather
+//! than refuses, so absorbing one would silently drop the first: `a` `U+0301`
+//! `U+0300` would become `à`, three characters read as one, and the sắc gone.
+//! Refusing leaves the second mark to be read on its own, which is what it is.
+
+use crate::unicode::marks::{self, Tone};
+use crate::unicode::shapes::{self, VowelShape};
+
+use super::marks::Mark;
+
+/// A letter under construction: a base, and at most one shape and one tone.
+pub(super) struct Letter {
+    base: char,
+    shape: Option<VowelShape>,
+    tone: Option<Tone>,
+    /// Whether each part arrived as a combining mark rather than already being
+    /// part of the base character. Together they decide whether the source used
+    /// this charset's own spelling — see [`Letter::is_canonical`].
+    shape_from_mark: bool,
+    tone_from_mark: bool,
+}
+
+impl Letter {
+    /// Take a character apart into slots. A non-vowel keeps its slots empty and so
+    /// accepts no marks at all, which is how `n` + sắc and `đ` + nặng come out as
+    /// a letter followed by an orphan.
+    pub(super) fn seed(c: char) -> Self {
+        let Some(base) = shapes::base_vowel(c) else {
+            return Self {
+                base: c,
+                shape: None,
+                tone: None,
+                shape_from_mark: false,
+                tone_from_mark: false,
+            };
+        };
+        Self {
+            base,
+            shape: shapes::shape_on_vowel(c),
+            tone: marks::tone_on_vowel(c),
+            shape_from_mark: false,
+            tone_from_mark: false,
+        }
+    }
+
+    /// Try to put `mark` in its slot. `false` when the slot is taken or the letter
+    /// cannot carry that mark — either way the caller stops and leaves it behind.
+    pub(super) fn absorb(&mut self, mark: Mark) -> bool {
+        match mark {
+            Mark::Shape(shape) => {
+                if self.shape.is_some() || shapes::apply_shape(self.base, shape).is_none() {
+                    return false;
+                }
+                self.shape = Some(shape);
+                self.shape_from_mark = true;
+            }
+            Mark::Tone(tone) => {
+                if self.tone.is_some() || marks::apply_tone(self.stem(), tone).is_none() {
+                    return false;
+                }
+                self.tone = Some(tone);
+                self.tone_from_mark = true;
+            }
+        }
+        true
+    }
+
+    /// The letter with its shape but no tone.
+    fn stem(&self) -> char {
+        match self.shape {
+            Some(shape) => shapes::apply_shape(self.base, shape)
+                .expect("absorb checks the shape before taking it"),
+            None => self.base,
+        }
+    }
+
+    /// The finished letter.
+    pub(super) fn compose(&self) -> char {
+        match self.tone {
+            Some(tone) => marks::apply_tone(self.stem(), tone)
+                .expect("absorb checks the tone before taking it"),
+            None => self.stem(),
+        }
+    }
+
+    /// Whether the source spelled this letter the way this charset spells it:
+    /// shape precomposed into the base, tone riding as its own mark.
+    ///
+    /// A precomposed `ấ` fails on the tone; full NFD `a` `U+0302` `U+0301` fails on
+    /// the shape. Both are read correctly and rewritten — they are not losses.
+    pub(super) fn is_canonical(&self) -> bool {
+        !self.shape_from_mark && (self.tone.is_none() || self.tone_from_mark)
+    }
+}

--- a/crates/funput-core/src/charset/codecs/combining/marks.rs
+++ b/crates/funput-core/src/charset/codecs/combining/marks.rs
@@ -1,0 +1,99 @@
+//! The eight combining marks this charset reads, and the five it writes.
+//!
+//! Code points checked against the canonical NFD of the whole Vietnamese
+//! inventory, taken from a Unicode normalizer rather than from memory.
+//!
+//! Tones are read *and* written. Shapes are **read only**: the UniKey convention
+//! keeps `ă â ê ô ơ ư` precomposed, so [`super::encode`] never emits one. They are
+//! listed here because real NFD text — from a macOS filesystem, from a web form —
+//! does contain them, and refusing to read it would help nobody.
+
+use crate::unicode::marks::Tone;
+use crate::unicode::shapes::VowelShape;
+
+/// What a combining mark adds to the letter before it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Mark {
+    Tone(Tone),
+    Shape(VowelShape),
+}
+
+/// Tone marks, in the inventory's own order: sắc, huyền, hỏi, ngã, nặng.
+const TONES: [(char, Tone); 5] = [
+    ('\u{301}', Tone::Sac),
+    ('\u{300}', Tone::Huyen),
+    ('\u{309}', Tone::Hoi),
+    ('\u{303}', Tone::Nga),
+    ('\u{323}', Tone::Nang),
+];
+
+/// Shape marks. Read-only — see the module doc.
+const SHAPES: [(char, VowelShape); 3] = [
+    ('\u{302}', VowelShape::Circumflex),
+    ('\u{306}', VowelShape::Breve),
+    ('\u{31B}', VowelShape::Horn),
+];
+
+/// What `c` adds to the letter before it, or `None` when it is not one of the
+/// eight — in which case it is a letter in its own right, not a mark.
+pub(super) fn mark_of(c: char) -> Option<Mark> {
+    if let Some(&(_, tone)) = TONES.iter().find(|&&(mark, _)| mark == c) {
+        return Some(Mark::Tone(tone));
+    }
+    let &(_, shape) = SHAPES.iter().find(|&&(mark, _)| mark == c)?;
+    Some(Mark::Shape(shape))
+}
+
+/// The mark that writes `tone`.
+pub(super) fn tone_mark(tone: Tone) -> char {
+    TONES
+        .iter()
+        .find(|&&(_, candidate)| candidate == tone)
+        .map(|&(mark, _)| mark)
+        .expect("every tone has a combining mark")
+}
+
+/// Whether `c` is one of the eight.
+///
+/// [`super::encode`] needs this to refuse a passthrough that would fuse with the
+/// letter before it: writing a bare `U+0301` after an `a` produces text that reads
+/// back as `á`, which is a different string.
+pub(super) fn is_mark(c: char) -> bool {
+    mark_of(c).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A transcribed code point is invisible to the eye, so pin the whole map:
+    /// every tone and every shape is present exactly once, and no code point does
+    /// double duty.
+    #[test]
+    fn the_map_covers_every_tone_and_shape_exactly_once() {
+        for tone in [Tone::Sac, Tone::Huyen, Tone::Hoi, Tone::Nga, Tone::Nang] {
+            assert_eq!(mark_of(tone_mark(tone)), Some(Mark::Tone(tone)));
+        }
+        for shape in [VowelShape::Circumflex, VowelShape::Breve, VowelShape::Horn] {
+            let found = SHAPES.iter().filter(|&&(_, s)| s == shape).count();
+            assert_eq!(found, 1, "{shape:?}");
+        }
+
+        let mut points: Vec<char> = TONES
+            .iter()
+            .map(|&(mark, _)| mark)
+            .chain(SHAPES.iter().map(|&(mark, _)| mark))
+            .collect();
+        assert_eq!(points.len(), 8);
+        points.sort_unstable();
+        points.dedup();
+        assert_eq!(points.len(), 8, "two marks share a code point");
+    }
+
+    #[test]
+    fn a_letter_is_not_a_mark() {
+        for c in ['a', 'â', 'ơ', 'đ', 'Đ', '₫', ' '] {
+            assert!(!is_mark(c), "{c}");
+        }
+    }
+}

--- a/crates/funput-core/src/charset/codecs/combining/mod.rs
+++ b/crates/funput-core/src/charset/codecs/combining/mod.rs
@@ -1,0 +1,124 @@
+//! Unicode tổ hợp — UniKey's convention, where the tone rides as a combining mark
+//! and the vowel keeps its shape.
+//!
+//! `ậ` is `â` plus `U+0323`; `ắ` is `ă` plus `U+0301`; `ơ` and `đ` are themselves.
+//! This is **not** NFD, which would take the shape apart too (`ậ` = `a` `U+0323`
+//! `U+0302`). The marks live in [`marks`], the letter-building in [`compose`].
+//!
+//! # Lenient in, strict out
+//!
+//! Reading accepts the UniKey spelling, full NFD, a precomposed letter, and the
+//! marks in **either order** — NFD's own order flips depending on the tone, so
+//! order-independence is less work *and* more correct than following the combining
+//! classes. Writing only ever produces the UniKey spelling.
+//!
+//! Anything read but rewritten is reported as `normalized`, not `unmapped`:
+//! nothing was lost and nothing was guessed, only the spelling changed. Reading
+//! ordinary precomposed Vietnamese this way therefore reports roughly one per
+//! toned letter — correct, and worth knowing before `detect` is written.
+//!
+//! # What it cannot spell
+//!
+//! Nothing. It is Unicode, so `₫` and `日` come through exactly, which no legacy
+//! charset can claim. The one refusal is a bare combining mark arriving as a
+//! passthrough: writing it after a letter would fuse the two, and the text would
+//! read back as something else.
+
+mod compose;
+mod marks;
+
+use crate::charset::pivot::Atom;
+use crate::charset::transcode::{Cursor, Decoded, Reading};
+
+use compose::Letter;
+
+/// How many marks a letter can carry: one shape and one tone. NFD never needs
+/// more, and without a ceiling a base followed by sixty marks would read as one
+/// letter and hide fifty-nine of them.
+const MAX_MARKS: usize = 2;
+
+/// Read one letter at the cursor, taking the marks that belong to it.
+pub(super) fn decode(cur: &Cursor<'_>) -> Decoded {
+    let first = cur.first();
+    if marks::is_mark(first) {
+        // A mark with no letter before it. `Atom::from_char` would be wrong here:
+        // it classifies, and there is nothing to classify — this is debris.
+        return Decoded {
+            atom: Atom::Other(first),
+            consumed: 1,
+            reading: Reading::Unknown,
+        };
+    }
+
+    let mut letter = Letter::seed(first);
+    let mut consumed = 1;
+    for next in cur.following().take(MAX_MARKS) {
+        let Some(mark) = marks::mark_of(next) else {
+            break;
+        };
+        if !letter.absorb(mark) {
+            break;
+        }
+        consumed += 1;
+    }
+
+    Decoded {
+        atom: Atom::from_char(letter.compose()),
+        consumed,
+        reading: if letter.is_canonical() {
+            Reading::Exact
+        } else {
+            Reading::Rewritten
+        },
+    }
+}
+
+/// Write `atom` the way UniKey writes it: the shaped vowel precomposed, the tone
+/// as its own mark.
+pub(super) fn encode(atom: Atom, out: &mut String) -> bool {
+    match atom {
+        Atom::Vowel {
+            family,
+            tone,
+            upper,
+        } => {
+            let stem = Atom::vowel(family.into(), 0, upper)
+                .expect("a family always has a toneless slot")
+                .to_char();
+            out.push(stem);
+            if let Some(tone) = tone_of(tone) {
+                out.push(marks::tone_mark(tone));
+            }
+            true
+        }
+        // `đ` has no canonical decomposition; there is nothing to take apart.
+        Atom::Stroke { .. } => {
+            out.push(atom.to_char());
+            true
+        }
+        // Unicode holds anything — except one of this charset's own marks, which
+        // would attach itself to the letter before it and change what the text
+        // says. `₫` is exact here; a stray `U+0301` is not.
+        Atom::Other(c) => {
+            out.push(c);
+            !marks::is_mark(c)
+        }
+    }
+}
+
+/// The tone an [`Atom`]'s slot index stands for: 0 is toneless, 1–5 are the tones
+/// in the inventory's order.
+fn tone_of(slot: u8) -> Option<crate::unicode::marks::Tone> {
+    use crate::unicode::marks::Tone;
+    match slot {
+        1 => Some(Tone::Sac),
+        2 => Some(Tone::Huyen),
+        3 => Some(Tone::Hoi),
+        4 => Some(Tone::Nga),
+        5 => Some(Tone::Nang),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/funput-core/src/charset/codecs/combining/tests.rs
+++ b/crates/funput-core/src/charset/codecs/combining/tests.rs
@@ -1,0 +1,252 @@
+use crate::charset::Charset;
+use crate::charset::transcode::transcode;
+use crate::unicode::vowels;
+
+/// `(text, unmapped, normalized)`.
+fn to_combining(text: &str) -> (String, usize, usize) {
+    let out = transcode(text, Charset::Unicode, Charset::UnicodeCombining);
+    (out.text, out.unmapped, out.normalized)
+}
+
+fn from_combining(text: &str) -> (String, usize, usize) {
+    let out = transcode(text, Charset::UnicodeCombining, Charset::Unicode);
+    (out.text, out.unmapped, out.normalized)
+}
+
+fn points(text: &str) -> Vec<u32> {
+    text.chars().map(|c| c as u32).collect()
+}
+
+/// **The reason `compose.rs` is not a fold.**
+///
+/// Canonical NFD puts the tone first whenever it is nặng — `U+0323` has a lower
+/// combining class than the circumflex and the breve. Applying the marks one at a
+/// time to a `char` would strip the tone when the shape arrives and hand back `â`.
+/// These four letters are `Việt`, `một`, `cộng`, `nặng`.
+#[test]
+fn the_tone_first_nfd_order_keeps_its_tone() {
+    for (nfd, expected) in [
+        ("a\u{323}\u{302}", "ậ"),
+        ("a\u{323}\u{306}", "ặ"),
+        ("e\u{323}\u{302}", "ệ"),
+        ("o\u{323}\u{302}", "ộ"),
+        ("A\u{323}\u{302}", "Ậ"),
+        ("O\u{323}\u{302}", "Ộ"),
+    ] {
+        let (out, unmapped, normalized) = from_combining(nfd);
+        assert_eq!(out, expected, "reading {:?}", points(nfd));
+        assert_eq!(unmapped, 0, "nothing is lost, only rewritten");
+        assert_eq!(normalized, 1);
+    }
+}
+
+/// The sweep. This charset is Unicode, so nothing in the inventory is unspellable
+/// — the loss set is empty, as with VNI and unlike TCVN3.
+#[test]
+fn the_whole_inventory_round_trips_with_nothing_lost() {
+    for family in 0..vowels::FAMILY_COUNT {
+        for tone in 0..6 {
+            for upper in [false, true] {
+                let c = vowels::vowel_glyph(family, tone, upper).expect("in inventory");
+                let (encoded, unmapped, normalized) = to_combining(&c.to_string());
+                assert_eq!((unmapped, normalized), (0, 0), "{c} should be spellable");
+                assert_eq!(from_combining(&encoded).0, c.to_string(), "{c}");
+                assert_eq!(from_combining(&encoded).1, 0, "{c} reads back exactly");
+                assert_eq!(from_combining(&encoded).2, 0, "{c} reads back canonically");
+            }
+        }
+    }
+}
+
+/// Three spellings of the same letter all land on it. Only the middle one is what
+/// this charset writes, and the sweep above already proves that.
+#[test]
+fn every_spelling_of_a_letter_decodes_to_the_same_letter() {
+    for (nfd, unikey, precomposed) in [
+        ("a\u{302}\u{301}", "â\u{301}", "ấ"),
+        ("a\u{306}\u{301}", "ă\u{301}", "ắ"),
+        ("o\u{31b}\u{323}", "ơ\u{323}", "ợ"),
+        ("e\u{302}\u{300}", "ê\u{300}", "ề"),
+        ("u\u{31b}\u{309}", "ư\u{309}", "ử"),
+    ] {
+        for spelling in [nfd, unikey, precomposed] {
+            assert_eq!(from_combining(spelling).0, precomposed, "{spelling:?}");
+        }
+    }
+}
+
+/// A spelling this charset does not use is rewritten, not lost — that distinction
+/// is the whole reason `Conversion` carries two counts. Full NFD decomposes the
+/// shape; a precomposed letter keeps the tone attached. Neither loses anything.
+#[test]
+fn a_non_canonical_spelling_is_rewritten_not_lost() {
+    for (text, expected) in [
+        ("ơ\u{323}", 0),        // exactly what this charset writes
+        ("a\u{302}\u{301}", 1), // full NFD — the shape was taken apart
+        ("ấ", 1),               // precomposed — the tone was not separated
+        ("á", 1),
+    ] {
+        let (_, unmapped, normalized) = from_combining(text);
+        assert_eq!(unmapped, 0, "{text:?} loses nothing");
+        assert_eq!(normalized, expected, "{text:?}");
+    }
+}
+
+/// A second mark of the same kind is left behind rather than overwriting the
+/// first. `apply_tone` *replaces*, so absorbing it would drop the sắc silently and
+/// break `an_exact_conversion_is_reversible`.
+#[test]
+fn a_second_tone_mark_ends_the_letter() {
+    let (out, unmapped, normalized) = from_combining("a\u{301}\u{300}");
+    assert_eq!(out, "á\u{300}", "the second tone is a letter of its own");
+    assert_eq!(unmapped, 1, "the orphan mark is the guess");
+    assert_eq!(normalized, 0);
+}
+
+#[test]
+fn a_second_shape_mark_ends_the_letter() {
+    let (out, unmapped, _) = from_combining("a\u{306}\u{302}");
+    assert_eq!(out, "ă\u{302}", "the ă is not re-shaped into â");
+    assert_eq!(unmapped, 1);
+
+    // The shape is already on the base character, so the mark repeating it is
+    // just as much an orphan.
+    let (out, unmapped, _) = from_combining("â\u{302}");
+    assert_eq!(out, "â\u{302}");
+    assert_eq!(unmapped, 1);
+}
+
+/// A mark with nothing before it is debris, not a letter. It must not go through
+/// `Atom::from_char`, which would classify it as though it meant something.
+#[test]
+fn a_mark_with_no_base_passes_through_and_is_reported() {
+    for text in ["\u{301}", "n\u{301}", "đ\u{301}", "Đ\u{323}", "5\u{300}"] {
+        let (out, unmapped, _) = from_combining(text);
+        assert_eq!(out, text, "{text:?} survives unchanged");
+        assert_eq!(unmapped, 1, "{text:?}");
+    }
+}
+
+/// Not every vowel takes every shape. The mark stays where it is.
+#[test]
+fn a_shape_a_vowel_cannot_take_is_not_applied() {
+    for text in ["y\u{302}", "i\u{31b}", "e\u{306}", "u\u{302}", "a\u{31b}"] {
+        let (out, unmapped, _) = from_combining(text);
+        assert_eq!(out, text, "{text:?} should be unchanged");
+        assert_eq!(unmapped, 1, "{text:?}");
+    }
+}
+
+/// A base at the end of the text is a letter, not a truncated sequence.
+#[test]
+fn a_base_at_the_end_of_the_text_is_a_letter_on_its_own() {
+    for text in ["a", "â", "ơ", "đ", "a\u{301}"] {
+        let (out, unmapped, normalized) = from_combining(text);
+        assert_eq!(out.chars().count(), 1, "{text:?} is one letter");
+        assert_eq!((unmapped, normalized), (0, 0), "{text:?}");
+    }
+}
+
+/// Two marks fill the letter; a third belongs to whatever comes next.
+#[test]
+fn a_third_mark_is_left_for_the_next_letter() {
+    let (out, unmapped, normalized) = from_combining("a\u{302}\u{301}\u{323}");
+    assert_eq!(out, "ấ\u{323}");
+    assert_eq!(unmapped, 1, "the third mark is an orphan");
+    assert_eq!(normalized, 1, "the letter itself was full NFD");
+}
+
+/// The strict half of the policy: reading accepts a decomposed shape, writing
+/// never produces one.
+#[test]
+fn encode_never_emits_a_shape_mark() {
+    for family in 0..vowels::FAMILY_COUNT {
+        for tone in 0..6 {
+            for upper in [false, true] {
+                let c = vowels::vowel_glyph(family, tone, upper).expect("in inventory");
+                let encoded = to_combining(&c.to_string()).0;
+                for out in encoded.chars() {
+                    assert!(
+                        !matches!(out, '\u{302}' | '\u{306}' | '\u{31b}'),
+                        "{c} was written with a shape mark"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// `đ` has no canonical decomposition, so there is nothing to take apart.
+#[test]
+fn the_stroke_is_never_decomposed() {
+    for c in ['đ', 'Đ'] {
+        let (encoded, unmapped, normalized) = to_combining(&c.to_string());
+        assert_eq!(encoded, c.to_string());
+        assert_eq!((unmapped, normalized), (0, 0));
+    }
+}
+
+/// Known and reported, rather than discovered in the field. A bare mark written
+/// after a letter attaches itself to it, so the text reads back as something else
+/// — the direct twin of VNI's `ø` fusing with the letter before it.
+#[test]
+fn a_combining_mark_passthrough_can_fuse_with_the_letter_before_it() {
+    let (encoded, unmapped, _) = to_combining("a\u{301}");
+    assert_eq!(unmapped, 1, "a stray mark cannot be written exactly");
+    assert_eq!(from_combining(&encoded).0, "á", "the two fused");
+}
+
+/// The claim no legacy charset can make: this one is Unicode, so it spells
+/// everything.
+#[test]
+fn a_non_vietnamese_character_is_spellable() {
+    for c in ['₫', '日', 'ñ', '—'] {
+        let (encoded, unmapped, normalized) = to_combining(&c.to_string());
+        assert_eq!((unmapped, normalized), (0, 0), "{c}");
+        assert_eq!(from_combining(&encoded).0, c.to_string(), "{c}");
+    }
+}
+
+/// Uppercase differs only in the base character; the marks are the same.
+#[test]
+fn uppercase_is_the_same_marks_on_an_uppercase_base() {
+    for family in 0..vowels::FAMILY_COUNT {
+        for tone in 0..6 {
+            let lower = vowels::vowel_glyph(family, tone, false).expect("in inventory");
+            let upper = vowels::vowel_glyph(family, tone, true).expect("in inventory");
+            let (lowered, raised) = (
+                to_combining(&lower.to_string()).0,
+                to_combining(&upper.to_string()).0,
+            );
+            assert_eq!(
+                lowered.chars().skip(1).collect::<String>(),
+                raised.chars().skip(1).collect::<String>(),
+                "{upper} carries different marks from {lower}"
+            );
+            assert_eq!(raised.chars().count(), lowered.chars().count());
+        }
+    }
+}
+
+/// Two real words with their code points written out, so a table edit has to face
+/// a concrete example and not only a property.
+#[test]
+fn a_real_word_encodes_to_the_code_points_a_unikey_document_holds() {
+    let (encoded, unmapped, normalized) = to_combining("Việt Nam");
+    assert_eq!((unmapped, normalized), (0, 0));
+    assert_eq!(
+        points(&encoded),
+        vec![0x56, 0x69, 0xEA, 0x323, 0x74, 0x20, 0x4E, 0x61, 0x6D],
+        "V i ê +nặng t _ N a m"
+    );
+    assert_eq!(from_combining(&encoded).0, "Việt Nam");
+
+    let (encoded, unmapped, normalized) = to_combining("đường");
+    assert_eq!((unmapped, normalized), (0, 0));
+    assert_eq!(
+        points(&encoded),
+        vec![0x111, 0x1B0, 0x1A1, 0x300, 0x6E, 0x67],
+        "đ ư ơ +huyền n g"
+    );
+    assert_eq!(from_combining(&encoded).0, "đường");
+}

--- a/crates/funput-core/src/charset/codecs/mod.rs
+++ b/crates/funput-core/src/charset/codecs/mod.rs
@@ -20,12 +20,13 @@
 //!   what it wrote is not exact. It always writes *something*; a character never
 //!   disappears in conversion.
 
+mod combining;
 mod tcvn3;
 mod vni;
 
 use super::Charset;
 use super::pivot::Atom;
-use super::transcode::{Cursor, Decoded};
+use super::transcode::{Cursor, Decoded, Reading};
 
 /// Read one unit of `charset` at the cursor.
 pub(super) fn decode(charset: Charset, cur: &Cursor<'_>) -> Decoded {
@@ -35,10 +36,11 @@ pub(super) fn decode(charset: Charset, cur: &Cursor<'_>) -> Decoded {
         Charset::Unicode => Decoded {
             atom: Atom::from_char(cur.first()),
             consumed: 1,
-            recognized: true,
+            reading: Reading::Exact,
         },
         Charset::Tcvn3 => tcvn3::decode(cur),
         Charset::VniWindows => vni::decode(cur),
+        Charset::UnicodeCombining => combining::decode(cur),
     }
 }
 
@@ -52,6 +54,7 @@ pub(super) fn encode(charset: Charset, atom: Atom, out: &mut String) -> bool {
         }
         Charset::Tcvn3 => tcvn3::encode(atom, out),
         Charset::VniWindows => vni::encode(atom, out),
+        Charset::UnicodeCombining => combining::encode(atom, out),
     }
 }
 
@@ -60,7 +63,7 @@ pub(super) fn encode(charset: Charset, atom: Atom, out: &mut String) -> bool {
 /// [`crate::charset::decode_bytes`].
 pub(super) fn is_byte_oriented(charset: Charset) -> bool {
     match charset {
-        Charset::Unicode => false,
+        Charset::Unicode | Charset::UnicodeCombining => false,
         Charset::Tcvn3 | Charset::VniWindows => true,
     }
 }

--- a/crates/funput-core/src/charset/codecs/tcvn3/mod.rs
+++ b/crates/funput-core/src/charset/codecs/tcvn3/mod.rs
@@ -19,7 +19,7 @@
 mod table;
 
 use crate::charset::pivot::Atom;
-use crate::charset::transcode::{Cursor, Decoded};
+use crate::charset::transcode::{Cursor, Decoded, Reading};
 
 /// Read one TCVN3 byte at the cursor.
 ///
@@ -32,19 +32,19 @@ use crate::charset::transcode::{Cursor, Decoded};
 /// charset.
 pub(super) fn decode(cur: &Cursor<'_>) -> Decoded {
     let c = cur.first();
-    let (atom, recognized) = match u8::try_from(c as u32) {
+    let (atom, reading) = match u8::try_from(c as u32) {
         Ok(byte) if byte >= 0x80 => match atom_for_byte(byte) {
-            Some(atom) => (atom, true),
-            None => (Atom::Other(c), false),
+            Some(atom) => (atom, Reading::Exact),
+            None => (Atom::Other(c), Reading::Unknown),
         },
         // Below 0x80 TCVN3 is ASCII — but an ASCII vowel still has to pick up its
         // family coordinates, or the target charset could not re-spell it.
-        _ => (Atom::from_char(c), true),
+        _ => (Atom::from_char(c), Reading::Exact),
     };
     Decoded {
         atom,
         consumed: 1,
-        recognized,
+        reading,
     }
 }
 

--- a/crates/funput-core/src/charset/codecs/vni/mod.rs
+++ b/crates/funput-core/src/charset/codecs/vni/mod.rs
@@ -38,7 +38,7 @@ mod bytes;
 mod table;
 
 use crate::charset::pivot::Atom;
-use crate::charset::transcode::{Cursor, Decoded};
+use crate::charset::transcode::{Cursor, Decoded, Reading};
 
 use table::STROKE_LOWER;
 
@@ -53,7 +53,7 @@ pub(super) fn decode(cur: &Cursor<'_>) -> Decoded {
         return Decoded {
             atom: Atom::Stroke { upper: base_upper },
             consumed: 1,
-            recognized: true,
+            reading: Reading::Exact,
         };
     }
 
@@ -68,7 +68,11 @@ pub(super) fn decode(cur: &Cursor<'_>) -> Decoded {
             atom,
             consumed: 2,
             // VNI never writes a pair whose halves disagree on case.
-            recognized: base_upper == mark_upper,
+            reading: if base_upper == mark_upper {
+                Reading::Exact
+            } else {
+                Reading::Unknown
+            },
         };
     }
 
@@ -76,7 +80,7 @@ pub(super) fn decode(cur: &Cursor<'_>) -> Decoded {
         Some(atom) => Decoded {
             atom,
             consumed: 1,
-            recognized: true,
+            reading: Reading::Exact,
         },
         None => passthrough(first),
     }
@@ -89,12 +93,12 @@ fn passthrough(c: char) -> Decoded {
         Ok(byte) if byte >= 0x80 => Decoded {
             atom: Atom::Other(c),
             consumed: 1,
-            recognized: false,
+            reading: Reading::Unknown,
         },
         _ => Decoded {
             atom: Atom::from_char(c),
             consumed: 1,
-            recognized: true,
+            reading: Reading::Exact,
         },
     }
 }

--- a/crates/funput-core/src/charset/mod.rs
+++ b/crates/funput-core/src/charset/mod.rs
@@ -50,28 +50,39 @@ pub enum Charset {
     /// sit confusingly beside [`crate::InputMethod::Vni`] — a way of *typing*, not
     /// a way of storing.
     VniWindows,
+    /// Unicode tổ hợp, UniKey's convention: the shaped vowel stays precomposed and
+    /// only the **tone** rides as a combining mark, so `ậ` is `â` plus `U+0323`.
+    ///
+    /// Deliberately not called `Decomposed`: this is not NFD, which would take the
+    /// shape apart too. Reading accepts NFD anyway — see the codec — but writing
+    /// only ever produces this form.
+    UnicodeCombining,
 }
 
-/// Converted text, and how many characters did not survive it exactly.
+/// Converted text, and what happened to it on the way.
 ///
-/// `unmapped` counts characters, not bytes, and never counts *lost* text:
-/// conversion always writes something for every character, so the output holds as
-/// much as the input did. What the number says is how many places need the user's
-/// eye. A character lands there for one of two reasons:
+/// Both counts are in characters, and neither counts *lost* text: conversion
+/// always writes something for every character, so the output holds as much as the
+/// input did. A character lands in at most one of them.
 ///
-/// - the **target** cannot spell it — a `₫`, which no legacy charset has a code
-///   for, or an uppercase toned vowel, which is TCVN3's own gap rather than a
-///   general one: VNI-Windows spells those perfectly well;
-/// - the **source** never defined it, so reading it was a guess.
+/// **`unmapped`** — something was lost or guessed, so the output is not certainly
+/// equivalent to the input. Either the target cannot spell it (a `₫`, which no
+/// legacy charset has a code for; an uppercase toned vowel, which is TCVN3's own
+/// gap rather than a general one) or the source never defined it, making the
+/// reading a guess. Text read with the wrong source charset is mostly unrecognized
+/// units, so a count near the length of the input is the clearest signal there is
+/// that the user picked the wrong bảng mã.
 ///
-/// The second is worth watching. Text converted from the wrong source charset is
-/// mostly unrecognized units, so a count near the length of the input is the
-/// clearest signal there is that the user picked the wrong bảng mã.
+/// **`normalized`** — understood beyond doubt, nothing lost, only the spelling
+/// changed. Reading NFC text as Unicode tổ hợp lands here: every letter comes
+/// through intact, just written the charset's own way. Keeping it out of
+/// `unmapped` is what lets an interface say "nothing was lost" and mean it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct Conversion {
     pub text: String,
     pub unmapped: usize,
+    pub normalized: usize,
 }
 
 /// Convert text from one charset to another.
@@ -84,28 +95,41 @@ pub fn convert(text: &str, from: Charset, to: Charset) -> Conversion {
 
 /// Read raw bytes in `from` and return them as Unicode.
 ///
-/// For a legacy charset the bytes are read one-to-one as code points, which is
-/// exactly how the document that produced them was stored. For [`Charset::Unicode`]
-/// they are decoded as UTF-8, and any invalid sequence becomes `U+FFFD` and counts
-/// toward `unmapped` — a caller reading a file it merely *believes* is UTF-8 gets
-/// told when it was wrong instead of silently receiving replacement characters.
+/// A byte-oriented charset's bytes are read one-to-one as code points, which is
+/// exactly how the document that produced them was stored. The rest are decoded as
+/// UTF-8, where an invalid sequence becomes `U+FFFD` — a caller reading a file it
+/// merely *believes* is UTF-8 gets told when it was wrong instead of silently
+/// receiving replacement characters.
+///
+/// Either way the text then goes through [`convert`], and the two counts add up:
+/// broken bytes and characters the charset could not place are separate problems,
+/// and a byte that causes both deserves two looks.
 pub fn decode_bytes(bytes: &[u8], from: Charset) -> Conversion {
-    if codecs::is_byte_oriented(from) {
-        let text: String = bytes.iter().copied().map(char::from).collect();
-        return convert(&text, from, Charset::Unicode);
-    }
-    let Err(_) = std::str::from_utf8(bytes) else {
-        return Conversion {
-            text: String::from_utf8_lossy(bytes).into_owned(),
-            unmapped: 0,
-        };
+    let (text, damage) = if codecs::is_byte_oriented(from) {
+        // Latin-1 is total, so reading bytes as code points cannot fail.
+        (bytes.iter().copied().map(char::from).collect(), 0)
+    } else {
+        let text = String::from_utf8_lossy(bytes).into_owned();
+        (text, broken_sequences(bytes))
     };
-    let text = String::from_utf8_lossy(bytes).into_owned();
-    let unmapped = text
+    let out = convert(&text, from, Charset::Unicode);
+    Conversion {
+        unmapped: out.unmapped + damage,
+        ..out
+    }
+}
+
+/// How many characters lossy UTF-8 decoding had to replace. Zero for valid input,
+/// and replacement characters the source genuinely encoded are discounted so a
+/// document that legitimately contains one is not reported as damaged.
+fn broken_sequences(bytes: &[u8]) -> usize {
+    if std::str::from_utf8(bytes).is_ok() {
+        return 0;
+    }
+    String::from_utf8_lossy(bytes)
         .matches(char::REPLACEMENT_CHARACTER)
         .count()
-        .saturating_sub(genuine_replacements(bytes));
-    Conversion { text, unmapped }
+        .saturating_sub(genuine_replacements(bytes))
 }
 
 /// How many `U+FFFD` the bytes genuinely encode. Subtracting these is what keeps a

--- a/crates/funput-core/src/charset/transcode.rs
+++ b/crates/funput-core/src/charset/transcode.rs
@@ -11,9 +11,9 @@ use super::{Charset, Conversion};
 
 /// A read window onto the source, positioned at a unit boundary.
 ///
-/// A codec reads as far ahead as its encoding needs and reports how much it took.
-/// TCVN3 spells every letter in one char and only ever reads [`Cursor::first`];
-/// VNI-Windows spells most of them as a base plus a mark and needs both.
+/// A codec reads as far ahead as its spelling needs and reports how much it took.
+/// TCVN3 spells every letter in one char; VNI-Windows takes a base and a mark;
+/// Unicode tổ hợp can take a base and two combining marks.
 pub(super) struct Cursor<'a> {
     rest: &'a str,
 }
@@ -28,14 +28,37 @@ impl Cursor<'_> {
             .expect("cursor built on non-empty text")
     }
 
-    /// The char after it, or `None` at the end of the text.
+    /// Everything after [`Cursor::first`].
     ///
-    /// `None` must stay distinguishable from "some byte that happens to be zero":
-    /// a codec that folds the two together will match a one-char tail against a
-    /// two-char spelling and swallow whatever comes next.
-    pub(super) fn second(&self) -> Option<char> {
-        self.rest.chars().nth(1)
+    /// An iterator rather than an index, because "take up to two more" is what the
+    /// codecs actually do — and because the moment lookahead is numbered, one
+    /// reader counts from the cursor and the next counts from the char after it.
+    /// Running out is `None`, never a sentinel: a codec that folds "no more text"
+    /// into some zero value will match a truncated tail against a longer spelling
+    /// and swallow whatever follows.
+    pub(super) fn following(&self) -> std::str::Chars<'_> {
+        let mut chars = self.rest.chars();
+        chars.next();
+        chars
     }
+
+    /// The char after the cursor, when there is one.
+    pub(super) fn second(&self) -> Option<char> {
+        self.following().next()
+    }
+}
+
+/// How faithfully a codec managed to read the text at the cursor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Reading {
+    /// The source spelled this the way the charset spells it.
+    Exact,
+    /// Understood beyond doubt, but written another way — re-encoding will use the
+    /// charset's own spelling instead. Nothing is lost; only the spelling changes.
+    Rewritten,
+    /// The charset does not define this unit. Carrying the character through is a
+    /// guess, and the caller deserves to know it was one.
+    Unknown,
 }
 
 /// What a codec made of the text at the cursor.
@@ -44,29 +67,28 @@ pub(super) struct Decoded {
     /// How many chars this reading consumed. Must be at least 1, or the driver
     /// would not advance.
     pub(super) consumed: usize,
-    /// False when the source charset does not define this unit at all. The atom is
-    /// still usable — it carries the character through untouched — but the reading
-    /// is a guess, and the caller deserves to know.
-    pub(super) recognized: bool,
+    pub(super) reading: Reading,
 }
 
-/// Convert `text` from one charset to another, counting every character that did
-/// not survive exactly.
+/// Convert `text` from one charset to another, counting what happened to each
+/// character along the way.
 ///
-/// A character is counted once, whichever end failed it: the source charset does
-/// not define it, or the target cannot spell it. Both are things the user has to
-/// look at, and the commonest cause of the first one is picking the wrong source
-/// charset — which makes a high count the signal that they did.
+/// A character lands in at most one bucket, and loss outranks rewriting: if the
+/// target could not spell it exactly, that is what the user needs to see, however
+/// the source spelled it.
 pub(super) fn transcode(text: &str, from: Charset, to: Charset) -> Conversion {
     let mut out = String::with_capacity(text.len());
     let mut unmapped = 0;
+    let mut normalized = 0;
     let mut rest = text;
 
     while !rest.is_empty() {
         let decoded = codecs::decode(from, &Cursor { rest });
         let written_exactly = codecs::encode(to, decoded.atom, &mut out);
-        if !decoded.recognized || !written_exactly {
-            unmapped += 1;
+        match (decoded.reading, written_exactly) {
+            (_, false) | (Reading::Unknown, _) => unmapped += 1,
+            (Reading::Rewritten, true) => normalized += 1,
+            (Reading::Exact, true) => {}
         }
         rest = advance(rest, decoded.consumed);
     }
@@ -74,6 +96,7 @@ pub(super) fn transcode(text: &str, from: Charset, to: Charset) -> Conversion {
     Conversion {
         text: out,
         unmapped,
+        normalized,
     }
 }
 
@@ -111,10 +134,18 @@ mod tests {
     }
 
     #[test]
+    fn following_stops_at_the_end_rather_than_repeating() {
+        let cursor = Cursor { rest: "ab" };
+        assert_eq!(cursor.following().collect::<String>(), "b");
+        assert_eq!(Cursor { rest: "a" }.following().next(), None);
+    }
+
+    #[test]
     fn unicode_to_unicode_is_an_exact_identity() {
         let result = transcode("Chào bạn — 42₫", Charset::Unicode, Charset::Unicode);
         assert_eq!(result.text, "Chào bạn — 42₫");
         assert_eq!(result.unmapped, 0);
+        assert_eq!(result.normalized, 0);
     }
 
     #[test]

--- a/crates/funput-core/tests/charset/cases.rs
+++ b/crates/funput-core/tests/charset/cases.rs
@@ -64,3 +64,37 @@ pub const VNI_LOSSY: &[(&str, &str, usize, &str)] = &[
     // huyền mark, so reading the result back fuses it onto the `a` before it.
     ("a\u{F8}", "a\u{F8}", 1, "à"),
 ];
+
+/// The same phrases in Unicode tổ hợp: `(Unicode, tổ hợp)`.
+///
+/// A different escaping rule applies here, and it matters. The legacy columns
+/// escape everything because their characters are Latin-1 mojibake that mean
+/// nothing on their own. This column's *bases* are real letters, so they stay
+/// literal — but every **combining mark** is always `\u{..}`, because `"ệ"` and
+/// `"ê\u{323}"` are indistinguishable on screen. A fixture that got silently
+/// precomposed would make these tests assert nothing at all.
+pub const COMBINING_EXACT: &[(&str, &str)] = &[
+    ("Việt Nam", "Viê\u{323}t Nam"),
+    ("Chào bạn", "Cha\u{300}o ba\u{323}n"),
+    ("đường", "đươ\u{300}ng"),
+    ("Nghị định", "Nghi\u{323} đi\u{323}nh"),
+    (
+        "Cộng hòa Xã hội Chủ nghĩa Việt Nam",
+        "Cô\u{323}ng ho\u{300}a Xa\u{303} hô\u{323}i Chu\u{309} nghi\u{303}a Viê\u{323}t Nam",
+    ),
+    ("Ha Noi 1945", "Ha Noi 1945"),
+];
+
+/// Spellings Unicode tổ hợp reads but does not write: `(input, what it becomes,
+/// normalized)`.
+///
+/// There is no `COMBINING_LOSSY`. This charset is Unicode — it spells everything,
+/// so its only imperfection is a source written another way, and that costs
+/// nothing. `unmapped` is zero on every row here; the count that moves is
+/// `normalized`.
+pub const NON_CANONICAL: &[(&str, &str, usize)] = &[
+    ("a\u{302}\u{301}", "â\u{301}", 1), // full NFD
+    ("a\u{323}\u{302}", "â\u{323}", 1), // full NFD, tone first
+    ("ấ", "â\u{301}", 1),               // precomposed
+    ("Viê\u{323}t", "Viê\u{323}t", 0),  // already canonical
+];

--- a/crates/funput-core/tests/charset/properties.rs
+++ b/crates/funput-core/tests/charset/properties.rs
@@ -8,17 +8,42 @@ use proptest::prelude::*;
 /// Anything a legacy document could hold: one char per byte, the whole range.
 const LEGACY_TEXT: &str = "[\\x{20}-\\x{FF}]{0,64}";
 
+/// Bases, shaped vowels, and the eight combining marks. A separate generator is
+/// needed because every mark sits above `U+00FF`, so `LEGACY_TEXT` cannot produce
+/// one and any property run over it would be checking nothing.
+const COMBINING_TEXT: &str =
+    "[a-zA-Zâăêôơưđ \\x{300}\\x{301}\\x{303}\\x{309}\\x{323}\\x{302}\\x{306}\\x{31B}]{0,48}";
+
+/// The byte-oriented charsets — the ones whose output a file can hold one byte at
+/// a time.
 const LEGACY: [Charset; 2] = [Charset::Tcvn3, Charset::VniWindows];
+
+/// Every charset that is not the pivot. Wider than [`LEGACY`]: Unicode tổ hợp is
+/// a real charset with its own spelling, it is just not made of bytes.
+const NON_PIVOT: [Charset; 3] = [
+    Charset::Tcvn3,
+    Charset::VniWindows,
+    Charset::UnicodeCombining,
+];
+
+const ALL: [Charset; 4] = [
+    Charset::Unicode,
+    Charset::Tcvn3,
+    Charset::VniWindows,
+    Charset::UnicodeCombining,
+];
 
 proptest! {
     /// Conversion is total. Whatever the text is — and a user who picks the wrong
     /// source charset feeds it text that is *not* what it claims — it comes back
     /// as text, not as a panic.
     #[test]
-    fn conversion_never_panics(text in LEGACY_TEXT) {
-        for from in [Charset::Unicode, Charset::Tcvn3, Charset::VniWindows] {
-            for to in [Charset::Unicode, Charset::Tcvn3, Charset::VniWindows] {
-                let _ = convert(&text, from, to);
+    fn conversion_never_panics(text in LEGACY_TEXT, combining in COMBINING_TEXT) {
+        for source in [&text, &combining] {
+            for from in ALL {
+                for to in ALL {
+                    let _ = convert(source, from, to);
+                }
             }
         }
     }
@@ -28,8 +53,8 @@ proptest! {
     /// reversible. A table entry carrying two letters would break this.
     ///
     /// It is also the regression net for VNI's lenient mixed-case reading. A
-    /// decoder that took `61 D9` as `á` with `recognized = true` would re-encode
-    /// it as `61 F9` and fail here; counting it is what keeps the guard honest.
+    /// decoder that took `61 D9` as `á` with `Reading::Exact` would re-encode it
+    /// as `61 F9` and fail here; counting it is what keeps the guard honest.
     #[test]
     fn an_exact_conversion_is_reversible(text in LEGACY_TEXT) {
         for charset in LEGACY {
@@ -41,10 +66,26 @@ proptest! {
         }
     }
 
+    /// The same contract for Unicode tổ hợp, where `normalized` carries the weight:
+    /// a source spelled the charset's own way must come back byte for byte.
+    ///
+    /// This is the regression net for "a full slot ends the letter". A decoder that
+    /// let a second tone mark overwrite the first would read `a` `U+0301` `U+0300`
+    /// as `à` with nothing reported, and re-encoding gives `a` `U+0300` — one
+    /// character shorter than it started.
+    #[test]
+    fn an_exact_combining_conversion_is_reversible(text in COMBINING_TEXT) {
+        let unicode = convert(&text, Charset::UnicodeCombining, Charset::Unicode);
+        let back = convert(&unicode.text, Charset::Unicode, Charset::UnicodeCombining);
+        if unicode.unmapped == 0 && unicode.normalized == 0 && back.unmapped == 0 {
+            prop_assert_eq!(&back.text, &text);
+        }
+    }
+
     /// TCVN3 spells every letter in one code, so a conversion to or from it moves
     /// no character boundaries. This is a property of TCVN3, not of the module —
-    /// VNI-Windows spells most letters in two, and `a_letter_can_be_two_characters`
-    /// in its codec tests states the opposite for it.
+    /// VNI-Windows spells most letters in two, and Unicode tổ hợp spells a toned
+    /// one in two as well. Their codec tests state the opposite for them.
     #[test]
     fn tcvn3_conversion_preserves_the_character_count(text in LEGACY_TEXT) {
         let decoded = convert(&text, Charset::Tcvn3, Charset::Unicode);
@@ -55,28 +96,32 @@ proptest! {
     }
 
     /// Nothing is ever dropped. `>=` rather than `==` is the honest statement of
-    /// that, and the one the module actually promises: encoding to VNI can make
-    /// text longer, and only TCVN3 keeps the count.
+    /// that, and the one the module actually promises: encoding can make text
+    /// longer, and only TCVN3 keeps the count.
     #[test]
     fn no_character_is_ever_dropped(text in "\\PC{0,64}") {
-        for charset in LEGACY {
+        for charset in NON_PIVOT {
             let out = convert(&text, Charset::Unicode, charset);
             prop_assert!(out.text.chars().count() >= text.chars().count());
-            prop_assert!(out.unmapped <= text.chars().count());
+            prop_assert!(out.unmapped + out.normalized <= text.chars().count());
         }
     }
 
-    /// Decoding a legacy charset can only ever join characters, never invent them:
-    /// two bytes may become one letter, but one byte never becomes two. A decoder
-    /// that mistook a missing second char for a zero byte would break this by
-    /// consuming past the end.
+    /// Decoding can only ever join characters, never invent them: two may become
+    /// one letter, but one never becomes two. A decoder that mistook the end of the
+    /// text for a zero byte, or that emitted a letter *and* left its mark behind,
+    /// would break this.
     #[test]
-    fn decoding_never_invents_characters(text in LEGACY_TEXT) {
-        for charset in LEGACY {
-            let out = convert(&text, charset, Charset::Unicode);
+    fn decoding_never_invents_characters(text in LEGACY_TEXT, combining in COMBINING_TEXT) {
+        for (charset, source) in [
+            (Charset::Tcvn3, &text),
+            (Charset::VniWindows, &text),
+            (Charset::UnicodeCombining, &combining),
+        ] {
+            let out = convert(source, charset, Charset::Unicode);
             prop_assert!(
-                out.text.chars().count() <= text.chars().count(),
-                "{:?} grew {:?} into {:?}", charset, text, out.text
+                out.text.chars().count() <= source.chars().count(),
+                "{:?} grew {:?} into {:?}", charset, source, out.text
             );
         }
     }
@@ -84,12 +129,28 @@ proptest! {
     /// A legacy document has to be storable as bytes. Any character in the output
     /// above `U+00FF` could not have come from the charset, so it must have been
     /// counted — otherwise `decode_bytes` would hand back text a file cannot hold.
+    ///
+    /// Deliberately over [`LEGACY`] and not [`NON_PIVOT`]: Unicode tổ hợp is not
+    /// byte-oriented and writes `ơ` (`U+01A1`) with nothing to report, so it fails
+    /// this and rightly so. Please do not "fix" the inconsistency.
     #[test]
     fn a_legacy_charset_writes_only_bytes_or_reports_it(text in "\\PC{0,64}") {
         for charset in LEGACY {
             let out = convert(&text, Charset::Unicode, charset);
             let wide = out.text.chars().filter(|c| *c > '\u{FF}').count();
             prop_assert!(wide <= out.unmapped, "{:?} wrote {} unreported wide chars", charset, wide);
+        }
+    }
+
+    /// The strict half of "lenient in, strict out": whatever Unicode tổ hợp writes
+    /// is in its own spelling, so reading it back reports no rewriting. Nothing in
+    /// the fixed cases proves this over arbitrary text.
+    #[test]
+    fn combining_output_is_always_canonical(text in "\\PC{0,64}") {
+        let out = convert(&text, Charset::Unicode, Charset::UnicodeCombining);
+        if out.unmapped == 0 {
+            let reread = convert(&out.text, Charset::UnicodeCombining, Charset::UnicodeCombining);
+            prop_assert_eq!(reread.normalized, 0, "wrote a spelling it would rewrite");
         }
     }
 }

--- a/crates/funput-core/tests/charset/round_trip.rs
+++ b/crates/funput-core/tests/charset/round_trip.rs
@@ -2,7 +2,7 @@
 
 use funput_core::charset::{Charset, convert, decode_bytes};
 
-use crate::cases::{EXACT, TCVN3_LOSSY, VNI_LOSSY};
+use crate::cases::{COMBINING_EXACT, EXACT, NON_CANONICAL, TCVN3_LOSSY, VNI_LOSSY};
 
 /// Every fixture row, once per legacy charset: `(charset, Unicode, its spelling)`.
 fn legacy_rows() -> impl Iterator<Item = (Charset, &'static str, &'static str)> {
@@ -110,4 +110,80 @@ fn reading_a_file_agrees_with_reading_the_clipboard() {
         assert_eq!(out.text, unicode, "{charset:?} reading {legacy:?}");
         assert_eq!(out.unmapped, 0);
     }
+}
+
+#[test]
+fn unicode_encodes_to_the_code_points_a_unikey_document_holds() {
+    for (unicode, combining) in COMBINING_EXACT {
+        let out = convert(unicode, Charset::Unicode, Charset::UnicodeCombining);
+        assert_eq!(&out.text, combining, "encoding {unicode:?}");
+        assert_eq!((out.unmapped, out.normalized), (0, 0), "{unicode:?}");
+    }
+}
+
+#[test]
+fn a_unikey_document_decodes_back_to_unicode() {
+    for (unicode, combining) in COMBINING_EXACT {
+        let out = convert(combining, Charset::UnicodeCombining, Charset::Unicode);
+        assert_eq!(&out.text, unicode, "decoding {combining:?}");
+        assert_eq!((out.unmapped, out.normalized), (0, 0), "{combining:?}");
+    }
+}
+
+/// A spelling this charset reads but does not write costs `normalized`, never
+/// `unmapped`. Splitting the two counts is what lets an interface say "nothing was
+/// lost" about an NFD document and mean it.
+#[test]
+fn a_spelling_it_does_not_write_is_normalized_not_lost() {
+    for (input, expected, normalized) in NON_CANONICAL {
+        let out = convert(input, Charset::UnicodeCombining, Charset::UnicodeCombining);
+        assert_eq!(&out.text, expected, "{input:?}");
+        assert_eq!(out.unmapped, 0, "{input:?} loses nothing");
+        assert_eq!(out.normalized, *normalized, "{input:?}");
+    }
+}
+
+/// The pivot again, on a harder pair: both ends spell a letter in more than one
+/// character, which `TCVN3 ↔ VNI` never exercises. Still no code written for it.
+#[test]
+fn converting_between_combining_and_a_legacy_charset_needs_no_code_of_its_own() {
+    for ((unicode, tcvn3, vni), (_, combining)) in EXACT.iter().zip(COMBINING_EXACT) {
+        for (legacy, charset) in [(tcvn3, Charset::Tcvn3), (vni, Charset::VniWindows)] {
+            let out = convert(combining, Charset::UnicodeCombining, charset);
+            assert_eq!(&out.text, legacy, "tổ hợp to {charset:?} for {unicode:?}");
+            assert_eq!(out.unmapped, 0);
+
+            let back = convert(legacy, charset, Charset::UnicodeCombining);
+            assert_eq!(
+                &back.text, combining,
+                "{charset:?} to tổ hợp for {unicode:?}"
+            );
+            assert_eq!(back.unmapped, 0);
+        }
+    }
+}
+
+/// The file door for a charset that is not byte-oriented: its bytes are UTF-8, not
+/// one byte per character. This is what `decode_bytes` gets wrong until it runs the
+/// decoded text through `convert` rather than handing it straight back.
+#[test]
+fn reading_a_unikey_file_converts_it() {
+    for (unicode, combining) in COMBINING_EXACT {
+        let out = decode_bytes(combining.as_bytes(), Charset::UnicodeCombining);
+        assert_eq!(&out.text, unicode, "reading {combining:?} as a file");
+        assert_eq!(out.unmapped, 0);
+    }
+}
+
+/// Broken bytes and characters the charset could not place are separate problems,
+/// so they add up. Here `0xFF` is not UTF-8 at all, and the replacement character
+/// it becomes orphans the combining mark that followed.
+#[test]
+fn broken_utf8_and_conversion_damage_are_both_counted() {
+    let mut bytes = b"a".to_vec();
+    bytes.push(0xFF);
+    bytes.extend_from_slice("\u{301}".as_bytes());
+
+    let out = decode_bytes(&bytes, Charset::UnicodeCombining);
+    assert_eq!(out.unmapped, 2, "one broken byte, one orphaned mark");
 }

--- a/docs/features/charset.md
+++ b/docs/features/charset.md
@@ -2,8 +2,8 @@
 
 ## Trạng thái
 
-Đã có: khung core, **TCVN3**, **VNI-Windows**. Còn lại: Unicode tổ hợp, `detect()`,
-rồi các consumer (xem "Thứ tự hiện thực" ở cuối).
+Đã có: khung core và cả bốn bảng mã — **TCVN3**, **VNI-Windows**, **Unicode tổ hợp**.
+Còn lại: `detect()`, rồi các consumer (xem "Thứ tự hiện thực" ở cuối).
 
 Tài liệu này chốt mô hình *trước* khi có code và được review riêng; nó vẫn là nơi
 mọi quyết định thiết kế sống, nên mỗi bảng mã mới cập nhật lại nó trong cùng PR.
@@ -225,18 +225,72 @@ v1 **rộng rãi khi nhận, nghiêm ngặt khi xuất**:
 - **Encode** luôn xuất theo quy ước UniKey: nguyên âm có hình dạng dựng sẵn, dấu
   thanh rời.
 
-## Ngữ nghĩa `unmapped`
+### Thứ tự dấu không cố định — và một cái bẫy chí mạng
 
-```rust
-struct Conversion { text: String, unmapped: usize }
+NFD chuẩn **không** luôn đặt dấu hình dạng trước. Bốn chữ đặt dấu thanh trước, vì
+`U+0323` (nặng) có combining class 220 còn mũ/trăng là 230:
+
+```text
+ặ = 0061 0323 0306      ậ = 0061 0323 0302
+ệ = 0065 0323 0302      ộ = 006F 0323 0302
 ```
 
-`unmapped` đếm số ký tự **không đi qua nguyên vẹn**. Một ký tự bị đếm vì một trong
-hai lý do, và chỉ đếm một lần:
+Mọi trường hợp hai dấu khác đều hình-dạng-trước (`ợ` = `006F 031B 0323`). Vì chính
+thứ tự đã lật, **nhận dấu theo thứ tự bất kỳ** vừa ít việc hơn vừa đúng hơn là mã
+hoá lại luật combining class.
+
+Cái bẫy: cách hiện thực hiển nhiên là gộp lần lượt từng dấu vào một `char`. Nó
+**hỏng**. `apply_shape_to_vowel` gọi `base_vowel`, mà hàm đó bóc **cả thanh lẫn hình
+dạng** — test của chính crate tên là `apply_shape_to_vowel_strips_tone`. Gộp NFD của
+`ậ` sẽ ra `ạ` rồi `â`, mất dấu nặng. Trúng đúng bốn chữ trên, tức là `Việt`, `một`,
+`cộng`, `nặng`.
+
+Nên codec tích dấu vào **các ô rời** rồi ghép **một lần** ở cuối. Và **ô đã đầy thì
+kết thúc chữ**: `apply_tone` *thay* dấu chứ không từ chối, nên nhận dấu thanh thứ hai
+sẽ âm thầm nuốt mất dấu thứ nhất.
+
+### Chữ nào là "đúng chính tả" của bảng mã này
+
+```text
+Exact khi: hình dạng (nếu có) nằm sẵn trong ký tự nền
+       và  thanh điệu (nếu có) đến từ một dấu rời
+```
+
+`ấ` dựng sẵn không đạt (thanh chưa tách), NFD `a`+`0302`+`0301` cũng không (hình dạng
+bị tách). Cả hai vẫn đọc đúng, vẫn được viết lại — và vào `normalized`, **không** vào
+`unmapped`. Hệ quả phải biết trước: **đọc văn bản dựng sẵn thông thường bằng bảng mã
+này cho `normalized` ≈ một trên mỗi chữ có dấu.** Đúng như vậy; `detect()` phải tính
+đến điều đó.
+
+### Thứ duy nhất nó không viết được
+
+Không có gì — đây là Unicode, nên `₫` và `日` đi qua chính xác, điều mà không bảng mã
+cũ nào làm được. Ngoại lệ duy nhất là **một dấu rời đi lạc**: viết nó sau một chữ thì
+hai thứ dính vào nhau và văn bản đọc lại thành chữ khác. Đó là bản sao của ca `ø`
+dính dấu bên VNI.
+
+## Hai bộ đếm
+
+```rust
+struct Conversion { text: String, unmapped: usize, normalized: usize }
+```
+
+Hai chuyện khác hẳn nhau, nên hai con số. Một ký tự rơi vào **nhiều nhất một** ô, và
+mất mát thắng chuẩn hoá.
+
+**`normalized`** — hiểu chắc chắn, không mất gì, **chỉ cách viết đổi**. Đọc văn bản
+dựng sẵn hay NFD bằng bảng mã tổ hợp rơi vào đây. Gộp nó vào `unmapped` sẽ khiến giao
+diện báo "N ký tự không chính xác" cho một tài liệu hoàn toàn lành lặn.
+
+**`unmapped`** — có thứ bị **mất hoặc phải đoán**. Một ký tự bị đếm vì một trong hai
+lý do:
 
 - **Bảng mã đích không viết được nó** — `Ề` trong TCVN3, hay `₫` trong bất kỳ bảng
   mã cũ nào.
 - **Bảng mã nguồn chưa từng định nghĩa nó**, nên việc đọc chỉ là phỏng đoán.
+
+Bên trong, `Decoded` mang `enum Reading { Exact, Rewritten, Unknown }` thay cho một
+cờ bool — đó là thứ cho driver biết đếm vào ô nào.
 
 Lý do thứ hai đáng giá hơn vẻ ngoài của nó. Đọc nhầm bảng mã thì hầu hết đơn vị đều
 không nhận ra được, nên một con số gần bằng độ dài văn bản chính là **tín hiệu rõ
@@ -290,8 +344,8 @@ match. Trục, driver và `detect` không đổi.
 ## API công khai
 
 ```rust
-#[non_exhaustive] pub enum Charset { Unicode, Tcvn3, VniWindows, /* … */ }
-#[non_exhaustive] pub struct Conversion { pub text: String, pub unmapped: usize }
+#[non_exhaustive] pub enum Charset { Unicode, Tcvn3, VniWindows, UnicodeCombining }
+#[non_exhaustive] pub struct Conversion { pub text: String, pub unmapped: usize, pub normalized: usize }
 
 pub fn convert(text: &str, from: Charset, to: Charset) -> Conversion;
 pub fn decode_bytes(bytes: &[u8], from: Charset) -> Conversion;
@@ -318,6 +372,8 @@ Mỗi mục một PR:
 3. **VNI-Windows**. Bảng mã đầu tiên có chữ dài hai ký tự, nên nó cũng là phép thử
    thật đầu tiên cho mô hình trục: `TCVN3 ↔ VNI` chạy được mà không codec nào biết
    codec kia.
-4. Unicode tổ hợp → 5. `detect()`.
+4. **Unicode tổ hợp**. Bảng mã duy nhất không phải byte, nên nó làm lộ hai lỗi thật
+   trong `decode_bytes` và buộc `unmapped` tách làm hai.
+5. `detect()`.
 6. `funput-config` (sửa import UniKey) → 7. `funput convert` → 8. UI Windows →
    9. UI Linux GTK.


### PR DESCRIPTION
Stacked on #224 — land that first, and this diff is the fourth charset alone.

The last of the four, and the only one that is not made of bytes. That difference uncovered two real bugs the byte-oriented codecs had been hiding, and forced `unmapped` to split in two.

### The decoder is not a fold, and that is the whole design

`apply_shape_to_vowel` goes through `base_vowel`, which strips the **tone** as well as the shape — the crate's own test for it is called `apply_shape_to_vowel_strips_tone`.

Canonical NFD puts the tone *first* whenever it is nặng, because U+0323 has a lower combining class than the circumflex and breve:

```
ặ = 0061 0323 0306      ậ = 0061 0323 0302
ệ = 0065 0323 0302      ộ = 006F 0323 0302
```

So folding `a` U+0323 U+0302 gives `ạ`, then throws the tone away and returns `â`. Those four letters are `Việt`, `một`, `cộng`, `nặng` — the most common decomposed Vietnamese text there is.

Marks go into slots and the letter is composed once. Order stops mattering, which is right anyway since NFD's own order flips. A **full slot ends the letter** rather than overwriting: `apply_tone` replaces rather than refuses, so absorbing a second tone would silently drop the first and break `an_exact_conversion_is_reversible`.

`the_tone_first_nfd_order_keeps_its_tone` is the regression net. I found this by pulling real NFD out of a Unicode normalizer instead of reasoning about it — I had guessed the shape always came first, and it does not.

### `unmapped` split in two

Reading NFC or NFD text as tổ hợp gives the right letters and loses nothing; only the spelling changes. One counter had to report that, which would have an interface call a perfectly sound NFD document damaged.

`Conversion` gains **`normalized`**. `unmapped` keeps meaning lost-or-guessed. `Decoded` carries a three-state `Reading` instead of a bool.

**TCVN3 and VNI are behaviourally unchanged** — I walked every case (TCVN3's uppercase gap, VNI's mixed-case pair, unassigned bytes, `₫`, the `ø` fusion) and all remain losses or guesses. Their `tests.rs` files are untouched and still pass, which is the proof. Their codecs changed only `recognized: true/false` → `Reading::Exact/Unknown`.

### `decode_bytes` had two bugs

Both invisible while `Charset::Unicode` was the only non-byte-oriented charset:

- it never called `convert` on that path, so a tổ hợp file came back **untranscoded**;
- it returned early with `unmapped: 0` for valid UTF-8, which cannot see an orphaned combining mark.

It now always converts, and the two counts **add** — broken bytes and unplaceable characters are separate problems, and a byte causing both deserves two looks. `reading_a_unikey_file_converts_it` fails against the old code; that is its point.

### Smaller things

- `Cursor` gained `following()` for the third character of lookahead. VNI's `second()` is now a one-liner over it, so its call site and tests are untouched.
- `Atom::Other` on encode is **not** unconditionally exact here. A bare combining mark written after a letter fuses with it — `convert("a\u{301}", Unicode, Combining)` would otherwise claim `unmapped == 0` and read back as `á`. The rule is false for exactly this codec's eight marks, true for everything else including `₫` and `日`, which no legacy charset can claim.
- Named `UnicodeCombining`, not `Decomposed` — it is not NFD, and the name would over-promise.
- `EXACT` stayed a 3-tuple. A tổ hợp column is not the same kind of thing as two columns of Latin-1 mojibake escapes, and three consumers destructure it positionally. `COMBINING_EXACT` and `NON_CANONICAL` sit beside it, with their own escaping rule documented: bases literal, every mark `\u{..}`, because `"ệ"` and `"ê\u{323}"` are indistinguishable on screen and a silently-precomposed fixture would assert nothing.
- The pivot claim extended to a pair where **both** ends move character boundaries, which `TCVN3 ↔ VNI` never tested.

### Verification

All four `rust` job commands clean with the feature **off**. With it on: 152 lib tests, 21 integration, 8 proptests. `check-loc.sh` went 290 → 293, exactly the three new `src/` files.

**One thing for the next PR:** `charset/mod.rs` is at **144/150**. `detect.rs` will add roughly four lines to it and still fit, but barely. I chose not to trim the module doc to buy room — the prose there explains real decisions and cutting it to chase six lines is the wrong trade — so whoever writes `detect()` should expect to tighten something. `src/charset/` and `codecs/` are both at 4 entries, one slot each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
