### PR TITLE
feat(android): compose Telex and VNI from a hardware keyboard

### DIFF
--- a/platforms/android/ime/README.md
+++ b/platforms/android/ime/README.md
@@ -31,6 +31,14 @@ composition, and keep both symbol pages free of candidate and emoji UI.
 `setComposingText()`. JNI is intentionally narrow: one synchronous call per text
 key, no network or storage, and safe registry IDs instead of native pointers.
 
+A hardware keyboard hides the soft Funput view (Android's default
+`onEvaluateInputViewShown`). The IME stays bound: `onKeyDown` / `onKeyUp` map
+printable keys, Space, Enter, and Backspace onto the same `KeyAction` path as
+taps, so Telex and VNI still compose. Navigation and Ctrl/Alt/Meta shortcuts
+finish the current composition and pass through to the host. A few OEM builds
+do not deliver hardware keys while the input view is hidden; enable the system
+*Show on-screen keyboard* setting in that case.
+
 The system-keyboard globe is intentionally always hidden until its interaction
 is revisited in a later plan. The dormant switch callback remains isolated from
 the typing path.

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/FunputInputMethodService.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/FunputInputMethodService.kt
@@ -2,11 +2,13 @@ package app.funput.funput.ime
 
 import android.content.res.Configuration
 import android.inputmethodservice.InputMethodService
+import android.view.KeyEvent
 import android.view.View
 import android.view.inputmethod.CompletionInfo
 import android.view.inputmethod.EditorInfo
 import app.funput.funput.ime.editing.InputConnectionEditor
-import app.funput.funput.keyboard.model.KeyboardInputMethod
+import app.funput.funput.ime.hardware.ImeHardwareKeyHandler
+import app.funput.funput.ime.hardware.toHardwareKeyStroke
 import app.funput.funput.keyboard.model.ShiftState
 import app.funput.funput.keyboard.ui.FunputKeyboardView
 import app.funput.funput.keyboard.ui.emoji.EmojiCatalogPreloader
@@ -25,6 +27,7 @@ class FunputInputMethodService : InputMethodService() {
     private var keyboardView: FunputKeyboardView? = null
     private lateinit var session: ImeEditingSession
     private lateinit var settings: ImeSettingsController
+    private lateinit var hardwareKeys: ImeHardwareKeyHandler
 
     private val nativeEngine get() = session.nativeEngine
     private val actionHandler get() = session.actionHandler
@@ -48,12 +51,13 @@ class FunputInputMethodService : InputMethodService() {
         )
         settings = ImeSettingsController(
             engine = nativeEngine,
-            onInputMethodChanged = ::restartComposition,
+            onInputMethodChanged = { method -> session.restartComposition(method, keyboardView) },
             onViewSettingsChanged = { keyboardView?.let(::updateInputView) },
             onPersonalSuggestionsChanged = suggestionService::configure,
             onAutoCapitalizeChanged = editorRuntime::setAutoCapitalizeEnabled,
         )
         settings.observe(this, serviceScope)
+        hardwareKeys = ImeHardwareKeyHandler.bind(session) { keyboardView?.shiftState ?: ShiftState.OFF }
     }
     override fun onCreateInputView(): View = FunputKeyboardView(this).also { view ->
         keyboardView = view
@@ -123,15 +127,12 @@ class FunputInputMethodService : InputMethodService() {
         nativeEngine.close()
     }
 
-    private fun restartComposition(method: KeyboardInputMethod) {
-        actionHandler.finish()
-        session.startActionHandler()
-        suggestionService.start(editorRuntime.policy)
-        keyboardView?.inputMethod = method
-    }
+    override fun onKeyDown(keyCode: Int, event: KeyEvent) =
+        hardwareKeys.onKeyDown(event.toHardwareKeyStroke()) || super.onKeyDown(keyCode, event)
 
-    // Switching the system between light and dark changes which theme applies, and no settings
-    // flow fires for it because nothing the user stored has changed.
+    override fun onKeyUp(keyCode: Int, event: KeyEvent) =
+        hardwareKeys.onKeyUp(event.toHardwareKeyStroke()) || super.onKeyUp(keyCode, event)
+
     override fun onComputeInsets(outInsets: InputMethodService.Insets) {
         super.onComputeInsets(outInsets)
         ImeOverlayInsets.apply(outInsets, keyboardView?.overlayPadTop ?: 0)

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/ImeEditingSession.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/ImeEditingSession.kt
@@ -16,6 +16,7 @@ import app.funput.funput.ime.nativebridge.NativeVietnameseEngine
 import app.funput.funput.ime.settings.ClipboardSettings
 import app.funput.funput.ime.settings.PersonalSuggestionSettings
 import app.funput.funput.ime.suggestions.PersonalSuggestionService
+import app.funput.funput.keyboard.model.KeyboardInputMethod
 import app.funput.funput.keyboard.model.ShiftState
 import app.funput.funput.keyboard.ui.FunputKeyboardView
 import kotlinx.coroutines.CoroutineScope
@@ -63,6 +64,13 @@ internal class ImeEditingSession(
     fun finishInputView() { clipboardController.stop(); clipboardHistoryController.stop() }
 
     fun bindClipboard(view: FunputKeyboardView) = clipboardUiBinding.attach(view)
+
+    fun restartComposition(method: KeyboardInputMethod, view: FunputKeyboardView?) {
+        actionHandler.finish()
+        startActionHandler()
+        suggestionService.start(editorRuntime.policy)
+        view?.inputMethod = method
+    }
 
     fun windowHidden() {
         clipboardController.stop()

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/ImeKeyboardCallbackBinder.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/ImeKeyboardCallbackBinder.kt
@@ -3,9 +3,19 @@ package app.funput.funput.ime
 import app.funput.funput.ime.editing.ImeEditorRuntime
 import app.funput.funput.ime.editing.ImeKeyActionHandler
 import app.funput.funput.ime.suggestions.PersonalSuggestionService
+import app.funput.funput.keyboard.model.KeyAction
 import app.funput.funput.keyboard.ui.FunputKeyboardView
 
 internal object ImeKeyboardCallbackBinder {
+    fun dispatch(
+        handler: ImeKeyActionHandler,
+        suggestions: PersonalSuggestionService,
+        action: KeyAction,
+    ) {
+        handler.onKeyAction(action)
+        suggestions.consume(handler.takeSuggestionUpdate())
+    }
+
     fun bind(
         view: FunputKeyboardView,
         handler: ImeKeyActionHandler,
@@ -13,10 +23,7 @@ internal object ImeKeyboardCallbackBinder {
         suggestions: PersonalSuggestionService,
         switcher: SystemInputMethodSwitcher,
     ) = with(view.callbacks) {
-        onKeyAction = { action ->
-            handler.onKeyAction(action)
-            suggestions.consume(handler.takeSuggestionUpdate())
-        }
+        onKeyAction = { action -> dispatch(handler, suggestions, action) }
         onInputMethodSwitchRequested = {
             handler.finish()
             suggestions.finish()

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/hardware/HardwareInputCasing.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/hardware/HardwareInputCasing.kt
@@ -1,0 +1,17 @@
+package app.funput.funput.ime.hardware
+
+import app.funput.funput.keyboard.model.KeyAction
+import app.funput.funput.keyboard.model.ShiftState
+
+/**
+ * Applies the hidden soft-keyboard shift state to a hardware [KeyAction.Input].
+ *
+ * Physical Shift/Caps already sit in `unicodeChar`; this covers Funput auto-cap.
+ */
+internal fun KeyAction.applyHardwareCasing(shift: ShiftState): KeyAction {
+    val input = this as? KeyAction.Input ?: return this
+    if (!shift.isActive) return this
+    val first = input.text.firstOrNull() ?: return this
+    if (!first.isLowerCase()) return this
+    return input.copy(text = input.text.replaceFirstChar { it.titlecaseChar() })
+}

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/hardware/HardwareKeyActionMapper.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/hardware/HardwareKeyActionMapper.kt
@@ -1,0 +1,69 @@
+package app.funput.funput.ime.hardware
+
+import android.view.KeyCharacterMap
+import android.view.KeyEvent
+import app.funput.funput.keyboard.model.KeyAction
+
+/** Verdict for one hardware stroke: consume into Funput, commit then pass, or ignore. */
+internal sealed interface HardwareKeyDecision {
+    data class Consume(val action: KeyAction) : HardwareKeyDecision
+    data object FinishAndPass : HardwareKeyDecision
+    data object Pass : HardwareKeyDecision
+}
+
+/** Maps a hardware stroke onto a [HardwareKeyDecision] without touching the editor. */
+internal object HardwareKeyActionMapper {
+    fun map(stroke: HardwareKeyStroke): HardwareKeyDecision {
+        if (stroke.isCanceled || stroke.keyCode in PassThroughKeys) return HardwareKeyDecision.Pass
+        if (stroke.isCtrl || stroke.isMeta) return HardwareKeyDecision.FinishAndPass
+        specialAction(stroke.keyCode)?.let { return HardwareKeyDecision.Consume(it) }
+        if (stroke.keyCode in NavigationKeys) return HardwareKeyDecision.FinishAndPass
+        if (stroke.isAlt && printableText(stroke.codePoint) == null) {
+            return HardwareKeyDecision.FinishAndPass
+        }
+        val text = printableText(stroke.codePoint) ?: return HardwareKeyDecision.Pass
+        return HardwareKeyDecision.Consume(KeyAction.Input("hardware-${stroke.keyCode}", text))
+    }
+}
+
+private fun specialAction(keyCode: Int): KeyAction? = when (keyCode) {
+    KeyEvent.KEYCODE_DEL -> KeyAction.Backspace
+    KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_NUMPAD_ENTER -> KeyAction.Enter
+    KeyEvent.KEYCODE_SPACE -> KeyAction.Space
+    else -> null
+}
+
+private fun printableText(codePoint: Int): String? {
+    if (codePoint == 0 || codePoint and KeyCharacterMap.COMBINING_ACCENT != 0) return null
+    if (Character.isISOControl(codePoint)) return null
+    return String(Character.toChars(codePoint))
+}
+
+private val PassThroughKeys = setOf(
+    KeyEvent.KEYCODE_BACK,
+    KeyEvent.KEYCODE_TAB,
+    KeyEvent.KEYCODE_SHIFT_LEFT,
+    KeyEvent.KEYCODE_SHIFT_RIGHT,
+    KeyEvent.KEYCODE_CTRL_LEFT,
+    KeyEvent.KEYCODE_CTRL_RIGHT,
+    KeyEvent.KEYCODE_ALT_LEFT,
+    KeyEvent.KEYCODE_ALT_RIGHT,
+    KeyEvent.KEYCODE_META_LEFT,
+    KeyEvent.KEYCODE_META_RIGHT,
+    KeyEvent.KEYCODE_CAPS_LOCK,
+    KeyEvent.KEYCODE_NUM_LOCK,
+    KeyEvent.KEYCODE_FUNCTION,
+)
+
+private val NavigationKeys = setOf(
+    KeyEvent.KEYCODE_DPAD_UP,
+    KeyEvent.KEYCODE_DPAD_DOWN,
+    KeyEvent.KEYCODE_DPAD_LEFT,
+    KeyEvent.KEYCODE_DPAD_RIGHT,
+    KeyEvent.KEYCODE_DPAD_CENTER,
+    KeyEvent.KEYCODE_MOVE_HOME,
+    KeyEvent.KEYCODE_MOVE_END,
+    KeyEvent.KEYCODE_PAGE_UP,
+    KeyEvent.KEYCODE_PAGE_DOWN,
+    KeyEvent.KEYCODE_FORWARD_DEL,
+)

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/hardware/HardwareKeyStroke.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/hardware/HardwareKeyStroke.kt
@@ -1,0 +1,30 @@
+package app.funput.funput.ime.hardware
+
+import android.view.KeyEvent
+
+/**
+ * A hardware key press that unit tests can construct without calling KeyEvent getters.
+ *
+ * Android's JVM stubs throw on those getters; the IME converts a real event at runtime.
+ */
+internal data class HardwareKeyStroke(
+    val keyCode: Int,
+    val codePoint: Int = 0,
+    val repeatCount: Int = 0,
+    val isCtrl: Boolean = false,
+    val isAlt: Boolean = false,
+    val isMeta: Boolean = false,
+    val isShift: Boolean = false,
+    val isCanceled: Boolean = false,
+)
+
+internal fun KeyEvent.toHardwareKeyStroke() = HardwareKeyStroke(
+    keyCode = keyCode,
+    codePoint = unicodeChar,
+    repeatCount = repeatCount,
+    isCtrl = isCtrlPressed,
+    isAlt = isAltPressed,
+    isMeta = isMetaPressed,
+    isShift = isShiftPressed,
+    isCanceled = isCanceled,
+)

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/hardware/ImeHardwareKeyHandler.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/hardware/ImeHardwareKeyHandler.kt
@@ -1,0 +1,44 @@
+package app.funput.funput.ime.hardware
+
+import app.funput.funput.ime.ImeEditingSession
+import app.funput.funput.ime.ImeKeyboardCallbackBinder
+import app.funput.funput.keyboard.model.KeyAction
+import app.funput.funput.keyboard.model.ShiftState
+
+/**
+ * Consumes hardware key downs that Funput can type, and the matching ups.
+ *
+ * Repeats are dispatched (held Backspace). Ups never type a second character.
+ */
+internal class ImeHardwareKeyHandler(
+    private val currentShift: () -> ShiftState,
+    private val dispatch: (KeyAction) -> Unit,
+    private val finish: () -> Unit,
+) {
+    private val consumedDown = mutableSetOf<Int>()
+
+    fun onKeyDown(stroke: HardwareKeyStroke): Boolean = when (val decision = HardwareKeyActionMapper.map(stroke)) {
+        is HardwareKeyDecision.Consume -> {
+            dispatch(decision.action.applyHardwareCasing(currentShift()))
+            consumedDown.add(stroke.keyCode)
+            true
+        }
+        HardwareKeyDecision.FinishAndPass -> {
+            finish()
+            false
+        }
+        HardwareKeyDecision.Pass -> false
+    }
+
+    fun onKeyUp(stroke: HardwareKeyStroke): Boolean = consumedDown.remove(stroke.keyCode)
+
+    companion object {
+        fun bind(session: ImeEditingSession, currentShift: () -> ShiftState) = ImeHardwareKeyHandler(
+            currentShift = currentShift,
+            dispatch = { action ->
+                ImeKeyboardCallbackBinder.dispatch(session.actionHandler, session.suggestionService, action)
+            },
+            finish = session.actionHandler::finish,
+        )
+    }
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/hardware/HardwareInputCasingTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/hardware/HardwareInputCasingTest.kt
@@ -1,0 +1,39 @@
+package app.funput.funput.ime.hardware
+
+import app.funput.funput.keyboard.model.KeyAction
+import app.funput.funput.keyboard.model.ShiftState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HardwareInputCasingTest {
+    @Test
+    fun `active shift title-cases a lowercase letter`() {
+        val action = KeyAction.Input("hardware-29", "a").applyHardwareCasing(ShiftState.ON)
+        assertEquals(KeyAction.Input("hardware-29", "A"), action)
+    }
+
+    @Test
+    fun `caps lock title-cases like one-shot shift`() {
+        val action = KeyAction.Input("hardware-29", "a").applyHardwareCasing(ShiftState.CAPS_LOCK)
+        assertEquals(KeyAction.Input("hardware-29", "A"), action)
+    }
+
+    @Test
+    fun `already uppercase input is left unchanged`() {
+        val action = KeyAction.Input("hardware-29", "A").applyHardwareCasing(ShiftState.ON)
+        assertEquals(KeyAction.Input("hardware-29", "A"), action)
+    }
+
+    @Test
+    fun `inactive shift leaves lowercase input unchanged`() {
+        val action = KeyAction.Input("hardware-29", "a").applyHardwareCasing(ShiftState.OFF)
+        assertEquals(KeyAction.Input("hardware-29", "a"), action)
+    }
+
+    @Test
+    fun `non-input actions ignore shift`() {
+        assertEquals(KeyAction.Space, KeyAction.Space.applyHardwareCasing(ShiftState.ON))
+        assertEquals(KeyAction.Enter, KeyAction.Enter.applyHardwareCasing(ShiftState.ON))
+        assertEquals(KeyAction.Backspace, KeyAction.Backspace.applyHardwareCasing(ShiftState.ON))
+    }
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/hardware/HardwareKeyActionMapperTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/hardware/HardwareKeyActionMapperTest.kt
@@ -1,0 +1,76 @@
+package app.funput.funput.ime.hardware
+
+import android.view.KeyEvent
+import app.funput.funput.keyboard.model.KeyAction
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HardwareKeyActionMapperTest {
+    @Test
+    fun `letters and VNI digits are consumed as input`() {
+        assertInput(KeyEvent.KEYCODE_A, 'a'.code, "a")
+        assertInput(KeyEvent.KEYCODE_6, '6'.code, "6")
+        assertInput(KeyEvent.KEYCODE_W, 'w'.code, "w")
+    }
+
+    @Test
+    fun `space enter and delete are consumed as editing actions`() {
+        assertEquals(KeyAction.Space, consume(HardwareKeyStroke(KeyEvent.KEYCODE_SPACE)))
+        assertEquals(KeyAction.Enter, consume(HardwareKeyStroke(KeyEvent.KEYCODE_ENTER)))
+        assertEquals(KeyAction.Enter, consume(HardwareKeyStroke(KeyEvent.KEYCODE_NUMPAD_ENTER)))
+        assertEquals(KeyAction.Backspace, consume(HardwareKeyStroke(KeyEvent.KEYCODE_DEL)))
+    }
+
+    @Test
+    fun `arrows and ctrl shortcuts finish then pass`() {
+        assertEquals(
+            HardwareKeyDecision.FinishAndPass,
+            HardwareKeyActionMapper.map(HardwareKeyStroke(KeyEvent.KEYCODE_DPAD_LEFT)),
+        )
+        assertEquals(
+            HardwareKeyDecision.FinishAndPass,
+            HardwareKeyActionMapper.map(HardwareKeyStroke(KeyEvent.KEYCODE_C, isCtrl = true)),
+        )
+        assertEquals(
+            HardwareKeyDecision.FinishAndPass,
+            HardwareKeyActionMapper.map(HardwareKeyStroke(KeyEvent.KEYCODE_MOVE_HOME)),
+        )
+    }
+
+    @Test
+    fun `back tab and shift pass without finishing`() {
+        assertEquals(HardwareKeyDecision.Pass, HardwareKeyActionMapper.map(HardwareKeyStroke(KeyEvent.KEYCODE_BACK)))
+        assertEquals(HardwareKeyDecision.Pass, HardwareKeyActionMapper.map(HardwareKeyStroke(KeyEvent.KEYCODE_TAB)))
+        assertEquals(
+            HardwareKeyDecision.Pass,
+            HardwareKeyActionMapper.map(HardwareKeyStroke(KeyEvent.KEYCODE_SHIFT_LEFT)),
+        )
+    }
+
+    @Test
+    fun `canceled strokes and combining accents pass`() {
+        assertEquals(
+            HardwareKeyDecision.Pass,
+            HardwareKeyActionMapper.map(HardwareKeyStroke(KeyEvent.KEYCODE_A, isCanceled = true)),
+        )
+        assertEquals(
+            HardwareKeyDecision.Pass,
+            HardwareKeyActionMapper.map(HardwareKeyStroke(KeyEvent.KEYCODE_E, codePoint = Int.MIN_VALUE)),
+        )
+    }
+
+    private fun assertInput(keyCode: Int, codePoint: Int, text: String) {
+        val action = consume(HardwareKeyStroke(keyCode, codePoint))
+        assertTrue(action is KeyAction.Input)
+        action as KeyAction.Input
+        assertEquals("hardware-$keyCode", action.keyId)
+        assertEquals(text, action.text)
+    }
+
+    private fun consume(stroke: HardwareKeyStroke): KeyAction {
+        val decision = HardwareKeyActionMapper.map(stroke)
+        assertTrue(decision is HardwareKeyDecision.Consume)
+        return (decision as HardwareKeyDecision.Consume).action
+    }
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/hardware/ImeHardwareKeyHandlerTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/hardware/ImeHardwareKeyHandlerTest.kt
@@ -1,0 +1,85 @@
+package app.funput.funput.ime.hardware
+
+import android.view.KeyEvent
+import app.funput.funput.keyboard.model.KeyAction
+import app.funput.funput.keyboard.model.ShiftState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImeHardwareKeyHandlerTest {
+    @Test
+    fun `consumed down is matched by up without a second dispatch`() {
+        val dispatched = mutableListOf<KeyAction>()
+        val handler = handler(dispatched)
+
+        val down = HardwareKeyStroke(KeyEvent.KEYCODE_A, 'a'.code)
+        assertTrue(handler.onKeyDown(down))
+        assertEquals(listOf(KeyAction.Input("hardware-${KeyEvent.KEYCODE_A}", "a")), dispatched)
+
+        assertTrue(handler.onKeyUp(down))
+        assertEquals(1, dispatched.size)
+        assertFalse(handler.onKeyUp(down))
+    }
+
+    @Test
+    fun `held backspace repeats on each down`() {
+        val dispatched = mutableListOf<KeyAction>()
+        val handler = handler(dispatched)
+        val stroke = HardwareKeyStroke(KeyEvent.KEYCODE_DEL, repeatCount = 1)
+
+        assertTrue(handler.onKeyDown(stroke))
+        assertTrue(handler.onKeyDown(stroke.copy(repeatCount = 2)))
+        assertEquals(listOf(KeyAction.Backspace, KeyAction.Backspace), dispatched)
+        assertTrue(handler.onKeyUp(stroke))
+    }
+
+    @Test
+    fun `auto-cap shift is applied before dispatch`() {
+        val dispatched = mutableListOf<KeyAction>()
+        val handler = handler(dispatched, shift = ShiftState.ON)
+
+        assertTrue(handler.onKeyDown(HardwareKeyStroke(KeyEvent.KEYCODE_A, 'a'.code)))
+        assertEquals(listOf(KeyAction.Input("hardware-${KeyEvent.KEYCODE_A}", "A")), dispatched)
+    }
+
+    @Test
+    fun `finish-and-pass finishes composition and returns false`() {
+        var finished = 0
+        val dispatched = mutableListOf<KeyAction>()
+        val handler = ImeHardwareKeyHandler(
+            currentShift = { ShiftState.OFF },
+            dispatch = dispatched::add,
+            finish = { finished += 1 },
+        )
+
+        assertFalse(handler.onKeyDown(HardwareKeyStroke(KeyEvent.KEYCODE_DPAD_LEFT)))
+        assertEquals(1, finished)
+        assertEquals(emptyList<KeyAction>(), dispatched)
+        assertFalse(handler.onKeyUp(HardwareKeyStroke(KeyEvent.KEYCODE_DPAD_LEFT)))
+    }
+
+    @Test
+    fun `pass-through keys neither dispatch nor finish`() {
+        var finished = 0
+        val handler = ImeHardwareKeyHandler(
+            currentShift = { ShiftState.OFF },
+            dispatch = { error("should not dispatch") },
+            finish = { finished += 1 },
+        )
+
+        assertFalse(handler.onKeyDown(HardwareKeyStroke(KeyEvent.KEYCODE_BACK)))
+        assertFalse(handler.onKeyDown(HardwareKeyStroke(KeyEvent.KEYCODE_SHIFT_LEFT)))
+        assertEquals(0, finished)
+    }
+
+    private fun handler(
+        dispatched: MutableList<KeyAction>,
+        shift: ShiftState = ShiftState.OFF,
+    ) = ImeHardwareKeyHandler(
+        currentShift = { shift },
+        dispatch = dispatched::add,
+        finish = { error("should not finish") },
+    )
+}


### PR DESCRIPTION
## Summary
- Keep Funput bound when a hardware keyboard hides the soft view, and route printable keys through the existing Telex/VNI path.

## Test plan
- [x] `:ime:testDebugUnitTest --tests 'app.funput.funput.ime.hardware.*'`
- [x] On device: Telex/VNI with Bluetooth keyboard; Backspace retone; arrows/Ctrl pass through; email/password stay ASCII


Made with [Cursor](https://cursor.com)