### PR TITLE
refactor(convert): extract the window's logic into funput-convert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "funput-convert"
+version = "0.1.0"
+dependencies = [
+ "funput-core",
+]
+
+[[package]]
 name = "funput-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/funput-core",
     "crates/funput-config",
+    "crates/funput-convert",
     "crates/funput-engine",
     "crates/funput-suggestions",
     "crates/funput-cli",

--- a/crates/funput-convert/Cargo.toml
+++ b/crates/funput-convert/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "funput-convert"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "The Chuyển mã window's logic: reading a batch, naming what a conversion costs, writing copies out."
+
+[lints]
+workspace = true
+
+[dependencies]
+# Every decision here is expressed in `Charset` terms, and the charset names the
+# warnings quote come from `Charset::name()` — the one place they are written, so
+# a menu on Windows and a menu on Linux cannot drift apart.
+funput-core = { path = "../funput-core", features = ["charset"] }

--- a/crates/funput-convert/README.md
+++ b/crates/funput-convert/README.md
@@ -1,0 +1,88 @@
+# funput-convert
+
+Ruột của cửa sổ **Chuyển mã**, trừ đi phần cửa sổ.
+
+Mọi shell desktop có công cụ chuyển mã đều cần đúng bốn việc, và không việc nào là đồ hoạ:
+đọc một lô tệp được thả vào **theo từng tệp**, nói ra phép chuyển sẽ tốn gì, ghi bản sao ra
+mà không bao giờ đụng vào bản gốc, và thuật lại chuyện đã xảy ra. Crate này là bốn việc đó.
+
+```
+[shell: kéo-thả, clipboard, hộp thoại] → funput-convert → funput-core::charset
+              tuỳ nền tảng                    thuần              thuần
+```
+
+## Vì sao nó ở đây chứ không ở trong một shell
+
+Cửa sổ Windows có bốn việc này trước, viết bằng Rust thuần — không một dòng Win32, không
+một dòng Slint. Chép chúng sang cửa sổ GTK sẽ đặt **câu cảnh báo mất chữ**, **luật
+`vanban (2).txt`** và **tên thư mục đầu ra** vào hai chỗ cùng lúc, và
+`platforms/linux/README.md` đã kể sẵn chuyện xảy ra tiếp theo: một cây quyết định gõ phím
+từng tồn tại hai bản, mỗi shell một, rồi trôi khỏi nhau.
+
+Tiền lệ cho phần chuỗi là `funput_core::charset::Charset::name()` — nó sống trong lõi
+chính là để một menu trên Windows và một menu trên Linux không tự đặt tên lấy rồi lệch nhau.
+Hai câu trong `loss()` cùng hạng: chúng là *phát biểu về tài liệu*, không phải chrome.
+
+Còn một lợi ích thứ hai, lớn hơn: `platforms/windows` và `platforms/linux/settings-gtk` đều
+nằm **ngoài** cargo workspace, nên `cargo clippy --workspace`, `cargo test --workspace` và
+`scripts/check-loc.sh` không với tới cái nào. Ở đây thì cả ba đều với tới — ở mỗi pull
+request, cho **cả hai** nền tảng.
+
+## Cái gì ở lại trong shell
+
+Hộp thoại tệp, clipboard, drop target, và cách nền tảng đó đẩy việc ra khỏi luồng UI.
+Những thứ đó khác nhau theo bản chất; không thứ nào dưới đây khác nhau.
+
+## API
+
+```rust
+pub use funput_core::charset;   // để consumer chỉ cần MỘT dependency
+
+pub enum Mode { Empty, Text, Files }
+impl Mode { pub fn of(files: &[Entry], input: &str) -> Self; }
+
+// Một đoạn văn bản
+pub fn preview(text: &str, from: Charset, to: Charset) -> Conversion;
+pub fn bytes(text: &str, from: Charset, to: Charset) -> Vec<u8>;
+pub fn loss(text: &str, from: Charset, to: Charset) -> String;
+pub fn capped(text: &str) -> String;
+
+// Một lô tệp
+pub struct Entry { pub path: PathBuf, pub text: String,
+                   pub charset: Option<Charset>, pub unmapped: usize }
+pub fn collect(paths: &[PathBuf]) -> Vec<PathBuf>;
+pub fn scan(paths: &[PathBuf]) -> Vec<Entry>;
+pub fn measure(entries: &mut [Entry], target: Charset);
+pub fn ready(entries: &[Entry]) -> usize;
+pub fn out_dir_label(entries: &[Entry]) -> String;
+
+// Ghi ra
+pub const OUT_DIR: &str;        // "Đã chuyển mã"
+pub struct Outcome { pub written: usize, pub skipped: usize, pub failed: usize }
+pub fn write_all(entries: &[Entry], target: Charset) -> Outcome;
+pub fn report(outcome: &Outcome) -> String;
+```
+
+## Ba điều đáng biết trước
+
+**`Mode` do nội dung quyết định, không do một nút chuyển chế độ.** Thứ người dùng bỏ vào đã
+nói sẵn đây là một đoạn văn hay một lô tệp. Và **một tệp đi theo hình dạng text, không phải
+bảng một hàng**: một tệp không có gì để so sánh, nên bảng sẽ giấu mất đúng thứ người dùng
+muốn xem — tiếng Việt có ra đúng không.
+
+**`loss()` là hai câu, không phải một.** Đọc có thể hỏng (ký tự bảng mã *nguồn* không định
+nghĩa — nghĩa là chọn sai nguồn, hoặc tệp đã hỏng) và ghi có thể hỏng (ký tự bảng mã *đích*
+không viết được — một cái giá để chấp nhận hoặc né). Chỉ báo cái thứ hai chính là thứ từng
+để một phỏng đoán nguồn sai đi qua trong im lặng. Câu phía đích **gọi tên** ký tự, tối đa
+sáu chữ: một con số nói cho người ta biết có gì đó sai mà không nói phải nhìn vào đâu.
+
+**`write_all` không bao giờ ghi đè bản gốc.** Chúng thường là bản duy nhất còn lại. Bản sao
+đi vào thư mục `Đã chuyển mã` cạnh tệp nguồn, và chạy lần hai ra `vanban (2).txt`. Tệp không
+đoán được bảng mã thì **bỏ qua**, không đoán bừa.
+
+## Test
+
+15 test colocated, chạy bằng `cargo test -p funput-convert` (và bằng
+`cargo test --workspace` ở CI). Chúng ghim những phán quyết dễ mất khi viết lại: thứ tự ưu
+tiên của hai câu cảnh báo, luật đặt tên chống đè, "một cấp, không đệ quy" của `collect`, và
+việc `normalized` **không** được đếm là mất mát.

--- a/crates/funput-convert/src/batch.rs
+++ b/crates/funput-convert/src/batch.rs
@@ -1,0 +1,197 @@
+//! The batch: one entry per dropped file, each read on its own terms.
+//!
+//! This is the part that beats the tool people are coming from. UniKey's file
+//! converter takes one source charset for a whole folder, so an archive holding
+//! documents from different eras converts most of itself to nonsense. Here every
+//! file goes through [`charset::document::read`] by itself, and one that nothing
+//! explains waits for the user instead of being swept along.
+
+use std::path::PathBuf;
+
+use funput_core::charset::{self, Charset, document};
+
+/// One file, as read.
+#[derive(Clone)]
+pub struct Entry {
+    pub path: PathBuf,
+    /// The document as characters — already past the two doors.
+    pub text: String,
+    /// `None` when nothing explained the bytes. The user picks, or it is skipped.
+    pub charset: Option<Charset>,
+    /// Characters the current target cannot represent. Recomputed on target change.
+    pub unmapped: usize,
+}
+
+impl Entry {
+    pub fn name(&self) -> String {
+        self.path.file_name().map_or_else(
+            || self.path.display().to_string(),
+            |n| n.to_string_lossy().into_owned(),
+        )
+    }
+}
+
+/// Expand what was dropped into the files to read.
+///
+/// **One level, never recursive.** Dropping a folder of documents is the ordinary
+/// case and has to work; walking a whole home directory because someone let go over
+/// the wrong icon is the failure mode that makes a tool feel dangerous. A folder
+/// inside a folder is a deliberate second drop away.
+///
+/// Order is `read_dir` order, which is the filesystem's, not sorted: the rows carry
+/// file names and the user reads those, not positions.
+pub fn collect(paths: &[PathBuf]) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for path in paths {
+        if path.is_dir() {
+            let Ok(dir) = std::fs::read_dir(path) else {
+                continue;
+            };
+            out.extend(dir.flatten().map(|e| e.path()).filter(|p| p.is_file()));
+        } else {
+            out.push(path.clone());
+        }
+    }
+    out
+}
+
+/// Read every path, skipping what cannot be read at all.
+///
+/// I/O bound over a folder of a few hundred documents, so a shell calls this off its
+/// UI thread — inline would hold the window still for the whole drop.
+pub fn scan(paths: &[PathBuf]) -> Vec<Entry> {
+    paths
+        .iter()
+        .filter(|path| path.is_file())
+        .filter_map(|path| {
+            let bytes = std::fs::read(path).ok()?;
+            let doc = document::read(bytes).ok()?;
+            Some(Entry {
+                path: path.clone(),
+                text: doc.text,
+                charset: doc.charset,
+                unmapped: 0,
+            })
+        })
+        .collect()
+}
+
+/// Recompute what each file would lose when written as `target`.
+///
+/// Conversion only, no I/O, so this is cheap enough to run every time the target
+/// changes. The bytes are thrown away and made again at write time: keeping a
+/// converted copy of every document in memory costs more than converting twice.
+pub fn measure(entries: &mut [Entry], target: Charset) {
+    for entry in entries {
+        entry.unmapped = match entry.charset {
+            Some(from) => {
+                let unicode = charset::convert(&entry.text, from, Charset::Unicode);
+                charset::convert(&unicode.text, Charset::Unicode, target).unmapped
+            }
+            None => 0,
+        };
+    }
+}
+
+/// How many files are ready to convert — the ones a charset was settled for.
+pub fn ready(entries: &[Entry]) -> usize {
+    entries.iter().filter(|e| e.charset.is_some()).count()
+}
+
+/// Where the converted copies will go, for a footer to show before committing.
+pub fn out_dir_label(entries: &[Entry]) -> String {
+    let mut dirs: Vec<&std::path::Path> = entries.iter().filter_map(|e| e.path.parent()).collect();
+    dirs.sort_unstable();
+    dirs.dedup();
+    match dirs.as_slice() {
+        [] => String::new(),
+        [only] => only.join(crate::OUT_DIR).display().to_string(),
+        // Dropped from several folders: each keeps its own, so no name can collide
+        // with a same-named file from somewhere else.
+        many => format!("{} trong {} thư mục", crate::OUT_DIR, many.len()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("funput-scan-{name}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        dir
+    }
+
+    /// The reason this window exists rather than the one people use today. UniKey's
+    /// file converter takes one source charset for a whole folder, so an archive
+    /// holding documents from different eras converts most of itself to nonsense.
+    #[test]
+    fn a_folder_of_mixed_charsets_is_read_one_file_at_a_time() {
+        let dir = scratch("mixed");
+        // The same sentence, stored three different ways, plus one nothing explains.
+        std::fs::write(dir.join("a.txt"), b"vi\xD6t nam h\xB5 n\xE9i").unwrap();
+        std::fs::write(dir.join("b.txt"), "việt nam hà nội").unwrap();
+        std::fs::write(dir.join("c.txt"), b"the quick brown \xFF fox jumps over it").unwrap();
+
+        let paths = [dir.join("a.txt"), dir.join("b.txt"), dir.join("c.txt")];
+        let entries = scan(&paths);
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].charset, Some(Charset::Tcvn3));
+        assert_eq!(entries[1].charset, Some(Charset::Unicode));
+        assert_eq!(entries[2].charset, None, "nothing explains these bytes");
+        assert_eq!(ready(&entries), 2, "only the two that were identified");
+    }
+
+    /// The count behind "N chữ sẽ mất", and it must follow the target rather than be
+    /// fixed at read time.
+    #[test]
+    fn what_will_be_lost_is_measured_against_the_target_of_the_moment() {
+        let dir = scratch("measure");
+        std::fs::write(dir.join("hoa.txt"), "Ổn").unwrap();
+        let mut entries = scan(&[dir.join("hoa.txt")]);
+
+        // TCVN3 has no code for an uppercase toned vowel.
+        measure(&mut entries, Charset::Tcvn3);
+        assert_eq!(entries[0].unmapped, 1);
+
+        // The same document costs nothing going somewhere that can spell it.
+        measure(&mut entries, Charset::UnicodeCombining);
+        assert_eq!(entries[0].unmapped, 0);
+    }
+
+    /// Dropping a folder of documents has to work; dropping a home directory must
+    /// not walk it. One level, and no further.
+    #[test]
+    fn a_dropped_folder_is_read_one_level_deep() {
+        let dir = scratch("folder");
+        std::fs::write(dir.join("top.txt"), "việt").unwrap();
+        std::fs::create_dir_all(dir.join("nested")).unwrap();
+        std::fs::write(dir.join("nested").join("deep.txt"), "nam").unwrap();
+
+        let collected = collect(std::slice::from_ref(&dir));
+
+        assert_eq!(collected.len(), 1, "the nested folder was walked into");
+        assert_eq!(collected[0], dir.join("top.txt"));
+    }
+
+    /// One folder names itself; several cannot, because each keeps its own output
+    /// folder beside it.
+    #[test]
+    fn several_source_folders_are_counted_rather_than_listed() {
+        let a = scratch("label-a");
+        let b = scratch("label-b");
+        let entry = |dir: &PathBuf| Entry {
+            path: dir.join("x.txt"),
+            text: String::new(),
+            charset: None,
+            unmapped: 0,
+        };
+        assert!(out_dir_label(&[entry(&a)]).ends_with(crate::OUT_DIR));
+        assert_eq!(
+            out_dir_label(&[entry(&a), entry(&b)]),
+            format!("{} trong 2 thư mục", crate::OUT_DIR)
+        );
+    }
+}

--- a/crates/funput-convert/src/lib.rs
+++ b/crates/funput-convert/src/lib.rs
@@ -1,0 +1,89 @@
+//! The Chuyển mã window, minus the window.
+//!
+//! Every desktop shell that offers charset conversion needs the same four things,
+//! and none of them are graphics: read a dropped batch file by file, say what a
+//! conversion will cost, write the copies out without ever touching an original,
+//! and report what happened. This crate is those four things.
+//!
+//! **Why they live here rather than in a shell.** The Windows window had them first,
+//! as plain Rust with no Win32 and no Slint in sight. Copying them into the GTK
+//! window would put the wording of the loss warning, the `vanban (2).txt` rule and
+//! the name of the output folder in two places at once — and
+//! `platforms/linux/README.md` already tells the story of what happens next, about a
+//! typing decision tree that existed once per shell and drifted. The precedent for
+//! the strings is [`funput_core::charset::Charset::name`], which lives in core for
+//! exactly this reason.
+//!
+//! There is a second gain, and it is the larger one. `platforms/windows` and
+//! `platforms/linux/settings-gtk` are both excluded from the cargo workspace, so
+//! `cargo clippy --workspace`, `cargo test --workspace` and `scripts/check-loc.sh`
+//! reach neither. Here, all three do — on every pull request, for both shells.
+//!
+//! **What stays in a shell**: the file dialogs, the clipboard, the drop target, and
+//! whatever that platform does to get work off its UI thread. Those differ per
+//! platform by nature; nothing below does.
+//!
+//! - [`text`] — a paragraph: what it becomes, and what it costs.
+//! - [`batch`] — a drop: what each file turned out to be.
+//! - [`write`] — the copies, written beside the originals and never over them.
+
+mod batch;
+mod text;
+mod write;
+
+/// Re-exported so a consumer needs one dependency rather than two, and so the
+/// `charset` feature is switched on in exactly one manifest.
+pub use funput_core::charset;
+
+pub use batch::{Entry, collect, measure, out_dir_label, ready, scan};
+pub use text::{bytes, capped, loss, preview};
+pub use write::{OUT_DIR, Outcome, report, write_all};
+
+/// Which of the three shapes the window is in.
+///
+/// **The content decides, not a mode switch.** What the user put in already says
+/// whether this is a paragraph or a batch, so asking would be asking them to repeat
+/// themselves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// Nothing yet: the drop zone.
+    Empty,
+    /// A pasted paragraph — **or exactly one file**. One file has nothing to compare
+    /// against, so a one-row table would hide the thing the user actually wants to
+    /// see; it gets the before/after panes instead.
+    Text,
+    /// Two or more files: a table, because the interesting thing is that the rows
+    /// differ.
+    Files,
+}
+
+impl Mode {
+    pub fn of(files: &[Entry], input: &str) -> Self {
+        match files.len() {
+            0 if input.is_empty() => Self::Empty,
+            0 | 1 => Self::Text,
+            _ => Self::Files,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The rule the Windows window expressed inline in `refresh()` and never tested:
+    /// one file is not a one-row table.
+    #[test]
+    fn one_file_is_shown_as_text_and_two_as_a_table() {
+        let entry = || Entry {
+            path: std::path::PathBuf::from("a.txt"),
+            text: String::new(),
+            charset: None,
+            unmapped: 0,
+        };
+        assert_eq!(Mode::of(&[], ""), Mode::Empty);
+        assert_eq!(Mode::of(&[], "việt"), Mode::Text);
+        assert_eq!(Mode::of(&[entry()], ""), Mode::Text);
+        assert_eq!(Mode::of(&[entry(), entry()], ""), Mode::Files);
+    }
+}

--- a/crates/funput-convert/src/text.rs
+++ b/crates/funput-convert/src/text.rs
@@ -1,0 +1,198 @@
+//! A paragraph: what it becomes, and what it costs.
+//!
+//! No byte door here. Text arriving through the clipboard is already characters —
+//! a TCVN3 paragraph pasted out of Word is code points `U+0020..=U+00FF` standing in
+//! for bytes, which is exactly what [`charset::convert`] takes. Only a *file* has to
+//! go through `charset::document`, and that is [`crate::batch`]'s problem.
+
+use funput_core::charset::{self, Charset, Conversion};
+
+/// How many characters to name before the warning gets longer than it is useful.
+const NAMED: usize = 6;
+
+/// How much of a document to put in a pane.
+///
+/// Panes are for *looking* at, and nobody reads a megabyte in one. The conversion and
+/// the warning still run over the whole document — only the display is cut, so a large
+/// file cannot make the window crawl while the counts stay honest.
+const PREVIEW: usize = 20_000;
+
+/// Convert `text` for the preview pane.
+pub fn preview(text: &str, from: Charset, to: Charset) -> Conversion {
+    charset::convert(text, from, to)
+}
+
+/// The bytes to save, for a target that stores one byte per letter.
+pub fn bytes(text: &str, from: Charset, to: Charset) -> Vec<u8> {
+    let unicode = charset::convert(text, from, Charset::Unicode);
+    charset::encode_bytes(&unicode.text, to).0
+}
+
+/// The warning, or empty when nothing will be lost.
+///
+/// **Two different problems, and they are not the same sentence.** Reading can fail —
+/// characters the *source* charset does not define, which means the wrong source was
+/// picked or the document is damaged, and the user can act on that. Writing can fail —
+/// characters the *target* cannot represent, which is a cost to accept or avoid by
+/// choosing elsewhere. Reporting only the second is what let a wrong source guess pass
+/// silently, which is the thing this window was built to stop.
+///
+/// The target line **names the characters**. A count tells someone something is wrong
+/// without telling them where to look, and a conversion that quietly drops `Ề` from a
+/// letterhead is the failure the whole window exists to prevent.
+///
+/// `normalized` is deliberately not mentioned: converting to Unicode tổ hợp respells
+/// every toned vowel and loses nothing, so counting it would teach people to ignore
+/// this line.
+pub fn loss(text: &str, from: Charset, to: Charset) -> String {
+    let unicode = charset::convert(text, from, Charset::Unicode);
+    let mut lines = Vec::new();
+    if unicode.unmapped > 0 {
+        lines.push(format!(
+            "{} chữ không thuộc {} — có thể bảng mã nguồn chọn sai, hoặc tệp đã hỏng",
+            unicode.unmapped,
+            from.name()
+        ));
+    }
+    if let Some(line) = target_line(&unicode.text, to) {
+        lines.push(line);
+    }
+    lines.join("\n")
+}
+
+/// What the target cannot represent, named rather than counted.
+fn target_line(unicode: &str, to: Charset) -> Option<String> {
+    let lost = unrepresentable(unicode, to);
+    if lost.is_empty() {
+        return None;
+    }
+    let shown: String = lost
+        .iter()
+        .take(NAMED)
+        .map(char::to_string)
+        .collect::<Vec<_>>()
+        .join("  ");
+    let rest = lost.len().saturating_sub(NAMED);
+    let tail = if rest > 0 {
+        format!(" và {rest} chữ khác")
+    } else {
+        String::new()
+    };
+    Some(format!(
+        "{} chữ không có trong {}:  {shown}{tail}",
+        lost.len(),
+        to.name()
+    ))
+}
+
+/// The distinct characters `to` cannot represent, in the order they first appear.
+///
+/// Asked one character at a time because the counter core returns is a total, not a
+/// list. Distinct characters in a document are few — a few hundred at most — so this
+/// costs a great deal less than it looks like it does.
+fn unrepresentable(unicode: &str, to: Charset) -> Vec<char> {
+    let mut seen = std::collections::HashSet::new();
+    let mut lost = Vec::new();
+    for ch in unicode.chars() {
+        if !seen.insert(ch) {
+            continue;
+        }
+        if charset::convert(&ch.to_string(), Charset::Unicode, to).unmapped > 0 {
+            lost.push(ch);
+        }
+    }
+    lost
+}
+
+/// A document trimmed to what a pane can usefully show, and made safe to show.
+///
+/// **The control characters are the Linux half of this.** A damaged legacy file
+/// decodes into a `String` that may hold `U+0000` or `U+001A`; GTK's `TextBuffer`
+/// takes the length rather than stopping at a NUL, so it measures and draws the rest
+/// wrongly and Pango complains in the log. Windows never noticed, which is exactly
+/// why the sanitising belongs here rather than in one shell.
+///
+/// Only the *preview* is sanitised. The conversion and both counters still run over
+/// the real text, so nothing this hides can hide a lost character.
+pub fn capped(text: &str) -> String {
+    let cut = text
+        .char_indices()
+        .nth(PREVIEW)
+        .map_or(text.len(), |(index, _)| index);
+    let mut out: String = text[..cut]
+        .chars()
+        .map(|c| match c {
+            '\n' | '\t' => c,
+            c if c.is_control() => char::REPLACEMENT_CHARACTER,
+            c => c,
+        })
+        .collect();
+    if cut < text.len() {
+        out.push('…');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole reason the line exists: it says *which* characters, not how many.
+    #[test]
+    fn the_warning_names_the_characters_that_will_not_survive() {
+        let line = loss("Ề 5₫", Charset::Unicode, Charset::Tcvn3);
+        assert!(line.contains('Ề'), "{line}");
+        assert!(line.contains('₫'), "{line}");
+        assert!(line.contains("TCVN3"), "{line}");
+    }
+
+    /// The gap a screenshot found. A character the *source* charset does not define
+    /// used to pass through in silence, so picking the wrong source looked like a
+    /// clean conversion. `U+0131` has no TCVN3 code.
+    #[test]
+    fn a_character_the_source_charset_does_not_define_is_reported() {
+        let line = loss("ngh\u{131}a", Charset::Tcvn3, Charset::Unicode);
+        assert!(line.contains("không thuộc"), "{line}");
+        assert!(line.contains("TCVN3"), "{line}");
+    }
+
+    /// The two problems are separate sentences, because they call for different
+    /// things: one says the source is wrong, the other says the target cannot cope.
+    #[test]
+    fn a_source_and_a_target_problem_are_reported_apart() {
+        let line = loss("ngh\u{131}a Ề", Charset::Tcvn3, Charset::Tcvn3);
+        assert_eq!(line.lines().count(), 2, "{line}");
+    }
+
+    /// Silent when nothing is lost, so the line keeps meaning something.
+    #[test]
+    fn nothing_is_said_when_nothing_is_lost() {
+        assert_eq!(loss("việt nam", Charset::Unicode, Charset::Tcvn3), "");
+    }
+
+    /// Respelling is not losing. Every toned vowel changes shape going to tổ hợp and
+    /// the round trip is exact, so the warning must stay quiet.
+    #[test]
+    fn respelling_is_not_reported_as_loss() {
+        assert_eq!(
+            loss("Việt Nam", Charset::Unicode, Charset::UnicodeCombining),
+            ""
+        );
+    }
+
+    /// A NUL reaching a GTK `TextBuffer` makes it measure and draw the rest of the
+    /// document wrongly, so the preview never carries one.
+    #[test]
+    fn a_control_character_cannot_reach_the_preview() {
+        let shown = capped("vi\u{0}\u{1a}t\ttab\nline");
+        assert!(!shown.contains('\u{0}'), "{shown:?}");
+        assert!(!shown.contains('\u{1a}'), "{shown:?}");
+        assert!(shown.contains('\t') && shown.contains('\n'), "{shown:?}");
+    }
+
+    /// A legacy target is written as bytes, not as UTF-8 of the same code points.
+    #[test]
+    fn saving_to_a_legacy_charset_writes_one_byte_per_letter() {
+        assert_eq!(bytes("Việt", Charset::Unicode, Charset::Tcvn3), b"Vi\xD6t");
+    }
+}

--- a/crates/funput-convert/src/write.rs
+++ b/crates/funput-convert/src/write.rs
@@ -1,4 +1,4 @@
-//! Writing the converted copies out.
+//! Writing the converted copies out, and saying what happened.
 //!
 //! Never over the originals. These are the documents someone still needs, often the
 //! only copy, and a conversion tool that edits them in place is one bad guess away
@@ -9,23 +9,27 @@ use std::path::{Path, PathBuf};
 
 use funput_core::charset::{self, Charset};
 
-use super::Entry;
+use crate::Entry;
 
 /// The subfolder converted copies land in, beside the originals.
-pub(in crate::ui::convert) const OUT_DIR: &str = "Đã chuyển mã";
+///
+/// The empty state promises this name out loud, so a shell that shows the sentence
+/// must build it from here rather than spell it again.
+pub const OUT_DIR: &str = "Đã chuyển mã";
 
 /// What a batch came to.
-pub(in crate::ui::convert) struct Outcome {
-    pub(in crate::ui::convert) written: usize,
-    pub(in crate::ui::convert) skipped: usize,
-    pub(in crate::ui::convert) failed: usize,
+pub struct Outcome {
+    pub written: usize,
+    pub skipped: usize,
+    pub failed: usize,
 }
 
-/// Convert and write every entry that has a charset. Runs off the UI thread.
+/// Convert and write every entry that has a charset. I/O over every entry, so a
+/// shell calls this off its UI thread.
 ///
 /// A file with no charset is *skipped*, not guessed at — the row is still on screen
 /// with its own picker, and the user can settle it and run again.
-pub(in crate::ui::convert) fn write_all(entries: &[Entry], target: Charset) -> Outcome {
+pub fn write_all(entries: &[Entry], target: Charset) -> Outcome {
     let mut outcome = Outcome {
         written: 0,
         skipped: 0,
@@ -47,6 +51,19 @@ pub(in crate::ui::convert) fn write_all(entries: &[Entry], target: Charset) -> O
         }
     }
     outcome
+}
+
+/// What to tell the user afterwards. A skipped file is not a failure — its row is
+/// still on screen with its own picker, waiting to be settled.
+pub fn report(outcome: &Outcome) -> String {
+    let mut parts = vec![format!("Đã chuyển {} tệp", outcome.written)];
+    if outcome.skipped > 0 {
+        parts.push(format!("bỏ qua {} tệp chưa rõ bảng mã", outcome.skipped));
+    }
+    if outcome.failed > 0 {
+        parts.push(format!("{} tệp ghi không được", outcome.failed));
+    }
+    parts.join(", ")
 }
 
 /// A path in the output folder that no file occupies yet.
@@ -156,5 +173,10 @@ mod tests {
 
         assert_eq!((outcome.written, outcome.skipped), (1, 1));
         assert!(!dir.join(OUT_DIR).join("mystery.txt").exists());
+        assert!(
+            report(&outcome).contains("bỏ qua 1 tệp"),
+            "{}",
+            report(&outcome)
+        );
     }
 }

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -58,6 +58,9 @@ self-replace = "1" # replace the currently running executable (crate `self_repla
 # `charset` is spelled out rather than left to feature unification through
 # funput-config: this shell calls it directly, so it should ask for it directly.
 funput-core = { path = "../../crates/funput-core", features = ["charset"] }
+# The Chuyển mã window's logic, shared with the GTK window on Linux so the two
+# cannot drift — see crates/funput-convert/README.md.
+funput-convert = { path = "../../crates/funput-convert" }
 funput-engine = { path = "../../crates/funput-engine" }
 funput-desktop = { path = "../../crates/funput-desktop" }
 # Settings model + Export/Import document, shared with the other desktop shells.

--- a/platforms/windows/src/ui/convert/files/mod.rs
+++ b/platforms/windows/src/ui/convert/files/mod.rs
@@ -1,87 +1,17 @@
-//! The batch: one entry per dropped file, each read on its own terms.
+//! Running the batch from the window.
 //!
-//! This is the part that beats the tool people are coming from. UniKey's file
-//! converter takes one source charset for a whole folder, so an archive holding
-//! documents from different eras converts most of itself to nonsense. Here every
-//! file goes through [`charset::document::read`] by itself, and one that nothing
-//! explains waits for the user instead of being swept along.
+//! Reading each file on its own terms, measuring what a target will cost, and writing
+//! the copies out all live in [`funput_convert`], shared with the GTK window on Linux.
+//! What is left here is the part that cannot be: getting the work off the UI thread
+//! and putting the result back on it.
+//!
+//! - [`rows`] — turning entries into what the window shows.
 
 mod rows;
-mod write;
-
-use std::path::PathBuf;
-
-use funput_core::charset::{self, Charset, document};
 
 use super::view;
 
 pub(super) use rows::{show_many, show_one};
-pub(super) use write::{OUT_DIR, Outcome, write_all};
-
-/// One file, as read.
-#[derive(Clone)]
-pub(super) struct Entry {
-    pub(super) path: PathBuf,
-    /// The document as characters — already past the two doors.
-    pub(super) text: String,
-    /// `None` when nothing explained the bytes. The user picks, or it is skipped.
-    pub(super) charset: Option<Charset>,
-    /// Characters the current target cannot represent. Recomputed on target change.
-    pub(super) unmapped: usize,
-}
-
-impl Entry {
-    pub(super) fn name(&self) -> String {
-        self.path
-            .file_name()
-            .map_or_else(|| self.path.display().to_string(), |n| {
-                n.to_string_lossy().into_owned()
-            })
-    }
-}
-
-/// Read every path, skipping what cannot be read at all.
-///
-/// Runs off the UI thread — a folder of a few hundred documents is I/O bound, and
-/// doing it inline would freeze the window for the whole drop.
-pub(super) fn scan(paths: &[PathBuf]) -> Vec<Entry> {
-    paths
-        .iter()
-        .filter(|path| path.is_file())
-        .filter_map(|path| {
-            let bytes = std::fs::read(path).ok()?;
-            let doc = document::read(bytes).ok()?;
-            Some(Entry {
-                path: path.clone(),
-                text: doc.text,
-                charset: doc.charset,
-                unmapped: 0,
-            })
-        })
-        .collect()
-}
-
-/// Recompute what each file would lose when written as `target`.
-///
-/// Conversion only, no I/O, so this is cheap enough to run every time the target
-/// changes. The bytes are thrown away and made again at write time: keeping a
-/// converted copy of every document in memory costs more than converting twice.
-pub(super) fn measure(entries: &mut [Entry], target: Charset) {
-    for entry in entries {
-        entry.unmapped = match entry.charset {
-            Some(from) => {
-                let unicode = charset::convert(&entry.text, from, Charset::Unicode);
-                charset::convert(&unicode.text, Charset::Unicode, target).unmapped
-            }
-            None => 0,
-        };
-    }
-}
-
-/// How many files are ready to convert — the ones a charset was settled for.
-pub(super) fn ready(entries: &[Entry]) -> usize {
-    entries.iter().filter(|e| e.charset.is_some()).count()
-}
 
 /// Convert and write the batch, off the UI thread — it is file I/O over every entry.
 pub(super) fn convert_all() {
@@ -93,74 +23,17 @@ pub(super) fn convert_all() {
     window.set_can_convert(false);
     window.set_progress("Đang chuyển…".into());
     std::thread::spawn(move || {
-        let outcome = write_all(&entries, target);
+        let outcome = funput_convert::write_all(&entries, target);
         let _ = slint::invoke_from_event_loop(move || {
             let Some(window) = view::current() else { return };
-            window.set_progress(report(&outcome).into());
+            window.set_progress(funput_convert::report(&outcome).into());
             window.set_can_convert(true);
         });
     });
 }
 
-/// What to tell the user afterwards. A skipped file is not a failure — its row is
-/// still on screen with its own picker, waiting to be settled.
-fn report(outcome: &Outcome) -> String {
-    let mut parts = vec![format!("Đã chuyển {} tệp", outcome.written)];
-    if outcome.skipped > 0 {
-        parts.push(format!("bỏ qua {} tệp chưa rõ bảng mã", outcome.skipped));
-    }
-    if outcome.failed > 0 {
-        parts.push(format!("{} tệp ghi không được", outcome.failed));
-    }
-    parts.join(", ")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn scratch(name: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("funput-scan-{name}"));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch dir");
-        dir
-    }
-
-    /// The reason this window exists rather than the one people use today. UniKey's
-    /// file converter takes one source charset for a whole folder, so an archive
-    /// holding documents from different eras converts most of itself to nonsense.
-    #[test]
-    fn a_folder_of_mixed_charsets_is_read_one_file_at_a_time() {
-        let dir = scratch("mixed");
-        // The same sentence, stored three different ways, plus one nothing explains.
-        std::fs::write(dir.join("a.txt"), b"vi\xD6t nam h\xB5 n\xE9i").unwrap();
-        std::fs::write(dir.join("b.txt"), "việt nam hà nội").unwrap();
-        std::fs::write(dir.join("c.txt"), b"the quick brown \xFF fox jumps over it").unwrap();
-
-        let paths = [dir.join("a.txt"), dir.join("b.txt"), dir.join("c.txt")];
-        let entries = scan(&paths);
-
-        assert_eq!(entries.len(), 3);
-        assert_eq!(entries[0].charset, Some(Charset::Tcvn3));
-        assert_eq!(entries[1].charset, Some(Charset::Unicode));
-        assert_eq!(entries[2].charset, None, "nothing explains these bytes");
-        assert_eq!(ready(&entries), 2, "only the two that were identified");
-    }
-
-    /// The count behind "N chữ sẽ mất", and it must follow the target rather than be
-    /// fixed at read time.
-    #[test]
-    fn what_will_be_lost_is_measured_against_the_target_of_the_moment() {
-        let dir = scratch("measure");
-        std::fs::write(dir.join("hoa.txt"), "Ổn").unwrap();
-        let mut entries = scan(&[dir.join("hoa.txt")]);
-
-        // TCVN3 has no code for an uppercase toned vowel.
-        measure(&mut entries, Charset::Tcvn3);
-        assert_eq!(entries[0].unmapped, 1);
-
-        // The same document costs nothing going somewhere that can spell it.
-        measure(&mut entries, Charset::UnicodeCombining);
-        assert_eq!(entries[0].unmapped, 0);
-    }
+/// Read every dropped path, off the UI thread. A folder of a few hundred documents is
+/// I/O bound, and doing it inline would freeze the window for the whole drop.
+pub(super) fn scan(paths: &[std::path::PathBuf]) -> Vec<funput_convert::Entry> {
+    funput_convert::scan(&funput_convert::collect(paths))
 }

--- a/platforms/windows/src/ui/convert/files/rows.rs
+++ b/platforms/windows/src/ui/convert/files/rows.rs
@@ -6,20 +6,11 @@
 //! the user actually wants — whether the Vietnamese comes out right. It gets the same
 //! before/after panes a pasted paragraph does.
 
-use funput_core::charset::Charset;
+use funput_convert::{Entry, capped, charset::Charset};
 use slint::{ModelRc, VecModel};
 
-use crate::ui::convert::{text, view};
+use crate::ui::convert::view;
 use crate::{ConvertWindow, FileRow};
-
-use super::Entry;
-
-/// How much of a document to put in a pane.
-///
-/// Panes are for *looking* at, and nobody reads a megabyte in one. The conversion and
-/// the warning still run over the whole file — only the display is cut, so a large
-/// document cannot make the window crawl while the counts stay honest.
-const PREVIEW: usize = 20_000;
 
 /// The batch: a row per file, and what the button will do.
 pub(in crate::ui::convert) fn show_many(window: &ConvertWindow, entries: &[Entry]) {
@@ -41,9 +32,9 @@ pub(in crate::ui::convert) fn show_many(window: &ConvertWindow, entries: &[Entry
         })
         .collect();
     window.set_files(ModelRc::new(VecModel::from(rows)));
-    window.set_out_dir(out_dir_label(entries).into());
+    window.set_out_dir(funput_convert::out_dir_label(entries).into());
 
-    let ready = super::ready(entries);
+    let ready = funput_convert::ready(entries);
     window.set_can_convert(ready > 0);
     window.set_action_label(format!("Chuyển {ready} tệp").into());
 }
@@ -68,29 +59,7 @@ pub(in crate::ui::convert) fn show_one(window: &ConvertWindow, entry: &Entry, ta
         window.set_loss(slint::SharedString::new());
         return;
     };
-    let converted = text::preview(&entry.text, from, target);
+    let converted = funput_convert::preview(&entry.text, from, target);
     window.set_output_text(capped(&converted.text).into());
-    window.set_loss(text::loss(&entry.text, from, target).into());
-}
-
-/// Where the converted copies will go, for the footer to show before committing.
-pub(in crate::ui::convert) fn out_dir_label(entries: &[Entry]) -> String {
-    let mut dirs: Vec<&std::path::Path> =
-        entries.iter().filter_map(|e| e.path.parent()).collect();
-    dirs.sort_unstable();
-    dirs.dedup();
-    match dirs.as_slice() {
-        [] => String::new(),
-        [only] => only.join(super::OUT_DIR).display().to_string(),
-        // Dropped from several folders: each keeps its own, so no name can collide
-        // with a same-named file from somewhere else.
-        many => format!("{} trong {} thư mục", super::OUT_DIR, many.len()),
-    }
-}
-
-fn capped(text: &str) -> String {
-    match text.char_indices().nth(PREVIEW) {
-        Some((cut, _)) => format!("{}…", &text[..cut]),
-        None => text.to_string(),
-    }
+    window.set_loss(funput_convert::loss(&entry.text, from, target).into());
 }

--- a/platforms/windows/src/ui/convert/mod.rs
+++ b/platforms/windows/src/ui/convert/mod.rs
@@ -3,9 +3,13 @@
 //! Runs in its own short-lived process like Settings — see [`crate::ui`]. This file
 //! owns the window's lifetime and its callbacks; everything else lives next door.
 //!
+//! Everything about *what* a conversion is and costs lives in [`funput_convert`],
+//! shared with the GTK window on Linux so the two cannot drift. What is here is this
+//! shell's half of it.
+//!
 //! - [`view`] — the state, and everything the window shows from it.
-//! - [`text`] — what a pasted paragraph is, becomes, and costs, and saving it.
-//! - [`files`] — the batch: reading each file on its own, and writing them out.
+//! - [`text`] — saving a pasted paragraph through a Save dialog.
+//! - [`files`] — running the batch off the UI thread.
 //! - [`win32`] — the two things Slint cannot do: file drop and clipboard buttons.
 
 mod files;
@@ -17,7 +21,7 @@ use std::path::PathBuf;
 
 use slint::{ComponentHandle, ModelRc, VecModel};
 
-use funput_core::charset;
+use funput_convert::charset;
 
 use crate::ui::{mica, system_accent};
 use crate::{ConvertWindow, Theme};
@@ -111,7 +115,7 @@ fn wire(window: &ConvertWindow) {
                 [only] => (only.charset, only.text.as_str()),
                 _ => (state.source.map(at), state.input.as_str()),
             };
-            from.map(|from| text::preview(input, from, at(state.target)).text)
+            from.map(|from| funput_convert::preview(input, from, at(state.target)).text)
         });
         if let Some(converted) = converted {
             win32::write(&converted);

--- a/platforms/windows/src/ui/convert/text.rs
+++ b/platforms/windows/src/ui/convert/text.rs
@@ -1,104 +1,10 @@
-//! The pasted-text state: what it is, what it will become, what it will cost.
+//! Saving a pasted paragraph to a file the user picks.
 //!
-//! No byte door here. Text arriving through the clipboard is already characters —
-//! a TCVN3 paragraph pasted out of Word is code points `U+0020..=U+00FF` standing in
-//! for bytes, which is exactly what [`charset::convert`] takes. Only a *file* has to
-//! go through `charset::document`, and that is the batch's problem.
-
-use funput_core::charset::{self, Charset, Conversion};
+//! Everything else about a paragraph — what it becomes, and what it costs — lives in
+//! [`funput_convert`], shared with the GTK window on Linux. What is left here is the
+//! one part that cannot be: the Save dialog.
 
 use super::view;
-
-/// How many characters to name before the warning gets longer than it is useful.
-const NAMED: usize = 6;
-
-/// Convert `text` for the preview pane.
-pub(super) fn preview(text: &str, from: Charset, to: Charset) -> Conversion {
-    charset::convert(text, from, to)
-}
-
-/// The bytes to save, for a target that stores one byte per letter.
-pub(super) fn bytes(text: &str, from: Charset, to: Charset) -> Vec<u8> {
-    let unicode = charset::convert(text, from, Charset::Unicode);
-    charset::encode_bytes(&unicode.text, to).0
-}
-
-/// The warning, or empty when nothing will be lost.
-///
-/// **Two different problems, and they are not the same sentence.** Reading can fail —
-/// characters the *source* charset does not define, which means the wrong source was
-/// picked or the document is damaged, and the user can act on that. Writing can fail —
-/// characters the *target* cannot represent, which is a cost to accept or avoid by
-/// choosing elsewhere. Reporting only the second is what let a wrong source guess pass
-/// silently, which is the thing this window was built to stop.
-///
-/// The target line **names the characters**. A count tells someone something is wrong
-/// without telling them where to look, and a conversion that quietly drops `Ề` from a
-/// letterhead is the failure the whole window exists to prevent.
-///
-/// `normalized` is deliberately not mentioned: converting to Unicode tổ hợp respells
-/// every toned vowel and loses nothing, so counting it would teach people to ignore
-/// this line.
-pub(super) fn loss(text: &str, from: Charset, to: Charset) -> String {
-    let unicode = charset::convert(text, from, Charset::Unicode);
-    let mut lines = Vec::new();
-    if unicode.unmapped > 0 {
-        lines.push(format!(
-            "{} chữ không thuộc {} — có thể bảng mã nguồn chọn sai, hoặc tệp đã hỏng",
-            unicode.unmapped,
-            from.name()
-        ));
-    }
-    if let Some(line) = target_line(&unicode.text, to) {
-        lines.push(line);
-    }
-    lines.join("\n")
-}
-
-/// What the target cannot represent, named rather than counted.
-fn target_line(unicode: &str, to: Charset) -> Option<String> {
-    let lost = unrepresentable(unicode, to);
-    if lost.is_empty() {
-        return None;
-    }
-    let shown: String = lost
-        .iter()
-        .take(NAMED)
-        .map(char::to_string)
-        .collect::<Vec<_>>()
-        .join("  ");
-    let rest = lost.len().saturating_sub(NAMED);
-    let tail = if rest > 0 {
-        format!(" và {rest} chữ khác")
-    } else {
-        String::new()
-    };
-    Some(format!(
-        "{} chữ không có trong {}:  {shown}{tail}",
-        lost.len(),
-        to.name()
-    ))
-}
-
-/// The distinct characters `to` cannot represent, in the order they first appear.
-///
-/// Asked one character at a time because the counter core returns is a total, not a
-/// list. Distinct characters in a document are few — a few hundred at most — so this
-/// costs a great deal less than it looks like it does.
-fn unrepresentable(unicode: &str, to: Charset) -> Vec<char> {
-    let mut seen = std::collections::HashSet::new();
-    let mut lost = Vec::new();
-    for ch in unicode.chars() {
-        if !seen.insert(ch) {
-            continue;
-        }
-        if charset::convert(&ch.to_string(), Charset::Unicode, to).unmapped > 0 {
-            lost.push(ch);
-        }
-    }
-    lost
-}
-
 
 /// Save the converted paragraph to a file the user picks.
 ///
@@ -123,63 +29,9 @@ pub(super) fn save() {
     else {
         return;
     };
-    let message = match std::fs::write(&path, bytes(&input, from, to)) {
+    let message = match std::fs::write(&path, funput_convert::bytes(&input, from, to)) {
         Ok(()) => format!("Đã lưu {}", path.display()),
         Err(err) => format!("Không lưu được: {err}"),
     };
     window.set_progress(message.into());
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The whole reason the line exists: it says *which* characters, not how many.
-    #[test]
-    fn the_warning_names_the_characters_that_will_not_survive() {
-        let line = loss("Ề 5₫", Charset::Unicode, Charset::Tcvn3);
-        assert!(line.contains('Ề'), "{line}");
-        assert!(line.contains('₫'), "{line}");
-        assert!(line.contains("TCVN3"), "{line}");
-    }
-
-    /// The gap a screenshot found. A character the *source* charset does not define
-    /// used to pass through in silence, so picking the wrong source looked like a
-    /// clean conversion. `U+0131` has no TCVN3 code.
-    #[test]
-    fn a_character_the_source_charset_does_not_define_is_reported() {
-        let line = loss("ngh\u{131}a", Charset::Tcvn3, Charset::Unicode);
-        assert!(line.contains("không thuộc"), "{line}");
-        assert!(line.contains("TCVN3"), "{line}");
-    }
-
-    /// The two problems are separate sentences, because they call for different
-    /// things: one says the source is wrong, the other says the target cannot cope.
-    #[test]
-    fn a_source_and_a_target_problem_are_reported_apart() {
-        let line = loss("ngh\u{131}a Ề", Charset::Tcvn3, Charset::Tcvn3);
-        assert_eq!(line.lines().count(), 2, "{line}");
-    }
-
-    /// Silent when nothing is lost, so the line keeps meaning something.
-    #[test]
-    fn nothing_is_said_when_nothing_is_lost() {
-        assert_eq!(loss("việt nam", Charset::Unicode, Charset::Tcvn3), "");
-    }
-
-    /// Respelling is not losing. Every toned vowel changes shape going to tổ hợp and
-    /// the round trip is exact, so the warning must stay quiet.
-    #[test]
-    fn respelling_is_not_reported_as_loss() {
-        assert_eq!(
-            loss("Việt Nam", Charset::Unicode, Charset::UnicodeCombining),
-            ""
-        );
-    }
-
-    /// A legacy target is written as bytes, not as UTF-8 of the same code points.
-    #[test]
-    fn saving_to_a_legacy_charset_writes_one_byte_per_letter() {
-        assert_eq!(bytes("Việt", Charset::Unicode, Charset::Tcvn3), b"Vi\xD6t");
-    }
 }

--- a/platforms/windows/src/ui/convert/view.rs
+++ b/platforms/windows/src/ui/convert/view.rs
@@ -11,12 +11,15 @@
 
 use std::cell::RefCell;
 
-use funput_core::charset::{self, Charset};
+use funput_convert::{
+    Mode,
+    charset::{self, Charset},
+};
 use slint::Weak;
 
 use crate::ConvertWindow;
 
-use super::{files, text};
+use super::files;
 
 thread_local! {
     pub(super) static WINDOW: RefCell<Option<Weak<ConvertWindow>>> = const { RefCell::new(None) };
@@ -30,7 +33,7 @@ pub(super) struct State {
     /// Text state. `None` until something is identified or the user picks.
     pub(super) source: Option<usize>,
     pub(super) input: String,
-    pub(super) files: Vec<files::Entry>,
+    pub(super) files: Vec<funput_convert::Entry>,
 }
 
 impl State {
@@ -61,30 +64,34 @@ pub(super) fn index_of(charset: Charset) -> Option<usize> {
 
 /// Rebuild the whole window from the state.
 ///
-/// **One file takes the text shape, not a one-row table.** A table earns its place
-/// when the rows differ — that is the whole point of reading a batch file by file.
-/// With one file there is nothing to compare against, and the before/after panes show
-/// what the user came to see.
+/// Which shape it takes is [`Mode::of`]'s call, shared with the GTK window on Linux —
+/// including the rule that one file takes the text shape rather than a one-row table.
 pub(super) fn refresh() {
     let Some(window) = current() else { return };
     STATE.with(|s| {
         let mut state = s.borrow_mut();
         let target = at(state.target);
         window.set_target_index(i32::try_from(state.target).unwrap_or(0));
-        files::measure(&mut state.files, target);
+        funput_convert::measure(&mut state.files, target);
 
-        match state.files.as_slice() {
-            [] if state.input.is_empty() => window.set_mode("empty".into()),
-            [] => {
+        match Mode::of(&state.files, &state.input) {
+            Mode::Empty => window.set_mode("empty".into()),
+            // Two arms for one shape: a pasted paragraph and a single file look the
+            // same on screen but are filled from different places. Split rather than
+            // matched on `first()` because the `None` arm needs `state` mutably, and
+            // the borrow taken to ask the question outlives the answer.
+            Mode::Text if state.files.is_empty() => {
                 show_pasted(&window, &mut state, target);
                 window.set_mode("text".into());
             }
-            [only] => {
-                files::show_one(&window, only, target);
+            Mode::Text => {
+                if let Some(only) = state.files.first() {
+                    files::show_one(&window, only, target);
+                }
                 window.set_mode("text".into());
             }
-            many => {
-                files::show_many(&window, many);
+            Mode::Files => {
+                files::show_many(&window, &state.files);
                 window.set_mode("files".into());
             }
         }
@@ -109,6 +116,6 @@ fn show_pasted(window: &ConvertWindow, state: &mut State, target: Charset) {
         window.set_loss(slint::SharedString::new());
         return;
     };
-    window.set_output_text(text::preview(&state.input, from, target).text.into());
-    window.set_loss(text::loss(&state.input, from, target).into());
+    window.set_output_text(funput_convert::preview(&state.input, from, target).text.into());
+    window.set_loss(funput_convert::loss(&state.input, from, target).into());
 }


### PR DESCRIPTION
Ruột của cửa sổ Chuyển mã là Rust thuần — không Win32, không Slint. Tách ra `crates/funput-convert` **trước** khi có cửa sổ thứ hai, để câu cảnh báo mất chữ, luật `vanban (2).txt` và tên thư mục `Đã chuyển mã` không tồn tại hai bản.

Lợi ích thứ hai lớn hơn: `platforms/windows` và `platforms/linux/settings-gtk` đều ngoài cargo workspace, nên `clippy --workspace`, `test --workspace` và `check-loc.sh` không với tới cái nào. 11 test đi kèm giờ chạy ở **mỗi PR**, cho cả hai nền tảng — trước đây chỉ chạy lúc phát hành.

Windows giữ thứ không dời được: hộp thoại Lưu, threading, dựng model Slint. **Hành vi không đổi** — 11 test đi cùng là thứ nói điều đó.

⚠️ Chưa biên dịch được trên máy Linux (không có target chéo). Cần chạy trên Windows trước khi merge:
```
cargo clippy --release --all-targets -- -D warnings && cargo test --release
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)