### PR TITLE
fix(ios): add keyboard edge hit UI tests and enhance keyboard control layout

### DIFF
--- a/platforms/ios/FunputUITests/KeyboardEdgeHitUITests.swift
+++ b/platforms/ios/FunputUITests/KeyboardEdgeHitUITests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+/// Drives the installed keyboard extension at the physical screen edges.
+final class KeyboardEdgeHitUITests: XCTestCase {
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = ["-uitest-typing-harness"]
+        app.launch()
+    }
+
+    override func tearDownWithError() throws {
+        app?.terminate()
+        app = nil
+    }
+
+    @MainActor
+    func testAlphabeticRowOwnsBothScreenEdges() throws {
+        let field = app.textViews["typingHarness.field"]
+        XCTAssertTrue(field.waitForExistence(timeout: 10))
+        field.tap()
+        XCTAssertTrue(FunputKeyboardDriver.switchToFunputKeyboard(app))
+
+        let frames = FunputKeyboardDriver.resolveKeyFrames(app, for: "xabl")
+        let origin = app.coordinate(withNormalizedOffset: .zero)
+        let offsets: [CGFloat] = [1, 4, 8, 12, 16, 20, 24, 25, 26, 28, 32, 36, 40]
+        let leftXs = offsets
+        let rightXs = offsets.map { app.frame.maxX - $0 }
+
+        for x in leftXs {
+            tap(x: x, y: frames["a"]!.midY, from: origin)
+            tapCenter(of: frames["b"]!, from: origin)
+        }
+        for x in rightXs {
+            tap(x: x, y: frames["l"]!.midY, from: origin)
+            tapCenter(of: frames["b"]!, from: origin)
+        }
+
+        let expected = String(repeating: "ab", count: leftXs.count)
+            + String(repeating: "lb", count: rightXs.count)
+        XCTAssertEqual(field.value as? String, expected, """
+        app=\(app.frame), a=\(frames["a"]!), l=\(frames["l"]!), \
+        left=\(leftXs), right=\(rightXs)
+        """)
+    }
+
+    private func tapCenter(of frame: CGRect, from origin: XCUICoordinate) {
+        tap(x: frame.midX, y: frame.midY, from: origin)
+    }
+
+    private func tap(x: CGFloat, y: CGFloat, from origin: XCUICoordinate) {
+        origin.withOffset(CGVector(dx: x, dy: y)).tap()
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/KeyboardKeyControl.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/KeyboardKeyControl.swift
@@ -2,11 +2,9 @@
 import KeyboardLayout
 import ThemeSchema
 import UIKit
-
 @MainActor
 final class KeyboardKeyControl: UIControl {
     var onEvent: ((KeyboardKeyEvent) -> Void)?
-
     private let spec: KeySpec
     private let interactionControl = UIControl()
     private let contentView = KeyboardKeyContentView()
@@ -16,6 +14,7 @@ final class KeyboardKeyControl: UIControl {
     private var appliedInterfaceStyle: UIUserInterfaceStyle?
     private var appliedReduceTransparency: Bool?
     private var swipeTracker = KeySwipeGestureTracker()
+    private var visualFrame = CGRect.zero
     var role: KeyRole { spec.role }
 
     init(spec: KeySpec) {
@@ -34,11 +33,12 @@ final class KeyboardKeyControl: UIControl {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        let keycapHeight = bounds.height * theme.keycapHeightScale
+        let visual = visualFrame.isEmpty ? bounds : visualFrame
+        let keycapHeight = visual.height * theme.keycapHeightScale
         surface.frame = CGRect(
-            x: 0,
-            y: (bounds.height - keycapHeight) / 2,
-            width: bounds.width,
+            x: visual.minX,
+            y: visual.midY - keycapHeight / 2,
+            width: visual.width,
             height: keycapHeight
         )
         interactionControl.frame = bounds
@@ -46,6 +46,11 @@ final class KeyboardKeyControl: UIControl {
         surface.updateShape(cornerRadius: theme.cornerRadius)
     }
 
+    func applyFrames(interaction: CGRect, visual: CGRect) {
+        frame = interaction
+        visualFrame = visual.offsetBy(dx: -interaction.minX, dy: -interaction.minY)
+        setNeedsLayout()
+    }
     func apply(presentation: KeyboardPresentation, traits: UITraitCollection) {
         theme = presentation.theme
         applySurfaceIfNeeded(traits: traits)
@@ -81,6 +86,9 @@ final class KeyboardKeyControl: UIControl {
     private func configureInteraction() {
         contentView.isUserInteractionEnabled = false
         interactionControl.isMultipleTouchEnabled = false
+        // The iOS 27 remote keyboard host excludes fully transparent pixels from its hit region.
+        // A nonzero alpha keeps the touch grid live without a perceptible visual change.
+        interactionControl.backgroundColor = UIColor.white.withAlphaComponent(0.001)
         interactionControl.addAction(UIAction { [weak self] _ in
             self?.handleTouch(.pressed)
         }, for: .touchDown)

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView+InteractionFrames.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView+InteractionFrames.swift
@@ -1,0 +1,41 @@
+#if canImport(UIKit)
+import KeyboardLayout
+import UIKit
+
+extension KeyboardSurfaceView {
+    /// Gives fallback controls a complete, non-overlapping touch grid while their keycaps keep
+    /// the authored visual frames. The central overlay remains the primary multi-touch path.
+    func layoutKeyControls(in geometry: ResolvedKeyboard) {
+        let rows = geometry.rows.map { $0.filter { $0.spec.role != .placeholder } }
+            .filter { !$0.isEmpty }
+        for (rowIndex, row) in rows.enumerated() {
+            let visualMinY = row.map(\.frame.minY).min() ?? 0
+            let visualMaxY = row.map(\.frame.maxY).max() ?? bounds.height
+            let minY = rowIndex == rows.startIndex
+                ? geometry.toolbarFrame?.maxY ?? 0
+                : midpoint(rows[rowIndex - 1].visualMaxY, visualMinY)
+            let maxY = rowIndex == rows.index(before: rows.endIndex)
+                ? bounds.height
+                : midpoint(visualMaxY, rows[rowIndex + 1].visualMinY)
+
+            for (keyIndex, key) in row.enumerated() {
+                let minX = keyIndex == row.startIndex
+                    ? 0 : midpoint(row[keyIndex - 1].frame.maxX, key.frame.minX)
+                let maxX = keyIndex == row.index(before: row.endIndex)
+                    ? bounds.width : midpoint(key.frame.maxX, row[keyIndex + 1].frame.minX)
+                let interaction = CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+                keyControls[key.spec.id]?.applyFrames(interaction: interaction, visual: key.frame)
+            }
+        }
+    }
+
+    private func midpoint(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
+        lhs + (rhs - lhs) / 2
+    }
+}
+
+private extension Array where Element == ResolvedKey {
+    var visualMinY: CGFloat { map(\.frame.minY).min() ?? 0 }
+    var visualMaxY: CGFloat { map(\.frame.maxY).max() ?? 0 }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView.swift
@@ -100,9 +100,7 @@ public final class KeyboardSurfaceView: UIView {
         guard bounds.width > 0, bounds.height > 0 else { return }
         let geometry = resolvedGeometry()
         toolbarView.frame = geometry.toolbarFrame ?? .zero
-        geometry.keys.forEach { key in
-            keyControls[key.spec.id]?.frame = key.frame
-        }
+        layoutKeyControls(in: geometry)
         // The coordinator owns the snapshot and its revision; the overlay borrows the same one.
         touchCoordinator.updateGeometry(geometry)
         touchOverlay.adoptGeometry(touchCoordinator.geometrySnapshot)

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardTouchUIKit/Geometry/KeyboardGeometrySnapshot.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardTouchUIKit/Geometry/KeyboardGeometrySnapshot.swift
@@ -27,8 +27,8 @@ public struct KeyboardGeometrySnapshot: Sendable {
     /// left of `a` the nearest keycap is `q` above or `shift` below, never `a` — and landing on
     /// a modifier produces no character, which is indistinguishable from a dropped key.
     ///
-    /// Outside every band — the gaps between rows, and the slack above the first row and below
-    /// the last — the plain nearest-key search still decides, unchanged.
+    /// Row gaps are divided at their vertical midpoint. Only the slack above the first row and
+    /// below the last falls back to a plain nearest-key search.
     public func touchHit(at point: CGPoint) -> KeyboardTouchHit? {
         guard trackingBounds.contains(point) else { return nil }
         let candidates = rowBands.keys(containing: point.y) ?? keys

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardTouchUIKit/Geometry/KeyboardRowBands.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardTouchUIKit/Geometry/KeyboardRowBands.swift
@@ -1,14 +1,20 @@
 import CoreGraphics
 import KeyboardLayout
 
-/// The vertical band each keycap row occupies, resolved once so a hit test can ask which row a
-/// finger is in before it asks which key is nearest.
+/// The vertical band each keycap row owns, resolved once so a hit test can ask which row a
+/// finger intends before it asks which key is nearest.
 ///
 /// Without this, a row that is inset — the ASDF row is, half a key on each side, standard for
 /// QWERTY — leaves a strip at the rim where the nearest keycap by plain distance belongs to the
 /// row above or below. Every point in that strip resolves to `q` or `shift` rather than `a`,
 /// which reads to the user as the key not registering at all when the winner is a modifier.
 struct KeyboardRowBands: Sendable {
+    private struct Extent: Sendable {
+        let minY: CGFloat
+        let maxY: CGFloat
+        let keys: [ResolvedKey]
+    }
+
     private struct Band: Sendable {
         let minY: CGFloat
         let maxY: CGFloat
@@ -18,21 +24,33 @@ struct KeyboardRowBands: Sendable {
     private let bands: [Band]
 
     init(rows: [[ResolvedKey]]) {
-        bands = rows.compactMap { row in
+        let extents = rows.compactMap { row -> Extent? in
             let keys = row.filter { $0.spec.role != .placeholder }
             guard let minY = keys.map(\.frame.minY).min(),
                   let maxY = keys.map(\.frame.maxY).max() else { return nil }
-            return Band(minY: minY, maxY: maxY, keys: keys)
+            return Extent(minY: minY, maxY: maxY, keys: keys)
+        }
+        bands = extents.enumerated().map { index, extent in
+            let minY = index == extents.startIndex
+                ? extent.minY
+                : Self.midpoint(extents[index - 1].maxY, extent.minY)
+            let maxY = index == extents.index(before: extents.endIndex)
+                ? extent.maxY
+                : Self.midpoint(extent.maxY, extents[index + 1].minY)
+            return Band(minY: minY, maxY: maxY, keys: extent.keys)
         }
     }
 
-    /// The keys of the row whose band contains `y`, or `nil` when the point sits in a row gap or
-    /// past the outermost row. Callers fall back to searching every key in that case, which is
-    /// the behaviour every gap had before rows were considered at all.
+    /// Interior gaps are split at their midpoint. Past the outermost rows, callers fall back to
+    /// searching every key so the existing top and bottom tolerance remains unchanged.
     func keys(containing y: CGFloat) -> [ResolvedKey]? {
         for band in bands where y >= band.minY && y <= band.maxY {
             return band.keys
         }
         return nil
+    }
+
+    private static func midpoint(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
+        lhs + (rhs - lhs) / 2
     }
 }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardTouchUIKit/Geometry/KeyboardTrackingBounds.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardTouchUIKit/Geometry/KeyboardTrackingBounds.swift
@@ -13,7 +13,15 @@ public enum KeyboardTrackingBounds {
     public static func resolve(for geometry: ResolvedKeyboard) -> CGRect {
         let union = geometry.keys.reduce(CGRect.null) { $0.union($1.frame) }
         guard !union.isNull else { return .null }
-        let padded = union.insetBy(dx: -outerTolerance, dy: -outerTolerance)
+        let tolerated = union.insetBy(dx: -outerTolerance, dy: -outerTolerance)
+        // Theme padding can be wider than `outerTolerance`. Always own the full horizontal
+        // surface so a thumb against either screen edge still reaches the inset A/L row.
+        let padded = CGRect(
+            x: min(0, tolerated.minX),
+            y: tolerated.minY,
+            width: max(geometry.size.width, tolerated.maxX) - min(0, tolerated.minX),
+            height: tolerated.height
+        )
         // The toolbar handles its own touches. Letting the keycap slack reach over it would
         // swallow the bottom edge of every suggestion.
         //

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardTouchUIKitTests/Geometry/KeyboardRowBandsTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardTouchUIKitTests/Geometry/KeyboardRowBandsTests.swift
@@ -33,22 +33,47 @@ struct KeyboardRowBandsTests {
         #expect(snapshot.touchHit(at: CGPoint(x: 388, y: 195))?.key.id == "character-l")
     }
 
-    /// Between two rows no band contains the point, so the global nearest-key search still
-    /// decides. This is the path every row gap takes, and it must not change.
-    @Test("A point in the row gap still falls back to the nearest key")
-    func rowGapFallsBackToNearest() {
+    @Test("The gap above the inset row is split at its midpoint")
+    func upperRowGapIsSplit() {
         let snapshot = makeSnapshot()
-        // The 7pt gap between the qwerty row (…148.6) and the ASDF row (155.6…).
-        let hit = snapshot.touchHit(at: CGPoint(x: 200, y: 152))
 
-        #expect(hit != nil)
+        #expect(snapshot.touchHit(at: CGPoint(x: 2, y: 151))?.key.id == "character-q")
+        #expect(snapshot.touchHit(at: CGPoint(x: 2, y: 153))?.key.id == "character-a")
+        #expect(snapshot.touchHit(at: CGPoint(x: 388, y: 151))?.key.id == "character-p")
+        #expect(snapshot.touchHit(at: CGPoint(x: 388, y: 153))?.key.id == "character-l")
     }
 
-    private func makeSnapshot() -> KeyboardGeometrySnapshot {
+    @Test("The gap below the inset row is split at its midpoint")
+    func lowerRowGapIsSplit() {
+        let snapshot = makeSnapshot()
+
+        #expect(snapshot.touchHit(at: CGPoint(x: 2, y: 200))?.key.id == "character-a")
+        #expect(snapshot.touchHit(at: CGPoint(x: 2, y: 204))?.key.id == "shift")
+        #expect(snapshot.touchHit(at: CGPoint(x: 388, y: 200))?.key.id == "character-l")
+        #expect(snapshot.touchHit(at: CGPoint(x: 388, y: 204))?.key.id == "backspace")
+    }
+
+    @Test("Every alphabetic editor gives its side runway to A and L", arguments: [
+        KeyboardEditorMode.text, .search, .email, .url, .password,
+    ])
+    func alphabeticEditorsOwnTheirRims(editorMode: KeyboardEditorMode) {
+        let snapshot = makeSnapshot(editorMode: editorMode)
+        let row = snapshot.geometry.rows.first { $0.contains { $0.spec.id == "character-a" } }!
+        let y = row[0].frame.midY
+
+        #expect(snapshot.touchHit(at: CGPoint(x: 2, y: y))?.key.id == "character-a")
+        #expect(snapshot.touchHit(at: CGPoint(x: 388, y: y))?.key.id == "character-l")
+    }
+
+    private func makeSnapshot(editorMode: KeyboardEditorMode = .text) -> KeyboardGeometrySnapshot {
         KeyboardGeometrySnapshot(
             revision: 1,
             geometry: KeyboardGeometry.resolve(
-                layout: KeyboardLayoutResolver.resolve(inputMethod: .vni, mode: .letters),
+                layout: KeyboardLayoutResolver.resolve(
+                    inputMethod: .vni,
+                    mode: .letters,
+                    editorMode: editorMode
+                ),
                 size: CGSize(width: 390, height: 304),
                 sizing: KeyboardSizingProfile()
             )

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardTouchUIKitTests/Geometry/KeyboardTrackingSweepTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardTouchUIKitTests/Geometry/KeyboardTrackingSweepTests.swift
@@ -58,23 +58,32 @@ struct KeyboardTrackingSweepTests {
         #expect(strays.isEmpty, "\(strays.count) stray(s), first: \(strays.first as Any)")
     }
 
-    /// The region is built by padding the keycap union, so it can reach past the surface's own
-    /// bounds — and UIKit never routes a touch to a view outside those bounds. The slack that
-    /// escapes is therefore dead, and the tolerance a finger actually gets at the rim is the
-    /// layout's padding, not `outerTolerance`. Kept as an assertion so the gap between the two
-    /// numbers stays visible instead of reading as a 12pt promise.
-    @Test("Rim tolerance is bounded by the surface, not by outerTolerance")
-    func rimToleranceIsClampedByTheSurface() {
+    @Test("The tracking region reaches both surface edges")
+    func trackingReachesSurfaceEdges() {
         let (_, bounds, geometry) = makeGeometry()
         let keys = geometry.keys.map(\.frame)
         let leftmost = keys.map(\.minX).min() ?? 0
 
-        #expect(bounds.minX < 0)
-        #expect(bounds.maxX > size.width)
-        // Outside the surface the region cannot receive anything, so the usable slack on the
-        // left is the distance from the view edge to the first keycap.
+        #expect(bounds.minX <= 0)
+        #expect(bounds.maxX >= size.width)
         #expect(leftmost == 6)
         #expect(KeyboardTrackingBounds.outerTolerance == 12)
+    }
+
+    @Test("Maximum theme padding leaves no dead strip beside A or L")
+    func maximumPaddingKeepsRimsLive() {
+        let sizing = KeyboardSizingProfile(horizontalPadding: 16)
+        let geometry = KeyboardGeometry.resolve(
+            layout: KeyboardLayoutResolver.resolve(inputMethod: .vni, mode: .letters),
+            size: size,
+            sizing: sizing
+        )
+        let snapshot = KeyboardGeometrySnapshot(revision: 1, geometry: geometry)
+        let aRow = geometry.rows.first { $0.contains { $0.spec.id == "character-a" } }!
+        let y = aRow[0].frame.midY
+
+        #expect(snapshot.touchHit(at: CGPoint(x: 0.5, y: y))?.key.id == "character-a")
+        #expect(snapshot.touchHit(at: CGPoint(x: size.width - 0.5, y: y))?.key.id == "character-l")
     }
 
     private func makeGeometry() -> (KeyboardGeometrySnapshot, CGRect, ResolvedKeyboard) {


### PR DESCRIPTION
- Introduced `KeyboardEdgeHitUITests` to validate keyboard behavior at screen edges.
- Updated `KeyboardKeyControl` to support visual frame adjustments for better layout handling.
- Added `layoutKeyControls` method in `KeyboardSurfaceView` to ensure proper key interaction areas.
- Enhanced `KeyboardRowBands` to split gaps at midpoints for improved touch accuracy.
- Updated tests to verify new behavior in keyboard geometry and interaction.