### PR TITLE
feat(core): guess which charset a piece of text is written in

### DIFF
--- a/crates/funput-core/src/charset/codecs/mod.rs
+++ b/crates/funput-core/src/charset/codecs/mod.rs
@@ -59,13 +59,37 @@ pub(super) fn encode(charset: Charset, atom: Atom, out: &mut String) -> bool {
 }
 
 /// Whether a charset spells text in single bytes drawn by a legacy font, so bytes
-/// read from a file are Latin-1 rather than UTF-8. Used only by
-/// [`crate::charset::decode_bytes`].
+/// read from a file are Latin-1 rather than UTF-8.
+///
+/// This and the two below are everything [`crate::charset::decode_bytes`] needs to
+/// know about the byte layer, which is why they live together down here rather
+/// than beside it.
 pub(super) fn is_byte_oriented(charset: Charset) -> bool {
     match charset {
         Charset::Unicode | Charset::UnicodeCombining => false,
         Charset::Tcvn3 | Charset::VniWindows => true,
     }
+}
+
+/// How many characters lossy UTF-8 decoding had to replace. Zero for valid input,
+/// and replacement characters the source genuinely encoded are discounted so a
+/// document that legitimately contains one is not reported as damaged.
+pub(super) fn broken_sequences(bytes: &[u8]) -> usize {
+    if std::str::from_utf8(bytes).is_ok() {
+        return 0;
+    }
+    String::from_utf8_lossy(bytes)
+        .matches(char::REPLACEMENT_CHARACTER)
+        .count()
+        .saturating_sub(genuine_replacements(bytes))
+}
+
+/// How many `U+FFFD` the bytes genuinely encode.
+fn genuine_replacements(bytes: &[u8]) -> usize {
+    bytes
+        .windows(3)
+        .filter(|window| *window == [0xEF, 0xBF, 0xBD])
+        .count()
 }
 
 #[cfg(test)]

--- a/crates/funput-core/src/charset/codecs/tcvn3/mod.rs
+++ b/crates/funput-core/src/charset/codecs/tcvn3/mod.rs
@@ -39,7 +39,11 @@ pub(super) fn decode(cur: &Cursor<'_>) -> Decoded {
         },
         // Below 0x80 TCVN3 is ASCII — but an ASCII vowel still has to pick up its
         // family coordinates, or the target charset could not re-spell it.
-        _ => (Atom::from_char(c), Reading::Exact),
+        Ok(_) => (Atom::from_char(c), Reading::Exact),
+        // Above U+00FF the character is not merely unassigned: a `.VnTime`
+        // document stores one byte per character and cannot hold it at all. It
+        // still comes through — nothing is lost — but this text is not TCVN3.
+        Err(_) => (Atom::from_char(c), Reading::Unknown),
     };
     Decoded {
         atom,

--- a/crates/funput-core/src/charset/codecs/tcvn3/tests.rs
+++ b/crates/funput-core/src/charset/codecs/tcvn3/tests.rs
@@ -163,3 +163,15 @@ fn a_real_word_encodes_to_the_bytes_a_vntime_document_holds() {
     );
     assert_eq!(to_unicode(&encoded), "Việt Nam");
 }
+
+/// A `.VnTime` document stores one byte per character, so it cannot hold `ệ` at
+/// all. Reading precomposed Unicode as TCVN3 must say so — the text comes through
+/// intact, but the count is what tells a user they picked the wrong bảng mã, and
+/// what lets `detect` tell the two apart. Without this the two charsets score
+/// identically on ordinary Vietnamese and detection is impossible.
+#[test]
+fn a_character_no_byte_could_hold_is_reported() {
+    let out = transcode("Việt Nam", Charset::Tcvn3, Charset::Unicode);
+    assert_eq!(out.text, "Việt Nam", "nothing is lost");
+    assert_eq!(out.unmapped, 1, "but `ệ` was never TCVN3");
+}

--- a/crates/funput-core/src/charset/codecs/vni/mod.rs
+++ b/crates/funput-core/src/charset/codecs/vni/mod.rs
@@ -86,20 +86,24 @@ pub(super) fn decode(cur: &Cursor<'_>) -> Decoded {
     }
 }
 
-/// A char VNI does not spell. ASCII is still classified, so an ASCII vowel keeps
-/// the family coordinates another charset would need to re-spell it.
+/// A char VNI does not spell.
+///
+/// A character above `U+00FF` is not merely unassigned — a `VNI-Times` document
+/// stores one byte per character and physically cannot hold it. So it is carried
+/// through (nothing is lost) but reported: whatever this text is, it is not VNI,
+/// and saying so is what makes a wrong-charset reading show up as a count.
 fn passthrough(c: char) -> Decoded {
-    match u8::try_from(c as u32) {
-        Ok(byte) if byte >= 0x80 => Decoded {
-            atom: Atom::Other(c),
-            consumed: 1,
-            reading: Reading::Unknown,
-        },
-        _ => Decoded {
-            atom: Atom::from_char(c),
-            consumed: 1,
-            reading: Reading::Exact,
-        },
+    let (atom, reading) = match u8::try_from(c as u32) {
+        Ok(byte) if byte >= 0x80 => (Atom::Other(c), Reading::Unknown),
+        // ASCII is still classified, so an ASCII vowel keeps the family
+        // coordinates another charset would need to re-spell it.
+        Ok(_) => (Atom::from_char(c), Reading::Exact),
+        Err(_) => (Atom::from_char(c), Reading::Unknown),
+    };
+    Decoded {
+        atom,
+        consumed: 1,
+        reading,
     }
 }
 

--- a/crates/funput-core/src/charset/codecs/vni/tests.rs
+++ b/crates/funput-core/src/charset/codecs/vni/tests.rs
@@ -288,3 +288,13 @@ fn a_letter_can_be_two_characters() {
     assert_eq!(to_vni("ạ").0.chars().count(), 2);
     assert_eq!(to_vni("í").0.chars().count(), 1, "the i family is one byte");
 }
+
+/// A `VNI-Times` document stores one byte per character, so it cannot hold `ệ`.
+/// Reading precomposed Unicode as VNI reports it — see the twin test in the TCVN3
+/// codec for why detection depends on this.
+#[test]
+fn a_character_no_byte_could_hold_is_reported() {
+    let (out, unmapped) = from_vni("Việt Nam");
+    assert_eq!(out, "Việt Nam", "nothing is lost");
+    assert_eq!(unmapped, 1, "but `ệ` was never VNI");
+}

--- a/crates/funput-core/src/charset/detect/mod.rs
+++ b/crates/funput-core/src/charset/detect/mod.rs
@@ -1,0 +1,121 @@
+//! Guessing which charset a piece of text is written in.
+//!
+//! Every candidate is tried: decode the text as that charset and see how much of
+//! the result is spellable Vietnamese. The right charset produces words; a wrong
+//! one produces letters that do not go together. `None` when the evidence does not
+//! separate them, which is the honest answer more often than it looks — pure ASCII
+//! reads the same under all four, and no amount of it says anything.
+//!
+//! # What it cannot do
+//!
+//! Every judgement here is *relative*: the best of four hypotheses wins. A charset
+//! nobody implemented has no hypothesis of its own, so it is answered with its
+//! nearest neighbour. VISCII shares Latin-1's letters with TCVN3, so VISCII text
+//! is confidently reported as TCVN3 and converts to something subtly wrong. No
+//! cheap threshold fixes this — the only real fix is to implement VISCII.
+//! `tests.rs` pins the behaviour so the next reader finds it already known.
+//!
+//! # Cost
+//!
+//! Detection decodes the text once per candidate, so it reads a **prefix** rather
+//! than a whole document. An interface that detects on the prefix and converts the
+//! whole text is doing the right thing.
+
+mod score;
+
+use super::{Charset, Conversion, convert, decode_bytes};
+use score::{Score, score};
+
+/// How much text is enough to decide. Four full decodings run over this, and the
+/// answer stops changing long before it: a few hundred words already separate the
+/// charsets by a wide margin.
+const PREFIX: usize = 8 * 1024;
+
+/// Every charset detection considers.
+const CANDIDATES: [Charset; 4] = [
+    Charset::Unicode,
+    Charset::Tcvn3,
+    Charset::VniWindows,
+    Charset::UnicodeCombining,
+];
+
+/// Guess the charset `text` is written in, or `None` when the evidence does not
+/// pick one out.
+///
+/// `None` covers three different situations on purpose — no evidence at all
+/// (empty, digits), a genuine tie between two charsets that spell this text the
+/// same way, and text that reads identically under every charset. A caller that
+/// needs to tell them apart should ask [`convert`] for each candidate and compare
+/// [`Conversion`] itself.
+pub fn detect(text: &str) -> Option<Charset> {
+    best(|charset| convert(prefix(text), charset, Charset::Unicode))
+}
+
+/// Guess the charset of raw bytes — the door for a file rather than a clipboard.
+///
+/// Not the same question as [`detect`] on the same content, and the difference is
+/// real rather than an oversight: bytes can be invalid UTF-8, and that is strong
+/// evidence *against* the two Unicode charsets which `detect` cannot see, because
+/// by the time it has a `&str` the damage has already been repaired.
+pub fn detect_bytes(bytes: &[u8]) -> Option<Charset> {
+    let head = &bytes[..PREFIX.min(bytes.len())];
+    best(|charset| decode_bytes(head, charset))
+}
+
+/// The candidate that explains `decoded` best, if one does.
+fn best(decoded: impl Fn(Charset) -> Conversion) -> Option<Charset> {
+    let mut ranked: Vec<(Score, Charset)> = CANDIDATES
+        .iter()
+        .map(|&charset| (score(&decoded(charset)), charset))
+        .collect();
+    // Descending, so the winner and the runner-up are the first two.
+    ranked.sort_unstable_by_key(|&(score, _)| core::cmp::Reverse(score));
+
+    let (winner, charset) = ranked[0];
+    let (runner_up, _) = ranked[1];
+    (winner > runner_up && winner.is_plausible()).then_some(charset)
+}
+
+/// The leading `PREFIX` bytes, cut at a character boundary.
+fn prefix(text: &str) -> &str {
+    if text.len() <= PREFIX {
+        return text;
+    }
+    let mut end = PREFIX;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    &text[..end]
+}
+
+/// Adding a `Charset` variant must break the build here rather than silently drop
+/// the charset out of detection.
+///
+/// [`CANDIDATES`] is an array, and an array throws away the exhaustiveness that
+/// [`super::codecs`] gets for free from its `match`. This is the array's substitute:
+/// the match below fails to compile on a fifth variant, and the assertion catches a
+/// variant that has a slot but was left out of the array.
+const _: () = {
+    const fn slot(charset: Charset) -> usize {
+        match charset {
+            Charset::Unicode => 0,
+            Charset::Tcvn3 => 1,
+            Charset::VniWindows => 2,
+            Charset::UnicodeCombining => 3,
+        }
+    }
+    let mut listed = [false; CANDIDATES.len()];
+    let mut i = 0;
+    while i < CANDIDATES.len() {
+        listed[slot(CANDIDATES[i])] = true;
+        i += 1;
+    }
+    let mut i = 0;
+    while i < listed.len() {
+        assert!(listed[i], "a charset has no entry in CANDIDATES");
+        i += 1;
+    }
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/funput-core/src/charset/detect/score.rs
+++ b/crates/funput-core/src/charset/detect/score.rs
@@ -1,0 +1,164 @@
+//! How well one candidate charset explains the text.
+//!
+//! The measure is Vietnamese spelling: decode the text as the candidate, split it
+//! into words, and count how many are real syllables. A wrong charset turns
+//! Vietnamese letters into other letters, and the result stops being spellable
+//! almost everywhere — that is the whole signal.
+
+use core::cmp::Reverse;
+
+use crate::charset::Conversion;
+use crate::is_complete_syllable;
+
+/// A candidate's showing, ordered so that a larger value is a better explanation.
+///
+/// The order of the fields is the order of the comparison, and each rung only
+/// matters when the ones above it tie:
+///
+/// 1. `valid` — the real evidence.
+/// 2. `Reverse(invalid)` — a denominator. Three syllables out of three beats three
+///    out of forty.
+/// 3. `Reverse(unmapped)` — the source charset could not place a character.
+/// 4. `Reverse(normalized)` — it could, but the source spelled it another way.
+///
+/// The last rung is what separates the two Unicode charsets on ordinary
+/// precomposed text: both read it correctly and score the same syllables, but
+/// Unicode tổ hợp reports a rewrite for every toned letter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) struct Score {
+    valid: usize,
+    invalid: Reverse<usize>,
+    unmapped: Reverse<usize>,
+    normalized: Reverse<usize>,
+}
+
+impl Score {
+    /// Whether enough of the text parses as Vietnamese to be worth believing.
+    ///
+    /// A majority rule rather than a fixed floor: a fixed one either rejects
+    /// legitimately short input — `"Việt Nam"` is two words — or sits too low to
+    /// refuse anything. This stops binary data and prose that is not Vietnamese at
+    /// all, where a token parses now and then by accident.
+    pub(super) fn is_plausible(self) -> bool {
+        self.valid > 0 && self.valid > self.invalid.0
+    }
+}
+
+/// Score a decoding of the text.
+pub(super) fn score(out: &Conversion) -> Score {
+    let mut valid = 0;
+    let mut invalid = 0;
+    for word in words(&out.text) {
+        if is_complete_syllable(word) {
+            valid += 1;
+        } else {
+            invalid += 1;
+        }
+    }
+    Score {
+        valid,
+        invalid: Reverse(invalid),
+        unmapped: Reverse(out.unmapped),
+        normalized: Reverse(out.normalized),
+    }
+}
+
+/// Split text into candidate words: runs of ASCII letters and non-ASCII.
+///
+/// Both obvious rules are wrong, each in its own way.
+///
+/// **Splitting on whitespace and trimming non-letters off the ends** throws away
+/// the evidence. TCVN3 gives its commonest letters Latin-1 *symbols* rather than
+/// letters — `ả` is `0xB6` (`¶`), `á` is `0xB8` (`¸`), `ơ` is `0xAC` (`¬`) — so
+/// `hoả` misread as Unicode is `ho¶`, and trimming leaves `ho`, a perfectly good
+/// syllable. The wrong candidate scores by discarding the byte that identified the
+/// right one. It also loses the first Vietnamese word of every line of a `gõ tắt`
+/// file, whose format is `trigger:expansion` with no space.
+///
+/// **Splitting on everything that is not a letter** tears `Viê` `t` apart at the
+/// combining mark and kills the Unicode tổ hợp candidate outright.
+///
+/// So: break on ASCII non-letters, keep every non-ASCII character inside the word.
+/// Digits, `:`, `/` and punctuation separate; marks and legacy symbols do not.
+fn words(text: &str) -> impl Iterator<Item = &str> {
+    text.split(|c: char| !(c.is_ascii_alphabetic() || is_word_body(c)))
+        .filter(|word| !word.is_empty())
+}
+
+/// Whether a non-ASCII char belongs inside a word rather than between two.
+///
+/// A byte-order mark is neither: it carries no text and would poison the word it
+/// landed in.
+fn is_word_body(c: char) -> bool {
+    !c.is_ascii() && c != '\u{FEFF}'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn split(text: &str) -> Vec<&str> {
+        words(text).collect()
+    }
+
+    #[test]
+    fn a_word_keeps_the_legacy_symbol_that_identifies_its_charset() {
+        // `hoả` in TCVN3 misread as Unicode. Trimming the `¶` would leave `ho`,
+        // which is a syllable, and hand the wrong candidate a free point.
+        assert_eq!(split("ho\u{B6}"), vec!["ho\u{B6}"]);
+        assert!(!is_complete_syllable("ho\u{B6}"));
+    }
+
+    #[test]
+    fn a_word_keeps_its_combining_marks() {
+        assert_eq!(split("Viê\u{323}t Nam"), vec!["Viê\u{323}t", "Nam"]);
+    }
+
+    /// The `gõ tắt` file format is `trigger:expansion`. Splitting on whitespace
+    /// alone would hand the scorer `vn:việt` and lose the Vietnamese word inside.
+    #[test]
+    fn ascii_punctuation_separates_words() {
+        assert_eq!(split("vn:việt nam"), vec!["vn", "việt", "nam"]);
+        assert_eq!(split("\"Việt\", (Nam)"), vec!["Việt", "Nam"]);
+    }
+
+    /// Non-ASCII punctuation stays *inside* the word, and it has to: `«` is
+    /// `U+00AB`, and `0xAB` is how TCVN3 spells `ô`. There is no way to tell a
+    /// quotation mark from a letter without already knowing the charset, which is
+    /// the question being asked. Keeping it is harmless — the word then fails to
+    /// parse under every candidate alike, so it decides nothing either way.
+    #[test]
+    fn non_ascii_punctuation_cannot_be_stripped() {
+        assert_eq!(split("«Việt»"), vec!["«Việt»"]);
+    }
+
+    #[test]
+    fn digits_are_not_part_of_a_word() {
+        assert_eq!(split("1945 2024 30/4"), Vec::<&str>::new());
+        assert_eq!(split("Ha Noi 1945"), vec!["Ha", "Noi"]);
+    }
+
+    #[test]
+    fn a_byte_order_mark_does_not_join_the_word_after_it() {
+        assert_eq!(split("\u{FEFF}Việt"), vec!["Việt"]);
+    }
+
+    #[test]
+    fn a_majority_of_words_has_to_parse() {
+        let plausible = Score {
+            valid: 2,
+            invalid: Reverse(0),
+            unmapped: Reverse(0),
+            normalized: Reverse(0),
+        };
+        assert!(plausible.is_plausible(), "two words, both Vietnamese");
+
+        let noise = Score {
+            valid: 1,
+            invalid: Reverse(40),
+            unmapped: Reverse(0),
+            normalized: Reverse(0),
+        };
+        assert!(!noise.is_plausible(), "one accident in forty words");
+    }
+}

--- a/crates/funput-core/src/charset/detect/tests.rs
+++ b/crates/funput-core/src/charset/detect/tests.rs
@@ -1,0 +1,148 @@
+use super::*;
+
+/// **The regression net for the codec fix this feature depended on.**
+///
+/// Reading precomposed Unicode as TCVN3 or VNI used to report nothing wrong, so all
+/// three charsets scored identically and detection was impossible on the commonest
+/// input there is. If this returns `None`, the byte-oriented codecs have gone back
+/// to accepting characters no byte could hold.
+#[test]
+fn ordinary_unicode_is_detected_as_unicode() {
+    assert_eq!(detect("Việt Nam"), Some(Charset::Unicode));
+    assert_eq!(detect("Cộng hòa Xã hội Chủ nghĩa"), Some(Charset::Unicode));
+}
+
+#[test]
+fn a_legacy_document_is_detected_by_the_letters_it_spells() {
+    // `Việt Nam` as each legacy charset stores it.
+    assert_eq!(detect("Vi\u{D6}t Nam"), Some(Charset::Tcvn3));
+    assert_eq!(detect("Vi\u{65}\u{E4}t Nam"), Some(Charset::VniWindows));
+}
+
+#[test]
+fn the_unikey_convention_and_full_nfd_both_read_as_combining() {
+    assert_eq!(
+        detect("Viê\u{323}t Nam"),
+        Some(Charset::UnicodeCombining),
+        "the UniKey spelling"
+    );
+    assert_eq!(
+        detect("Vie\u{323}\u{302}t Nam"),
+        Some(Charset::UnicodeCombining),
+        "canonical NFD, which reads correctly and is rewritten"
+    );
+}
+
+/// Text every charset spells the same way carries no evidence at all. Saying so is
+/// more useful than picking one at random — and every answer would be correct.
+#[test]
+fn text_that_reads_the_same_everywhere_is_not_detected() {
+    for text in ["Ha Noi 1945", "cho toi mot ly ca phe", ""] {
+        assert_eq!(detect(text), None, "{text:?}");
+    }
+}
+
+/// `is_complete_syllable` accepts a fair amount of English (`the`, `can`, `long`),
+/// so an English document scores well — but it scores *equally* well under every
+/// candidate, which is what actually rules it out.
+#[test]
+fn an_english_document_is_not_detected() {
+    assert_eq!(detect("The quick brown fox jumps over the lazy dog"), None);
+}
+
+#[test]
+fn text_with_no_words_at_all_is_not_detected() {
+    for text in ["   ", "1945 2024 30/4", "!!! ??? ..."] {
+        assert_eq!(detect(text), None, "{text:?}");
+    }
+}
+
+/// Sixteen bytes are a letter in both legacy charsets, so a single short word can
+/// be genuinely undecidable. `0xF4` is `ụ` in TCVN3 and `ơ` in VNI, and `cụ` and
+/// `cơ` are both real words.
+#[test]
+fn a_word_two_charsets_spell_the_same_way_is_not_detected() {
+    assert_eq!(detect("c\u{F4}"), None, "cụ or cơ — no way to tell");
+    assert_eq!(detect("t\u{F6}"), None, "tử or tư");
+}
+
+/// Vietnamese official documents are full of all-caps headings, and the syllable
+/// checker is case-insensitive, so they detect like anything else.
+#[test]
+fn an_all_caps_legacy_heading_is_detected() {
+    assert_eq!(detect("H\u{B5} N\u{E9}I"), Some(Charset::Tcvn3));
+}
+
+/// The shape of a `gõ tắt` file: `trigger:expansion`, no space after the colon.
+/// This is what the word splitter exists for — splitting on whitespace alone would
+/// hand the scorer `vn:vi\u{D6}t` and lose the Vietnamese word inside every line.
+#[test]
+fn a_unikey_macro_file_is_detected_from_its_bytes() {
+    let file = b"vn:vi\xD6t nam\r\nhn:h\xB5 n\xE9i\r\n";
+    assert_eq!(detect_bytes(file), Some(Charset::Tcvn3));
+}
+
+#[test]
+fn a_utf8_file_is_detected_from_its_bytes() {
+    assert_eq!(detect_bytes("Việt Nam".as_bytes()), Some(Charset::Unicode));
+    assert_eq!(
+        detect_bytes("Viê\u{323}t Nam".as_bytes()),
+        Some(Charset::UnicodeCombining)
+    );
+}
+
+/// The two doors answer differently on the same content, and that is the point
+/// rather than an oversight: bytes can be invalid UTF-8, which is evidence against
+/// the Unicode charsets. By the time `detect` holds a `&str` the damage has been
+/// repaired and the evidence is gone.
+#[test]
+fn the_two_doors_may_disagree_and_that_is_intended() {
+    let bytes = b"vi\xD6t nam";
+    let as_chars: String = bytes.iter().copied().map(char::from).collect();
+
+    assert_eq!(detect_bytes(bytes), Some(Charset::Tcvn3));
+    assert_eq!(detect(&as_chars), Some(Charset::Tcvn3));
+
+    // Latin-1 that is *also* Vietnamese under no charset in particular: the byte
+    // door sees the UTF-8 damage, the text door never had it.
+    assert_eq!(detect_bytes(&[0xFF, 0xFE, 0x41]), None);
+}
+
+/// **A known limitation, pinned so the next reader finds it already known.**
+///
+/// VISCII is Latin-1-compatible for the letters it shares with TCVN3, and nobody
+/// has implemented it. Every judgement here is relative — the best of four
+/// hypotheses — so an unimplemented charset is always answered with its nearest
+/// neighbour rather than refused. `c\u{E0} ph\u{EA}` is `cà phê` in VISCII and
+/// converts to `cà phờ` under the answer given here.
+///
+/// No threshold fixes this; implementing VISCII does.
+#[test]
+fn an_unimplemented_charset_is_answered_with_its_nearest_neighbour() {
+    let viscii = "c\u{E0} ph\u{EA}";
+    assert_eq!(
+        detect(viscii),
+        Some(Charset::Unicode),
+        "read as Latin-1 this happens to be right, by luck rather than judgement"
+    );
+    assert_eq!(
+        detect_bytes(b"c\xE0 ph\xEA"),
+        Some(Charset::Tcvn3),
+        "and as bytes it is confidently wrong — see the doc comment"
+    );
+}
+
+#[test]
+fn a_prefix_is_enough_and_a_long_document_is_not_read_whole() {
+    let long = "Việt Nam ".repeat(4096);
+    assert!(long.len() > PREFIX);
+    assert_eq!(detect(&long), Some(Charset::Unicode));
+}
+
+#[test]
+fn the_prefix_cut_lands_on_a_character_boundary() {
+    // Multi-byte characters straddling the cut must not panic or split.
+    let text = "ệ".repeat(PREFIX);
+    assert!(prefix(&text).len() <= PREFIX);
+    assert!(text.starts_with(prefix(&text)));
+}

--- a/crates/funput-core/src/charset/mod.rs
+++ b/crates/funput-core/src/charset/mod.rs
@@ -29,13 +29,16 @@
 //! ```
 
 mod codecs;
+mod detect;
 mod pivot;
 mod transcode;
 
+pub use detect::{detect, detect_bytes};
+
 /// A Vietnamese character encoding.
 ///
-/// `#[non_exhaustive]`: Unicode tổ hợp is still to come, and adding it should not
-/// break callers. Match with a wildcard arm.
+/// `#[non_exhaustive]`: VIQR, VISCII and the rest are out of scope today but not
+/// forever, and adding one should not break callers. Match with a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum Charset {
@@ -87,7 +90,7 @@ pub struct Conversion {
 
 /// Convert text from one charset to another.
 ///
-/// `from` must be what the text actually is; guessing it is a separate job, and
+/// `from` must be what the text actually is; guessing it is [`detect`]'s job, and
 /// not one this function does.
 pub fn convert(text: &str, from: Charset, to: Charset) -> Conversion {
     transcode::transcode(text, from, to)
@@ -110,36 +113,13 @@ pub fn decode_bytes(bytes: &[u8], from: Charset) -> Conversion {
         (bytes.iter().copied().map(char::from).collect(), 0)
     } else {
         let text = String::from_utf8_lossy(bytes).into_owned();
-        (text, broken_sequences(bytes))
+        (text, codecs::broken_sequences(bytes))
     };
     let out = convert(&text, from, Charset::Unicode);
     Conversion {
         unmapped: out.unmapped + damage,
         ..out
     }
-}
-
-/// How many characters lossy UTF-8 decoding had to replace. Zero for valid input,
-/// and replacement characters the source genuinely encoded are discounted so a
-/// document that legitimately contains one is not reported as damaged.
-fn broken_sequences(bytes: &[u8]) -> usize {
-    if std::str::from_utf8(bytes).is_ok() {
-        return 0;
-    }
-    String::from_utf8_lossy(bytes)
-        .matches(char::REPLACEMENT_CHARACTER)
-        .count()
-        .saturating_sub(genuine_replacements(bytes))
-}
-
-/// How many `U+FFFD` the bytes genuinely encode. Subtracting these is what keeps a
-/// source that legitimately contains a replacement character from being reported
-/// as damaged.
-fn genuine_replacements(bytes: &[u8]) -> usize {
-    bytes
-        .windows(3)
-        .filter(|window| *window == [0xEF, 0xBF, 0xBD])
-        .count()
 }
 
 #[cfg(test)]

--- a/crates/funput-core/tests/charset.rs
+++ b/crates/funput-core/tests/charset.rs
@@ -19,6 +19,8 @@
 mod cases;
 
 // Test modules.
+#[path = "charset/detect.rs"]
+mod detect;
 #[path = "charset/properties.rs"]
 mod properties;
 #[path = "charset/round_trip.rs"]

--- a/crates/funput-core/tests/charset/cases.rs
+++ b/crates/funput-core/tests/charset/cases.rs
@@ -98,3 +98,20 @@ pub const NON_CANONICAL: &[(&str, &str, usize)] = &[
     ("ấ", "â\u{301}", 1),               // precomposed
     ("Viê\u{323}t", "Viê\u{323}t", 0),  // already canonical
 ];
+
+/// Multi-word Vietnamese for the detector, in Unicode only — the test converts
+/// them itself, so no spelling is written by hand.
+///
+/// Multi-word on purpose. Sixteen bytes are a letter in **both** legacy charsets
+/// (`0xF4` is `ụ` in TCVN3 and `ơ` in VNI), so a one-word phrase is often genuinely
+/// undecidable and would fail the test for being right. Every phrase also avoids an
+/// uppercase toned vowel, which TCVN3 cannot spell — the test skips lossy
+/// conversions anyway, but a fixture that is silently skipped tests nothing.
+pub const DETECT_PHRASES: &[&str] = &[
+    "Cộng hòa Xã hội Chủ nghĩa Việt Nam",
+    "Nghị định của Chính phủ",
+    "Hà Nội mùa thu",
+    "Tôi yêu tiếng nước tôi",
+    "Bộ Giáo dục và Đào tạo",
+    "đường phố Sài Gòn",
+];

--- a/crates/funput-core/tests/charset/detect.rs
+++ b/crates/funput-core/tests/charset/detect.rs
@@ -1,0 +1,80 @@
+//! Detection, through the public API only.
+
+use funput_core::charset::{Charset, convert, detect};
+
+use crate::cases::DETECT_PHRASES;
+
+const CANDIDATES: [Charset; 4] = [
+    Charset::Unicode,
+    Charset::Tcvn3,
+    Charset::VniWindows,
+    Charset::UnicodeCombining,
+];
+
+/// Whether a phrase carries a tone anywhere.
+///
+/// Asked through the module's own signal rather than by inspecting characters:
+/// Unicode tổ hợp reports a rewrite once per toned letter, so a phrase with no
+/// tones converts to it unchanged and with nothing to report.
+fn has_a_tone(phrase: &str) -> bool {
+    convert(phrase, Charset::Unicode, Charset::UnicodeCombining).normalized > 0
+}
+
+/// The real use case, stated as a test: take Vietnamese text, write it the way a
+/// charset writes it, and the detector has to name that charset again. No spelling
+/// is hand-written anywhere — the fixtures are Unicode and the test does the rest.
+#[test]
+fn text_written_in_a_charset_is_detected_as_that_charset() {
+    for phrase in DETECT_PHRASES {
+        for charset in CANDIDATES {
+            let encoded = convert(phrase, Charset::Unicode, charset);
+            if encoded.unmapped > 0 {
+                continue; // the charset cannot spell this phrase; nothing to detect
+            }
+            if charset == Charset::UnicodeCombining && !has_a_tone(phrase) {
+                // With no tone to separate, this is byte-for-byte the Unicode
+                // spelling. A tie is the honest answer — see the test below.
+                continue;
+            }
+            assert_eq!(
+                detect(&encoded.text),
+                Some(charset),
+                "{phrase:?} written as {charset:?}"
+            );
+        }
+    }
+}
+
+/// The two Unicode charsets spell toneless text identically, so nothing can tell
+/// them apart — and nothing needs to, since either answer converts correctly.
+#[test]
+fn toneless_text_does_not_separate_the_two_unicode_charsets() {
+    // Shaped vowels but no tones: `Đ` and `ô` stay precomposed in both charsets.
+    let toneless = "Đông Nam kinh doanh";
+    assert!(!has_a_tone(toneless), "no tone marks in this phrase");
+    assert_eq!(
+        convert(toneless, Charset::Unicode, Charset::UnicodeCombining).text,
+        toneless
+    );
+}
+
+/// Every phrase in every charset, and detection never claims a charset that cannot
+/// actually read the text back.
+#[test]
+fn a_detected_charset_reads_the_text_without_loss() {
+    for phrase in DETECT_PHRASES {
+        for charset in CANDIDATES {
+            let encoded = convert(phrase, Charset::Unicode, charset);
+            if encoded.unmapped > 0 {
+                continue;
+            }
+            if let Some(guess) = detect(&encoded.text) {
+                let read = convert(&encoded.text, guess, Charset::Unicode);
+                assert_eq!(
+                    read.unmapped, 0,
+                    "{phrase:?} as {charset:?}, read as {guess:?}"
+                );
+            }
+        }
+    }
+}

--- a/crates/funput-core/tests/charset/properties.rs
+++ b/crates/funput-core/tests/charset/properties.rs
@@ -2,7 +2,7 @@
 //! arbitrary byte soup, half-words, unassigned codes, marks with nothing to
 //! attach to.
 
-use funput_core::charset::{Charset, convert};
+use funput_core::charset::{Charset, convert, detect, detect_bytes};
 use proptest::prelude::*;
 
 /// Anything a legacy document could hold: one char per byte, the whole range.
@@ -26,6 +26,10 @@ const NON_PIVOT: [Charset; 3] = [
     Charset::UnicodeCombining,
 ];
 
+/// Every charset. Unlike the in-crate `CANDIDATES` array this one **cannot** be
+/// guarded by a match: `Charset` is `#[non_exhaustive]`, so code outside the crate
+/// is required to write a wildcard arm and a fifth variant would slip past it.
+/// The compile-time guard lives in `charset::detect` instead.
 const ALL: [Charset; 4] = [
     Charset::Unicode,
     Charset::Tcvn3,
@@ -152,5 +156,27 @@ proptest! {
             let reread = convert(&out.text, Charset::UnicodeCombining, Charset::UnicodeCombining);
             prop_assert_eq!(reread.normalized, 0, "wrote a spelling it would rewrite");
         }
+    }
+
+    /// Detection is total: whatever the text is, it answers rather than panicking.
+    #[test]
+    fn detect_never_panics(text in LEGACY_TEXT, combining in COMBINING_TEXT, wide in "\\PC{0,64}") {
+        for source in [&text, &combining, &wide] {
+            let _ = detect(source);
+        }
+    }
+
+    /// Same for the byte door, on bytes that were never text at all.
+    #[test]
+    fn detect_bytes_never_panics(bytes in prop::collection::vec(any::<u8>(), 0..256)) {
+        let _ = detect_bytes(&bytes);
+    }
+
+    /// Every charset spells ASCII the same way, so ASCII can never separate them.
+    /// This is what makes an English document — or a plain one — come back `None`,
+    /// and it locks that guarantee against any future change to the scoring.
+    #[test]
+    fn no_charset_is_detected_from_pure_ascii(text in "[ -~]{0,64}") {
+        prop_assert_eq!(detect(&text), None, "{:?}", text);
     }
 }

--- a/docs/features/charset.md
+++ b/docs/features/charset.md
@@ -2,8 +2,8 @@
 
 ## Trạng thái
 
-Đã có: khung core và cả bốn bảng mã — **TCVN3**, **VNI-Windows**, **Unicode tổ hợp**.
-Còn lại: `detect()`, rồi các consumer (xem "Thứ tự hiện thực" ở cuối).
+Đã có: khung core, cả bốn bảng mã, và `detect()`. Còn lại là các consumer —
+`funput-config`, `funput convert`, rồi UI (xem "Thứ tự hiện thực" ở cuối).
 
 Tài liệu này chốt mô hình *trước* khi có code và được review riêng; nó vẫn là nơi
 mọi quyết định thiết kế sống, nên mỗi bảng mã mới cập nhật lại nó trong cùng PR.
@@ -349,13 +349,30 @@ match. Trục, driver và `detect` không đổi.
 
 pub fn convert(text: &str, from: Charset, to: Charset) -> Conversion;
 pub fn decode_bytes(bytes: &[u8], from: Charset) -> Conversion;
+pub fn detect(text: &str) -> Option<Charset>;
+pub fn detect_bytes(bytes: &[u8]) -> Option<Charset>;
 ```
 
-`detect(text) -> Option<Charset>` đến ở PR sau. Nó chấm điểm bằng cách thử giải mã
-theo từng bảng mã rồi đếm xem kết quả cho ra bao nhiêu âm tiết tiếng Việt hợp lệ,
-dùng `is_complete_syllable` sẵn có — giải mã sai bảng mã cho ra rác, và rác thì trượt
-bộ kiểm tra chính tả gần như hoàn toàn. Dưới ngưỡng chắc chắn thì trả `None` thay vì
-đoán bừa.
+Hai hàm `detect` chấm điểm bằng cách thử giải mã theo từng bảng mã rồi đếm xem kết
+quả cho ra bao nhiêu âm tiết tiếng Việt hợp lệ, dùng `is_complete_syllable` sẵn có —
+giải mã sai bảng mã cho ra rác, và rác thì trượt bộ kiểm tra chính tả gần như hoàn
+toàn. Hoà thì trả `None` thay vì đoán bừa.
+
+**Có hai cửa vì hai câu hỏi khác nhau.** `funput-config` cầm `&[u8]`: nhánh `None` của
+`encoding::decode` nghĩa là "không BOM, không phải UTF-8", mà chính điều đó là bằng
+chứng mạnh **chống lại** hai bảng mã Unicode — bằng chứng mà `detect(&str)` không thể
+thấy, vì lúc nó cầm được `&str` thì hư hỏng đã được vá rồi. Hai cửa **bất đồng** trên
+cùng một nội dung Latin-1; đó là bản chất, và có test ghim lại.
+
+### Thứ nó không làm được
+
+Mọi phán đoán ở đây đều **tương đối**: bốn giả thuyết, cái nào khớp nhất thì thắng.
+Một bảng mã chưa hiện thực không có giả thuyết riêng, nên nó luôn được trả lời bằng
+láng giềng gần nhất. VISCII chia sẻ chữ cái Latin-1 với TCVN3, nên văn bản VISCII bị
+báo là TCVN3 một cách tự tin và chuyển ra thứ sai một cách tinh vi.
+
+Không ngưỡng rẻ nào sửa được — cách sửa thật là hiện thực VISCII. Có test ghim hành vi
+này để người sau thấy đây là chuyện đã biết.
 
 Module nằm trong không gian tên riêng (`funput_core::charset::…`), **không** re-export
 ra gốc crate: khối "API FROZEN (Phase 8)" ở `lib.rs` liệt kê bề mặt cho
@@ -374,6 +391,8 @@ Mỗi mục một PR:
    codec kia.
 4. **Unicode tổ hợp**. Bảng mã duy nhất không phải byte, nên nó làm lộ hai lỗi thật
    trong `decode_bytes` và buộc `unmapped` tách làm hai.
-5. `detect()`.
+5. **`detect()`**. Nó làm lộ một lỗi thật trong hai codec byte: ký tự trên `U+00FF`
+   được nhận là `Exact`, nên `convert("Việt Nam", Tcvn3, Unicode)` báo 0 lỗi và ba
+   bảng mã hoà nhau tuyệt đối.
 6. `funput-config` (sửa import UniKey) → 7. `funput convert` → 8. UI Windows →
    9. UI Linux GTK.


### PR DESCRIPTION
Stacked on #225 — land that first, and this diff is `detect` alone.

Try every candidate, decode the text as each, count how much of the result is spellable Vietnamese. The right charset produces words; a wrong one produces letters that do not go together. A tie is `None`.

### Writing it uncovered a real bug in the shipped codecs

The byte-oriented codecs matched `_` for anything that was not a high byte, which caught `Err` from `u8::try_from` as well as ASCII. So `ệ` read as TCVN3 came back `Reading::Exact`:

```
convert("Việt Nam", Tcvn3,      Unicode) → "Việt Nam", unmapped 0
convert("Việt Nam", VniWindows, Unicode) → "Việt Nam", unmapped 0
convert("Việt Nam", Unicode,    Unicode) → "Việt Nam", unmapped 0
```

Three charsets tied exactly, so `detect` returned `None` for **every piece of ordinary Unicode Vietnamese** — the commonest input there is. It also made `Conversion`'s own doc false: it promises that reading with the wrong charset shows up as a high count, and for the most obvious case it did not.

A `.VnTime` document stores one byte per character and cannot hold `ệ` at all, so that reading is now `Unknown`. The character still comes through; the charset just says it was never its own. **No existing assertion changed** — both codec test files gained tests and lost none (`git diff --numstat`: 12/0 and 10/0). After the fix `detect` works with no special-case gate: `unmapped` simply means what it says.

`ordinary_unicode_is_detected_as_unicode` is the regression net.

### The word splitter is where the subtlety went

Both obvious rules are wrong:

- **Whitespace + trim non-letters off the ends** throws away the evidence. TCVN3 gives its commonest letters Latin-1 *symbols*, not letters — `ả` is `¶`, `á` is `¸`, `ơ` is `¬`. So `hoả` misread as Unicode is `ho¶`, trimming leaves `ho`, and the **wrong** candidate scores a syllable by discarding the byte that identified the right one. It also loses the first Vietnamese word of every line of a gõ tắt file (`trigger:expansion`, no space).
- **Split on everything that is not a letter** tears `Viê`/`t` apart at the combining mark and kills the tổ hợp candidate.

So: break on ASCII non-letters, keep every non-ASCII character inside the word. That includes `«` — which *cannot* be stripped, because `0xAB` is how TCVN3 spells `ô`. My first test asserted otherwise and was wrong; the corrected test now documents why.

### `is_complete_syllable`, not `is_reopenable_syllable`

The looser check would seem to help by accepting undiacriticked Vietnamese — but that is ASCII, which decodes identically under all four candidates and cancels out of every comparison. It buys nothing and costs real accuracy: its wider acceptance set is exactly where wrong decodings land. VNI `cà` misread as TCVN3 gives `caứ`, which the loose check accepts, tying the wrong candidate with the right one.

### Confidence is a margin, not a floor

The winner must beat the runner-up outright, and a majority of words must parse. A fixed floor either rejects legitimately short input (`"Việt Nam"` is two words) or sits too low to refuse anything.

### What it cannot do, pinned rather than hidden

Every judgement is relative — the best of four hypotheses. A charset nobody implemented has no hypothesis, so it gets answered with its nearest neighbour. **VISCII text is confidently reported as TCVN3** and converts to something subtly wrong. No cheap threshold fixes this; implementing VISCII does. `an_unimplemented_charset_is_answered_with_its_nearest_neighbour` pins the behaviour so the next reader finds it already known.

Also pinned: `detect` and `detect_bytes` disagree on the same Latin-1 content. That is inherent — bytes can be invalid UTF-8, which is evidence a `&str` no longer carries.

### `#[non_exhaustive]` and the candidate array

An array throws away the exhaustiveness `codecs` gets from its match, so a `const` block maps every variant to a slot and fails the build on a fifth. The same array in `tests/charset/properties.rs` **cannot** be guarded that way — `#[non_exhaustive]` forces a wildcard arm outside the crate — and now says so instead of pretending.

### Tests

The main one is generative: take Unicode phrases, write each the way a charset writes it, and detection has to name that charset again. No spelling is hand-written; the fixtures are Unicode and the test converts. Four skips are principled and commented — lossy forward conversions, and toneless phrases where the two Unicode charsets are genuinely indistinguishable.

### Verification

All four `rust` job commands clean with the feature **off**. With it on: 175 lib tests, 27 integration, 11 proptests. `check-loc.sh` went 293 → 295, exactly the two new `src/` files — and `charset/mod.rs` **dropped** from 144 to 124, because room for `mod detect;` came from moving the two UTF-8 byte helpers next to `is_byte_oriented`, whose doc already called them the byte layer's business.

**`src/charset/` is now at 5 entries — full.** The next thing that needs a home there has to earn its way in by merging something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
