### PR TITLE
fix(ios): keep long-press alternates above the source key

### DIFF
--- a/platforms/ios/Keyboard/Controller/KeyboardViewController.swift
+++ b/platforms/ios/Keyboard/Controller/KeyboardViewController.swift
@@ -57,7 +57,7 @@ final class KeyboardViewController: UIInputViewController {
         enterAction: .newLine,
         initialLayoutMode: .letters
     )
-    private let heightController = KeyboardHeightController()
+    let heightController = KeyboardHeightController()
     private(set) var isKeyboardVisible = false
 
     var cachedBackgroundImage: UIImage? { backgroundImageCache.value }

--- a/platforms/ios/Keyboard/Controller/Surfaces/KeyboardViewController+PrimarySurfaceLifecycle.swift
+++ b/platforms/ios/Keyboard/Controller/Surfaces/KeyboardViewController+PrimarySurfaceLifecycle.swift
@@ -19,6 +19,13 @@ extension KeyboardViewController {
             surface.onKeyEvent = { [weak self] event in
                 self?.handleKeyEvent(event)
             }
+            surface.onOverlayPadChanged = { [weak self] pad in
+                guard let self else { return }
+                UIView.performWithoutAnimation {
+                    self.heightController.setOverlayPad(pad)
+                    self.view.layoutIfNeeded()
+                }
+            }
             installClipboard(on: surface)
             installPersonalSuggestions(on: surface)
             view.addSubview(surface)

--- a/platforms/ios/Keyboard/Presentation/KeyboardHeightController.swift
+++ b/platforms/ios/Keyboard/Presentation/KeyboardHeightController.swift
@@ -12,13 +12,14 @@ final class KeyboardHeightController {
     }
 
     private var heightConstraint: NSLayoutConstraint?
-    private var requestedHeight: CGFloat?
+    private var baseHeight: CGFloat?
+    private var overlayPad: CGFloat = 0
 
     func install(on view: UIView) {
         guard heightConstraint == nil else { return }
 
         let constraint = view.heightAnchor.constraint(
-            equalToConstant: requestedHeight ?? 0
+            equalToConstant: appliedHeight
         )
         constraint.identifier = Constants.constraintIdentifier
         constraint.priority = Constants.constraintPriority
@@ -26,7 +27,7 @@ final class KeyboardHeightController {
     }
 
     func activate() {
-        guard let heightConstraint, requestedHeight != nil else {
+        guard let heightConstraint, baseHeight != nil else {
             assertionFailure("Install and update the keyboard height before activating it.")
             return
         }
@@ -43,10 +44,17 @@ final class KeyboardHeightController {
             traits: traits,
             scale: presentation.sizing.heightScale
         )
-        guard requestedHeight != height else { return }
+        guard baseHeight != height else { return }
 
-        requestedHeight = height
-        heightConstraint?.constant = height
+        baseHeight = height
+        applyHeight()
+    }
+
+    func setOverlayPad(_ pad: CGFloat) {
+        let next = ceil(pad)
+        guard overlayPad != next else { return }
+        overlayPad = next
+        applyHeight()
     }
 
     @discardableResult
@@ -57,5 +65,14 @@ final class KeyboardHeightController {
 
         heightConstraint.isActive = false
         return true
+    }
+
+    private var appliedHeight: CGFloat { (baseHeight ?? 0) + overlayPad }
+
+    private func applyHeight() {
+        guard baseHeight != nil else { return }
+        UIView.performWithoutAnimation {
+            heightConstraint?.constant = appliedHeight
+        }
     }
 }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/Preview/KeyboardAlternatePaletteLayout.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Keys/Preview/KeyboardAlternatePaletteLayout.swift
@@ -5,9 +5,10 @@ struct KeyboardAlternatePaletteLayout: Equatable {
     let frame: CGRect
     let itemFrames: [CGRect]
     let sourceFrame: CGRect
-    /// True when the palette had to be clamped over the key it came from, which happens
-    /// on the top row where there is no room above for every cell.
+    /// True when the palette still intersects its key after placement.
     let overlapsSource: Bool
+    /// Pixels the palette extends above the keyboard surface and needs an IME overlay pad.
+    var overflowAbove: CGFloat { max(0, -frame.minY) }
 
     /// Preferred grid width. The palette stays narrow and wraps into more rows so it
     /// reads as a block above the finger rather than a long strip across the keyboard.
@@ -37,10 +38,9 @@ struct KeyboardAlternatePaletteLayout: Equatable {
             max(safe.minX, sourceFrame.midX - width / 2),
             safe.maxX - width
         )
-        // The palette always rises from the key. Flipping it below would put it under the
-        // hand and away from the finger, so a palette too tall for the space above is
-        // clamped to the top edge instead.
-        let y = max(safe.minY, min(sourceFrame.minY - sourceGap - height, safe.maxY - height))
+        // Sit fully above the key, like Gboard. Covering a top-row key made the hold
+        // harder to aim; overflow above the surface is drawn in a transparent IME pad.
+        let y = sourceFrame.minY - sourceGap - height
         let frame = CGRect(x: x, y: y, width: width, height: height)
         let contentWidth = width - padding * 2 - CGFloat(columns - 1) * gap
         let cellWidth = contentWidth / CGFloat(columns)

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/Input/KeyboardSurfaceView+Interaction.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/Input/KeyboardSurfaceView+Interaction.swift
@@ -17,7 +17,7 @@ extension KeyboardSurfaceView {
             sourceFrame: sourceFrame,
             presentation: presentation,
             traits: traitCollection,
-            containerBounds: bounds
+            containerBounds: keyboardBounds
         )
         bringSubviewToFront(previewView)
     }
@@ -27,6 +27,7 @@ extension KeyboardSurfaceView {
         layout: KeyboardAlternatePaletteLayout?,
         selectedIndex: Int?
     ) {
+        syncOverlayPad(layout?.overflowAbove ?? 0)
         guard let key, let layout else {
             alternatePaletteView.hide()
             return
@@ -38,7 +39,16 @@ extension KeyboardSurfaceView {
             presentation: presentation,
             traits: traitCollection
         )
+        alternatePaletteView.frame = layout.frame.offsetBy(dx: 0, dy: overlayPadTop)
         bringSubviewToFront(alternatePaletteView)
+    }
+
+    func syncOverlayPad(_ overflow: CGFloat) {
+        let next = ceil(overflow)
+        guard overlayPadTop != next else { return }
+        overlayPadTop = next
+        onOverlayPadChanged?(next)
+        setNeedsLayout()
     }
 }
 #endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView+InteractionFrames.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView+InteractionFrames.swift
@@ -10,19 +10,19 @@ extension KeyboardSurfaceView {
             .filter { !$0.isEmpty }
         for (rowIndex, row) in rows.enumerated() {
             let visualMinY = row.map(\.frame.minY).min() ?? 0
-            let visualMaxY = row.map(\.frame.maxY).max() ?? bounds.height
+            let visualMaxY = row.map(\.frame.maxY).max() ?? keyboardSize.height
             let minY = rowIndex == rows.startIndex
                 ? geometry.toolbarFrame?.maxY ?? 0
                 : midpoint(rows[rowIndex - 1].visualMaxY, visualMinY)
             let maxY = rowIndex == rows.index(before: rows.endIndex)
-                ? bounds.height
+                ? keyboardSize.height
                 : midpoint(visualMaxY, rows[rowIndex + 1].visualMinY)
 
             for (keyIndex, key) in row.enumerated() {
                 let minX = keyIndex == row.startIndex
                     ? 0 : midpoint(row[keyIndex - 1].frame.maxX, key.frame.minX)
                 let maxX = keyIndex == row.index(before: row.endIndex)
-                    ? bounds.width : midpoint(key.frame.maxX, row[keyIndex + 1].frame.minX)
+                    ? keyboardSize.width : midpoint(key.frame.maxX, row[keyIndex + 1].frame.minX)
                 let interaction = CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
                 keyControls[key.spec.id]?.applyFrames(interaction: interaction, visual: key.frame)
             }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView+Presentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView+Presentation.swift
@@ -107,7 +107,7 @@ extension KeyboardSurfaceView {
                 key: hit.key,
                 point: point,
                 sourceFrame: hit.frame,
-                containerBounds: bounds,
+                containerBounds: keyboardBounds,
                 presentation: presentation
             )
         }
@@ -133,17 +133,17 @@ extension KeyboardSurfaceView {
 
     func resolvedGeometry() -> ResolvedKeyboard {
         if let cache = geometryCache,
-           cache.size == bounds.size,
+           cache.size == keyboardSize,
            cache.layout == presentation.layout,
            cache.sizing == presentation.sizing {
             return cache.value
         }
         let value = KeyboardGeometry.resolve(
             layout: presentation.layout,
-            size: bounds.size,
+            size: keyboardSize,
             sizing: presentation.sizing
         )
-        geometryCache = (bounds.size, presentation.layout, presentation.sizing, value)
+        geometryCache = (keyboardSize, presentation.layout, presentation.sizing, value)
         return value
     }
 }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView.swift
@@ -29,6 +29,12 @@ public final class KeyboardSurfaceView: UIView {
     public var onKeyEvent: ((KeyboardKeyEvent) -> Void)?
     public var onSuggestionSelected: ((KeyboardSuggestionCandidate) -> Void)?
     public var onClipboardPaste: ((String) -> Void)?
+    public var onOverlayPadChanged: ((CGFloat) -> Void)?
+    var overlayPadTop: CGFloat = 0
+    var keyboardSize: CGSize {
+        CGSize(width: bounds.width, height: max(0, bounds.height - overlayPadTop))
+    }
+    var keyboardBounds: CGRect { CGRect(origin: .zero, size: keyboardSize) }
 
     let backdropView = KeyboardBackdropView()
     let toolbarView = KeyboardToolbarView()
@@ -92,12 +98,13 @@ public final class KeyboardSurfaceView: UIView {
 
     public override func layoutSubviews() {
         super.layoutSubviews()
-        backdropView.frame = bounds
-        contentHost.frame = bounds
-        keysHost.frame = bounds
-        touchOverlay.frame = bounds
+        let band = CGRect(origin: CGPoint(x: 0, y: overlayPadTop), size: keyboardSize)
+        backdropView.frame = band
+        contentHost.frame = band
+        keysHost.frame = contentHost.bounds
+        touchOverlay.frame = contentHost.bounds
 
-        guard bounds.width > 0, bounds.height > 0 else { return }
+        guard keyboardSize.width > 0, keyboardSize.height > 0 else { return }
         let geometry = resolvedGeometry()
         toolbarView.frame = geometry.toolbarFrame ?? .zero
         layoutKeyControls(in: geometry)

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Alternates/KeyboardAlternatePaletteLayoutTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Alternates/KeyboardAlternatePaletteLayoutTests.swift
@@ -35,8 +35,8 @@ struct KeyboardAlternatePaletteLayoutTests {
                 sourceFrame: source,
                 bounds: bounds
             )
-            #expect(layout.frame.minY < source.minY)
-            #expect(bounds.contains(layout.frame))
+            #expect(layout.frame.maxY <= source.minY)
+            #expect(!layout.overlapsSource)
         }
     }
 
@@ -59,6 +59,21 @@ struct KeyboardAlternatePaletteLayoutTests {
         }
     }
 
+    @Test("Vietnamese diacritic keys keep the palette above a top-row hold")
+    func vietnameseTopRow() {
+        let bounds = CGRect(x: 0, y: 0, width: 390, height: 304)
+        for count in [6, 12, 18] {
+            let source = CGRect(x: 102, y: 62, width: 36, height: 40)
+            let layout = KeyboardAlternatePaletteLayout.resolve(
+                count: count,
+                sourceFrame: source,
+                bounds: bounds
+            )
+            #expect(layout.frame.maxY <= source.minY)
+            #expect(!layout.overlapsSource)
+        }
+    }
+
     @Test("Short sets stay on one row")
     func shortSets() {
         let layout = KeyboardAlternatePaletteLayout.resolve(
@@ -70,20 +85,36 @@ struct KeyboardAlternatePaletteLayoutTests {
         #expect(layout.itemFrames.count == 2)
     }
 
-    @Test("A palette clamped over its key keeps the default until the finger travels")
-    func clampedOverSource() {
-        // Nineteen alternates cannot fit above a top-row key, so the palette covers it.
+    @Test("A top-row Vietnamese catalog overflows above the surface instead of covering the key")
+    func overflowsAboveSurface() {
         let source = CGRect(x: 300, y: 62, width: 36, height: 40)
         let layout = KeyboardAlternatePaletteLayout.resolve(
             count: 19,
             sourceFrame: source,
             bounds: CGRect(x: 0, y: 0, width: 390, height: 260)
         )
-        #expect(layout.overlapsSource)
+        #expect(layout.frame.maxY <= source.minY)
+        #expect(!layout.overlapsSource)
+        #expect(layout.overflowAbove > 0)
+        let start = CGPoint(x: source.midX, y: source.midY)
+        #expect(layout.selection(at: start, from: start) == 0)
+    }
+
+    @Test("A palette overlapping its key keeps the default until the finger travels")
+    func holdSlopWhenOverlapping() {
+        let source = CGRect(x: 300, y: 62, width: 36, height: 40)
+        let layout = KeyboardAlternatePaletteLayout(
+            frame: CGRect(x: 280, y: 50, width: 76, height: 60),
+            itemFrames: [
+                CGRect(x: 2, y: 2, width: 34, height: 38),
+                CGRect(x: 38, y: 2, width: 36, height: 38),
+            ],
+            sourceFrame: source,
+            overlapsSource: true
+        )
         let start = CGPoint(x: source.midX, y: source.midY)
         #expect(layout.selection(at: start, from: start) == 0)
         #expect(layout.selection(at: CGPoint(x: start.x + 6, y: start.y), from: start) == 0)
-        // The cell sitting over the key stays reachable once the finger has moved.
         let covering = layout.index(at: start)
         #expect(covering != nil)
         #expect(covering != 0)


### PR DESCRIPTION
## Summary
- Long-press alternate palettes now sit fully above the held key, including top-row Telex `e` / `y` / `u` / `o`.
- Overflow grows a transparent pad and pins keys to the bottom so the finger does not jump.
- iOS has no public IME overlay-inset API, so the host document may rise while a large top-row palette is open.

## Test plan
- [x] `KeyboardAlternatePaletteLayoutTests` / `KeyboardAlternateInteractionTests`
- [x] `check-swift-loc.sh` and `check-keyboard-touch-layout.sh`
- [x] On device: hold top-row `e` / `y` / `u` / `o` — palette above the key, not covering it; lower rows unchanged; finger stays on the same keycap when the pad appears


Made with [Cursor](https://cursor.com)