### PR TITLE
fix(android): retone after Backspace when the editor hides the word

### DIFF
--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/AndroidCompositionSession.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/AndroidCompositionSession.kt
@@ -13,11 +13,11 @@ internal class AndroidCompositionSession(
     private val composingTextFactory: (String) -> CharSequence = ::unstyledComposingText,
 ) {
     private val documentEditor = CompositionDocumentEditor(composingTextFactory)
+    private val committedTail = CommittedWordTail()
     private var renderMode = CompositionRenderMode.COMPOSING
     var composingText: String = ""
         private set
     private var completedToken: String? = null
-    private var recentCompletedToken: String? = null
 
     val isComposing: Boolean get() = composingText.isNotEmpty()
 
@@ -34,7 +34,6 @@ internal class AndroidCompositionSession(
         return if (CompositionBoundary.isBoundary(codePoint, engine.inputMethod)) {
             commitBoundary(connection, text, codePoint)
         } else {
-            recentCompletedToken = null
             updateComposing(connection, engine.process(codePoint), text)
         }
     }
@@ -55,7 +54,7 @@ internal class AndroidCompositionSession(
     fun reset() {
         composingText = ""
         completedToken = null
-        recentCompletedToken = null
+        committedTail.clear()
         engine.clear()
     }
 
@@ -64,6 +63,7 @@ internal class AndroidCompositionSession(
     fun acceptSuggestion(connection: InputConnection, prefix: String, candidate: String): Boolean {
         if (composingText != prefix) return false
         val accepted = documentEditor.acceptSuggestion(connection, renderMode, prefix, candidate)
+        if (accepted) committedTail.record("$candidate ")
         composingText = ""
         completedToken = null
         engine.clear()
@@ -78,7 +78,7 @@ internal class AndroidCompositionSession(
         val previous = composingText
         val replacement = engine.processBoundary(codePoint)
         completedToken = replacement?.removeSuffix(text)?.ifEmpty { null } ?: previous.ifEmpty { null }
-        recentCompletedToken = completedToken
+        committedTail.record(replacement ?: previous + text)
         composingText = ""
         return documentEditor.commitBoundary(connection, renderMode, previous, replacement, text)
     }
@@ -96,23 +96,17 @@ internal class AndroidCompositionSession(
     }
 
     /**
-     * Re-opens the word the caret now sits behind, so the next keystroke edits it
-     * instead of typing a literal letter (`chào` ⌫ then `s` gives `cháo`).
-     *
-     * Called only from the Backspace path that did *not* have a live composition, so
-     * typing never pays for it. Uses one bounded [wordBeforeCursor] read, on a
-     * keystroke where the editor is already being consulted, and
-     * asks the engine before touching the document, so a non-Vietnamese word is left
-     * exactly as it was.
+     * Re-opens the word behind the caret so the next keystroke can retone it.
+     * Walks [committedTail] when the editor withholds or stale-reads surrounding text.
      */
     fun reopenPreviousWord(connection: InputConnection?): Boolean {
         if (connection == null || isComposing) return false
         if (!connection.getSelectedText(0).isNullOrEmpty()) return false
-        val word = listOfNotNull(connection.wordBeforeCursor(), recentCompletedToken)
+        val word = listOfNotNull(committedTail.backspace(), connection.wordBeforeCursor())
             .distinct()
             .firstOrNull(engine::adopt)
-            ?: return false
-        recentCompletedToken = null
+        committedTail.resolve(word != null)
+        if (word == null) return false
 
         connection.beginBatchEdit()
         val reopened = try {

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CommittedWordTail.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CommittedWordTail.kt
@@ -1,0 +1,58 @@
+package app.funput.funput.ime.editing
+
+import app.funput.funput.ime.editing.composition.CompositionBoundary
+
+/**
+ * Last committed word plus trailing separators, walked back on each Backspace.
+ *
+ * Fresh [wordBeforeCursor] reads are enough on well-behaved editors. Committed-mode
+ * hosts often withhold or stale-read surrounding text, so a refused word (`dungh`)
+ * has to stay in this suffix until a later delete makes it adoptable (`dung`).
+ */
+internal class CommittedWordTail {
+    private val tail = StringBuilder()
+    private var wordStart = 0
+
+    fun clear() {
+        tail.setLength(0)
+        wordStart = 0
+    }
+
+    fun record(committed: String) {
+        tail.append(committed)
+        trim()
+    }
+
+    fun backspace(): String? {
+        if (tail.isEmpty()) return null
+        val last = Character.codePointBefore(tail, tail.length)
+        tail.setLength(tail.length - Character.charCount(last))
+        val word = tail.wordAtEnd() ?: return null
+        wordStart = tail.length - word.length
+        return word
+    }
+
+    fun resolve(adopted: Boolean) {
+        if (adopted) tail.setLength(wordStart)
+    }
+
+    private fun trim() {
+        if (tail.length <= CAPACITY) return
+        val floor = tail.length - CAPACITY
+        var index = 0
+        while (index < tail.length) {
+            val codePoint = Character.codePointAt(tail, index)
+            val width = Character.charCount(codePoint)
+            if (index >= floor && CompositionBoundary.isBoundary(codePoint)) {
+                tail.delete(0, index + width)
+                return
+            }
+            index += width
+        }
+        tail.setLength(0)
+    }
+
+    private companion object {
+        const val CAPACITY = 64
+    }
+}

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/WordBeforeCursor.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/WordBeforeCursor.kt
@@ -13,13 +13,15 @@ private const val WordLookback = 12
  * Reads at most [WordLookback] characters: enough for any Vietnamese syllable, and
  * small enough to stay cheap on the one keystroke that asks for it.
  */
-internal fun InputConnection.wordBeforeCursor(): String? {
-    val tail = getTextBeforeCursor(WordLookback, 0)?.toString() ?: return null
-    var start = tail.length
+internal fun InputConnection.wordBeforeCursor(): String? =
+    getTextBeforeCursor(WordLookback, 0)?.wordAtEnd()
+
+internal fun CharSequence.wordAtEnd(): String? {
+    var start = length
     while (start > 0) {
-        val codePoint = tail.codePointBefore(start)
+        val codePoint = Character.codePointBefore(this, start)
         if (CompositionBoundary.isBoundary(codePoint)) break
         start -= Character.charCount(codePoint)
     }
-    return tail.substring(start).ifEmpty { null }
+    return if (start == length) null else subSequence(start, length).toString()
 }

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CommittedCompositionSessionTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CommittedCompositionSessionTest.kt
@@ -1,8 +1,6 @@
 package app.funput.funput.ime.editing
 
-import android.view.inputmethod.InputConnection
 import app.funput.funput.keyboard.model.KeyAction
-import java.lang.reflect.Proxy
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -86,41 +84,34 @@ class CommittedCompositionSessionTest {
         assertEquals("cháo", editor.text)
         assertEquals(0, editor.setComposingCount)
     }
-}
 
-private class CommittedEditor(
-    var text: String = "",
-    private val exposesSurroundingText: Boolean = true,
-) {
-    var setComposingCount = 0
+    @Test
+    fun `withheld surrounding text retones after backspacing a refused coda`() {
+        val editor = CommittedEditor(exposesSurroundingText = false)
+        val engine = ScriptedEngine(
+            processed = ArrayDeque(listOf("d", "du", "dun", "dung", "dungh", "dúng")),
+        ).apply { adoptable = setOf("dung") }
+        val session = testSession(engine)
+        val handler = ImeKeyActionHandler(
+            composition = session,
+            editor = InputConnectionEditor(),
+            connection = { editor.proxy },
+            enterCommand = { ImeEditCommand.CommitText("\n") },
+        )
+        handler.start(renderMode = CompositionRenderMode.COMMITTED)
 
-    val proxy: InputConnection = Proxy.newProxyInstance(
-        InputConnection::class.java.classLoader,
-        arrayOf(InputConnection::class.java),
-    ) { _, method, arguments ->
-        when (method.name) {
-            "beginBatchEdit", "endBatchEdit" -> true
-            "commitText" -> true.also { text += arguments?.first().toString() }
-            "deleteSurroundingText" -> true.also {
-                text = text.dropLast(arguments?.first() as Int)
-            }
-            "getSelectedText" -> null
-            "getTextBeforeCursor" -> {
-                val count = arguments?.first() as Int
-                if (!exposesSurroundingText || count >= GraphemeLookback) null else text.takeLast(count)
-            }
-            "deleteSurroundingTextInCodePoints" -> true.also {
-                repeat(arguments?.first() as Int) {
-                    if (text.isNotEmpty()) text = text.dropLast(1)
-                }
-            }
-            "setComposingText" -> true.also { setComposingCount++ }
-            "toString" -> "CommittedEditor"
-            else -> false
-        }
-    } as InputConnection
+        "dungh".forEach { session.input(editor.proxy, it.toString()) }
+        session.input(editor.proxy, " ")
+        handler.onKeyAction(KeyAction.Backspace)
+        handler.onSelectionChanged(newStart = 5, newEnd = 5, composingEnd = -1)
+        assertEquals("dungh", editor.text)
+        assertEquals("", session.composingText)
 
-    private companion object {
-        const val GraphemeLookback = 128
+        handler.onKeyAction(KeyAction.Backspace)
+        handler.onSelectionChanged(newStart = 4, newEnd = 4, composingEnd = -1)
+        handler.onKeyAction(KeyAction.Input(keyId = "character-s", text = "s"))
+
+        assertEquals("dúng", editor.text)
+        assertEquals("dung", engine.adopted)
     }
 }

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CommittedWordTailTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CommittedWordTailTest.kt
@@ -1,0 +1,54 @@
+package app.funput.funput.ime.editing
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CommittedWordTailTest {
+    @Test
+    fun `backspace over the space reopens the word`() {
+        val tail = CommittedWordTail()
+        tail.record("phủ ")
+
+        assertEquals("phủ", tail.backspace())
+        tail.resolve(true)
+        assertNull(tail.backspace())
+    }
+
+    @Test
+    fun `a refused word stays shadowed until a later backspace makes it a syllable`() {
+        val tail = CommittedWordTail()
+        tail.record("chào ")
+        tail.record("dungh ")
+
+        assertEquals("dungh", tail.backspace())
+        tail.resolve(false)
+        assertEquals("dung", tail.backspace())
+        tail.resolve(true)
+        assertEquals("chào", tail.backspace())
+    }
+
+    @Test
+    fun `every separator has to be deleted before the word is offered`() {
+        val tail = CommittedWordTail()
+        tail.record("phủ, ")
+
+        assertNull(tail.backspace())
+        assertEquals("phủ", tail.backspace())
+    }
+
+    @Test
+    fun `clear forgets the shadow`() {
+        val tail = CommittedWordTail()
+        tail.record("phủ ")
+        tail.clear()
+        assertNull(tail.backspace())
+    }
+
+    @Test
+    fun `backspacing an empty shadow is a no-op`() {
+        val tail = CommittedWordTail()
+        assertNull(tail.backspace())
+        assertNull(tail.backspace())
+    }
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CompositionSessionTestSupport.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CompositionSessionTestSupport.kt
@@ -64,3 +64,48 @@ internal class RecordingConnection {
         }
     } as InputConnection
 }
+
+/**
+ * Committed-mode host that can hide surrounding text the way Reddit and similar
+ * editors do: deletes still apply, but [InputConnection.getTextBeforeCursor] is null.
+ */
+internal class CommittedEditor(
+    var text: String = "",
+    private val exposesSurroundingText: Boolean = true,
+) {
+    var setComposingCount = 0
+
+    val proxy: InputConnection = Proxy.newProxyInstance(
+        InputConnection::class.java.classLoader,
+        arrayOf(InputConnection::class.java),
+    ) { _, method, arguments ->
+        when (method.name) {
+            "beginBatchEdit", "endBatchEdit" -> true
+            "commitText" -> true.also { text += arguments?.first().toString() }
+            "deleteSurroundingText" -> true.also {
+                text = text.dropLast(arguments?.first() as Int)
+            }
+            "getSelectedText" -> null
+            "getTextBeforeCursor" -> {
+                val count = arguments?.first() as Int
+                if (!exposesSurroundingText || count >= GraphemeLookback) {
+                    null
+                } else {
+                    text.takeLast(count)
+                }
+            }
+            "deleteSurroundingTextInCodePoints" -> true.also {
+                repeat(arguments?.first() as Int) {
+                    if (text.isNotEmpty()) text = text.dropLast(1)
+                }
+            }
+            "setComposingText" -> true.also { setComposingCount++ }
+            "toString" -> "CommittedEditor"
+            else -> false
+        }
+    } as InputConnection
+
+    private companion object {
+        const val GraphemeLookback = 128
+    }
+}


### PR DESCRIPTION
## Summary
- Walk a committed-word shadow on Backspace, matching Windows `CommittedTail`, so a refused syllable (`dungh`) can shrink to an adoptable one (`dung`) after another delete.
- Keeps retone working on hosts that withhold or stale-read `getTextBeforeCursor` (Reddit, and the same committed-mode path as Firefox / Facebook / Instagram).
- Live Telex/VNI composition is unchanged; the engine still refuses non-syllables.

## Test plan
- [x] Telex on Firefox (or Facebook / Instagram): `dungh` + Space, Backspace, Backspace, `s` → `dúng`
- [x] `chào` + Space + Backspace + `s` → `cháo` (existing retone path)
- [x] English word + Space + Backspace + letter stays literal (`hellos`)
- [x] Ordinary composing (tone while still in the word) is unchanged
- [x] `./gradlew :ime:testDebugUnitTest --tests 'app.funput.funput.ime.editing.*'`
- [x] `scripts/check-kotlin-loc.sh`


Made with [Cursor](https://cursor.com)