### PR TITLE
fix(convert): stop marking Windows line endings as damage

### DIFF
--- a/crates/funput-convert/src/text.rs
+++ b/crates/funput-convert/src/text.rs
@@ -102,6 +102,12 @@ pub fn unreadable_line(files: &[Unreadable]) -> String {
 /// wrongly and Pango complains in the log. Windows never noticed, which is exactly
 /// why the sanitising belongs here rather than in one shell.
 ///
+/// A carriage return is **not** one of them. `\r` is a control character, but it is
+/// also how every Windows document ends a line, and the whole point of this tool is
+/// Windows documents — marking each one would put a `�` at the end of every line of
+/// every file it was built for. Line endings are normalised to `\n` instead: GTK and
+/// Slint both draw that as one break, where a raw `\r\n` risks two.
+///
 /// Only the *preview* is sanitised. The conversion and every counter still run over
 /// the real text, so nothing this hides can hide a lost character.
 pub fn capped(text: &str) -> String {
@@ -109,14 +115,20 @@ pub fn capped(text: &str) -> String {
         .char_indices()
         .nth(PREVIEW)
         .map_or(text.len(), |(index, _)| index);
-    let mut out: String = text[..cut]
-        .chars()
-        .map(|c| match c {
+    let mut out = String::with_capacity(cut);
+    let mut chars = text[..cut].chars().peekable();
+    while let Some(c) = chars.next() {
+        out.push(match c {
+            '\r' => {
+                // A lone `\r` still becomes a break rather than vanishing.
+                chars.next_if_eq(&'\n');
+                '\n'
+            }
             '\n' | '\t' => c,
             c if c.is_control() => char::REPLACEMENT_CHARACTER,
             c => c,
-        })
-        .collect();
+        });
+    }
     if cut < text.len() {
         out.push('…');
     }

--- a/crates/funput-convert/src/text/tests.rs
+++ b/crates/funput-convert/src/text/tests.rs
@@ -68,3 +68,22 @@ fn a_control_character_cannot_reach_the_preview() {
     assert!(!shown.contains('\u{1a}'), "{shown:?}");
     assert!(shown.contains('\t') && shown.contains('\n'), "{shown:?}");
 }
+
+/// The regression that shipped: `\r` is a control character, so sanitising them all
+/// put a `�` at the end of every line of every CRLF document — which is every
+/// Windows document, the entire reason this tool exists.
+#[test]
+fn a_windows_line_ending_is_not_marked_as_damage() {
+    let shown = capped("Cộng hòa\r\nĐộc lập\r\n");
+    assert!(!shown.contains('\u{FFFD}'), "{shown:?}");
+    assert_eq!(shown, "Cộng hòa\nĐộc lập\n");
+}
+
+/// Normalised rather than passed through: a raw `\r\n` risks drawing as two breaks
+/// in GTK, and a lone `\r` must still separate lines rather than disappear.
+#[test]
+fn every_line_ending_becomes_exactly_one_break() {
+    assert_eq!(capped("a\r\nb").lines().count(), 2);
+    assert_eq!(capped("a\rb").lines().count(), 2);
+    assert_eq!(capped("a\nb").lines().count(), 2);
+}


### PR DESCRIPTION
Fixes the stray characters reported at the end of every line:

```
#Cộng hòa Xã hội Chủ nghĩa Việt Nam�
Độc lập - Tự do - Hạnh phúc�
```

## Cause

`text::capped` sanitises control characters before a document reaches a preview pane. That guard is real and stays: a damaged legacy file can decode into a NUL, and GTK's `TextBuffer` takes the length rather than stopping at one, so it measures and draws the rest of the document wrongly.

But `\r` is a control character, and the allowlist beside it was `'\n' | '\t'`. So every CRLF became a line break **plus** a replacement character — on every line, of every Windows document, which is the entire kind of file this tool exists to open.

Introduced by 35f65c2 (`refactor(convert): extract the window's logic into funput-convert`), where the sanitising was added for GTK. Windows had no such need, so nothing on that side pushed back when `\r` went with the rest.

## Fix

Line endings are normalised to `\n` for the preview rather than passed through. GTK and Slint both draw that as exactly one break, where a raw `\r\n` risks two; a lone `\r` still separates lines rather than vanishing.

## Nothing was damaged

Preview only, and it always was. Measured on the reported file:

| | before | after |
|---|---|---|
| written file | 0 × `U+FFFD` | 0 × `U+FFFD` |
| preview pane | **5** × `U+FFFD` (5 lines) | 0 |

Every file already converted is fine. `funput convert` on the command line was never affected — it does not go through a preview.

Two tests added: one pins that a CRLF document carries no replacement character, one that each of `\r\n`, `\r` and `\n` yields exactly one break. The NUL test that motivated the guard still passes.

Verified by dropping the reported file into the window and looking: the marks are gone from both panes. The leading `#` stays, and correctly — that is UniKey's own placeholder for the byte-order mark it treated as content, and it really is in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)