### PR TITLE
feat(linux): wait for surrounding text before Fcitx5 non-preedit

### DIFF
--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -143,13 +143,15 @@ that refuses it will simply appear to ignore Backspace. A Backspace *inside* a w
 still left to the app; the same hazard applies in principle, but nothing has been seen
 to fail there.
 
-Whether it engages is decided per input context, and the two shells cannot decide it
-the same way. Fcitx5 settles it once at focus-in, from `surroundingText().isValid()`.
-IBus has no such question to ask that early — surrounding text only starts arriving
-after the client answers — so it re-asks between words, on any keystroke with nothing
-composing. Never mid-word in either shell: the modes disagree about where the
-composing word lives, and switching under one leaves the engine and the client
-describing different things.
+Whether it engages is decided per input context. Both shells wait until the client
+has actually sent surrounding text this focus — Fcitx5 via `SurroundingTextUpdated`,
+IBus via `set_surrounding_text` — then re-ask between words, on any keystroke with
+nothing composing. Neither snapshots capability flags or a cache at focus-in: the
+text often arrives only after the client answers (Calc, an empty GTK field), and a
+stale `isValid()` from the previous focus would turn the mode on in a terminal that
+never sends updates. Never mid-word: the modes disagree about where the composing
+word lives, and switching under one leaves the engine and the client describing
+different things.
 
 ### What was measured, and what follows from it
 

--- a/platforms/linux/fcitx5/src/funput_engine.cpp
+++ b/platforms/linux/fcitx5/src/funput_engine.cpp
@@ -12,13 +12,32 @@ FunputEngine::FunputEngine(fcitx::Instance *instance) : instance_(instance) {
                 return true;
             });
     }
+    surroundingWatch_ = instance_->watchEvent(
+        fcitx::EventType::InputContextSurroundingTextUpdated,
+        fcitx::EventWatcherPhase::Default, [this](fcitx::Event &event) {
+            auto *ic = static_cast<fcitx::InputContextEvent &>(event).inputContext();
+            if (ic != instance_->lastFocusedInputContext()) return;
+            // isValid(), not CapabilityFlag::SurroundingText: on GNOME/Wayland the
+            // flag lies both ways. Empty text with cursor 0 is still valid — a blank
+            // GTK field, and the IBus shell's "the client has spoken".
+            lastSurroundingOk_ = ic->surroundingText().isValid();
+        });
 }
 
 void FunputEngine::applyNonPreeditMode() {
-    // isValid(), not CapabilityFlag::SurroundingText: on GNOME/Wayland the flag is
-    // absent on contexts whose surrounding text works perfectly and present on some
-    // that report nothing, so it decides nothing here. See platforms/linux/README.md.
+    // Never mid-word. The two modes disagree about where the composing word lives,
+    // so flipping under one leaves the engine and the client describing different
+    // things. Same gate as the IBus shell's applyNonPreeditMode().
+    if (composer_.isComposing()) return;
+    const bool wasNonPreedit = composer_.nonPreedit();
     composer_.setNonPreedit(composer_.settings().nonPreedit && lastSurroundingOk_);
+    if (wasNonPreedit || !composer_.nonPreedit()) return;
+    // Mode just turned on between words. A leftover preedit would sit as a ghost
+    // while the new mode writes into the document — same cleanup as a live settings
+    // reload, cheap if the panel is already empty.
+    if (fcitx::InputContext *context = instance_->lastFocusedInputContext()) {
+        clearPreedit(context);
+    }
 }
 
 void FunputEngine::onSettingsChanged() {
@@ -47,7 +66,9 @@ void FunputEngine::activate(const fcitx::InputMethodEntry &, fcitx::InputContext
     composer_.onFocusChanged();
     lastProgram_ = event.inputContext()->program();
     composer_.applyPerAppDefault(lastProgram_);
-    lastSurroundingOk_ = event.inputContext()->surroundingText().isValid();
+    // Like IBus `sawSurroundingText`: a new client has said nothing yet. `isValid()`
+    // here can be leftover from the previous focus, so do not snapshot it.
+    lastSurroundingOk_ = false;
     applyNonPreeditMode();
     noteRecentApp(lastProgram_);
 }

--- a/platforms/linux/fcitx5/src/funput_engine.h
+++ b/platforms/linux/fcitx5/src/funput_engine.h
@@ -26,6 +26,7 @@
 #include <fcitx-config/configuration.h>
 #include <fcitx-config/option.h>
 #include <fcitx-utils/event.h>
+#include <fcitx-utils/handlertable.h>
 #include <fcitx-utils/key.h>
 
 #include "compose/composer/composer.h"
@@ -65,9 +66,10 @@ private:
     void clearPreedit(fcitx::InputContext *ic);
     void noteRecentApp(const std::string &program); // record for the Settings picker
     // Turn non-preedit on for the focused client: the setting has to ask for it and
-    // the client has to report surrounding text, since the mode repairs the document
-    // by reading it back. Re-applied after every `applySettings()`, which reseeds the
-    // mode from the setting alone and so forgets the client half of that.
+    // the client has to have sent surrounding text this focus, since the mode repairs
+    // the document by reading it back. No-op while a word is composing — the two
+    // modes disagree about where that word lives. Re-applied after every
+    // `applySettings()`, which reseeds the mode from the setting alone.
     void applyNonPreeditMode();
     // Reload settings live when the watcher fires (Settings app wrote the file), and
     // re-apply the per-app default for the currently-focused app.
@@ -79,13 +81,16 @@ private:
     // Program() of the most recently focused app, so a live settings reload can
     // re-apply the per-app default without waiting for the next focus-in.
     std::string lastProgram_;
-    // Whether that app reports surrounding text. Remembered for the same reason as
-    // lastProgram_: a live settings reload has to re-decide without a focus change.
+    // Whether the focused client has sent surrounding text this focus — the IBus
+    // shell's `sawSurroundingText`. Not a snapshot of `isValid()` at focus-in: that
+    // cache can be stale, and surrounding text often arrives only after the client
+    // answers. Set by SurroundingTextUpdated; cleared on activate().
     bool lastSurroundingOk_ = false;
     // Live settings reload: an inotify fd (settingsWatcher_) wired into Fcitx5's
     // event loop (settingsWatch_).
     funput::SettingsWatcher settingsWatcher_;
     std::unique_ptr<fcitx::EventSourceIO> settingsWatch_;
+    std::unique_ptr<fcitx::HandlerTableEntry<fcitx::EventHandler>> surroundingWatch_;
 };
 
 class FunputEngineFactory : public fcitx::AddonFactory {

--- a/platforms/linux/fcitx5/src/funput_input.cpp
+++ b/platforms/linux/fcitx5/src/funput_input.cpp
@@ -28,6 +28,11 @@ void FunputEngine::keyEvent(const fcitx::InputMethodEntry &, fcitx::KeyEvent &ev
     // them, and each framework reports them differently.
     if (event.isRelease()) return;
 
+    // Between words, re-ask whether this client can take a document repair. Surrounding
+    // text often arrives only after the client answers — Calc, an empty GTK field —
+    // so unlike the old focus-in snapshot there is no single moment early enough.
+    applyNonPreeditMode();
+
     const funput::KeyEvent ev = toKeyEvent(event.key());
     // One read of the document, used twice. It lets the composer check that its last
     // repair actually landed — a client that takes commits but drops deletes turns

--- a/scripts/check-loc.sh
+++ b/scripts/check-loc.sh
@@ -37,10 +37,10 @@ done < <(
         find crates/*/src platforms -path '*/src/*' -name '*.rs' \
             -not -name 'tests.rs' -not -path '*/tests/*' -not -path '*/target/*'
         # The Linux shells and the code they share. Not under a `src/` dir in the
-        # `common/` case, so this needs its own pass. `build/` is CMake/CPack
-        # output, and `_deps/` inside it is the fetched test framework.
+        # `common/` case, so this needs its own pass. `build/` and `build-*` are
+        # CMake/CPack output, and `_deps/` inside them is the fetched test framework.
         find platforms/linux \( -name '*.h' -o -name '*.cpp' \) \
-            -not -path '*/build/*' -not -path '*/target/*'
+            -not -path '*/build/*' -not -path '*/build-*/*' -not -path '*/target/*'
     } | sort -u
 )
 


### PR DESCRIPTION
## Summary
- Enable Fcitx5 non-preedit only after the client sends surrounding text this focus, and only between words — same model as IBus.
- Fixes Calc / empty GTK fields that speak late, and avoids turning the mode on from a stale `isValid()` in terminals that never update.

## Test plan
- [x] Empty GTK field: first word may stay preedit if ST is late; later words go non-preedit
- [x] LibreOffice Calc cell
- [x] Chrome
- [x] VTE terminal stays preedit (no doubled characters)

Made with [Cursor](https://cursor.com)