### PR TITLE
fix(linux): let the dock find the Funput icon

### DIFF
--- a/platforms/linux/packaging/funput-convert.desktop
+++ b/platforms/linux/packaging/funput-convert.desktop
@@ -6,5 +6,10 @@ Comment=Chuyển văn bản và tệp giữa Unicode, TCVN3 (ABC) và VNI-Window
 Exec=funput-settings --convert
 Icon=funput
 Terminal=false
+
+# GNOME/Wayland matches a window to its launcher by the Wayland app-id, which GTK
+# takes from the GApplication id — `app.funput.funput`, not this file's name. Without
+# this line nothing matches and the dock shows a generic icon instead of ours.
+StartupWMClass=app.funput.funput
 Categories=Utility;TextTools;
 Keywords=chuyển mã;bảng mã;tcvn3;abc;vni;unicode;unikey;convert;charset;

--- a/platforms/linux/packaging/funput-settings.desktop
+++ b/platforms/linux/packaging/funput-settings.desktop
@@ -6,5 +6,10 @@ Comment=Configure Funput — Telex, Full Telex & VNI Vietnamese typing
 Exec=funput-settings
 Icon=funput
 Terminal=false
+
+# GNOME/Wayland matches a window to its launcher by the Wayland app-id, which GTK
+# takes from the GApplication id — `app.funput.funput`, not this file's name. Without
+# this line nothing matches and the dock shows a generic icon instead of ours.
+StartupWMClass=app.funput.funput
 Categories=Utility;Settings;
 Keywords=vietnamese;telex;vni;input;gõ;tiếng việt;

--- a/platforms/linux/settings-gtk/src/convert/open.rs
+++ b/platforms/linux/settings-gtk/src/convert/open.rs
@@ -58,6 +58,9 @@ fn build(app: &Application) -> Rc<Convert> {
     let window = adw::ApplicationWindow::builder()
         .application(app)
         .title("Funput — Chuyển mã")
+        // Every window this app opens carries the icon, so an X11 session and the
+        // window's own decorations get it even where the dock matches by app-id.
+        .icon_name("funput")
         .default_width(880)
         .default_height(600)
         .width_request(640)

--- a/platforms/linux/settings-gtk/src/onboarding.rs
+++ b/platforms/linux/settings-gtk/src/onboarding.rs
@@ -19,6 +19,7 @@ const STEPS: u32 = 4;
 pub fn build(app: &Application) -> adw::Window {
     let window = adw::Window::builder()
         .title("Chào mừng đến Funput")
+        .icon_name("funput")
         .default_width(460)
         .default_height(560)
         .build();


### PR DESCRIPTION
Cả hai cửa sổ hiện icon mặc định trên dock thay vì icon Funput.

GNOME/Wayland khớp cửa sổ với launcher bằng **app-id**, thứ GTK lấy từ GApplication id — `app.funput.funput`. Không tệp `.desktop` nào tên đó, cũng không tệp nào khai `StartupWMClass`, nên không có gì khớp và shell rơi về icon mặc định. Bản thân icon vẫn nằm đúng chỗ trong theme từ đầu — chỉ là không ai đi tìm nó.

`StartupWMClass=app.funput.funput` là đúng cơ chế freedesktop đặt ra cho trường hợp tên tệp khác app-id.

Hai tệp cùng khai một class nên shell chọn một để nhóm cả hai cửa sổ; cả hai đều `Icon=funput` nên icon đúng dù nó chọn cái nào. Đổi tên tệp cho khớp app-id sẽ gọn hơn nhưng phá mọi launcher người dùng đã ghim — không đáng đổi chỉ để sửa việc nhóm.

Cửa sổ Chuyển mã và onboarding cũng thiếu `icon_name`; Cài đặt thì có. Không ảnh hưởng dock trên Wayland (app-id quyết định), nhưng đó là thứ phiên X11 và khung cửa sổ đọc.

**Đã kiểm trên máy thật** (Ubuntu GNOME/Wayland): dựng, cài vào `~/.local`, icon dock hiện đúng cho cả hai cửa sổ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)