### PR TITLE
feat(config): import a UniKey table written before Unicode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,18 +38,32 @@ jobs:
       - name: Test
         run: cargo test --workspace
 
-      # Optional features are invisible to the three steps above: with `charset`
-      # off, nothing lints or runs `funput-core/src/charset/**` and it would rot
-      # unnoticed. Same runner, so the cache is already warm and this costs one
-      # incremental build.
+      # `funput-config` enables `funput-core/charset`, and `funput-desktop` depends
+      # on it, so the three steps above resolve the feature **on** for the whole
+      # workspace. That covers the charset module — and leaves nothing checking the
+      # build *without* it, which is the shape the iOS and Android keyboards get
+      # from their `-p funput-ffi` / `-p funput-jni` scripts.
+      #
+      # So these two are the inverse of what they used to be. Naming the packages
+      # keeps `funput-config` out of the resolve graph, which is what keeps the
+      # feature off.
       #
       # Format and the line budget need no second pass: `cargo fmt` walks `mod`
       # items whatever their `cfg`, and check-loc.sh walks the filesystem.
-      - name: Clippy (charset)
-        run: cargo clippy -p funput-core --all-targets --features charset -- -D warnings
+      - name: Clippy (no charset — the mobile shape)
+        run: cargo clippy -p funput-core -p funput-ffi --all-targets -- -D warnings
 
-      - name: Test (charset)
-        run: cargo test -p funput-core --features charset
+      - name: Test (no charset — the mobile shape)
+        run: cargo test -p funput-core -p funput-ffi
+
+      # Compiling proves charset-off still builds; it does not prove the mobile
+      # artifacts are free of it. Add `funput-config` to `funput-ffi`'s dependencies
+      # and the step above stays green while the charset tables quietly land in the
+      # keyboard's cdylib. Only the dependency graph answers that.
+      - name: charset stays out of the mobile crates
+        run: |
+          ! cargo tree -p funput-ffi -e features | grep -q charset
+          ! cargo tree -p funput-jni -e features | grep -q charset
 
       - name: Line budget
         run: bash scripts/check-loc.sh

--- a/crates/funput-config/Cargo.toml
+++ b/crates/funput-config/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dependencies]
 # `Method`/`ToneStyle` convert to the engine's own enums, so the wire format and
 # the engine can never drift apart.
-funput-core = { path = "../funput-core" }
+# The UniKey import reads legacy Vietnamese encodings, which is `charset`'s job.
+funput-core = { path = "../funput-core", features = ["charset"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/funput-config/src/unikey.rs
+++ b/crates/funput-config/src/unikey.rs
@@ -19,11 +19,15 @@
 //! merge rule and the counters instead of restating them.
 
 mod encoding;
+mod trigger;
 
 use std::fmt;
 use std::path::Path;
 
+use funput_core::charset::Charset;
+
 use crate::transfer::PortableShortcut;
+use trigger::normalize_trigger;
 
 /// Why a macro table could not be turned into shortcut rows.
 ///
@@ -33,8 +37,11 @@ use crate::transfer::PortableShortcut;
 pub enum MacroError {
     /// The file could not be opened or read at all.
     Unreadable,
-    /// Read, but the bytes are not text this can decode — most likely a legacy
-    /// 8-bit Vietnamese encoding (TCVN3, VNI-Windows).
+    /// Read, but no encoding explains the bytes.
+    ///
+    /// The legacy Vietnamese charsets **were** tried, so reaching this means
+    /// detection declined — an encoding nobody has implemented, a genuine tie, or
+    /// too little Vietnamese to judge. Not that guessing was never attempted.
     UnknownEncoding,
     /// Decoded, but held no usable `trigger:expansion` line.
     NoEntries,
@@ -44,8 +51,10 @@ impl fmt::Display for MacroError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let text = match self {
             Self::Unreadable => "Không đọc được tệp bảng gõ tắt.",
+            // Naming the charsets that were tried would rot the day another is
+            // added, and the advice is the same either way.
             Self::UnknownEncoding => {
-                "Bảng mã của tệp này không đọc được. Hãy mở lại bằng UniKey và ghi \
+                "Không nhận ra bảng mã của tệp này. Hãy mở lại bằng UniKey và ghi \
                  bảng gõ tắt ra tệp mới (Unicode)."
             }
             Self::NoEntries => "Tệp không có mục gõ tắt nào.",
@@ -56,15 +65,36 @@ impl fmt::Display for MacroError {
 
 impl std::error::Error for MacroError {}
 
+/// What a macro file yielded.
+///
+/// `#[non_exhaustive]`: the shell will want the conversion's own counts the first
+/// time a TCVN3 file with an uppercase toned vowel turns up, and that is a matter of
+/// when rather than whether.
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct MacroImport {
+    pub rows: Vec<PortableShortcut>,
+    /// The charset the file turned out to be in, or `None` when nothing needed
+    /// deciding — an ASCII table reads the same either way, and claiming Unicode
+    /// there would invent a certainty nobody has.
+    ///
+    /// Worth showing the user: detection can be confidently wrong about an encoding
+    /// nobody has implemented, and naming its guess is the only warning available.
+    pub charset: Option<Charset>,
+}
+
 /// Read a UniKey macro file and turn it into shortcut rows.
-pub fn read_macro_file(path: &Path) -> Result<Vec<PortableShortcut>, MacroError> {
+pub fn read_macro_file(path: &Path) -> Result<MacroImport, MacroError> {
     let bytes = std::fs::read(path).map_err(|_| MacroError::Unreadable)?;
-    let text = encoding::decode(&bytes).ok_or(MacroError::UnknownEncoding)?;
-    let rows = parse_macros(&text);
+    let decoded = encoding::decode(&bytes).ok_or(MacroError::UnknownEncoding)?;
+    let rows = parse_macros(&decoded.text);
     if rows.is_empty() {
         return Err(MacroError::NoEntries);
     }
-    Ok(rows)
+    Ok(MacroImport {
+        rows,
+        charset: decoded.charset,
+    })
 }
 
 /// Parse the text of a macro table. Unusable lines are dropped, not reported: a
@@ -110,38 +140,6 @@ fn parse_line(line: &str) -> Option<PortableShortcut> {
         trigger,
         expansion: expansion.to_string(),
     })
-}
-
-/// Store the trigger the way the engine expects to find it.
-///
-/// `funput_engine`'s `classify_case` folds a typed word to lowercase before looking
-/// it up whenever its letters form a clean pattern, so `vn`, `Vn` and `VN` all reach
-/// a trigger stored as `vn` and re-case the expansion to match. A trigger stored in
-/// any other casing is only ever found by an exact match — so folding is what makes
-/// an imported `VN` usable, and *not* folding is what keeps a deliberate `iOS` from
-/// becoming unreachable.
-fn normalize_trigger(trigger: &str) -> String {
-    if folds_to_lowercase(trigger) {
-        trigger.to_lowercase()
-    } else {
-        trigger.to_string()
-    }
-}
-
-/// Mirrors `classify_case` returning `Some`: letters only, digits and punctuation
-/// ignored; first letter lowercase with the rest lowercase, or first letter
-/// uppercase with the rest all one case. A trigger with no letters folds to itself.
-fn folds_to_lowercase(trigger: &str) -> bool {
-    let mut letters = trigger.chars().filter(|c| c.is_alphabetic());
-    let Some(first) = letters.next() else {
-        return true;
-    };
-    let rest: Vec<char> = letters.collect();
-    if first.is_lowercase() {
-        rest.iter().all(|c| c.is_lowercase())
-    } else {
-        rest.iter().all(|c| c.is_uppercase()) || rest.iter().all(|c| c.is_lowercase())
-    }
 }
 
 #[cfg(test)]

--- a/crates/funput-config/src/unikey/encoding.rs
+++ b/crates/funput-config/src/unikey/encoding.rs
@@ -1,25 +1,125 @@
-//! Turning a macro file's bytes into text.
+//! Turning a macro file's bytes into text, whatever charset wrote it.
 //!
-//! Reading bytes rather than `fs::read_to_string` is deliberate: that helper hard-
-//! fails on anything that is not UTF-8 and cannot tell "this is UTF-16" from "this
-//! is corrupt". A legacy 8-bit Vietnamese encoding (TCVN3, VNI-Windows) still fails
-//! here, but as its own answer, so the caller can say what to do about it — guessing
-//! at one of those would silently import mojibake the user then has to hunt down row
-//! by row.
+//! Two questions, in order. **How are the bytes stored** — UTF-8, UTF-16, or one
+//! byte per character? Then **which Vietnamese charset spells the text** — Unicode,
+//! or one of the legacy ones a `.VnTime` or `VNI-Times` document uses.
+//!
+//! The second question is [`funput_core::charset`]'s, and asking it is what lets a
+//! UniKey table written before Unicode import at all. It used to be refused, with a
+//! message telling the user to go re-export from UniKey.
+//!
+//! # Guessing, carefully
+//!
+//! The old refusal had a good reason: guessing wrong "would silently import mojibake
+//! the user then has to hunt down row by row". Three things keep that from happening
+//! now. `detect` declines rather than picks when the evidence does not separate the
+//! charsets. Bytes that failed a UTF-8 decode may only be answered with a
+//! byte-oriented charset, or `decode_bytes` would hand back replacement characters
+//! dressed up as a reading. And whatever is guessed comes back to the caller, so the
+//! user is told rather than left to find out.
 
-/// Decode by byte-order mark, falling back to plain UTF-8. `None` when the bytes are
-/// none of those.
-pub(super) fn decode(bytes: &[u8]) -> Option<String> {
-    if let Some(rest) = bytes.strip_prefix(&[0xEF, 0xBB, 0xBF]) {
-        return String::from_utf8(rest.to_vec()).ok();
-    }
+use funput_core::charset::{self, Charset};
+
+/// Text from a macro file, and the charset it turned out to be written in.
+///
+/// `None` means nothing needed deciding — the file is ASCII, or carries too little
+/// Vietnamese to judge. Reporting `Unicode` there would invent a certainty nobody
+/// has.
+pub(super) struct Decoded {
+    pub(super) text: String,
+    pub(super) charset: Option<Charset>,
+}
+
+/// Read a macro file's bytes as text. `None` when nothing explains them.
+pub(super) fn decode(bytes: &[u8]) -> Option<Decoded> {
+    // A UTF-16 byte-order mark is unambiguous. Falling through to detection here
+    // would trade a precise diagnosis for a guess at Latin-1 nonsense.
     if let Some(rest) = bytes.strip_prefix(&[0xFF, 0xFE]) {
-        return utf16(rest, u16::from_le_bytes);
+        return utf16(rest, u16::from_le_bytes).map(unicode_text);
     }
     if let Some(rest) = bytes.strip_prefix(&[0xFE, 0xFF]) {
-        return utf16(rest, u16::from_be_bytes);
+        return utf16(rest, u16::from_be_bytes).map(unicode_text);
     }
-    String::from_utf8(bytes.to_vec()).ok()
+    // A UTF-8 BOM is a hint, not a verdict: editors write one regardless of what
+    // follows. Strip it and judge the rest — including falling through to the byte
+    // door, which is why the stripped bytes are what carries on.
+    let body = bytes.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(bytes);
+    match std::str::from_utf8(body) {
+        Ok(text) => Some(unicode_text(text.to_string())),
+        Err(_) => from_legacy_bytes(body),
+    }
+}
+
+/// Text that is already valid Unicode, normalised if it turns out to be spelled in
+/// some other Vietnamese charset.
+///
+/// Two of those reach here. A file in Unicode tổ hợp is valid UTF-8 already. So is a
+/// TCVN3 file that someone opened in Notepad and saved again — cp1252 and Latin-1
+/// agree across the whole range TCVN3 uses, so every code point survives and the
+/// result is valid UTF-8 whose *text* is still TCVN3. Both used to import as
+/// nonsense, silently.
+fn unicode_text(text: String) -> Decoded {
+    let sample = sample(text.as_bytes());
+    // Cutting at ASCII bytes of valid UTF-8 always lands on a character boundary,
+    // so the sample is valid UTF-8 too.
+    let sample = std::str::from_utf8(&sample).unwrap_or(&text);
+    let Some(charset) = charset::detect(sample) else {
+        return Decoded {
+            text,
+            charset: None,
+        };
+    };
+    if charset == Charset::Unicode {
+        return Decoded {
+            text,
+            charset: Some(charset),
+        };
+    }
+    Decoded {
+        text: charset::convert(&text, charset, Charset::Unicode).text,
+        charset: Some(charset),
+    }
+}
+
+/// Bytes that are not UTF-8 at all: one byte per character, if any charset says so.
+fn from_legacy_bytes(bytes: &[u8]) -> Option<Decoded> {
+    let charset = charset::detect_bytes(&sample(bytes))?;
+    // These bytes already failed a UTF-8 decode, so a charset that is not stored one
+    // byte per character cannot be the answer. Accepting one would run them through
+    // lossy decoding and import `U+FFFD` as though it were text.
+    if !charset::is_byte_oriented(charset) {
+        return None;
+    }
+    Some(Decoded {
+        text: charset::decode_bytes(bytes, charset).text,
+        charset: Some(charset),
+    })
+}
+
+/// The part of a macro file worth judging: everything to the right of the first
+/// colon on each line.
+///
+/// A trigger is a key, not prose — `vn`, `ct`, `sdt`, `url`. None of them is a
+/// Vietnamese syllable, so counting them drags every candidate down alike and a
+/// table mixing Vietnamese with phone numbers and URLs stops being detectable at
+/// all. Judging the values is not a workaround; it is the right question.
+///
+/// The split works *before* the charset is known because `:` and `\n` are ASCII in
+/// every charset here, and cutting at an ASCII byte always lands on a character
+/// boundary — so one function over bytes serves both doors.
+fn sample(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(bytes.len());
+    for line in bytes.split(|&b| b == b'\n') {
+        if line.first() == Some(&b';') {
+            continue;
+        }
+        let Some(colon) = line.iter().position(|&b| b == b':') else {
+            continue;
+        };
+        out.extend_from_slice(&line[colon + 1..]);
+        out.push(b'\n');
+    }
+    out
 }
 
 fn utf16(bytes: &[u8], unit: fn([u8; 2]) -> u16) -> Option<String> {
@@ -37,15 +137,23 @@ fn utf16(bytes: &[u8], unit: fn([u8; 2]) -> u16) -> Option<String> {
 mod tests {
     use super::*;
 
+    fn text_of(bytes: &[u8]) -> Option<String> {
+        decode(bytes).map(|d| d.text)
+    }
+
+    fn charset_of(bytes: &[u8]) -> Option<Charset> {
+        decode(bytes).and_then(|d| d.charset)
+    }
+
     #[test]
     fn a_utf8_bom_is_stripped_rather_than_decoded_into_the_text() {
-        assert_eq!(decode(b"\xEF\xBB\xBFvn").as_deref(), Some("vn"));
+        assert_eq!(text_of(b"\xEF\xBB\xBFvn").as_deref(), Some("vn"));
     }
 
     #[test]
     fn plain_utf8_without_a_bom_still_decodes() {
         assert_eq!(
-            decode("vn:việt nam".as_bytes()).as_deref(),
+            text_of("vn:việt nam".as_bytes()).as_deref(),
             Some("vn:việt nam")
         );
     }
@@ -59,18 +167,44 @@ mod tests {
             le.extend_from_slice(&unit.to_le_bytes());
             be.extend_from_slice(&unit.to_be_bytes());
         }
-        assert_eq!(decode(&le).as_deref(), Some(text));
-        assert_eq!(decode(&be).as_deref(), Some(text));
+        assert_eq!(text_of(&le).as_deref(), Some(text));
+        assert_eq!(text_of(&be).as_deref(), Some(text));
     }
 
+    /// A UTF-16 byte-order mark is a verdict, not a hint: a truncated file gets a
+    /// precise refusal rather than falling through to be guessed at as Latin-1.
     #[test]
     fn a_truncated_utf16_file_is_refused_rather_than_half_read() {
-        assert_eq!(decode(&[0xFF, 0xFE, 0x76]), None);
+        assert!(decode(&[0xFF, 0xFE, 0x76]).is_none());
     }
 
+    /// The feature: a legacy file used to be refused, and now reads.
     #[test]
-    fn a_legacy_eight_bit_encoding_is_refused() {
-        // 0xFF mid-stream: not valid UTF-8, no BOM to explain it.
-        assert_eq!(decode(b"vn:vi\xFFt nam"), None);
+    fn a_legacy_eight_bit_file_is_read_and_named() {
+        let file = b"vn:vi\xD6t nam\r\nhn:h\xB5 n\xE9i\r\n";
+        assert_eq!(charset_of(file), Some(Charset::Tcvn3));
+        assert!(text_of(file).unwrap().contains("việt nam"));
+    }
+
+    /// Bytes no charset explains are still refused — the old promise, kept.
+    #[test]
+    fn bytes_nothing_explains_are_still_refused() {
+        assert!(decode(b"note:the quick brown fox \xFF jumps over the lazy dog").is_none());
+    }
+
+    /// A file that needs no deciding says so, rather than claiming Unicode.
+    #[test]
+    fn an_ascii_file_names_no_charset() {
+        assert_eq!(charset_of(b"vn:viet nam\nhn:ha noi\n"), None);
+    }
+
+    /// Only the values are judged. A table whose triggers outnumber its Vietnamese
+    /// would otherwise drag every candidate below the detector's majority rule.
+    #[test]
+    fn only_the_value_side_of_a_line_is_judged() {
+        assert_eq!(
+            sample(b";comment\nvn:vi\xD6t nam\nno-colon\n"),
+            b"vi\xD6t nam\n"
+        );
     }
 }

--- a/crates/funput-config/src/unikey/encoding.rs
+++ b/crates/funput-config/src/unikey/encoding.rs
@@ -63,21 +63,31 @@ fn unicode_text(text: String) -> Decoded {
     // Cutting at ASCII bytes of valid UTF-8 always lands on a character boundary,
     // so the sample is valid UTF-8 too.
     let sample = std::str::from_utf8(&sample).unwrap_or(&text);
-    let Some(charset) = charset::detect(sample) else {
+    let detected = charset::detect(sample);
+    let Some(other) = detected.filter(|&c| c != Charset::Unicode) else {
         return Decoded {
             text,
-            charset: None,
+            charset: detected,
         };
     };
-    if charset == Charset::Unicode {
+
+    // Overriding a UTF-8 decode that already worked takes more than a majority
+    // vote: the reinterpretation has to explain **everything**.
+    //
+    // What this refuses is a table of typographic shortcuts. `µ` is TCVN3's `à` and
+    // `¶` is its `ả`, so two values in three read as Vietnamese and the vote
+    // carries — but `°` has no TCVN3 code at all, and that leftover is the tell.
+    // Without this, `mu:µ` imports as `mu:à`.
+    let converted = charset::convert(&text, other, Charset::Unicode);
+    if converted.unmapped > 0 {
         return Decoded {
             text,
-            charset: Some(charset),
+            charset: Some(Charset::Unicode),
         };
     }
     Decoded {
-        text: charset::convert(&text, charset, Charset::Unicode).text,
-        charset: Some(charset),
+        text: converted.text,
+        charset: Some(other),
     }
 }
 

--- a/crates/funput-config/src/unikey/tests.rs
+++ b/crates/funput-config/src/unikey/tests.rs
@@ -1,11 +1,13 @@
 use std::fs;
 
+use funput_core::charset::Charset;
+
 use super::*;
 use crate::test_support::unique_dir;
 
 /// Write `bytes` to a scratch file and read it back through the real entry point,
 /// so BOM handling and decoding are exercised rather than bypassed.
-fn read_bytes(bytes: &[u8]) -> Result<Vec<PortableShortcut>, MacroError> {
+fn read_bytes(bytes: &[u8]) -> Result<MacroImport, MacroError> {
     let dir = unique_dir("unikey");
     let path = dir.join("ukmacro.txt");
     fs::write(&path, bytes).expect("write scratch macro file");
@@ -27,7 +29,7 @@ const SAMPLE: &[u8] =
 #[test]
 fn the_stock_unikey_file_yields_its_one_pair() {
     let rows = read_bytes(SAMPLE);
-    let rows = rows.expect("the stock file must import");
+    let rows = rows.expect("the stock file must import").rows;
     assert_eq!(pairs(&rows), vec![("vn", "việt nam")]);
 }
 
@@ -36,7 +38,7 @@ fn the_bom_never_leaks_into_the_first_trigger() {
     // A stray U+FEFF on the trigger would make it unmatchable while looking right
     // in the settings list — the kind of bug that costs an afternoon.
     let rows = read_bytes(b"\xEF\xBB\xBFvn:viet nam");
-    let rows = rows.expect("import");
+    let rows = rows.expect("import").rows;
     assert_eq!(rows[0].trigger, "vn");
 }
 
@@ -120,7 +122,7 @@ fn a_utf16_file_decodes_through_its_bom() {
         bytes.extend_from_slice(&unit.to_le_bytes());
     }
     let rows = read_bytes(&bytes);
-    assert_eq!(pairs(&rows.expect("import")), vec![("vn", "việt nam")]);
+    assert_eq!(pairs(&rows.expect("import").rows), vec![("vn", "việt nam")]);
 }
 
 #[test]
@@ -129,11 +131,20 @@ fn a_file_with_nothing_usable_is_an_error() {
     assert_eq!(rows, Err(MacroError::NoEntries));
 }
 
+/// Detection now runs, and declines. `0xFF` is in no charset's table, so every
+/// candidate scores alike and none wins outright.
+///
+/// This one survives on a three-word majority, so the test below fails for the
+/// sturdier reason — a tie no amount of extra text can break.
 #[test]
-fn a_legacy_encoding_is_named_rather_than_guessed_at() {
-    // 0xFF is not valid UTF-8 and carries no BOM: report it instead of importing
-    // mojibake the user would have to hunt down row by row.
+fn a_file_no_charset_explains_is_still_refused() {
     let rows = read_bytes(b"vn:vi\xFFt nam");
+    assert_eq!(rows, Err(MacroError::UnknownEncoding));
+}
+
+#[test]
+fn english_text_ties_every_candidate_and_is_refused() {
+    let rows = read_bytes(b"note:the quick brown fox \xFF jumps over the lazy dog");
     assert_eq!(rows, Err(MacroError::UnknownEncoding));
 }
 
@@ -143,4 +154,110 @@ fn a_missing_file_is_unreadable() {
     let result = read_macro_file(&dir.join("nope.txt"));
     let _ = fs::remove_dir_all(&dir);
     assert_eq!(result, Err(MacroError::Unreadable));
+}
+
+/// **The reason this feature exists.** A table written before Unicode used to be
+/// refused with a message telling the user to go re-export from UniKey.
+#[test]
+fn a_tcvn3_table_imports_and_names_its_charset() {
+    let file = b"vn:vi\xD6t nam\r\nhn:h\xB5 n\xE9i\r\n";
+    let import = read_bytes(file).expect("a TCVN3 table must import");
+    assert_eq!(
+        pairs(&import.rows),
+        vec![("vn", "việt nam"), ("hn", "hà nội")]
+    );
+    assert_eq!(import.charset, Some(Charset::Tcvn3));
+}
+
+#[test]
+fn a_vni_table_imports_and_names_its_charset() {
+    let file = b"vn:vie\xE4t nam\r\nhn:ha\xF8 no\xE4i\r\n";
+    let import = read_bytes(file).expect("a VNI table must import");
+    assert_eq!(
+        pairs(&import.rows),
+        vec![("vn", "việt nam"), ("hn", "hà nội")]
+    );
+    assert_eq!(import.charset, Some(Charset::VniWindows));
+}
+
+/// **The regression net for the worst thing this change could have done.**
+///
+/// A UTF-8 file with one continuation byte lost is not any charset. Detection would
+/// happily answer `Unicode` — the surviving words still parse — and lossy decoding
+/// would then import a row containing `U+FFFD`, straight into `settings.json`.
+/// Bytes that failed a UTF-8 decode may only be answered with a byte-oriented
+/// charset, and refusing beats importing damage.
+#[test]
+fn broken_utf8_is_refused_rather_than_imported_with_replacement_characters() {
+    // `ệ` is E1 BB 87 and its last byte is gone, so the sequence runs into the `t`.
+    // No assertion that this is invalid UTF-8: `invalid_from_utf8` proves it at
+    // compile time, and writing the check anyway fails the build.
+    let broken = b"vn:vi\xE1\xBBt nam\nhn:h\xC3\xA0 n\xE1\xBB\x99i\n";
+    assert_eq!(read_bytes(broken), Err(MacroError::UnknownEncoding));
+}
+
+/// A file in Unicode tổ hợp is valid UTF-8 already, so it used to import with its
+/// combining marks intact — expansions that render correctly but never match what
+/// Funput itself types.
+#[test]
+fn a_combining_table_is_normalised_to_precomposed() {
+    let file = "vn:viê\u{323}t nam".as_bytes();
+    let import = read_bytes(file).expect("import");
+    assert_eq!(pairs(&import.rows), vec![("vn", "việt nam")]);
+    assert_eq!(import.charset, Some(Charset::UnicodeCombining));
+}
+
+/// A UTF-8 BOM is a hint, not a verdict — editors write one whatever follows. It is
+/// stripped, and the rest is judged on its own.
+#[test]
+fn a_utf8_bom_in_front_of_legacy_bytes_does_not_block_detection() {
+    let file = b"\xEF\xBB\xBFvn:vi\xD6t nam\r\nhn:h\xB5 n\xE9i\r\n";
+    let import = read_bytes(file).expect("import");
+    assert_eq!(import.charset, Some(Charset::Tcvn3));
+}
+
+/// Nothing to decide, so nothing is claimed. Reporting `Unicode` here would invent
+/// a certainty the file does not carry.
+#[test]
+fn an_ascii_table_imports_unchanged_and_names_no_charset() {
+    let import = read_bytes(b"vn:viet nam\nhn:ha noi\n").expect("import");
+    assert_eq!(
+        pairs(&import.rows),
+        vec![("vn", "viet nam"), ("hn", "ha noi")]
+    );
+    assert_eq!(import.charset, None);
+}
+
+/// **What judging only the values buys.** Triggers are keys — `vn`, `url`, `sdt` —
+/// and none is a Vietnamese syllable. Counting them drags every candidate below the
+/// detector's majority rule, and a table mixing Vietnamese with URLs and phone
+/// numbers stops being detectable at all. Judging the right-hand side is not a
+/// workaround; it is the right question.
+#[test]
+fn a_table_mixing_vietnamese_with_urls_is_still_detected() {
+    let file = b"vn:vi\xD6t nam\nurl:https://funput.app\nsdt:0912345678\nhn:h\xB5 n\xE9i\n";
+    let import = read_bytes(file).expect("import");
+    assert_eq!(import.charset, Some(Charset::Tcvn3));
+    assert_eq!(import.rows.len(), 4);
+}
+
+/// Emptiness beats encoding: a file with no pairs is `NoEntries`, never a charset
+/// complaint. Pins the ordering inside `read_macro_file`.
+#[test]
+fn a_file_with_no_pairs_is_reported_as_empty_not_as_an_encoding_problem() {
+    assert_eq!(read_bytes(b""), Err(MacroError::NoEntries));
+    assert_eq!(read_bytes(b";just a comment\n"), Err(MacroError::NoEntries));
+}
+
+/// **A known limitation, pinned rather than hidden.**
+///
+/// VISCII shares Latin-1's letters with TCVN3 and nobody has implemented it, so
+/// detection answers with the nearest charset it does know. `cà phê` imports as
+/// `cà phờ`. The charset report exists precisely so the user is told which bảng mã
+/// was assumed; the real fix is implementing VISCII, in `funput-core`.
+#[test]
+fn a_charset_nobody_implemented_imports_as_its_nearest_neighbour() {
+    let import = read_bytes(b"cf:c\xE0 ph\xEA").expect("import");
+    assert_eq!(import.charset, Some(Charset::Tcvn3));
+    assert_eq!(pairs(&import.rows), vec![("cf", "cà phờ")]);
 }

--- a/crates/funput-config/src/unikey/tests.rs
+++ b/crates/funput-config/src/unikey/tests.rs
@@ -261,3 +261,26 @@ fn a_charset_nobody_implemented_imports_as_its_nearest_neighbour() {
     assert_eq!(import.charset, Some(Charset::Tcvn3));
     assert_eq!(pairs(&import.rows), vec![("cf", "cà phờ")]);
 }
+
+/// A table of typographic shortcuts is not Vietnamese, and must not be read as
+/// though it were.
+///
+/// `µ` is TCVN3's `à` and `¶` is its `ả`, so two values in three read as syllables
+/// and the detector's majority vote carries. Judging only the values — right in
+/// principle — removed the accidental protection the triggers used to give. What
+/// stops it is that overriding a UTF-8 decode that already worked has to explain
+/// *everything*, and `°` has no TCVN3 code.
+#[test]
+fn a_symbol_table_is_not_reinterpreted_as_vietnamese() {
+    let import = read_bytes("mu:µ\npara:¶\ndeg:°\n".as_bytes()).expect("import");
+    assert_eq!(
+        pairs(&import.rows),
+        vec![("mu", "µ"), ("para", "¶"), ("deg", "°")],
+        "the symbols must survive as themselves"
+    );
+    assert_eq!(
+        import.charset,
+        Some(Charset::Unicode),
+        "read as the Unicode it decoded as, not as the charset that was declined"
+    );
+}

--- a/crates/funput-config/src/unikey/trigger.rs
+++ b/crates/funput-config/src/unikey/trigger.rs
@@ -1,0 +1,33 @@
+//! Storing an imported trigger the way the engine will look for it.
+
+/// Store the trigger the way the engine expects to find it.
+///
+/// `funput_engine`'s `classify_case` folds a typed word to lowercase before looking
+/// it up whenever its letters form a clean pattern, so `vn`, `Vn` and `VN` all reach
+/// a trigger stored as `vn` and re-case the expansion to match. A trigger stored in
+/// any other casing is only ever found by an exact match — so folding is what makes
+/// an imported `VN` usable, and *not* folding is what keeps a deliberate `iOS` from
+/// becoming unreachable.
+pub(super) fn normalize_trigger(trigger: &str) -> String {
+    if folds_to_lowercase(trigger) {
+        trigger.to_lowercase()
+    } else {
+        trigger.to_string()
+    }
+}
+
+/// Mirrors `classify_case` returning `Some`: letters only, digits and punctuation
+/// ignored; first letter lowercase with the rest lowercase, or first letter
+/// uppercase with the rest all one case. A trigger with no letters folds to itself.
+fn folds_to_lowercase(trigger: &str) -> bool {
+    let mut letters = trigger.chars().filter(|c| c.is_alphabetic());
+    let Some(first) = letters.next() else {
+        return true;
+    };
+    let rest: Vec<char> = letters.collect();
+    if first.is_lowercase() {
+        rest.iter().all(|c| c.is_lowercase())
+    } else {
+        rest.iter().all(|c| c.is_uppercase()) || rest.iter().all(|c| c.is_lowercase())
+    }
+}

--- a/crates/funput-core/src/charset/mod.rs
+++ b/crates/funput-core/src/charset/mod.rs
@@ -88,6 +88,20 @@ pub struct Conversion {
     pub normalized: usize,
 }
 
+/// Whether a charset stores one byte per character, drawn by a legacy font.
+///
+/// The distinction a caller needs when it already knows something about the bytes.
+/// Text that failed a UTF-8 decode cannot be in a charset that is *not* byte
+/// oriented, so a caller detecting the charset of such bytes must refuse those
+/// candidates — feeding them to [`decode_bytes`] would hand back replacement
+/// characters, which is a worse answer than admitting defeat.
+///
+/// Asking this instead of naming charsets is what lets a consumer keep working when
+/// a new one is added.
+pub fn is_byte_oriented(charset: Charset) -> bool {
+    codecs::is_byte_oriented(charset)
+}
+
 /// Convert text from one charset to another.
 ///
 /// `from` must be what the text actually is; guessing it is [`detect`]'s job, and

--- a/docs/features/charset.md
+++ b/docs/features/charset.md
@@ -2,8 +2,9 @@
 
 ## Trạng thái
 
-Đã có: khung core, cả bốn bảng mã, và `detect()`. Còn lại là các consumer —
-`funput-config`, `funput convert`, rồi UI (xem "Thứ tự hiện thực" ở cuối).
+Đã có: khung core, cả bốn bảng mã, `detect()`, và consumer đầu tiên — nhập bảng gõ
+tắt UniKey ở bảng mã cũ. Còn lại: `funput convert`, rồi UI (xem "Thứ tự hiện thực"
+ở cuối).
 
 Tài liệu này chốt mô hình *trước* khi có code và được review riêng; nó vẫn là nơi
 mọi quyết định thiết kế sống, nên mỗi bảng mã mới cập nhật lại nó trong cùng PR.
@@ -21,8 +22,8 @@ Chuyển **văn bản có sẵn** giữa các bảng mã tiếng Việt thông d
 - **Unicode tổ hợp** — theo quy ước UniKey, xem mục riêng bên dưới.
 
 Ngoài nhu cầu người dùng, tính năng này có một khách hàng nội bộ: import bảng gõ
-tắt UniKey hiện dừng ở `MacroError::UnknownEncoding` và bảo người dùng đi cài
-UniKey để dùng được Funput.
+tắt UniKey **từng** dừng ở `MacroError::UnknownEncoding` và bảo người dùng đi cài
+UniKey để dùng được Funput. Đã sửa.
 
 ## Không thuộc phạm vi
 
@@ -394,5 +395,8 @@ Mỗi mục một PR:
 5. **`detect()`**. Nó làm lộ một lỗi thật trong hai codec byte: ký tự trên `U+00FF`
    được nhận là `Exact`, nên `convert("Việt Nam", Tcvn3, Unicode)` báo 0 lỗi và ba
    bảng mã hoà nhau tuyệt đối.
-6. `funput-config` (sửa import UniKey) → 7. `funput convert` → 8. UI Windows →
-   9. UI Linux GTK.
+6. **`funput-config`** (sửa import UniKey). Consumer đầu tiên. Nó buộc `is_byte_oriented`
+   thành API công khai: byte đã trượt `from_utf8` thì không thể là bảng mã Unicode,
+   và nói điều đó mà không gọi tên bảng mã nào là thứ giữ cho consumer không phải
+   sửa khi có bảng mã mới.
+7. `funput convert` → 8. UI Windows → 9. UI Linux GTK.

--- a/platforms/windows/src/shared/commands/config.rs
+++ b/platforms/windows/src/shared/commands/config.rs
@@ -7,6 +7,7 @@ use funput_config::transfer::{
     self, ConfigDocument, ConfigError, ImportSummary, Source, SCHEMA_ID,
 };
 use funput_config::unikey::{self, MacroError};
+use funput_core::charset::Charset;
 
 use crate::shared::shell;
 
@@ -37,19 +38,22 @@ pub fn import_config(path: &Path) -> Result<ImportSummary, ConfigError> {
 /// (a repeated trigger takes the incoming expansion, rows absent from the file
 /// survive) and the same counters back. Restating that here would be a second copy
 /// of a rule that has to stay identical in both places.
-pub fn import_unikey_macros(path: &Path) -> Result<ImportSummary, MacroError> {
-    let shortcuts = unikey::read_macro_file(path)?;
+/// The charset comes back with the summary because reading a legacy table means
+/// *guessing* which one it was, and a guess the user cannot see is one they cannot
+/// check. `None` means nothing had to be guessed.
+pub fn import_unikey_macros(path: &Path) -> Result<(ImportSummary, Option<Charset>), MacroError> {
+    let import = unikey::read_macro_file(path)?;
     let document = ConfigDocument {
         schema: SCHEMA_ID.to_string(),
         version: transfer::CURRENT_VERSION,
         exported_at: None,
         source: None,
         preferences: None,
-        shortcuts: Some(shortcuts),
+        shortcuts: Some(import.rows),
         platform: None,
     };
     let mut settings = shell::snapshot();
     let summary = transfer::apply(&mut settings, &document);
     shell::replace_settings(settings);
-    Ok(summary)
+    Ok((summary, import.charset))
 }

--- a/platforms/windows/src/ui/settings_callbacks/config.rs
+++ b/platforms/windows/src/ui/settings_callbacks/config.rs
@@ -5,11 +5,15 @@
 //! overlay rather than `rfd::MessageDialog`, which draws a system message box with
 //! none of this window's Fluent tokens and no idea about the Mica backdrop.
 
+mod message;
+
 use slint::ComponentHandle;
 
 use crate::shared::commands;
 use crate::SettingsWindow;
-use funput_config::transfer::{self, ImportSummary};
+use funput_config::transfer;
+
+use message::{import_body, shown_path, unikey_body};
 
 use super::super::settings_window;
 
@@ -71,9 +75,14 @@ pub(super) fn wire(window: &SettingsWindow) {
             return;
         };
         match result {
-            Ok(summary) => {
+            Ok((summary, charset)) => {
                 settings_window::populate(&window);
-                notice(&window, "Đã nhập từ UniKey", &unikey_body(&summary), false);
+                notice(
+                    &window,
+                    "Đã nhập từ UniKey",
+                    &unikey_body(&summary, charset),
+                    false,
+                );
             }
             Err(err) => notice(
                 &window,
@@ -92,44 +101,4 @@ fn notice(window: &SettingsWindow, title: &str, body: &str, danger: bool) {
     window.set_notice_body(body.into());
     window.set_notice_danger(danger);
     window.set_notice_open(true);
-}
-
-/// Just the file name: the full path is the user's own choice from a dialog they
-/// just dismissed, and spelling it out crowds the notice for no new information.
-fn shown_path(path: &std::path::Path) -> String {
-    path.file_name()
-        .map(|name| name.to_string_lossy().into_owned())
-        .unwrap_or_else(|| path.display().to_string())
-}
-
-/// A macro file carries only gõ tắt, so this says nothing about typing options —
-/// unlike [`import_body`], which reports a whole config document. Zero of both
-/// means every row was already present with the same text.
-fn unikey_body(summary: &ImportSummary) -> String {
-    if summary.shortcuts_added == 0 && summary.shortcuts_updated == 0 {
-        return "Bảng gõ tắt đã có sẵn các mục này, không có gì thay đổi.".to_string();
-    }
-    format!(
-        "Gõ tắt: thêm {}, cập nhật {}.",
-        summary.shortcuts_added, summary.shortcuts_updated
-    )
-}
-
-fn import_body(summary: &ImportSummary) -> String {
-    let mut lines = vec!["Đã áp các tuỳ chọn gõ.".to_string()];
-    if summary.shortcuts_added > 0 || summary.shortcuts_updated > 0 {
-        lines.push(format!(
-            "Gõ tắt: thêm {}, cập nhật {}.",
-            summary.shortcuts_added, summary.shortcuts_updated
-        ));
-    } else {
-        lines.push("Không có gõ tắt mới.".to_string());
-    }
-    if summary.applied_platform {
-        lines.push("Đã áp phím tắt và danh sách app bỏ qua.".to_string());
-    }
-    if summary.newer_version {
-        lines.push("Lưu ý: tệp từ phiên bản mới hơn — một số mục có thể bị bỏ qua.".to_string());
-    }
-    lines.join("\n")
 }

--- a/platforms/windows/src/ui/settings_callbacks/config/message.rs
+++ b/platforms/windows/src/ui/settings_callbacks/config/message.rs
@@ -32,10 +32,14 @@ pub(super) fn unikey_body(summary: &ImportSummary, charset: Option<Charset>) -> 
             summary.shortcuts_added, summary.shortcuts_updated
         )
     };
-    match charset.map(charset_label) {
-        Some(label) => {
-            format!("{counts}\nĐọc bằng bảng mã {label} — hãy kiểm lại nếu chữ trông lạ.")
-        }
+    // Only when the text was actually *reinterpreted*. A file that read as ordinary
+    // Unicode had nothing guessed about it, and warning on every import teaches the
+    // user to ignore the line that matters.
+    match charset.filter(|&c| c != Charset::Unicode) {
+        Some(other) => format!(
+            "{counts}\nĐọc bằng bảng mã {} — hãy kiểm lại nếu chữ trông lạ.",
+            charset_label(other)
+        ),
         None => counts,
     }
 }

--- a/platforms/windows/src/ui/settings_callbacks/config/message.rs
+++ b/platforms/windows/src/ui/settings_callbacks/config/message.rs
@@ -1,0 +1,73 @@
+//! What each notice on the Dữ liệu page says.
+//!
+//! Split from the callbacks next door because building a sentence and wiring a
+//! Slint handler are different jobs, and only one of them is worth reading when
+//! the wording turns out to be wrong.
+
+use funput_config::transfer::ImportSummary;
+use funput_core::charset::Charset;
+
+/// Just the file name: the full path is the user's own choice from a dialog they
+/// just dismissed, and spelling it out crowds the notice for no new information.
+pub(super) fn shown_path(path: &std::path::Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+/// A macro file carries only gõ tắt, so this says nothing about typing options —
+/// unlike [`import_body`], which reports a whole config document. Zero of both
+/// means every row was already present with the same text.
+///
+/// A named charset means the file was written before Unicode and the encoding had
+/// to be *guessed*. Saying which one is the only warning available: the guess can
+/// be confidently wrong about an encoding Funput does not implement, and the user
+/// is the only one who can look at the result and tell.
+pub(super) fn unikey_body(summary: &ImportSummary, charset: Option<Charset>) -> String {
+    let counts = if summary.shortcuts_added == 0 && summary.shortcuts_updated == 0 {
+        "Bảng gõ tắt đã có sẵn các mục này, không có gì thay đổi.".to_string()
+    } else {
+        format!(
+            "Gõ tắt: thêm {}, cập nhật {}.",
+            summary.shortcuts_added, summary.shortcuts_updated
+        )
+    };
+    match charset.map(charset_label) {
+        Some(label) => {
+            format!("{counts}\nĐọc bằng bảng mã {label} — hãy kiểm lại nếu chữ trông lạ.")
+        }
+        None => counts,
+    }
+}
+
+/// What to call a charset in front of a user. `Charset` is `#[non_exhaustive]`, so
+/// the wildcard is required rather than a shortcut — and a charset with no name
+/// here simply goes unmentioned, which is better than a debug string.
+pub(super) fn charset_label(charset: Charset) -> &'static str {
+    match charset {
+        Charset::Unicode => "Unicode",
+        Charset::Tcvn3 => "TCVN3 (ABC)",
+        Charset::VniWindows => "VNI-Windows",
+        Charset::UnicodeCombining => "Unicode tổ hợp",
+        _ => "khác",
+    }
+}
+
+pub(super) fn import_body(summary: &ImportSummary) -> String {
+    let mut lines = vec!["Đã áp các tuỳ chọn gõ.".to_string()];
+    if summary.shortcuts_added > 0 || summary.shortcuts_updated > 0 {
+        lines.push(format!(
+            "Gõ tắt: thêm {}, cập nhật {}.",
+            summary.shortcuts_added, summary.shortcuts_updated
+        ));
+    } else {
+        lines.push("Không có gõ tắt mới.".to_string());
+    }
+    if summary.applied_platform {
+        lines.push("Đã áp phím tắt và danh sách app bỏ qua.".to_string());
+    }
+    if summary.newer_version {
+        lines.push("Lưu ý: tệp từ phiên bản mới hơn — một số mục có thể bị bỏ qua.".to_string());
+    }
+    lines.join("\n")
+}


### PR DESCRIPTION
Stacked on #226 — land that first, and this diff is the consumer alone.

The charset module's first consumer, and the reason it was written. A gõ tắt table in TCVN3 or VNI used to be refused with a message telling the user to go re-export from UniKey — that is, to install the program Funput replaces.

### The guard that separates a feature from a regression

Detection would answer `Unicode` for a UTF-8 file with one continuation byte lost — the surviving words still parse — and lossy decoding would then import a row containing **`U+FFFD` straight into `settings.json`**, past the `is_complete` filter that import never meets. Today that file is a clean `UnknownEncoding`.

Bytes that failed a UTF-8 decode cannot be in a Unicode charset, so the byte door refuses one. `broken_utf8_is_refused_rather_than_imported_with_replacement_characters` is the regression net.

Doing that **without naming charsets** is what keeps this consumer working when a new one lands, so `charset::is_byte_oriented` is now public — the one API addition, and the only place `funput-config` would otherwise have had to hard-code a list.

### Decoding, layered

Two questions in order: how are the bytes stored, then which charset spells the text.

- **UTF-16 BOM answers the first outright** — a truncated file keeps its precise refusal rather than being guessed at as Latin-1.
- **A UTF-8 BOM does not.** Editors write one whatever follows, so it is stripped and the rest judged on its own — including falling through to the byte door.

Converting only when the answer is tổ hợp would have been an arbitrary narrowing. The commonest case is **a TCVN3 file opened in Notepad and saved again**: cp1252 and Latin-1 agree across the whole range TCVN3 uses, so every code point survives and the result is valid UTF-8 whose *text* is still TCVN3. That imported as nonsense, silently. Anything not already Unicode is now converted.

### Detection judges the values, not the keys

Triggers are keys — `vn`, `url`, `sdt` — and none is a Vietnamese syllable. Counting them drags every candidate below the detector's majority rule, so a table mixing Vietnamese with URLs and phone numbers stops being detectable at all. `a_table_mixing_vietnamese_with_urls_is_still_detected` is the test that would fail without this.

The split works *before* the charset is known because `:` and `\n` are ASCII in all four — which also means one function over bytes serves both doors.

### The guess is visible

`read_macro_file` returns `MacroImport { rows, charset: Option<Charset> }` and the Windows notice names the bảng mã. A guess the user cannot see is one they cannot check, and detection can be confidently wrong about an encoding nobody has implemented — `a_charset_nobody_implemented_imports_as_its_nearest_neighbour` pins exactly that for VISCII, mirroring the core-side test.

`Option`, not `Charset`: an ASCII table needs no deciding, and reporting `Unicode` there would invent a certainty the file does not carry. `#[non_exhaustive]` from day one, because the shell will want `unmapped` the first time a TCVN3 file with an uppercase toned vowel turns up.

### CI's charset steps are now inverted

`funput-config` enables the feature and `funput-desktop` depends on it, so `--workspace` resolves charset **on**. The dedicated steps were checking nothing; what went unchecked was the build *without* it — the shape the iOS and Android keyboards get from their `-p`-scoped scripts.

A `cargo tree` assertion covers what compiling cannot: adding `funput-config` to `funput-ffi`'s dependencies would keep the build green while the tables quietly landed in the keyboard's cdylib.

### Verification

All workspace gates clean, plus the new charset-off pair and both tree assertions. 66 `funput-config` tests.

**`platforms/windows` is excluded from the workspace and CI never builds it**, so its caller was updated here and `cargo build` run locally rather than left to break at release. Splitting the notice text out of `settings_callbacks/config.rs` kept it inside the line budget (166 → 104).

### Two things deliberately not done

- **`platforms/windows` has two pre-existing clippy failures** (`shared/update/mod.rs`, `background/instance.rs`) — neither file is in this diff, and they fail on the base commit too. The release workflow runs `cargo build`, not clippy, so lint drift accumulated unnoticed. Worth a follow-up; not this PR's subject.
- **`funput-config/src/` has 6 entries and `src/settings/` has 9**, above the ≤5 convention the charset module follows. That crate predates the convention, and `src/`'s count is partly an artifact of the `mod.rs`-less layout. Restructuring it would conflict with every open branch here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
