### PR TITLE
fix(convert): make the preview show what the file will hold

### DIFF
--- a/crates/funput-cli/src/convert/mod.rs
+++ b/crates/funput-cli/src/convert/mod.rs
@@ -78,11 +78,12 @@ pub fn run(args: ConvertArgs) -> CliResult {
     };
 
     // Through the pivot, which is what makes this one command rather than one per
-    // pair: core reads `from` into Unicode, and writes Unicode back out as `to`.
-    let read = charset::convert(&input.text, from, Charset::Unicode);
-    let (bytes, written) = charset::encode_bytes(&read.text, to);
-    sink::write(&bytes)?;
-    report::losses(&read, &written);
+    // pair: core reads `from` into Unicode, and renders Unicode back out as `to`.
+    // The same two calls the converter windows make, so a document converted here
+    // and a document converted there cannot come out differently.
+    let rendered = charset::render(&charset::read(&input.text, from), to);
+    sink::write(&rendered.bytes)?;
+    report::losses(&rendered.cost);
     Ok(ExitCode::SUCCESS)
 }
 

--- a/crates/funput-cli/src/convert/report.rs
+++ b/crates/funput-cli/src/convert/report.rs
@@ -3,7 +3,7 @@
 //! All of it goes to standard error, because standard output carries the converted
 //! document and `funput convert … > out.txt` has to produce exactly that file.
 
-use funput_core::charset::{self, Charset, Conversion};
+use funput_core::charset::{self, Charset, Cost};
 
 /// What to say when nothing could be guessed and nothing was declared.
 pub(super) const UNDETECTED: &str =
@@ -47,18 +47,18 @@ pub(super) fn unknown_slug(slug: &str) -> String {
 /// `normalized` is deliberately silent. Converting to Unicode tổ hợp respells every
 /// toned vowel and none of it is a loss, so counting it would train the reader to
 /// ignore this line.
-pub(super) fn losses(read: &Conversion, written: &Conversion) {
-    if read.unmapped > 0 {
+pub(super) fn losses(cost: &Cost) {
+    if cost.undefined > 0 {
         eprintln!(
             "warning: {} character(s) the source charset does not define — \
              the file may be damaged, or --from may be wrong",
-            read.unmapped
+            cost.undefined
         );
     }
-    if written.unmapped > 0 {
+    if cost.unrepresentable > 0 {
         eprintln!(
             "warning: {} character(s) the target charset cannot represent",
-            written.unmapped
+            cost.unrepresentable
         );
     }
 }

--- a/crates/funput-cli/src/convert/tests.rs
+++ b/crates/funput-cli/src/convert/tests.rs
@@ -7,9 +7,12 @@ use super::*;
 fn pipeline(bytes: &[u8], to: Charset) -> (Vec<u8>, usize, usize) {
     let doc = document::read(bytes.to_vec()).expect("well-formed fixture");
     let from = doc.charset.expect("fixture should be identifiable");
-    let read = charset::convert(&doc.text, from, Charset::Unicode);
-    let (out, written) = charset::encode_bytes(&read.text, to);
-    (out, read.unmapped, written.unmapped)
+    let rendered = charset::render(&charset::read(&doc.text, from), to);
+    (
+        rendered.bytes,
+        rendered.cost.undefined,
+        rendered.cost.unrepresentable,
+    )
 }
 
 #[test]

--- a/crates/funput-convert/README.md
+++ b/crates/funput-convert/README.md
@@ -21,7 +21,7 @@ từng tồn tại hai bản, mỗi shell một, rồi trôi khỏi nhau.
 
 Tiền lệ cho phần chuỗi là `funput_core::charset::Charset::name()` — nó sống trong lõi
 chính là để một menu trên Windows và một menu trên Linux không tự đặt tên lấy rồi lệch nhau.
-Hai câu trong `loss()` cùng hạng: chúng là *phát biểu về tài liệu*, không phải chrome.
+Hai câu trong `warning()` cùng hạng: chúng là *phát biểu về tài liệu*, không phải chrome.
 
 Còn một lợi ích thứ hai, lớn hơn: `platforms/windows` và `platforms/linux/settings-gtk` đều
 nằm **ngoài** cargo workspace, nên `cargo clippy --workspace`, `cargo test --workspace` và
@@ -41,10 +41,9 @@ pub use funput_core::charset;   // để consumer chỉ cần MỘT dependency
 pub enum Mode { Empty, Text, Files }
 impl Mode { pub fn of(files: &[Entry], input: &str) -> Self; }
 
-// Một đoạn văn bản
-pub fn preview(text: &str, from: Charset, to: Charset) -> Conversion;
-pub fn bytes(text: &str, from: Charset, to: Charset) -> Vec<u8>;
-pub fn loss(text: &str, from: Charset, to: Charset) -> String;
+// Một đoạn văn bản. Phép chuyển là `charset::read` + `charset::render` của core —
+// dùng chung với `funput convert`; ở đây chỉ còn câu chữ và bản cắt để hiển thị.
+pub fn warning(cost: &Cost, from: Charset, to: Charset) -> String;
 pub fn capped(text: &str) -> String;
 
 // Một lô tệp
@@ -70,7 +69,7 @@ nói sẵn đây là một đoạn văn hay một lô tệp. Và **một tệp �
 bảng một hàng**: một tệp không có gì để so sánh, nên bảng sẽ giấu mất đúng thứ người dùng
 muốn xem — tiếng Việt có ra đúng không.
 
-**`loss()` là hai câu, không phải một.** Đọc có thể hỏng (ký tự bảng mã *nguồn* không định
+**`warning()` là hai câu, không phải một.** Đọc có thể hỏng (ký tự bảng mã *nguồn* không định
 nghĩa — nghĩa là chọn sai nguồn, hoặc tệp đã hỏng) và ghi có thể hỏng (ký tự bảng mã *đích*
 không viết được — một cái giá để chấp nhận hoặc né). Chỉ báo cái thứ hai chính là thứ từng
 để một phỏng đoán nguồn sai đi qua trong im lặng. Câu phía đích **gọi tên** ký tự, tối đa

--- a/crates/funput-convert/src/batch.rs
+++ b/crates/funput-convert/src/batch.rs
@@ -9,7 +9,7 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-use funput_core::charset::{self, Charset, document};
+use funput_core::charset::{Charset, document, read, render};
 
 /// One file, as read.
 #[derive(Clone)]
@@ -96,8 +96,9 @@ pub fn measure(entries: &mut [Entry], target: Charset) {
     for entry in entries {
         entry.unmapped = match entry.charset {
             Some(from) => {
-                let unicode = charset::convert(&entry.text, from, Charset::Unicode);
-                charset::convert(&unicode.text, Charset::Unicode, target).unmapped
+                render(&read(&entry.text, from), target)
+                    .cost
+                    .unrepresentable
             }
             None => 0,
         };

--- a/crates/funput-convert/src/lib.rs
+++ b/crates/funput-convert/src/lib.rs
@@ -36,7 +36,7 @@ mod write;
 pub use funput_core::charset;
 
 pub use batch::{Entry, collect, measure, out_dir_label, ready, scan};
-pub use text::{bytes, capped, loss, preview};
+pub use text::{capped, warning};
 pub use write::{OUT_DIR, Outcome, report, write_all};
 
 /// Which of the three shapes the window is in.

--- a/crates/funput-convert/src/text.rs
+++ b/crates/funput-convert/src/text.rs
@@ -1,11 +1,10 @@
-//! A paragraph: what it becomes, and what it costs.
+//! Saying what a conversion costs, in the words a window uses.
 //!
-//! No byte door here. Text arriving through the clipboard is already characters —
-//! a TCVN3 paragraph pasted out of Word is code points `U+0020..=U+00FF` standing in
-//! for bytes, which is exactly what [`charset::convert`] takes. Only a *file* has to
-//! go through `charset::document`, and that is [`crate::batch`]'s problem.
+//! The measuring is [`charset::Cost`]'s, in core, because a terminal needs the same
+//! numbers and words them differently. What is here is the sentence — one copy, so
+//! the window on Windows and the window on Linux cannot word it for themselves.
 
-use funput_core::charset::{self, Charset, Conversion};
+use funput_core::charset::{Charset, Cost};
 
 /// How many characters to name before the warning gets longer than it is useful.
 const NAMED: usize = 6;
@@ -17,18 +16,7 @@ const NAMED: usize = 6;
 /// file cannot make the window crawl while the counts stay honest.
 const PREVIEW: usize = 20_000;
 
-/// Convert `text` for the preview pane.
-pub fn preview(text: &str, from: Charset, to: Charset) -> Conversion {
-    charset::convert(text, from, to)
-}
-
-/// The bytes to save, for a target that stores one byte per letter.
-pub fn bytes(text: &str, from: Charset, to: Charset) -> Vec<u8> {
-    let unicode = charset::convert(text, from, Charset::Unicode);
-    charset::encode_bytes(&unicode.text, to).0
-}
-
-/// The warning, or empty when nothing will be lost.
+/// The warning line, or empty when nothing will be lost.
 ///
 /// **Two different problems, and they are not the same sentence.** Reading can fail —
 /// characters the *source* charset does not define, which means the wrong source was
@@ -44,28 +32,23 @@ pub fn bytes(text: &str, from: Charset, to: Charset) -> Vec<u8> {
 /// `normalized` is deliberately not mentioned: converting to Unicode tổ hợp respells
 /// every toned vowel and loses nothing, so counting it would teach people to ignore
 /// this line.
-pub fn loss(text: &str, from: Charset, to: Charset) -> String {
-    let unicode = charset::convert(text, from, Charset::Unicode);
+pub fn warning(cost: &Cost, from: Charset, to: Charset) -> String {
     let mut lines = Vec::new();
-    if unicode.unmapped > 0 {
+    if cost.undefined > 0 {
         lines.push(format!(
             "{} chữ không thuộc {} — có thể bảng mã nguồn chọn sai, hoặc tệp đã hỏng",
-            unicode.unmapped,
+            cost.undefined,
             from.name()
         ));
     }
-    if let Some(line) = target_line(&unicode.text, to) {
-        lines.push(line);
+    if !cost.lost.is_empty() {
+        lines.push(target_line(&cost.lost, to));
     }
     lines.join("\n")
 }
 
 /// What the target cannot represent, named rather than counted.
-fn target_line(unicode: &str, to: Charset) -> Option<String> {
-    let lost = unrepresentable(unicode, to);
-    if lost.is_empty() {
-        return None;
-    }
+fn target_line(lost: &[char], to: Charset) -> String {
     let shown: String = lost
         .iter()
         .take(NAMED)
@@ -78,30 +61,11 @@ fn target_line(unicode: &str, to: Charset) -> Option<String> {
     } else {
         String::new()
     };
-    Some(format!(
+    format!(
         "{} chữ không có trong {}:  {shown}{tail}",
         lost.len(),
         to.name()
-    ))
-}
-
-/// The distinct characters `to` cannot represent, in the order they first appear.
-///
-/// Asked one character at a time because the counter core returns is a total, not a
-/// list. Distinct characters in a document are few — a few hundred at most — so this
-/// costs a great deal less than it looks like it does.
-fn unrepresentable(unicode: &str, to: Charset) -> Vec<char> {
-    let mut seen = std::collections::HashSet::new();
-    let mut lost = Vec::new();
-    for ch in unicode.chars() {
-        if !seen.insert(ch) {
-            continue;
-        }
-        if charset::convert(&ch.to_string(), Charset::Unicode, to).unmapped > 0 {
-            lost.push(ch);
-        }
-    }
-    lost
+    )
 }
 
 /// A document trimmed to what a pane can usefully show, and made safe to show.
@@ -112,7 +76,7 @@ fn unrepresentable(unicode: &str, to: Charset) -> Vec<char> {
 /// wrongly and Pango complains in the log. Windows never noticed, which is exactly
 /// why the sanitising belongs here rather than in one shell.
 ///
-/// Only the *preview* is sanitised. The conversion and both counters still run over
+/// Only the *preview* is sanitised. The conversion and every counter still run over
 /// the real text, so nothing this hides can hide a lost character.
 pub fn capped(text: &str) -> String {
     let cut = text
@@ -134,65 +98,4 @@ pub fn capped(text: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The whole reason the line exists: it says *which* characters, not how many.
-    #[test]
-    fn the_warning_names_the_characters_that_will_not_survive() {
-        let line = loss("Ề 5₫", Charset::Unicode, Charset::Tcvn3);
-        assert!(line.contains('Ề'), "{line}");
-        assert!(line.contains('₫'), "{line}");
-        assert!(line.contains("TCVN3"), "{line}");
-    }
-
-    /// The gap a screenshot found. A character the *source* charset does not define
-    /// used to pass through in silence, so picking the wrong source looked like a
-    /// clean conversion. `U+0131` has no TCVN3 code.
-    #[test]
-    fn a_character_the_source_charset_does_not_define_is_reported() {
-        let line = loss("ngh\u{131}a", Charset::Tcvn3, Charset::Unicode);
-        assert!(line.contains("không thuộc"), "{line}");
-        assert!(line.contains("TCVN3"), "{line}");
-    }
-
-    /// The two problems are separate sentences, because they call for different
-    /// things: one says the source is wrong, the other says the target cannot cope.
-    #[test]
-    fn a_source_and_a_target_problem_are_reported_apart() {
-        let line = loss("ngh\u{131}a Ề", Charset::Tcvn3, Charset::Tcvn3);
-        assert_eq!(line.lines().count(), 2, "{line}");
-    }
-
-    /// Silent when nothing is lost, so the line keeps meaning something.
-    #[test]
-    fn nothing_is_said_when_nothing_is_lost() {
-        assert_eq!(loss("việt nam", Charset::Unicode, Charset::Tcvn3), "");
-    }
-
-    /// Respelling is not losing. Every toned vowel changes shape going to tổ hợp and
-    /// the round trip is exact, so the warning must stay quiet.
-    #[test]
-    fn respelling_is_not_reported_as_loss() {
-        assert_eq!(
-            loss("Việt Nam", Charset::Unicode, Charset::UnicodeCombining),
-            ""
-        );
-    }
-
-    /// A NUL reaching a GTK `TextBuffer` makes it measure and draw the rest of the
-    /// document wrongly, so the preview never carries one.
-    #[test]
-    fn a_control_character_cannot_reach_the_preview() {
-        let shown = capped("vi\u{0}\u{1a}t\ttab\nline");
-        assert!(!shown.contains('\u{0}'), "{shown:?}");
-        assert!(!shown.contains('\u{1a}'), "{shown:?}");
-        assert!(shown.contains('\t') && shown.contains('\n'), "{shown:?}");
-    }
-
-    /// A legacy target is written as bytes, not as UTF-8 of the same code points.
-    #[test]
-    fn saving_to_a_legacy_charset_writes_one_byte_per_letter() {
-        assert_eq!(bytes("Việt", Charset::Unicode, Charset::Tcvn3), b"Vi\xD6t");
-    }
-}
+mod tests;

--- a/crates/funput-convert/src/text/tests.rs
+++ b/crates/funput-convert/src/text/tests.rs
@@ -1,0 +1,70 @@
+use funput_core::charset::{Charset, read, render};
+
+use super::{capped, warning};
+
+/// The sentence for a document converted between two charsets, the way a window
+/// asks for it.
+fn line(text: &str, from: Charset, to: Charset) -> String {
+    warning(&render(&read(text, from), to).cost, from, to)
+}
+
+/// The whole reason the line exists: it says *which* characters, not how many.
+#[test]
+fn the_warning_names_the_characters_that_will_not_survive() {
+    let out = line("Ề 5₫", Charset::Unicode, Charset::Tcvn3);
+    assert!(out.contains('Ề'), "{out}");
+    assert!(out.contains('₫'), "{out}");
+    assert!(out.contains("TCVN3"), "{out}");
+}
+
+/// The gap a screenshot found. A character the *source* charset does not define
+/// used to pass through in silence, so picking the wrong source looked like a
+/// clean conversion. `U+0131` has no TCVN3 code.
+#[test]
+fn a_character_the_source_charset_does_not_define_is_reported() {
+    let out = line("ngh\u{131}a", Charset::Tcvn3, Charset::Unicode);
+    assert!(out.contains("không thuộc"), "{out}");
+    assert!(out.contains("TCVN3"), "{out}");
+}
+
+/// The two problems are separate sentences, because they call for different
+/// things: one says the source is wrong, the other says the target cannot cope.
+#[test]
+fn a_source_and_a_target_problem_are_reported_apart() {
+    let out = line("ngh\u{131}a Ề", Charset::Tcvn3, Charset::Tcvn3);
+    assert_eq!(out.lines().count(), 2, "{out}");
+}
+
+/// Silent when nothing is lost, so the line keeps meaning something.
+#[test]
+fn nothing_is_said_when_nothing_is_lost() {
+    assert_eq!(line("việt nam", Charset::Unicode, Charset::Tcvn3), "");
+}
+
+/// Respelling is not losing. Every toned vowel changes shape going to tổ hợp and
+/// the round trip is exact, so the warning must stay quiet.
+#[test]
+fn respelling_is_not_reported_as_loss() {
+    assert_eq!(
+        line("Việt Nam", Charset::Unicode, Charset::UnicodeCombining),
+        ""
+    );
+}
+
+/// Long lists get a tail rather than a paragraph — six names is where a warning
+/// stops helping and starts being skipped.
+#[test]
+fn a_long_list_is_cut_short_and_says_so() {
+    let out = line("日本語のテキストです", Charset::Unicode, Charset::Tcvn3);
+    assert!(out.contains("chữ khác"), "{out}");
+}
+
+/// A NUL reaching a GTK `TextBuffer` makes it measure and draw the rest of the
+/// document wrongly, so the preview never carries one.
+#[test]
+fn a_control_character_cannot_reach_the_preview() {
+    let shown = capped("vi\u{0}\u{1a}t\ttab\nline");
+    assert!(!shown.contains('\u{0}'), "{shown:?}");
+    assert!(!shown.contains('\u{1a}'), "{shown:?}");
+    assert!(shown.contains('\t') && shown.contains('\n'), "{shown:?}");
+}

--- a/crates/funput-convert/src/write.rs
+++ b/crates/funput-convert/src/write.rs
@@ -8,7 +8,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use funput_core::charset::{self, Charset};
+use funput_core::charset::{Charset, read, render};
 
 use crate::Entry;
 
@@ -19,6 +19,7 @@ use crate::Entry;
 pub const OUT_DIR: &str = "Đã chuyển mã";
 
 /// What a batch came to.
+#[non_exhaustive]
 pub struct Outcome {
     pub written: usize,
     pub skipped: usize,
@@ -47,11 +48,11 @@ pub fn write_all(entries: &[Entry], target: Charset) -> Outcome {
             outcome.skipped += 1;
             continue;
         };
-        // Through the pivot, same as everywhere else: read into Unicode, then write
-        // Unicode out as the target. `encode_bytes` is what makes a legacy target one
-        // byte per letter rather than two.
-        let unicode = charset::convert(&entry.text, from, Charset::Unicode);
-        let (bytes, _) = charset::encode_bytes(&unicode.text, target);
+        // The same two steps every consumer takes, and the same call: read the
+        // document, then render it. `render` is what makes a legacy target one byte
+        // per letter rather than two — and what makes these bytes the ones the
+        // window promised in its preview pane.
+        let bytes = render(&read(&entry.text, from), target).bytes;
         match destination(&entry.path, &mut taken)
             .and_then(|path| std::fs::write(path, &bytes).ok())
         {

--- a/crates/funput-core/src/charset/mod.rs
+++ b/crates/funput-core/src/charset/mod.rs
@@ -32,12 +32,14 @@ mod codecs;
 mod detect;
 pub mod document;
 mod identity;
+mod pipeline;
 mod pivot;
 mod transcode;
 
 pub use codecs::{decode_bytes, encode_bytes, is_byte_oriented};
 pub use detect::{detect, detect_bytes};
 pub use identity::{ALL, Charset};
+pub use pipeline::{Cost, Pivoted, Rendered, read, render};
 // `Conversion` is defined beside the loop that fills in its two counters.
 pub use transcode::Conversion;
 

--- a/crates/funput-core/src/charset/pipeline/cost.rs
+++ b/crates/funput-core/src/charset/pipeline/cost.rs
@@ -1,0 +1,74 @@
+//! What a conversion costs, as numbers and characters — never as a sentence.
+//!
+//! Two consumers need this and they word it differently: a window names the
+//! characters in Vietnamese, a terminal counts them in English. Both are right for
+//! where they are, so the wording lives with each of them and only the measurement
+//! lives here.
+
+use super::super::{Charset, Conversion, convert};
+use super::Pivoted;
+
+/// Everything a conversion lost or respelled, measured.
+///
+/// **The two failures are separate because they call for different things.** Reading
+/// can fail — characters the *source* charset does not define, which means the wrong
+/// source was picked or the document is damaged, and the user can act on that.
+/// Writing can fail — characters the *target* cannot represent, which is a cost to
+/// accept or to avoid by choosing elsewhere. A consumer that reports only the second
+/// lets a wrong source guess pass in silence.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Cost {
+    /// Characters the **source** charset never defined.
+    pub undefined: usize,
+    /// The distinct characters the **target** cannot represent, in the order they
+    /// first appear. A list rather than a count because a count tells someone
+    /// something is wrong without telling them where to look.
+    pub lost: Vec<char>,
+    /// How many times those characters occur — which is a different number, and the
+    /// one a terminal reports. `lost.len()` is what a menu names.
+    pub unrepresentable: usize,
+    /// Characters the **source** understood exactly but spelled its own way — a
+    /// tổ hợp document read as tổ hợp, or an NFD one.
+    ///
+    /// **Not a loss, and worth keeping apart from one.** The round trip is exact;
+    /// folding this into the numbers above would teach people to ignore them. It
+    /// counts on the reading side because that is the only side that can see it:
+    /// writing always starts from precomposed Unicode, which is spelled one way.
+    pub normalized: usize,
+}
+
+impl Cost {
+    /// True when nothing was lost or guessed at. Respelling does not count.
+    pub fn is_clean(&self) -> bool {
+        self.undefined == 0 && self.unrepresentable == 0
+    }
+
+    pub(super) fn of(pivoted: &Pivoted, to: Charset, out: &Conversion) -> Self {
+        Self {
+            undefined: pivoted.undefined,
+            lost: unrepresentable(&pivoted.text, to),
+            unrepresentable: out.unmapped,
+            normalized: pivoted.normalized,
+        }
+    }
+}
+
+/// The distinct characters `to` cannot represent, in the order they first appear.
+///
+/// Asked one character at a time because the counter the driver returns is a total,
+/// not a list. Distinct characters in a document are few — a few hundred at most —
+/// so this costs a great deal less than it looks like it does.
+fn unrepresentable(unicode: &str, to: Charset) -> Vec<char> {
+    let mut seen = std::collections::HashSet::new();
+    let mut lost = Vec::new();
+    for ch in unicode.chars() {
+        if !seen.insert(ch) {
+            continue;
+        }
+        if convert(&ch.to_string(), Charset::Unicode, to).unmapped > 0 {
+            lost.push(ch);
+        }
+    }
+    lost
+}

--- a/crates/funput-core/src/charset/pipeline/mod.rs
+++ b/crates/funput-core/src/charset/pipeline/mod.rs
@@ -1,0 +1,91 @@
+//! Converting a whole document, in the two steps a converter UI actually needs.
+//!
+//! [`convert`](super::convert) is one pass: `source → Atom → target`. That is the
+//! right shape for a string, and the wrong one for a window, for two reasons.
+//!
+//! **A window shows the result before it writes it.** The bytes a file receives are
+//! not the characters a pane shows — [`encode_bytes`] narrows anything that will not
+//! fit in a byte to `?`. A window that previews with one call and saves with another
+//! shows text the file will not hold. So [`render`] returns **both**, made together,
+//! and their agreement is structural rather than a convention someone has to keep.
+//!
+//! **A window changes the target, over and over.** Reading the source is the
+//! expensive half and it does not depend on the target, so it is split out:
+//! [`read`] once, [`render`] per target. That also fixes the subtler problem — a
+//! one-pass `source → target` and a two-step `source → Unicode → target` are not the
+//! same conversion, because the round trip through a real Unicode string is an extra
+//! `Atom::from_char(atom.to_char())`. That is identity for a letter the source
+//! defines and **not** for a code it does not: TCVN3's `0xC2` passes through as `Â`,
+//! whose real TCVN3 code is `0xA2`. Having one way to do this is what stops two
+//! shells from disagreeing about the same document.
+//!
+//! Not to be confused with [`pivot`](super::pivot), which is the `Atom` every codec
+//! maps to. This is the pipeline *over* it.
+
+mod cost;
+
+use super::{Charset, convert, encode_bytes, is_byte_oriented};
+
+pub use cost::Cost;
+
+/// A document read into precomposed Unicode — the half that does not depend on the
+/// target, so a window can keep it while the user tries one target after another.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Pivoted {
+    /// The document as precomposed Unicode.
+    pub text: String,
+    /// Characters the **source** charset never defined, so reading them was a guess.
+    /// A number near the length of the document is the clearest sign there is that
+    /// the wrong source was picked.
+    pub undefined: usize,
+    /// Characters understood exactly whose spelling the source wrote differently.
+    /// Not a loss.
+    pub normalized: usize,
+}
+
+/// What a target makes of a document: the characters, the bytes, and the cost.
+///
+/// `text` and `bytes` are two views of one result, not two results. For a
+/// byte-oriented target `text` is `bytes` read back as Latin-1, so a pane showing
+/// `text` shows exactly what a file holding `bytes` holds — `?` included.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Rendered {
+    pub text: String,
+    pub bytes: Vec<u8>,
+    pub cost: Cost,
+}
+
+/// Read a document into Unicode. The expensive half, and the target-independent one.
+///
+/// `from` must be what the text actually **is**; guessing it is
+/// [`detect`](super::detect)'s job, not this one's.
+pub fn read(text: &str, from: Charset) -> Pivoted {
+    let out = convert(text, from, Charset::Unicode);
+    Pivoted {
+        text: out.text,
+        undefined: out.unmapped,
+        normalized: out.normalized,
+    }
+}
+
+/// Write a read document out as `to` spells it.
+///
+/// Built on [`encode_bytes`] rather than beside it, so the bytes here are the bytes
+/// a file gets, and `text` is derived from them rather than computed in parallel.
+pub fn render(pivoted: &Pivoted, to: Charset) -> Rendered {
+    let (bytes, out) = encode_bytes(&pivoted.text, to);
+    let cost = Cost::of(pivoted, to, &out);
+    // Latin-1 is total, so reading the bytes back cannot fail — and it is the only
+    // honest answer to "what will the pane show", because it is what the file holds.
+    let text = if is_byte_oriented(to) {
+        bytes.iter().copied().map(char::from).collect()
+    } else {
+        out.text
+    };
+    Rendered { text, bytes, cost }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/funput-core/src/charset/pipeline/tests.rs
+++ b/crates/funput-core/src/charset/pipeline/tests.rs
@@ -1,0 +1,89 @@
+use super::super::Charset;
+use super::{read, render};
+
+/// **The bug this module exists to remove.** A pane showed one thing while the file
+/// received another, because the preview took the one-pass route and the save took
+/// the two-step one. `₫` has no byte in TCVN3, so the file gets `?` — and now the
+/// pane says so.
+#[test]
+fn the_text_shown_is_the_bytes_written() {
+    for to in [Charset::Tcvn3, Charset::VniWindows] {
+        let rendered = render(&read("giá 5₫", Charset::Unicode), to);
+        assert_eq!(
+            rendered.text.chars().map(|c| c as u32).collect::<Vec<_>>(),
+            rendered
+                .bytes
+                .iter()
+                .map(|&b| u32::from(b))
+                .collect::<Vec<_>>(),
+            "{to:?} shows text its own bytes do not hold",
+        );
+        assert!(rendered.text.contains('?'), "{:?}", rendered.text);
+    }
+}
+
+/// The other half: a target that is not made of bytes gets UTF-8, and the text is
+/// the text — no narrowing, and `₫` survives.
+#[test]
+fn a_target_that_is_not_bytes_keeps_every_character() {
+    let rendered = render(&read("giá 5₫", Charset::Unicode), Charset::UnicodeCombining);
+    assert!(rendered.text.contains('₫'));
+    assert_eq!(rendered.bytes, rendered.text.as_bytes());
+}
+
+/// Reading is the target-independent half, which is the whole reason it is a step of
+/// its own: a window changing the target must not pay for it twice.
+#[test]
+fn one_read_serves_every_target() {
+    let pivoted = read(
+        b"vi\xD6t nam"
+            .iter()
+            .map(|&b| char::from(b))
+            .collect::<String>()
+            .as_str(),
+        Charset::Tcvn3,
+    );
+    assert_eq!(pivoted.text, "việt nam");
+    for to in [Charset::Unicode, Charset::Tcvn3, Charset::VniWindows] {
+        assert_eq!(render(&pivoted, to).cost.undefined, 0, "{to:?}");
+    }
+}
+
+/// A code the source never defined is counted, and stays counted no matter which
+/// target is asked for — it is a fact about the *reading*, not about the writing.
+#[test]
+fn a_code_the_source_never_defined_is_reported_for_every_target() {
+    let pivoted = read("\u{C2}", Charset::Tcvn3);
+    assert_eq!(pivoted.undefined, 1);
+    for to in [Charset::Unicode, Charset::Tcvn3, Charset::VniWindows] {
+        assert_eq!(render(&pivoted, to).cost.undefined, 1, "{to:?}");
+    }
+}
+
+/// The two numbers behind the two sentences a consumer writes: how many *distinct*
+/// characters cannot be spelled, and how many times they occur. A menu names the
+/// first; a terminal counts the second.
+#[test]
+fn distinct_characters_and_total_occurrences_are_counted_apart() {
+    let cost = render(&read("₫₫₫ Ề", Charset::Unicode), Charset::Tcvn3).cost;
+    assert_eq!(cost.lost, vec!['₫', 'Ề']);
+    assert_eq!(cost.unrepresentable, 4, "three ₫ and one Ề");
+    assert!(!cost.is_clean());
+}
+
+/// Respelling is not losing.
+///
+/// It is counted on the **reading** side, because that is the only side that can see
+/// it: writing always starts from precomposed Unicode, which is spelled one way. So
+/// this reads ordinary precomposed text *as tổ hợp* — understood exactly, spelled
+/// differently — and the two loss numbers must stay at zero.
+#[test]
+fn respelling_is_not_counted_as_loss() {
+    let cost = render(
+        &read("Việt Nam", Charset::UnicodeCombining),
+        Charset::Unicode,
+    )
+    .cost;
+    assert!(cost.is_clean(), "{cost:?}");
+    assert!(cost.normalized > 0, "the spelling did change: {cost:?}");
+}

--- a/docs/features/charset.md
+++ b/docs/features/charset.md
@@ -318,6 +318,45 @@ Một chữ thường hiển thị đúng thì người dùng sửa được; m�
 văn bản `.VnTime` là rác câm. Và `unmapped` cho họ biết chính xác còn bao nhiêu chỗ
 cần để mắt tới.
 
+## Hai bước, không phải một
+
+`convert` là **một lượt**: `nguồn → Atom → đích`. Đúng cho một chuỗi, sai cho một cửa
+sổ, vì hai lý do.
+
+**Cửa sổ cho xem trước khi ghi.** Byte một tệp nhận được **không** phải ký tự khung xem
+hiển thị: `encode_bytes` thu hẹp thứ không lọt vào một byte thành `?`. Cửa sổ nào xem
+bằng một lời gọi và lưu bằng một lời gọi khác thì đang hiện thứ tệp sẽ không chứa. Nên
+`render` trả **cả hai**, làm ra cùng lúc, và việc chúng khớp nhau là chuyện cấu trúc
+chứ không phải một quy ước ai đó phải nhớ giữ.
+
+**Cửa sổ đổi bảng mã đích liên tục.** Đọc nguồn là nửa tốn kém và nó không phụ thuộc
+đích, nên tách ra: `read` một lần, `render` mỗi đích.
+
+Việc tách còn sửa một chỗ tinh tế hơn. Một lượt `nguồn → đích` và hai bước
+`nguồn → Unicode → đích` **không phải cùng một phép chuyển**: vòng qua chuỗi Unicode
+thật thêm một `Atom::from_char(atom.to_char())`, vốn là identity với chữ mà bảng mã
+nguồn có định nghĩa, và **không** phải với mã nó không định nghĩa. `0xC2` của TCVN3 đi
+qua thành `Â`, mà mã TCVN3 thật của `Â` là `0xA2`. Ca VNI còn lệch cả độ dài: `0xFD` ra
+`ý`, viết lại thành hai byte.
+
+Trước khi có tầng này, cửa sổ Windows xem bằng đường một lượt và ghi bằng đường hai
+bước — nên nó **hiển thị một đằng, lưu một nẻo**, đúng lúc người dùng cần tin vào khung
+xem nhất. Có một property test trong `tests/charset/properties.rs` ghim điều duy nhất
+khiến việc gộp chúng an toàn: hai đường chỉ khác nhau ở chỗ phép **đọc đã đếm**, nên
+đổi đường không bao giờ dịch chuyển một ký tự mà người dùng chưa được cảnh báo.
+
+### `Cost` mang số, không mang câu
+
+Hai consumer cần cùng phép đo và diễn đạt khác nhau: cửa sổ **gọi tên** ký tự bằng
+tiếng Việt, terminal **đếm** chúng bằng tiếng Anh. Nên `Cost` chỉ mang số và danh sách
+`lost`, còn câu chữ sống ở từng consumer — `funput_convert::warning()` cho hai cửa sổ,
+`funput-cli/src/convert/report.rs` cho dòng lệnh.
+
+Hai con số về đích, cố ý tách: `lost.len()` là số chữ **riêng biệt** không viết được
+(thứ một menu gọi tên), `unrepresentable` là số **lần xuất hiện** (thứ một terminal
+đếm). `normalized` đếm ở phía **đọc**, vì đó là phía duy nhất thấy được nó — phép ghi
+luôn xuất phát từ Unicode dựng sẵn, vốn chỉ có một cách viết.
+
 ## Hợp đồng mở rộng
 
 Mỗi bảng mã là một module codec cung cấp đúng hai hàm:
@@ -368,6 +407,17 @@ pub fn decode_bytes(bytes: &[u8], from: Charset) -> Conversion;
 pub fn encode_bytes(text: &str, to: Charset) -> (Vec<u8>, Conversion);
 pub fn detect(text: &str) -> Option<Charset>;
 pub fn detect_bytes(bytes: &[u8]) -> Option<Charset>;
+
+// Tầng trên cho consumer chuyển cả tài liệu — xem "Hai bước, không phải một".
+#[non_exhaustive] pub struct Pivoted { pub text: String, pub undefined: usize, pub normalized: usize }
+#[non_exhaustive] pub struct Rendered { pub text: String, pub bytes: Vec<u8>, pub cost: Cost }
+#[non_exhaustive] pub struct Cost {
+    pub undefined: usize, pub lost: Vec<char>, pub unrepresentable: usize, pub normalized: usize,
+}
+impl Cost { pub fn is_clean(&self) -> bool; }
+
+pub fn read(text: &str, from: Charset) -> Pivoted;
+pub fn render(pivoted: &Pivoted, to: Charset) -> Rendered;
 
 mod document {
     pub struct Document { pub text: String, pub charset: Option<Charset> }

--- a/platforms/linux/settings-gtk/src/convert/io/act.rs
+++ b/platforms/linux/settings-gtk/src/convert/io/act.rs
@@ -10,6 +10,8 @@ use std::rc::Rc;
 use adw::prelude::*;
 use gtk::{gio, glib};
 
+use funput_convert::charset;
+
 use crate::convert::Convert;
 
 /// Paste the clipboard into the text pane.
@@ -38,7 +40,7 @@ pub(in crate::convert) fn copy_result(convert: &Rc<Convert>) {
         let state = convert.state.borrow();
         state
             .conversion()
-            .map(|(text, from, to)| funput_convert::preview(text, from, to).text)
+            .map(|(text, from, to)| charset::render(&charset::read(text, from), to).text)
     };
     let Some(converted) = converted else { return };
     convert.window().clipboard().set_text(&converted);
@@ -55,7 +57,7 @@ pub(in crate::convert) fn save_result(convert: &Rc<Convert>) {
         let state = convert.state.borrow();
         state
             .conversion()
-            .map(|(text, from, to)| funput_convert::bytes(text, from, to))
+            .map(|(text, from, to)| charset::render(&charset::read(text, from), to).bytes)
     };
     let Some(bytes) = bytes else { return };
 

--- a/platforms/linux/settings-gtk/src/convert/ui/text/show.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/text/show.rs
@@ -8,6 +8,8 @@ use std::rc::Rc;
 
 use adw::prelude::*;
 
+use funput_convert::charset;
+
 use crate::convert::state::{self, State};
 use crate::convert::ui::widget;
 use crate::convert::Convert;
@@ -69,7 +71,11 @@ impl Pane {
 /// until the picker is used — a wrong guess dressed up as a result is exactly what
 /// this window exists to prevent.
 ///
-/// The panes are capped; the conversion and both counters are not. A long document
+/// One `read`, one `render`. The right pane is `render`'s own text, which for a
+/// legacy target is its bytes read back — so what is on screen is what the file will
+/// hold, `?` and all, rather than a second conversion that happens to look similar.
+///
+/// The panes are capped; the conversion and every counter are not. A long document
 /// cannot make the window crawl, and the numbers stay honest.
 fn views(state: &State) -> (String, String, String) {
     let Some((text, from, to)) = state.conversion() else {
@@ -80,9 +86,10 @@ fn views(state: &State) -> (String, String, String) {
         let shown = funput_convert::capped(text);
         return (shown.clone(), shown, String::new());
     };
+    let rendered = charset::render(&charset::read(text, from), to);
     (
         funput_convert::capped(text),
-        funput_convert::capped(&funput_convert::preview(text, from, to).text),
-        funput_convert::loss(text, from, to),
+        funput_convert::capped(&rendered.text),
+        funput_convert::warning(&rendered.cost, from, to),
     )
 }

--- a/platforms/windows/src/ui/convert/files/mod.rs
+++ b/platforms/windows/src/ui/convert/files/mod.rs
@@ -15,7 +15,9 @@ pub(super) use rows::{show_many, show_one};
 
 /// Convert and write the batch, off the UI thread — it is file I/O over every entry.
 pub(super) fn convert_all() {
-    let Some(window) = view::current() else { return };
+    let Some(window) = view::current() else {
+        return;
+    };
     let (entries, target) = view::STATE.with(|s| {
         let state = s.borrow();
         (state.files.clone(), view::at(state.target))
@@ -25,7 +27,9 @@ pub(super) fn convert_all() {
     std::thread::spawn(move || {
         let outcome = funput_convert::write_all(&entries, target);
         let _ = slint::invoke_from_event_loop(move || {
-            let Some(window) = view::current() else { return };
+            let Some(window) = view::current() else {
+                return;
+            };
             window.set_progress(funput_convert::report(&outcome).into());
             window.set_can_convert(true);
         });

--- a/platforms/windows/src/ui/convert/files/rows.rs
+++ b/platforms/windows/src/ui/convert/files/rows.rs
@@ -6,7 +6,11 @@
 //! the user actually wants — whether the Vietnamese comes out right. It gets the same
 //! before/after panes a pasted paragraph does.
 
-use funput_convert::{Entry, capped, charset::Charset};
+use funput_convert::{
+    capped,
+    charset::{self, Charset},
+    Entry,
+};
 use slint::{ModelRc, VecModel};
 
 use crate::ui::convert::view;
@@ -59,7 +63,7 @@ pub(in crate::ui::convert) fn show_one(window: &ConvertWindow, entry: &Entry, ta
         window.set_loss(slint::SharedString::new());
         return;
     };
-    let converted = funput_convert::preview(&entry.text, from, target);
-    window.set_output_text(capped(&converted.text).into());
-    window.set_loss(funput_convert::loss(&entry.text, from, target).into());
+    let rendered = charset::render(&charset::read(&entry.text, from), target);
+    window.set_output_text(capped(&rendered.text).into());
+    window.set_loss(funput_convert::warning(&rendered.cost, from, target).into());
 }

--- a/platforms/windows/src/ui/convert/mod.rs
+++ b/platforms/windows/src/ui/convert/mod.rs
@@ -26,7 +26,7 @@ use funput_convert::charset;
 use crate::ui::{mica, system_accent};
 use crate::{ConvertWindow, Theme};
 
-use view::{STATE, WINDOW, at, current, refresh};
+use view::{at, current, refresh, STATE, WINDOW};
 
 pub(super) fn open() {
     let window = ConvertWindow::new().expect("create convert window");
@@ -115,7 +115,7 @@ fn wire(window: &ConvertWindow) {
                 [only] => (only.charset, only.text.as_str()),
                 _ => (state.source.map(at), state.input.as_str()),
             };
-            from.map(|from| funput_convert::preview(input, from, at(state.target)).text)
+            from.map(|from| charset::render(&charset::read(input, from), at(state.target)).text)
         });
         if let Some(converted) = converted {
             win32::write(&converted);

--- a/platforms/windows/src/ui/convert/text.rs
+++ b/platforms/windows/src/ui/convert/text.rs
@@ -4,6 +4,8 @@
 //! [`funput_convert`], shared with the GTK window on Linux. What is left here is the
 //! one part that cannot be: the Save dialog.
 
+use funput_convert::charset;
+
 use super::view;
 
 /// Save the converted paragraph to a file the user picks.
@@ -12,7 +14,9 @@ use super::view;
 /// characters as UTF-8 would spend two on each and produce a file `.VnTime` cannot
 /// read back — the one mistake that would make the whole window pointless.
 pub(super) fn save() {
-    let Some(window) = view::current() else { return };
+    let Some(window) = view::current() else {
+        return;
+    };
     let (input, from, to) = view::STATE.with(|s| {
         let state = s.borrow();
         (
@@ -29,7 +33,10 @@ pub(super) fn save() {
     else {
         return;
     };
-    let message = match std::fs::write(&path, funput_convert::bytes(&input, from, to)) {
+    let message = match std::fs::write(
+        &path,
+        charset::render(&charset::read(&input, from), to).bytes,
+    ) {
         Ok(()) => format!("Đã lưu {}", path.display()),
         Err(err) => format!("Không lưu được: {err}"),
     };

--- a/platforms/windows/src/ui/convert/view.rs
+++ b/platforms/windows/src/ui/convert/view.rs
@@ -12,8 +12,8 @@
 use std::cell::RefCell;
 
 use funput_convert::{
-    Mode,
     charset::{self, Charset},
+    Mode,
 };
 use slint::Weak;
 
@@ -116,6 +116,10 @@ fn show_pasted(window: &ConvertWindow, state: &mut State, target: Charset) {
         window.set_loss(slint::SharedString::new());
         return;
     };
-    window.set_output_text(funput_convert::preview(&state.input, from, target).text.into());
-    window.set_loss(funput_convert::loss(&state.input, from, target).into());
+    // One read, one render. The pane shows `render`'s own text, which for a legacy
+    // target is its bytes read back — so what is on screen is what a saved file will
+    // hold rather than a second conversion that happens to look similar.
+    let rendered = charset::render(&charset::read(&state.input, from), target);
+    window.set_output_text(rendered.text.into());
+    window.set_loss(funput_convert::warning(&rendered.cost, from, target).into());
 }


### PR DESCRIPTION
**Lỗi thật.** Cửa sổ xem trước bằng `convert(text, from, to)` và lưu bằng `encode_bytes(convert(text, from, Unicode).text, to)`. Hai phép chuyển **khác nhau**, nên nó hiện một đằng và lưu một nẻo — đúng lúc người dùng cần tin vào khung xem nhất: tệp hỏng, hoặc chọn sai bảng mã nguồn.

Hai chỗ lệch, và test của core đã ghim sẵn cả hai:

- Một lượt decode thẳng ra `Atom`; đi vòng qua chuỗi Unicode thật thêm một `Atom::from_char(atom.to_char())`, vốn không phải identity với mã bảng mã nguồn không định nghĩa. `0xC2` của TCVN3 ra `Â`, mà mã thật của `Â` là `0xA2`. VNI còn lệch cả độ dài.
- `encode_bytes` thu hẹp thứ không lọt vào một byte thành `?`. `convert` thì không — nên `giá 5₫` xem thấy `₫` mà lưu ra `gi<á> 5?`.

`charset::read` + `charset::render` thay cả hai đường. `render` trả text và bytes **làm ra cùng lúc**, và với bảng mã byte thì text *chính là* bytes đọc ngược lại — khớp nhau về cấu trúc, không phải do quy ước.

Đặt trong **core** chứ không phải `funput-convert`, vì `funput convert` cũng cần và nó không phụ thuộc crate đó — nó có bản sao pivot riêng, helper test của nó là bản thứ tư. Giờ phép pivot tồn tại **một** bản trong repo.

⚠️ **Hành vi Windows đổi** với tài liệu chứa mã bảng mã nguồn không định nghĩa: khung xem giờ hiện đúng thứ tệp sẽ chứa. Property test ở PR trước nói rằng thay đổi này chỉ dịch chuyển được những ký tự dòng cảnh báo đã báo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)