### PR TITLE
fix(ios): enable Caps Lock from a Shift double-tap in either case

### DIFF
--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/State/ShiftStateController.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/State/ShiftStateController.swift
@@ -22,9 +22,10 @@ struct ShiftStateController {
         }
 
         let tapTime = clock()
-        if state == .uppercase,
-           let lastTapTime,
-           tapTime - lastTapTime <= doubleTapInterval {
+        // Caps Lock is a double tap from either case. Gating on `.uppercase`
+        // only locked when the first tap had come from lowercase — a sentence
+        // start that already had Shift armed just toggled twice.
+        if let lastTapTime, tapTime - lastTapTime <= doubleTapInterval {
             resetTapSequence()
             return .capsLocked
         }

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Coordinator/KeyboardInputStateTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Coordinator/KeyboardInputStateTests.swift
@@ -42,8 +42,8 @@ struct KeyboardInputStateTests {
         #expect(coordinator.state.shiftState == .uppercase)
     }
 
-    @Test("Double-tapping Shift enables Caps Lock until Shift is tapped again")
-    func capsLock() {
+    @Test("Double-tapping Shift from lowercase enables Caps Lock until Shift is tapped again")
+    func capsLockFromLowercase() {
         var time = 10.0
         let coordinator = KeyboardInputCoordinator(shiftClock: { time })
         let document = TestKeyboardWriter()
@@ -58,6 +58,28 @@ struct KeyboardInputStateTests {
 
         coordinator.handle(testKey(.shift), writer: document)
         #expect(coordinator.state.shiftState == .lowercase)
+    }
+
+    @Test("Double-tapping Shift from uppercase enables Caps Lock")
+    func capsLockFromUppercase() {
+        var time = 10.0
+        let coordinator = KeyboardInputCoordinator(shiftClock: { time })
+        let document = TestKeyboardWriter()
+        coordinator.updateContext(inputContext(
+            editorMode: .text,
+            enterAction: .newLine,
+            autocapitalization: .sentences
+        ))
+        coordinator.synchronizeDocument(document, event: .activated)
+        #expect(coordinator.state.shiftState == .uppercase)
+
+        coordinator.handle(testKey(.shift), writer: document)
+        time += 0.1
+        coordinator.handle(testKey(.shift), writer: document)
+        type("xi", with: coordinator, into: document)
+
+        #expect(document.text == "XI")
+        #expect(coordinator.state.shiftState == .capsLocked)
     }
 
     @Test("Layout navigation switches between letters and symbol pages")

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/State/ShiftStateControllerTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/State/ShiftStateControllerTests.swift
@@ -1,0 +1,62 @@
+#if os(iOS) && canImport(FunputCore)
+@testable import KeyboardInput
+import KeyboardLayout
+import Testing
+
+@MainActor
+struct ShiftStateControllerTests {
+    @Test("Double-tapping from lowercase enables Caps Lock")
+    func doubleTapFromLowercase() {
+        var now: Double = 0
+        var controller = ShiftStateController(doubleTapInterval: 0.3) { now }
+
+        let first = controller.toggle(from: .lowercase)
+        now = 0.1
+        let second = controller.toggle(from: first)
+
+        #expect(first == .uppercase)
+        #expect(second == .capsLocked)
+    }
+
+    @Test("Double-tapping from uppercase enables Caps Lock")
+    func doubleTapFromUppercase() {
+        var now: Double = 0
+        var controller = ShiftStateController(doubleTapInterval: 0.3) { now }
+
+        let first = controller.toggle(from: .uppercase)
+        now = 0.1
+        let second = controller.toggle(from: first)
+
+        #expect(first == .lowercase)
+        #expect(second == .capsLocked)
+    }
+
+    @Test("A delayed second tap still toggles instead of locking")
+    func outsideWindowToggles() {
+        var now: Double = 0
+        var controller = ShiftStateController(doubleTapInterval: 0.3) { now }
+
+        let first = controller.toggle(from: .uppercase)
+        now = 0.4
+        let second = controller.toggle(from: first)
+
+        #expect(first == .lowercase)
+        #expect(second == .uppercase)
+    }
+
+    @Test("Tapping Shift while Caps Lock is on turns it off")
+    func capsLockReleases() {
+        var now: Double = 0
+        var controller = ShiftStateController(doubleTapInterval: 0.3) { now }
+
+        _ = controller.toggle(from: .lowercase)
+        now = 0.1
+        let locked = controller.toggle(from: .uppercase)
+        now = 0.15
+        let released = controller.toggle(from: locked)
+
+        #expect(locked == .capsLocked)
+        #expect(released == .lowercase)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Double-tapping Shift now enables Caps Lock from both lowercase and uppercase, including a sentence start that already has Shift armed.

## Test plan

- [x] `KeyboardInputTests` — `ShiftStateController`, `KeyboardInputState`, `KeyboardAutocapitalization`
- [x] On device: double-tap Shift at a sentence start and mid-word; both should lock Caps Lock

Made with [Cursor](https://cursor.com)