### PR TITLE
fix(windows): spend the lead character only where autofill can happen

### DIFF
--- a/platforms/windows/src/background/hook/foreground.rs
+++ b/platforms/windows/src/background/hook/foreground.rs
@@ -13,10 +13,12 @@ use windows::Win32::System::Threading::{
     OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION,
 };
 use windows::Win32::UI::Accessibility::HWINEVENTHOOK;
-use windows::Win32::UI::WindowsAndMessaging::{GetWindowThreadProcessId, EVENT_SYSTEM_FOREGROUND};
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetClassNameW, GetWindowThreadProcessId, EVENT_SYSTEM_FOREGROUND,
+};
 
 use super::{toggle, FOREGROUND_IS_FUNPUT};
-use crate::background::tray;
+use crate::background::{inject, tray};
 use crate::shared::shell;
 
 static OWN_EXE_ID: OnceLock<String> = OnceLock::new();
@@ -34,7 +36,15 @@ pub(super) unsafe extern "system" fn win_event_proc(
     if event != EVENT_SYSTEM_FOREGROUND {
         return;
     }
-    let Some(id) = exe_of_window(hwnd) else {
+    // Whether a replacement sent to this app needs the lead character that makes its
+    // Backspaces unambiguous, or would only be hurt by the extra Backspace the lead
+    // costs — see `inject::send_plan`. Decided from the window's class first, so a
+    // window whose process cannot be resolved still updates it rather than leaving
+    // the previous app's answer standing.
+    let id = exe_of_window(hwnd);
+    inject::note_foreground(&class_of_window(hwnd), id.as_deref().unwrap_or_default());
+
+    let Some(id) = id else {
         return;
     };
     let is_funput = id == own_exe_id().as_str();
@@ -68,6 +78,18 @@ fn own_exe_id() -> &'static String {
             .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_lowercase()))
             .unwrap_or_else(|| "funput.exe".to_string())
     })
+}
+
+/// A window's class name — what the toolkit that drew it calls itself, which is how
+/// [`inject::note_foreground`] recognizes a browser engine without knowing the
+/// browser. Empty when the window is gone or has no class, which reads as "not a
+/// browser" and is the safe answer.
+unsafe fn class_of_window(hwnd: HWND) -> String {
+    // Class names are capped at 256 characters by `RegisterClass`, so this cannot
+    // truncate one that matters.
+    let mut buf = [0u16; 257];
+    let len = GetClassNameW(hwnd, &mut buf);
+    String::from_utf16_lossy(&buf[..len.max(0) as usize])
 }
 
 /// Resolve a window's owning process to its app id — the lowercased exe file name

--- a/platforms/windows/src/background/inject.rs
+++ b/platforms/windows/src/background/inject.rs
@@ -6,13 +6,16 @@
 //! caret is never steered with an arrow key. Everything a plan replaces sits
 //! *behind* the caret, so an injection is built to be incapable of reaching what is
 //! in front of it — including when the app holds a selection there, which
-//! [`send_plan`] neutralizes without having to know that it does.
+//! [`send_plan`] neutralizes with a lead character where that can happen at all.
+//! Where that is is [`lead`]'s business, and its alone.
 
 mod events;
+mod lead;
 mod modifiers;
 
 use funput_desktop::InjectPlan;
 
+pub use lead::note_foreground;
 pub use modifiers::send_plan_unmodified;
 
 use events::{deletions, raw_send, text};
@@ -29,8 +32,7 @@ fn leading_char(units: &[u16]) -> Option<&[u16]> {
     Some(&units[..if paired { 2 } else { 1 }])
 }
 
-/// Send a plan as one atomic `SendInput` batch. The only injection route there is —
-/// no app is special-cased, and none needs to be.
+/// Send a plan as one atomic `SendInput` batch. The only injection route there is.
 ///
 /// # The ambiguous first Backspace
 ///
@@ -69,6 +71,16 @@ fn leading_char(units: &[u16]) -> Option<&[u16]> {
 /// needed to get back. A pure insert (`backspaces == 0`) skips all this: its text is
 /// already the one keystroke that neutralizes a selection.
 ///
+/// # Why the lead is not paid everywhere
+///
+/// That extra Backspace is the whole cost of the trick, and some apps cannot pay it:
+/// a text engine that drops a key arriving in the same burst as the glyph before it
+/// loses precisely the lead's own Backspace and lands one character short. CorelDRAW
+/// does exactly that. So the lead is spent only where a selection can actually turn
+/// up in front of the caret, which [`lead`] decides by asking which engine drew the
+/// window rather than which app it is — and where being wrong is free in both
+/// directions, unlike the `Delete` primer.
+///
 /// # What it does not cover
 ///
 /// The lead only holds if it leaves the app with nothing to re-select, and a batch
@@ -92,7 +104,7 @@ pub fn send_plan(plan: &InjectPlan) {
     if plan.is_noop() {
         return;
     }
-    let lead = (plan.backspaces > 0)
+    let lead = (plan.backspaces > 0 && lead::wanted())
         .then(|| leading_char(&plan.units))
         .flatten();
     let mut inputs = Vec::new();
@@ -110,14 +122,19 @@ pub fn send_plan(plan: &InjectPlan) {
 mod tests {
     use windows::Win32::UI::Input::KeyboardAndMouse::{KEYEVENTF_KEYUP, VK_BACK, VK_DELETE};
 
+    use super::events::VK_BACK_SCAN;
     use super::*;
 
     /// The batch [`send_plan`] would emit, as `(wVk, wScan, keyup)` per event.
     /// Mirrors its assembly rather than calling it, since `send_plan` ends in
     /// `SendInput` and would type into whatever window the test runner has focused.
-    fn batch(backspaces: usize, output: &str) -> Vec<(u16, u16, bool)> {
+    /// `leading` stands in for [`lead::wanted`], which the real thing reads off the
+    /// foreground app.
+    fn batch(backspaces: usize, output: &str, leading: bool) -> Vec<(u16, u16, bool)> {
         let units: Vec<u16> = output.encode_utf16().collect();
-        let lead = (backspaces > 0).then(|| leading_char(&units)).flatten();
+        let lead = (backspaces > 0 && leading)
+            .then(|| leading_char(&units))
+            .flatten();
         let mut inputs = Vec::new();
         match lead {
             Some(lead) => {
@@ -156,14 +173,14 @@ mod tests {
         // lay down the text. The lead is what makes the deletions unambiguous even
         // when the app holds a selection in front of the caret.
         assert_eq!(
-            batch(1, "ộ"),
+            batch(1, "ộ", true),
             vec![
                 (0, 'ộ' as u16, false),
                 (0, 'ộ' as u16, true),
-                (VK_BACK.0, 0, false),
-                (VK_BACK.0, 0, true),
-                (VK_BACK.0, 0, false),
-                (VK_BACK.0, 0, true),
+                (VK_BACK.0, VK_BACK_SCAN, false),
+                (VK_BACK.0, VK_BACK_SCAN, true),
+                (VK_BACK.0, VK_BACK_SCAN, false),
+                (VK_BACK.0, VK_BACK_SCAN, true),
                 (0, 'ộ' as u16, false),
                 (0, 'ộ' as u16, true),
             ]
@@ -175,26 +192,53 @@ mod tests {
         // Whatever the plan, the batch deletes exactly the characters it typed on
         // top of the ones the plan asked for — never a character more.
         for (backspaces, output) in [(1, "ộ"), (3, "card "), (7, "Việt Nam ")] {
-            let (typed, deleted) = typed_and_deleted(&batch(backspaces, output));
+            let (typed, deleted) = typed_and_deleted(&batch(backspaces, output, true));
             assert_eq!(deleted, backspaces + 1, "plan ({backspaces}, {output:?})");
             assert_eq!(typed, output.chars().count() + 1);
         }
     }
 
     #[test]
+    fn without_the_lead_a_plan_is_sent_exactly_as_written() {
+        // The regression CorelDRAW reported: its text tool drops the Backspace that
+        // arrives right behind an inserted glyph, so the lead's own Backspace never
+        // lands and "dương" (4 Backspaces + "ương") came out "duương". No lead, no
+        // extra Backspace, nothing for it to lose.
+        assert_eq!(
+            batch(4, "ương", false),
+            [
+                [
+                    (VK_BACK.0, VK_BACK_SCAN, false),
+                    (VK_BACK.0, VK_BACK_SCAN, true)
+                ]
+                .repeat(4),
+                "ương"
+                    .encode_utf16()
+                    .flat_map(|u| [(0, u, false), (0, u, true)])
+                    .collect(),
+            ]
+            .concat()
+        );
+        let (typed, deleted) = typed_and_deleted(&batch(4, "ương", false));
+        assert_eq!((typed, deleted), ("ương".chars().count(), 4));
+    }
+
+    #[test]
     fn a_pure_insert_needs_no_lead() {
         // Its own text is already the keystroke that neutralizes a selection.
-        assert_eq!(
-            batch(0, "à"),
-            vec![(0, 'à' as u16, false), (0, 'à' as u16, true)]
-        );
+        for leading in [true, false] {
+            assert_eq!(
+                batch(0, "à", leading),
+                vec![(0, 'à' as u16, false), (0, 'à' as u16, true)]
+            );
+        }
     }
 
     #[test]
     fn a_surrogate_pair_leads_with_both_halves() {
         // One character, two units: splitting it would type half a code point and
         // then spend one Backspace on something the app never rendered.
-        let emitted = batch(1, "😀x");
+        let emitted = batch(1, "😀x", true);
         let units: Vec<u16> = "😀".encode_utf16().collect();
         assert_eq!(units.len(), 2);
         assert_eq!(
@@ -216,12 +260,14 @@ mod tests {
         // front of it. A `Delete` primer here once cost one character of existing
         // text per keystroke typed into the middle of a line — see [`send_plan`].
         for (backspaces, output) in [(0, "à"), (1, "ộ"), (3, "card ")] {
-            assert!(
-                batch(backspaces, output)
-                    .iter()
-                    .all(|&(vk, ..)| vk != VK_DELETE.0),
-                "forward delete in plan ({backspaces}, {output:?})"
-            );
+            for leading in [true, false] {
+                assert!(
+                    batch(backspaces, output, leading)
+                        .iter()
+                        .all(|&(vk, ..)| vk != VK_DELETE.0),
+                    "forward delete in plan ({backspaces}, {output:?})"
+                );
+            }
         }
     }
 }

--- a/platforms/windows/src/background/inject/events.rs
+++ b/platforms/windows/src/background/inject/events.rs
@@ -12,8 +12,21 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 
 use crate::shared::shell::INJECT_TAG;
 
-/// One virtual-key press or release.
-pub(super) fn vk_event(vk: VIRTUAL_KEY, up: bool) -> INPUT {
+/// Backspace's scan code. A position on the keyboard rather than a character, so
+/// it is the same on every layout, which is why it can be a constant here instead
+/// of a `MapVirtualKeyW` call on the hook's hot path.
+///
+/// Windows dispatches these events by `wVk` — `wScan` is along for the ride, and
+/// with the flags we use it changes nothing about *delivery*. What it changes is
+/// what the app reads: the scan code lands in the low-level hook struct and in
+/// `WM_KEYDOWN`'s `lParam`, and an app that keys off that instead of the virtual
+/// key sees a hardware Backspace rather than one claiming to come from nowhere.
+/// Costs nothing to be right about.
+pub(super) const VK_BACK_SCAN: u16 = 0x0E;
+
+/// One virtual-key press or release. `scan` is the key's scan code, or 0 when the
+/// event only has to reach apps that read `wVk` (see [`VK_BACK_SCAN`]).
+pub(super) fn vk_event(vk: VIRTUAL_KEY, scan: u16, up: bool) -> INPUT {
     let dw_flags = if up {
         KEYEVENTF_KEYUP
     } else {
@@ -24,7 +37,7 @@ pub(super) fn vk_event(vk: VIRTUAL_KEY, up: bool) -> INPUT {
         Anonymous: INPUT_0 {
             ki: KEYBDINPUT {
                 wVk: vk,
-                wScan: 0,
+                wScan: scan,
                 dwFlags: dw_flags,
                 time: 0,
                 dwExtraInfo: INJECT_TAG,
@@ -57,8 +70,8 @@ fn unicode_event(unit: u16, up: bool) -> INPUT {
 pub(super) fn deletions(n: usize) -> Vec<INPUT> {
     let mut v = Vec::with_capacity(n * 2);
     for _ in 0..n {
-        v.push(vk_event(VK_BACK, false));
-        v.push(vk_event(VK_BACK, true));
+        v.push(vk_event(VK_BACK, VK_BACK_SCAN, false));
+        v.push(vk_event(VK_BACK, VK_BACK_SCAN, true));
     }
     v
 }

--- a/platforms/windows/src/background/inject/lead.rs
+++ b/platforms/windows/src/background/inject/lead.rs
@@ -1,0 +1,167 @@
+//! Which foreground app needs [`super::send_plan`]'s lead character.
+//!
+//! The lead is what makes a plan's Backspaces unambiguous when the app has put a
+//! selection in front of the caret without being asked — see [`super::send_plan`]
+//! for the mechanism. It is not free: it costs one extra Backspace on every
+//! replacement, and an app whose text engine drops a key arriving in the same
+//! `SendInput` burst as the glyph before it loses precisely that Backspace and lands
+//! one character short.
+//!
+//! CorelDRAW is such an app. Its text tool draws on the canvas rather than through
+//! an edit control; measured with `duong` + `w`, whose plan is 4 Backspaces and
+//! "ương", the lead makes it 5, four land, and "dương" comes out "duương". The count
+//! is off by exactly one whether the plan asks for 1 Backspace or 5, which is what
+//! identifies the lead's own Backspace as the one being lost. Illustrator, Photoshop
+//! and every other canvas text engine are the same shape of program.
+//!
+//! # Asking the engine, not the app
+//!
+//! Inline autofill — a selected suffix completed as the user types — is a *browser
+//! engine* behaviour, not something each browser reinvents. So the question this
+//! module answers is which engine drew the window, which it reads off the top-level
+//! window class. Two strings cover every Chromium and every Gecko browser there is
+//! or will be: no fork to chase, no exe name to keep current, nothing for a user to
+//! configure. A list of browser executables would have been wrong the moment someone
+//! opened Thorium, and wrong in a way nobody could see.
+//!
+//! Autofill is not *only* a browser habit, though — Excel completes a cell from the
+//! column above the same way — and those apps share no engine to ask. They come in
+//! by exe name through [`AUTOFILL_APPS`], one measurement at a time.
+//!
+//! # Why being wrong here is cheap
+//!
+//! An earlier fix listed browsers to give them a `Delete` primer, and being on that
+//! list was *destructive*: `Delete` ate the character to the right of the caret in
+//! every page field of those browsers. This test is the opposite. Matching wrongly
+//! costs nothing — a lead is typed and paid back inside the same batch — which is
+//! what makes it safe that `Chrome_WidgetWin_1` also catches every Electron app.
+//! Those render text through Blink and pay the extra Backspace without noticing.
+//! Missing a match costs one visibly wrong syllable in an address bar, while inline
+//! autofill is actually showing. Neither direction can lose text.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Top-level window class of every Chromium-based browser, and of Electron and CEF
+/// apps along with them. The trailing number is a widget-type counter rather than a
+/// version, so this matches as a prefix.
+const CHROMIUM_CLASS_PREFIX: &str = "Chrome_WidgetWin_";
+
+/// Top-level window class of every Gecko-based browser — Firefox and its forks,
+/// Tor Browser included, all of which ship as `firefox.exe` anyway.
+const GECKO_CLASS: &str = "MozillaWindowClass";
+
+/// Apps that inline-autofill without being a browser, by lowercased exe file name —
+/// the same app id the per-app VI/EN memory uses.
+///
+/// Excel is here because it was measured, not assumed: its AutoComplete offers a
+/// value from the column above with the unmatched suffix selected, exactly the
+/// omnibox shape. Given "mai anh" in the cell above, typing `mai` shows "mai[ anh]"
+/// and the plan for `f` (2 Backspaces, "ài") came out "maài" — the first Backspace
+/// spent on the selection, "i" surviving, "ài" landing on top.
+///
+/// Nothing else is listed, and that is a claim rather than an oversight. Outlook's
+/// recipient fields and Explorer's address bar behave the same way to the eye but
+/// have not been put through the same test, and a Vietnamese tone rarely lands while
+/// one of their completions is live: the typed prefix stops matching the moment a
+/// diacritic appears, which is what makes this so much rarer than it looks. Each
+/// needs its own measurement before it earns a line, since guessing would put the
+/// lead's extra Backspace back on apps that never needed it.
+const AUTOFILL_APPS: &[&str] = &["excel.exe"];
+
+/// Whether the focused app is one of them. Written by the foreground hook, read by
+/// [`super::send_plan`] inside `WH_KEYBOARD_LL` — an atomic rather than a trip
+/// through the shell mutex, since that is the hot path.
+static FOREGROUND_INLINE_AUTOFILLS: AtomicBool = AtomicBool::new(false);
+
+/// The judgement itself, over what the foreground hook could see: the window's class
+/// and the owning process's exe name. Anything unrecognized gets no lead, which is
+/// also the state Funput starts in — before the first foreground event there is
+/// nothing to be wrong about.
+fn inline_autofills(window_class: &str, app_id: &str) -> bool {
+    window_class.starts_with(CHROMIUM_CLASS_PREFIX)
+        || window_class == GECKO_CLASS
+        || AUTOFILL_APPS.contains(&app_id)
+}
+
+/// Record the app that just took focus.
+pub fn note_foreground(window_class: &str, app_id: &str) {
+    let autofills = inline_autofills(window_class, app_id);
+    FOREGROUND_INLINE_AUTOFILLS.store(autofills, Ordering::Relaxed);
+}
+
+/// Whether a replacement should lead with its first character.
+pub(super) fn wanted() -> bool {
+    FOREGROUND_INLINE_AUTOFILLS.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_chromium_and_gecko_browser_leads() {
+        // Measured on this machine: Chrome reports `Chrome_WidgetWin_1`. Every
+        // Chromium fork inherits it, which is the whole point of matching here
+        // instead of on an exe name that changes with each new browser.
+        assert!(inline_autofills("Chrome_WidgetWin_1", "chrome.exe"));
+        assert!(inline_autofills("Chrome_WidgetWin_1", "thorium.exe"));
+        assert!(inline_autofills(
+            "Chrome_WidgetWin_0",
+            "some-old-chromium.exe"
+        ));
+        // Measured too: Firefox reports `MozillaWindowClass`, which its forks and
+        // Tor Browser inherit unchanged.
+        assert!(inline_autofills("MozillaWindowClass", "firefox.exe"));
+        assert!(inline_autofills("MozillaWindowClass", "librewolf.exe"));
+    }
+
+    #[test]
+    fn excel_leads_on_its_exe_name_because_no_engine_class_claims_it() {
+        // Measured: Excel is `XLMAIN`, which neither engine prefix matches, so it
+        // reaches the lead only through `AUTOFILL_APPS`. Both halves are asserted —
+        // if someone widens the class test to cover Excel, the exe entry becomes
+        // dead weight and should go with it.
+        assert!(inline_autofills("XLMAIN", "excel.exe"));
+        assert!(!"XLMAIN".starts_with(CHROMIUM_CLASS_PREFIX));
+        assert_ne!("XLMAIN", GECKO_CLASS);
+    }
+
+    #[test]
+    fn a_canvas_text_engine_does_not() {
+        // The regression this module exists for. Class measured on CorelDRAW 2026;
+        // the version suffix means the string itself must never be matched against.
+        assert!(!inline_autofills("CorelDRAW27", "coreldrw.exe"));
+        assert!(!inline_autofills("Notepad", "notepad.exe"));
+        assert!(!inline_autofills("SunAwtFrame", "idea64.exe"));
+        // A window whose class or process could not be read arrives as empty.
+        assert!(!inline_autofills("", ""));
+    }
+
+    #[test]
+    fn an_electron_app_is_caught_and_that_is_fine() {
+        // Claude and Cursor both report `Chrome_WidgetWin_1`, so they take the lead
+        // they have no address bar to need. Blink pays the extra Backspace, so this
+        // is the harmless direction — asserted so a future reader sees it is known
+        // and intended rather than a hole.
+        assert!(inline_autofills("Chrome_WidgetWin_1", "cursor.exe"));
+    }
+
+    #[test]
+    fn the_escape_hatch_is_spelled_the_way_the_hook_spells_apps() {
+        // `exe_of_window` lowercases, so an entry that is not lowercase is dead.
+        for id in AUTOFILL_APPS {
+            assert_eq!(*id, id.to_lowercase(), "{id} would never match");
+            assert!(id.ends_with(".exe"), "{id} is not an exe file name");
+        }
+    }
+
+    /// The only test that touches the process-global flag, so nothing it does can
+    /// race another test reading it.
+    #[test]
+    fn the_flag_follows_the_foreground_app_in_both_directions() {
+        note_foreground("Chrome_WidgetWin_1", "chrome.exe");
+        assert!(wanted());
+        note_foreground("CorelDRAW27", "coreldrw.exe");
+        assert!(!wanted());
+    }
+}

--- a/platforms/windows/src/background/inject/modifiers.rs
+++ b/platforms/windows/src/background/inject/modifiers.rs
@@ -37,7 +37,9 @@ pub fn send_plan_unmodified(plan: &InjectPlan, held: Mods) {
         return;
     }
 
-    let events = |up: bool| -> Vec<_> { down.iter().map(|&vk| vk_event(vk, up)).collect() };
+    // No scan code: these only have to convince Windows' own modifier state, which
+    // reads `wVk`. Backspace is the one key an app is likely to inspect itself.
+    let events = |up: bool| -> Vec<_> { down.iter().map(|&vk| vk_event(vk, 0, up)).collect() };
     raw_send(&events(true));
     send_plan(plan);
     raw_send(&events(false));


### PR DESCRIPTION
## The bug

Typing Vietnamese into CorelDRAW dropped one character per replacement: `Phus` gave `Phuú` instead of `Phú`.

`send_plan` leads every replacement with its first character, to neutralize a selection the app may be holding in front of the caret (Chrome's omnibox inline-autofills a selected suffix, and a bare Backspace would spend itself on that instead of on a character). The lead costs one extra Backspace. CorelDRAW cannot pay it — its text tool draws on the canvas rather than through an edit control, and a Backspace arriving in the same `SendInput` burst as the glyph before it gets swallowed.

Confirmed with a second case that pins the mechanism: `duong` + `w` is a 4-Backspace plan with `"ương"`, the lead makes it 5, four land, and `dương` came out `duương`. Off by exactly one whether the plan asks for 1 Backspace or 5 — which identifies the lead's *own* Backspace as the one being lost, not a general Backspace problem.

## The fix

Spend the lead only where a selection can actually turn up, and ask the **engine** rather than the app — the top-level window class:

| | |
|---|---|
| `Chrome_WidgetWin_` (prefix) | every Chromium browser, plus Electron and CEF |
| `MozillaWindowClass` | every Gecko browser, forks and Tor Browser included |

Two strings instead of a browser list that would have been wrong the moment someone opened Thorium, and wrong in a way nobody could see. Nothing to maintain, nothing for a user to configure.

Excel autofills without an engine to ask, so it comes in by exe name through `AUTOFILL_APPS` — measured, not assumed: with `mai anh` in the cell above, typing `mai` shows `mai[ anh]` and `f` produced `maài`.

## Why being wrong here is cheap

This is the property that separates it from the `Delete` primer removed earlier, where being on the list was destructive:

- **Matching wrongly costs nothing** — the lead is typed and paid back inside the same batch. That is why it is fine that `Chrome_WidgetWin_1` also catches every Electron app; Blink pays the extra Backspace without noticing. There is a test asserting this so it reads as intended rather than as a hole.
- **Missing a match** costs one visibly wrong syllable, transient, while a completion is showing.

Neither direction can lose text, and the default is the plain correct behaviour. That matters because the population is not enumerable: WinForms and WPF offer `AutoCompleteMode.Append` to every TextBox, so any line-of-business app can behave like Excel with no outward signal.

## Also

Backspace now carries its scan code (`0x0E`) instead of leaving `wScan` at 0. Windows dispatches on `wVk` so delivery is unchanged, but the scan code reaches the app's `lParam`, and apps that read it see a hardware Backspace. Modifier events in `modifiers.rs` deliberately keep `0` — they only have to convince Windows' own modifier state.

## Verification

Measured on Windows 11, both directions of the trade-off:

- **CorelDRAW** — `Phus` → `Phú`, `duongw` → `dương` ✅
- **Chrome omnibox** — `gow` → `gơ`, i.e. no regression on what the lead exists for ✅
- **Excel** — the autofill case gives `mài`, and ordinary typing in an empty column still correct now that Excel pays the extra Backspace ✅

`cargo fmt --check`, `cargo clippy --all-targets` (no new warnings), 58 tests pass, `scripts/check-loc.sh` OK — `lead.rs` is 96 code lines against the 150 budget.

## Known gaps, left unlisted on purpose

Outlook classic and Explorer's address bar look similar to the eye but have not been put through the same measurement, so they are documented in `lead.rs` rather than guessed into the list. A Vietnamese tone rarely lands while such a completion is live — the typed prefix stops matching the moment a diacritic appears, which is why Excel needed a deliberate setup to reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
