### PR TITLE
fix(ios): disarm automatic Shift after deleting sentence boundary

### DIFF
--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/KeyboardInputCoordinator+Document.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/KeyboardInputCoordinator+Document.swift
@@ -124,11 +124,17 @@ extension KeyboardInputCoordinator {
     ) {
         guard !snapshot.hasSelection else { return }
         if preserveCapsLock, state.shiftState == .capsLocked { return }
-        if preserveOneShotShift, state.shiftState == .uppercase { return }
+        // Punctuation/space/backspace ask to keep a manual one-shot Shift, but an
+        // autocapitalization arm must follow the new context — otherwise deleting
+        // ". " leaves the keyboard stuck uppercase.
+        if preserveOneShotShift,
+           state.shiftState == .uppercase,
+           !automaticShiftArmed { return }
         let uppercase = KeyboardCapitalizationResolver.shouldUppercase(
             mode: state.autocapitalization,
             contextBeforeInput: snapshot.contextBeforeInput
         )
+        automaticShiftArmed = uppercase
         replaceState(shiftState: uppercase ? .uppercase : .lowercase)
     }
 }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/KeyboardInputCoordinator.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/KeyboardInputCoordinator.swift
@@ -15,6 +15,10 @@ public final class KeyboardInputCoordinator {
     public internal(set) var smartGesturesEnabled = true
     var documentSynchronizer = KeyboardDocumentSynchronizer()
     var suggestionTracker = AuthoredTokenTracker()
+    /// True while Shift was raised by autocapitalization (sentence/word start), not by
+    /// a Shift key tap. Backspace must recompute in that case; a manual one-shot Shift
+    /// must survive punctuation/space/delete.
+    var automaticShiftArmed = false
     var personalSuggestionsEnabled = true
     var suggestionTrackingActive = true
     var preferredTelexMethod: KeyboardInputMethod

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/State/KeyboardInputCoordinator+State.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/Coordinator/State/KeyboardInputCoordinator+State.swift
@@ -13,6 +13,7 @@ extension KeyboardInputCoordinator {
         if inputContextChanged {
             composer.clear()
             shiftController.resetTapSequence()
+            automaticShiftArmed = false
             documentSynchronizer.invalidate()
             resetPersonalSuggestionTracking()
         }
@@ -31,10 +32,12 @@ extension KeyboardInputCoordinator {
     func consumeOneShotShift() {
         guard state.shiftState == .uppercase else { return }
         shiftController.resetTapSequence()
+        automaticShiftArmed = false
         replaceState(shiftState: .lowercase)
     }
 
     func toggleShift() {
+        automaticShiftArmed = false
         replaceState(shiftState: shiftController.toggle(from: state.shiftState))
     }
 

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Coordinator/KeyboardAutocapitalizationDeletionTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Coordinator/KeyboardAutocapitalizationDeletionTests.swift
@@ -1,0 +1,52 @@
+#if os(iOS) && canImport(FunputCore)
+import Foundation
+import KeyboardInput
+import KeyboardLayout
+import Testing
+
+@MainActor
+struct KeyboardAutocapitalizationDeletionTests {
+    @Test("Deleting a sentence boundary disarms automatic Shift")
+    func deletionRecomputesAutomaticShift() {
+        let (coordinator, document) = makeSubject(context: "Hello")
+
+        type(".", role: .punctuation, with: coordinator, into: document)
+        type(" ", role: .space, with: coordinator, into: document)
+        #expect(coordinator.state.shiftState == .uppercase)
+
+        coordinator.handle(testKey(.backspace), writer: document)
+        #expect(document.text == "Hello.")
+        #expect(coordinator.state.shiftState == .lowercase)
+
+        coordinator.handle(testKey(.backspace), writer: document)
+        #expect(document.text == "Hello")
+        #expect(coordinator.state.shiftState == .lowercase)
+    }
+
+    @Test("Backspace preserves Shift when the user enabled it")
+    func deletionPreservesManualShift() {
+        let (coordinator, document) = makeSubject(context: "Hello.")
+
+        coordinator.handle(testKey(.shift), writer: document)
+        coordinator.handle(testKey(.backspace), writer: document)
+
+        #expect(document.text == "Hello")
+        #expect(coordinator.state.shiftState == .uppercase)
+    }
+
+    private func makeSubject(
+        context: String
+    ) -> (KeyboardInputCoordinator, TestKeyboardWriter) {
+        let coordinator = KeyboardInputCoordinator()
+        let document = TestKeyboardWriter()
+        document.replaceTextExternally(with: context)
+        coordinator.updateContext(inputContext(
+            editorMode: .text,
+            enterAction: .newLine,
+            autocapitalization: .sentences
+        ))
+        coordinator.synchronizeDocument(document, event: .activated)
+        return (coordinator, document)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Fix Shift stuck uppercase after deleting `.` + Space when autocapitalization is on
- Distinguish automatic vs manual one-shot Shift so backspace recomputes only for autocap

## Test plan
- [x] Enable Tự động viết hoa → type `Hello.` + Space → Shift uppercase
- [x] Backspace Space then `.` → layout returns to lowercase
- [x] Manual Shift + backspace still keeps uppercase


Made with [Cursor](https://cursor.com)