### PR TITLE
feat(linux): add the Chuyển mã window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ name: CI
 # tested and inside the per-file line budget.
 #
 # The toolchain comes from rust-toolchain.toml (1.97.1 + rustfmt + clippy), so
-# bumping the pin moves CI with it. The two excluded shells
-# (platforms/windows, platforms/linux/settings-gtk) need system libraries and are
-# covered by the release builds instead — build-windows.yml runs clippy and the
-# tests for the Windows shell there, since nothing in this file can reach it.
+# bumping the pin moves CI with it. The two excluded shells need system libraries, so
+# neither is reachable from the `rust` job: the GTK4 Settings app gets a job of its own
+# below, and the Windows shell is covered by build-windows.yml, which runs clippy and
+# its tests there because nothing in this file can.
 
 on:
   pull_request:
@@ -97,6 +97,40 @@ jobs:
 
       - name: Line budget
         run: bash scripts/check-loc.sh
+
+  # The GTK4 Settings app, which also hosts the Chuyển mã window. Excluded from the
+  # cargo workspace because it links system gtk4/libadwaita, so the `rust` job above —
+  # which deliberately installs no system libraries — cannot see it. Before this job it
+  # had no gate at all: build-linux.yml only ran `cargo build --release`, at release
+  # time, so a lint failure or a broken test could sit in main for weeks.
+  #
+  # Dev profile, unlike the Windows shell's `--release`: there is no slint/skia here to
+  # recompile, so debug is faster and its cache is separate from the release build
+  # anyway. `cargo fmt --all` in the `rust` job does not reach an excluded package,
+  # which is why formatting is checked here too.
+  settings-gtk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build deps
+        run: sudo apt-get update && sudo apt-get install -y libgtk-4-dev libadwaita-1-dev
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: platforms/linux/settings-gtk -> target
+
+      - name: Format
+        working-directory: platforms/linux/settings-gtk
+        run: cargo fmt -- --check
+
+      - name: Clippy
+        working-directory: platforms/linux/settings-gtk
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Test
+        working-directory: platforms/linux/settings-gtk
+        run: cargo test
 
   # The shared Linux code (platforms/linux/common): the settings bridge and the
   # composition state machine both shells drive. It links no Fcitx5 or IBus symbol,

--- a/docs/features/charset.md
+++ b/docs/features/charset.md
@@ -2,9 +2,10 @@
 
 ## Trạng thái
 
-Đã có: khung core, cả bốn bảng mã, `detect()`, và consumer đầu tiên — nhập bảng gõ
-tắt UniKey ở bảng mã cũ. Còn lại: `funput convert`, rồi UI (xem "Thứ tự hiện thực"
-ở cuối).
+Đã xong toàn bộ danh sách ở "Thứ tự hiện thực" cuối tài liệu: khung core, cả bốn bảng
+mã, `detect()`, `funput-config`, C ABI, `funput convert`, và hai cửa sổ — Windows
+(Slint) và Linux (GTK4). Ruột của hai cửa sổ nằm ở **`crates/funput-convert`**, không
+phải ở từng shell; xem mục 11. Còn lại là bảng mã mới, nếu có.
 
 Tài liệu này chốt mô hình *trước* khi có code và được review riêng; nó vẫn là nơi
 mọi quyết định thiết kế sống, nên mỗi bảng mã mới cập nhật lại nó trong cùng PR.
@@ -478,4 +479,34 @@ Mỗi mục một PR:
     mọc ra từ thứ UniKey không có (`detect` + hai bộ đếm): không hỏi bảng mã nguồn mà **nói**
     ra; thấy trước/sau theo thời gian thực; **gọi tên** những chữ sẽ mất chứ không chỉ đếm; và
     nhận diện **từng tệp** trong lô thay vì ép một bảng mã cho cả thư mục.
-11. UI Linux GTK.
+11. **`crates/funput-convert`** — tách ruột của cửa sổ ra khỏi shell, **trước** khi có cửa sổ
+    thứ hai. Bốn việc trong đó không có gì là đồ hoạ (đọc lô theo từng tệp, nói ra cái giá,
+    ghi bản sao cạnh bản gốc, thuật lại), và chép chúng sang GTK sẽ đặt câu cảnh báo mất chữ,
+    luật `vanban (2).txt` và tên thư mục `Đã chuyển mã` vào hai chỗ cùng lúc. Đây là cùng
+    một phán quyết đã ra ở mục 7 cho `Charset::name()`, chỉ ở quy mô lớn hơn.
+
+    Lợi ích thứ hai lớn hơn ý định ban đầu: `platforms/windows` và
+    `platforms/linux/settings-gtk` đều nằm ngoài cargo workspace, nên `clippy --workspace`,
+    `test --workspace` và `check-loc.sh` không với tới cái nào — 11 test của cửa sổ Windows
+    chỉ chạy lúc phát hành. Đưa vào `crates/` là lần đầu chúng chạy ở mỗi PR, cho cả hai nền
+    tảng.
+12. **UI Linux GTK** — cùng ba trạng thái, cùng bốn nước đi, cùng từng câu chữ. Ba điều
+    riêng của nền tảng:
+
+    - **Không có tray.** Fcitx5 và iBus tự vẽ status icon, nên mục tray của Windows không có
+      chỗ đứng. Thay bằng hai cửa: một hàng trong Settings → Chung, và
+      `funput-convert.desktop` chạy `funput-settings --convert`. Cùng một tiến trình, cùng
+      một thể hiện — `HANDLES_COMMAND_LINE`, vì cờ mặc định của `GApplication` không chuyển
+      tiếp argv và `--convert` sẽ mất lặng lẽ.
+    - **Dựng lại từ state, có điều chỉnh.** Thuộc tính Slint là giá trị nên Windows dựng lại
+      được cả cửa sổ; tạo lại một `TextView` mỗi phím gõ thì giết focus và con trỏ. Bộ khung
+      dựng một lần, `refresh()` chỉ đặt thuộc tính, và **một** cờ `refreshing` chặn tái nhập
+      cho cả bốn tín hiệu mà chính `refresh()` phát ra — nếu không thì mỗi lần nó đặt một
+      dropdown sẽ là một `borrow_mut` lồng nhau, tức panic.
+    - **Ký tự điều khiển.** `TextBuffer` của GTK nhận cả độ dài chứ không dừng ở NUL, nên một
+      tệp cũ hỏng làm nó đo và vẽ sai phần còn lại. `capped()` khử C0 — trong lõi dùng chung,
+      nên Windows được hưởng luôn, dù ở đó chưa ai thấy.
+
+    Fcitx5 và iBus **dùng chung** cửa sổ này: nó không hỏi khung nào đang chạy, không đọc
+    `settings.json`, không nói chuyện với engine. Cả hai đã phụ thuộc gói `funput-settings`
+    tại đúng phiên bản, nên cả hai nhận nó mà không sửa một dòng C++.

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -37,7 +37,9 @@ ibus/src/               IBus engine -> ibus-engine-funput
   engine/                 internal.h, object.cpp, callbacks.cpp, client.cpp
 settings-gtk/           GTK4 + libadwaita Settings app (its own cargo crate,
                         and its own package — see Build)
-packaging/              .desktop file, apt/dnf repo metadata
+  src/settings_window/    one submodule per preferences page
+  src/convert/            the Chuyển mã window — see below
+packaging/              two .desktop files, apt/dnf repo metadata
 ```
 
 Directories are kept to five files or fewer; when one grows past that, it splits by
@@ -111,6 +113,37 @@ Note that the two **shells** are only compiled by the release workflow, so a cha
 under `fcitx5/` or `ibus/` still wants a local build before merging.
 
 Every file here is held to 150 lines by `scripts/check-loc.sh`, test files included.
+
+## Chuyển mã
+
+The charset converter (`settings-gtk/src/convert/`) is **shared by both shells** in the
+strongest sense: it never asks which one is running, never reads `settings.json`, and
+never touches the engine. Fcitx5 and IBus both depend on the `funput-settings` package
+at the exact version, so both get it without a line of C++ changing.
+
+Everything about *what* a conversion is and costs lives in `crates/funput-convert`,
+shared with the Slint window on Windows — the loss warning, the batch rules, the
+`Đã chuyển mã` folder name and its collision-avoiding `vanban (2).txt`. Writing those
+twice is how the two platforms would start disagreeing about the same document. What
+stays here is drag-and-drop, the clipboard, the dialogs, and getting file I/O off the
+UI thread.
+
+Two ways in, because **there is no tray** for the item Windows puts there:
+
+- Settings → **Chung** → "Công cụ chuyển mã", mirroring Windows' Settings → Dữ liệu.
+- `funput-convert.desktop`, which runs `funput-settings --convert`.
+
+Both reach the same process. That needs `ApplicationFlags::HANDLES_COMMAND_LINE` —
+GApplication's default flags do not forward argv to the running instance, so `--convert`
+would vanish without a trace — and it is why `route()` in `main.rs` looks for a window
+*of the right type* rather than calling `active_window()`, which would raise the
+converter when someone asked for Settings.
+
+`src/convert/state.rs` is the only file under `convert/` that decides anything, and the
+only one with tests. The `ui/*` files read the state and set properties; they decide
+nothing. One `refreshing` latch guards every signal a refresh fires — without it, a
+refresh setting a dropdown re-enters through `notify::selected` and panics on a nested
+`borrow_mut`.
 
 ## Non-preedit mode
 

--- a/platforms/linux/packaging/funput-convert.desktop
+++ b/platforms/linux/packaging/funput-convert.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Chuyển mã
+GenericName=Vietnamese Charset Converter
+Comment=Chuyển văn bản và tệp giữa Unicode, TCVN3 (ABC) và VNI-Windows
+Exec=funput-settings --convert
+Icon=funput
+Terminal=false
+Categories=Utility;TextTools;
+Keywords=chuyển mã;bảng mã;tcvn3;abc;vni;unicode;unikey;convert;charset;

--- a/platforms/linux/settings-gtk/CMakeLists.txt
+++ b/platforms/linux/settings-gtk/CMakeLists.txt
@@ -36,6 +36,15 @@ install(PROGRAMS "${FUNPUT_SETTINGS_BIN}" DESTINATION "${CMAKE_INSTALL_BINDIR}")
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../packaging/funput-settings.desktop"
         DESTINATION "${CMAKE_INSTALL_DATADIR}/applications")
 
+# The same binary under a second launcher (`funput-settings --convert`). Linux has no
+# tray, so the tray item Windows offers has nowhere to live; this is what stands in for
+# it, and without it the converter would only be reachable through Settings.
+#
+# No packaging changes go with it: it lands in this package, and unlike the four files
+# below it was never owned by a shell, so it needs no Replaces/Breaks.
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../packaging/funput-convert.desktop"
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/applications")
+
 # Shipped here rather than with a shell because the shells reference them by name
 # (`Icon=funput`) and would otherwise each need their own copy — the very duplication
 # this package exists to remove.

--- a/platforms/linux/settings-gtk/Cargo.lock
+++ b/platforms/linux/settings-gtk/Cargo.lock
@@ -91,10 +91,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "funput-convert"
+version = "0.1.0"
+dependencies = [
+ "funput-core",
+]
+
+[[package]]
+name = "funput-core"
+version = "0.1.0"
+
+[[package]]
 name = "funput-settings"
 version = "1.2026.1"
 dependencies = [
  "dirs",
+ "funput-convert",
  "gtk4",
  "libadwaita",
  "serde",

--- a/platforms/linux/settings-gtk/Cargo.toml
+++ b/platforms/linux/settings-gtk/Cargo.toml
@@ -15,6 +15,12 @@ path = "src/main.rs"
 # minimum we actually use (v4_10 for gtk, v1_5 for AdwAboutDialog + the rows) so the
 # crate links against 24.04's system libraries.
 [dependencies]
+# The Chuyển mã window's logic — reading a batch file by file, naming what a
+# conversion costs, writing copies beside the originals. Shared with the Windows
+# window so the two cannot drift; see crates/funput-convert/README.md. It re-exports
+# `funput_core::charset`, so this is the only edge needed and the `charset` feature is
+# switched on in exactly one manifest.
+funput-convert = { path = "../../../crates/funput-convert" }
 gtk = { package = "gtk4", version = "0.9", features = ["v4_10"] }
 adw = { package = "libadwaita", version = "0.7", features = ["v1_5"] }
 serde = { version = "1", features = ["derive"] }

--- a/platforms/linux/settings-gtk/src/convert.rs
+++ b/platforms/linux/settings-gtk/src/convert.rs
@@ -1,0 +1,96 @@
+//! The Chuyển mã window: paste a paragraph or drop files, and convert them.
+//!
+//! Framework-agnostic on purpose. Fcitx5 and IBus both depend on the
+//! `funput-settings` package at the exact version, so both get this window without a
+//! line of C++ changing — it never asks which shell is running, never reads
+//! `settings.json`, and never talks to the engine.
+//!
+//! Everything about *what* a conversion is and costs lives in [`funput_convert`],
+//! shared with the Slint window on Windows so the two cannot drift. What is here is
+//! this platform's half of it.
+//!
+//! - [`state`] — the state, and every decision made from it. The only pure file.
+//! - [`ui`] — the widget tree, and pushing the state into it.
+//! - [`io`] — drag-and-drop, the clipboard, the dialogs, and getting file work off
+//!   the UI thread.
+//! - [`open`] — building the window, and reusing the one already up.
+
+mod io;
+mod open;
+mod state;
+mod ui;
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use state::State;
+
+pub use open::present;
+
+/// The window, its state, and the two latches that keep signals honest.
+pub struct Convert {
+    window: adw::ApplicationWindow,
+    restart: gtk::Button,
+    pub(crate) state: RefCell<State>,
+    panes: ui::Panes,
+    /// Set while [`Self::refresh`] is writing into widgets.
+    ///
+    /// Every write it makes — a dropdown selection, a text buffer, a rebuilt row —
+    /// fires the same signal a user would, and each of those handlers edits the state
+    /// and refreshes again. That is a re-entrant `borrow_mut` on `state`, i.e. a
+    /// panic, and where it does not panic it quietly rewrites what it just read.
+    /// One latch, checked at the top of every handler, settles all of them.
+    refreshing: Cell<bool>,
+    /// Set while a batch is being written, so the button cannot start a second one.
+    busy: Cell<bool>,
+    /// The footer line: what just happened, or empty.
+    progress: RefCell<String>,
+}
+
+impl Convert {
+    /// Rebuild the window from the state. Every callback ends here.
+    pub(crate) fn refresh(self: &Rc<Self>) {
+        if self.refreshing.replace(true) {
+            return;
+        }
+        let mut state = self.state.borrow_mut();
+        // What each file would lose follows the target of the moment, not the target
+        // it was read under, so it is remeasured here rather than at read time. It is
+        // conversion only, no I/O, which is what makes that affordable.
+        let target = state::at(state.target);
+        funput_convert::measure(&mut state.files, target);
+        // Nothing to start over from when nothing has been put in yet.
+        self.restart
+            .set_visible(state.mode() != funput_convert::Mode::Empty);
+        self.panes.refresh(self, &mut state);
+        drop(state);
+        self.refreshing.set(false);
+    }
+
+    pub(crate) fn window(&self) -> &adw::ApplicationWindow {
+        &self.window
+    }
+
+    pub(crate) fn is_refreshing(&self) -> bool {
+        self.refreshing.get()
+    }
+
+    pub(crate) fn is_busy(&self) -> bool {
+        self.busy.get()
+    }
+
+    pub(crate) fn set_busy(&self, busy: bool) {
+        self.busy.set(busy);
+    }
+
+    pub(crate) fn progress(&self) -> String {
+        self.progress.borrow().clone()
+    }
+
+    pub(crate) fn set_progress(self: &Rc<Self>, message: String) {
+        *self.progress.borrow_mut() = message;
+        self.refresh();
+    }
+}

--- a/platforms/linux/settings-gtk/src/convert/io.rs
+++ b/platforms/linux/settings-gtk/src/convert/io.rs
@@ -1,0 +1,95 @@
+//! The parts that are this platform's, not the feature's.
+//!
+//! Drag-and-drop, the clipboard, the two dialogs, and getting file work off the UI
+//! thread. Everything they hand around — what a document is, what it becomes, where
+//! the copy goes — comes from [`funput_convert`].
+//!
+//! Here: how files get in, and how reading them stays off the UI thread. The four
+//! things the buttons do are [`act`]'s.
+
+use std::path::PathBuf;
+use std::rc::{Rc, Weak};
+
+use adw::prelude::*;
+use gtk::{gdk, gio, glib};
+
+mod act;
+
+use super::Convert;
+
+pub(super) use act::{convert_files, copy_result, paste, save_result};
+
+/// Accept files dropped anywhere on the window.
+///
+/// Two targets, not one. `GdkFileList` is what a modern file manager sends, but some
+/// sources — older Qt apps, a few portal implementations — hand over a single `GFile`
+/// instead, and a window that only listens for the list silently rejects those.
+pub(super) fn accept_drops(convert: &Rc<Convert>) {
+    let list = gtk::DropTarget::new(gdk::FileList::static_type(), gdk::DragAction::COPY);
+    let weak = Rc::downgrade(convert);
+    list.connect_drop(move |_, value, _, _| {
+        let Ok(files) = value.get::<gdk::FileList>() else {
+            return false;
+        };
+        let paths = files.files().iter().filter_map(gio::File::path).collect();
+        take(&weak, paths);
+        true
+    });
+    convert.window().add_controller(list);
+
+    let single = gtk::DropTarget::new(gio::File::static_type(), gdk::DragAction::COPY);
+    let weak = Rc::downgrade(convert);
+    single.connect_drop(move |_, value, _, _| {
+        let Ok(file) = value.get::<gio::File>() else {
+            return false;
+        };
+        let Some(path) = file.path() else {
+            return false;
+        };
+        take(&weak, vec![path]);
+        true
+    });
+    convert.window().add_controller(single);
+}
+
+pub(super) fn pick_files(convert: &Rc<Convert>) {
+    let dialog = gtk::FileDialog::builder()
+        .title("Chọn tệp cần chuyển mã")
+        .modal(true)
+        .build();
+    let weak = Rc::downgrade(convert);
+    dialog.open_multiple(
+        Some(convert.window()),
+        gio::Cancellable::NONE,
+        move |result| {
+            let Ok(files) = result else { return };
+            let paths = (0..files.n_items())
+                .filter_map(|i| files.item(i))
+                .filter_map(|obj| obj.downcast::<gio::File>().ok())
+                .filter_map(|file| file.path())
+                .collect();
+            take(&weak, paths);
+        },
+    );
+}
+
+/// Read what arrived, off the UI thread.
+///
+/// A folder of a few hundred documents is I/O bound, and doing it inline would hold
+/// the window still for the whole drop. `gio::spawn_blocking` hands back a future, so
+/// the result lands on the main context with no channel in between —
+/// `glib::MainContext::channel` was removed in glib 0.20.
+fn take(convert: &Weak<Convert>, paths: Vec<PathBuf>) {
+    let weak = convert.clone();
+    glib::spawn_future_local(async move {
+        let entries =
+            gio::spawn_blocking(move || funput_convert::scan(&funput_convert::collect(&paths)))
+                .await;
+        let Some(convert) = weak.upgrade() else {
+            return;
+        };
+        let Ok(entries) = entries else { return };
+        convert.state.borrow_mut().files = entries;
+        convert.set_progress(String::new());
+    });
+}

--- a/platforms/linux/settings-gtk/src/convert/io/act.rs
+++ b/platforms/linux/settings-gtk/src/convert/io/act.rs
@@ -1,0 +1,108 @@
+//! What the four buttons do.
+//!
+//! **The clipboard is never watched.** It is read when the button is pressed and
+//! written when the result is copied, and at no other time. A Vietnamese input method
+//! reading the clipboard in the background is exactly the thing users are right to be
+//! suspicious of.
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+use gtk::{gio, glib};
+
+use crate::convert::Convert;
+
+/// Paste the clipboard into the text pane.
+pub(in crate::convert) fn paste(convert: &Rc<Convert>) {
+    let clipboard = convert.window().clipboard();
+    let weak = Rc::downgrade(convert);
+    glib::spawn_future_local(async move {
+        let Ok(Some(text)) = clipboard.read_text_future().await else {
+            return;
+        };
+        let Some(convert) = weak.upgrade() else {
+            return;
+        };
+        convert.state.borrow_mut().set_input(text.to_string());
+        convert.set_progress(String::new());
+    });
+}
+
+/// Copy the converted document.
+///
+/// **From the state, not from the pane.** The pane holds a capped preview of a long
+/// document, and copying that would hand over a document with its tail quietly
+/// missing.
+pub(in crate::convert) fn copy_result(convert: &Rc<Convert>) {
+    let converted = {
+        let state = convert.state.borrow();
+        state
+            .conversion()
+            .map(|(text, from, to)| funput_convert::preview(text, from, to).text)
+    };
+    let Some(converted) = converted else { return };
+    convert.window().clipboard().set_text(&converted);
+    convert.set_progress("Đã chép kết quả".to_string());
+}
+
+/// Save the converted paragraph to a file the user picks.
+///
+/// Bytes, not text. A legacy target stores one byte per letter, and writing the same
+/// characters as UTF-8 would spend two on each and produce a file `.VnTime` cannot
+/// read back — the one mistake that would make the whole window pointless.
+pub(in crate::convert) fn save_result(convert: &Rc<Convert>) {
+    let bytes = {
+        let state = convert.state.borrow();
+        state
+            .conversion()
+            .map(|(text, from, to)| funput_convert::bytes(text, from, to))
+    };
+    let Some(bytes) = bytes else { return };
+
+    let dialog = gtk::FileDialog::builder()
+        .title("Lưu tệp đã chuyển mã")
+        .modal(true)
+        .build();
+    dialog.set_initial_name(Some("chuyen-ma.txt"));
+    let weak = Rc::downgrade(convert);
+    dialog.save(
+        Some(convert.window()),
+        gio::Cancellable::NONE,
+        move |result| {
+            let Some(path) = result.ok().and_then(|file| file.path()) else {
+                return;
+            };
+            let Some(convert) = weak.upgrade() else {
+                return;
+            };
+            convert.set_progress(match std::fs::write(&path, &bytes) {
+                Ok(()) => format!("Đã lưu {}", path.display()),
+                Err(error) => format!("Không lưu được: {error}"),
+            });
+        },
+    );
+}
+
+/// Convert and write the batch, off the UI thread.
+pub(in crate::convert) fn convert_files(convert: &Rc<Convert>) {
+    let (entries, target) = {
+        let state = convert.state.borrow();
+        (state.files.clone(), crate::convert::state::at(state.target))
+    };
+    convert.set_busy(true);
+    convert.set_progress("Đang chuyển…".to_string());
+
+    let weak = Rc::downgrade(convert);
+    glib::spawn_future_local(async move {
+        let outcome =
+            gio::spawn_blocking(move || funput_convert::write_all(&entries, target)).await;
+        let Some(convert) = weak.upgrade() else {
+            return;
+        };
+        convert.set_busy(false);
+        convert.set_progress(match outcome {
+            Ok(outcome) => funput_convert::report(&outcome),
+            Err(_) => "Không chuyển được".to_string(),
+        });
+    });
+}

--- a/platforms/linux/settings-gtk/src/convert/open.rs
+++ b/platforms/linux/settings-gtk/src/convert/open.rs
@@ -1,0 +1,82 @@
+//! Building the Chuyển mã window, and reusing the one already up.
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use adw::prelude::*;
+use adw::Application;
+use gtk::glib;
+
+use super::state::State;
+use super::{io, ui, Convert};
+
+thread_local! {
+    /// The open window, or nothing.
+    ///
+    /// It has to be held somewhere: every closure the widgets own takes a `Weak`, so
+    /// without this the whole thing would be freed the moment `present` returned and
+    /// the window would go dead on its first click. It doubles as the lookup that
+    /// makes a second launch re-present rather than open a duplicate.
+    static OPEN: RefCell<Option<Rc<Convert>>> = const { RefCell::new(None) };
+}
+
+/// Show the Chuyển mã window, reusing the one already open.
+///
+/// Deliberately does **not** send a first-run user through onboarding first: someone
+/// who opened the converter from the app grid asked for the converter, and this
+/// window needs no settings to work.
+pub fn present(app: &Application) {
+    if let Some(convert) = OPEN.with(|open| open.borrow().clone()) {
+        convert.window.present();
+        return;
+    }
+    let convert = build(app);
+    convert.window.connect_close_request(|_| {
+        OPEN.with(|open| *open.borrow_mut() = None);
+        glib::Propagation::Proceed
+    });
+    OPEN.with(|open| *open.borrow_mut() = Some(convert.clone()));
+    convert.window.present();
+}
+
+fn build(app: &Application) -> Rc<Convert> {
+    let panes = ui::Panes::new();
+    let restart = gtk::Button::with_label("Bắt đầu lại");
+    let header = adw::HeaderBar::new();
+    header.pack_end(&restart);
+
+    let content = adw::ToolbarView::builder().content(&panes.stack).build();
+    content.add_top_bar(&header);
+
+    let window = adw::ApplicationWindow::builder()
+        .application(app)
+        .title("Funput — Chuyển mã")
+        .default_width(880)
+        .default_height(600)
+        .width_request(640)
+        .height_request(460)
+        .content(&content)
+        .build();
+
+    let convert = Rc::new(Convert {
+        window,
+        restart,
+        state: RefCell::new(State::new()),
+        panes,
+        refreshing: Cell::new(false),
+        busy: Cell::new(false),
+        progress: RefCell::new(String::new()),
+    });
+
+    convert.panes.wire(&convert);
+    io::accept_drops(&convert);
+    let weak = Rc::downgrade(&convert);
+    convert.restart.connect_clicked(move |_| {
+        if let Some(convert) = weak.upgrade() {
+            *convert.state.borrow_mut() = State::new();
+            convert.set_progress(String::new());
+        }
+    });
+    convert.refresh();
+    convert
+}

--- a/platforms/linux/settings-gtk/src/convert/state.rs
+++ b/platforms/linux/settings-gtk/src/convert/state.rs
@@ -1,0 +1,180 @@
+//! The window's state, and every decision made from it.
+//!
+//! **This is the only file under `convert/` that holds a decision.** Which shape the
+//! window is in, which source charset wins, what a picker index means, what happens
+//! when an index is out of range — all of it lives here, so all of it is testable
+//! without a display. The `ui/*` files read this and set properties; they decide
+//! nothing.
+//!
+//! A charset is an **index into [`charset::ALL`]**, here and in every dropdown. No
+//! file under `convert/` names a charset, so implementing VISCII in core lengthens
+//! every menu in this window without a line changing in it.
+
+use funput_convert::{
+    charset::{self, Charset},
+    Entry, Mode,
+};
+
+pub struct State {
+    /// Index into [`charset::ALL`]. Unicode by default: converting *to* it is what
+    /// nearly everyone opening this window came to do.
+    pub target: usize,
+    /// Text state. `None` until something is identified or the user picks.
+    pub source: Option<usize>,
+    pub input: String,
+    pub files: Vec<Entry>,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl State {
+    pub const fn new() -> Self {
+        Self {
+            target: 0,
+            source: None,
+            input: String::new(),
+            files: Vec::new(),
+        }
+    }
+
+    pub fn mode(&self) -> Mode {
+        Mode::of(&self.files, &self.input)
+    }
+
+    /// The source charset for the pasted paragraph, identifying it if nothing has
+    /// been settled yet.
+    ///
+    /// **The user's own choice outranks the guess**: they are looking at the document
+    /// and the detector is looking at statistics. Caches the answer back into
+    /// `source`, so the guess is made once per document rather than once per redraw.
+    pub fn resolve_source(&mut self) -> Option<usize> {
+        let source = self
+            .source
+            .map_or_else(|| charset::detect(&self.input).and_then(index_of), Some);
+        self.source = source;
+        source
+    }
+
+    /// A fresh paste is a fresh document: what the user chose for the last one says
+    /// nothing about this one, so it is identified again.
+    pub fn set_input(&mut self, text: String) {
+        self.input = text;
+        self.source = None;
+    }
+
+    /// The source picker was used.
+    ///
+    /// The same picker serves a pasted paragraph and a single file — they share the
+    /// text shape on screen — so it has to land on whichever one is showing.
+    pub fn pick_source(&mut self, picked: Option<usize>) {
+        match self.files.as_mut_slice() {
+            [only] => only.charset = picked.map(at),
+            _ => self.source = picked,
+        }
+    }
+
+    /// A row's own picker was used, in the batch shape.
+    pub fn pick_file_source(&mut self, row: usize, picked: usize) {
+        if let Some(entry) = self.files.get_mut(row) {
+            entry.charset = Some(at(picked));
+        }
+    }
+
+    /// The source and target the current content converts through, or `None` when
+    /// nothing has explained it yet.
+    pub fn conversion(&self) -> Option<(&str, Charset, Charset)> {
+        let (from, text) = match self.files.as_slice() {
+            [only] => (only.charset, only.text.as_str()),
+            _ => (self.source.map(at), self.input.as_str()),
+        };
+        from.map(|from| (text, from, at(self.target)))
+    }
+}
+
+/// The charset an index names, clamped.
+///
+/// An index can only come from a menu this window built out of `ALL`, so clamping
+/// keeps a future mistake a wrong entry rather than a panic.
+pub fn at(index: usize) -> Charset {
+    charset::ALL[index.min(charset::ALL.len() - 1)]
+}
+
+pub fn index_of(charset: Charset) -> Option<usize> {
+    charset::ALL.iter().position(|&c| c == charset)
+}
+
+/// The display names for every dropdown, in `ALL`'s order.
+pub fn names() -> Vec<&'static str> {
+    charset::ALL.iter().map(|c| c.name()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(charset: Option<Charset>) -> Entry {
+        Entry {
+            path: std::path::PathBuf::from("a.txt"),
+            text: "việt".to_string(),
+            charset,
+            unmapped: 0,
+        }
+    }
+
+    /// The user is looking at the document; the detector is looking at statistics.
+    #[test]
+    fn a_charset_the_user_picked_outranks_the_detected_one() {
+        let mut state = State::new();
+        state.set_input("việt nam".to_string());
+        state.pick_source(Some(1));
+
+        assert_eq!(state.resolve_source(), Some(1));
+    }
+
+    /// What was chosen for the last document says nothing about this one.
+    #[test]
+    fn a_fresh_paste_forgets_the_charset_of_the_last_one() {
+        let mut state = State::new();
+        state.set_input("việt nam".to_string());
+        state.pick_source(Some(2));
+        state.set_input("hà nội".to_string());
+
+        assert_eq!(state.source, None, "the last choice outlived its document");
+    }
+
+    /// A single file wears the text shape, so the one source picker on screen has to
+    /// write into the file — not into the pasted-text slot nobody can see.
+    #[test]
+    fn the_source_picker_lands_on_the_single_file_when_one_is_open() {
+        let mut state = State {
+            files: vec![entry(None)],
+            ..State::new()
+        };
+        state.pick_source(Some(1));
+
+        assert_eq!(state.files[0].charset, Some(at(1)));
+        assert_eq!(state.source, None, "it wrote into the wrong slot");
+    }
+
+    /// A longer menu than `ALL` can only come from a bug; it must land on a wrong
+    /// entry rather than take the window down.
+    #[test]
+    fn an_index_from_a_longer_menu_is_clamped_rather_than_panicking() {
+        assert_eq!(at(99), charset::ALL[charset::ALL.len() - 1]);
+    }
+
+    /// Two files are a table; one is not.
+    #[test]
+    fn the_content_decides_the_shape() {
+        let mut state = State::new();
+        assert_eq!(state.mode(), Mode::Empty);
+        state.set_input("việt".to_string());
+        assert_eq!(state.mode(), Mode::Text);
+        state.files = vec![entry(None), entry(None)];
+        assert_eq!(state.mode(), Mode::Files);
+    }
+}

--- a/platforms/linux/settings-gtk/src/convert/ui.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui.rs
@@ -1,0 +1,82 @@
+//! The window's widget tree, and pushing the state into it.
+//!
+//! **The skeleton is built once and only ever has properties set on it.** Windows can
+//! literally rebuild its window on every change because Slint properties are values;
+//! recreating a `TextView` here would destroy focus, the caret and the selection on
+//! every keystroke. What survives the translation is the discipline that matters:
+//! every callback is *mutate the state, then refresh*, no callback touches a widget
+//! directly, and [`Panes::refresh`] sets every property it owns rather than the ones
+//! it thinks changed.
+//!
+//! Two places deviate, and each says why where it happens: the input buffer in
+//! [`text::Pane`], and the batch list in [`files::Pane`], which is the closest thing
+//! GTK has to Slint swapping a model.
+
+mod empty;
+mod files;
+mod text;
+mod widget;
+
+use std::rc::Rc;
+
+use funput_convert::Mode;
+
+use crate::convert::state::State;
+use crate::convert::Convert;
+
+/// The three shapes, and the stack that shows one of them.
+pub(super) struct Panes {
+    pub(super) stack: gtk::Stack,
+    empty: empty::Pane,
+    text: text::Pane,
+    files: files::Pane,
+}
+
+impl Panes {
+    pub(super) fn new() -> Self {
+        let empty = empty::Pane::new();
+        let text = text::Pane::new();
+        let files = files::Pane::new();
+
+        let stack = gtk::Stack::builder()
+            .vexpand(true)
+            .margin_top(18)
+            .margin_bottom(18)
+            .margin_start(18)
+            .margin_end(18)
+            .build();
+        stack.add_named(&empty.root, Some("empty"));
+        stack.add_named(&text.root, Some("text"));
+        stack.add_named(&files.root, Some("files"));
+
+        Self {
+            stack,
+            empty,
+            text,
+            files,
+        }
+    }
+
+    pub(super) fn wire(&self, convert: &Rc<Convert>) {
+        self.empty.wire(convert);
+        self.text.wire(convert);
+        self.files.wire(convert);
+    }
+
+    pub(super) fn refresh(&self, convert: &Rc<Convert>, state: &mut State) {
+        match state.mode() {
+            Mode::Empty => self.stack.set_visible_child_name("empty"),
+            // One shape, two sources. A pasted paragraph and a single file look the
+            // same on screen; which one it is decides where the panes are filled
+            // from, and the pane settles that for itself.
+            Mode::Text => {
+                self.text.refresh(convert, state);
+                self.stack.set_visible_child_name("text");
+            }
+            Mode::Files => {
+                self.files.refresh(convert, state);
+                self.stack.set_visible_child_name("files");
+            }
+        }
+    }
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/empty.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/empty.rs
@@ -1,0 +1,88 @@
+//! The starting state: the drop zone, and the two ways in without dragging.
+//!
+//! Files arrive by drop, which is registered on the window rather than here — see
+//! [`crate::convert::io`]. Nothing in this pane listens for one; this is only what
+//! the user is told and the two buttons that do the same thing by hand.
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::{io, Convert};
+
+pub(in crate::convert) struct Pane {
+    pub(in crate::convert) root: adw::StatusPage,
+    paste: gtk::Button,
+    pick: gtk::Button,
+}
+
+impl Pane {
+    pub(in crate::convert) fn new() -> Self {
+        let paste = gtk::Button::builder()
+            .label("Dán văn bản")
+            .css_classes(["suggested-action", "pill"])
+            .build();
+        let pick = gtk::Button::builder()
+            .label("Chọn tệp…")
+            .css_classes(["pill"])
+            .build();
+
+        let buttons = gtk::Box::builder()
+            .orientation(gtk::Orientation::Horizontal)
+            .spacing(12)
+            .halign(gtk::Align::Center)
+            .build();
+        buttons.append(&paste);
+        buttons.append(&pick);
+
+        // Worth saying out loud: the tool people are coming from takes one source
+        // charset for a whole folder, so nobody expects a batch to be read file by
+        // file. It is the reason to drag more than one thing in here.
+        //
+        // The folder name comes from `funput_convert::OUT_DIR` rather than being
+        // spelled again — this sentence is a promise about where the file will be,
+        // and the user goes looking there.
+        let batch = gtk::Label::builder()
+            .label(format!(
+                "Hỗ trợ chuyển đổi nhiều tệp cùng lúc, tệp chuyển đổi xong sẽ được lưu \
+                 vào thư mục {} — cùng cấp với tệp nguồn.",
+                funput_convert::OUT_DIR
+            ))
+            .wrap(true)
+            .justify(gtk::Justification::Center)
+            .css_classes(["dim-label", "caption"])
+            .build();
+
+        let body = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .spacing(18)
+            .build();
+        body.append(&batch);
+        body.append(&buttons);
+
+        let root = adw::StatusPage::builder()
+            .icon_name("document-edit-symbolic")
+            .title("Thả tệp vào đây, hoặc dán văn bản")
+            .description("Funput tự nhận ra bảng mã — không cần chọn nguồn.")
+            .child(&body)
+            .vexpand(true)
+            .build();
+
+        Self { root, paste, pick }
+    }
+
+    pub(in crate::convert) fn wire(&self, convert: &Rc<Convert>) {
+        let weak = Rc::downgrade(convert);
+        self.paste.connect_clicked(move |_| {
+            if let Some(convert) = weak.upgrade() {
+                io::paste(&convert);
+            }
+        });
+        let weak = Rc::downgrade(convert);
+        self.pick.connect_clicked(move |_| {
+            if let Some(convert) = weak.upgrade() {
+                io::pick_files(&convert);
+            }
+        });
+    }
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/files.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/files.rs
@@ -1,0 +1,134 @@
+//! Batch state: one row per file, each with the charset **it** turned out to be.
+//!
+//! This is where the tool beats the one it replaces. UniKey's file converter takes a
+//! single source charset for a whole folder, so an archive holding documents from
+//! different eras converts most of itself to nonsense. Here every file is read on its
+//! own, and a file nothing explains is left alone with its own picker rather than
+//! being swept along with the rest.
+//!
+//! A `ListBox` rebuilt from the state, not a `ColumnView`. `ColumnView` recycles its
+//! rows, and a recycled row's dropdown fires `notify::selected` while it is being
+//! bound — which writes a "choice" into whichever entry the row used to show. That is
+//! a nasty bug to own, and the boxed list is what the rest of this app looks like.
+
+mod row;
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::state::{self, State};
+use crate::convert::ui::widget;
+use crate::convert::{io, Convert};
+
+/// How many rows to build. The counts and the writing run over the whole batch, so a
+/// capped list stays honest — it is the rebuilding of two thousand rows on every
+/// target change that is visibly slow.
+const ROWS: usize = 500;
+
+pub(in crate::convert) struct Pane {
+    pub(in crate::convert) root: gtk::Box,
+    count: gtk::Label,
+    target: gtk::DropDown,
+    list: gtk::ListBox,
+    progress: gtk::Label,
+    action: gtk::Button,
+}
+
+impl Pane {
+    pub(in crate::convert) fn new() -> Self {
+        let count = gtk::Label::builder().css_classes(["dim-label"]).build();
+        let target = gtk::DropDown::from_strings(&state::names());
+
+        let head = gtk::Box::builder().spacing(8).build();
+        head.append(&count);
+        head.append(&gtk::Box::builder().hexpand(true).build());
+        head.append(&widget::caption("Sang"));
+        head.append(&target);
+
+        let list = gtk::ListBox::builder()
+            .selection_mode(gtk::SelectionMode::None)
+            .css_classes(["boxed-list"])
+            .build();
+        let scroller = gtk::ScrolledWindow::builder()
+            .child(&list)
+            .vexpand(true)
+            .build();
+
+        let progress = widget::caption("");
+        progress.set_hexpand(true);
+        progress.set_ellipsize(gtk::pango::EllipsizeMode::Middle);
+        let action = gtk::Button::builder()
+            .css_classes(["suggested-action"])
+            .build();
+
+        let footer = gtk::Box::builder().spacing(8).build();
+        footer.append(&progress);
+        footer.append(&action);
+
+        let root = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .spacing(12)
+            .build();
+        root.append(&head);
+        root.append(&scroller);
+        root.append(&footer);
+
+        Self {
+            root,
+            count,
+            target,
+            list,
+            progress,
+            action,
+        }
+    }
+
+    pub(in crate::convert) fn wire(&self, convert: &Rc<Convert>) {
+        widget::connect_dropdown(&self.target, convert, |convert, index| {
+            convert.state.borrow_mut().target = index;
+        });
+        let weak = Rc::downgrade(convert);
+        self.action.connect_clicked(move |_| {
+            if let Some(convert) = weak.upgrade() {
+                io::convert_files(&convert);
+            }
+        });
+    }
+
+    pub(in crate::convert) fn refresh(&self, convert: &Rc<Convert>, state: &State) {
+        let total = state.files.len();
+        self.count.set_label(&format!("{total} tệp"));
+        widget::select(&self.target, Some(state.target));
+
+        while let Some(child) = self.list.first_child() {
+            self.list.remove(&child);
+        }
+        for (index, entry) in state.files.iter().take(ROWS).enumerate() {
+            self.list.append(&row::build(convert, index, entry));
+        }
+        if total > ROWS {
+            let rest = total - ROWS;
+            let more = adw::ActionRow::builder()
+                .title(format!("và {rest} tệp khác"))
+                .css_classes(["dim-label"])
+                .build();
+            self.list.append(&more);
+        }
+
+        // A file nothing explained is skipped, not guessed at, so the button counts
+        // only what is settled — and says so, rather than promising the whole batch.
+        let ready = funput_convert::ready(&state.files);
+        self.action.set_label(&format!("Chuyển {ready} tệp"));
+        self.action.set_sensitive(ready > 0 && !convert.is_busy());
+        // Before a run, the footer is a promise about where the files will land; once
+        // one has happened, it is the report. Never both, and never the promise after.
+        let progress = convert.progress();
+        let footer = if progress.is_empty() {
+            format!("Lưu vào: {}", funput_convert::out_dir_label(&state.files))
+        } else {
+            progress
+        };
+        self.progress.set_label(&footer);
+    }
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/files/row.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/files/row.rs
@@ -1,0 +1,35 @@
+//! One file's row in the batch list.
+//!
+//! Built fresh on every refresh rather than recycled. That is the whole reason this
+//! list is a `ListBox` and not a `ColumnView` — see the module doc next door.
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::state;
+use crate::convert::ui::widget;
+use crate::convert::Convert;
+
+/// One file's row: what it is, what it will cost, and its own escape hatch.
+pub(super) fn build(
+    convert: &Rc<Convert>,
+    index: usize,
+    entry: &funput_convert::Entry,
+) -> adw::ActionRow {
+    let picker = gtk::DropDown::from_strings(&state::names());
+    picker.set_valign(gtk::Align::Center);
+    widget::select(&picker, entry.charset.and_then(state::index_of));
+    widget::connect_dropdown(&picker, convert, move |convert, picked| {
+        convert.state.borrow_mut().pick_file_source(index, picked);
+    });
+
+    let row = adw::ActionRow::builder().title(entry.name()).build();
+    row.set_title_lines(1);
+    if entry.unmapped > 0 {
+        row.set_subtitle(&format!("{} chữ sẽ mất", entry.unmapped));
+        row.add_css_class("warning");
+    }
+    row.add_suffix(&picker);
+    row
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/text.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/text.rs
@@ -1,0 +1,115 @@
+//! Text state: what you have on the left, what it will become on the right.
+//!
+//! Also the shape a **single** dropped file takes. A batch needs a table because no
+//! two rows are alike; one file has nothing to compare against, and a one-row table
+//! hides the thing the user actually wants to see — whether the Vietnamese comes out
+//! right. What differs is the footer, which is [`footer`]'s problem.
+//!
+//! The source is *stated*, not asked for — `Đây là` with the dropdown demoted to an
+//! escape hatch. That inversion is the point of the whole window: the tool can read
+//! the document, so it should not make the user guess first.
+//!
+//! Filling all of this from the state is [`show`]'s job.
+
+mod footer;
+mod show;
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::state;
+use crate::convert::ui::widget;
+use crate::convert::Convert;
+
+pub(in crate::convert) struct Pane {
+    pub(in crate::convert) root: gtk::Box,
+    source_label: gtk::Label,
+    source: gtk::DropDown,
+    target: gtk::DropDown,
+    input: gtk::TextView,
+    output: gtk::TextView,
+    loss: gtk::Label,
+    footer: footer::Footer,
+}
+
+impl Pane {
+    pub(in crate::convert) fn new() -> Self {
+        let names = state::names();
+        let source_label = gtk::Label::builder().css_classes(["dim-label"]).build();
+        let source = gtk::DropDown::from_strings(&names);
+        let target = gtk::DropDown::from_strings(&names);
+
+        let head = gtk::Box::builder().spacing(8).build();
+        head.append(&source_label);
+        head.append(&source);
+        head.append(&gtk::Box::builder().hexpand(true).build());
+        head.append(&widget::caption("Sang"));
+        head.append(&target);
+
+        let (input, input_box) = widget::pane("Đang có");
+        let (output, output_box) = widget::pane("Sẽ thành");
+        output.set_editable(false);
+        output.set_cursor_visible(false);
+
+        let panes = gtk::Box::builder().spacing(12).vexpand(true).build();
+        panes.append(&input_box);
+        panes.append(&output_box);
+
+        // Only shown when something will actually be lost. A line that shows every
+        // time is a line people stop reading.
+        let loss = gtk::Label::builder()
+            .wrap(true)
+            .xalign(0.0)
+            .css_classes(["warning", "caption"])
+            .build();
+
+        let footer = footer::Footer::new();
+        let root = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .spacing(12)
+            .build();
+        root.append(&head);
+        root.append(&panes);
+        root.append(&loss);
+        root.append(&footer.root);
+
+        Self {
+            root,
+            source_label,
+            source,
+            target,
+            input,
+            output,
+            loss,
+            footer,
+        }
+    }
+
+    pub(in crate::convert) fn wire(&self, convert: &Rc<Convert>) {
+        let weak = Rc::downgrade(convert);
+        self.input.buffer().connect_changed(move |buffer| {
+            let Some(convert) = weak.upgrade() else {
+                return;
+            };
+            // A refresh writing into this buffer is not the user typing, and the
+            // handler below treats every edit as a fresh paste — without this guard,
+            // dropping a file would forget what the file turned out to be.
+            if convert.is_refreshing() {
+                return;
+            }
+            let (start, end) = buffer.bounds();
+            let typed = buffer.text(&start, &end, false).to_string();
+            convert.state.borrow_mut().set_input(typed);
+            convert.refresh();
+        });
+
+        widget::connect_dropdown(&self.source, convert, |convert, index| {
+            convert.state.borrow_mut().pick_source(Some(index));
+        });
+        widget::connect_dropdown(&self.target, convert, |convert, index| {
+            convert.state.borrow_mut().target = index;
+        });
+        self.footer.wire(convert);
+    }
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/text/footer.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/text/footer.rs
@@ -1,0 +1,84 @@
+//! The text pane's footer: what happened, and what to do about it.
+//!
+//! Two primary buttons, never both. Pasted text goes through a Save dialog to a
+//! path the user picks; a **dropped file** goes to the folder beside it under its own
+//! name, the same way a batch does — no dialog, and never over the original.
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::state::State;
+use crate::convert::ui::widget;
+use crate::convert::{io, Convert};
+
+pub(in crate::convert) struct Footer {
+    pub(in crate::convert) root: gtk::Box,
+    progress: gtk::Label,
+    copy: gtk::Button,
+    save: gtk::Button,
+    convert_file: gtk::Button,
+}
+
+impl Footer {
+    pub(in crate::convert) fn new() -> Self {
+        let progress = widget::caption("");
+        progress.set_hexpand(true);
+        progress.set_ellipsize(gtk::pango::EllipsizeMode::Middle);
+
+        let copy = gtk::Button::with_label("Chép kết quả");
+        let save = gtk::Button::builder()
+            .label("Lưu tệp…")
+            .css_classes(["suggested-action"])
+            .build();
+        let convert_file = gtk::Button::builder()
+            .label("Chuyển tệp")
+            .css_classes(["suggested-action"])
+            .build();
+
+        let root = gtk::Box::builder().spacing(8).build();
+        root.append(&progress);
+        root.append(&copy);
+        root.append(&save);
+        root.append(&convert_file);
+
+        Self {
+            root,
+            progress,
+            copy,
+            save,
+            convert_file,
+        }
+    }
+
+    pub(in crate::convert) fn wire(&self, convert: &Rc<Convert>) {
+        click(&self.copy, convert, io::copy_result);
+        click(&self.save, convert, io::save_result);
+        click(&self.convert_file, convert, io::convert_files);
+    }
+
+    pub(in crate::convert) fn refresh(
+        &self,
+        convert: &Rc<Convert>,
+        state: &State,
+        from_file: bool,
+    ) {
+        self.save.set_visible(!from_file);
+        self.convert_file.set_visible(from_file);
+        // Nothing to copy or write until something has explained the document.
+        let ready = state.conversion().is_some();
+        self.copy.set_sensitive(ready);
+        self.save.set_sensitive(ready);
+        self.convert_file.set_sensitive(ready && !convert.is_busy());
+        self.progress.set_label(&convert.progress());
+    }
+}
+
+fn click(button: &gtk::Button, convert: &Rc<Convert>, action: fn(&Rc<Convert>)) {
+    let weak = Rc::downgrade(convert);
+    button.connect_clicked(move |_| {
+        if let Some(convert) = weak.upgrade() {
+            action(&convert);
+        }
+    });
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/text/show.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/text/show.rs
@@ -1,0 +1,88 @@
+//! Filling the text pane from the state.
+//!
+//! Every property this pane owns is set on every refresh, unconditionally. With
+//! three shapes and two charsets in play, setting them one at a time is how a window
+//! ends up showing a target it is no longer converting to.
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::state::{self, State};
+use crate::convert::ui::widget;
+use crate::convert::Convert;
+
+use super::Pane;
+
+impl Pane {
+    pub(in crate::convert) fn refresh(&self, convert: &Rc<Convert>, state: &mut State) {
+        let from_file = !state.files.is_empty();
+        let source = match state.files.first() {
+            Some(only) => only.charset.and_then(state::index_of),
+            None => state.resolve_source(),
+        };
+
+        // Stated, not asked — until nothing can state it, and then it has to ask.
+        self.source_label.set_label(if source.is_some() {
+            "Đây là"
+        } else {
+            "Chưa đoán được — chọn bảng mã:"
+        });
+        self.source_label.set_css_classes(if source.is_some() {
+            &["dim-label"]
+        } else {
+            &["warning"]
+        });
+        widget::select(&self.source, source);
+        widget::select(&self.target, Some(state.target));
+
+        // A file is a document being converted, not a draft being written.
+        self.input.set_editable(!from_file);
+
+        let (shown, converted, loss) = views(state);
+        self.show_input(&shown);
+        self.output.buffer().set_text(&converted);
+        self.loss.set_label(&loss);
+        self.loss.set_visible(!loss.is_empty());
+        self.footer.refresh(convert, state, from_file);
+    }
+
+    /// Write the input pane without moving the caret.
+    ///
+    /// Rewriting a buffer that already holds this text sends the cursor home, so
+    /// every keystroke would bounce the caret to position zero. Not writing at all is
+    /// the fix; the *other* hazard — this write being read as typing — is settled by
+    /// [`Convert::is_refreshing`], because it bites four different signals.
+    fn show_input(&self, text: &str) {
+        let buffer = self.input.buffer();
+        let (start, end) = buffer.bounds();
+        if buffer.text(&start, &end, false) != text {
+            buffer.set_text(text);
+        }
+    }
+}
+
+/// What the two panes and the warning line show for the current state.
+///
+/// **Nothing is converted under a guess.** With no source settled the right pane
+/// shows the document back rather than a conversion, and the warning stays quiet
+/// until the picker is used — a wrong guess dressed up as a result is exactly what
+/// this window exists to prevent.
+///
+/// The panes are capped; the conversion and both counters are not. A long document
+/// cannot make the window crawl, and the numbers stay honest.
+fn views(state: &State) -> (String, String, String) {
+    let Some((text, from, to)) = state.conversion() else {
+        let text = state
+            .files
+            .first()
+            .map_or(state.input.as_str(), |file| file.text.as_str());
+        let shown = funput_convert::capped(text);
+        return (shown.clone(), shown, String::new());
+    };
+    (
+        funput_convert::capped(text),
+        funput_convert::capped(&funput_convert::preview(text, from, to).text),
+        funput_convert::loss(text, from, to),
+    )
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/widget.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/widget.rs
@@ -1,0 +1,81 @@
+//! The widget-building bits more than one pane needs.
+//!
+//! Nothing here decides anything — that is [`crate::convert::state`]'s job. These
+//! only build, and set what they are told to set.
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::Convert;
+
+/// A titled `TextView` in a scroller, for one half of the before/after pair.
+pub(in crate::convert) fn pane(title: &str) -> (gtk::TextView, gtk::Box) {
+    let view = gtk::TextView::builder()
+        .wrap_mode(gtk::WrapMode::WordChar)
+        .left_margin(8)
+        .right_margin(8)
+        .top_margin(8)
+        .bottom_margin(8)
+        .build();
+    let scroller = gtk::ScrolledWindow::builder()
+        .child(&view)
+        .vexpand(true)
+        .has_frame(true)
+        .build();
+    let boxed = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .spacing(4)
+        .hexpand(true)
+        .build();
+    boxed.append(&caption(title));
+    boxed.append(&scroller);
+    (view, boxed)
+}
+
+pub(in crate::convert) fn caption(text: &str) -> gtk::Label {
+    gtk::Label::builder()
+        .label(text)
+        .xalign(0.0)
+        .css_classes(["dim-label", "caption"])
+        .build()
+}
+
+/// Point a dropdown at a charset index, or at nothing.
+///
+/// `INVALID_LIST_POSITION` is the GTK spelling of "nothing settled yet" — the same
+/// thing the Windows window says with `-1`. Skipping an unchanged write keeps the
+/// signal traffic down; the guard that actually matters is
+/// [`Convert::is_refreshing`], because this write does fire `notify::selected`.
+pub(in crate::convert) fn select(dropdown: &gtk::DropDown, index: Option<usize>) {
+    let wanted = index.map_or(gtk::INVALID_LIST_POSITION, |i| i as u32);
+    if dropdown.selected() != wanted {
+        dropdown.set_selected(wanted);
+    }
+}
+
+/// Connect a dropdown to a state edit.
+///
+/// Ignores the "no selection" position that [`select`] writes when nothing has been
+/// settled — a window populating itself is not a user making a choice.
+pub(in crate::convert) fn connect_dropdown(
+    dropdown: &gtk::DropDown,
+    convert: &Rc<Convert>,
+    edit: impl Fn(&Rc<Convert>, usize) + 'static,
+) {
+    let weak = Rc::downgrade(convert);
+    dropdown.connect_selected_notify(move |dropdown| {
+        let Some(convert) = weak.upgrade() else {
+            return;
+        };
+        if convert.is_refreshing() {
+            return;
+        }
+        let selected = dropdown.selected();
+        if selected == gtk::INVALID_LIST_POSITION {
+            return;
+        }
+        edit(&convert, selected as usize);
+        convert.refresh();
+    });
+}

--- a/platforms/linux/settings-gtk/src/main.rs
+++ b/platforms/linux/settings-gtk/src/main.rs
@@ -1,9 +1,14 @@
-//! Funput Linux — Settings & Onboarding window (GTK4 + libadwaita).
+//! Funput Linux — Settings, Onboarding, and the Chuyển mã window (GTK4 + libadwaita).
 //!
 //! Typing is handled by the Fcitx5 addon (`platforms/linux/fcitx5`) or the IBus
-//! engine (`platforms/linux/ibus`); this binary only edits the shared settings
-//! file (`~/.config/Funput/settings.json`). No tray: VI/EN toggling and the status
-//! icon are provided by Fcitx5/IBus themselves. Replaces the retired Tauri shell.
+//! engine (`platforms/linux/ibus`); this binary edits the shared settings file
+//! (`~/.config/Funput/settings.json`) and hosts the charset converter. No tray: VI/EN
+//! toggling and the status icon are provided by Fcitx5/IBus themselves. Replaces the
+//! retired Tauri shell.
+//!
+//! One binary, two launchers. `funput-settings.desktop` runs it plain;
+//! `funput-convert.desktop` runs it with `--convert`. Both reach the *same* process,
+//! which is what keeps one settings file and one instance.
 
 #[cfg(not(target_os = "linux"))]
 compile_error!(
@@ -11,12 +16,14 @@ compile_error!(
 );
 
 mod config_transfer;
+mod convert;
 mod onboarding;
 mod settings;
 mod settings_window;
 
 use adw::prelude::*;
 use adw::Application;
+use gtk::gio;
 use gtk::glib;
 
 use crate::settings::Settings;
@@ -24,26 +31,59 @@ use crate::settings::Settings;
 // Matches the bundle identifier used across platforms.
 const APP_ID: &str = "app.funput.funput";
 
+/// The flag the second launcher passes.
+const CONVERT: &str = "--convert";
+
 fn main() -> glib::ExitCode {
-    let app = Application::builder().application_id(APP_ID).build();
-    app.connect_activate(on_activate);
-    // run() reads std::env::args; AdwApplication initializes libadwaita on startup.
+    // `HANDLES_COMMAND_LINE`, not the default flags, because the default ones do not
+    // forward argv to the running instance at all — the primary only ever sees
+    // `activate`, and `--convert` would vanish without a trace. `HANDLES_OPEN` is the
+    // wrong tool too: it forwards *files*, not flags.
+    let app = Application::builder()
+        .application_id(APP_ID)
+        .flags(gio::ApplicationFlags::HANDLES_COMMAND_LINE)
+        .build();
+    app.connect_command_line(|app, command_line| {
+        let wants_convert = command_line
+            .arguments()
+            .iter()
+            .any(|arg| arg == std::ffi::OsStr::new(CONVERT));
+        route(app, wants_convert);
+        0
+    });
+    // Still needed: a desktop file with `DBusActivatable`, or a session restoring the
+    // app, activates it without ever going through a command line.
+    app.connect_activate(|app| route(app, false));
     app.run()
 }
 
-/// Single-instance behaviour: GApplication routes a second launch here, so just
-/// re-present the existing window instead of opening a duplicate. First run walks
-/// onboarding; afterwards it opens Settings directly.
-fn on_activate(app: &Application) {
-    if let Some(win) = app.active_window() {
-        win.present();
+fn route(app: &Application, wants_convert: bool) {
+    if wants_convert {
+        convert::present(app);
         return;
     }
-
-    let settings = Settings::load();
-    if settings.has_completed_onboarding {
+    // Re-present the *settings* window, not whatever happens to be focused.
+    // `active_window()` would raise the Chuyển mã window when it is the one in front,
+    // so asking for Settings while converting would appear to do nothing at all.
+    if let Some(window) = window_named(app, SETTINGS) {
+        window.present();
+        return;
+    }
+    if Settings::load().has_completed_onboarding {
         settings_window::build(app).present();
     } else {
         onboarding::build(app).present();
     }
+}
+
+/// The name Settings answers to. Onboarding and Settings are both `adw::Window` and
+/// Chuyển mã is an `adw::ApplicationWindow`, so a downcast cannot tell the first two
+/// apart — they say who they are instead.
+pub(crate) const SETTINGS: &str = "settings";
+
+/// The application's window with a given name, if one is open.
+fn window_named(app: &Application, name: &str) -> Option<gtk::Window> {
+    app.windows()
+        .into_iter()
+        .find(|window| window.widget_name() == name)
 }

--- a/platforms/linux/settings-gtk/src/settings_window.rs
+++ b/platforms/linux/settings-gtk/src/settings_window.rs
@@ -4,8 +4,8 @@
 
 mod keyboard;
 mod overview;
-mod sidebar;
 mod shortcuts;
+mod sidebar;
 mod typing;
 
 use adw::prelude::*;
@@ -24,6 +24,9 @@ pub fn build(app: &Application) -> Window {
         .icon_name("funput")
         .build();
     window.set_application(Some(app));
+    // `route` in main.rs finds this by name: Settings and onboarding are both
+    // `adw::Window`, so a downcast cannot tell them apart.
+    window.set_widget_name(crate::SETTINGS);
 
     let stack = ViewStack::new();
     let title = WindowTitle::new(Destination::Overview.title(), "");

--- a/platforms/linux/settings-gtk/src/settings_window/shortcuts.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/shortcuts.rs
@@ -15,6 +15,14 @@ use crate::settings::{Settings, Shortcut};
 mod empty;
 mod row;
 
+/// The "throw the list away and build it again" closure, held so the rows it builds
+/// can call it.
+///
+/// `AdwPreferencesGroup` has no "remove every row", so a list that changes is rebuilt
+/// by hand — and each row needs to reach the very closure that made it. That is a
+/// cycle by nature, so it goes through a cell filled *after* the closure exists.
+pub(super) type Rebuild = Rc<RefCell<Option<Rc<dyn Fn()>>>>;
+
 pub(super) fn page() -> gtk::Widget {
     let list_page = PreferencesPage::builder()
         .title("Gõ tắt")
@@ -32,7 +40,7 @@ pub(super) fn page() -> gtk::Widget {
     let pages = gtk::Stack::new();
     let rows: Rc<RefCell<Vec<gtk::Widget>>> = Rc::new(RefCell::new(Vec::new()));
     let focus_new = Rc::new(Cell::new(false));
-    let rebuild: Rc<RefCell<Option<Rc<dyn Fn()>>>> = Rc::new(RefCell::new(None));
+    let rebuild: Rebuild = Rc::new(RefCell::new(None));
 
     let rebuild_impl: Rc<dyn Fn()> = {
         let group = group.clone();

--- a/platforms/linux/settings-gtk/src/settings_window/shortcuts/row.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/shortcuts/row.rs
@@ -1,6 +1,3 @@
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use adw::prelude::*;
 use adw::{EntryRow, ExpanderRow};
 use gtk::{Align, Button};
@@ -10,7 +7,7 @@ use crate::settings::{Settings, Shortcut};
 pub(super) fn build(
     index: usize,
     shortcut: &Shortcut,
-    rebuild: &Rc<RefCell<Option<Rc<dyn Fn()>>>>,
+    rebuild: &super::Rebuild,
 ) -> (ExpanderRow, EntryRow) {
     let expander = ExpanderRow::builder()
         .title(if shortcut.trigger.is_empty() {
@@ -77,7 +74,7 @@ fn bind_focus(index: usize, entry: &EntryRow, trigger: bool) {
     entry.add_controller(focus);
 }
 
-fn delete_button(index: usize, rebuild: &Rc<RefCell<Option<Rc<dyn Fn()>>>>) -> Button {
+fn delete_button(index: usize, rebuild: &super::Rebuild) -> Button {
     let button = Button::builder()
         .icon_name("user-trash-symbolic")
         .valign(Align::Center)

--- a/platforms/linux/settings-gtk/src/settings_window/sidebar.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/sidebar.rs
@@ -2,12 +2,15 @@
 //! A new page is one [`Destination`] variant plus a `ViewStack` child.
 
 pub(super) mod about;
+mod destination;
 mod tools;
 mod transfer;
 
 use adw::prelude::*;
 use adw::{ActionRow, NavigationSplitView, ViewStack, WindowTitle};
 use gtk::{ListBox, Orientation, SelectionMode};
+
+pub(in crate::settings_window) use destination::Destination;
 
 /// Switch the content pane and header. Overview status rows and the sidebar
 /// list both call this so a later shortcut (step 4) can reuse the same path.
@@ -25,66 +28,13 @@ pub(super) fn show(
     split.set_show_content(true);
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub(super) enum Destination {
-    Overview,
-    Typing,
-    Keyboard,
-    Shortcuts,
-    About,
-}
-
-impl Destination {
-    pub(super) const ALL: [Self; 5] = [
-        Self::Overview,
-        Self::Typing,
-        Self::Keyboard,
-        Self::Shortcuts,
-        Self::About,
-    ];
-
-    pub(super) const fn id(self) -> &'static str {
-        match self {
-            Self::Overview => "overview",
-            Self::Typing => "typing",
-            Self::Keyboard => "keyboard",
-            Self::Shortcuts => "shortcuts",
-            Self::About => "about",
-        }
-    }
-
-    pub(super) const fn title(self) -> &'static str {
-        match self {
-            Self::Overview => "Tổng quan",
-            Self::Typing => "Cách gõ",
-            Self::Keyboard => "Phím tắt",
-            Self::Shortcuts => "Gõ tắt",
-            Self::About => "Giới thiệu",
-        }
-    }
-
-    pub(super) const fn icon(self) -> &'static str {
-        match self {
-            Self::Overview => "preferences-system-symbolic",
-            Self::Typing => "input-keyboard-symbolic",
-            Self::Keyboard => "preferences-desktop-keyboard-shortcuts-symbolic",
-            Self::Shortcuts => "edit-find-replace-symbolic",
-            Self::About => "help-about-symbolic",
-        }
-    }
-
-    fn from_id(id: &str) -> Option<Self> {
-        Self::ALL.into_iter().find(|dest| dest.id() == id)
-    }
-}
-
 pub(super) fn widget(
     stack: &ViewStack,
     split: &NavigationSplitView,
     window: &adw::Window,
     title: &WindowTitle,
 ) -> gtk::Widget {
-    let list = nav_list(stack, split, title);
+    let list = nav_list(stack, split, window, title);
     let list_sync = list.clone();
     stack.connect_visible_child_name_notify(move |stack| {
         sync_list(&list_sync, stack);
@@ -114,7 +64,12 @@ fn sync_list(list: &ListBox, stack: &ViewStack) {
     }
 }
 
-fn nav_list(stack: &ViewStack, split: &NavigationSplitView, title: &WindowTitle) -> ListBox {
+fn nav_list(
+    stack: &ViewStack,
+    split: &NavigationSplitView,
+    window: &adw::Window,
+    title: &WindowTitle,
+) -> ListBox {
     let list = ListBox::new();
     list.add_css_class("navigation-sidebar");
     list.set_selection_mode(SelectionMode::Single);
@@ -126,6 +81,13 @@ fn nav_list(stack: &ViewStack, split: &NavigationSplitView, title: &WindowTitle)
             .build();
         row.add_prefix(&gtk::Image::from_icon_name(dest.icon()));
         list.append(&row);
+        // Chuyển mã sits with the pages because that is where people look for it,
+        // but it is not one: it opens a window of its own. Linux has no tray, so
+        // this row and `funput-convert.desktop` are what stand in for the item
+        // Windows puts there.
+        if dest == Destination::Shortcuts {
+            list.append(&tools::convert_row(window));
+        }
     }
 
     let stack = stack.clone();
@@ -143,4 +105,3 @@ fn nav_list(stack: &ViewStack, split: &NavigationSplitView, title: &WindowTitle)
     }
     list
 }
-

--- a/platforms/linux/settings-gtk/src/settings_window/sidebar/about.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/sidebar/about.rs
@@ -45,10 +45,7 @@ fn hero() -> gtk::Widget {
     tagline.set_wrap(true);
     tagline.set_justify(Justification::Left);
     tagline.set_halign(Align::Start);
-    let version = gtk::Label::new(Some(&format!(
-        "Phiên bản {}",
-        env!("CARGO_PKG_VERSION")
-    )));
+    let version = gtk::Label::new(Some(&format!("Phiên bản {}", env!("CARGO_PKG_VERSION"))));
     version.add_css_class("caption");
     version.add_css_class("dim-label");
     version.set_halign(Align::Start);

--- a/platforms/linux/settings-gtk/src/settings_window/sidebar/destination.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/sidebar/destination.rs
@@ -1,0 +1,54 @@
+//! The sidebar's pages. Adding one is a variant here plus a `ViewStack` child.
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(in crate::settings_window) enum Destination {
+    Overview,
+    Typing,
+    Keyboard,
+    Shortcuts,
+    About,
+}
+
+impl Destination {
+    pub(in crate::settings_window) const ALL: [Self; 5] = [
+        Self::Overview,
+        Self::Typing,
+        Self::Keyboard,
+        Self::Shortcuts,
+        Self::About,
+    ];
+
+    pub(in crate::settings_window) const fn id(self) -> &'static str {
+        match self {
+            Self::Overview => "overview",
+            Self::Typing => "typing",
+            Self::Keyboard => "keyboard",
+            Self::Shortcuts => "shortcuts",
+            Self::About => "about",
+        }
+    }
+
+    pub(in crate::settings_window) const fn title(self) -> &'static str {
+        match self {
+            Self::Overview => "Tổng quan",
+            Self::Typing => "Cách gõ",
+            Self::Keyboard => "Phím tắt",
+            Self::Shortcuts => "Gõ tắt",
+            Self::About => "Giới thiệu",
+        }
+    }
+
+    pub(in crate::settings_window) const fn icon(self) -> &'static str {
+        match self {
+            Self::Overview => "preferences-system-symbolic",
+            Self::Typing => "input-keyboard-symbolic",
+            Self::Keyboard => "preferences-desktop-keyboard-shortcuts-symbolic",
+            Self::Shortcuts => "edit-find-replace-symbolic",
+            Self::About => "help-about-symbolic",
+        }
+    }
+
+    pub(super) fn from_id(id: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|dest| dest.id() == id)
+    }
+}

--- a/platforms/linux/settings-gtk/src/settings_window/sidebar/tools.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/sidebar/tools.rs
@@ -1,4 +1,5 @@
-//! Import / export rows at the bottom of the sidebar.
+//! Sidebar rows that *do* something rather than go somewhere: the converter, and
+//! import / export.
 
 use adw::prelude::*;
 use adw::ActionRow;
@@ -26,5 +27,34 @@ pub(super) fn widget(window: &adw::Window) -> ListBox {
 fn tool_row(title: &str, icon: &str) -> ActionRow {
     let row = ActionRow::builder().title(title).activatable(true).build();
     row.add_prefix(&gtk::Image::from_icon_name(icon));
+    row
+}
+
+/// The Chuyển mã row: looks like a destination, acts like a button.
+///
+/// **Not selectable, and that is the whole trick.** The list selects one row and the
+/// content pane follows it; a row with no page behind it would leave the sidebar
+/// highlighting one thing while the pane shows another. A non-selectable row still
+/// activates, so the highlight stays on whichever page is actually open.
+pub(super) fn convert_row(window: &adw::Window) -> ActionRow {
+    let row = ActionRow::builder()
+        .title("Chuyển mã")
+        .activatable(true)
+        .selectable(false)
+        .build();
+    row.add_prefix(&gtk::Image::from_icon_name(
+        "accessories-character-map-symbolic",
+    ));
+    let parent = window.clone();
+    row.connect_activated(move |_| {
+        // Through the same door the launcher uses, so there is one path in and one
+        // place that decides whether to reuse the window already open.
+        if let Some(app) = parent
+            .application()
+            .and_then(|app| app.downcast::<adw::Application>().ok())
+        {
+            crate::convert::present(&app);
+        }
+    });
     row
 }


### PR DESCRIPTION
Bản GTK4 của cửa sổ Slint trên Windows — cùng ba trạng thái, cùng bốn nước đi hơn UniKey, cùng từng câu chữ. **Fcitx5 và iBus dùng chung**: nó không hỏi khung nào đang chạy, không đọc `settings.json`, không chạm engine. Cả hai đã phụ thuộc gói `funput-settings` tại đúng phiên bản nên nhận nó mà không sửa dòng C++ nào.

Ba thứ khác Windows:

- **Không có tray.** Fcitx5/iBus tự vẽ status icon. Thay bằng hai cửa: hàng **Chuyển mã** trong sidebar Cài đặt (ngay dưới Gõ tắt), và `funput-convert.desktop` chạy `funput-settings --convert`. Hàng đó nằm cùng các trang vì đó là chỗ người ta tìm, nhưng nó không phải một trang — nó mở cửa sổ riêng, nên `.selectable(false)`: một hàng không có trang phía sau sẽ khiến sidebar sáng ở một chỗ trong khi pane hiện chỗ khác. Cùng một tiến trình → cần `HANDLES_COMMAND_LINE`, vì cờ mặc định của GApplication không chuyển tiếp argv.
- **Dựng lại từ state, có điều chỉnh.** Tạo lại `TextView` mỗi phím gõ sẽ giết focus và con trỏ, nên bộ khung dựng một lần và một cờ `refreshing` chặn tái nhập cho cả bốn tín hiệu mà `refresh()` tự phát.
- **Ký tự điều khiển.** `TextBuffer` nhận cả độ dài chứ không dừng ở NUL. `capped()` khử C0 trong crate dùng chung → Windows hưởng luôn.

Kèm **cổng CI đầu tiên** cho `settings-gtk`: fmt + clippy + test. Cần GTK hệ thống nên phải là job riêng.

Lỗi clippy có sẵn (`type_complexity`, 4 chỗ) tách thành commit riêng đứng trước, nếu không nhánh đỏ ở commit giữa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
