### PR TITLE
feat(cli): add funput convert, the charset-conversion tool

### DIFF
--- a/crates/funput-cli/Cargo.toml
+++ b/crates/funput-cli/Cargo.toml
@@ -12,7 +12,7 @@ name = "funput"
 path = "src/main.rs"
 
 [dependencies]
-funput-core = { path = "../funput-core" }
+funput-core = { path = "../funput-core", features = ["charset"] }
 funput-engine = { path = "../funput-engine" }
 funput-term = { path = "../funput-term" }
 clap = { version = "4.6.1", features = ["derive"] }

--- a/crates/funput-cli/README.en.md
+++ b/crates/funput-cli/README.en.md
@@ -61,6 +61,32 @@ funput dev coverage benchmarks/sample.txt --show-mismatches 10
 funput dev coverage benchmarks/.corpus/Viet74K.txt --json
 ```
 
+## Usage — `funput convert`
+
+Convert text between Unicode and the legacy charsets Vietnamese government paperwork still uses
+(TCVN3/`.VnTime`, VNI-Windows). It converts **text that already exists**; typing in a legacy
+charset is out of scope.
+
+```bash
+funput convert --list                            # the charsets, with the slug you type
+funput convert doc.txt --detect                  # what charset does this file look like?
+funput convert doc.txt --to unicode > new.txt    # TCVN3/VNI → Unicode, source guessed
+funput convert --to tcvn3 < new.txt > old.txt    # and back, as **bytes**, one per letter
+funput convert old.txt --from tcvn3 --to vni-windows
+```
+
+Leave `--from` off and the charset is worked out; give it and what you say wins over what was
+guessed. When nothing can be worked out — the bytes are not UTF-8 and no charset explains them —
+the command stops and asks for `--from` rather than guessing.
+
+**Standard output is the document; standard error is the talking.** `--list`/`--detect` and the
+warnings stay out of the result, so `funput convert … > out.txt` produces exactly that file.
+Converting to a legacy charset writes **one byte per letter** — that is what a `.VnTime` document
+holds; writing it as UTF-8 would produce a file Word cannot read.
+
+No charset is named in the code here: `--to tcvn3` is matched against `funput_core::charset::ALL`
+by slug, so implementing VISCII is one PR in core and this command picks it up.
+
 ## Platform simulation (`dev/sim.rs` — the heart; pure, tested)
 
 `simulate(method, input) -> Simulation { app_text, steps }` does **exactly** what a platform shell
@@ -85,6 +111,11 @@ src/
 ├── cli.rs         # Cli, Command{Term, Dev}, MethodArg(→InputMethod), CliError/CliResult
 ├── term/
 │   └── mod.rs     # args + handler for `funput term` (wrapper via funput-term + install)
+├── convert/       # `funput convert` — the charset-conversion tool
+│   ├── mod.rs     # args + the flow: read → identify → convert → write
+│   ├── source.rs  # bytes → text + charset (two doors: UTF-8 or byte-oriented)
+│   ├── sink.rs    # writes **bytes** to stdout, not text
+│   └── report.rs  # --list, --detect, loss warnings (all to stderr)
 └── dev/
     ├── mod.rs     # args + dispatch for `funput dev` (run/repl/coverage)
     ├── sim.rs     # simulate() — platform simulation; pure, tested

--- a/crates/funput-cli/README.md
+++ b/crates/funput-cli/README.md
@@ -60,6 +60,31 @@ funput dev coverage benchmarks/sample.txt --show-mismatches 10
 funput dev coverage benchmarks/.corpus/Viet74K.txt --json
 ```
 
+## Dùng — `funput convert`
+
+Chuyển văn bản giữa Unicode và các bảng mã cũ mà văn bản Nhà nước còn dùng (TCVN3/`.VnTime`,
+VNI-Windows). Chỉ **chuyển văn bản đã có**; gõ bằng bảng mã cũ không nằm trong phạm vi.
+
+```bash
+funput convert --list                            # bảng mã + slug để gõ
+funput convert vanban.txt --detect               # đoán xem tệp này bảng mã gì
+funput convert vanban.txt --to unicode > moi.txt # TCVN3/VNI → Unicode (tự nhận diện)
+funput convert --to tcvn3 < moi.txt > cu.txt     # ngược lại, ghi ra **byte** một byte/chữ
+funput convert cu.txt --from tcvn3 --to vni-windows
+```
+
+Bỏ `--from` thì bảng mã được đoán; khai báo `--from` thì lời khai thắng phép đoán. Không đoán được
+(byte không phải UTF-8 và không bảng mã nào giải thích nổi) thì lệnh dừng và bảo dùng `--from`,
+chứ không đoán bừa.
+
+**stdout là tài liệu, stderr là lời nói.** `--list`/`--detect` và cảnh báo không lẫn vào tệp kết
+quả, nên `funput convert … > out.txt` cho ra đúng tệp đó. Chuyển sang bảng mã cũ ghi **một byte
+mỗi chữ** — đó là thứ tệp `.VnTime` chứa; ghi thành UTF-8 sẽ ra tệp Word đọc không được.
+
+Không bảng mã nào bị gọi tên trong code ở đây: `--to tcvn3` đối chiếu với
+`funput_core::charset::ALL` bằng slug, nên thêm VISCII là một PR trong core và lệnh này hưởng miễn
+phí.
+
 ## Mô phỏng platform (`dev/sim.rs` — trái tim, thuần, có test)
 
 `simulate(method, input) -> Simulation { app_text, steps }` làm **đúng** việc một platform shell làm:
@@ -84,6 +109,11 @@ src/
 ├── cli.rs         # Cli, Command{Term, Dev}, MethodArg(→InputMethod), CliError/CliResult
 ├── term/
 │   └── mod.rs     # args + handler `funput term` (wrapper qua funput-term + install)
+├── convert/       # `funput convert` — công cụ chuyển mã
+│   ├── mod.rs     # args + luồng: đọc → nhận diện → chuyển → ghi
+│   ├── source.rs  # bytes → text + bảng mã (hai cửa: UTF-8 hay theo byte)
+│   ├── sink.rs    # ghi **bytes** ra stdout (không phải text)
+│   └── report.rs  # --list, --detect, cảnh báo mất mát (đều ra stderr)
 └── dev/
     ├── mod.rs     # args + dispatch `funput dev` (run/repl/coverage)
     ├── sim.rs     # simulate() — mô phỏng platform, thuần, có test

--- a/crates/funput-cli/src/cli.rs
+++ b/crates/funput-cli/src/cli.rs
@@ -11,6 +11,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 use funput_core::InputMethod;
 
+use crate::convert::ConvertArgs;
 use crate::dev::DevArgs;
 use crate::term::TermArgs;
 
@@ -31,6 +32,8 @@ pub enum Command {
     Term(TermArgs),
     /// Developer & CI tools that drive funput-engine directly.
     Dev(DevArgs),
+    /// Convert Vietnamese text between Unicode and the legacy charsets.
+    Convert(ConvertArgs),
 }
 
 /// Input method as selected on the command line. Kept at the CLI layer (a clap

--- a/crates/funput-cli/src/convert/mod.rs
+++ b/crates/funput-cli/src/convert/mod.rs
@@ -1,0 +1,100 @@
+//! `funput convert`: the charset-conversion tool (công cụ chuyển mã).
+//!
+//! Vietnamese government documents still circulate in TCVN3, drawn by the `.VnTime`
+//! fonts, and in VNI-Windows. This turns them into Unicode and back. It converts
+//! text that already exists; typing in a legacy charset is not offered and is not
+//! planned — see `docs/features/charset.md`.
+//!
+//! - [`source`] — turning an argument or standard input into text, and working out
+//!   what charset spelled it.
+//! - [`sink`] — writing the result back out, as bytes when the target is a legacy
+//!   charset and as UTF-8 when it is not.
+//! - [`report`] — everything printed to standard error: the charset table, the
+//!   detected name, and the warning when something could not be represented.
+//!
+//! Nothing here names a charset. `--to tcvn3` is matched against
+//! `funput_core::charset::ALL` by slug, so implementing VISCII in core is one PR
+//! there and this command picks it up.
+
+mod report;
+mod sink;
+mod source;
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Args;
+
+use funput_core::charset::{self, Charset};
+
+use crate::cli::{CliError, CliResult};
+
+#[derive(Debug, Args)]
+pub struct ConvertArgs {
+    /// File to convert. Reads standard input when omitted.
+    pub file: Option<PathBuf>,
+
+    /// Charset to convert to, by slug (`funput convert --list`).
+    #[arg(short, long, value_name = "CHARSET", required_unless_present_any = ["detect", "list"])]
+    pub to: Option<String>,
+
+    /// Charset the input is in. Guessed when omitted.
+    #[arg(short, long, value_name = "CHARSET")]
+    pub from: Option<String>,
+
+    /// Print the charset the input looks like and stop.
+    #[arg(long, conflicts_with = "to")]
+    pub detect: bool,
+
+    /// List the charsets and stop.
+    #[arg(long, exclusive = true)]
+    pub list: bool,
+}
+
+/// Run `funput convert`.
+pub fn run(args: ConvertArgs) -> CliResult {
+    if args.list {
+        report::list();
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    // Both slugs are resolved before anything is read, so a typo in `--to` is
+    // answered straight away rather than after standard input has been drained.
+    let to = args.to.as_deref().map(by_slug).transpose()?;
+    let declared = args.from.as_deref().map(by_slug).transpose()?;
+
+    let input = source::read(args.file.as_deref())?;
+    // A charset the user named beats one that was worked out: they are looking at
+    // the document, and the detector is looking at statistics.
+    let Some(from) = declared.or(input.charset) else {
+        return Err(CliError::Msg(report::UNDETECTED.to_string()));
+    };
+
+    // No `--to` means `--detect`: clap makes each one required unless the other is
+    // present, so there is no third case to handle.
+    let Some(to) = to else {
+        report::detected(from);
+        return Ok(ExitCode::SUCCESS);
+    };
+
+    // Through the pivot, which is what makes this one command rather than one per
+    // pair: core reads `from` into Unicode, and writes Unicode back out as `to`.
+    let read = charset::convert(&input.text, from, Charset::Unicode);
+    let (bytes, written) = charset::encode_bytes(&read.text, to);
+    sink::write(&bytes)?;
+    report::losses(&read, &written);
+    Ok(ExitCode::SUCCESS)
+}
+
+/// The charset a slug names. The error lists what would have worked, since a wrong
+/// slug is nearly always a typo or a guess at the spelling.
+fn by_slug(slug: &str) -> Result<Charset, CliError> {
+    charset::ALL
+        .iter()
+        .copied()
+        .find(|c| c.slug() == slug)
+        .ok_or_else(|| CliError::Msg(report::unknown_slug(slug)))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/funput-cli/src/convert/report.rs
+++ b/crates/funput-cli/src/convert/report.rs
@@ -1,0 +1,64 @@
+//! Everything this command says, as opposed to everything it converts.
+//!
+//! All of it goes to standard error, because standard output carries the converted
+//! document and `funput convert … > out.txt` has to produce exactly that file.
+
+use funput_core::charset::{self, Charset, Conversion};
+
+/// What to say when nothing could be guessed and nothing was declared.
+pub(super) const UNDETECTED: &str =
+    "cannot tell which charset this is — say so with --from (see --list)";
+
+/// The charset table, for `--list`. Slug first: that is the word the user types.
+pub(super) fn list() {
+    let width = charset::ALL
+        .iter()
+        .map(|c| c.slug().len())
+        .max()
+        .unwrap_or(0);
+    for charset in charset::ALL {
+        println!("{:width$}  {}", charset.slug(), charset.name());
+    }
+}
+
+/// The answer to `--detect`, on standard output because it *is* the answer here —
+/// there is no document being written for it to get mixed up with.
+pub(super) fn detected(charset: Charset) {
+    println!("{}  {}", charset.slug(), charset.name());
+}
+
+pub(super) fn unknown_slug(slug: &str) -> String {
+    let known: Vec<&str> = charset::ALL.iter().map(|c| c.slug()).collect();
+    format!(
+        "unknown charset {slug:?} — try one of: {}",
+        known.join(", ")
+    )
+}
+
+/// Warn about what did not survive, if anything did not.
+///
+/// Two different counts, and only one of them usually matters. `read` is characters
+/// the *source* charset does not define, which means the file is damaged or `--from`
+/// is wrong. `written` is characters the target cannot represent — an uppercase toned
+/// vowel going to TCVN3, say, which has no code for one. Neither is fatal: a
+/// character is never dropped, only spelled badly, so the document is still written
+/// and the user is told where to look.
+///
+/// `normalized` is deliberately silent. Converting to Unicode tổ hợp respells every
+/// toned vowel and none of it is a loss, so counting it would train the reader to
+/// ignore this line.
+pub(super) fn losses(read: &Conversion, written: &Conversion) {
+    if read.unmapped > 0 {
+        eprintln!(
+            "warning: {} character(s) the source charset does not define — \
+             the file may be damaged, or --from may be wrong",
+            read.unmapped
+        );
+    }
+    if written.unmapped > 0 {
+        eprintln!(
+            "warning: {} character(s) the target charset cannot represent",
+            written.unmapped
+        );
+    }
+}

--- a/crates/funput-cli/src/convert/sink.rs
+++ b/crates/funput-cli/src/convert/sink.rs
@@ -1,0 +1,22 @@
+//! Writing the converted document out.
+
+use std::io::Write;
+
+use crate::cli::CliError;
+
+/// Write `bytes` to standard output, untouched.
+///
+/// Bytes, not a string, and `print!` would be wrong here. Converting to TCVN3 or
+/// VNI-Windows produces one byte per Vietnamese letter — that is what a `.VnTime`
+/// document holds — and printing it as text would write two bytes for each and
+/// produce a file Word cannot read back.
+///
+/// A closed pipe is not an error. `funput convert … | head` closes the pipe as soon
+/// as it has enough, and reporting that as a failure would make the exit code lie.
+pub(super) fn write(bytes: &[u8]) -> Result<(), CliError> {
+    let mut out = std::io::stdout().lock();
+    match out.write_all(bytes).and_then(|()| out.flush()) {
+        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        other => Ok(other?),
+    }
+}

--- a/crates/funput-cli/src/convert/source.rs
+++ b/crates/funput-cli/src/convert/source.rs
@@ -1,0 +1,187 @@
+//! Getting the input, and working out what charset spelled it.
+//!
+//! The output is a `String`, and that is the whole subject of this module.
+//! `funput_core::charset::convert` takes text rather than bytes because that is what
+//! the input actually is: a legacy document is stored as code points `U+0020..=U+00FF`
+//! standing in for bytes, and converting it means reading those code points back as
+//! charset codes. Getting a file to that form is the job here, and there are two ways
+//! in depending on what the bytes turn out to be.
+
+use std::io::Read;
+use std::path::Path;
+
+use funput_core::charset::{self, Charset};
+
+use crate::cli::CliError;
+
+/// The document as characters, and what charset those characters spell.
+pub(super) struct Input {
+    pub(super) text: String,
+    /// `None` only when the bytes are not UTF-8 **and** no byte-oriented charset
+    /// explains them. The command then asks for `--from` rather than guessing.
+    pub(super) charset: Option<Charset>,
+}
+
+/// Read `path`, or standard input when it is `None`.
+pub(super) fn read(path: Option<&Path>) -> Result<Input, CliError> {
+    let bytes = match path {
+        Some(path) => std::fs::read(path)
+            .map_err(|e| CliError::Msg(format!("cannot read {}: {e}", path.display())))?,
+        None => {
+            let mut buffer = Vec::new();
+            std::io::stdin().read_to_end(&mut buffer)?;
+            buffer
+        }
+    };
+    from_bytes(bytes)
+}
+
+/// Interpret bytes already in hand.
+///
+/// Split from [`read`] so that everything this module decides can be exercised
+/// without a file or a pipe — the deciding is the part worth testing.
+pub(super) fn from_bytes(bytes: Vec<u8>) -> Result<Input, CliError> {
+    Ok(identify(marks(bytes)?))
+}
+
+/// Deal with the byte-order marks, so what comes out is either UTF-8 or legacy bytes.
+///
+/// UTF-16 is decided by its mark rather than guessed at: falling through would trade
+/// a certainty for a wrong answer, since UTF-16 text is not valid UTF-8 and would be
+/// read as a legacy charset and confidently mangled. A UTF-8 mark is only a hint —
+/// editors write one whatever follows — so it is stripped and the rest judged on its
+/// own merits.
+fn marks(bytes: Vec<u8>) -> Result<Vec<u8>, CliError> {
+    for (mark, unit) in [
+        ([0xFF, 0xFE], u16::from_le_bytes as fn([u8; 2]) -> u16),
+        ([0xFE, 0xFF], u16::from_be_bytes),
+    ] {
+        if let Some(rest) = bytes.strip_prefix(&mark) {
+            return utf16(rest, unit)
+                .map(String::into_bytes)
+                .ok_or_else(|| CliError::Msg("this is a truncated UTF-16 file".into()));
+        }
+    }
+    Ok(match bytes.strip_prefix(&[0xEF, 0xBB, 0xBF]) {
+        Some(rest) => rest.to_vec(),
+        None => bytes,
+    })
+}
+
+/// Turn the bytes into characters, and say what charset those characters are in.
+///
+/// **Two doors, because there are two questions.** Bytes that decode as UTF-8 are
+/// judged as *text*, and the characters are the ones UTF-8 spelled. That covers a
+/// TCVN3 document someone opened in Notepad and saved again — valid UTF-8 whose text
+/// is still TCVN3, and the commonest way a legacy file arrives today. Reading those
+/// same bytes one-to-one instead would give `Ã` and `–` where the document has `Ö`.
+///
+/// Bytes that do not decode were never Unicode. They are read one-to-one, which is
+/// how the program that wrote them stored them, and a charset that is *not* stored
+/// one byte per character cannot be the answer — accepting one would convert
+/// replacement characters as though they were the document.
+fn identify(bytes: Vec<u8>) -> Input {
+    match String::from_utf8(bytes) {
+        Ok(text) => {
+            // Falling back to `Unicode` is not a guess. `detect` returning `None`
+            // means no legacy charset explains this better than Unicode does — and
+            // the bytes just decoded as UTF-8, so Unicode is what they are.
+            let charset = charset::detect(&text).or(Some(Charset::Unicode));
+            Input { text, charset }
+        }
+        Err(err) => {
+            let bytes = err.as_bytes();
+            let charset = charset::detect_bytes(bytes).filter(|&c| charset::is_byte_oriented(c));
+            let text = bytes.iter().copied().map(char::from).collect();
+            Input { text, charset }
+        }
+    }
+}
+
+fn utf16(bytes: &[u8], unit: fn([u8; 2]) -> u16) -> Option<String> {
+    if !bytes.len().is_multiple_of(2) {
+        return None;
+    }
+    let units: Vec<u16> = bytes
+        .chunks_exact(2)
+        .map(|pair| unit([pair[0], pair[1]]))
+        .collect();
+    String::from_utf16(&units).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn of(bytes: &[u8]) -> Input {
+        identify(marks(bytes.to_vec()).expect("well-formed fixture"))
+    }
+
+    /// The door that used to be taken by mistake. These bytes are valid UTF-8, so the
+    /// characters are what UTF-8 spells — reading them one-to-one instead would give
+    /// `Ã` where the document has `Ö`, and convert that.
+    #[test]
+    fn a_legacy_document_re_saved_as_utf8_is_read_as_text() {
+        let input = of("vi\u{D6}t nam h\u{B5} n\u{E9}i".as_bytes());
+        assert_eq!(input.charset, Some(Charset::Tcvn3));
+        assert!(input.text.starts_with("vi\u{D6}t"), "{:?}", input.text);
+    }
+
+    /// The other door: a file that really is one byte per character.
+    #[test]
+    fn a_legacy_document_stored_as_bytes_is_read_one_to_one() {
+        let input = of(b"vi\xD6t nam h\xB5 n\xE9i");
+        assert_eq!(input.charset, Some(Charset::Tcvn3));
+        assert_eq!(input.text.chars().next(), Some('v'));
+        assert!(input.text.contains('\u{D6}'));
+    }
+
+    /// Not a guess: the bytes decoded as UTF-8, so Unicode is what they are. Only the
+    /// byte door is allowed to come back with nothing.
+    #[test]
+    fn text_with_nothing_to_decide_is_unicode_rather_than_undecided() {
+        assert_eq!(of(b"hello world").charset, Some(Charset::Unicode));
+    }
+
+    #[test]
+    fn bytes_nothing_explains_are_left_undecided() {
+        let input = of(b"the quick brown \xFF fox jumps over the lazy dog");
+        assert_eq!(input.charset, None);
+    }
+
+    /// A charset that is not stored one byte per character cannot explain bytes that
+    /// already failed a UTF-8 decode; accepting one would convert `U+FFFD` as
+    /// though it were the document.
+    #[test]
+    fn the_byte_door_never_answers_with_a_unicode_charset() {
+        for fixture in [
+            b"vi\xD6t nam h\xB5 n\xE9i".as_slice(),
+            b"\xFF\x00\xFE".as_slice(),
+        ] {
+            let charset = of(fixture).charset;
+            assert!(
+                charset.is_none_or(charset::is_byte_oriented)
+                    || std::str::from_utf8(fixture).is_ok(),
+                "{charset:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_utf8_mark_is_stripped_rather_than_converted() {
+        assert_eq!(of(b"\xEF\xBB\xBFvn").text, "vn");
+    }
+
+    /// A UTF-16 mark is a verdict, not a hint. Without this the bytes would fail the
+    /// UTF-8 decode and be read as a legacy charset — confidently, and wrongly.
+    #[test]
+    fn utf16_is_decoded_from_its_mark_in_both_byte_orders() {
+        assert_eq!(of(b"\xFF\xFEV\x00i\x00\xC7\x1Et\x00").text, "Việt");
+        assert_eq!(of(b"\xFE\xFF\x00V\x00i\x1E\xC7\x00t").text, "Việt");
+    }
+
+    #[test]
+    fn a_truncated_utf16_file_is_refused_rather_than_half_read() {
+        assert!(marks(b"\xFF\xFEv".to_vec()).is_err());
+    }
+}

--- a/crates/funput-cli/src/convert/tests.rs
+++ b/crates/funput-cli/src/convert/tests.rs
@@ -1,0 +1,77 @@
+use funput_core::charset::{self, Charset};
+
+use super::*;
+
+/// Everything `run` does between reading and writing, with the I/O left out.
+fn pipeline(bytes: &[u8], to: Charset) -> (Vec<u8>, usize, usize) {
+    let input = source::from_bytes(bytes.to_vec()).expect("well-formed fixture");
+    let from = input.charset.expect("fixture should be identifiable");
+    let read = charset::convert(&input.text, from, Charset::Unicode);
+    let (out, written) = charset::encode_bytes(&read.text, to);
+    (out, read.unmapped, written.unmapped)
+}
+
+#[test]
+fn every_slug_in_the_list_resolves_and_nothing_else_does() {
+    for charset in charset::ALL {
+        assert_eq!(by_slug(charset.slug()).ok(), Some(charset));
+    }
+    assert!(by_slug("viscii").is_err());
+    assert!(by_slug("").is_err());
+}
+
+/// The error is what the user reads after a typo, so it has to say what would have
+/// worked — and it is built from `ALL`, so a charset added to core joins it.
+#[test]
+fn an_unknown_slug_is_answered_with_the_ones_that_work() {
+    let message = report::unknown_slug("tcvn");
+    assert!(message.contains("tcvn"));
+    for charset in charset::ALL {
+        assert!(message.contains(charset.slug()), "{message}");
+    }
+}
+
+/// The feature, end to end: a `.VnTime` document becomes Unicode.
+#[test]
+fn a_legacy_document_converts_to_unicode() {
+    let (bytes, read, written) = pipeline(b"vi\xD6t nam h\xB5 n\xE9i", Charset::Unicode);
+    assert_eq!(String::from_utf8(bytes).unwrap(), "việt nam hà nội");
+    assert_eq!((read, written), (0, 0));
+}
+
+/// And back the other way, as the bytes a `.VnTime` document holds — one per letter,
+/// not the two UTF-8 would spend on each.
+#[test]
+fn converting_to_a_legacy_charset_writes_one_byte_per_letter() {
+    let (bytes, _, written) = pipeline("Việt".as_bytes(), Charset::Tcvn3);
+    assert_eq!(bytes, b"Vi\xD6t");
+    assert_eq!(written, 0);
+}
+
+#[test]
+fn text_survives_a_trip_out_to_every_charset_and_back() {
+    for charset in charset::ALL {
+        let (there, ..) = pipeline("Việt Nam, Hà Nội".as_bytes(), charset);
+        let (back, ..) = pipeline(&there, Charset::Unicode);
+        assert_eq!(
+            String::from_utf8(back).unwrap(),
+            "Việt Nam, Hà Nội",
+            "{}",
+            charset.slug()
+        );
+    }
+}
+
+/// TCVN3 has no code for an uppercase toned vowel and none for `₫`. Neither is
+/// dropped — the document is still written — but the count is what the warning is
+/// built from.
+#[test]
+fn what_the_target_cannot_represent_is_counted_rather_than_dropped() {
+    let (bytes, read, written) = pipeline("Ề 5₫".as_bytes(), Charset::Tcvn3);
+    assert_eq!(written, 2);
+    assert_eq!(
+        read, 0,
+        "the source is fine; it is the target that cannot cope"
+    );
+    assert!(!bytes.is_empty());
+}

--- a/crates/funput-cli/src/main.rs
+++ b/crates/funput-cli/src/main.rs
@@ -6,8 +6,11 @@
 //!   (the reusable [`funput_term`] library; not an IME, no permissions).
 //! - `funput dev …` — feed a string through `funput-engine` and print what a
 //!   platform shell would show, for quick checks, debugging, and CI.
+//! - `funput convert …` — turn a document between Unicode and the legacy charsets
+//!   Vietnamese government paperwork still arrives in (TCVN3, VNI-Windows).
 
 mod cli;
+mod convert;
 mod dev;
 mod term;
 
@@ -21,6 +24,7 @@ fn main() -> ExitCode {
     let result = match Cli::parse().command {
         Command::Term(args) => term::run(args),
         Command::Dev(args) => dev::run(args),
+        Command::Convert(args) => convert::run(args),
     };
     match result {
         Ok(code) => code,

--- a/crates/funput-core/src/charset/codecs/mod.rs
+++ b/crates/funput-core/src/charset/codecs/mod.rs
@@ -28,9 +28,12 @@
 
 mod combining;
 mod tcvn3;
+mod utf8;
 mod vni;
 
 use super::Charset;
+use utf8::broken_sequences;
+
 use super::pivot::Atom;
 use super::transcode::{Conversion, Cursor, Decoded, Reading};
 
@@ -107,25 +110,29 @@ pub fn decode_bytes(bytes: &[u8], from: Charset) -> Conversion {
     }
 }
 
-/// How many characters lossy UTF-8 decoding had to replace. Zero for valid input,
-/// and replacement characters the source genuinely encoded are discounted so a
-/// document that legitimately contains one is not reported as damaged.
-fn broken_sequences(bytes: &[u8]) -> usize {
-    if std::str::from_utf8(bytes).is_ok() {
-        return 0;
+/// Write `text` as `to` spells it, as the bytes a file should hold.
+///
+/// The mirror of [`decode_bytes`], and the call a shell makes when the user saves a
+/// converted document. A byte-oriented charset's text is code points `U+0020..=U+00FF`
+/// standing in for bytes, so writing it as UTF-8 would store two bytes per Vietnamese
+/// letter and produce a file `.VnTime` cannot read. Anything else is written as UTF-8,
+/// which is what it already is.
+///
+/// A character the target cannot represent is still written — `encode` never drops
+/// one — but it may be a character the *byte* form has no room for, and those become
+/// `?`. Every one of them is already counted in [`Conversion::unmapped`], so the
+/// caller learns about it from the same number it would check anyway.
+pub fn encode_bytes(text: &str, to: Charset) -> (Vec<u8>, Conversion) {
+    let out = super::convert(text, Charset::Unicode, to);
+    if !is_byte_oriented(to) {
+        return (out.text.as_bytes().to_vec(), out);
     }
-    String::from_utf8_lossy(bytes)
-        .matches(char::REPLACEMENT_CHARACTER)
-        .count()
-        .saturating_sub(genuine_replacements(bytes))
-}
-
-/// How many `U+FFFD` the bytes genuinely encode.
-fn genuine_replacements(bytes: &[u8]) -> usize {
-    bytes
-        .windows(3)
-        .filter(|window| *window == [0xEF, 0xBF, 0xBD])
-        .count()
+    let bytes = out
+        .text
+        .chars()
+        .map(|c| u8::try_from(c as u32).unwrap_or(b'?'))
+        .collect();
+    (bytes, out)
 }
 
 #[cfg(test)]
@@ -177,5 +184,31 @@ mod tests {
         let out = decode_bytes("a\u{FFFD}b".as_bytes(), Charset::Unicode);
         assert_eq!(out.text, "a\u{FFFD}b");
         assert_eq!(out.unmapped, 0);
+    }
+
+    /// The point of the function: a `.VnTime` file holds one byte per letter, and
+    /// writing the same text as UTF-8 would give two and a file Word cannot read.
+    #[test]
+    fn a_byte_oriented_charset_is_written_one_byte_per_letter() {
+        let (bytes, out) = encode_bytes("Việt", Charset::Tcvn3);
+        assert_eq!(bytes.len(), 4);
+        assert_eq!(out.unmapped, 0);
+        assert_eq!(decode_bytes(&bytes, Charset::Tcvn3).text, "Việt");
+    }
+
+    #[test]
+    fn a_unicode_charset_is_written_as_utf8() {
+        let (bytes, _) = encode_bytes("Việt", Charset::Unicode);
+        assert_eq!(bytes, "Việt".as_bytes());
+    }
+
+    /// `₫` has no TCVN3 code, so `encode` passes it through as itself — and a code
+    /// point above `U+00FF` has no room in a byte. It becomes `?` rather than a
+    /// truncated byte, and the caller already knows from `unmapped`.
+    #[test]
+    fn a_character_with_no_byte_to_put_it_in_becomes_a_question_mark() {
+        let (bytes, out) = encode_bytes("5₫", Charset::Tcvn3);
+        assert_eq!(bytes, b"5?");
+        assert_eq!(out.unmapped, 1);
     }
 }

--- a/crates/funput-core/src/charset/codecs/utf8.rs
+++ b/crates/funput-core/src/charset/codecs/utf8.rs
@@ -1,0 +1,26 @@
+//! Accounting for what lossy UTF-8 decoding destroyed.
+//!
+//! Only [`super::decode_bytes`] needs this, and only on the branch where the bytes
+//! were supposed to be UTF-8. It lives apart because it is a different subject from
+//! the rest of `codecs`: nothing here knows what a charset is.
+
+/// How many characters lossy UTF-8 decoding had to replace. Zero for valid input,
+/// and replacement characters the source genuinely encoded are discounted so a
+/// document that legitimately contains one is not reported as damaged.
+pub(super) fn broken_sequences(bytes: &[u8]) -> usize {
+    if std::str::from_utf8(bytes).is_ok() {
+        return 0;
+    }
+    String::from_utf8_lossy(bytes)
+        .matches(char::REPLACEMENT_CHARACTER)
+        .count()
+        .saturating_sub(genuine_replacements(bytes))
+}
+
+/// How many `U+FFFD` the bytes genuinely encode.
+fn genuine_replacements(bytes: &[u8]) -> usize {
+    bytes
+        .windows(3)
+        .filter(|window| *window == [0xEF, 0xBF, 0xBD])
+        .count()
+}

--- a/crates/funput-core/src/charset/identity.rs
+++ b/crates/funput-core/src/charset/identity.rs
@@ -1,0 +1,176 @@
+//! Which charset this is, what to call it, and how to write it down.
+//!
+//! Three things a consumer cannot work out for itself, because [`Charset`] is
+//! `#[non_exhaustive]`: code outside this crate has to match with a wildcard arm, so
+//! it would silently miss a variant added later. Everything here is forced by the
+//! compiler instead — [`ALL`] by the guard at the bottom, the two names by their
+//! exhaustive matches.
+//!
+//! [`Charset::name`] is for a person and [`Charset::slug`] is for a machine, and the
+//! split is the point. A name may be reworded; a slug is a command-line value and a
+//! setting written to disk, so it may not be.
+
+/// A Vietnamese character encoding.
+///
+/// `#[non_exhaustive]`: VIQR, VISCII and the rest are out of scope today but not
+/// forever, and adding one should not break callers. Match with a wildcard arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Charset {
+    /// Precomposed Unicode (NFC) — the pivot, and what every modern system uses.
+    Unicode,
+    /// TCVN3, also called ABC: the `.VnTime` encoding of Vietnamese government
+    /// documents. One byte per letter, and no code for an uppercase toned vowel.
+    Tcvn3,
+    /// VNI-Windows, the `VNI-Times` encoding. Spells most letters as a base byte
+    /// plus a mark byte, so a letter is not a character and conversion moves
+    /// character boundaries. Named for the encoding rather than `Vni`, which would
+    /// sit confusingly beside [`crate::InputMethod::Vni`] — a way of *typing*, not
+    /// a way of storing.
+    VniWindows,
+    /// Unicode tổ hợp, UniKey's convention: the shaped vowel stays precomposed and
+    /// only the **tone** rides as a combining mark, so `ậ` is `â` plus `U+0323`.
+    ///
+    /// Deliberately not called `Decomposed`: this is not NFD, which would take the
+    /// shape apart too. Reading accepts NFD anyway — see the codec — but writing
+    /// only ever produces this form.
+    UnicodeCombining,
+}
+
+impl Charset {
+    /// What to call this charset in front of a user.
+    ///
+    /// The encoding's own name rather than interface copy — `TCVN3 (ABC)` reads the
+    /// same in any language, and these are the names UniKey uses, which is what
+    /// Vietnamese users already know them by. Keeping them here is what stops a menu
+    /// on Windows and one on Linux from drifting apart.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Unicode => "Unicode dựng sẵn",
+            Self::Tcvn3 => "TCVN3 (ABC)",
+            Self::VniWindows => "VNI-Windows",
+            Self::UnicodeCombining => "Unicode tổ hợp",
+        }
+    }
+
+    /// How this charset is written down: on a command line, in a config file,
+    /// anywhere a machine reads it back.
+    ///
+    /// ASCII, lowercase, and mirroring the variant name, so it is guessable from the
+    /// documentation and typeable without a Vietnamese keyboard. **Unlike
+    /// [`name`](Self::name), a slug is a contract.** It ends up in a saved setting and
+    /// in a script someone wrote a year ago, so it may not be reworded — which is also
+    /// why it is not derived from the name.
+    ///
+    /// A consumer needs no lookup function for the other direction:
+    /// `ALL.iter().find(|c| c.slug() == input)`.
+    pub const fn slug(self) -> &'static str {
+        match self {
+            Self::Unicode => "unicode",
+            Self::Tcvn3 => "tcvn3",
+            Self::VniWindows => "vni-windows",
+            Self::UnicodeCombining => "unicode-combining",
+        }
+    }
+}
+
+/// Every charset, in the order an interface should offer them.
+///
+/// A caller cannot build this list for itself: `Charset` is `#[non_exhaustive]`, so
+/// code outside this crate must write a wildcard arm and would silently miss a
+/// variant added later. [`detect`] scores exactly this list, so a charset a user can
+/// choose is one the tool can also recognise.
+pub const ALL: [Charset; 4] = [
+    Charset::Unicode,
+    Charset::Tcvn3,
+    Charset::VniWindows,
+    Charset::UnicodeCombining,
+];
+
+/// Adding a variant must break the build here rather than drop it out of every menu.
+///
+/// [`Charset::name`] already forces a name for each one; this catches the other
+/// half — a variant that has a name but never made it into [`ALL`].
+const _: () = {
+    const fn slot(charset: Charset) -> u32 {
+        match charset {
+            Charset::Unicode => 0,
+            Charset::Tcvn3 => 1,
+            Charset::VniWindows => 2,
+            Charset::UnicodeCombining => 3,
+        }
+    }
+    let (mut listed, mut i) = (0u32, 0);
+    while i < ALL.len() {
+        listed |= 1 << slot(ALL[i]);
+        i += 1;
+    }
+    assert!(
+        listed == (1 << ALL.len()) - 1,
+        "a charset is missing from ALL"
+    );
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two menu entries reading the same, or a blank one, are the failures a shared
+    /// list exists to make impossible.
+    #[test]
+    fn every_charset_has_a_distinct_name() {
+        let mut names: Vec<&str> = ALL.iter().map(|c| c.name()).collect();
+        assert!(names.iter().all(|n| !n.is_empty()));
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), ALL.len(), "two charsets share a name");
+    }
+
+    /// The two Unicode charsets are the pair a user actually has to choose between,
+    /// so neither may be called just "Unicode".
+    #[test]
+    fn the_two_unicode_charsets_are_told_apart_by_name() {
+        assert_ne!(Charset::Unicode.name(), Charset::UnicodeCombining.name());
+        assert!(Charset::Unicode.name().contains("dựng sẵn"));
+        assert!(Charset::UnicodeCombining.name().contains("tổ hợp"));
+    }
+
+    /// A slug is typed at a shell prompt and stored in config files, so anything but
+    /// lowercase ASCII would be a trap somewhere.
+    #[test]
+    fn every_slug_is_distinct_and_typeable() {
+        let mut slugs: Vec<&str> = ALL.iter().map(|c| c.slug()).collect();
+        for slug in &slugs {
+            assert!(!slug.is_empty());
+            assert!(
+                slug.bytes()
+                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-'),
+                "{slug} is not lowercase ASCII"
+            );
+        }
+        slugs.sort_unstable();
+        slugs.dedup();
+        assert_eq!(slugs.len(), ALL.len(), "two charsets share a slug");
+    }
+
+    /// The lookup this crate deliberately does not provide, shown to work — a
+    /// consumer builds it from `ALL` rather than being given a function.
+    #[test]
+    fn a_slug_finds_its_charset_again() {
+        for charset in ALL {
+            let found = ALL.iter().find(|c| c.slug() == charset.slug());
+            assert_eq!(found, Some(&charset));
+        }
+        assert!(ALL.iter().all(|c| c.slug() != "viscii"));
+    }
+
+    /// Pins the published values. Rewording one breaks a saved setting and a script
+    /// someone wrote a year ago, so it has to break this first.
+    #[test]
+    fn the_published_slugs_do_not_change() {
+        assert_eq!(Charset::Unicode.slug(), "unicode");
+        assert_eq!(Charset::Tcvn3.slug(), "tcvn3");
+        assert_eq!(Charset::VniWindows.slug(), "vni-windows");
+        assert_eq!(Charset::UnicodeCombining.slug(), "unicode-combining");
+    }
+}

--- a/crates/funput-core/src/charset/mod.rs
+++ b/crates/funput-core/src/charset/mod.rs
@@ -30,94 +30,15 @@
 
 mod codecs;
 mod detect;
+mod identity;
 mod pivot;
 mod transcode;
 
-pub use codecs::{decode_bytes, is_byte_oriented};
+pub use codecs::{decode_bytes, encode_bytes, is_byte_oriented};
 pub use detect::{detect, detect_bytes};
+pub use identity::{ALL, Charset};
 // `Conversion` is defined beside the loop that fills in its two counters.
 pub use transcode::Conversion;
-
-/// A Vietnamese character encoding.
-///
-/// `#[non_exhaustive]`: VIQR, VISCII and the rest are out of scope today but not
-/// forever, and adding one should not break callers. Match with a wildcard arm.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[non_exhaustive]
-pub enum Charset {
-    /// Precomposed Unicode (NFC) — the pivot, and what every modern system uses.
-    Unicode,
-    /// TCVN3, also called ABC: the `.VnTime` encoding of Vietnamese government
-    /// documents. One byte per letter, and no code for an uppercase toned vowel.
-    Tcvn3,
-    /// VNI-Windows, the `VNI-Times` encoding. Spells most letters as a base byte
-    /// plus a mark byte, so a letter is not a character and conversion moves
-    /// character boundaries. Named for the encoding rather than `Vni`, which would
-    /// sit confusingly beside [`crate::InputMethod::Vni`] — a way of *typing*, not
-    /// a way of storing.
-    VniWindows,
-    /// Unicode tổ hợp, UniKey's convention: the shaped vowel stays precomposed and
-    /// only the **tone** rides as a combining mark, so `ậ` is `â` plus `U+0323`.
-    ///
-    /// Deliberately not called `Decomposed`: this is not NFD, which would take the
-    /// shape apart too. Reading accepts NFD anyway — see the codec — but writing
-    /// only ever produces this form.
-    UnicodeCombining,
-}
-
-impl Charset {
-    /// What to call this charset in front of a user.
-    ///
-    /// The encoding's own name rather than interface copy — `TCVN3 (ABC)` reads the
-    /// same in any language, and these are the names UniKey uses, which is what
-    /// Vietnamese users already know them by. Keeping them here is what stops a menu
-    /// on Windows and one on Linux from drifting apart.
-    pub const fn name(self) -> &'static str {
-        match self {
-            Self::Unicode => "Unicode dựng sẵn",
-            Self::Tcvn3 => "TCVN3 (ABC)",
-            Self::VniWindows => "VNI-Windows",
-            Self::UnicodeCombining => "Unicode tổ hợp",
-        }
-    }
-}
-
-/// Every charset, in the order an interface should offer them.
-///
-/// A caller cannot build this list for itself: `Charset` is `#[non_exhaustive]`, so
-/// code outside this crate must write a wildcard arm and would silently miss a
-/// variant added later. [`detect`] scores exactly this list, so a charset a user can
-/// choose is one the tool can also recognise.
-pub const ALL: [Charset; 4] = [
-    Charset::Unicode,
-    Charset::Tcvn3,
-    Charset::VniWindows,
-    Charset::UnicodeCombining,
-];
-
-/// Adding a variant must break the build here rather than drop it out of every menu.
-///
-/// [`Charset::name`] already forces a name for each one; this catches the other
-/// half — a variant that has a name but never made it into [`ALL`].
-const _: () = {
-    const fn slot(charset: Charset) -> u32 {
-        match charset {
-            Charset::Unicode => 0,
-            Charset::Tcvn3 => 1,
-            Charset::VniWindows => 2,
-            Charset::UnicodeCombining => 3,
-        }
-    }
-    let (mut listed, mut i) = (0u32, 0);
-    while i < ALL.len() {
-        listed |= 1 << slot(ALL[i]);
-        i += 1;
-    }
-    assert!(
-        listed == (1 << ALL.len()) - 1,
-        "a charset is missing from ALL"
-    );
-};
 
 /// Convert text from one charset to another.
 ///
@@ -130,28 +51,6 @@ pub fn convert(text: &str, from: Charset, to: Charset) -> Conversion {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Two menus showing the same name for different charsets, or a blank entry,
-    /// are the failures a shared list is supposed to make impossible.
-    #[test]
-    fn every_charset_has_a_distinct_name() {
-        let mut names: Vec<&str> = ALL.iter().map(|c| c.name()).collect();
-        assert!(names.iter().all(|n| !n.is_empty()));
-
-        assert_eq!(names.len(), ALL.len());
-        names.sort_unstable();
-        names.dedup();
-        assert_eq!(names.len(), ALL.len(), "two charsets share a name");
-    }
-
-    /// The two Unicode charsets are the pair a user actually has to choose between,
-    /// so neither may be called just "Unicode".
-    #[test]
-    fn the_two_unicode_charsets_are_told_apart_by_name() {
-        assert_ne!(Charset::Unicode.name(), Charset::UnicodeCombining.name());
-        assert!(Charset::Unicode.name().contains("dựng sẵn"));
-        assert!(Charset::UnicodeCombining.name().contains("tổ hợp"));
-    }
 
     /// Anything offered in a menu has to be something the tool can also recognise —
     /// otherwise "Tự động nhận diện" could never return what the user picked.

--- a/docs/features/charset.md
+++ b/docs/features/charset.md
@@ -357,10 +357,14 @@ build, chứ không phải vỡ giao diện.
 /// Mọi bảng mã, theo thứ tự giao diện nên bày ra. Consumer không dựng được danh sách
 /// này: `Charset` là `#[non_exhaustive]`.
 pub const ALL: [Charset; 4];
-impl Charset { pub const fn name(self) -> &'static str; }
+impl Charset {
+    pub const fn name(self) -> &'static str;  // cho người đọc
+    pub const fn slug(self) -> &'static str;  // cho máy đọc — là hợp đồng, không sửa lời được
+}
 
 pub fn convert(text: &str, from: Charset, to: Charset) -> Conversion;
 pub fn decode_bytes(bytes: &[u8], from: Charset) -> Conversion;
+pub fn encode_bytes(text: &str, to: Charset) -> (Vec<u8>, Conversion);
 pub fn detect(text: &str) -> Option<Charset>;
 pub fn detect_bytes(bytes: &[u8]) -> Option<Charset>;
 ```
@@ -375,6 +379,17 @@ toàn. Hoà thì trả `None` thay vì đoán bừa.
 chứng mạnh **chống lại** hai bảng mã Unicode — bằng chứng mà `detect(&str)` không thể
 thấy, vì lúc nó cầm được `&str` thì hư hỏng đã được vá rồi. Hai cửa **bất đồng** trên
 cùng một nội dung Latin-1; đó là bản chất, và có test ghim lại.
+
+### Hai cửa byte
+
+`decode_bytes` đọc tệp vào; `encode_bytes` ghi tệp ra. Cái sau không phải đối xứng cho đẹp: bảng
+mã theo byte lưu **một byte mỗi chữ**, nên ghi text của nó ra dạng UTF-8 sẽ thành hai byte mỗi chữ
+và cho ra tệp `.VnTime` đọc không được. Mọi consumer lưu tệp cũ đều cần đúng phép này, nên nó ở
+core chứ không phải viết lại ở từng nơi.
+
+Chữ mà bảng mã đích không có vẫn được ghi — `encode` không bao giờ làm rơi ký tự — nhưng có thể là
+ký tự dạng byte không chứa nổi (`₫` chẳng hạn); những chữ đó thành `?`. Chúng đã nằm trong
+`unmapped`, nên caller biết được từ chính con số nó vẫn phải xem.
 
 ### Cửa C ABI (`funput-ffi`, feature `charset`, mặc định tắt)
 
@@ -435,4 +450,9 @@ Mỗi mục một PR:
    mà UI Windows đã phải tự viết ở bước 6 — hai cửa sổ cài đặt tự đặt tên lấy là cách
    chúng trôi khỏi nhau.
 8. **C ABI trong `funput-ffi`** (feature `charset`, mặc định tắt) — cửa cho macOS.
-9. `funput convert` (CLI) → 10. UI Windows → 11. UI Linux GTK.
+9. **`funput convert`** (CLI). Consumer đầu tiên chuyển cả tài liệu, nên nó đòi hai thứ core còn
+   thiếu: `Charset::slug()` (cờ dòng lệnh cần một tên máy đọc — `name()` là chữ hiển thị, sửa lời
+   là đổi hợp đồng) và `encode_bytes` (ghi tệp cũ ra byte). Nó cũng là chỗ **hai cửa** lộ rõ nhất:
+   tệp TCVN3 mở bằng Notepad rồi lưu lại là UTF-8 hợp lệ mà nội dung vẫn TCVN3, và đọc lại theo
+   byte sẽ ra `Ã` ở chỗ tài liệu có `Ö`.
+10. UI Windows → 11. UI Linux GTK.


### PR DESCRIPTION
Stacked on #237. Step 9 of the order in `docs/features/charset.md` — the last piece of the shared core, before any platform UI.

## The command

```bash
funput convert --list                            # the charsets, with the slug you type
funput convert doc.txt --detect                  # what charset does this file look like?
funput convert doc.txt --to unicode > new.txt    # TCVN3/VNI → Unicode, source guessed
funput convert --to tcvn3 < new.txt > old.txt    # and back, as bytes, one per letter
funput convert old.txt --from tcvn3 --to vni-windows
```

Standard output is the document; `--list`, `--detect` and the warnings go to standard error, so `funput convert … > out.txt` produces exactly that file.

**No charset is named in the command's code.** `--to tcvn3` is matched against `charset::ALL` by slug, so implementing VISCII stays one PR in core.

## Two things core was missing

Converting a whole document is what showed them, which is why they are in this PR rather than a separate one — the justification is not visible without the consumer.

- **`Charset::slug()`** — `--to` needs a word a person can type. `name()` is display text (`Unicode dựng sẵn`) and may be reworded; a slug ends up in a saved setting and in someone's script, so it may not. A test pins the published values so a rewording has to break the build first. No `from_slug` — `ALL.iter().find(|c| c.slug() == input)` is one line, and that is the point of `ALL` being public.
- **`encode_bytes`** — the mirror of `decode_bytes`. A byte-oriented charset stores one byte per letter; writing its text as UTF-8 spends two and produces a file `.VnTime` cannot read back. Every consumer that saves a legacy file needs exactly this. A character the target cannot represent is still written, but may be one a *byte* has no room for (`₫`); those become `?`, and were already counted in `unmapped`.

## Reading is where the subtlety is

Two doors, and I got this wrong first:

- Bytes that **decode as UTF-8** are judged as *text*. That covers a TCVN3 document someone opened in Notepad and saved again — valid UTF-8 whose text is still TCVN3, and the commonest way a legacy file arrives today. My first version ran the raw bytes through `decode_bytes` regardless, which read `Ã` where the document has `Ö` and converted that. Pinned by `a_legacy_document_re_saved_as_utf8_is_read_as_text`.
- Bytes that **do not decode** were never Unicode, and a charset not stored one byte per character cannot be the answer; accepting one would convert `U+FFFD` as though it were the document.

Two smaller fixes found the same way: `--to viscii` reported "cannot tell which charset this is" because the input was read before the slug was validated, and a short Vietnamese document was refused outright because `detect` declined. The second was a design error — when the bytes decoded as UTF-8, falling back to `Unicode` is not a guess, and only the byte door can genuinely fail.

## Layout

`ALL` and the two names move to `charset/identity.rs`; the UTF-8 damage accounting to `codecs/utf8.rs`. Nothing lands near the line budget: `charset/mod.rs` 129 → 50, `codecs/mod.rs` 137.

`crates/funput-core/src/charset/` goes to 6 entries. Two of them are directories, and `identity.rs` is a real subject — which charset this is, what to call it, how to write it down — so I would rather report the rule bent than leave two files at 145/150 the way `transfer/apply.rs` sits today.

## Checks

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, the charset-off pair, the charset-on `funput-ffi` pair, both `cargo tree` assertions, the symbol guard, `scripts/check-loc.sh` (306 files), and a local `cargo build` in `platforms/windows`, which CI never touches.

Beyond the tests, the binary was driven by hand over every path: all four charsets detect and round-trip, both doors, UTF-8 and UTF-16 marks, a truncated UTF-16 file, a missing file, an unknown slug, undecidable bytes, and `| head` closing the pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)