### PR TITLE
feat(core): name the charsets and list them from one place

### DIFF
--- a/crates/funput-core/src/charset/codecs/mod.rs
+++ b/crates/funput-core/src/charset/codecs/mod.rs
@@ -149,4 +149,33 @@ mod tests {
         assert!(!is_byte_oriented(Charset::Unicode));
         assert!(is_byte_oriented(Charset::Tcvn3));
     }
+
+    #[test]
+    fn legacy_bytes_are_read_one_to_one_as_code_points() {
+        // 0xD6 is `ệ`; the rest is ASCII. This is what a .VnTime file holds.
+        let bytes = [0x56, 0x69, 0xD6, 0x74];
+        let out = decode_bytes(&bytes, Charset::Tcvn3);
+        assert_eq!(out.text, "Việt");
+        assert_eq!(out.unmapped, 0);
+    }
+
+    #[test]
+    fn utf8_bytes_are_decoded_as_utf8() {
+        let out = decode_bytes("Việt".as_bytes(), Charset::Unicode);
+        assert_eq!(out.text, "Việt");
+        assert_eq!(out.unmapped, 0);
+    }
+
+    #[test]
+    fn broken_utf8_is_reported_rather_than_silently_replaced() {
+        let out = decode_bytes(&[0x56, 0xFF, 0x69], Charset::Unicode);
+        assert_eq!(out.unmapped, 1);
+    }
+
+    #[test]
+    fn a_replacement_character_in_the_source_is_not_counted_as_damage() {
+        let out = decode_bytes("a\u{FFFD}b".as_bytes(), Charset::Unicode);
+        assert_eq!(out.text, "a\u{FFFD}b");
+        assert_eq!(out.unmapped, 0);
+    }
 }

--- a/crates/funput-core/src/charset/codecs/mod.rs
+++ b/crates/funput-core/src/charset/codecs/mod.rs
@@ -1,4 +1,10 @@
-//! Where a charset says how it spells an [`Atom`] — the extension point.
+//! Where a charset says how it spells an [`Atom`] — the extension point — and the
+//! byte layer that feeds it.
+//!
+//! The second half is here because it is the same question asked one level down:
+//! *how does this charset put itself in a file?* [`decode_bytes`] and
+//! [`is_byte_oriented`] are public, and the two UTF-8 helpers below them exist only
+//! to serve the first.
 //!
 //! Adding a charset means adding a codec module here plus a [`Charset`] variant.
 //! The pivot, the driver, and every consumer stay as they are, and the compiler
@@ -14,8 +20,8 @@
 //! Each codec provides two functions:
 //!
 //! - `decode(&Cursor) -> Decoded` — read one unit at the cursor. Total: anything
-//!   the charset does not define comes back as [`Atom::Other`] with `recognized`
-//!   false, never as an error.
+//!   the charset does not define comes back as [`Atom::Other`] with a `reading` of
+//!   [`Reading::Unknown`], never as an error.
 //! - `encode(Atom, &mut String) -> bool` — write the atom, returning `false` when
 //!   what it wrote is not exact. It always writes *something*; a character never
 //!   disappears in conversion.
@@ -26,7 +32,7 @@ mod vni;
 
 use super::Charset;
 use super::pivot::Atom;
-use super::transcode::{Cursor, Decoded, Reading};
+use super::transcode::{Conversion, Cursor, Decoded, Reading};
 
 /// Read one unit of `charset` at the cursor.
 pub(super) fn decode(charset: Charset, cur: &Cursor<'_>) -> Decoded {
@@ -58,23 +64,53 @@ pub(super) fn encode(charset: Charset, atom: Atom, out: &mut String) -> bool {
     }
 }
 
-/// Whether a charset spells text in single bytes drawn by a legacy font, so bytes
-/// read from a file are Latin-1 rather than UTF-8.
+/// Whether a charset stores one byte per character, drawn by a legacy font.
 ///
-/// This and the two below are everything [`crate::charset::decode_bytes`] needs to
-/// know about the byte layer, which is why they live together down here rather
-/// than beside it.
-pub(super) fn is_byte_oriented(charset: Charset) -> bool {
+/// The distinction a caller needs when it already knows something about the bytes.
+/// Text that failed a UTF-8 decode cannot be in a charset that is *not* byte
+/// oriented, so a caller detecting the charset of such bytes must refuse those
+/// candidates — feeding them to [`decode_bytes`] would hand back replacement
+/// characters, which is a worse answer than admitting defeat.
+///
+/// Asking this instead of naming charsets is what lets a consumer keep working when
+/// a new one is added.
+pub fn is_byte_oriented(charset: Charset) -> bool {
     match charset {
         Charset::Unicode | Charset::UnicodeCombining => false,
         Charset::Tcvn3 | Charset::VniWindows => true,
     }
 }
 
+/// Read raw bytes in `from` and return them as Unicode.
+///
+/// A byte-oriented charset's bytes are read one-to-one as code points, which is
+/// exactly how the document that produced them was stored. The rest are decoded as
+/// UTF-8, where an invalid sequence becomes `U+FFFD` — a caller reading a file it
+/// merely *believes* is UTF-8 gets told when it was wrong instead of silently
+/// receiving replacement characters.
+///
+/// Either way the text then goes through [`convert`], and the two counts add up:
+/// broken bytes and characters the charset could not place are separate problems,
+/// and a byte that causes both deserves two looks.
+pub fn decode_bytes(bytes: &[u8], from: Charset) -> Conversion {
+    let (text, damage) = if is_byte_oriented(from) {
+        // Latin-1 is total, so reading bytes as code points cannot fail.
+        (bytes.iter().copied().map(char::from).collect(), 0)
+    } else {
+        let text = String::from_utf8_lossy(bytes).into_owned();
+        (text, broken_sequences(bytes))
+    };
+    let out = super::convert(&text, from, Charset::Unicode);
+    Conversion {
+        unmapped: out.unmapped + damage,
+        ..out
+    }
+}
+
 /// How many characters lossy UTF-8 decoding had to replace. Zero for valid input,
 /// and replacement characters the source genuinely encoded are discounted so a
 /// document that legitimately contains one is not reported as damaged.
-pub(super) fn broken_sequences(bytes: &[u8]) -> usize {
+fn broken_sequences(bytes: &[u8]) -> usize {
     if std::str::from_utf8(bytes).is_ok() {
         return 0;
     }

--- a/crates/funput-core/src/charset/detect/mod.rs
+++ b/crates/funput-core/src/charset/detect/mod.rs
@@ -23,21 +23,13 @@
 
 mod score;
 
-use super::{Charset, Conversion, convert, decode_bytes};
+use super::{ALL, Charset, Conversion, convert, decode_bytes};
 use score::{Score, score};
 
 /// How much text is enough to decide. Four full decodings run over this, and the
 /// answer stops changing long before it: a few hundred words already separate the
 /// charsets by a wide margin.
 const PREFIX: usize = 8 * 1024;
-
-/// Every charset detection considers.
-const CANDIDATES: [Charset; 4] = [
-    Charset::Unicode,
-    Charset::Tcvn3,
-    Charset::VniWindows,
-    Charset::UnicodeCombining,
-];
 
 /// Guess the charset `text` is written in, or `None` when the evidence does not
 /// pick one out.
@@ -64,7 +56,7 @@ pub fn detect_bytes(bytes: &[u8]) -> Option<Charset> {
 
 /// The candidate that explains `decoded` best, if one does.
 fn best(decoded: impl Fn(Charset) -> Conversion) -> Option<Charset> {
-    let mut ranked: Vec<(Score, Charset)> = CANDIDATES
+    let mut ranked: Vec<(Score, Charset)> = ALL
         .iter()
         .map(|&charset| (score(&decoded(charset)), charset))
         .collect();
@@ -87,35 +79,6 @@ fn prefix(text: &str) -> &str {
     }
     &text[..end]
 }
-
-/// Adding a `Charset` variant must break the build here rather than silently drop
-/// the charset out of detection.
-///
-/// [`CANDIDATES`] is an array, and an array throws away the exhaustiveness that
-/// [`super::codecs`] gets for free from its `match`. This is the array's substitute:
-/// the match below fails to compile on a fifth variant, and the assertion catches a
-/// variant that has a slot but was left out of the array.
-const _: () = {
-    const fn slot(charset: Charset) -> usize {
-        match charset {
-            Charset::Unicode => 0,
-            Charset::Tcvn3 => 1,
-            Charset::VniWindows => 2,
-            Charset::UnicodeCombining => 3,
-        }
-    }
-    let mut listed = [false; CANDIDATES.len()];
-    let mut i = 0;
-    while i < CANDIDATES.len() {
-        listed[slot(CANDIDATES[i])] = true;
-        i += 1;
-    }
-    let mut i = 0;
-    while i < listed.len() {
-        assert!(listed[i], "a charset has no entry in CANDIDATES");
-        i += 1;
-    }
-};
 
 #[cfg(test)]
 mod tests;

--- a/crates/funput-core/src/charset/mod.rs
+++ b/crates/funput-core/src/charset/mod.rs
@@ -33,7 +33,10 @@ mod detect;
 mod pivot;
 mod transcode;
 
+pub use codecs::{decode_bytes, is_byte_oriented};
 pub use detect::{detect, detect_bytes};
+// `Conversion` is defined beside the loop that fills in its two counters.
+pub use transcode::Conversion;
 
 /// A Vietnamese character encoding.
 ///
@@ -62,45 +65,59 @@ pub enum Charset {
     UnicodeCombining,
 }
 
-/// Converted text, and what happened to it on the way.
-///
-/// Both counts are in characters, and neither counts *lost* text: conversion
-/// always writes something for every character, so the output holds as much as the
-/// input did. A character lands in at most one of them.
-///
-/// **`unmapped`** — something was lost or guessed, so the output is not certainly
-/// equivalent to the input. Either the target cannot spell it (a `₫`, which no
-/// legacy charset has a code for; an uppercase toned vowel, which is TCVN3's own
-/// gap rather than a general one) or the source never defined it, making the
-/// reading a guess. Text read with the wrong source charset is mostly unrecognized
-/// units, so a count near the length of the input is the clearest signal there is
-/// that the user picked the wrong bảng mã.
-///
-/// **`normalized`** — understood beyond doubt, nothing lost, only the spelling
-/// changed. Reading NFC text as Unicode tổ hợp lands here: every letter comes
-/// through intact, just written the charset's own way. Keeping it out of
-/// `unmapped` is what lets an interface say "nothing was lost" and mean it.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct Conversion {
-    pub text: String,
-    pub unmapped: usize,
-    pub normalized: usize,
+impl Charset {
+    /// What to call this charset in front of a user.
+    ///
+    /// The encoding's own name rather than interface copy — `TCVN3 (ABC)` reads the
+    /// same in any language, and these are the names UniKey uses, which is what
+    /// Vietnamese users already know them by. Keeping them here is what stops a menu
+    /// on Windows and one on Linux from drifting apart.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Unicode => "Unicode dựng sẵn",
+            Self::Tcvn3 => "TCVN3 (ABC)",
+            Self::VniWindows => "VNI-Windows",
+            Self::UnicodeCombining => "Unicode tổ hợp",
+        }
+    }
 }
 
-/// Whether a charset stores one byte per character, drawn by a legacy font.
+/// Every charset, in the order an interface should offer them.
 ///
-/// The distinction a caller needs when it already knows something about the bytes.
-/// Text that failed a UTF-8 decode cannot be in a charset that is *not* byte
-/// oriented, so a caller detecting the charset of such bytes must refuse those
-/// candidates — feeding them to [`decode_bytes`] would hand back replacement
-/// characters, which is a worse answer than admitting defeat.
+/// A caller cannot build this list for itself: `Charset` is `#[non_exhaustive]`, so
+/// code outside this crate must write a wildcard arm and would silently miss a
+/// variant added later. [`detect`] scores exactly this list, so a charset a user can
+/// choose is one the tool can also recognise.
+pub const ALL: [Charset; 4] = [
+    Charset::Unicode,
+    Charset::Tcvn3,
+    Charset::VniWindows,
+    Charset::UnicodeCombining,
+];
+
+/// Adding a variant must break the build here rather than drop it out of every menu.
 ///
-/// Asking this instead of naming charsets is what lets a consumer keep working when
-/// a new one is added.
-pub fn is_byte_oriented(charset: Charset) -> bool {
-    codecs::is_byte_oriented(charset)
-}
+/// [`Charset::name`] already forces a name for each one; this catches the other
+/// half — a variant that has a name but never made it into [`ALL`].
+const _: () = {
+    const fn slot(charset: Charset) -> u32 {
+        match charset {
+            Charset::Unicode => 0,
+            Charset::Tcvn3 => 1,
+            Charset::VniWindows => 2,
+            Charset::UnicodeCombining => 3,
+        }
+    }
+    let (mut listed, mut i) = (0u32, 0);
+    while i < ALL.len() {
+        listed |= 1 << slot(ALL[i]);
+        i += 1;
+    }
+    assert!(
+        listed == (1 << ALL.len()) - 1,
+        "a charset is missing from ALL"
+    );
+};
 
 /// Convert text from one charset to another.
 ///
@@ -110,62 +127,43 @@ pub fn convert(text: &str, from: Charset, to: Charset) -> Conversion {
     transcode::transcode(text, from, to)
 }
 
-/// Read raw bytes in `from` and return them as Unicode.
-///
-/// A byte-oriented charset's bytes are read one-to-one as code points, which is
-/// exactly how the document that produced them was stored. The rest are decoded as
-/// UTF-8, where an invalid sequence becomes `U+FFFD` — a caller reading a file it
-/// merely *believes* is UTF-8 gets told when it was wrong instead of silently
-/// receiving replacement characters.
-///
-/// Either way the text then goes through [`convert`], and the two counts add up:
-/// broken bytes and characters the charset could not place are separate problems,
-/// and a byte that causes both deserves two looks.
-pub fn decode_bytes(bytes: &[u8], from: Charset) -> Conversion {
-    let (text, damage) = if codecs::is_byte_oriented(from) {
-        // Latin-1 is total, so reading bytes as code points cannot fail.
-        (bytes.iter().copied().map(char::from).collect(), 0)
-    } else {
-        let text = String::from_utf8_lossy(bytes).into_owned();
-        (text, codecs::broken_sequences(bytes))
-    };
-    let out = convert(&text, from, Charset::Unicode);
-    Conversion {
-        unmapped: out.unmapped + damage,
-        ..out
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Two menus showing the same name for different charsets, or a blank entry,
+    /// are the failures a shared list is supposed to make impossible.
     #[test]
-    fn legacy_bytes_are_read_one_to_one_as_code_points() {
-        // 0xD6 is `ệ`; the rest is ASCII. This is what a .VnTime file holds.
-        let bytes = [0x56, 0x69, 0xD6, 0x74];
-        let out = decode_bytes(&bytes, Charset::Tcvn3);
-        assert_eq!(out.text, "Việt");
-        assert_eq!(out.unmapped, 0);
+    fn every_charset_has_a_distinct_name() {
+        let mut names: Vec<&str> = ALL.iter().map(|c| c.name()).collect();
+        assert!(names.iter().all(|n| !n.is_empty()));
+
+        assert_eq!(names.len(), ALL.len());
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), ALL.len(), "two charsets share a name");
     }
 
+    /// The two Unicode charsets are the pair a user actually has to choose between,
+    /// so neither may be called just "Unicode".
     #[test]
-    fn utf8_bytes_are_decoded_as_utf8() {
-        let out = decode_bytes("Việt".as_bytes(), Charset::Unicode);
-        assert_eq!(out.text, "Việt");
-        assert_eq!(out.unmapped, 0);
+    fn the_two_unicode_charsets_are_told_apart_by_name() {
+        assert_ne!(Charset::Unicode.name(), Charset::UnicodeCombining.name());
+        assert!(Charset::Unicode.name().contains("dựng sẵn"));
+        assert!(Charset::UnicodeCombining.name().contains("tổ hợp"));
     }
 
+    /// Anything offered in a menu has to be something the tool can also recognise —
+    /// otherwise "Tự động nhận diện" could never return what the user picked.
     #[test]
-    fn broken_utf8_is_reported_rather_than_silently_replaced() {
-        let out = decode_bytes(&[0x56, 0xFF, 0x69], Charset::Unicode);
-        assert_eq!(out.unmapped, 1);
-    }
-
-    #[test]
-    fn a_replacement_character_in_the_source_is_not_counted_as_damage() {
-        let out = decode_bytes("a\u{FFFD}b".as_bytes(), Charset::Unicode);
-        assert_eq!(out.text, "a\u{FFFD}b");
-        assert_eq!(out.unmapped, 0);
+    fn every_listed_charset_can_be_converted_to_and_from() {
+        for charset in ALL {
+            let there = convert("Việt Nam", Charset::Unicode, charset);
+            assert_eq!(
+                convert(&there.text, charset, Charset::Unicode).text,
+                "Việt Nam",
+                "{charset:?}"
+            );
+        }
     }
 }

--- a/crates/funput-core/src/charset/transcode.rs
+++ b/crates/funput-core/src/charset/transcode.rs
@@ -5,9 +5,9 @@
 //! knowledge in [`crate::charset::pivot`], so this file stays the same shape no
 //! matter how many charsets exist.
 
+use super::Charset;
 use super::codecs;
 use super::pivot::Atom;
-use super::{Charset, Conversion};
 
 /// A read window onto the source, positioned at a unit boundary.
 ///
@@ -46,6 +46,32 @@ impl Cursor<'_> {
     pub(super) fn second(&self) -> Option<char> {
         self.following().next()
     }
+}
+
+/// Converted text, and what happened to it on the way.
+///
+/// Both counts are in characters, and neither counts *lost* text: conversion
+/// always writes something for every character, so the output holds as much as the
+/// input did. A character lands in at most one of them.
+///
+/// **`unmapped`** — something was lost or guessed, so the output is not certainly
+/// equivalent to the input. Either the target cannot spell it (a `₫`, which no
+/// legacy charset has a code for; an uppercase toned vowel, which is TCVN3's own
+/// gap rather than a general one) or the source never defined it, making the
+/// reading a guess. Text read with the wrong source charset is mostly unrecognized
+/// units, so a count near the length of the input is the clearest signal there is
+/// that the user picked the wrong bảng mã.
+///
+/// **`normalized`** — understood beyond doubt, nothing lost, only the spelling
+/// changed. Reading NFC text as Unicode tổ hợp lands here: every letter comes
+/// through intact, just written the charset's own way. Keeping it out of
+/// `unmapped` is what lets an interface say "nothing was lost" and mean it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Conversion {
+    pub text: String,
+    pub unmapped: usize,
+    pub normalized: usize,
 }
 
 /// How faithfully a codec managed to read the text at the cursor.

--- a/docs/features/charset.md
+++ b/docs/features/charset.md
@@ -340,13 +340,24 @@ pub(super) fn encode(atom: Atom, out: &mut String) -> bool;
 `Charset::Unicode` không cần module riêng — nó là nhánh identity của cả hai chiều.
 
 Thêm một bảng mã nghĩa là: một biến thể `Charset`, một thư mục codec, hai nhánh
-match. Trục, driver và `detect` không đổi.
+match, một tên trong `Charset::name`, một mục trong `ALL`. Trục, driver và `detect`
+không đổi.
+
+Bốn thứ đầu do trình biên dịch đòi. Mục thứ năm thì không — thiếu nó, bảng mã mới
+biên dịch sạch nhưng không bao giờ hiện ra trong bất kỳ menu nào. Nên có một khối
+`const _: () = ...` dựng mặt nạ bit từ `ALL` rồi `assert!` rằng đủ mặt: quên là vỡ
+build, chứ không phải vỡ giao diện.
 
 ## API công khai
 
 ```rust
 #[non_exhaustive] pub enum Charset { Unicode, Tcvn3, VniWindows, UnicodeCombining }
 #[non_exhaustive] pub struct Conversion { pub text: String, pub unmapped: usize, pub normalized: usize }
+
+/// Mọi bảng mã, theo thứ tự giao diện nên bày ra. Consumer không dựng được danh sách
+/// này: `Charset` là `#[non_exhaustive]`.
+pub const ALL: [Charset; 4];
+impl Charset { pub const fn name(self) -> &'static str; }
 
 pub fn convert(text: &str, from: Charset, to: Charset) -> Conversion;
 pub fn decode_bytes(bytes: &[u8], from: Charset) -> Conversion;
@@ -399,4 +410,10 @@ Mỗi mục một PR:
    thành API công khai: byte đã trượt `from_utf8` thì không thể là bảng mã Unicode,
    và nói điều đó mà không gọi tên bảng mã nào là thứ giữ cho consumer không phải
    sửa khi có bảng mã mới.
-7. `funput convert` → 8. UI Windows → 9. UI Linux GTK.
+7. **`ALL` + `Charset::name()`**. Hai thứ duy nhất consumer không tự suy ra được:
+   `Charset` là `#[non_exhaustive]`, nên code ngoài crate phải viết nhánh wildcard và
+   sẽ âm thầm bỏ sót biến thể thêm sau. Đây cũng là chỗ xoá bản sao `charset_label`
+   mà UI Windows đã phải tự viết ở bước 6 — hai cửa sổ cài đặt tự đặt tên lấy là cách
+   chúng trôi khỏi nhau.
+8. **C ABI trong `funput-ffi`** (feature `charset`, mặc định tắt) — cửa cho macOS.
+9. `funput convert` (CLI) → 10. UI Windows → 11. UI Linux GTK.

--- a/platforms/windows/src/ui/settings_callbacks/config/message.rs
+++ b/platforms/windows/src/ui/settings_callbacks/config/message.rs
@@ -36,24 +36,14 @@ pub(super) fn unikey_body(summary: &ImportSummary, charset: Option<Charset>) -> 
     // Unicode had nothing guessed about it, and warning on every import teaches the
     // user to ignore the line that matters.
     match charset.filter(|&c| c != Charset::Unicode) {
+        // The name comes from core rather than from here: this window and the Linux
+        // settings window would otherwise each invent their own, and a charset added
+        // later would go unnamed in whichever one nobody remembered to update.
         Some(other) => format!(
             "{counts}\nĐọc bằng bảng mã {} — hãy kiểm lại nếu chữ trông lạ.",
-            charset_label(other)
+            other.name()
         ),
         None => counts,
-    }
-}
-
-/// What to call a charset in front of a user. `Charset` is `#[non_exhaustive]`, so
-/// the wildcard is required rather than a shortcut — and a charset with no name
-/// here simply goes unmentioned, which is better than a debug string.
-pub(super) fn charset_label(charset: Charset) -> &'static str {
-    match charset {
-        Charset::Unicode => "Unicode",
-        Charset::Tcvn3 => "TCVN3 (ABC)",
-        Charset::VniWindows => "VNI-Windows",
-        Charset::UnicodeCombining => "Unicode tổ hợp",
-        _ => "khác",
     }
 }
 


### PR DESCRIPTION
Stacked on #229. Step 7 of the order in `docs/features/charset.md`.

## Why

A settings window cannot enumerate `Charset` or put a name on one. The enum is `#[non_exhaustive]`, so code outside the crate must write a wildcard arm and would silently drop a variant added later — the failure being that a new charset compiles clean and never appears in any menu.

#229 already showed this: the Windows import notice grew its own `charset_label` with its own wording, and the Linux settings window would have grown a second copy with different wording. These are the two things a consumer genuinely cannot derive, so the crate owes them.

## What

- `charset::ALL` — every charset, in the order an interface should offer them.
- `Charset::name()` — the encoding's own name, which is what UniKey uses and what Vietnamese users already know them by.
- A `const` block builds a bitmask from `ALL` and asserts every variant is present. `name()` already forces a name per variant; this catches the other half. A duplicate in `ALL` trips it too, since a duplicate means something else is missing.
- `detect` now scores `ALL` rather than its own private `CANDIDATES`, so a charset a user can pick is one the tool can also recognise.
- `charset_label` deleted from the Windows notice.

## Moves, no behaviour change

`crates/funput-core/src/charset/mod.rs` hit exactly 150/150 with the additions, and `src/charset/` is already at the 5-entry limit, so nothing could be added beside it. Two things went where they already belonged:

- `Conversion` → `transcode.rs`, next to the loop that assigns `unmapped` and `normalized`. Re-exported, so the public path is unchanged.
- `decode_bytes` → `codecs/mod.rs`, following `is_byte_oriented`, with its four tests.

`mod.rs` 150 → 129, `transcode.rs` → 137, `codecs/mod.rs` → 130.

## Checks

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, the charset-off pair (`-p funput-core -p funput-ffi`), `scripts/check-loc.sh` (297 files, all within budget), and both `cargo tree` assertions — charset stays out of `funput-ffi` and `funput-jni`.

`platforms/windows` is excluded from the workspace, so CI never builds it; `cargo build` there was run locally and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)