### PR TITLE
feat(android): add a Settings toggle for sentence auto-capitalization

### DIFF
--- a/platforms/android/app/src/main/java/app/funput/funput/ui/SettingsRoute.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/SettingsRoute.kt
@@ -44,8 +44,7 @@ internal fun SettingsRoute(
         keySizeProfile = settings.keySizeProfile,
         hapticsEnabled = settings.feedback.hapticsEnabled,
         soundsEnabled = settings.feedback.soundsEnabled,
-        smartRestoreEnabled = settings.smartComposition.smartRestoreEnabled,
-        spellCheckEnabled = settings.smartComposition.spellCheckEnabled,
+        smartComposition = settings.smartComposition,
         personalSuggestionsEnabled = settings.personalSuggestions.enabled,
         clipboardPreferences = settings.clipboard,
         smartGesturesEnabled = settings.smartGesturesEnabled,
@@ -69,6 +68,9 @@ internal fun SettingsRoute(
         },
         onSpellCheckChanged = { enabled ->
             scope.launch { settings.smartCompositionStore.setSpellCheckEnabled(enabled) }
+        },
+        onAutoCapitalizeChanged = { enabled ->
+            scope.launch { settings.smartCompositionStore.setAutoCapitalizeEnabled(enabled) }
         },
         onPersonalSuggestionsChanged = { enabled ->
             scope.launch { settings.personalSuggestionStore.setEnabled(enabled) }

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/settings/SettingsPreviews.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/settings/SettingsPreviews.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.funput.funput.ime.settings.AppearanceMode
 import app.funput.funput.ime.settings.ClipboardPreferences
+import app.funput.funput.ime.settings.SmartCompositionPreferences
 import app.funput.funput.ime.settings.ToneStyle
 import app.funput.funput.keyboard.layout.KeyboardSizingProfile
 import app.funput.funput.keyboard.model.KeyboardInputMethod
@@ -60,8 +61,7 @@ private fun SettingsPreview(
             keySizeProfile = KeyboardSizingProfile.Normal,
             hapticsEnabled = true,
             soundsEnabled = false,
-            smartRestoreEnabled = true,
-            spellCheckEnabled = false,
+            smartComposition = SmartCompositionPreferences.Default,
             personalSuggestionsEnabled = true,
             clipboardPreferences = ClipboardPreferences.Default,
             smartGesturesEnabled = true,
@@ -75,6 +75,7 @@ private fun SettingsPreview(
             onSmartGesturesChanged = {},
             onSmartRestoreChanged = {},
             onSpellCheckChanged = {},
+            onAutoCapitalizeChanged = {},
             onPersonalSuggestionsChanged = {},
             onClipboardEnabledChanged = {},
             onClipboardExpirySelected = {},

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/settings/SettingsScreen.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/settings/SettingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import app.funput.funput.ime.clipboard.model.ClipboardExpiry
 import app.funput.funput.ime.settings.ClipboardPreferences
+import app.funput.funput.ime.settings.SmartCompositionPreferences
 import app.funput.funput.ime.settings.ToneStyle
 import app.funput.funput.keyboard.layout.KeyboardSizingProfile
 import app.funput.funput.keyboard.model.KeyboardInputMethod
@@ -29,8 +30,7 @@ internal fun SettingsScreen(
     keySizeProfile: KeyboardSizingProfile,
     hapticsEnabled: Boolean,
     soundsEnabled: Boolean,
-    smartRestoreEnabled: Boolean,
-    spellCheckEnabled: Boolean,
+    smartComposition: SmartCompositionPreferences,
     personalSuggestionsEnabled: Boolean,
     clipboardPreferences: ClipboardPreferences,
     smartGesturesEnabled: Boolean,
@@ -44,6 +44,7 @@ internal fun SettingsScreen(
     onSmartGesturesChanged: (Boolean) -> Unit,
     onSmartRestoreChanged: (Boolean) -> Unit,
     onSpellCheckChanged: (Boolean) -> Unit,
+    onAutoCapitalizeChanged: (Boolean) -> Unit,
     onPersonalSuggestionsChanged: (Boolean) -> Unit,
     onClipboardEnabledChanged: (Boolean) -> Unit,
     onClipboardExpirySelected: (ClipboardExpiry) -> Unit,
@@ -69,8 +70,7 @@ internal fun SettingsScreen(
             keySizeProfile = keySizeProfile,
             hapticsEnabled = hapticsEnabled,
             soundsEnabled = soundsEnabled,
-            smartRestoreEnabled = smartRestoreEnabled,
-            spellCheckEnabled = spellCheckEnabled,
+            smartComposition = smartComposition,
             personalSuggestionsEnabled = personalSuggestionsEnabled,
             clipboardPreferences = clipboardPreferences,
             smartGesturesEnabled = smartGesturesEnabled,
@@ -84,6 +84,7 @@ internal fun SettingsScreen(
             onSmartGesturesChanged = onSmartGesturesChanged,
             onSmartRestoreChanged = onSmartRestoreChanged,
             onSpellCheckChanged = onSpellCheckChanged,
+            onAutoCapitalizeChanged = onAutoCapitalizeChanged,
             onPersonalSuggestionsChanged = onPersonalSuggestionsChanged,
             onClipboardEnabledChanged = onClipboardEnabledChanged,
             onClearClipboardHistory = onClearClipboardHistory,

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/settings/SettingsScreenSections.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/settings/SettingsScreenSections.kt
@@ -12,8 +12,8 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import app.funput.funput.ime.settings.ClipboardPreferences
+import app.funput.funput.ime.settings.SmartCompositionPreferences
 import app.funput.funput.ime.settings.ToneStyle
 import app.funput.funput.keyboard.layout.KeyboardSizingProfile
 import app.funput.funput.keyboard.model.KeyboardInputMethod
@@ -40,8 +40,7 @@ internal fun SettingsScreenSections(
     keySizeProfile: KeyboardSizingProfile,
     hapticsEnabled: Boolean,
     soundsEnabled: Boolean,
-    smartRestoreEnabled: Boolean,
-    spellCheckEnabled: Boolean,
+    smartComposition: SmartCompositionPreferences,
     personalSuggestionsEnabled: Boolean,
     clipboardPreferences: ClipboardPreferences,
     smartGesturesEnabled: Boolean,
@@ -56,6 +55,7 @@ internal fun SettingsScreenSections(
     onSmartGesturesChanged: (Boolean) -> Unit,
     onSmartRestoreChanged: (Boolean) -> Unit,
     onSpellCheckChanged: (Boolean) -> Unit,
+    onAutoCapitalizeChanged: (Boolean) -> Unit,
     onPersonalSuggestionsChanged: (Boolean) -> Unit,
     onClipboardEnabledChanged: (Boolean) -> Unit,
     onClearClipboardHistory: () -> Unit,
@@ -108,10 +108,10 @@ internal fun SettingsScreenSections(
         item(key = "smart") {
             Box(modifier = Modifier.staggeredEntry(2, tracker)) {
                 SmartSettingsSection(
-                    smartRestoreEnabled = smartRestoreEnabled,
-                    spellCheckEnabled = spellCheckEnabled,
+                    preferences = smartComposition,
                     onSmartRestoreChanged = onSmartRestoreChanged,
                     onSpellCheckChanged = onSpellCheckChanged,
+                    onAutoCapitalizeChanged = onAutoCapitalizeChanged,
                 )
             }
         }

--- a/platforms/android/app/src/main/java/app/funput/funput/ui/settings/smart/SmartSettingsSection.kt
+++ b/platforms/android/app/src/main/java/app/funput/funput/ui/settings/smart/SmartSettingsSection.kt
@@ -3,15 +3,16 @@ package app.funput.funput.ui.settings.smart
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import app.funput.funput.R
+import app.funput.funput.ime.settings.SmartCompositionPreferences
 import app.funput.funput.ui.settings.components.SettingsSection
 import app.funput.funput.ui.settings.components.SettingsSwitchRow
 
 @Composable
 internal fun SmartSettingsSection(
-    smartRestoreEnabled: Boolean,
-    spellCheckEnabled: Boolean,
+    preferences: SmartCompositionPreferences,
     onSmartRestoreChanged: (Boolean) -> Unit,
     onSpellCheckChanged: (Boolean) -> Unit,
+    onAutoCapitalizeChanged: (Boolean) -> Unit,
 ) {
     SettingsSection(
         title = stringResource(R.string.settings_section_smart),
@@ -20,7 +21,7 @@ internal fun SmartSettingsSection(
                 SettingsSwitchRow(
                     position = position,
                     title = stringResource(R.string.settings_smart_restore_title),
-                    checked = smartRestoreEnabled,
+                    checked = preferences.smartRestoreEnabled,
                     iconRes = R.drawable.ic_globe,
                     onCheckedChange = onSmartRestoreChanged,
                 )
@@ -29,9 +30,19 @@ internal fun SmartSettingsSection(
                 SettingsSwitchRow(
                     position = position,
                     title = stringResource(R.string.settings_spell_check_title),
-                    checked = spellCheckEnabled,
+                    checked = preferences.spellCheckEnabled,
                     iconRes = R.drawable.ic_check,
                     onCheckedChange = onSpellCheckChanged,
+                )
+            },
+            { position ->
+                SettingsSwitchRow(
+                    position = position,
+                    title = stringResource(R.string.settings_auto_capitalize_title),
+                    summary = stringResource(R.string.settings_auto_capitalize_summary),
+                    checked = preferences.autoCapitalizeEnabled,
+                    iconRes = R.drawable.ic_keyboard,
+                    onCheckedChange = onAutoCapitalizeChanged,
                 )
             },
         ),

--- a/platforms/android/app/src/main/res/values/strings.xml
+++ b/platforms/android/app/src/main/res/values/strings.xml
@@ -191,6 +191,8 @@
     <string name="settings_sounds_title">Âm thanh phím</string>
     <string name="settings_smart_restore_title">Tự khôi phục từ tiếng Anh</string>
     <string name="settings_spell_check_title">Kiểm tra chính tả</string>
+    <string name="settings_auto_capitalize_title">Tự viết hoa</string>
+    <string name="settings_auto_capitalize_summary">Viết hoa ký tự đầu câu khi phù hợp.</string>
     <string name="settings_personal_suggestions_section">Gợi ý cá nhân</string>
     <string name="settings_personal_suggestions_title">Gợi ý từ cá nhân</string>
     <string name="settings_personal_suggestions_description">Chỉ học chữ Funput gõ và lưu trên thiết bị.</string>

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/FunputInputMethodService.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/FunputInputMethodService.kt
@@ -51,6 +51,7 @@ class FunputInputMethodService : InputMethodService() {
             onInputMethodChanged = ::restartComposition,
             onViewSettingsChanged = { keyboardView?.let(::updateInputView) },
             onPersonalSuggestionsChanged = suggestionService::configure,
+            onAutoCapitalizeChanged = editorRuntime::setAutoCapitalizeEnabled,
         )
         settings.observe(this, serviceScope)
     }
@@ -65,6 +66,7 @@ class FunputInputMethodService : InputMethodService() {
     override fun onStartInput(attribute: EditorInfo, restarting: Boolean) {
         super.onStartInput(attribute, restarting)
         editorRuntime.configure(attribute)
+        editorRuntime.setAutoCapitalizeEnabled(settings.autoCapitalizeEnabled)
         session.startActionHandler()
         suggestionService.start(editorRuntime.policy)
     }

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/ImeSettingsController.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/ImeSettingsController.kt
@@ -27,6 +27,7 @@ internal class ImeSettingsController(
     private val onInputMethodChanged: (KeyboardInputMethod) -> Unit,
     private val onViewSettingsChanged: () -> Unit,
     private val onPersonalSuggestionsChanged: (PersonalSuggestionPreferences) -> Unit,
+    private val onAutoCapitalizeChanged: (Boolean) -> Unit = {},
 ) {
     var inputMethod = InputMethodSettings.DefaultInputMethod
         private set
@@ -40,6 +41,7 @@ internal class ImeSettingsController(
         private set
     var smartGesturesEnabled = SmartGestureSettings.DefaultEnabled
         private set
+    val autoCapitalizeEnabled get() = smartComposition.autoCapitalizeEnabled
 
     // Seeded with the same defaults the settings flows fall back to, so the engine
     // configuration below is always complete — no option has to be invented when one
@@ -91,6 +93,7 @@ internal class ImeSettingsController(
         if (value == smartComposition) return
         smartComposition = value
         applyEngineConfiguration()
+        onAutoCapitalizeChanged(value.autoCapitalizeEnabled)
     }
 
     /**

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/AutoCapitalizationController.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/AutoCapitalizationController.kt
@@ -1,5 +1,6 @@
 package app.funput.funput.ime.editing
 
+import android.text.TextUtils
 import app.funput.funput.keyboard.model.ShiftState
 
 /** Synchronizes one-shot Shift with the editor's capitalization state. */
@@ -9,14 +10,20 @@ internal class AutoCapitalizationController(
     private val updateShiftState: (ShiftState) -> Unit,
 ) {
     private var requestedModes = 0
+    private var enabled = true
 
     fun configure(capitalizationModes: Int) {
         requestedModes = capitalizationModes
     }
 
+    fun setEnabled(enabled: Boolean) {
+        this.enabled = enabled
+    }
+
     fun update(preserveCapsLock: Boolean = true) {
         if (preserveCapsLock && currentShiftState() == ShiftState.CAPS_LOCK) return
-        val shouldCapitalize = requestedModes != 0 && cursorCapsMode(requestedModes) != 0
+        val modes = if (enabled) requestedModes else requestedModes and TextUtils.CAP_MODE_CHARACTERS
+        val shouldCapitalize = modes != 0 && cursorCapsMode(modes) != 0
         updateShiftState(if (shouldCapitalize) ShiftState.ON else ShiftState.OFF)
     }
 }

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/ImeEditorRuntime.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/ImeEditorRuntime.kt
@@ -40,6 +40,11 @@ internal class ImeEditorRuntime(
         completions.configure(enabled = false)
     }
 
+    fun setAutoCapitalizeEnabled(enabled: Boolean) {
+        autoCapitalization.setEnabled(enabled)
+        autoCapitalization.update()
+    }
+
     fun updateCapitalization(preserveCapsLock: Boolean = true) =
         autoCapitalization.update(preserveCapsLock)
 

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/settings/SmartCompositionPreferences.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/settings/SmartCompositionPreferences.kt
@@ -3,11 +3,13 @@ package app.funput.funput.ime.settings
 data class SmartCompositionPreferences(
     val spellCheckEnabled: Boolean,
     val smartRestoreEnabled: Boolean,
+    val autoCapitalizeEnabled: Boolean,
 ) {
     companion object {
         val Default = SmartCompositionPreferences(
             spellCheckEnabled = false,
             smartRestoreEnabled = true,
+            autoCapitalizeEnabled = true,
         )
     }
 }

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/settings/SmartCompositionSettingCodec.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/settings/SmartCompositionSettingCodec.kt
@@ -4,8 +4,11 @@ internal object SmartCompositionSettingCodec {
     fun decode(
         spellCheckEnabled: Boolean?,
         smartRestoreEnabled: Boolean?,
+        autoCapitalizeEnabled: Boolean?,
     ) = SmartCompositionPreferences(
         spellCheckEnabled = spellCheckEnabled ?: SmartCompositionPreferences.Default.spellCheckEnabled,
         smartRestoreEnabled = smartRestoreEnabled ?: SmartCompositionPreferences.Default.smartRestoreEnabled,
+        autoCapitalizeEnabled = autoCapitalizeEnabled
+            ?: SmartCompositionPreferences.Default.autoCapitalizeEnabled,
     )
 }

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/settings/SmartCompositionSettings.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/settings/SmartCompositionSettings.kt
@@ -22,6 +22,7 @@ class SmartCompositionSettings(context: Context) {
             SmartCompositionSettingCodec.decode(
                 spellCheckEnabled = values[SpellCheckEnabledKey],
                 smartRestoreEnabled = values[SmartRestoreEnabledKey],
+                autoCapitalizeEnabled = values[AutoCapitalizeEnabledKey],
             )
         }
         .distinctUntilChanged()
@@ -34,8 +35,13 @@ class SmartCompositionSettings(context: Context) {
         dataStore.edit { it[SmartRestoreEnabledKey] = enabled }
     }
 
+    suspend fun setAutoCapitalizeEnabled(enabled: Boolean) {
+        dataStore.edit { it[AutoCapitalizeEnabledKey] = enabled }
+    }
+
     private companion object {
         val SpellCheckEnabledKey = booleanPreferencesKey("spell_check_enabled")
         val SmartRestoreEnabledKey = booleanPreferencesKey("smart_restore_enabled")
+        val AutoCapitalizeEnabledKey = booleanPreferencesKey("auto_capitalize_enabled")
     }
 }

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/ImeSettingsControllerTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/ImeSettingsControllerTest.kt
@@ -33,6 +33,7 @@ class ImeSettingsControllerTest {
                 smartRestore = SmartCompositionPreferences.Default.smartRestoreEnabled,
                 eagerRestore = SmartCompositionPreferences.Default.smartRestoreEnabled,
                 spellCheck = SmartCompositionPreferences.Default.spellCheckEnabled,
+                autoCapitalize = false,
             ),
             engine.configurations.single(),
         )

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AutoCapitalizationControllerTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AutoCapitalizationControllerTest.kt
@@ -1,5 +1,6 @@
 package app.funput.funput.ime.editing
 
+import android.text.TextUtils
 import app.funput.funput.keyboard.model.ShiftState
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -8,15 +9,15 @@ class AutoCapitalizationControllerTest {
     private var cursorCapsMode = 0
     private var shiftState = ShiftState.OFF
     private val controller = AutoCapitalizationController(
-        cursorCapsMode = { cursorCapsMode },
+        cursorCapsMode = { modes -> if (modes == 0) 0 else cursorCapsMode },
         currentShiftState = { shiftState },
         updateShiftState = { value -> shiftState = value },
     )
 
     @Test
     fun `cursor caps mode enables and disables one shot shift`() {
-        controller.configure(capitalizationModes = 0x4000)
-        cursorCapsMode = 0x4000
+        controller.configure(capitalizationModes = TextUtils.CAP_MODE_SENTENCES)
+        cursorCapsMode = TextUtils.CAP_MODE_SENTENCES
         controller.update()
         assertEquals(ShiftState.ON, shiftState)
 
@@ -26,9 +27,31 @@ class AutoCapitalizationControllerTest {
     }
 
     @Test
+    fun `disabling the preference silences sentence and word modes`() {
+        controller.configure(capitalizationModes = TextUtils.CAP_MODE_SENTENCES)
+        cursorCapsMode = TextUtils.CAP_MODE_SENTENCES
+        controller.setEnabled(false)
+
+        controller.update()
+
+        assertEquals(ShiftState.OFF, shiftState)
+    }
+
+    @Test
+    fun `a field demanding all caps still shifts when the preference is off`() {
+        controller.configure(capitalizationModes = TextUtils.CAP_MODE_CHARACTERS)
+        cursorCapsMode = TextUtils.CAP_MODE_CHARACTERS
+        controller.setEnabled(false)
+
+        controller.update()
+
+        assertEquals(ShiftState.ON, shiftState)
+    }
+
+    @Test
     fun `selection updates preserve manual caps lock`() {
         shiftState = ShiftState.CAPS_LOCK
-        controller.configure(capitalizationModes = 0x4000)
+        controller.configure(capitalizationModes = TextUtils.CAP_MODE_SENTENCES)
 
         controller.update()
 

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/settings/SmartCompositionSettingCodecTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/settings/SmartCompositionSettingCodecTest.kt
@@ -8,18 +8,20 @@ import org.junit.Test
 class SmartCompositionSettingCodecTest {
     @Test
     fun `missing keys fall back to defaults`() {
-        val decoded = SmartCompositionSettingCodec.decode(null, null)
+        val decoded = SmartCompositionSettingCodec.decode(null, null, null)
 
         assertFalse(decoded.spellCheckEnabled)
         assertTrue(decoded.smartRestoreEnabled)
+        assertTrue(decoded.autoCapitalizeEnabled)
         assertEquals(SmartCompositionPreferences.Default, decoded)
     }
 
     @Test
-    fun `both flags round trip`() {
+    fun `flags round trip including a disabled auto-capitalize`() {
         val expected = SmartCompositionPreferences(
             spellCheckEnabled = true,
             smartRestoreEnabled = false,
+            autoCapitalizeEnabled = false,
         )
 
         assertEquals(
@@ -27,6 +29,7 @@ class SmartCompositionSettingCodecTest {
             SmartCompositionSettingCodec.decode(
                 spellCheckEnabled = expected.spellCheckEnabled,
                 smartRestoreEnabled = expected.smartRestoreEnabled,
+                autoCapitalizeEnabled = expected.autoCapitalizeEnabled,
             ),
         )
     }


### PR DESCRIPTION
## Summary
- Add **Tự viết hoa** under Gõ thông minh, default on for new installs and existing users who have no stored key.
- When on, Shift still follows the editor's `CAP_SENTENCES` / `CAP_WORDS` / `CAP_CHARACTERS` (start of a sentence and after `.!?`). Search fields that omit those flags stay lowercase, same as Gboard.
- When off, sentence/word caps are silenced; fields that demand all caps still shift. Engine `autoCapitalize` stays off so letters are not capitalized twice.

## Test plan
- [x] Fresh install: toggle is on
- [x] Notes: empty field and `xin chào. ` light Shift; first letters capitalize
- [x] Toggle off: Notes no longer auto-shifts (except an ALL CAPS field)
- [x] System / Facebook search stays lowercase with the toggle on
- [x] `./gradlew :ime:testDebugUnitTest --tests '...SmartCompositionSettingCodecTest' --tests '...AutoCapitalizationControllerTest' --tests '...ImeSettingsControllerTest'`
- [x] `scripts/check-kotlin-loc.sh`


Made with [Cursor](https://cursor.com)