### PR TITLE
feat(ffi): open the charset door for shells that cannot link Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,36 @@ jobs:
       - name: Test (no charset — the mobile shape)
         run: cargo test -p funput-core -p funput-ffi
 
+      # The other half. `funput-ffi` carries the charset C ABI behind a feature of
+      # its own, and nothing above compiles it: the workspace steps do not build
+      # `funput-ffi` with it, and the two steps above are the charset-off shape by
+      # construction. Without these, the module would ship unbuilt and unlinted.
+      - name: Clippy (funput-ffi with charset)
+        run: cargo clippy -p funput-ffi --features charset --all-targets -- -D warnings
+
+      - name: Test (funput-ffi with charset)
+        run: cargo test -p funput-ffi --features charset
+
       # Compiling proves charset-off still builds; it does not prove the mobile
-      # artifacts are free of it. Add `funput-config` to `funput-ffi`'s dependencies
-      # and the step above stays green while the charset tables quietly land in the
-      # keyboard's cdylib. Only the dependency graph answers that.
+      # artifacts are free of it. Two different ways that can go wrong, so two checks.
+      #
+      # `cargo tree` catches a dependency that drags charset in unconditionally —
+      # add `funput-config` to `funput-ffi`'s dependencies and the steps above stay
+      # green while the tables quietly land in the keyboard's cdylib.
+      #
+      # It cannot catch the other one. `funput-ffi`'s own `charset` feature ending up
+      # on by default renders no edge at all, so the assertion would pass while
+      # saying nothing. Ask the library instead: a default build must export no
+      # `funput_charset_*` symbol. The line before it is a positive control — if the
+      # symbol lookup itself ever stops working, this fails loudly rather than
+      # quietly passing forever.
       - name: charset stays out of the mobile crates
         run: |
           ! cargo tree -p funput-ffi -e features | grep -q charset
           ! cargo tree -p funput-jni -e features | grep -q charset
+          cargo build -p funput-ffi
+          nm -D --defined-only target/debug/libfunput_ffi.so | grep -q funput_process_char
+          ! nm -D --defined-only target/debug/libfunput_ffi.so | grep -q funput_charset
 
       - name: Line budget
         run: bash scripts/check-loc.sh

--- a/crates/funput-ffi/Cargo.toml
+++ b/crates/funput-ffi/Cargo.toml
@@ -12,6 +12,13 @@ workspace = true
 # rlib: lets the round-trip tests call the extern "C" functions in-process.
 crate-type = ["cdylib", "staticlib", "rlib"]
 
+[features]
+# Charset conversion (công cụ chuyển mã) for a desktop shell that cannot link
+# `funput-core` directly. **Off by default**: the iOS and Android keyboards link
+# this crate and have no use for the tables, so they never carry them. CI asserts
+# both halves — that the default build is free of it, and that this one compiles.
+charset = ["funput-core/charset"]
+
 [dependencies]
 funput-core = { path = "../funput-core" }
 funput-engine = { path = "../funput-engine" }

--- a/crates/funput-ffi/README.en.md
+++ b/crates/funput-ffi/README.en.md
@@ -142,6 +142,10 @@ src/app_language/   # per-app VI/EN memory C API (FunputAppLanguage), independen
                     #   handle.rs (handle new/free + shared UTF-8 marshalling),
                     #   memory.rs (seed/clear/forget), focus.rs (note_focus/note_toggle),
                     #   types.rs (APP_LANG_UNKNOWN/ENGLISH/VIETNAMESE)
+src/charset/       # C API charset conversion (convert + detect), behind `charset`
+                    #   mod.rs      count/name + charset indices + UTF-32 writing
+                    #   convert.rs  #[repr(C)] FunputConversion + funput_charset_convert
+                    #   detect.rs   funput_charset_detect
 src/abi/            # shared C-ABI plumbing
                     #   guard.rs safe(): catch_unwind + null-handle; codec.rs UTF-32 marshalling
 cbindgen.toml
@@ -157,6 +161,31 @@ include `funput.h`.
 
 Edition 2024 note: use `#[unsafe(no_mangle)]` and explicit `unsafe { }` around `Box::from_raw` /
 `ptr.as_mut()`.
+
+## The `charset` feature (**off** by default)
+
+Charset conversion (`funput_charset_*`) sits behind a cargo feature. The iOS and Android keyboards
+link this crate and have no use for the tables, so the default build does not carry them. CI checks
+both halves: the default library exports no `funput_charset_*` symbol, and the feature-on build still
+lints and tests clean.
+
+A desktop shell turns it on in two places — the library and the header:
+
+```bash
+cargo build -p funput-ffi --release --features charset
+cc -DFUNPUT_CHARSET ...        # the header declares them inside #ifdef FUNPUT_CHARSET
+```
+
+`platforms/macos/scripts/build-ffi.sh` does **not** enable it yet: no macOS UI calls it, and enabling
+it early only puts tables in a binary nothing reads. When that UI is written, add `--features charset`
+to the script's `cargo build` and `FUNPUT_CHARSET` to the Xcode target's
+`GCC_PREPROCESSOR_DEFINITIONS`.
+
+A charset is named by its **index** into `funput_core::charset::ALL`, not by a name the host spells
+for itself: `Charset` is `#[non_exhaustive]`, so no code outside `funput-core` can enumerate it.
+`funput_charset_count()` and `funput_charset_name()` are between them enough to build a menu, and a
+charset added later turns up in it. That list is **append-only**, so the index is safe to persist as
+the user's saved choice.
 
 ## Dependencies & callers
 

--- a/crates/funput-ffi/README.md
+++ b/crates/funput-ffi/README.md
@@ -141,6 +141,10 @@ src/app_language/   # C API per-app VI/EN memory (FunputAppLanguage), độc l�
                     #   handle.rs (handle new/free + marshalling UTF-8 dùng chung),
                     #   memory.rs (seed/clear/forget), focus.rs (note_focus/note_toggle),
                     #   types.rs (APP_LANG_UNKNOWN/ENGLISH/VIETNAMESE)
+src/charset/       # C API chuyển mã (chuyển đổi + nhận diện), sau feature `charset`
+                    #   mod.rs      count/name + chỉ số bảng mã + ghi UTF-32
+                    #   convert.rs  #[repr(C)] FunputConversion + funput_charset_convert
+                    #   detect.rs   funput_charset_detect
 src/abi/            # plumbing C-ABI dùng chung
                     #   guard.rs safe(): catch_unwind + null-handle; codec.rs UTF-32 marshalling
 cbindgen.toml
@@ -155,6 +159,28 @@ engine trực tiếp); addon Fcitx5 và engine IBus trên Linux link `libfunput_
 
 Lưu ý edition 2024: dùng `#[unsafe(no_mangle)]` và `unsafe { }` tường minh quanh
 `Box::from_raw` / `ptr.as_mut()`.
+
+## Feature `charset` (mặc định **tắt**)
+
+Công cụ chuyển mã (`funput_charset_*`) nằm sau một cargo feature. Bàn phím iOS và Android link crate
+này và không dùng tới bảng mã, nên bản mặc định không mang chúng theo. CI kiểm cả hai nửa: bản mặc
+định **không** export symbol `funput_charset_*` nào, và bản bật feature vẫn lint/test sạch.
+
+Một shell desktop bật nó bằng hai bước — thư viện và header:
+
+```bash
+cargo build -p funput-ffi --release --features charset
+cc -DFUNPUT_CHARSET ...        # header khai báo trong #ifdef FUNPUT_CHARSET
+```
+
+`platforms/macos/scripts/build-ffi.sh` **chưa** bật feature này: chưa có UI macOS nào gọi tới, và bật
+sớm chỉ nhét bảng mã vào binary mà không ai dùng. Khi viết UI đó, thêm `--features charset` vào lệnh
+`cargo build` trong script và `FUNPUT_CHARSET` vào `GCC_PREPROCESSOR_DEFINITIONS` của target Xcode.
+
+Bảng mã được gọi tên bằng **chỉ số** trong `funput_core::charset::ALL`, không phải bằng tên host tự
+đặt: `Charset` là `#[non_exhaustive]` nên không code nào ngoài `funput-core` liệt kê được nó.
+`funput_charset_count()` + `funput_charset_name()` đủ để dựng menu, và bảng mã thêm sau tự hiện ra.
+Danh sách đó **chỉ thêm vào cuối**, nên chỉ số dùng làm lựa chọn lưu lại được.
 
 ## Phụ thuộc & ai gọi
 

--- a/crates/funput-ffi/cbindgen.toml
+++ b/crates/funput-ffi/cbindgen.toml
@@ -9,6 +9,7 @@ style = "type"
 [export]
 include = [
     "FunputConfig",
+    "FunputConversion",
     "FunputResult",
     "FunputSuggestionCandidate",
     "FunputSuggestionResult",
@@ -19,3 +20,7 @@ include = [
 parse_deps = false
 
 [defines]
+# The charset door is behind a cargo feature, so its declarations come out wrapped
+# in `#ifdef FUNPUT_CHARSET`. The header stays one file, and a host that built
+# without the feature does not see functions that are not in the library.
+"feature = charset" = "FUNPUT_CHARSET"

--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -26,6 +26,14 @@
  */
 #define APP_LANG_VIETNAMESE 1
 
+#if defined(FUNPUT_CHARSET)
+/**
+ * [`funput_charset_detect`] when the evidence does not pick a charset out — the
+ * text is ASCII, or reads the same under every candidate. Not an error.
+ */
+#define FUNPUT_CHARSET_UNKNOWN -1
+#endif
+
 /**
  * [`funput_process_key`] source: main keyboard — digits may act as VNI modifiers.
  */
@@ -80,6 +88,34 @@ typedef struct FunputEngine FunputEngine;
  * Vietnamese composition engine and must be driven from a serial worker.
  */
 typedef struct FunputSuggestionEngine FunputSuggestionEngine;
+
+#if defined(FUNPUT_CHARSET)
+/**
+ * What a conversion produced. POD, returned by value — nothing is allocated and
+ * there is nothing to free.
+ *
+ * The two counters are separate because the problems are: `unmapped` is text that
+ * came out **wrong or guessed at**, and is the number worth putting in front of a
+ * user. `normalized` is text understood exactly whose spelling changed — converting
+ * to Unicode tổ hợp changes every toned vowel and none of it is a loss.
+ */
+typedef struct {
+    /**
+     * Codepoints the conversion produced, whether or not they fit in `out`.
+     */
+    uintptr_t len;
+    /**
+     * Characters the target charset could not represent, or represented by
+     * guessing. Non-zero means the result is worth showing the user before use.
+     */
+    uintptr_t unmapped;
+    /**
+     * Characters understood exactly whose spelling the target charset writes
+     * differently. Not a loss, and converting back returns the original.
+     */
+    uintptr_t normalized;
+} FunputConversion;
+#endif
 
 /**
  * Result of one keystroke, returned by value (POD, no allocation, no free).
@@ -213,6 +249,85 @@ void funput_app_language_clear(FunputAppLanguage *handle);
  */
 bool funput_app_language_forget(FunputAppLanguage *handle, const uint8_t *id, uintptr_t id_len);
 
+#if defined(FUNPUT_CHARSET)
+/**
+ * How many charsets there are. Valid indices run `0..funput_charset_count()`.
+ */
+uintptr_t funput_charset_count(void);
+#endif
+
+#if defined(FUNPUT_CHARSET)
+/**
+ * Write the display name of the charset at `index` into `out` as UTF-32, returning
+ * its length in codepoints. An index out of range gives 0.
+ *
+ * The name comes from core so that two platforms' menus cannot drift apart. It is
+ * the encoding's own name (`TCVN3 (ABC)`, `VNI-Windows`), which reads the same in
+ * any interface language.
+ *
+ * Sizing works the same way as [`funput_charset_convert`]: the length is returned
+ * whether or not it fit, and nothing is written unless all of it fits.
+ *
+ * # Safety
+ * `out` must point to at least `cap` writable `u32` values, or be null.
+ */
+uintptr_t funput_charset_name(uintptr_t index, uint32_t *out, uintptr_t cap);
+#endif
+
+#if defined(FUNPUT_CHARSET)
+/**
+ * Convert UTF-32 `text` from one charset to another, writing the result into `out`.
+ *
+ * `from` and `to` are indices into the charset list — see the module doc. Either
+ * one out of range yields a zeroed [`FunputConversion`], as does a panic anywhere
+ * inside.
+ *
+ * # Sizing
+ *
+ * `len` is the length of the result whether or not it fit, and **nothing is written
+ * unless all of it fits**. So a host either guesses a buffer generously and is done
+ * in one call, or passes `out = NULL, cap = 0` to learn the length and calls again.
+ * A conversion is not always shorter than its input: VNI-Windows spells most toned
+ * letters as two characters, so a guess of `text_len` is not enough.
+ *
+ * `unmapped` and `normalized` are filled in on the sizing call too, so a host can
+ * warn about what will be lost before it allocates anything.
+ *
+ * `from` must be what the text actually **is**; guessing it is
+ * [`funput_charset_detect`](super::funput_charset_detect)'s job, not this one's.
+ *
+ * # Safety
+ * `text` must point to at least `text_len` readable `u32` values, or be null.
+ * `out` must point to at least `cap` writable `u32` values, or be null.
+ */
+FunputConversion funput_charset_convert(const uint32_t *text,
+                                        uintptr_t text_len,
+                                        uintptr_t from,
+                                        uintptr_t to,
+                                        uint32_t *out,
+                                        uintptr_t cap);
+#endif
+
+#if defined(FUNPUT_CHARSET)
+/**
+ * Guess which charset `text` is written in. Returns an index into the charset
+ * list, or [`FUNPUT_CHARSET_UNKNOWN`] when the evidence does not pick one out.
+ *
+ * `FUNPUT_CHARSET_UNKNOWN` is not a failure and covers three honest situations: no
+ * evidence at all (ASCII, digits), a genuine tie between charsets that spell this
+ * text the same way, and text that reads identically under every one of them. A
+ * host should offer the user the list rather than treat it as an error.
+ *
+ * Detection reads a prefix rather than a whole document, so passing the whole text
+ * costs nothing. A host that detects on a prefix and converts the whole thing is
+ * doing the right thing.
+ *
+ * # Safety
+ * `text` must point to at least `text_len` readable `u32` values, or be null.
+ */
+int32_t funput_charset_detect(const uint32_t *text, uintptr_t text_len);
+#endif
+
 /**
  * Create a new engine. Release it with [`funput_engine_free`].
  */
@@ -306,8 +421,8 @@ FunputResult funput_flip_composing(FunputEngine *engine);
 /**
  * Re-open an already-committed word as the live composition, so the next keystroke
  * edits it (Backspace back onto `chào`, then `s` gives `cháo`). `word` is UTF-32, as in
- * [`funput_add_shortcut`](crate::funput_add_shortcut). Returns whether it was taken —
- * only a complete Vietnamese syllable is, so leave the document alone on `false`.
+ * [`funput_add_shortcut`](crate::funput_add_shortcut). Returns whether it was taken — only
+ * a Vietnamese syllable is, so leave the document alone on `false`.
  *
  * # Safety
  * `engine` must be a valid handle or null; `word` must point to `len` `u32` values or

--- a/crates/funput-ffi/src/charset/convert.rs
+++ b/crates/funput-ffi/src/charset/convert.rs
@@ -1,0 +1,75 @@
+//! Converting text from one charset to another across the C ABI.
+
+use funput_core::charset;
+
+use crate::abi::{safe, string_from_utf32};
+
+use super::{charset_at, write_text};
+
+/// What a conversion produced. POD, returned by value — nothing is allocated and
+/// there is nothing to free.
+///
+/// The two counters are separate because the problems are: `unmapped` is text that
+/// came out **wrong or guessed at**, and is the number worth putting in front of a
+/// user. `normalized` is text understood exactly whose spelling changed — converting
+/// to Unicode tổ hợp changes every toned vowel and none of it is a loss.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FunputConversion {
+    /// Codepoints the conversion produced, whether or not they fit in `out`.
+    pub len: usize,
+    /// Characters the target charset could not represent, or represented by
+    /// guessing. Non-zero means the result is worth showing the user before use.
+    pub unmapped: usize,
+    /// Characters understood exactly whose spelling the target charset writes
+    /// differently. Not a loss, and converting back returns the original.
+    pub normalized: usize,
+}
+
+/// Convert UTF-32 `text` from one charset to another, writing the result into `out`.
+///
+/// `from` and `to` are indices into the charset list — see the module doc. Either
+/// one out of range yields a zeroed [`FunputConversion`], as does a panic anywhere
+/// inside.
+///
+/// # Sizing
+///
+/// `len` is the length of the result whether or not it fit, and **nothing is written
+/// unless all of it fits**. So a host either guesses a buffer generously and is done
+/// in one call, or passes `out = NULL, cap = 0` to learn the length and calls again.
+/// A conversion is not always shorter than its input: VNI-Windows spells most toned
+/// letters as two characters, so a guess of `text_len` is not enough.
+///
+/// `unmapped` and `normalized` are filled in on the sizing call too, so a host can
+/// warn about what will be lost before it allocates anything.
+///
+/// `from` must be what the text actually **is**; guessing it is
+/// [`funput_charset_detect`](super::funput_charset_detect)'s job, not this one's.
+///
+/// # Safety
+/// `text` must point to at least `text_len` readable `u32` values, or be null.
+/// `out` must point to at least `cap` writable `u32` values, or be null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_charset_convert(
+    text: *const u32,
+    text_len: usize,
+    from: usize,
+    to: usize,
+    out: *mut u32,
+    cap: usize,
+) -> FunputConversion {
+    safe(FunputConversion::default(), || {
+        let (Some(from), Some(to)) = (charset_at(from), charset_at(to)) else {
+            return FunputConversion::default();
+        };
+        // SAFETY: forwarded from this function's own contract.
+        let text = unsafe { string_from_utf32(text, text_len) };
+        let converted = charset::convert(&text, from, to);
+        FunputConversion {
+            // SAFETY: likewise — `out` is the caller's, `cap` describes it.
+            len: unsafe { write_text(&converted.text, out, cap) },
+            unmapped: converted.unmapped,
+            normalized: converted.normalized,
+        }
+    })
+}

--- a/crates/funput-ffi/src/charset/detect.rs
+++ b/crates/funput-ffi/src/charset/detect.rs
@@ -1,0 +1,39 @@
+//! Guessing which charset a piece of text is written in, across the C ABI.
+
+use funput_core::charset;
+
+use crate::abi::{safe, string_from_utf32};
+
+use super::FUNPUT_CHARSET_UNKNOWN;
+
+/// Guess which charset `text` is written in. Returns an index into the charset
+/// list, or [`FUNPUT_CHARSET_UNKNOWN`] when the evidence does not pick one out.
+///
+/// `FUNPUT_CHARSET_UNKNOWN` is not a failure and covers three honest situations: no
+/// evidence at all (ASCII, digits), a genuine tie between charsets that spell this
+/// text the same way, and text that reads identically under every one of them. A
+/// host should offer the user the list rather than treat it as an error.
+///
+/// Detection reads a prefix rather than a whole document, so passing the whole text
+/// costs nothing. A host that detects on a prefix and converts the whole thing is
+/// doing the right thing.
+///
+/// # Safety
+/// `text` must point to at least `text_len` readable `u32` values, or be null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_charset_detect(text: *const u32, text_len: usize) -> i32 {
+    safe(FUNPUT_CHARSET_UNKNOWN, || {
+        // SAFETY: forwarded from this function's own contract.
+        let text = unsafe { string_from_utf32(text, text_len) };
+        let Some(detected) = charset::detect(&text) else {
+            return FUNPUT_CHARSET_UNKNOWN;
+        };
+        // The charset came from `ALL`, so it is always in it; the fallback is
+        // unreachable rather than a policy.
+        charset::ALL
+            .iter()
+            .position(|&c| c == detected)
+            .and_then(|index| i32::try_from(index).ok())
+            .unwrap_or(FUNPUT_CHARSET_UNKNOWN)
+    })
+}

--- a/crates/funput-ffi/src/charset/mod.rs
+++ b/crates/funput-ffi/src/charset/mod.rs
@@ -1,0 +1,104 @@
+//! Charset-conversion C ABI: turning Vietnamese text between Unicode and the
+//! legacy encodings, for a shell that cannot link `funput-core` directly.
+//!
+//! Behind the `charset` cargo feature, **off by default**. The iOS and Android
+//! keyboards link this crate and have no use for the tables, so they never carry
+//! them; a desktop shell asks for the feature and gets the whole door.
+//!
+//! # Naming a charset
+//!
+//! A charset is an **index into `funput_core::charset::ALL`**, not a name the host
+//! spells for itself. `Charset` is `#[non_exhaustive]`, so no code outside
+//! `funput-core` can enumerate it — a host writing its own list would silently miss
+//! a charset added later. [`funput_charset_count`] and [`funput_charset_name`] are
+//! between them enough to build a menu, and a charset added to core turns up in that
+//! menu without a line changing here.
+//!
+//! **That list is append-only, and it is what makes the index an identity.** A host
+//! may store the index as the user's saved choice. Reordering `ALL` would quietly
+//! turn a saved TCVN3 into VNI-Windows, so core does not reorder it.
+//!
+//! # Text, not files
+//!
+//! Both entry points take text, matching `funput_core::charset::convert`. Core has a
+//! second door for raw bytes and it is deliberately **not** here: a shell reading a
+//! *file* needs the whole cascade — UTF-16 byte-order marks, a UTF-8 attempt, and
+//! the rule that bytes which failed UTF-8 may only be answered with a byte-oriented
+//! charset. Exporting those three primitives would hand the subtle part to the
+//! caller and get it reimplemented once per platform, which is the duplication the
+//! shared core exists to prevent. When a file-reading shell needs it, that cascade
+//! belongs in core as one call, and this module gets one more export.
+
+mod convert;
+mod detect;
+
+use funput_core::charset::{self, Charset};
+
+use crate::abi::safe;
+
+pub use convert::{FunputConversion, funput_charset_convert};
+pub use detect::funput_charset_detect;
+
+/// [`funput_charset_detect`] when the evidence does not pick a charset out — the
+/// text is ASCII, or reads the same under every candidate. Not an error.
+pub const FUNPUT_CHARSET_UNKNOWN: i32 = -1;
+
+/// How many charsets there are. Valid indices run `0..funput_charset_count()`.
+#[unsafe(no_mangle)]
+pub extern "C" fn funput_charset_count() -> usize {
+    charset::ALL.len()
+}
+
+/// Write the display name of the charset at `index` into `out` as UTF-32, returning
+/// its length in codepoints. An index out of range gives 0.
+///
+/// The name comes from core so that two platforms' menus cannot drift apart. It is
+/// the encoding's own name (`TCVN3 (ABC)`, `VNI-Windows`), which reads the same in
+/// any interface language.
+///
+/// Sizing works the same way as [`funput_charset_convert`]: the length is returned
+/// whether or not it fit, and nothing is written unless all of it fits.
+///
+/// # Safety
+/// `out` must point to at least `cap` writable `u32` values, or be null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_charset_name(index: usize, out: *mut u32, cap: usize) -> usize {
+    safe(0, || {
+        let Some(charset) = charset_at(index) else {
+            return 0;
+        };
+        unsafe { write_text(charset.name(), out, cap) }
+    })
+}
+
+/// The charset an ABI index names, or `None` when the host passed one out of range.
+pub(crate) fn charset_at(index: usize) -> Option<Charset> {
+    charset::ALL.get(index).copied()
+}
+
+/// Write `text` into `out` as UTF-32, returning its length in codepoints — whether
+/// or not it fit.
+///
+/// **All-or-nothing, unlike [`crate::abi::copy_codepoints`], which truncates.** That
+/// one serves a 64-character composing buffer where a clipped tail is visible
+/// immediately. Here the text is a document, and half of one written into a
+/// too-small buffer is worse than none: the caller reads a success it did not get.
+/// Returning the required length lets it size the buffer and call again.
+///
+/// # Safety
+/// `out` must point to at least `cap` writable `u32` values, or be null.
+pub(crate) unsafe fn write_text(text: &str, out: *mut u32, cap: usize) -> usize {
+    let len = text.chars().count();
+    if out.is_null() || cap < len {
+        return len;
+    }
+    // SAFETY: the caller promises `cap` writable values, and `len <= cap` here.
+    let dst = unsafe { std::slice::from_raw_parts_mut(out, len) };
+    for (slot, ch) in dst.iter_mut().zip(text.chars()) {
+        *slot = ch as u32;
+    }
+    len
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/funput-ffi/src/charset/tests.rs
+++ b/crates/funput-ffi/src/charset/tests.rs
@@ -1,0 +1,196 @@
+use super::*;
+
+/// Convert a Rust string to the UTF-32 the ABI speaks.
+fn utf32(text: &str) -> Vec<u32> {
+    text.chars().map(|c| c as u32).collect()
+}
+
+fn read(out: &[u32], len: usize) -> String {
+    out[..len]
+        .iter()
+        .filter_map(|&c| char::from_u32(c))
+        .collect()
+}
+
+/// Call `funput_charset_convert` the way a host should: size, allocate, convert.
+fn convert(text: &str, from: usize, to: usize) -> (String, FunputConversion) {
+    let src = utf32(text);
+    let sizing = unsafe {
+        funput_charset_convert(src.as_ptr(), src.len(), from, to, std::ptr::null_mut(), 0)
+    };
+    let mut out = vec![0u32; sizing.len];
+    let done = unsafe {
+        funput_charset_convert(
+            src.as_ptr(),
+            src.len(),
+            from,
+            to,
+            out.as_mut_ptr(),
+            out.len(),
+        )
+    };
+    assert_eq!(sizing, done, "the sizing call must predict the real one");
+    (read(&out, done.len), done)
+}
+
+fn index_of(name: &str) -> usize {
+    (0..funput_charset_count())
+        .find(|&i| charset_at(i).is_some_and(|c| c.name() == name))
+        .expect("charset not in the list")
+}
+
+#[test]
+fn the_list_is_the_one_core_publishes() {
+    assert_eq!(funput_charset_count(), funput_core::charset::ALL.len());
+    assert!(funput_charset_count() > 0);
+}
+
+/// The point of exporting names at all: a host builds its menu without knowing a
+/// single charset, and a charset added to core turns up in it.
+#[test]
+fn every_index_names_a_charset_and_nothing_past_the_end_does() {
+    for index in 0..funput_charset_count() {
+        let len = unsafe { funput_charset_name(index, std::ptr::null_mut(), 0) };
+        assert!(len > 0, "charset {index} has no name");
+
+        let mut out = vec![0u32; len];
+        assert_eq!(
+            unsafe { funput_charset_name(index, out.as_mut_ptr(), out.len()) },
+            len
+        );
+        assert!(!read(&out, len).is_empty());
+    }
+    assert_eq!(
+        unsafe { funput_charset_name(funput_charset_count(), std::ptr::null_mut(), 0) },
+        0
+    );
+}
+
+/// All-or-nothing, not truncation: a buffer one short is left untouched, so a host
+/// that ignores the returned length reads nothing rather than half a document.
+#[test]
+fn a_buffer_that_is_one_short_is_not_written_to() {
+    let src = utf32("Việt Nam");
+    let unicode = index_of("Unicode dựng sẵn");
+    let sizing = unsafe {
+        funput_charset_convert(
+            src.as_ptr(),
+            src.len(),
+            unicode,
+            unicode,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+
+    let mut out = vec![0u32; sizing.len - 1];
+    let short = unsafe {
+        funput_charset_convert(
+            src.as_ptr(),
+            src.len(),
+            unicode,
+            unicode,
+            out.as_mut_ptr(),
+            out.len(),
+        )
+    };
+    assert_eq!(
+        short.len, sizing.len,
+        "the required length is still reported"
+    );
+    assert!(
+        out.iter().all(|&c| c == 0),
+        "nothing should have been written"
+    );
+}
+
+#[test]
+fn text_survives_a_trip_out_to_every_charset_and_back() {
+    let unicode = index_of("Unicode dựng sẵn");
+    for target in 0..funput_charset_count() {
+        let (there, _) = convert("Việt Nam", unicode, target);
+        let (back, _) = convert(&there, target, unicode);
+        assert_eq!(back, "Việt Nam", "charset {target}");
+    }
+}
+
+/// Pins the sizing advice in the doc: a conversion can be *longer* than its input,
+/// so `cap = text_len` is not a safe guess.
+#[test]
+fn converting_to_vni_produces_more_characters_than_it_was_given() {
+    let (text, out) = convert(
+        "Việt",
+        index_of("Unicode dựng sẵn"),
+        index_of("VNI-Windows"),
+    );
+    assert!(out.len > "Việt".chars().count(), "{text:?}");
+    assert_eq!(out.unmapped, 0);
+}
+
+/// TCVN3 has no code for an uppercase toned vowel, and the count says so on the
+/// sizing call — before the host has allocated anything.
+#[test]
+fn what_cannot_be_represented_is_counted_before_any_buffer_exists() {
+    let src = utf32("Ề");
+    let out = unsafe {
+        funput_charset_convert(
+            src.as_ptr(),
+            src.len(),
+            index_of("Unicode dựng sẵn"),
+            index_of("TCVN3 (ABC)"),
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    assert_eq!(out.unmapped, 1);
+    assert!(
+        out.len > 0,
+        "a character is never dropped, only spelled badly"
+    );
+}
+
+#[test]
+fn an_index_past_the_end_converts_nothing_rather_than_guessing() {
+    let src = utf32("Việt Nam");
+    let past = funput_charset_count();
+    let out = unsafe {
+        funput_charset_convert(src.as_ptr(), src.len(), past, 0, std::ptr::null_mut(), 0)
+    };
+    assert_eq!(out, FunputConversion::default());
+}
+
+#[test]
+fn null_text_is_an_empty_conversion_rather_than_a_crash() {
+    let out = unsafe { funput_charset_convert(std::ptr::null(), 7, 0, 0, std::ptr::null_mut(), 0) };
+    assert_eq!(out, FunputConversion::default());
+    assert_eq!(
+        unsafe { funput_charset_detect(std::ptr::null(), 7) },
+        FUNPUT_CHARSET_UNKNOWN
+    );
+}
+
+/// The index detection hands back is one `funput_charset_convert` accepts — the
+/// whole reason both speak in indices rather than names.
+#[test]
+fn what_detection_returns_can_be_fed_straight_back_in() {
+    let unicode = index_of("Unicode dựng sẵn");
+    let (tcvn3_text, _) = convert("việt nam hà nội", unicode, index_of("TCVN3 (ABC)"));
+
+    let src = utf32(&tcvn3_text);
+    let detected = unsafe { funput_charset_detect(src.as_ptr(), src.len()) };
+    assert_eq!(detected, index_of("TCVN3 (ABC)") as i32);
+
+    let (back, _) = convert(&tcvn3_text, detected as usize, unicode);
+    assert_eq!(back, "việt nam hà nội");
+}
+
+/// Declining is the honest answer for text that reads the same under every
+/// candidate, and a host must not treat it as a failure.
+#[test]
+fn ascii_is_declined_rather_than_guessed_at() {
+    let src = utf32("the quick brown fox");
+    assert_eq!(
+        unsafe { funput_charset_detect(src.as_ptr(), src.len()) },
+        FUNPUT_CHARSET_UNKNOWN
+    );
+}

--- a/crates/funput-ffi/src/lib.rs
+++ b/crates/funput-ffi/src/lib.rs
@@ -21,6 +21,10 @@
 //! - `app_language/` — per-app VI/EN memory ([`FunputAppLanguage`] + the
 //!   `funput_app_language_*` calls), independent of composition too; the host
 //!   wires its decision into [`funput_set_enabled`] itself.
+//! - `charset/` — converting text between Unicode and the legacy Vietnamese
+//!   encodings ([`funput_charset_convert`] and friends). Behind the `charset`
+//!   cargo feature, off by default, and independent of everything above: it takes
+//!   text and returns text, and never touches an engine handle.
 //! - `abi/` — the shared panic guard, null-handle check, and UTF-32 marshalling.
 //!
 //! # Safety
@@ -35,6 +39,8 @@
 
 mod abi;
 mod app_language;
+#[cfg(feature = "charset")]
+mod charset;
 mod engine;
 mod suggestion;
 
@@ -43,6 +49,11 @@ pub use app_language::{
     funput_app_language_clear, funput_app_language_forget, funput_app_language_free,
     funput_app_language_new, funput_app_language_note_focus, funput_app_language_note_toggle,
     funput_app_language_seed,
+};
+#[cfg(feature = "charset")]
+pub use charset::{
+    FUNPUT_CHARSET_UNKNOWN, FunputConversion, funput_charset_convert, funput_charset_count,
+    funput_charset_detect, funput_charset_name,
 };
 pub use engine::{
     ACTION_NONE, ACTION_RESTORE, ACTION_SEND, CHARS_CAP, FunputConfig, FunputEngine, FunputResult,

--- a/docs/features/charset.md
+++ b/docs/features/charset.md
@@ -376,6 +376,25 @@ chứng mạnh **chống lại** hai bảng mã Unicode — bằng chứng mà `
 thấy, vì lúc nó cầm được `&str` thì hư hỏng đã được vá rồi. Hai cửa **bất đồng** trên
 cùng một nội dung Latin-1; đó là bản chất, và có test ghim lại.
 
+### Cửa C ABI (`funput-ffi`, feature `charset`, mặc định tắt)
+
+Cho shell không link Rust được — macOS là ca thật. Bảng mã được gọi tên bằng **chỉ số trong
+`ALL`**, không phải hằng số riêng của FFI: viết `match charset` ngoài `funput-core` cần nhánh
+wildcard, nên bảng mã thêm sau sẽ âm thầm rơi ra ngoài. `funput_charset_count()` +
+`funput_charset_name()` đủ dựng menu. Đổi lại, **`ALL` chỉ được thêm vào cuối** — đảo thứ tự sẽ
+biến TCVN3 mà người dùng đã lưu thành VNI.
+
+Chuỗi đi qua UTF-32 + buffer của caller như phần còn lại của crate đó, nhưng **được ăn cả ngã
+không**: trả về độ dài cần thiết, và chỉ ghi khi vừa. `copy_codepoints` cắt bớt vì nó phục vụ
+buffer 64 ký tự đang gõ; ở đây đầu vào là cả văn bản, và một nửa văn bản ghi vào buffer thiếu chỗ
+tệ hơn là không ghi gì. Hai bộ đếm có mặt ngay ở lượt hỏi độ dài, nên host cảnh báo được trước khi
+cấp phát.
+
+**Chỉ cửa text.** Cửa byte không xuất ra: shell đọc *tệp* cần cả tầng giải mã (BOM UTF-16, thử
+UTF-8, và luật byte đã trượt UTF-8 thì chỉ được trả lời bằng bảng mã theo byte). Xuất ba nguyên
+thuỷ đó ra là giao phần tinh tế cho caller và để nó bị viết lại một lần mỗi nền tảng — đúng thứ
+core sinh ra để tránh. Khi có shell cần, tầng đó thuộc về core dưới dạng **một** lời gọi.
+
 ### Thứ nó không làm được
 
 Mọi phán đoán ở đây đều **tương đối**: bốn giả thuyết, cái nào khớp nhất thì thắng.


### PR DESCRIPTION
Stacked on #235. Step 8 of the order in `docs/features/charset.md`.

## Why

macOS drives the engine through the C ABI, so charset conversion has to arrive the same way. Windows and the CLI link `funput-core` directly and need none of this; a Swift shell has no other door.

## The surface

```c
#ifdef FUNPUT_CHARSET
#define FUNPUT_CHARSET_UNKNOWN -1

typedef struct FunputConversion { uintptr_t len, unmapped, normalized; } FunputConversion;

uintptr_t       funput_charset_count(void);
uintptr_t       funput_charset_name(uintptr_t index, uint32_t *out, uintptr_t cap);
int32_t         funput_charset_detect(const uint32_t *text, uintptr_t text_len);
FunputConversion funput_charset_convert(const uint32_t *text, uintptr_t text_len,
                                        uintptr_t from, uintptr_t to,
                                        uint32_t *out, uintptr_t cap);
#endif
```

**A charset is an index into `charset::ALL`, not an FFI constant of its own.** `Charset` is `#[non_exhaustive]`, so a `match` outside `funput-core` needs a wildcard arm and would silently drop a variant added later; an index cannot. `count()` + `name()` are between them enough to build a menu, and a charset added to core turns up in it without a line changing here — which is what #235 was for. The price is that `ALL` is append-only, since a host may persist the index as the user's saved choice; that is now written down in both places.

**All-or-nothing writes.** Strings go through UTF-32 and a caller buffer like the rest of the crate, but the required length comes back whether or not it fit, and nothing is written unless all of it does. `copy_codepoints` truncates because it serves a 64-character composing buffer where a clipped tail is visible at once; here the input is a whole document and half of one is worse than none. Both counters are filled in on the sizing call, so a host can warn about what will be lost before it allocates anything.

**Text only, deliberately.** Core's byte door is not exported. A shell reading a *file* needs the whole cascade — UTF-16 marks, a UTF-8 attempt, and the rule that bytes which failed UTF-8 may only be answered with a byte-oriented charset — and shipping the three primitives would hand the subtle part to each platform to rebuild, which is what the shared core exists to prevent. When a file-reading shell exists, that cascade belongs in core as one call and this module gets one more export. Stated in the module doc and the design doc rather than left as a gap.

## A CI guard that had gone quiet

`! cargo tree -p funput-ffi -e features | grep -q charset` catches a *dependency* dragging charset in — the case it was written for, still worth keeping. It cannot see a crate's **own** feature: `cargo tree -p funput-ffi -F charset` renders output byte-identical to the default, so the assertion would have passed while saying nothing about the thing this PR introduces.

The library is now asked directly:

```
nm -D --defined-only target/debug/libfunput_ffi.so | grep -q funput_process_char   # positive control
! nm -D --defined-only target/debug/libfunput_ffi.so | grep -q funput_charset
```

The control line is there so the check cannot go vacuous the way the last one did. Verified locally on the Windows artifact: 4 `funput_charset` symbols with the feature, 0 without, and the control present in both.

CI also gains `clippy`/`test` for `-p funput-ffi --features charset` — nothing else compiles the module, so without them it would ship unbuilt and unlinted.

## macOS build script: not yet

`platforms/macos/scripts/build-ffi.sh` deliberately does **not** gain `--features charset` in this PR. No macOS UI calls it, enabling it early only puts tables in a binary nothing reads, and the matching half (`FUNPUT_CHARSET` in the Xcode target's preprocessor defines) is a project change I would be guessing at. Both steps are written down in the crate READMEs for whoever builds that UI.

## Also

Regenerating the header picked up a doc comment on `funput_adopt` that had drifted from the Rust source before this branch. Regeneration is idempotent — verified by running it twice.

`crates/funput-ffi/src/` goes from 5 entries to 6. `charset/` is a peer C API, not part of `engine/` or `suggestion/`, so there is nowhere else honest to put it; `src/charset/` itself holds 4 files.

## Checks

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, the charset-off pair, the new charset-on pair, both `cargo tree` assertions, the symbol guard, and `scripts/check-loc.sh` (300 files, all within budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)