### PR TITLE
fix(engine): keep standalone shaped vowels in Telex at word boundary

### DIFF
--- a/crates/funput-core/README.en.md
+++ b/crates/funput-core/README.en.md
@@ -40,10 +40,14 @@ engine.
 | `is_valid(buffer) -> bool` | Buffer **could** still be a valid VN syllable (lenient) |
 | `is_complete_syllable(buffer) -> bool` | Buffer is a **complete** VN syllable (strict) |
 | `is_definitely_invalid(buffer) -> bool` | Buffer can **definitely** never become a VN syllable |
+| `is_bare_shaped_vowel(buffer) -> bool` | Buffer is exactly one vowel carrying mũ/móc/trần (`ă`, `â`, `ắ`) |
 
-The three `is_*` functions let `funput-engine` decide whether to keep the Vietnamese text or restore the
+The `is_*` functions let `funput-engine` decide whether to keep the Vietnamese text or restore the
 raw Latin: `is_complete_syllable` is used at a word boundary; `is_definitely_invalid` drives eager
-restore (flip back the instant it is certain the word is not Vietnamese).
+restore (flip back the instant it is certain the word is not Vietnamese). `is_bare_shaped_vowel` is a
+deliberate exception at a word boundary: Vietnamese has no open `ă`/`â` rhyme so they are not
+"complete", yet an isolated shaped vowel can only have been meant — which is how Telex `aw` keeps `ă`
+just as VNI `a8` does.
 
 ```rust
 use funput_core::{apply, InputMethod, ToneStyle, TransformKind};

--- a/crates/funput-core/README.md
+++ b/crates/funput-core/README.md
@@ -39,10 +39,13 @@ Bề mặt nhỏ và ổn định cho `funput-engine`. Đổi breaking cần đ�
 | `is_valid(buffer) -> bool` | Buffer **có thể** còn là âm tiết VN hợp lệ (lenient) |
 | `is_complete_syllable(buffer) -> bool` | Buffer là âm tiết VN **hoàn chỉnh** (strict) |
 | `is_definitely_invalid(buffer) -> bool` | Buffer **chắc chắn** không thể thành âm tiết VN |
+| `is_bare_shaped_vowel(buffer) -> bool` | Buffer chỉ gồm đúng một nguyên âm mang mũ/móc/trần (`ă`, `â`, `ắ`) |
 
-Ba hàm `is_*` là để `funput-engine` quyết định giữ chữ Việt hay khôi phục về Latin gốc:
+Các hàm `is_*` là để `funput-engine` quyết định giữ chữ Việt hay khôi phục về Latin gốc:
 `is_complete_syllable` dùng ở ranh giới từ; `is_definitely_invalid` dùng cho eager-restore (đổi lại
-ngay khi biết chắc không phải tiếng Việt).
+ngay khi biết chắc không phải tiếng Việt). `is_bare_shaped_vowel` là ngoại lệ có chủ đích ở ranh giới
+từ: tiếng Việt không có vần mở `ă`/`â` nên chúng không "hoàn chỉnh", nhưng gõ trơ một nguyên âm có dấu
+phụ thì chỉ có thể là chủ đích — nhờ đó Telex `aw` giữ được `ă` đúng như VNI `a8`.
 
 ```rust
 use funput_core::{apply, InputMethod, ToneStyle, TransformKind};

--- a/crates/funput-core/src/lib.rs
+++ b/crates/funput-core/src/lib.rs
@@ -9,7 +9,8 @@
 //! [`InputMethod`], [`TransformKind`], [`TransformResult`], [`apply`], and the
 //! syllable-structure checks [`is_valid`] (lenient) / [`is_complete_syllable`]
 //! (strict, for word boundaries) / [`is_reopenable_syllable`] (re-opening a
-//! committed word for editing).
+//! committed word for editing) / [`is_bare_shaped_vowel`] (the lone-vowel
+//! exception to the boundary check).
 //! Breaking changes require semver coordination with the engine.
 //!
 //! # Contract
@@ -70,7 +71,9 @@ pub struct TransformResult {
 /// );
 /// ```
 pub use validation::reachability::is_definitely_invalid;
-pub use validation::syllable::{is_complete_syllable, is_reopenable_syllable, is_valid};
+pub use validation::syllable::{
+    is_bare_shaped_vowel, is_complete_syllable, is_reopenable_syllable, is_valid,
+};
 
 #[inline]
 pub fn apply(

--- a/crates/funput-core/src/validation/syllable/mod.rs
+++ b/crates/funput-core/src/validation/syllable/mod.rs
@@ -3,22 +3,18 @@
 //! [`modifier`] decides whether a modifier keystroke should apply; the checks
 //! here answer the coarser question of whether a buffer *is* a Vietnamese
 //! syllable — leniently mid-typing ([`is_valid`]) or strictly at a word boundary
-//! ([`is_complete_syllable`]).
+//! ([`is_complete_syllable`]). The strict verdicts all read one [`status`] parse.
 
 mod modifier;
 mod spelling;
+mod status;
 
-use crate::orthography::glide;
-use crate::unicode::marks::Tone;
-use crate::validation::coda::{
-    STOP_CODAS, VALID_CODAS, coda_in, normalized_coda, nucleus_tone, toneless_rhyme,
-};
-use crate::validation::parse::{is_valid_onset, parse_syllable};
+use crate::unicode::shapes::shape_on_vowel;
+use crate::validation::parse::parse_syllable;
 use crate::validation::reachability::{has_shaped_rhyme_prefix, is_definitely_invalid_parts};
-use crate::validation::rhyme::{is_valid_rhyme, matches_deshaped};
 
 use modifier::{ModifierKind, validate_parts};
-use spelling::violates_ckg_spelling;
+use status::{SyllableStatus, classify};
 
 pub use modifier::{ModifierValidation, validate_shape, validate_stroke, validate_tone};
 
@@ -45,69 +41,6 @@ pub fn is_valid(buffer: &str) -> bool {
     )
 }
 
-/// How a finished buffer sits against Vietnamese syllable structure.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum SyllableStatus {
-    /// Not a Vietnamese syllable, and no diacritic can make it one: `cảd` (card),
-    /// `côl` (cool), `tẽt` (text).
-    Invalid,
-    /// Structurally a syllable, but still short of the **diacritics** the word
-    /// needs — which is exactly how a word looks when the user commits it before
-    /// finishing it. Three ways that happens:
-    /// - a **stop coda** (`p t c ch`) with no tone, where Vietnamese requires sắc
-    ///   or nặng: `chuc` → `chúc`, `tich` → `tích`;
-    /// - a rhyme that only exists shaped: `dien` → `diên`, `thuo` → `thuơ`;
-    /// - both at once: `nuoc` → `nước`.
-    AwaitingDiacritic,
-    /// A real Vietnamese syllable as it stands: `chào`, `việt`, `ma`, `tét`.
-    Complete,
-}
-
-fn classify(buffer: &str) -> SyllableStatus {
-    let parts = parse_syllable(buffer);
-    let Some((coda, coda_len)) = normalized_coda(&parts) else {
-        return SyllableStatus::Invalid;
-    };
-    let coda = &coda[..coda_len];
-
-    let structure_ok = !parts.invalid_onset
-        && is_valid_onset(parts.onset)
-        // A tone parked on the `qu`/`gi` glide is a mid-composition transient, not
-        // a finished syllable: `qúy` is a misspelling of `quý`.
-        && !glide::onset_holds_tone(parts.onset)
-        && parts.nucleus_chars().next().is_some()
-        && !violates_ckg_spelling(parts.onset, &parts)
-        && coda_in(VALID_CODAS, coda);
-    if !structure_ok {
-        return SyllableStatus::Invalid;
-    }
-
-    // The nucleus+coda must be a real Vietnamese rhyme (Level 2): keeps `việt`,
-    // `trường` … but reverts structurally-ok-but-nonexistent rhymes. A rhyme that
-    // exists only *shaped* is that same rhyme with its shape keys still to come —
-    // `ien` is `iên` minus the circumflex — so it is unfinished, not wrong.
-    let rhyme = toneless_rhyme(&parts, coda);
-    let status = if is_valid_rhyme(&rhyme) {
-        SyllableStatus::Complete
-    } else if matches_deshaped(&rhyme) {
-        SyllableStatus::AwaitingDiacritic
-    } else {
-        return SyllableStatus::Invalid;
-    };
-
-    // Phonotactics: a stop coda only allows sắc / nặng. A wrong tone (huyền / hỏi /
-    // ngã) is what catches English `text` (→ `tẽt`) or `coot` (→ `côt`); no tone at
-    // all is the un-toned form of a real word, which a tone key can still complete.
-    if coda_in(STOP_CODAS, coda) {
-        return match nucleus_tone(parts.nucleus_chars()) {
-            Some(Tone::Sac | Tone::Nang) => status,
-            None => SyllableStatus::AwaitingDiacritic,
-            Some(_) => SyllableStatus::Invalid,
-        };
-    }
-    status
-}
-
 /// Returns true if `buffer` is a *complete* valid Vietnamese syllable.
 ///
 /// **Strict**: the coda must be a real Vietnamese final (`c ch m n ng nh p t`),
@@ -117,6 +50,24 @@ fn classify(buffer: &str) -> SyllableStatus {
 /// `côl` (cool), `tẽt` (text).
 pub fn is_complete_syllable(buffer: &str) -> bool {
     matches!(classify(buffer), SyllableStatus::Complete)
+}
+
+/// Returns true if `buffer` is a lone shaped vowel: `ă`, `â`, `ắ`, `ậ` — one
+/// character, no onset, no coda, carrying mũ / móc / trần.
+///
+/// These are **not** complete syllables and [`is_complete_syllable`] rightly says
+/// so: `ă` and `â` never stand as an open rhyme in Vietnamese, they only appear
+/// before a coda (`ăn`, `âm`). But a *word* that is nothing but a shaped vowel is
+/// still unambiguous intent — no English word spells one, and naming the letter
+/// itself is a real thing users type. Callers deciding whether to restore raw
+/// keystrokes at a word boundary use this to keep the vowel; callers judging
+/// Vietnamese spelling must not.
+pub fn is_bare_shaped_vowel(buffer: &str) -> bool {
+    let mut chars = buffer.chars();
+    let Some(vowel) = chars.next() else {
+        return false;
+    };
+    chars.next().is_none() && shape_on_vowel(vowel).is_some()
 }
 
 /// Returns true if a committed `buffer` may be re-opened as a live composition

--- a/crates/funput-core/src/validation/syllable/status.rs
+++ b/crates/funput-core/src/validation/syllable/status.rs
@@ -1,0 +1,79 @@
+//! Where a finished buffer stands against Vietnamese syllable structure.
+//!
+//! One parse answers all three of the boundary questions in [`super`]: onset and
+//! coda must be legal, the rhyme must exist in the inventory, and a stop coda
+//! must carry a tone Vietnamese allows. The public predicates are thin readings
+//! of the [`SyllableStatus`] this returns.
+
+use crate::orthography::glide;
+use crate::unicode::marks::Tone;
+use crate::validation::coda::{
+    STOP_CODAS, VALID_CODAS, coda_in, normalized_coda, nucleus_tone, toneless_rhyme,
+};
+use crate::validation::parse::{is_valid_onset, parse_syllable};
+use crate::validation::rhyme::{is_valid_rhyme, matches_deshaped};
+
+use super::spelling::violates_ckg_spelling;
+
+/// How a finished buffer sits against Vietnamese syllable structure.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum SyllableStatus {
+    /// Not a Vietnamese syllable, and no diacritic can make it one: `cảd` (card),
+    /// `côl` (cool), `tẽt` (text).
+    Invalid,
+    /// Structurally a syllable, but still short of the **diacritics** the word
+    /// needs — which is exactly how a word looks when the user commits it before
+    /// finishing it. Three ways that happens:
+    /// - a **stop coda** (`p t c ch`) with no tone, where Vietnamese requires sắc
+    ///   or nặng: `chuc` → `chúc`, `tich` → `tích`;
+    /// - a rhyme that only exists shaped: `dien` → `diên`, `thuo` → `thuơ`;
+    /// - both at once: `nuoc` → `nước`.
+    AwaitingDiacritic,
+    /// A real Vietnamese syllable as it stands: `chào`, `việt`, `ma`, `tét`.
+    Complete,
+}
+
+pub(super) fn classify(buffer: &str) -> SyllableStatus {
+    let parts = parse_syllable(buffer);
+    let Some((coda, coda_len)) = normalized_coda(&parts) else {
+        return SyllableStatus::Invalid;
+    };
+    let coda = &coda[..coda_len];
+
+    let structure_ok = !parts.invalid_onset
+        && is_valid_onset(parts.onset)
+        // A tone parked on the `qu`/`gi` glide is a mid-composition transient, not
+        // a finished syllable: `qúy` is a misspelling of `quý`.
+        && !glide::onset_holds_tone(parts.onset)
+        && parts.nucleus_chars().next().is_some()
+        && !violates_ckg_spelling(parts.onset, &parts)
+        && coda_in(VALID_CODAS, coda);
+    if !structure_ok {
+        return SyllableStatus::Invalid;
+    }
+
+    // The nucleus+coda must be a real Vietnamese rhyme (Level 2): keeps `việt`,
+    // `trường` … but reverts structurally-ok-but-nonexistent rhymes. A rhyme that
+    // exists only *shaped* is that same rhyme with its shape keys still to come —
+    // `ien` is `iên` minus the circumflex — so it is unfinished, not wrong.
+    let rhyme = toneless_rhyme(&parts, coda);
+    let status = if is_valid_rhyme(&rhyme) {
+        SyllableStatus::Complete
+    } else if matches_deshaped(&rhyme) {
+        SyllableStatus::AwaitingDiacritic
+    } else {
+        return SyllableStatus::Invalid;
+    };
+
+    // Phonotactics: a stop coda only allows sắc / nặng. A wrong tone (huyền / hỏi /
+    // ngã) is what catches English `text` (→ `tẽt`) or `coot` (→ `côt`); no tone at
+    // all is the un-toned form of a real word, which a tone key can still complete.
+    if coda_in(STOP_CODAS, coda) {
+        return match nucleus_tone(parts.nucleus_chars()) {
+            Some(Tone::Sac | Tone::Nang) => status,
+            None => SyllableStatus::AwaitingDiacritic,
+            Some(_) => SyllableStatus::Invalid,
+        };
+    }
+    status
+}

--- a/crates/funput-core/src/validation/syllable/tests.rs
+++ b/crates/funput-core/src/validation/syllable/tests.rs
@@ -61,6 +61,25 @@ fn is_complete_syllable_cases() {
 }
 
 #[test]
+fn bare_shaped_vowel_cases() {
+    // A lone vowel carrying mũ / móc / trần, with or without a tone.
+    for ok in ["ă", "â", "Ă", "Â", "ê", "ô", "ơ", "ư", "ắ", "ậ", "Ừ"] {
+        assert!(is_bare_shaped_vowel(ok), "{ok} is a bare shaped vowel");
+    }
+    // Plain vowels carry no shape; an onset or coda means it is not bare.
+    for bad in ["", "a", "á", "A", "d", "că", "ăn", "âm", "ươ"] {
+        assert!(
+            !is_bare_shaped_vowel(bad),
+            "{bad} is not a bare shaped vowel"
+        );
+    }
+    // Deliberately independent of completeness: `ă`/`â` have no open rhyme, so
+    // the two predicates disagree here and that disagreement is the point.
+    assert!(is_bare_shaped_vowel("ă") && !is_complete_syllable("ă"));
+    assert!(is_bare_shaped_vowel("â") && !is_complete_syllable("â"));
+}
+
+#[test]
 fn real_syllables_are_complete() {
     // Broad battery of real Vietnamese syllables (incl. hard rhymes). A failure
     // means the rhyme table is missing an entry — add it to `rhyme.rs`.

--- a/crates/funput-engine/README.en.md
+++ b/crates/funput-engine/README.en.md
@@ -124,6 +124,14 @@ Dictionary-free: an English word that happens to be a valid VN syllable (`test` 
 auto-restored — in exchange it never breaks correctly-typed Vietnamese (like UniKey without a
 dictionary).
 
+A few keystroke patterns are **unambiguous Vietnamese intent** and are pinned, outranking the
+`is_complete_syllable` verdict: a composed `đ` in the buffer, any digit in `keys` (VNI's modifiers
+*are* digits), and a word that is nothing but a single shaped vowel
+(`funput_core::is_bare_shaped_vowel`). That last case is what commits `aw` → `ă` and `aa` → `â`:
+Vietnamese has no open `ă`/`â` rhyme so they are not complete syllables, yet an isolated one can only
+have been meant, and it makes Telex answer `Aw` the way VNI answers `A8`. An onset still means
+English: `caw`/`law` → `că`/`lă` are restored as before.
+
 ## Flip VN ⇄ raw keys
 
 `flip_composing()` flips the **composing word** between its Vietnamese form and its raw keystrokes

--- a/crates/funput-engine/README.md
+++ b/crates/funput-engine/README.md
@@ -120,6 +120,13 @@ việc này ngay khi buffer trở thành dead-end thay vì đợi dấu cách.
 Không từ điển: từ tiếng Anh tình cờ là âm tiết VN hợp lệ (`test` → `tét`) sẽ **không** auto-restore
 — đổi lại không bao giờ phá tiếng Việt đang gõ đúng (giống UniKey không từ điển).
 
+Một vài chuỗi phím là **ý định tiếng Việt rõ ràng** nên được ghim, bỏ qua kết luận của
+`is_complete_syllable`: buffer có `đ`, `keys` có chữ số (modifier của VNI *là* chữ số), và từ chỉ gồm
+đúng một nguyên âm mang dấu phụ (`funput_core::is_bare_shaped_vowel`). Trường hợp cuối cho `aw` → `ă`
+và `aa` → `â` được commit — tiếng Việt không có vần mở `ă`/`â` nên chúng không phải âm tiết hoàn
+chỉnh, nhưng gõ trơ một nguyên âm như vậy thì chỉ có thể là chủ đích, và nhờ đó Telex trả lời `Aw`
+giống VNI trả lời `A8`. Có âm đầu thì vẫn là tiếng Anh: `caw`/`law` → `că`/`lă` vẫn được restore.
+
 ## Lật VN ⇄ phím thô (flip)
 
 `flip_composing()` lật **từ đang soạn** giữa dạng tiếng Việt và chuỗi phím thô (`card` ⇄ `cải`), lật

--- a/crates/funput-engine/src/compose/boundary/mod.rs
+++ b/crates/funput-engine/src/compose/boundary/mod.rs
@@ -1,6 +1,8 @@
 //! Word-boundary handling — end-of-word clears composition state.
 
-use funput_core::{InputMethod, is_complete_syllable};
+mod shortcut;
+
+use funput_core::{InputMethod, is_bare_shaped_vowel, is_complete_syllable};
 
 use crate::ImeResult;
 use crate::compose::RestoreOverride;
@@ -22,95 +24,31 @@ pub(crate) fn should_restore(session: &Session) -> bool {
         && !keystrokes_intend_vietnamese(session)
 }
 
+/// Whether the keystrokes behind `buffer` can only have been meant as Vietnamese,
+/// which outranks the structural verdict of [`is_complete_syllable`].
+///
+/// Three signals say so:
+/// - a composed `đ`, unless a stray `w` shows the word is still mid-intent (`dwd`);
+/// - any digit in the keys — in VNI the modifiers *are* digits, so a word that
+///   used one was deliberately shaped;
+/// - a word that is nothing but a shaped vowel (`aw` → `ă`, `aa` → `â`). Neither
+///   is a complete syllable, since Vietnamese has no open `ă`/`â` rhyme, yet an
+///   isolated one is exactly the letter the user asked for. Telex needs this
+///   spelled out; VNI already lands here via its digit keys, and this keeps the
+///   two methods answering `Aw`/`A8` the same way. An onset still means English:
+///   `caw` and `law` compose to `că`/`lă` and are restored as before.
 fn keystrokes_intend_vietnamese(session: &Session) -> bool {
     let unresolved_w =
         session.config.method.is_telex_family() && session.buffer.contains(['w', 'W']);
     (session.buffer.contains(['đ', 'Đ']) && !unresolved_w)
         || session.keys.contains(|c: char| c.is_ascii_digit())
+        || is_bare_shaped_vowel(&session.buffer)
 }
 
 fn english_restore_result(session: &Session, boundary_key: char) -> ImeResult {
     let backspace = session.buffer.chars().count();
     let output = format!("{}{}", session.keys, boundary_key);
     ImeResult::send(backspace, output)
-}
-
-/// The letter-casing pattern of typed keys, used to mirror the expansion's case
-/// (`vn` → lowercase, `Vn` → Title Case, `VN` → UPPERCASE) — the same "propagate
-/// case" convention used by common text expanders like Espanso.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum ShortcutCase {
-    Lower,
-    Upper,
-    Title,
-}
-
-/// Classify the case pattern of `keys` from its cased characters (letters), ignoring
-/// digits and punctuation. Returns `None` when the keys don't fit a clean pattern
-/// (e.g. `vNa`), so the caller falls back to an exact, unmodified lookup — this keeps
-/// deliberately mixed-case triggers (like `iOS`) working exactly as defined.
-fn classify_case(keys: &str) -> Option<ShortcutCase> {
-    let mut letters = keys.chars().filter(|c| c.is_alphabetic());
-    let first = letters.next()?;
-    let rest: Vec<char> = letters.collect();
-    if first.is_lowercase() {
-        rest.iter()
-            .all(|c| c.is_lowercase())
-            .then_some(ShortcutCase::Lower)
-    } else if !rest.is_empty() && rest.iter().all(|c| c.is_uppercase()) {
-        Some(ShortcutCase::Upper)
-    } else if rest.iter().all(|c| c.is_lowercase()) {
-        // A single uppercase letter (`rest` empty) also lands here: capitalizing one
-        // word reads more naturally than shouting the whole expansion.
-        Some(ShortcutCase::Title)
-    } else {
-        None
-    }
-}
-
-/// Re-case `expansion` to match `case`, using Unicode-aware `to_uppercase`/
-/// `to_lowercase` so accented Vietnamese letters (`đ` → `Đ`, `ệ` → `Ệ`) come out right.
-fn apply_shortcut_case(expansion: &str, case: ShortcutCase) -> String {
-    match case {
-        ShortcutCase::Lower => expansion.to_string(),
-        ShortcutCase::Upper => expansion.to_uppercase(),
-        ShortcutCase::Title => {
-            let mut result = String::with_capacity(expansion.len());
-            let mut start_of_word = true;
-            for ch in expansion.chars() {
-                if ch.is_whitespace() {
-                    start_of_word = true;
-                    result.push(ch);
-                } else if start_of_word {
-                    result.extend(ch.to_uppercase());
-                    start_of_word = false;
-                } else {
-                    result.extend(ch.to_lowercase());
-                }
-            }
-            result
-        }
-    }
-}
-
-fn shortcut_expansion(session: &Session, boundary_key: char) -> Option<ImeResult> {
-    // Gated here rather than by clearing the table: the rows stay loaded, so the
-    // switch is instant in both directions and nothing has to be re-pushed.
-    if !session.config.shortcuts_enabled || session.keys.is_empty() {
-        return None;
-    }
-    let case = classify_case(&session.keys);
-    let lookup_key = match case {
-        Some(_) => session.keys.to_lowercase(),
-        None => session.keys.clone(),
-    };
-    let expansion = session.shortcuts.get(&lookup_key)?;
-    let cased = match case {
-        Some(case) => apply_shortcut_case(expansion, case),
-        None => expansion.clone(),
-    };
-    let output = format!("{cased}{boundary_key}");
-    Some(ImeResult::send(session.buffer.chars().count(), output))
 }
 
 fn update_caps_on_boundary(session: &mut Session, key: char) {
@@ -133,7 +71,7 @@ fn update_caps_on_boundary(session: &mut Session, key: char) {
 }
 
 pub(crate) fn on_word_boundary(session: &mut Session, boundary_key: char) -> ImeResult {
-    let result = if let Some(expansion) = shortcut_expansion(session, boundary_key) {
+    let result = if let Some(expansion) = shortcut::expansion(session, boundary_key) {
         expansion
     } else if should_restore(session) {
         english_restore_result(session, boundary_key)

--- a/crates/funput-engine/src/compose/boundary/shortcut.rs
+++ b/crates/funput-engine/src/compose/boundary/shortcut.rs
@@ -1,0 +1,82 @@
+//! Shortcut expansion at a word boundary, including case propagation.
+
+use crate::ImeResult;
+use crate::model::Session;
+
+/// The letter-casing pattern of typed keys, used to mirror the expansion's case
+/// (`vn` → lowercase, `Vn` → Title Case, `VN` → UPPERCASE) — the same "propagate
+/// case" convention used by common text expanders like Espanso.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ShortcutCase {
+    Lower,
+    Upper,
+    Title,
+}
+
+/// Classify the case pattern of `keys` from its cased characters (letters), ignoring
+/// digits and punctuation. Returns `None` when the keys don't fit a clean pattern
+/// (e.g. `vNa`), so the caller falls back to an exact, unmodified lookup — this keeps
+/// deliberately mixed-case triggers (like `iOS`) working exactly as defined.
+fn classify_case(keys: &str) -> Option<ShortcutCase> {
+    let mut letters = keys.chars().filter(|c| c.is_alphabetic());
+    let first = letters.next()?;
+    let rest: Vec<char> = letters.collect();
+    if first.is_lowercase() {
+        rest.iter()
+            .all(|c| c.is_lowercase())
+            .then_some(ShortcutCase::Lower)
+    } else if !rest.is_empty() && rest.iter().all(|c| c.is_uppercase()) {
+        Some(ShortcutCase::Upper)
+    } else if rest.iter().all(|c| c.is_lowercase()) {
+        // A single uppercase letter (`rest` empty) also lands here: capitalizing one
+        // word reads more naturally than shouting the whole expansion.
+        Some(ShortcutCase::Title)
+    } else {
+        None
+    }
+}
+
+/// Re-case `expansion` to match `case`, using Unicode-aware `to_uppercase`/
+/// `to_lowercase` so accented Vietnamese letters (`đ` → `Đ`, `ệ` → `Ệ`) come out right.
+fn apply_shortcut_case(expansion: &str, case: ShortcutCase) -> String {
+    match case {
+        ShortcutCase::Lower => expansion.to_string(),
+        ShortcutCase::Upper => expansion.to_uppercase(),
+        ShortcutCase::Title => {
+            let mut result = String::with_capacity(expansion.len());
+            let mut start_of_word = true;
+            for ch in expansion.chars() {
+                if ch.is_whitespace() {
+                    start_of_word = true;
+                    result.push(ch);
+                } else if start_of_word {
+                    result.extend(ch.to_uppercase());
+                    start_of_word = false;
+                } else {
+                    result.extend(ch.to_lowercase());
+                }
+            }
+            result
+        }
+    }
+}
+
+pub(super) fn expansion(session: &Session, boundary_key: char) -> Option<ImeResult> {
+    // Gated here rather than by clearing the table: the rows stay loaded, so the
+    // switch is instant in both directions and nothing has to be re-pushed.
+    if !session.config.shortcuts_enabled || session.keys.is_empty() {
+        return None;
+    }
+    let case = classify_case(&session.keys);
+    let lookup_key = match case {
+        Some(_) => session.keys.to_lowercase(),
+        None => session.keys.clone(),
+    };
+    let expansion = session.shortcuts.get(&lookup_key)?;
+    let cased = match case {
+        Some(case) => apply_shortcut_case(expansion, case),
+        None => expansion.clone(),
+    };
+    let output = format!("{cased}{boundary_key}");
+    Some(ImeResult::send(session.buffer.chars().count(), output))
+}

--- a/crates/funput-engine/src/compose/boundary/tests/restore.rs
+++ b/crates/funput-engine/src/compose/boundary/tests/restore.rs
@@ -23,6 +23,20 @@ fn explicit_vietnamese_modifiers_remain_pinned() {
 }
 
 #[test]
+fn lone_shaped_vowel_is_pinned_in_every_method() {
+    // `ă`/`â` are not complete syllables, but a word that is only the vowel was
+    // asked for explicitly — Telex must agree with what VNI's digits already do.
+    assert!(!should_restore(&session(InputMethod::Telex, "ă", "aw")));
+    assert!(!should_restore(&session(InputMethod::Telex, "Ă", "Aw")));
+    assert!(!should_restore(&session(InputMethod::Telex, "â", "aa")));
+    assert!(!should_restore(&session(InputMethod::Telex, "ắ", "aws")));
+    assert!(!should_restore(&session(InputMethod::Vni, "ă", "a8")));
+    // An onset makes it an English word again.
+    assert!(should_restore(&session(InputMethod::Telex, "că", "caw")));
+    assert!(should_restore(&session(InputMethod::Telex, "lă", "law")));
+}
+
+#[test]
 fn unresolved_multi_intent_is_not_pinned_by_stroke() {
     assert!(should_restore(&session(InputMethod::Telex, "đw", "dwd")));
 }

--- a/crates/funput-engine/tests/words/boundary.rs
+++ b/crates/funput-engine/tests/words/boundary.rs
@@ -92,6 +92,27 @@ fn valid_vietnamese_kept_on_boundary() {
 }
 
 #[test]
+fn standalone_shaped_vowel_kept_on_boundary() {
+    // A word that is only a shaped vowel commits as typed, the same in both
+    // methods: `aw`/`a8` → `ă`, `aa`/`a6` → `â`.
+    for (method, keys, expected) in [
+        (InputMethod::Telex, "aw ", "ă "),
+        (InputMethod::Telex, "Aw ", "Ă "),
+        (InputMethod::Telex, "aa ", "â "),
+        (InputMethod::Telex, "aws ", "ắ "),
+        (InputMethod::Telex, "aaj ", "ậ "),
+        (InputMethod::Vni, "a8 ", "ă "),
+        (InputMethod::Vni, "a6 ", "â "),
+    ] {
+        assert_eq!(crate::support::app_text(method, keys), expected, "{keys}");
+    }
+    // Still restored once an onset makes the word plain English.
+    assert_eq!(crate::support::app_text(InputMethod::Telex, "caw "), "caw ");
+    assert_eq!(crate::support::app_text(InputMethod::Telex, "law "), "law ");
+    assert_eq!(crate::support::app_text(InputMethod::Telex, "baa "), "baa ");
+}
+
+#[test]
 fn mixed_english_and_vietnamese_words() {
     assert_eq!(
         crate::support::app_text(InputMethod::Telex, "card mas "),


### PR DESCRIPTION
## Summary

Telex `Aw` + Space produced `Aw ` instead of `Ă `. The transform was correct —
`Aw` does compose to `Ă` — but the English-restore step at the word boundary
reverted it to the raw keystrokes.

`should_restore` keeps a word only when `is_complete_syllable` accepts it. `ă`
and `â` are correctly rejected there: Vietnamese has no open `ă`/`â` rhyme, they
only appear before a coda (`ăn`, `âm`). VNI escaped this by accident — its
modifiers are digits, and any digit in `keys` already counted as deliberate
Vietnamese, so `A8` was pinned while `Aw` was not.

Fix: add `funput_core::is_bare_shaped_vowel` and treat a word that is nothing but
a shaped vowel as unambiguous intent, alongside the existing `đ` and digit
signals. The rhyme inventory is untouched, so `is_complete_syllable` still says
`ă` is not a syllable and spell-check is unaffected.

Affects `aw`/`aa`/`aws`/`aaj` → `ă`/`â`/`ắ`/`ậ`. `ow`, `uw`, `ee`, `oo` already
worked, since those open rhymes exist.

## Notes

Two files went over the 150-line budget, so this also splits out
`validation/syllable/status.rs` (`SyllableStatus` + `classify`) and
`compose/boundary/shortcut.rs` (shortcut expansion + case propagation). Both are
verbatim moves.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `bash scripts/check-loc.sh`
- [x] Tests added at three levels: the core predicate, `should_restore`, and
      end-to-end typing.
- [x] English words with an onset still restore: `caw `, `law `, `baa `, `card `.