### PR TITLE
refactor(core): move document reading out of the CLI and into charset

### DIFF
--- a/crates/funput-cli/src/convert/source.rs
+++ b/crates/funput-cli/src/convert/source.rs
@@ -1,29 +1,19 @@
-//! Getting the input, and working out what charset spelled it.
+//! Getting the bytes — from a file, or from standard input.
 //!
-//! The output is a `String`, and that is the whole subject of this module.
-//! `funput_core::charset::convert` takes text rather than bytes because that is what
-//! the input actually is: a legacy document is stored as code points `U+0020..=U+00FF`
-//! standing in for bytes, and converting it means reading those code points back as
-//! charset codes. Getting a file to that form is the job here, and there are two ways
-//! in depending on what the bytes turn out to be.
+//! Only the fetching. Working out what characters those bytes hold and what charset
+//! spells them is [`funput_core::charset::document`]'s, and deliberately not this
+//! module's: the Windows and Linux shells ask the same question and must get the same
+//! answer, and this crate is the wrong place for logic they would have to copy.
 
 use std::io::Read;
 use std::path::Path;
 
-use funput_core::charset::{self, Charset};
+use funput_core::charset::document::{self, Document};
 
 use crate::cli::CliError;
 
-/// The document as characters, and what charset those characters spell.
-pub(super) struct Input {
-    pub(super) text: String,
-    /// `None` only when the bytes are not UTF-8 **and** no byte-oriented charset
-    /// explains them. The command then asks for `--from` rather than guessing.
-    pub(super) charset: Option<Charset>,
-}
-
-/// Read `path`, or standard input when it is `None`.
-pub(super) fn read(path: Option<&Path>) -> Result<Input, CliError> {
+/// Read `path`, or standard input when it is `None`, and say what it holds.
+pub(super) fn read(path: Option<&Path>) -> Result<Document, CliError> {
     let bytes = match path {
         Some(path) => std::fs::read(path)
             .map_err(|e| CliError::Msg(format!("cannot read {}: {e}", path.display())))?,
@@ -33,155 +23,5 @@ pub(super) fn read(path: Option<&Path>) -> Result<Input, CliError> {
             buffer
         }
     };
-    from_bytes(bytes)
-}
-
-/// Interpret bytes already in hand.
-///
-/// Split from [`read`] so that everything this module decides can be exercised
-/// without a file or a pipe — the deciding is the part worth testing.
-pub(super) fn from_bytes(bytes: Vec<u8>) -> Result<Input, CliError> {
-    Ok(identify(marks(bytes)?))
-}
-
-/// Deal with the byte-order marks, so what comes out is either UTF-8 or legacy bytes.
-///
-/// UTF-16 is decided by its mark rather than guessed at: falling through would trade
-/// a certainty for a wrong answer, since UTF-16 text is not valid UTF-8 and would be
-/// read as a legacy charset and confidently mangled. A UTF-8 mark is only a hint —
-/// editors write one whatever follows — so it is stripped and the rest judged on its
-/// own merits.
-fn marks(bytes: Vec<u8>) -> Result<Vec<u8>, CliError> {
-    for (mark, unit) in [
-        ([0xFF, 0xFE], u16::from_le_bytes as fn([u8; 2]) -> u16),
-        ([0xFE, 0xFF], u16::from_be_bytes),
-    ] {
-        if let Some(rest) = bytes.strip_prefix(&mark) {
-            return utf16(rest, unit)
-                .map(String::into_bytes)
-                .ok_or_else(|| CliError::Msg("this is a truncated UTF-16 file".into()));
-        }
-    }
-    Ok(match bytes.strip_prefix(&[0xEF, 0xBB, 0xBF]) {
-        Some(rest) => rest.to_vec(),
-        None => bytes,
-    })
-}
-
-/// Turn the bytes into characters, and say what charset those characters are in.
-///
-/// **Two doors, because there are two questions.** Bytes that decode as UTF-8 are
-/// judged as *text*, and the characters are the ones UTF-8 spelled. That covers a
-/// TCVN3 document someone opened in Notepad and saved again — valid UTF-8 whose text
-/// is still TCVN3, and the commonest way a legacy file arrives today. Reading those
-/// same bytes one-to-one instead would give `Ã` and `–` where the document has `Ö`.
-///
-/// Bytes that do not decode were never Unicode. They are read one-to-one, which is
-/// how the program that wrote them stored them, and a charset that is *not* stored
-/// one byte per character cannot be the answer — accepting one would convert
-/// replacement characters as though they were the document.
-fn identify(bytes: Vec<u8>) -> Input {
-    match String::from_utf8(bytes) {
-        Ok(text) => {
-            // Falling back to `Unicode` is not a guess. `detect` returning `None`
-            // means no legacy charset explains this better than Unicode does — and
-            // the bytes just decoded as UTF-8, so Unicode is what they are.
-            let charset = charset::detect(&text).or(Some(Charset::Unicode));
-            Input { text, charset }
-        }
-        Err(err) => {
-            let bytes = err.as_bytes();
-            let charset = charset::detect_bytes(bytes).filter(|&c| charset::is_byte_oriented(c));
-            let text = bytes.iter().copied().map(char::from).collect();
-            Input { text, charset }
-        }
-    }
-}
-
-fn utf16(bytes: &[u8], unit: fn([u8; 2]) -> u16) -> Option<String> {
-    if !bytes.len().is_multiple_of(2) {
-        return None;
-    }
-    let units: Vec<u16> = bytes
-        .chunks_exact(2)
-        .map(|pair| unit([pair[0], pair[1]]))
-        .collect();
-    String::from_utf16(&units).ok()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn of(bytes: &[u8]) -> Input {
-        identify(marks(bytes.to_vec()).expect("well-formed fixture"))
-    }
-
-    /// The door that used to be taken by mistake. These bytes are valid UTF-8, so the
-    /// characters are what UTF-8 spells — reading them one-to-one instead would give
-    /// `Ã` where the document has `Ö`, and convert that.
-    #[test]
-    fn a_legacy_document_re_saved_as_utf8_is_read_as_text() {
-        let input = of("vi\u{D6}t nam h\u{B5} n\u{E9}i".as_bytes());
-        assert_eq!(input.charset, Some(Charset::Tcvn3));
-        assert!(input.text.starts_with("vi\u{D6}t"), "{:?}", input.text);
-    }
-
-    /// The other door: a file that really is one byte per character.
-    #[test]
-    fn a_legacy_document_stored_as_bytes_is_read_one_to_one() {
-        let input = of(b"vi\xD6t nam h\xB5 n\xE9i");
-        assert_eq!(input.charset, Some(Charset::Tcvn3));
-        assert_eq!(input.text.chars().next(), Some('v'));
-        assert!(input.text.contains('\u{D6}'));
-    }
-
-    /// Not a guess: the bytes decoded as UTF-8, so Unicode is what they are. Only the
-    /// byte door is allowed to come back with nothing.
-    #[test]
-    fn text_with_nothing_to_decide_is_unicode_rather_than_undecided() {
-        assert_eq!(of(b"hello world").charset, Some(Charset::Unicode));
-    }
-
-    #[test]
-    fn bytes_nothing_explains_are_left_undecided() {
-        let input = of(b"the quick brown \xFF fox jumps over the lazy dog");
-        assert_eq!(input.charset, None);
-    }
-
-    /// A charset that is not stored one byte per character cannot explain bytes that
-    /// already failed a UTF-8 decode; accepting one would convert `U+FFFD` as
-    /// though it were the document.
-    #[test]
-    fn the_byte_door_never_answers_with_a_unicode_charset() {
-        for fixture in [
-            b"vi\xD6t nam h\xB5 n\xE9i".as_slice(),
-            b"\xFF\x00\xFE".as_slice(),
-        ] {
-            let charset = of(fixture).charset;
-            assert!(
-                charset.is_none_or(charset::is_byte_oriented)
-                    || std::str::from_utf8(fixture).is_ok(),
-                "{charset:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn a_utf8_mark_is_stripped_rather_than_converted() {
-        assert_eq!(of(b"\xEF\xBB\xBFvn").text, "vn");
-    }
-
-    /// A UTF-16 mark is a verdict, not a hint. Without this the bytes would fail the
-    /// UTF-8 decode and be read as a legacy charset — confidently, and wrongly.
-    #[test]
-    fn utf16_is_decoded_from_its_mark_in_both_byte_orders() {
-        assert_eq!(of(b"\xFF\xFEV\x00i\x00\xC7\x1Et\x00").text, "Việt");
-        assert_eq!(of(b"\xFE\xFF\x00V\x00i\x1E\xC7\x00t").text, "Việt");
-    }
-
-    #[test]
-    fn a_truncated_utf16_file_is_refused_rather_than_half_read() {
-        assert!(marks(b"\xFF\xFEv".to_vec()).is_err());
-    }
+    document::read(bytes).map_err(|e| CliError::Msg(e.to_string()))
 }

--- a/crates/funput-cli/src/convert/tests.rs
+++ b/crates/funput-cli/src/convert/tests.rs
@@ -1,12 +1,13 @@
+use funput_core::charset::document;
 use funput_core::charset::{self, Charset};
 
 use super::*;
 
 /// Everything `run` does between reading and writing, with the I/O left out.
 fn pipeline(bytes: &[u8], to: Charset) -> (Vec<u8>, usize, usize) {
-    let input = source::from_bytes(bytes.to_vec()).expect("well-formed fixture");
-    let from = input.charset.expect("fixture should be identifiable");
-    let read = charset::convert(&input.text, from, Charset::Unicode);
+    let doc = document::read(bytes.to_vec()).expect("well-formed fixture");
+    let from = doc.charset.expect("fixture should be identifiable");
+    let read = charset::convert(&doc.text, from, Charset::Unicode);
     let (out, written) = charset::encode_bytes(&read.text, to);
     (out, read.unmapped, written.unmapped)
 }

--- a/crates/funput-core/src/charset/document.rs
+++ b/crates/funput-core/src/charset/document.rs
@@ -1,0 +1,217 @@
+//! Reading a whole document's bytes: what characters are in it, and what charset
+//! spells them.
+//!
+//! The output is a `String`, and that is the subject of this module. [`convert`]
+//! takes text rather than bytes because that is what a legacy document *is*: code
+//! points `U+0020..=U+00FF` standing in for bytes, which a `.VnTime` font draws as
+//! Vietnamese. Getting a file to that form is the job here.
+//!
+//! # Why this is not `funput-config`'s cascade
+//!
+//! `funput-config` reads UniKey macro tables and asks a stricter question — it will
+//! not reinterpret a file unless the reinterpretation explains **every** character,
+//! because a table of three typographic shortcuts is too little evidence to overturn
+//! a UTF-8 decode that already worked. A document is not that: a page of Vietnamese
+//! that mostly reads as TCVN3 *is* TCVN3, and a stray `°` proves nothing. Same
+//! structure, different confidence, so they stay apart on purpose.
+//!
+//! [`convert`]: super::convert
+
+use super::{Charset, detect, detect_bytes, is_byte_oriented};
+
+/// A document as characters, and the charset those characters spell.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Document {
+    pub text: String,
+    /// `None` only when the bytes are not UTF-8 **and** no byte-oriented charset
+    /// explains them. A caller should ask the user rather than pick something.
+    pub charset: Option<Charset>,
+}
+
+/// The bytes carry a UTF-16 byte-order mark but do not decode as UTF-16.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TruncatedUtf16;
+
+impl core::fmt::Display for TruncatedUtf16 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("this is a truncated UTF-16 file")
+    }
+}
+
+impl core::error::Error for TruncatedUtf16 {}
+
+/// Read a document's bytes as characters, and work out what charset they are in.
+///
+/// Takes the bytes by value so the common path — no mark, valid UTF-8 — keeps the
+/// allocation instead of copying a whole document.
+pub fn read(bytes: Vec<u8>) -> Result<Document, TruncatedUtf16> {
+    Ok(identify(marks(bytes)?))
+}
+
+/// Deal with the byte-order marks, so what comes out is either UTF-8 or legacy bytes.
+///
+/// UTF-16 is decided by its mark rather than guessed at: falling through would trade
+/// a certainty for a wrong answer, since UTF-16 text is not valid UTF-8 and would be
+/// read as a legacy charset and confidently mangled. A UTF-8 mark is only a hint —
+/// editors write one whatever follows — so it is stripped and the rest judged on its
+/// own merits.
+fn marks(bytes: Vec<u8>) -> Result<Vec<u8>, TruncatedUtf16> {
+    for (mark, unit) in [
+        ([0xFF, 0xFE], u16::from_le_bytes as fn([u8; 2]) -> u16),
+        ([0xFE, 0xFF], u16::from_be_bytes),
+    ] {
+        if let Some(rest) = bytes.strip_prefix(&mark) {
+            return utf16(rest, unit)
+                .map(String::into_bytes)
+                .ok_or(TruncatedUtf16);
+        }
+    }
+    Ok(match bytes.strip_prefix(&[0xEF, 0xBB, 0xBF]) {
+        Some(rest) => rest.to_vec(),
+        None => bytes,
+    })
+}
+
+/// Turn the bytes into characters, and say what charset those characters are in.
+///
+/// **Two doors, because there are two questions.** Bytes that decode as UTF-8 are
+/// judged as *text*, and the characters are the ones UTF-8 spelled. That covers a
+/// TCVN3 document someone opened in Notepad and saved again — valid UTF-8 whose text
+/// is still TCVN3, and the commonest way a legacy file arrives today. Reading those
+/// same bytes one-to-one instead would give `Ã` and `–` where the document has `Ö`.
+///
+/// Bytes that do not decode were never Unicode. They are read one-to-one, which is
+/// how the program that wrote them stored them, and a charset that is *not* stored
+/// one byte per character cannot be the answer — accepting one would convert
+/// replacement characters as though they were the document.
+fn identify(bytes: Vec<u8>) -> Document {
+    match String::from_utf8(bytes) {
+        Ok(text) => {
+            // Falling back to `Unicode` is not a guess. `detect` returning `None`
+            // means no legacy charset explains this better than Unicode does — and
+            // the bytes just decoded as UTF-8, so Unicode is what they are.
+            let charset = detect(&text).or(Some(Charset::Unicode));
+            Document { text, charset }
+        }
+        Err(err) => {
+            let bytes = err.as_bytes();
+            let charset = detect_bytes(bytes).filter(|&c| is_byte_oriented(c));
+            let text = bytes.iter().copied().map(char::from).collect();
+            Document { text, charset }
+        }
+    }
+}
+
+fn utf16(bytes: &[u8], unit: fn([u8; 2]) -> u16) -> Option<String> {
+    if !bytes.len().is_multiple_of(2) {
+        return None;
+    }
+    let units: Vec<u16> = bytes
+        .chunks_exact(2)
+        .map(|pair| unit([pair[0], pair[1]]))
+        .collect();
+    String::from_utf16(&units).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn of(bytes: &[u8]) -> Document {
+        read(bytes.to_vec()).expect("well-formed fixture")
+    }
+
+    /// The door that is easy to take by mistake. These bytes are valid UTF-8, so the
+    /// characters are what UTF-8 spells — reading them one-to-one instead would give
+    /// `Ã` where the document has `Ö`, and convert that.
+    #[test]
+    fn a_legacy_document_re_saved_as_utf8_is_read_as_text() {
+        let doc = of("vi\u{D6}t nam h\u{B5} n\u{E9}i".as_bytes());
+        assert_eq!(doc.charset, Some(Charset::Tcvn3));
+        assert!(doc.text.starts_with("vi\u{D6}t"), "{:?}", doc.text);
+    }
+
+    /// The other door: a file that really is one byte per character.
+    #[test]
+    fn a_legacy_document_stored_as_bytes_is_read_one_to_one() {
+        let doc = of(b"vi\xD6t nam h\xB5 n\xE9i");
+        assert_eq!(doc.charset, Some(Charset::Tcvn3));
+        assert_eq!(doc.text.chars().next(), Some('v'));
+        assert!(doc.text.contains('\u{D6}'));
+    }
+
+    /// The two doors reach the same document from the two ways it can be stored, so
+    /// converting either one gives the same Vietnamese back.
+    #[test]
+    fn both_doors_agree_on_what_the_document_says() {
+        let as_text = of("vi\u{D6}t nam h\u{B5} n\u{E9}i".as_bytes());
+        let as_bytes = of(b"vi\xD6t nam h\xB5 n\xE9i");
+        assert_eq!(as_text, as_bytes);
+
+        let charset = as_text.charset.expect("identified");
+        let out = super::super::convert(&as_text.text, charset, Charset::Unicode);
+        assert_eq!(out.text, "việt nam hà nội");
+        assert_eq!(out.unmapped, 0);
+    }
+
+    /// Not a guess: the bytes decoded as UTF-8, so Unicode is what they are. Only the
+    /// byte door is allowed to come back with nothing.
+    #[test]
+    fn text_with_nothing_to_decide_is_unicode_rather_than_undecided() {
+        assert_eq!(of(b"hello world").charset, Some(Charset::Unicode));
+    }
+
+    #[test]
+    fn bytes_nothing_explains_are_left_undecided() {
+        let doc = of(b"the quick brown \xFF fox jumps over the lazy dog");
+        assert_eq!(doc.charset, None);
+    }
+
+    /// A charset that is not stored one byte per character cannot explain bytes that
+    /// already failed a UTF-8 decode; accepting one would convert `U+FFFD` as though it
+    /// were the document.
+    #[test]
+    fn the_byte_door_never_answers_with_a_unicode_charset() {
+        for fixture in [
+            b"vi\xD6t nam h\xB5 n\xE9i".as_slice(),
+            b"\xFF\x00\xFE".as_slice(),
+        ] {
+            let charset = of(fixture).charset;
+            assert!(
+                charset.is_none_or(is_byte_oriented) || std::str::from_utf8(fixture).is_ok(),
+                "{charset:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_utf8_mark_is_stripped_rather_than_converted() {
+        assert_eq!(of(b"\xEF\xBB\xBFvn").text, "vn");
+    }
+
+    /// A UTF-16 mark is a verdict, not a hint. Without this the bytes would fail the
+    /// UTF-8 decode and be read as a legacy charset — confidently, and wrongly.
+    #[test]
+    fn utf16_is_decoded_from_its_mark_in_both_byte_orders() {
+        assert_eq!(of(b"\xFF\xFEV\x00i\x00\xC7\x1Et\x00").text, "Việt");
+        assert_eq!(of(b"\xFE\xFF\x00V\x00i\x1E\xC7\x00t").text, "Việt");
+    }
+
+    #[test]
+    fn a_truncated_utf16_file_is_refused_rather_than_half_read() {
+        assert_eq!(read(b"\xFF\xFEv".to_vec()), Err(TruncatedUtf16));
+    }
+
+    /// UniKey writes a UTF-16 file with a mark and treats the mark as content when it
+    /// converts; Funput reads it as a mark. Pins that a mark never reaches the text.
+    #[test]
+    fn a_utf16_mark_is_never_part_of_the_document() {
+        for doc in [
+            of(b"\xFF\xFEV\x00i\x00\xC7\x1Et\x00"),
+            of(b"\xEF\xBB\xBFVi\xE1\xBB\x87t"),
+        ] {
+            assert!(!doc.text.contains('\u{FEFF}'), "{:?}", doc.text);
+        }
+    }
+}

--- a/crates/funput-core/src/charset/mod.rs
+++ b/crates/funput-core/src/charset/mod.rs
@@ -30,6 +30,7 @@
 
 mod codecs;
 mod detect;
+pub mod document;
 mod identity;
 mod pivot;
 mod transcode;

--- a/docs/features/charset.md
+++ b/docs/features/charset.md
@@ -367,6 +367,11 @@ pub fn decode_bytes(bytes: &[u8], from: Charset) -> Conversion;
 pub fn encode_bytes(text: &str, to: Charset) -> (Vec<u8>, Conversion);
 pub fn detect(text: &str) -> Option<Charset>;
 pub fn detect_bytes(bytes: &[u8]) -> Option<Charset>;
+
+mod document {
+    pub struct Document { pub text: String, pub charset: Option<Charset> }
+    pub fn read(bytes: Vec<u8>) -> Result<Document, TruncatedUtf16>;
+}
 ```
 
 Hai hàm `detect` chấm điểm bằng cách thử giải mã theo từng bảng mã rồi đếm xem kết
@@ -379,6 +384,20 @@ toàn. Hoà thì trả `None` thay vì đoán bừa.
 chứng mạnh **chống lại** hai bảng mã Unicode — bằng chứng mà `detect(&str)` không thể
 thấy, vì lúc nó cầm được `&str` thì hư hỏng đã được vá rồi. Hai cửa **bất đồng** trên
 cùng một nội dung Latin-1; đó là bản chất, và có test ghim lại.
+
+### Đọc cả tài liệu: `charset::document`
+
+`decode_bytes`/`encode_bytes` là hai cửa *một tầng*; `document::read` là tầng trên chúng, và là
+thứ một shell đọc tệp thật sự gọi. Nó xử lý BOM trước (UTF-16 là verdict, UTF-8 chỉ là gợi ý nên
+bị bóc), rồi chọn cửa: byte giải mã được UTF-8 thì xử như **text** — đó là ca tệp TCVN3 mở bằng
+Notepad rồi lưu lại, và là cách tệp cũ đến tay ta phổ biến nhất; byte không giải mã được thì đọc
+một-một và **chỉ** được trả lời bằng bảng mã theo byte.
+
+Nó **không** phải cascade của `funput-config`. Bảng gõ tắt hỏi câu chặt hơn: chỉ diễn giải lại
+khi cách đọc mới giải thích được **mọi** ký tự, vì ba dòng viết tắt là quá ít bằng chứng để lật
+một phép giải mã UTF-8 đã chạy được. Tài liệu thì khác: một trang tiếng Việt phần lớn đọc ra
+TCVN3 **là** TCVN3, và một dấu `°` lạc không chứng minh điều gì. Cùng cấu trúc, khác mức tự tin,
+nên chúng ở riêng một cách có chủ ý.
 
 ### Hai cửa byte
 


### PR DESCRIPTION
Stacked on #239. Groundwork for the Windows converter window — no behaviour change.

## Why

Reading a legacy document is more than one call:

- a UTF-16 mark is a **verdict** (falling through would read UTF-16 as a legacy charset and confidently mangle it)
- a UTF-8 mark is only a **hint** — editors write one whatever follows — so it is stripped
- bytes that decode as UTF-8 are judged as **text**, which covers a TCVN3 document opened in Notepad and saved again: valid UTF-8 whose text is still TCVN3, and the commonest way a legacy file arrives today
- bytes that do not decode were never Unicode, and may only be answered with a **byte-oriented** charset

All of that lived in `funput-cli/src/convert/source.rs`. The Windows converter needs the same answer, and `platforms/windows` is excluded from the workspace — copying it there would put subtle logic where CI never builds, lints, or tests it.

#237 said this cascade belongs in core as one call once a file-reading shell existed. It now does.

## What

```rust
pub mod document {
    pub struct Document { pub text: String, pub charset: Option<Charset> }
    pub struct TruncatedUtf16;
    pub fn read(bytes: Vec<u8>) -> Result<Document, TruncatedUtf16>;
}
```

Bytes by value, so the common path — no mark, valid UTF-8 — keeps the allocation instead of copying a whole document. `TruncatedUtf16` rather than a string, so each caller words its own error.

`funput-cli`'s `source.rs` drops from 111 lines to 27: read a file or stdin, hand the bytes over. The two-door tests moved to core with the logic; the CLI keeps its pipeline and slug tests.

## Not `funput-config`'s cascade

They look alike and must not be merged. A UniKey macro table is only reinterpreted when the reinterpretation explains **every** character, because three typographic shortcuts are too little evidence to overturn a UTF-8 decode that already worked — without that guard, `mu:µ` imports as `mu:à`. A document is not that: a page of Vietnamese that mostly reads as TCVN3 **is** TCVN3, and one stray `°` proves nothing.

Same structure, different confidence. The module doc says so, so the next reader does not "unify" them.

## Layout

`charset/` goes from six entries to **seven**. Bytes-to-text is a genuine fifth subject; `codecs/` (already at five) is about how each charset spells an atom, not about what a file is. Reporting the deviation rather than filing it somewhere wrong — same call as `identity.rs` in #239. Tests are inline rather than in a `document/` directory, which would have made it eight.

## Checks

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, the charset-off pair, `scripts/check-loc.sh` (307 files).

Behaviour pinned end-to-end by re-running the UniKey-verified fixtures: `check.ps1` still **12 passed**, and by hand a byte-oriented TCVN3 file and a UTF-8-BOM-plus-TCVN3 file both still convert to `việt nam hà nội`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)