### PR TITLE
refactor(convert): prove the session can cross a C ABI, before writing one

### DIFF
--- a/crates/funput-convert/src/lib.rs
+++ b/crates/funput-convert/src/lib.rs
@@ -46,7 +46,12 @@ pub use text::{capped, unreadable_line, warning};
 /// An index can only come from a menu built out of [`charset::ALL`], so clamping
 /// keeps a future mistake a wrong entry rather than a panic.
 pub fn at(index: usize) -> Charset {
-    charset::ALL[index.min(charset::ALL.len() - 1)]
+    charset::ALL[clamp(index)]
+}
+
+/// A menu position that exists, for the same reason [`at`] clamps.
+pub(crate) fn clamp(index: usize) -> usize {
+    index.min(charset::ALL.len() - 1)
 }
 
 pub fn index_of(charset: Charset) -> Option<usize> {

--- a/crates/funput-convert/src/session.rs
+++ b/crates/funput-convert/src/session.rs
@@ -25,7 +25,7 @@ mod query;
 mod view;
 
 use crate::batch::Entry;
-use crate::{at, index_of};
+use crate::{at, clamp, index_of};
 
 pub use job::Job;
 pub use view::{Mode, Row, Unreadable, View};
@@ -71,8 +71,11 @@ impl Session {
         self.source = None;
     }
 
+    /// Clamped on the way in, not on the way out: [`View::target`] is a position a
+    /// shell feeds straight back into its own menu, so it has to be one that exists.
+    /// A host storing the index across releases is exactly why `ALL` is append-only.
     pub fn set_target(&mut self, index: usize) {
-        self.target = index;
+        self.target = clamp(index);
     }
 
     /// The source picker was used.
@@ -83,7 +86,7 @@ impl Session {
     pub fn pick_source(&mut self, index: Option<usize>) {
         match self.files.as_mut_slice() {
             [only] => only.charset = index.map(at),
-            _ => self.source = index,
+            _ => self.source = index.map(clamp),
         }
     }
 

--- a/crates/funput-convert/tests/c_host.rs
+++ b/crates/funput-convert/tests/c_host.rs
@@ -1,0 +1,218 @@
+//! Driving a session the way a C host would, before there is a C host.
+//!
+//! macOS is Swift and cannot link this crate; its window will reach it through
+//! `funput-ffi`, whose charset door already ships the text half. Before writing that
+//! door it is worth proving the Rust side can actually cross it, because an ABI is
+//! append-only — a shape settled wrongly is settled forever.
+//!
+//! So this file exports **nothing**. It reimplements the door's conventions over the
+//! real API and drives them:
+//!
+//! - no `Charset`, no `PathBuf`, no `Option` and no borrow crosses; a charset is an
+//!   index into `charset::ALL`, "not settled" is `-1`, and text goes out UTF-32;
+//! - text writes are **all-or-nothing**: the length comes back whether or not it
+//!   fit, and nothing is written unless all of it fits (`funput-ffi`'s
+//!   `charset::write_text`, quoted in shape below);
+//! - every collection is reachable by index with a `_count` beside it;
+//! - a session that has been given nothing answers every question without panicking.
+//!
+//! What this cannot check is the `unsafe` marshalling itself. What it does check is
+//! that the values exist in a shape that marshalling can reach — which is the half
+//! that would be expensive to discover later.
+
+use funput_convert::{Job, Mode, Scan, Session};
+
+/// `funput-ffi`'s sizing rule, over a `&str` instead of a raw pointer.
+fn write_text(text: &str, out: &mut [u32]) -> usize {
+    let len = text.chars().count();
+    if out.len() < len {
+        return len;
+    }
+    for (slot, ch) in out.iter_mut().zip(text.chars()) {
+        *slot = ch as u32;
+    }
+    len
+}
+
+/// Ask for the length, allocate, ask again — the two-call dance a host does.
+fn read_text(text: &str) -> String {
+    let needed = write_text(text, &mut []);
+    let mut buffer = vec![0u32; needed];
+    let written = write_text(text, &mut buffer);
+    assert_eq!(written, needed, "the sizing call must predict the real one");
+    buffer.iter().filter_map(|&c| char::from_u32(c)).collect()
+}
+
+/// `Option<usize>` has no C spelling. `-1` is "nothing settled yet", and it is an
+/// answer rather than an error — the same thing `FUNPUT_CHARSET_UNKNOWN` means.
+const NOT_SETTLED: i32 = -1;
+
+fn position(value: Option<usize>) -> i32 {
+    value
+        .and_then(|i| i32::try_from(i).ok())
+        .unwrap_or(NOT_SETTLED)
+}
+
+fn mode_code(mode: Mode) -> u32 {
+    match mode {
+        Mode::Empty => 0,
+        Mode::Text => 1,
+        Mode::Files => 2,
+    }
+}
+
+fn scratch(name: &str, files: &[(&str, &[u8])]) -> Vec<std::path::PathBuf> {
+    let dir = std::env::temp_dir().join(format!("funput-c-host-{name}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    files
+        .iter()
+        .map(|(name, bytes)| {
+            let path = dir.join(name);
+            std::fs::write(&path, bytes).expect("seed file");
+            path
+        })
+        .collect()
+}
+
+/// The whole window, driven through nothing but integers and strings.
+#[test]
+fn a_host_can_run_the_window_without_a_single_rust_type() {
+    let mut session = Session::new();
+
+    // Build the menus. A host that spelled its own list would miss a charset added
+    // later, so it asks — count, then name by index.
+    let names = funput_convert::charset_names();
+    assert!(names.len() >= 4);
+    let named: Vec<String> = (0..names.len()).map(|i| read_text(names[i])).collect();
+    assert!(named.iter().all(|n| !n.is_empty()));
+
+    // Paste a paragraph: text in as UTF-32, a target as an index.
+    let pasted: Vec<u32> = "việt nam".chars().map(|c| c as u32).collect();
+    let text: String = pasted.iter().filter_map(|&c| char::from_u32(c)).collect();
+    session.set_input(text);
+    session.set_target(0);
+    session.refresh();
+
+    let view = session.view();
+    assert_eq!(mode_code(view.mode), 1);
+    assert_ne!(
+        position(view.source),
+        NOT_SETTLED,
+        "ASCII-free Vietnamese reads"
+    );
+    assert!(!read_text(&view.output_preview).is_empty());
+    // The left pane is the host's own buffer here, and the door must say so rather
+    // than hand back a string the host would write over its user's caret.
+    assert!(view.input_preview.is_none());
+
+    // Copy: the whole document, not the capped preview.
+    let copied = session.result_text().expect("something to copy");
+    assert_eq!(read_text(&copied), copied);
+}
+
+/// Rows are reachable by index, with a count beside them, and the window's offset is
+/// reported so a host can ask for the next slice.
+#[test]
+fn a_host_can_walk_the_batch_by_index() {
+    let paths = scratch(
+        "batch",
+        &[
+            ("a.txt", b"vi\xD6t nam"),
+            ("b.txt", "việt nam".as_bytes()),
+            ("c.txt", b"the quick \xFF brown fox jumps over"),
+        ],
+    );
+    let mut session = Session::new();
+    session.adopt(funput_convert::scan(&paths));
+    session.set_row_window(0, 2);
+    session.refresh();
+
+    let view = session.view();
+    assert_eq!(mode_code(view.mode), 2);
+    assert_eq!(view.rows_total, 3, "the count is the whole batch");
+    assert_eq!(view.rows.len(), 2, "the rows are the window");
+    assert_eq!(view.rows_first, 0);
+    for row in &view.rows {
+        assert!(!read_text(&row.name).is_empty());
+        let _: i32 = position(row.charset);
+        let _: String = read_text(&row.note);
+    }
+
+    // The next slice, asked for the same way.
+    session.set_row_window(2, 2);
+    session.refresh();
+    assert_eq!(session.view().rows_first, 2);
+    assert_eq!(session.view().rows.len(), 1);
+    assert_eq!(session.view().rows_total, 3);
+}
+
+/// A file nothing could read is reachable the same way, because a count cannot say
+/// *which* one.
+#[test]
+fn a_host_can_name_what_could_not_be_read() {
+    let paths = scratch("unreadable", &[("ok.txt", "việt".as_bytes())]);
+    let mut session = Session::new();
+    session.adopt(funput_convert::scan(&paths));
+    session.refresh();
+
+    let view = session.view();
+    for file in &view.unreadable {
+        assert!(!read_text(&file.name).is_empty());
+        assert!(!read_text(&file.reason).is_empty());
+    }
+    let _: String = read_text(&funput_convert::unreadable_line(&view.unreadable));
+}
+
+/// A charset index a host stored from an older build, or invented, lands on a wrong
+/// entry rather than taking the process down. Every door in `funput-ffi` answers a
+/// bad index with a default; nothing here may panic first.
+#[test]
+fn an_index_a_host_made_up_is_answered_rather_than_fatal() {
+    let mut session = Session::new();
+    session.set_input("việt".to_string());
+    session.set_target(usize::MAX);
+    session.pick_source(Some(usize::MAX));
+    session.pick_row_source(usize::MAX, usize::MAX);
+    session.set_row_window(usize::MAX, 0);
+    session.refresh();
+
+    // Every position the view reports has to be one a host can feed back into its
+    // own menu, so the clamping happens where the index arrives.
+    let view = session.view();
+    assert!(view.target < funput_convert::charset_names().len());
+    assert!(
+        view.source
+            .is_none_or(|i| i < funput_convert::charset_names().len())
+    );
+    assert!(view.rows.is_empty());
+}
+
+/// A handle that has been given nothing still answers everything — the shape of
+/// `funput-ffi`'s `null_and_empty_inputs_are_safe`, one layer up.
+#[test]
+fn a_session_given_nothing_answers_every_question() {
+    let mut session = Session::new();
+    session.refresh();
+
+    let view = session.view();
+    assert_eq!(mode_code(view.mode), 0);
+    assert_eq!(position(view.source), NOT_SETTLED);
+    assert_eq!(view.rows_total, 0);
+    assert_eq!(view.ready, 0);
+    assert_eq!(read_text(&view.output_preview), "");
+    assert_eq!(read_text(&view.warning), "");
+    assert!(session.result_text().is_none());
+    assert!(session.save_bytes().is_none());
+    assert_eq!(session.batch_job().run().written, 0);
+}
+
+/// The two values a shell moves off its thread have to be able to go. Both shells do
+/// it today and a C host will too — a future `Send` regression would be caught here
+/// rather than in a shell that cannot be built on this machine.
+#[test]
+fn the_work_a_shell_hands_off_can_leave_the_thread() {
+    fn assert_send<T: Send>() {}
+    assert_send::<Scan>();
+    assert_send::<Job>();
+}

--- a/crates/funput-ffi/README.en.md
+++ b/crates/funput-ffi/README.en.md
@@ -20,7 +20,7 @@ engine and the platform.
 Handle-based; results are returned **by value** (POD, no free needed); input is a **codepoint** (the
 platform maps keycode → char itself). Every function is **null-safe** (a null handle / invalid codepoint
 yields a `None` result) and **panic-safe**: every entry point that touches the engine runs inside
-`support::safe()` (`catch_unwind`), so a panic in the engine is caught at the boundary and turned into a
+`abi::safe()` (`catch_unwind`), so a panic in the engine is caught at the boundary and turned into a
 no-op result — it **never** unwinds into the host (which would abort the whole IME process).
 
 Personal suggestions use a separate opaque `FunputSuggestionEngine` handle. Queries return at most

--- a/crates/funput-ffi/README.md
+++ b/crates/funput-ffi/README.md
@@ -19,7 +19,7 @@ platform.
 
 Handle-based; kết quả trả **theo giá trị** (POD, không cần free); input là **codepoint** (platform
 tự map keycode → char). Mọi hàm **null-safe** (handle null / codepoint không hợp lệ → kết quả
-`None`) và **panic-safe**: mọi entry point chạm engine chạy trong `support::safe()`
+`None`) và **panic-safe**: mọi entry point chạm engine chạy trong `abi::safe()`
 (`catch_unwind`), nên panic trong engine bị chặn tại biên và trả kết quả no-op — **không bao giờ**
 unwind sang host (điều sẽ abort cả tiến trình IME).
 

--- a/docs/features/charset.md
+++ b/docs/features/charset.md
@@ -492,6 +492,60 @@ UTF-8, và luật byte đã trượt UTF-8 thì chỉ được trả lời bằn
 thuỷ đó ra là giao phần tinh tế cho caller và để nó bị viết lại một lần mỗi nền tảng — đúng thứ
 core sinh ra để tránh. Khi có shell cần, tầng đó thuộc về core dưới dạng **một** lời gọi.
 
+### Cửa cho cả cửa sổ — chưa viết, nhưng đã chốt hình dạng
+
+macOS cần hơn cửa text: nó cần cả cửa sổ. Thứ nó sẽ bọc là `funput_convert::Session`, và
+crate đó đã được nắn để việc bọc chỉ là cơ học — có
+`crates/funput-convert/tests/c_host.rs` lái nó **đúng theo quy ước của cửa này** để chứng
+minh, trước khi có một dòng `extern "C"` nào.
+
+Bốn điều kiện, và cả bốn đã đúng:
+
+- **Không kiểu Rust nào ở biên.** Bảng mã là chỉ số trong `ALL`; `Option<usize>` ra ngoài
+  thành `i32` với `-1` nghĩa là *chưa rõ* — một câu trả lời, không phải lỗi, y như
+  `FUNPUT_CHARSET_UNKNOWN`. Đường dẫn ra ngoài thành **tên**, không phải `PathBuf`.
+- **Không getter nào cần `&mut`.** Đó là lý do `Session` tách `refresh()` khỏi `view()`:
+  không borrow nào qua được C, nên `View` phải rã được thành từng accessor, và mỗi trường
+  phải là giá trị sở hữu chứ không phải thứ tính ra lúc hỏi.
+- **Mọi tập hợp đi được bằng chỉ số**, kèm một `_count`, và ổn định giữa hai lần `refresh`.
+- **Việc rời luồng rời dưới dạng giá trị.** `Scan` và `Job` là `Send`; `Session` ở lại.
+
+Phác hình dạng, để người làm macOS không phải thiết kế lại:
+
+```c
+FunputConvertSession *funput_convert_session_new(void);
+void funput_convert_session_free(FunputConvertSession *s);
+
+void funput_convert_set_input (FunputConvertSession*, const uint32_t *text, size_t len);
+void funput_convert_set_target(FunputConvertSession*, size_t index);
+void funput_convert_set_source(FunputConvertSession*, int32_t index);   // -1 = tự đoán
+void funput_convert_pick_row  (FunputConvertSession*, size_t row, size_t index);
+void funput_convert_set_window(FunputConvertSession*, size_t first, size_t len);
+void funput_convert_refresh   (FunputConvertSession*);   // lời gọi tốn kém — ghi rõ trong doc
+
+uint32_t funput_convert_mode(const FunputConvertSession*);
+int32_t  funput_convert_source(const FunputConvertSession*);        // -1 = chưa rõ
+int32_t  funput_convert_input_preview(const FunputConvertSession*, uint32_t *out, size_t cap);
+                                                                    // -1 = buffer của host là chủ
+size_t   funput_convert_output_preview(const FunputConvertSession*, uint32_t *out, size_t cap);
+size_t   funput_convert_warning(const FunputConvertSession*, uint32_t *out, size_t cap);
+size_t   funput_convert_row_count(const FunputConvertSession*);
+size_t   funput_convert_row_total(const FunputConvertSession*);
+int32_t  funput_convert_row_charset(const FunputConvertSession*, size_t i);
+size_t   funput_convert_row_name(const FunputConvertSession*, size_t i, uint32_t*, size_t);
+```
+
+Mọi chuỗi đi ra theo đúng luật **được ăn cả ngã không** của `write_text` ở trên. Mọi thân
+hàm nằm trong `abi::safe`. `FunputConvertOutcome` là POD mới duy nhất, và phải thêm tên
+vào `[export].include` của `cbindgen.toml`.
+
+**Một câu hỏi đã kiểm và không phải rào chắn.** Ranh giới `funput-ffi` tự tuyên bố là
+"chỉ marshal tại biên: không logic Telex/VNI, không hook/inject" — nó **không** cấm I/O
+tệp. Câu "handle không đọc/ghi file" trong README chỉ nói về `FunputAppLanguage`, và nói
+vì lý do riêng của handle đó (host tự nạp lại bằng `seed`). Cửa lô đọc và ghi tệp không
+phá vỡ gì cả: việc đọc lô nằm trong `funput-convert`, và cửa chỉ marshal lời gọi — đúng
+mô hình mục ngay trên đã lường ("tầng đó thuộc về core dưới dạng một lời gọi").
+
 ### Thứ nó không làm được
 
 Mọi phán đoán ở đây đều **tương đối**: bốn giả thuyết, cái nào khớp nhất thì thắng.


### PR DESCRIPTION
macOS là Swift, không link được crate này; cửa sổ của nó sẽ đi qua `funput-ffi`. ABI là append-only, nên hình dạng chốt sai là chốt vĩnh viễn — đáng biết ngay bây giờ phía Rust có qua được không.

`tests/c_host.rs` **không export gì**. Nó dựng lại quy ước của cửa trên API thật rồi lái cả cửa sổ qua đó: bảng mã là chỉ số, `-1` là "chưa rõ" chứ không phải lỗi, chuỗi ra UTF-32 theo luật được-ăn-cả-ngã-không, mọi tập hợp đi bằng chỉ số kèm `_count`, và một session chưa nhận gì vẫn trả lời được mọi câu.

**Nó tìm ra một khiếm khuyết thật.** `set_target(usize::MAX)` được lưu nguyên và lọt ra `View.target` — vốn là vị trí shell nạp thẳng vào menu của nó. Host lưu chỉ số từ bản cũ sẽ index trượt khỏi danh sách của chính mình. Giờ kẹp ngay chỗ chỉ số đi vào.

Cũng ghim `Scan` và `Job` là `Send` — cả hai shell mang chúng ra khỏi luồng UI, và hồi quy sẽ lộ ở đây thay vì trong bản release của shell không dựng được trên Linux.

Kèm phác hình dạng cửa trong `charset.md`, và sửa hai chỗ `support::safe()` cũ trong README `funput-ffi` (module đã là `abi::safe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)