### PR TITLE
fix(android): keep long-press alternates above the source key

### DIFF
--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/FunputInputMethodService.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/FunputInputMethodService.kt
@@ -130,6 +130,11 @@ class FunputInputMethodService : InputMethodService() {
 
     // Switching the system between light and dark changes which theme applies, and no settings
     // flow fires for it because nothing the user stored has changed.
+    override fun onComputeInsets(outInsets: InputMethodService.Insets) {
+        super.onComputeInsets(outInsets)
+        ImeOverlayInsets.apply(outInsets, keyboardView?.overlayPadTop ?: 0)
+    }
+
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         keyboardView?.let(::updateInputView)

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/ImeOverlayInsets.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/ImeOverlayInsets.kt
@@ -1,0 +1,37 @@
+package app.funput.funput.ime
+
+import android.inputmethodservice.InputMethodService
+
+/**
+ * Keeps the app anchored to the real keyboard when the input view grows a
+ * transparent overlay so an alternate palette can sit above a top-row key.
+ */
+internal object ImeOverlayInsets {
+    fun apply(outInsets: InputMethodService.Insets, overlayPadTop: Int) {
+        val next = adjustment(outInsets.contentTopInsets, outInsets.visibleTopInsets, overlayPadTop)
+        outInsets.contentTopInsets = next.contentTopInsets
+        outInsets.visibleTopInsets = next.visibleTopInsets
+        if (next.touchableFrame) {
+            outInsets.touchableInsets = InputMethodService.Insets.TOUCHABLE_INSETS_FRAME
+        }
+    }
+
+    fun adjustment(
+        contentTopInsets: Int,
+        visibleTopInsets: Int,
+        overlayPadTop: Int,
+    ): Adjustment {
+        if (overlayPadTop <= 0) return Adjustment(contentTopInsets, visibleTopInsets, false)
+        return Adjustment(
+            contentTopInsets = contentTopInsets - overlayPadTop,
+            visibleTopInsets = visibleTopInsets - overlayPadTop,
+            touchableFrame = true,
+        )
+    }
+
+    data class Adjustment(
+        val contentTopInsets: Int,
+        val visibleTopInsets: Int,
+        val touchableFrame: Boolean,
+    )
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/ImeOverlayInsetsTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/ImeOverlayInsetsTest.kt
@@ -1,0 +1,26 @@
+package app.funput.funput.ime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImeOverlayInsetsTest {
+    @Test
+    fun noPadLeavesInsetsAlone() {
+        val next = ImeOverlayInsets.adjustment(280, 280, overlayPadTop = 0)
+
+        assertEquals(280, next.contentTopInsets)
+        assertEquals(280, next.visibleTopInsets)
+        assertFalse(next.touchableFrame)
+    }
+
+    @Test
+    fun padKeepsTheAppAnchoredToTheKeyboard() {
+        val next = ImeOverlayInsets.adjustment(360, 360, overlayPadTop = 80)
+
+        assertEquals(280, next.contentTopInsets)
+        assertEquals(280, next.visibleTopInsets)
+        assertTrue(next.touchableFrame)
+    }
+}

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/KeyboardSurfaceView.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/KeyboardSurfaceView.kt
@@ -18,6 +18,7 @@ import app.funput.funput.keyboard.model.ShiftState
 import app.funput.funput.keyboard.surface.KeyboardSurfaceEventDispatcher
 import app.funput.funput.keyboard.surface.KeyboardSurfaceAccessibilityBinding
 import app.funput.funput.keyboard.surface.KeyboardSurfaceLayoutState
+import app.funput.funput.keyboard.surface.KeyboardSurfaceOverlayPad
 import app.funput.funput.keyboard.surface.KeyboardSurfaceRenderController
 import app.funput.funput.keyboard.surface.createKeyboardSurfaceInteraction
 import kotlin.math.roundToInt
@@ -26,6 +27,9 @@ class KeyboardSurfaceView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,
 ) : View(context, attrs, defStyleAttr) {
+    private val overlay = KeyboardSurfaceOverlayPad(::requestLayout) { onOverlayPadChanged?.invoke(it) }
+    val overlayPadTop: Int get() = overlay.pixels
+    var onOverlayPadChanged: ((Int) -> Unit)? = null
     private val layoutState = KeyboardSurfaceLayoutState(::updateKeyboardLayout)
     private val render = KeyboardSurfaceRenderController(
         context = context,
@@ -85,10 +89,13 @@ class KeyboardSurfaceView @JvmOverloads constructor(
             KeyboardHaptics.perform(this, type)
             KeyboardSounds.perform(this, type)
         },
-        onVisualStateChanged = ::postInvalidateOnAnimation,
+        onVisualStateChanged = {
+            overlay.sync(interaction.alternatePreview?.layout?.overflowAbove ?: 0f)
+            postInvalidateOnAnimation()
+        },
         onSemanticStateChanged = accessibility::refresh,
         keyBounds = { id -> resolvedKeyboard?.keys?.firstOrNull { it.spec.id == id }?.bounds },
-        surfaceBounds = { KeyBounds(0f, 0f, width.toFloat(), height.toFloat()) },
+        surfaceBounds = { KeyBounds(0f, 0f, width.toFloat(), overlay.keyboardHeight(height).toFloat()) },
     )
     private val events = KeyboardSurfaceEventDispatcher(
         host = this,
@@ -104,45 +111,40 @@ class KeyboardSurfaceView @JvmOverloads constructor(
         val heightDp = KeyboardDimensions.recommendedHeightDp(
             inputMethod, editorMode, sizingProfile, width / density, showsNumberRow,
         )
-        val height = resolveSize((heightDp * density).roundToInt(), heightMeasureSpec)
+        val height = resolveSize((heightDp * density).roundToInt() + overlay.pixels, heightMeasureSpec)
         setMeasuredDimension(width, height)
     }
     override fun onSizeChanged(width: Int, height: Int, oldWidth: Int, oldHeight: Int) {
         super.onSizeChanged(width, height, oldWidth, oldHeight)
         resolveGeometry()
-        render.updateSize(width, height)
+        render.updateSize(width, overlay.keyboardHeight(height))
     }
-    override fun onDraw(canvas: Canvas) { super.onDraw(canvas)
-        resolvedKeyboard?.let { render.draw(canvas, it, interaction, shiftState, language, editorMode) } }
-    override fun onTouchEvent(event: MotionEvent): Boolean = events.dispatchTouch(event, ::performClick)
-    override fun dispatchHoverEvent(event: MotionEvent): Boolean =
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        overlay.drawTranslated(canvas) {
+            resolvedKeyboard?.let { render.draw(canvas, it, interaction, shiftState, language, editorMode) }
+        }
+    }
+    override fun onTouchEvent(event: MotionEvent): Boolean =
+        overlay.withKeyboardCoordinates(event) { events.dispatchTouch(event, ::performClick) }
+    override fun dispatchHoverEvent(event: MotionEvent): Boolean = overlay.withKeyboardCoordinates(event) {
         events.dispatchHover(event) { super.dispatchHoverEvent(event) }
+    }
     override fun performClick(): Boolean {
         if (!events.enabled) return false
-        super.performClick()
-        return true
+        super.performClick(); return true
     }
-    override fun onWindowFocusChanged(hasWindowFocus: Boolean) { super.onWindowFocusChanged(hasWindowFocus)
-        if (!hasWindowFocus) interaction.clear() }
-    override fun onDetachedFromWindow() {
-        interaction.clear()
-        render.clear()
-        super.onDetachedFromWindow()
+    override fun onWindowFocusChanged(hasWindowFocus: Boolean) {
+        super.onWindowFocusChanged(hasWindowFocus); if (!hasWindowFocus) interaction.clear()
     }
+    override fun onDetachedFromWindow() { interaction.clear(); render.clear(); super.onDetachedFromWindow() }
     private fun resolveGeometry() {
         resolvedKeyboard = layoutState.layout.resolveGeometry(
-            width = width, height = height,
-            density = resources.displayMetrics.density,
-            profile = sizingProfile,
+            width = width, height = overlay.keyboardHeight(height),
+            density = resources.displayMetrics.density, profile = sizingProfile,
             showClipboard = clipboardKeyVisible && suggestionState.utilityKeysVisible,
         )
-        suggestionState.geometryChanged()
-        accessibility.refresh()
+        suggestionState.geometryChanged(); accessibility.refresh()
     }
-    private fun updateKeyboardLayout() {
-        interaction.reset()
-        requestLayout()
-        resolveGeometry()
-        invalidate()
-    }
+    private fun updateKeyboardLayout() { interaction.reset(); requestLayout(); resolveGeometry(); invalidate() }
 }

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/popover/rendering/AlternatePaletteLayout.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/popover/rendering/AlternatePaletteLayout.kt
@@ -7,12 +7,12 @@ internal data class AlternatePaletteLayout(
     val bounds: KeyBounds,
     val itemBounds: List<KeyBounds>,
     val sourceBounds: KeyBounds,
-    /**
-     * True when the palette had to be clamped over the key it came from, which happens on the
-     * top row where there is no room above for every cell.
-     */
+    /** True when the palette still intersects its key after placement. */
     val overlapsSource: Boolean,
 ) {
+    /** Pixels the palette extends above the keyboard surface and needs an IME overlay pad. */
+    val overflowAbove: Float get() = (-bounds.top).coerceAtLeast(0f)
+
     /**
      * The cell a moved finger is on. A palette clamped over its own key has no key region left
      * to stand for the default, so the touch's starting point holds it until the finger travels
@@ -73,13 +73,9 @@ internal data class AlternatePaletteLayout(
             val width = minOf(safe.width, columns * span - gap + padding * 2f)
             val height = rows * cellHeight + (rows - 1) * gap + padding * 2f
             val left = (source.centerX - width / 2f).coerceIn(safe.left, safe.right - width)
-            // The palette always rises from the key. Flipping it below would put it under the
-            // hand and away from the finger, so a palette too tall for the space above is
-            // clamped to the top edge instead.
-            val top = maxOf(
-                safe.top,
-                minOf(source.top - SourceGap * density - height, safe.bottom - height),
-            )
+            // Sit fully above the key, like Gboard. Covering a top-row key made the hold
+            // harder to aim; overflow above the surface is drawn in a transparent IME pad.
+            val top = source.top - SourceGap * density - height
             val bounds = KeyBounds(left, top, left + width, top + height)
             return AlternatePaletteLayout(
                 bounds = bounds,

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/surface/KeyboardSurfaceOverlayPad.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/surface/KeyboardSurfaceOverlayPad.kt
@@ -1,0 +1,49 @@
+package app.funput.funput.keyboard.surface
+
+import android.graphics.Canvas
+import android.view.MotionEvent
+import kotlin.math.ceil
+
+/**
+ * Grows a transparent strip above the keyboard so an alternate palette can sit
+ * fully above a top-row key without covering it. Drawing and touches stay in
+ * keyboard coordinates; the pad is only a viewport shift.
+ */
+internal class KeyboardSurfaceOverlayPad(
+    private val requestLayout: () -> Unit,
+    private val onPixelsChanged: (Int) -> Unit,
+) {
+    var pixels: Int = 0
+        private set
+
+    fun sync(overflowAbove: Float) {
+        val next = ceil(overflowAbove.toDouble()).toInt().coerceAtLeast(0)
+        if (pixels == next) return
+        pixels = next
+        onPixelsChanged(next)
+        requestLayout()
+    }
+
+    fun keyboardHeight(viewHeight: Int): Int = (viewHeight - pixels).coerceAtLeast(0)
+
+    fun drawTranslated(canvas: Canvas, draw: () -> Unit) {
+        if (pixels == 0) {
+            draw()
+            return
+        }
+        val checkpoint = canvas.save()
+        canvas.translate(0f, pixels.toFloat())
+        draw()
+        canvas.restoreToCount(checkpoint)
+    }
+
+    fun withKeyboardCoordinates(event: MotionEvent, block: () -> Boolean): Boolean {
+        if (pixels == 0) return block()
+        event.offsetLocation(0f, -pixels.toFloat())
+        return try {
+            block()
+        } finally {
+            event.offsetLocation(0f, pixels.toFloat())
+        }
+    }
+}

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/popover/rendering/AlternatePaletteLayoutTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/popover/rendering/AlternatePaletteLayoutTest.kt
@@ -21,12 +21,13 @@ class AlternatePaletteLayoutTest {
     }
 
     @Test
-    fun `the palette rises from the key instead of dropping below it`() {
+    fun `the palette sits fully above the key including a top-row hold`() {
         listOf(62f, 111f, 160f, 209f).forEach { top ->
             val source = KeyBounds(156f, top, 192f, top + 40f)
             val layout = resolve(13, source)
 
-            assertTrue("$top", layout.bounds.top < source.top)
+            assertTrue("$top", layout.bounds.bottom <= source.top)
+            assertTrue("$top", !layout.overlapsSource)
             assertTrue("$top", layout.bounds.left >= 6f && layout.bounds.right <= 384f)
         }
     }
@@ -46,6 +47,17 @@ class AlternatePaletteLayoutTest {
     }
 
     @Test
+    fun `Vietnamese diacritic keys keep the palette above a top-row hold`() {
+        listOf(6, 12, 18).forEach { count ->
+            val source = KeyBounds(102f, 62f, 138f, 102f)
+            val layout = resolve(count, source)
+
+            assertTrue("$count", layout.bounds.bottom <= source.top)
+            assertTrue("$count", !layout.overlapsSource)
+        }
+    }
+
+    @Test
     fun `short sets stay on one row`() {
         val layout = resolve(2, KeyBounds(156f, 160f, 192f, 200f))
 
@@ -54,21 +66,37 @@ class AlternatePaletteLayoutTest {
     }
 
     @Test
-    fun `a palette clamped over its key keeps the default until the finger travels`() {
-        // Nineteen alternates cannot fit above a top-row key, so the palette covers it.
+    fun `a top-row Vietnamese catalog overflows above the surface instead of covering the key`() {
         val source = KeyBounds(300f, 62f, 336f, 102f)
         val layout = resolve(19, source)
+
+        assertTrue(layout.bounds.bottom <= source.top)
+        assertTrue(!layout.overlapsSource)
+        assertTrue(layout.overflowAbove > 0f)
+        assertEquals(0, layout.selectionAt(source.centerX, source.centerY, source.centerX, source.centerY, 1f))
+    }
+
+    @Test
+    fun `a palette overlapping its key keeps the default until the finger travels`() {
+        val source = KeyBounds(300f, 62f, 336f, 102f)
+        val covering = KeyBounds(280f, 50f, 356f, 110f)
+        val layout = AlternatePaletteLayout(
+            bounds = covering,
+            itemBounds = listOf(
+                KeyBounds(282f, 52f, 316f, 90f),
+                KeyBounds(318f, 52f, 354f, 90f),
+            ),
+            sourceBounds = source,
+            overlapsSource = true,
+        )
         val startX = source.centerX
         val startY = source.centerY
 
-        assertTrue(layout.overlapsSource)
         assertEquals(0, layout.selectionAt(startX, startY, startX, startY, 1f))
         assertEquals(0, layout.selectionAt(startX + 6f, startY, startX, startY, 1f))
-        // The cell sitting over the key stays reachable once the finger has moved.
-        val covering = layout.indexAt(startX, startY, 1f)
-        assertNotEquals(null, covering)
-        assertNotEquals(0, covering)
-        assertEquals(covering, layout.selectionAt(startX, startY, startX, startY + 60f, 1f))
+        val covered = layout.indexAt(startX, startY, 1f)
+        assertNotEquals(null, covered)
+        assertEquals(covered, layout.selectionAt(startX, startY, startX, startY + 60f, 1f))
     }
 
     @Test

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/surface/KeyboardSurfaceOverlayPadTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/surface/KeyboardSurfaceOverlayPadTest.kt
@@ -1,0 +1,32 @@
+package app.funput.funput.keyboard.surface
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class KeyboardSurfaceOverlayPadTest {
+    @Test
+    fun syncRoundsOverflowUpAndIgnoresRepeats() {
+        var layouts = 0
+        var reported = 0
+        val pad = KeyboardSurfaceOverlayPad(requestLayout = { layouts++ }, onPixelsChanged = { reported = it })
+
+        pad.sync(40.2f)
+        pad.sync(40.2f)
+
+        assertEquals(41, pad.pixels)
+        assertEquals(41, reported)
+        assertEquals(1, layouts)
+        assertEquals(259, pad.keyboardHeight(300))
+    }
+
+    @Test
+    fun aClearedPaletteRemovesThePad() {
+        val pad = KeyboardSurfaceOverlayPad(requestLayout = {}, onPixelsChanged = {})
+
+        pad.sync(80f)
+        pad.sync(0f)
+
+        assertEquals(0, pad.pixels)
+        assertEquals(300, pad.keyboardHeight(300))
+    }
+}

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/FunputKeyboardView.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/FunputKeyboardView.kt
@@ -28,6 +28,8 @@ class FunputKeyboardView @JvmOverloads constructor(
     defStyleAttr: Int = 0,
 ) : FrameLayout(context, attrs, defStyleAttr) {
     private val keyboardSurface = KeyboardSurfaceView(context)
+    private val hostBackground = KeyboardHostBackground()
+    val overlayPadTop: Int get() = keyboardSurface.overlayPadTop
     val callbacks = FunputKeyboardCallbacks()
     private val clipboardState = KeyboardClipboardPanelState(
         keyboardSurface, { editorMode }, { activePanel }, ::showLettersPanel,
@@ -68,7 +70,7 @@ class FunputKeyboardView @JvmOverloads constructor(
         set(value) {
             keyboardSurface.keyboardTheme = value
             panelCoordinator.updateTheme(value)
-            setBackgroundColor(value.backgroundEndColor)
+            hostBackground.color = value.backgroundEndColor
         }
     var keyboardThemeBackgroundImage by keyboardSurface::keyboardThemeBackgroundImage
     var sizingProfile: KeyboardSizingProfile by keyboardSurface::sizingProfile
@@ -87,26 +89,25 @@ class FunputKeyboardView @JvmOverloads constructor(
     var soundsEnabled: Boolean by feedbackController::soundsEnabled
     private val safeArea = KeyboardSafeAreaController(this)
     init { KeyboardComposeLifecycle.install(this)
+        background = hostBackground
+        hostBackground.attach(keyboardSurface, ::requestLayout)
         addView(keyboardSurface, matchParentLayoutParams())
         keyboardSurface.callbacks.onKeyAction = ::handleKeyAction
         keyboardSurface.callbacks.onSuggestionSelected = callbacks::dispatchSuggestion
         keyboardSurface.callbacks.onEmojiRequested = ::openEmojiFromKeyboard
         keyboardSurface.callbacks.onClipboardPasteRequested = callbacks::dispatchClipboardPasteRequest
         keyboardSurface.callbacks.onClipboardPanelRequested = ::showClipboardPanel
-        setBackgroundColor(keyboardTheme.backgroundEndColor)
         safeArea.install()
     }
 
     fun showEmojiPanel(): Unit = panelCoordinator.showEmoji()
     fun showClipboardPanel() {
         if (!clipboardState.available() || activePanel == KeyboardPanel.CLIPBOARD) return
-        panelCoordinator.showClipboard()
-        callbacks.dispatchClipboardPanelOpened()
+        panelCoordinator.showClipboard(); callbacks.dispatchClipboardPanelOpened()
     }
 
-    fun showSymbolsPanel(mode: KeyboardLayoutMode = KeyboardLayoutMode.SYMBOLS_PRIMARY) {
+    fun showSymbolsPanel(mode: KeyboardLayoutMode = KeyboardLayoutMode.SYMBOLS_PRIMARY) =
         panelCoordinator.showSymbols(mode)
-    }
 
     fun showLettersPanel(): Unit = panelCoordinator.showLetters()
 
@@ -118,7 +119,9 @@ class FunputKeyboardView @JvmOverloads constructor(
         val heightDp = KeyboardDimensions.recommendedHeightDp(
             inputMethod, editorMode, sizingProfile, contentWidthDp, showsNumberRow,
         )
-        val height = resolveSize((heightDp * density).roundToInt() + safeArea.bottomInset, heightMeasureSpec)
+        val height = resolveSize(
+            (heightDp * density).roundToInt() + safeArea.bottomInset + overlayPadTop, heightMeasureSpec,
+        )
         super.onMeasure(
             MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
             MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY),
@@ -127,8 +130,7 @@ class FunputKeyboardView @JvmOverloads constructor(
 
     private fun openEmojiFromKeyboard() {
         if (editorMode.isPassword) return
-        showEmojiPanel()
-        callbacks.dispatchEmojiPanelOpened()
+        showEmojiPanel(); callbacks.dispatchEmojiPanelOpened()
     }
 
     private fun handleKeyAction(action: KeyAction) = when (action) {

--- a/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/KeyboardHostBackground.kt
+++ b/platforms/android/keyboard-ui/src/main/java/app/funput/funput/keyboard/ui/KeyboardHostBackground.kt
@@ -1,0 +1,56 @@
+package app.funput.funput.keyboard.ui
+
+import android.graphics.Canvas
+import android.graphics.ColorFilter
+import android.graphics.Paint
+import android.graphics.PixelFormat
+import android.graphics.drawable.Drawable
+import app.funput.funput.keyboard.KeyboardSurfaceView
+
+/**
+ * Fills the keyboard host except the transparent overlay strip used to draw an
+ * alternate palette above a top-row key without covering the app with theme color.
+ */
+internal class KeyboardHostBackground : Drawable() {
+    private val paint = Paint()
+    var color: Int
+        get() = paint.color
+        set(value) {
+            if (paint.color == value) return
+            paint.color = value
+            invalidateSelf()
+        }
+    var overlayPadTop: Int = 0
+        set(value) {
+            if (field == value) return
+            field = value
+            invalidateSelf()
+        }
+
+    override fun draw(canvas: Canvas) {
+        val bounds = bounds
+        canvas.drawRect(
+            bounds.left.toFloat(),
+            (bounds.top + overlayPadTop).toFloat(),
+            bounds.right.toFloat(),
+            bounds.bottom.toFloat(),
+            paint,
+        )
+    }
+
+    override fun setAlpha(alpha: Int) {
+        paint.alpha = alpha
+    }
+
+    override fun setColorFilter(colorFilter: ColorFilter?) {
+        paint.colorFilter = colorFilter
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun getOpacity(): Int = PixelFormat.OPAQUE
+
+    fun attach(surface: KeyboardSurfaceView, requestLayout: () -> Unit) {
+        color = surface.keyboardTheme.backgroundEndColor
+        surface.onOverlayPadChanged = { overlayPadTop = it; requestLayout() }
+    }
+}


### PR DESCRIPTION
## Summary

Long-press alternate palettes now sit fully above the key, including top-row Vietnamese diacritics. Overflow draws in a transparent IME overlay so the app does not jump.

## Test plan

- [x] `AlternatePaletteLayout`, `KeyboardSurfaceOverlayPad`, `ImeOverlayInsets` unit tests
- [x] On device: long-press `e` / `y` / `u` / `o` and drag up to pick a mark

Made with [Cursor](https://cursor.com)