### PR TITLE
fix(core): keep leading f/j as letters, not parked Telex tones

### DIFF
--- a/crates/funput-core/src/composition/intent/kinds/circumflex.rs
+++ b/crates/funput-core/src/composition/intent/kinds/circumflex.rs
@@ -50,9 +50,13 @@ fn revert(buffer: &str, key: char, target: Target) -> IntentResolution {
 }
 
 fn pending_tone(buffer: &str, before: usize) -> Option<(usize, Tone)> {
+    // A leading Telex tone letter is a literal onset (`fomo` → `fomo`), not a
+    // parked huyền. Same rule as deferred `w`: only a non-leading marker is a
+    // modifier (`chfana` → `chần`, `oso` → `ố`).
     buffer[..before]
         .char_indices()
         .rev()
+        .filter(|&(offset, _)| offset > 0)
         .find_map(|(offset, ch)| tone_from_key(ch).map(|tone| (offset, tone)))
 }
 

--- a/crates/funput-core/src/composition/intent/tests.rs
+++ b/crates/funput-core/src/composition/intent/tests.rs
@@ -35,3 +35,9 @@ fn early_tone_and_non_adjacent_revert() {
         IntentResolution::Reverted("chana".into())
     );
 }
+
+#[test]
+fn leading_tone_letter_stays_a_literal_onset() {
+    assert_eq!(apply("fom", 'o'), IntentResolution::Literal("fomo".into()));
+    assert_eq!(apply("jom", 'o'), IntentResolution::Literal("jomo".into()));
+}

--- a/crates/funput-core/tests/telex/basic.rs
+++ b/crates/funput-core/tests/telex/basic.rs
@@ -198,9 +198,17 @@ fn telex_validation_and_pass_through() {
         }
     );
     // Leading `f`/`j` and English words keep every keystroke (engine restores).
-    assert_eq!(type_keys("file"), "file");
-    assert_eq!(type_keys("from"), "from");
-    assert_eq!(type_keys("just"), "just");
+    // A free-position circumflex must not swallow a leading tone letter as a
+    // parked mark (`fomo` must not become `ồm`).
+    for method in [InputMethod::Telex, InputMethod::TelexAdvanced] {
+        for keys in ["file", "from", "just", "fomo", "jomo", "food"] {
+            assert_eq!(
+                crate::support::type_keys(method, keys),
+                keys,
+                "{method:?} {keys}"
+            );
+        }
+    }
     assert_eq!(
         apply("a", 'b', InputMethod::Telex, ToneStyle::Traditional),
         TransformResult {


### PR DESCRIPTION
## Summary

- Typing `fomo` in Telex / Telex+ no longer composes as `ồm`. A leading tone letter (`f`, `j`, …) is treated as a literal onset, matching deferred `w` (`offset > 0`).
- Free-position circumflex still applies a parked tone after an onset or vowel (`chfana` → `chần`, `oso` → `ố`). The same class of English words (`jomo`, `food`) stays Latin.
- Fix lives in `funput-core` only, so all five platforms pick it up.

## Test plan

- [x] `cargo test -p funput-core`
- [x] Telex: type `fomo` → `fomo` (not `ồm`); same for Telex+
- [x] Telex: `chfana` → `chần`, `oso` → `ố`, `homo` → `hôm` still hold
- [x] Telex: `file` / `from` / `just` / `jomo` / `food` stay Latin