### PR TITLE
feat(windows): switch to English while a foreign keyboard layout has focus

### DIFF
--- a/crates/funput-config/src/settings/model.rs
+++ b/crates/funput-config/src/settings/model.rs
@@ -66,9 +66,21 @@ pub struct Settings {
     /// would otherwise find it silently dead after an update.
     #[serde(default = "shortcuts_enabled_default")]
     pub shortcuts_enabled: bool,
+    /// Whether focusing a keyboard layout Vietnamese cannot be typed on — a CJK
+    /// IME, or a non-Latin script — suspends Vietnamese for as long as it is
+    /// active. Defaults to **on**, including for a file written before this field
+    /// existed: composing into a Japanese IME corrupts its text, and the users who
+    /// already hit that are exactly the ones who would never find the switch.
+    /// The suspension itself is live state, not settings — see `funput_desktop`.
+    #[serde(default = "auto_english_on_foreign_layout_default")]
+    pub auto_english_on_foreign_layout: bool,
 }
 
 fn shortcuts_enabled_default() -> bool {
+    true
+}
+
+fn auto_english_on_foreign_layout_default() -> bool {
     true
 }
 
@@ -106,6 +118,7 @@ impl Default for Settings {
             excluded_apps: Vec::new(),
             shortcuts: Vec::new(),
             shortcuts_enabled: true,
+            auto_english_on_foreign_layout: true,
         }
     }
 }

--- a/crates/funput-config/src/settings/model/tests.rs
+++ b/crates/funput-config/src/settings/model/tests.rs
@@ -137,3 +137,32 @@ fn the_shortcut_switch_round_trips_when_turned_off() {
     let back: Settings = serde_json::from_str(&text).expect("deserialize");
     assert!(!back.shortcuts_enabled);
 }
+
+/// Same rule as the gõ tắt switch: absent means on. Someone who has been fighting
+/// Funput inside a Japanese IME upgrades into the fix without going looking for it.
+#[test]
+fn a_file_without_the_foreign_layout_switch_still_auto_switches() {
+    let legacy = r#"{
+      "method": "vni",
+      "enabled": true,
+      "smartRestore": true,
+      "eagerRestore": true,
+      "toggleHotkey": "ctrl_backtick",
+      "launchAtLogin": false,
+      "hasCompletedOnboarding": false
+    }"#;
+    let s: Settings = serde_json::from_str(legacy).expect("legacy settings.json must decode");
+
+    assert!(s.auto_english_on_foreign_layout);
+}
+
+#[test]
+fn the_foreign_layout_switch_round_trips_when_turned_off() {
+    let s = Settings {
+        auto_english_on_foreign_layout: false,
+        ..Settings::default()
+    };
+    let text = serde_json::to_string(&s).expect("serialize");
+    let back: Settings = serde_json::from_str(&text).expect("deserialize");
+    assert!(!back.auto_english_on_foreign_layout);
+}

--- a/crates/funput-desktop/src/layout.rs
+++ b/crates/funput-desktop/src/layout.rs
@@ -1,0 +1,140 @@
+//! Which keyboard layouts Vietnamese can be typed on.
+//!
+//! A hook shell types *over* the focused app: it swallows a keystroke and sends
+//! back a replacement. That is fine on a plain Latin layout and ruinous on one
+//! that is already transforming the keystroke itself — a CJK IME is mid-conversion
+//! when Funput's Backspaces arrive, and a Cyrillic or Thai layout never produces
+//! the letters Telex/VNI are written in to begin with.
+//!
+//! So a layout is *foreign* when Vietnamese cannot be typed on it, and the shell
+//! suspends itself for as long as one is focused (see `ShellState::apply_for_layout`).
+//!
+//! The input here is a Windows `HKL` as a plain `u32`, which keeps this file free
+//! of OS imports and testable against real handles. Its layout:
+//!
+//! ```text
+//! 0xE0200411   high word = device / IME id     low word = LANGID
+//!   ^^          0xE… marks a TSF text service (an IME)
+//! ```
+//!
+//! Nothing here is platform-specific beyond that encoding, and nothing is stored:
+//! the answer is recomputed from the handle each time it changes.
+
+/// Primary language ids (`LANGID & 0x3FF`) written in a script Telex and VNI have
+/// no letters in. Sorted by id. Latin-script languages are deliberately absent —
+/// a French or Turkish layout still types `a`-`z`, so Vietnamese still works on it.
+///
+/// CJK is here as well as behind the IME check in [`is_foreign_layout`]: the two
+/// catch it at different moments — the handle says "IME" only while one is loaded,
+/// while the language holds for the bare keyboard layout too.
+const NON_LATIN_LANGUAGES: &[u16] = &[
+    0x01, // Arabic
+    0x02, // Bulgarian
+    0x04, // Chinese
+    0x08, // Greek
+    0x0D, // Hebrew
+    0x11, // Japanese
+    0x12, // Korean
+    0x19, // Russian
+    0x1E, // Thai
+    0x20, // Urdu
+    0x22, // Ukrainian
+    0x23, // Belarusian
+    0x28, // Tajik
+    0x29, // Persian
+    0x2B, // Armenian
+    0x37, // Georgian
+    0x39, // Hindi
+    0x40, // Kyrgyz
+    0x44, // Tatar
+    0x45, // Bengali
+    0x46, // Punjabi
+    0x47, // Gujarati
+    0x49, // Tamil
+    0x4A, // Telugu
+    0x4B, // Kannada
+    0x4C, // Malayalam
+    0x4E, // Marathi
+    0x50, // Mongolian
+    0x51, // Tibetan
+    0x53, // Khmer
+    0x54, // Lao
+    0x5E, // Amharic
+    0x61, // Nepali
+    0x65, // Divehi
+    0x80, // Uyghur
+];
+
+/// Vietnamese itself, which is never foreign however it is reached.
+const LANG_VIETNAMESE: u16 = 0x2A;
+
+/// Whether `hkl` is a layout Funput must keep its hands off.
+///
+/// A zero handle means the foreground window could not be resolved. That reads as
+/// "not foreign" — leaving the user's own VI/EN choice standing is the only safe
+/// answer when we cannot tell what they are typing on.
+pub fn is_foreign_layout(hkl: u32) -> bool {
+    if hkl == 0 {
+        return false;
+    }
+    let primary = (hkl & 0x3FF) as u16;
+    if primary == LANG_VIETNAMESE {
+        return false;
+    }
+    // A TSF text service — Microsoft IME for Japanese, Korean, or either Chinese.
+    // The nibble is the documented marker, and it survives the IME being switched
+    // to half-width alphanumeric, which is exactly when a keystroke still belongs
+    // to the IME's composition even though it looks like plain ASCII.
+    if hkl >> 28 == 0xE {
+        return true;
+    }
+    NON_LATIN_LANGUAGES.contains(&primary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_foreign_layout;
+
+    #[test]
+    fn a_latin_layout_is_where_vietnamese_is_typed() {
+        assert!(!is_foreign_layout(0x0409_0409)); // en-US
+        assert!(!is_foreign_layout(0x040C_040C)); // fr-FR
+        assert!(!is_foreign_layout(0x041F_041F)); // tr-TR
+    }
+
+    /// Alternative layouts put their own id in the high word. Only the language
+    /// half decides, so Dvorak and the US-International layout stay usable.
+    #[test]
+    fn an_alternative_latin_layout_is_still_latin() {
+        assert!(!is_foreign_layout(0xF001_0409)); // US-Dvorak
+        assert!(!is_foreign_layout(0x0001_0409)); // US-International
+    }
+
+    #[test]
+    fn the_vietnamese_layout_is_never_foreign() {
+        assert!(!is_foreign_layout(0x042A_042A));
+    }
+
+    #[test]
+    fn a_cjk_ime_is_foreign() {
+        assert!(is_foreign_layout(0xE020_0411)); // Microsoft IME (Japanese)
+        assert!(is_foreign_layout(0xE020_0412)); // Microsoft IME (Korean)
+        assert!(is_foreign_layout(0xE001_0804)); // Microsoft Pinyin
+        assert!(is_foreign_layout(0xE012_0404)); // Microsoft Bopomofo
+    }
+
+    /// The plain `ja-JP` keyboard handle, which is what a Japanese *layout* without
+    /// its IME loaded reports. Caught by the language list, not the IME nibble.
+    #[test]
+    fn a_non_latin_keyboard_is_foreign_without_an_ime() {
+        assert!(is_foreign_layout(0x0411_0411)); // Japanese
+        assert!(is_foreign_layout(0x0419_0419)); // Russian
+        assert!(is_foreign_layout(0x041E_041E)); // Thai
+        assert!(is_foreign_layout(0x0408_0408)); // Greek
+    }
+
+    #[test]
+    fn an_unresolved_window_changes_nothing() {
+        assert!(!is_foreign_layout(0));
+    }
+}

--- a/crates/funput-desktop/src/lib.rs
+++ b/crates/funput-desktop/src/lib.rs
@@ -10,6 +10,9 @@
 //! Two pure concerns: `key` (what a keystroke means — [`classify`] over a
 //! [`KeyEvent`]) and `inject` (what to emit — [`plan_inject`] into an [`InjectPlan`]).
 //!
+//! `layout` is a third: whether the keyboard layout under the caret is one
+//! Vietnamese can be typed on at all, decided from the handle the host hands it.
+//!
 //! `retone` adds the one piece of state such a shell needs: a [`CommittedTail`]
 //! shadow of the text it has typed, which stands in for the document it cannot read
 //! when Backspace should re-open a finished word.
@@ -20,11 +23,13 @@
 
 mod inject;
 mod key;
+mod layout;
 mod retone;
 mod shell;
 
 pub use funput_engine::{ImeResult, KeySource};
 pub use inject::{InjectPlan, plan_inject};
 pub use key::{KeyEvent, KeyKind, Mods, classify};
+pub use layout::is_foreign_layout;
 pub use retone::CommittedTail;
 pub use shell::ShellState;

--- a/crates/funput-desktop/src/shell/apps.rs
+++ b/crates/funput-desktop/src/shell/apps.rs
@@ -33,7 +33,15 @@ impl ShellState {
     /// keyboard hook, and a hook callback that overruns `LowLevelHooksTimeout` is
     /// silently unhooked by the OS — a file write cannot promise to beat it.
     pub fn toggle_enabled_hotkey(&mut self) -> bool {
-        let on = !self.settings.enabled;
+        // Against what is *running*: with Vietnamese suspended by a foreign layout
+        // the setting still says "on", and toggling that off would look dead.
+        let on = !self.effective_enabled();
+        if on && self.layout_suspended {
+            // They want Vietnamese on this keyboard after all — Funput has made its
+            // case, so stop suspending until they move to a different layout.
+            self.layout_suspended = false;
+            self.layout_override = self.last_layout;
+        }
         self.set_enabled_state(on);
         if let Some(id) = self.foreground_id().map(str::to_string) {
             self.remember(&id, on);
@@ -82,6 +90,7 @@ impl ShellState {
 
         // The map is persisted now, so a choice that binds without flipping the
         // state still has to reach disk — returning early here would drop it.
+        let before = self.effective_enabled();
         let flipped = self.settings.enabled != target;
         if flipped {
             self.set_enabled_state(target);
@@ -89,6 +98,48 @@ impl ShellState {
         if flipped || remembered {
             self.save();
         }
-        flipped.then_some(target)
+        // Reported against what is running: an app remembered as Vietnamese does
+        // not light the tray up while a foreign layout has it suspended.
+        let after = self.effective_enabled();
+        (after != before).then_some(after)
+    }
+
+    /// Decide VI/EN for the keyboard layout under the caret, from its handle.
+    ///
+    /// Unlike the per-app memory this is a rule, not a recollection: Vietnamese
+    /// cannot be typed on a CJK IME or a non-Latin layout at all (see
+    /// [`crate::is_foreign_layout`]). And it is the *last* word — the platform asks
+    /// it after [`Self::apply_for_app`], so it outranks a remembered choice.
+    ///
+    /// Nothing is persisted: the suspension describes the keyboard in front of the
+    /// user, would be stale by the next launch, and layouts change far too often to
+    /// spend a file write on. Returns `Some(on)` only when Vietnamese actually
+    /// started or stopped running, so the caller can refresh its tray.
+    pub fn apply_for_layout(&mut self, layout: u32) -> Option<bool> {
+        if layout == self.last_layout {
+            return None;
+        }
+        self.last_layout = layout;
+        // An override earns its keep only on the layout it was granted for.
+        if layout != self.layout_override {
+            self.layout_override = 0;
+        }
+        let suspend = self.settings.auto_english_on_foreign_layout
+            && layout != self.layout_override
+            && crate::is_foreign_layout(layout);
+        if suspend == self.layout_suspended {
+            return None;
+        }
+        let before = self.effective_enabled();
+        self.layout_suspended = suspend;
+        let after = self.effective_enabled();
+        if after == before {
+            return None; // the user is in English anyway; nothing to suspend
+        }
+        self.engine.set_enabled(after);
+        // Someone else's composition owns the caret now (or did), so the shadow of
+        // what Funput typed no longer describes the text sitting in front of it.
+        self.reset_composition();
+        Some(after)
     }
 }

--- a/crates/funput-desktop/src/shell/config.rs
+++ b/crates/funput-desktop/src/shell/config.rs
@@ -13,7 +13,7 @@ impl ShellState {
     /// Push everything in `settings` to the engine and start from a clean slate.
     pub(super) fn apply_settings(&mut self) {
         self.sync_engine_config();
-        self.engine.set_enabled(self.settings.enabled);
+        self.engine.set_enabled(self.effective_enabled());
         push_shortcuts(&mut self.engine, &self.settings.shortcuts);
         self.reset_composition();
     }
@@ -42,11 +42,20 @@ impl ShellState {
         self.tail.clear();
     }
 
+    /// Whether Vietnamese is actually running: the user asked for it *and* the
+    /// focused keyboard layout is one it can be typed on. The suspension is the
+    /// only thing that can override the setting, and it never writes to it — so a
+    /// layout change costs no disk write, and `reload_settings` below cannot
+    /// mistake a suspended session for the user having flipped VI/EN elsewhere.
+    pub(super) fn effective_enabled(&self) -> bool {
+        self.settings.enabled && !self.layout_suspended
+    }
+
     /// Apply a VI/EN state to both the persisted settings and the live engine.
     /// Callers persist themselves, since some batch this with other field writes.
     pub(super) fn set_enabled_state(&mut self, on: bool) {
         self.settings.enabled = on;
-        self.engine.set_enabled(on);
+        self.engine.set_enabled(self.effective_enabled());
         // Both directions: English-mode keystrokes never reach the engine, so
         // whatever the shadow held no longer describes the text at the caret.
         self.reset_composition();
@@ -86,6 +95,9 @@ impl ShellState {
         }
         self.settings = loaded;
         self.apply_settings();
+        // The foreign-layout switch may have been the thing that changed, and the
+        // layout it applies to has not moved — re-judge it rather than waiting.
+        self.redecide_layout();
         true
     }
 
@@ -95,6 +107,14 @@ impl ShellState {
         self.settings = new;
         self.apply_settings();
         self.save();
+    }
+
+    /// Re-run the layout rule against the layout already in front of the user,
+    /// after the settings changed under it: turning the auto-switch off has to give
+    /// Vietnamese back now, not at the next change of keyboard.
+    pub(super) fn redecide_layout(&mut self) {
+        let layout = std::mem::take(&mut self.last_layout);
+        self.apply_for_layout(layout);
     }
 
     /// Mutate one engine option, then re-sync the whole config and persist. Folding

--- a/crates/funput-desktop/src/shell/mod.rs
+++ b/crates/funput-desktop/src/shell/mod.rs
@@ -52,6 +52,18 @@ pub struct ShellState {
     /// app the user focuses. Session-only: re-arming a stale choice after a
     /// restart would be surprising, so it is never persisted.
     pending_override: Option<bool>,
+    /// The keyboard layout handle last judged by [`Self::apply_for_layout`], so an
+    /// unchanged layout costs nothing. `0` until the platform reports one.
+    last_layout: u32,
+    /// Vietnamese is suspended because the focused layout is one it cannot be typed
+    /// on. Not a settings field and never persisted: it describes the keyboard in
+    /// front of the user right now, and is recomputed from it — see
+    /// [`Self::effective_enabled`].
+    layout_suspended: bool,
+    /// The one foreign layout the user has overruled by turning Vietnamese back on
+    /// inside it. Kept until they move to a different layout, so Funput states its
+    /// case once and then lets them type. `0` when there is none.
+    layout_override: u32,
 }
 
 impl ShellState {
@@ -65,6 +77,9 @@ impl ShellState {
             settings_file,
             foreground: None,
             pending_override: None,
+            last_layout: 0,
+            layout_suspended: false,
+            layout_override: 0,
         };
         state.settings = state.read_settings();
         state.apply_settings();
@@ -76,8 +91,12 @@ impl ShellState {
     pub fn settings(&self) -> &Settings {
         &self.settings
     }
+    /// Whether Vietnamese is actually being typed right now — the user's choice
+    /// *and* the layout's veto. This is what the hook and the tray ask; the
+    /// Settings window reads `settings().enabled` instead, because it wants the
+    /// choice, not the momentary state of a keyboard it is not focused on.
     pub fn enabled(&self) -> bool {
-        self.settings.enabled
+        self.effective_enabled()
     }
     pub fn shortcuts(&self) -> &[Shortcut] {
         &self.settings.shortcuts

--- a/crates/funput-desktop/src/shell/options.rs
+++ b/crates/funput-desktop/src/shell/options.rs
@@ -43,6 +43,14 @@ impl ShellState {
         self.update_config(|s| s.shortcuts_enabled = on);
     }
 
+    /// Turn the foreign-layout auto-switch on or off. Re-judges the current layout
+    /// straight away, so turning it off lifts a suspension already in place instead
+    /// of leaving Vietnamese off until the user next changes keyboards.
+    pub fn set_auto_english_on_foreign_layout(&mut self, on: bool) {
+        self.update_config(|s| s.auto_english_on_foreign_layout = on);
+        self.redecide_layout();
+    }
+
     /// Picking a preset also clears any recorded custom combo — the two are
     /// alternatives, and the combo (when present) always wins in the hook.
     pub fn set_toggle_hotkey(&mut self, hotkey: Hotkey) {

--- a/crates/funput-desktop/src/shell/tests.rs
+++ b/crates/funput-desktop/src/shell/tests.rs
@@ -263,6 +263,120 @@ fn pruning_drops_drafts_and_keeps_complete_rows() {
     assert_eq!(state.shortcuts()[0].trigger, "vn");
 }
 
+// --- keyboard layout -------------------------------------------------------
+
+/// Real Windows layout handles. `JAPANESE_IME` is what Microsoft IME reports;
+/// `US` and `VIETNAMESE` are plain keyboard layouts.
+const US: u32 = 0x0409_0409;
+const VIETNAMESE: u32 = 0x042A_042A;
+const JAPANESE_IME: u32 = 0xE020_0411;
+const RUSSIAN: u32 = 0x0419_0419;
+
+#[test]
+fn a_foreign_layout_suspends_vietnamese_and_leaving_it_gives_it_back() {
+    let mut state = shell();
+    assert_eq!(state.apply_for_layout(US), None); // nothing to do, already typing
+
+    assert_eq!(state.apply_for_layout(JAPANESE_IME), Some(false));
+    assert!(!state.enabled());
+    assert_eq!(state.apply_for_layout(US), Some(true));
+    assert!(state.enabled());
+}
+
+#[test]
+fn the_same_layout_twice_reports_no_change() {
+    let mut state = shell();
+    assert_eq!(state.apply_for_layout(RUSSIAN), Some(false));
+    assert_eq!(state.apply_for_layout(RUSSIAN), None);
+}
+
+/// The suspension is about the keyboard, not about what the user asked for. Their
+/// setting has to survive it untouched, or returning to a Latin layout would come
+/// back to English and the choice would have been quietly eaten.
+#[test]
+fn a_suspension_never_writes_to_the_setting() {
+    let mut state = shell();
+    state.apply_for_layout(JAPANESE_IME);
+
+    assert!(!state.enabled(), "not running");
+    assert!(
+        state.settings().enabled,
+        "but still what the user asked for"
+    );
+}
+
+#[test]
+fn the_vietnamese_layout_is_not_a_foreign_one() {
+    let mut state = shell();
+    assert_eq!(state.apply_for_layout(VIETNAMESE), None);
+    assert!(state.enabled());
+}
+
+#[test]
+fn nothing_is_suspended_while_the_user_is_already_in_english() {
+    let mut state = shell_remembering(&[("code.exe", false)]);
+    assert_eq!(state.apply_for_app("code.exe"), Some(false));
+
+    // Already off: the layout has nothing left to take away, and the tray must not
+    // be told about a change that did not happen.
+    assert_eq!(state.apply_for_layout(JAPANESE_IME), None);
+}
+
+/// The platform applies the layout rule after the per-app one, so a layout veto is
+/// the last word: an app remembered as Vietnamese does not switch it back on while
+/// a Japanese IME is loaded.
+#[test]
+fn a_layout_veto_outranks_a_remembered_app() {
+    let mut state = shell_remembering(&[("code.exe", true)]);
+    state.apply_for_layout(JAPANESE_IME);
+
+    state.note_foreground("code.exe".to_string());
+    assert_eq!(state.apply_for_app("code.exe"), None);
+    assert_eq!(state.apply_for_layout(JAPANESE_IME), None);
+    assert!(!state.enabled());
+}
+
+#[test]
+fn the_hotkey_overrules_the_layout_until_the_user_moves_to_another_one() {
+    let mut state = shell();
+    assert_eq!(state.apply_for_layout(JAPANESE_IME), Some(false));
+
+    // The hotkey is measured against what is running, so this turns it back on
+    // rather than toggling the setting that already said "on".
+    assert!(state.toggle_enabled_hotkey());
+    assert!(state.enabled());
+    assert_eq!(
+        state.apply_for_layout(JAPANESE_IME),
+        None,
+        "no second opinion"
+    );
+
+    // The override was for that keyboard only.
+    assert_eq!(state.apply_for_layout(US), None);
+    assert_eq!(state.apply_for_layout(JAPANESE_IME), Some(false));
+}
+
+#[test]
+fn the_switch_being_off_leaves_every_layout_alone() {
+    let mut state = shell_with(Settings {
+        auto_english_on_foreign_layout: false,
+        ..Settings::default()
+    });
+    assert_eq!(state.apply_for_layout(JAPANESE_IME), None);
+    assert!(state.enabled());
+}
+
+/// Turning the switch off in Settings has to give Vietnamese back there and then —
+/// waiting for the user to change keyboards would look like the switch did nothing.
+#[test]
+fn turning_the_switch_off_lifts_a_suspension_already_in_place() {
+    let mut state = shell();
+    assert_eq!(state.apply_for_layout(JAPANESE_IME), Some(false));
+
+    state.set_auto_english_on_foreign_layout(false);
+    assert!(state.enabled());
+}
+
 // --- persistence -----------------------------------------------------------
 
 #[test]

--- a/docs/features/foreign-layout.md
+++ b/docs/features/foreign-layout.md
@@ -1,0 +1,89 @@
+# Tự tắt gõ tiếng Việt theo bàn phím ngoại
+
+## Trạng thái
+
+Đã có trong bản Windows. Setting `autoEnglishOnForeignLayout`, **mặc định bật**,
+công tắc nằm ở Cài đặt → Tổng quan → "Chế độ gõ".
+
+## Mục tiêu
+
+Funput là hook toàn cục: nó nuốt phím rồi gõ lại chuỗi thay thế. Cách đó chỉ đúng
+trên một layout Latin. Trên một IME tiếng Nhật, Backspace của Funput rơi vào giữa
+composition của IME và làm hỏng chữ; trên bàn phím Nga hay Thái thì phím gõ ra
+không bao giờ là chữ cái mà Telex/VNI viết bằng.
+
+Người dùng gõ tiếng Nhật thường xuyên trước đó phải tự nhớ tắt Funput mỗi lần đổi
+ngôn ngữ bàn phím. Tính năng này bỏ bước đó đi.
+
+## Layout nào bị coi là "ngoại"
+
+`funput_desktop::is_foreign_layout(hkl)` — hàm thuần, quyết định từ chính `HKL`:
+
+| Điều kiện | Ví dụ |
+| --- | --- |
+| Nibble cao là `0xE` → IME (TSF text service) | `0xE0200411` MS-IME Nhật, `0xE0010804` MS Pinyin |
+| Primary language (`LANGID & 0x3FF`) thuộc bảng chữ không-Latin | `0x0419` Nga, `0x041E` Thái, `0x0408` Hy Lạp |
+
+Tiếng Việt (`0x2A`) không bao giờ là ngoại. Layout Latin biến thể vẫn là Latin —
+Dvorak (`0xF0010409`) và US-International giữ nguyên phần ngôn ngữ, nên chỉ nửa
+thấp quyết định.
+
+CJK nằm ở **cả hai** nhánh: handle chỉ nói "IME" khi IME đang được nạp, còn ngôn
+ngữ thì đúng cho cả layout bàn phím trần.
+
+## Trạng thái treo không phải là setting
+
+`ShellState` giữ ba trường **chỉ sống trong session**: `last_layout`,
+`layout_suspended`, `layout_override`. `enabled()` trả về
+`settings.enabled && !layout_suspended`.
+
+Cố ý không ghi đè `settings.enabled`:
+
+- Đổi layout xảy ra rất thường xuyên — mỗi lần một lượt ghi file là quá đắt.
+- `reload_settings()` so `loaded.enabled` với `settings.enabled` để phát hiện một
+  lần lật VI/EN từ process khác. Bẻ trường đó sẽ sinh `pending_override` giả.
+- Trạng thái treo mô tả bàn phím đang trước mặt người dùng; nó vô nghĩa sau khi
+  khởi động lại và được tính lại từ đầu.
+
+## Windows đọc layout ở đâu
+
+Không có thông báo toàn cục nào cho việc đổi ngôn ngữ nhập.
+`WM_INPUTLANGCHANGE` chỉ đến cửa sổ của chính app tạo ra thay đổi, còn các sink
+TSF (`ITfInputProcessorProfileActivationSink`, `ITfLanguageProfileNotifySink`)
+chỉ theo thread và cần TSF thread manager nằm trong process đó. Nên phải hỏi.
+
+`keymap::foreground_layout()` hỏi bằng ba lời gọi user32 rẻ:
+`GetForegroundWindow` → `GetWindowThreadProcessId` → `GetKeyboardLayout(tid)`.
+Ngôn ngữ nhập là thuộc tính của **thread** sở hữu cửa sổ, nên câu hỏi này đúng dù
+người dùng đặt Windows dùng chung một ngôn ngữ hay mỗi cửa sổ một ngôn ngữ.
+
+Hỏi ở hai chỗ:
+
+1. Đầu mỗi keydown trong `WH_KEYBOARD_LL`, **trước** khi có gì quyết định số phận
+   phím đó. Windows xử lý xong Win+Space trước phím kế tiếp, nên phím đầu tiên gõ
+   bằng layout mới đã được xét đúng — không có phím nào bị inject sai.
+2. Trong hook `EVENT_SYSTEM_FOREGROUND`, **sau** `apply_for_app`: layout là tiếng
+   nói cuối cùng, và vì ngôn ngữ nhập theo thread nên đổi app có thể đổi layout mà
+   không có keystroke nào ở giữa.
+
+`apply_for_layout` trả `None` cho layout nó vừa thấy, tức gần như mọi lần được
+hỏi, nên chi phí thường trực chỉ là ba lời gọi đó cộng một lần khoá mutex.
+
+## Người dùng vẫn có tiếng nói cuối
+
+Bấm hotkey VI/EN trong lúc đang bị treo sẽ bật tiếng Việt trở lại và ghi
+`layout_override` cho đúng layout đó — Funput nói ý của mình một lần rồi thôi.
+Override mất hiệu lực khi người dùng chuyển sang layout khác.
+
+Tắt công tắc trong Cài đặt gỡ ngay trạng thái treo đang có
+(`ShellState::redecide_layout`), không đợi tới lần đổi bàn phím kế tiếp.
+
+## Điều đã biết
+
+- Icon khay hệ thống chỉ cập nhật khi có một keystroke hoặc một lần đổi app. Cố ý:
+  đánh đổi lấy việc không phải nuôi một `SetTimer` chỉ để bắt kịp cái icon.
+- Hotkey mặc định `Alt Shift` của Funput trùng với hotkey đổi ngôn ngữ nhập mặc
+  định của Windows. Ai dùng cả hai sẽ thấy hai hành vi chồng lên nhau — không phải
+  do tính năng này, nhưng đây là chỗ nó lộ ra rõ nhất.
+- Setting không nằm trong file xuất/nhập cấu hình, cùng nhóm với `launchAtLogin`
+  và `enabled` — đều là lựa chọn cục bộ của một máy.

--- a/platforms/windows/src/background/hook/foreground.rs
+++ b/platforms/windows/src/background/hook/foreground.rs
@@ -18,7 +18,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 
 use super::{toggle, FOREGROUND_IS_FUNPUT};
-use crate::background::{inject, tray};
+use crate::background::{inject, keymap, tray};
 use crate::shared::shell;
 
 static OWN_EXE_ID: OnceLock<String> = OnceLock::new();
@@ -66,8 +66,16 @@ pub(super) unsafe extern "system" fn win_event_proc(
     shell::note_foreground(id.clone());
     // Focus on a new app is the start of input: arm so the first letter is capitalized.
     shell::arm_capitalization();
-    if let Some(on) = shell::apply_for_app(&id) {
-        toggle::notify(on); // keep tray checkmark / tooltip in sync with the auto-switch
+    let by_app = shell::apply_for_app(&id);
+    // The layout rule gets the last word, so an app remembered as Vietnamese does
+    // not turn it back on inside an app whose thread is running a Japanese IME.
+    // Input language is per-thread, so changing app can change it with no keystroke
+    // in between — this is the other place it has to be asked.
+    let by_layout = shell::apply_for_layout(keymap::foreground_layout());
+    if by_app.is_some() || by_layout.is_some() {
+        // Read back rather than trusting either answer: when both fired, only the
+        // second one is still true. Keeps the tray icon and tooltip in sync.
+        toggle::notify(shell::enabled());
     }
 }
 

--- a/platforms/windows/src/background/hook/keyboard.rs
+++ b/platforms/windows/src/background/hook/keyboard.rs
@@ -79,6 +79,18 @@ fn handle_keydown(kbd: &KBDLLHOOKSTRUCT) -> bool {
     let vk = VIRTUAL_KEY(kbd.vkCode as u16);
     let mods = keymap::read_mods();
 
+    // Before anything decides what to do with this key: the user may have changed
+    // input language since the last one (Win+Space, Alt+Shift), and Vietnamese
+    // cannot be typed into a Japanese IME. Windows offers no notification for that,
+    // so it is asked here — where the answer lands one key *ahead* of the first
+    // keystroke it would affect. Funput's own windows are excluded so the state
+    // stays put while Settings has focus.
+    if !FOREGROUND_IS_FUNPUT.load(Ordering::Relaxed)
+        && shell::apply_for_layout(keymap::foreground_layout()).is_some()
+    {
+        toggle::defer_notify();
+    }
+
     if let Some(hit) = hotkey::on_keydown(vk, mods) {
         if fire(hit) {
             return true;

--- a/platforms/windows/src/background/hook/toggle.rs
+++ b/platforms/windows/src/background/hook/toggle.rs
@@ -30,6 +30,11 @@ static ON_TOGGLE: OnceLock<ToggleCb> = OnceLock::new();
 /// ten, and the last state is the only one worth saving.
 static PENDING: AtomicBool = AtomicBool::new(false);
 
+/// The same, for a VI/EN change that has nothing to write down — the foreign-layout
+/// auto-switch, which lives in memory only. Separate from [`PENDING`] so it cannot
+/// swallow a real toggle's file write, or add one the layout rule never wanted.
+static PENDING_NOTIFY: AtomicBool = AtomicBool::new(false);
+
 pub fn set_on_toggle(f: impl Fn(bool) + Send + Sync + 'static) {
     let _ = ON_TOGGLE.set(Box::new(f));
 }
@@ -38,6 +43,18 @@ pub fn set_on_toggle(f: impl Fn(bool) + Send + Sync + 'static) {
 /// it must not block — posting a message never waits on the receiver.
 pub(super) fn defer() {
     PENDING.store(true, Ordering::Relaxed);
+    post();
+}
+
+/// Refresh the tray after a VI/EN change that is not the user's stored choice, so
+/// nothing is persisted. Same reason for deferring: repainting the tray is two
+/// cross-process calls into Explorer, and this is called from inside the hook.
+pub(super) fn defer_notify() {
+    PENDING_NOTIFY.store(true, Ordering::Relaxed);
+    post();
+}
+
+fn post() {
     unsafe {
         let _ = PostThreadMessageW(GetCurrentThreadId(), WM_TOGGLED, WPARAM(0), LPARAM(0));
     }
@@ -45,10 +62,18 @@ pub(super) fn defer() {
 
 /// Run those side effects, on the pump thread and off the hook.
 pub(super) fn run_pending() {
-    if !PENDING.swap(false, Ordering::Relaxed) {
-        return; // a burst of toggles: an earlier message already covered this one
+    // Both are taken every time: a toggle and a layout switch can land between two
+    // messages, and leaving either flag standing would spend a later message on it.
+    let toggled = PENDING.swap(false, Ordering::Relaxed);
+    let notified = PENDING_NOTIFY.swap(false, Ordering::Relaxed);
+    if !toggled && !notified {
+        return; // a burst of changes: an earlier message already covered this one
     }
-    shell::save_settings();
+    if toggled {
+        shell::save_settings();
+    }
+    // Read the state fresh rather than carrying it in the message: by now several
+    // may have landed, and the tray only ever wants the current one.
     notify(shell::enabled());
 }
 

--- a/platforms/windows/src/background/keymap.rs
+++ b/platforms/windows/src/background/keymap.rs
@@ -7,7 +7,9 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
     VK_CAPITAL, VK_CONTROL, VK_DELETE, VK_DOWN, VK_END, VK_ESCAPE, VK_HOME, VK_INSERT, VK_LEFT,
     VK_LWIN, VK_MENU, VK_NEXT, VK_PRIOR, VK_RETURN, VK_RIGHT, VK_RWIN, VK_SHIFT, VK_TAB, VK_UP,
 };
-use windows::Win32::UI::WindowsAndMessaging::KBDLLHOOKSTRUCT;
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetForegroundWindow, GetWindowThreadProcessId, KBDLLHOOKSTRUCT,
+};
 
 fn async_down(vk: VIRTUAL_KEY) -> bool {
     (unsafe { GetAsyncKeyState(vk.0 as i32) } as u16 & 0x8000) != 0
@@ -20,6 +22,32 @@ pub fn read_mods() -> Mods {
         alt: async_down(VK_MENU),
         win: async_down(VK_LWIN) || async_down(VK_RWIN),
         shift: async_down(VK_SHIFT),
+    }
+}
+
+/// The keyboard layout handle of whatever has focus, as a plain `u32` for
+/// [`funput_desktop::is_foreign_layout`]. Zero when there is no foreground window.
+///
+/// The input language is a property of the *thread* that owns the window, which is
+/// what makes this the right question to ask however the user has Windows set up:
+/// one language for everything, or one per app window. `GetKeyboardLayout(0)`
+/// above answers for Funput's own hook thread instead, which is a different
+/// question and never changes.
+///
+/// Three cheap user32 calls that read session state — no cross-process work, no
+/// blocking — which is what makes this safe to do from inside the hook. Windows
+/// has no global notification for an input-language change (`WM_INPUTLANGCHANGE`
+/// goes only to the app that owns the change, and the TSF sinks are per-thread),
+/// so asking on each keystroke is the only way to know; and asking *there* is also
+/// what guarantees the first key typed after Win+Space is already judged right.
+pub fn foreground_layout() -> u32 {
+    unsafe {
+        let hwnd = GetForegroundWindow();
+        if hwnd.0.is_null() {
+            return 0;
+        }
+        let tid = GetWindowThreadProcessId(hwnd, None);
+        GetKeyboardLayout(tid).0 as usize as u32
     }
 }
 

--- a/platforms/windows/src/shared/commands/settings.rs
+++ b/platforms/windows/src/shared/commands/settings.rs
@@ -35,6 +35,10 @@ pub fn set_shortcuts_enabled(on: bool) {
     shell::set_shortcuts_enabled(on);
 }
 
+pub fn set_auto_english_layout(on: bool) {
+    shell::set_auto_english_on_foreign_layout(on);
+}
+
 pub fn set_enabled(on: bool) {
     shell::set_enabled(on);
 }

--- a/platforms/windows/src/shared/shell/mod.rs
+++ b/platforms/windows/src/shared/shell/mod.rs
@@ -58,6 +58,12 @@ pub fn note_foreground(id: String) {
 pub fn apply_for_app(id: &str) -> Option<bool> {
     with(|s| s.apply_for_app(id))
 }
+/// Judge the keyboard layout now under the caret, given its `HKL`. Called on every
+/// keystroke, so it answers `None` — and does nothing else — for the layout it saw
+/// last, which is all but always the case.
+pub fn apply_for_layout(layout: u32) -> Option<bool> {
+    with(|s| s.apply_for_layout(layout))
+}
 /// Flip VI/EN from the keyboard hotkey; returns the new state. In memory only —
 /// [`save_settings`] finishes the job off the hook.
 pub fn toggle_enabled_hotkey() -> bool {

--- a/platforms/windows/src/shared/shell/settings.rs
+++ b/platforms/windows/src/shared/shell/settings.rs
@@ -78,6 +78,9 @@ pub fn set_auto_capitalize(on: bool) {
 pub fn set_shortcuts_enabled(on: bool) {
     with(|s| s.set_shortcuts_enabled(on));
 }
+pub fn set_auto_english_on_foreign_layout(on: bool) {
+    with(|s| s.set_auto_english_on_foreign_layout(on));
+}
 pub fn set_toggle_hotkey(hotkey: Hotkey) {
     with(|s| s.set_toggle_hotkey(hotkey));
 }

--- a/platforms/windows/src/ui/settings_callbacks.rs
+++ b/platforms/windows/src/ui/settings_callbacks.rs
@@ -88,6 +88,7 @@ pub(super) fn wire(window: &SettingsWindow) {
     window.on_set_eager(commands::set_eager_restore);
     window.on_set_spell(commands::set_spell_check);
     window.on_set_auto_cap(commands::set_auto_capitalize);
+    window.on_set_auto_english_layout(commands::set_auto_english_layout);
     window.on_set_shortcuts_enabled(commands::set_shortcuts_enabled);
     window.on_set_launch(commands::set_launch_at_login);
 

--- a/platforms/windows/src/ui/settings_window.rs
+++ b/platforms/windows/src/ui/settings_window.rs
@@ -96,6 +96,7 @@ pub(super) fn populate(window: &SettingsWindow) {
     window.set_eager_restore(settings.eager_restore);
     window.set_spell_check(settings.spell_check);
     window.set_auto_capitalize(settings.auto_capitalize);
+    window.set_auto_english_layout(settings.auto_english_on_foreign_layout);
     window.set_launch_at_login(settings.launch_at_login);
     window.set_version(env!("CARGO_PKG_VERSION").into());
     window.set_update_state("idle".into());

--- a/platforms/windows/ui/pages/overview/page.slint
+++ b/platforms/windows/ui/pages/overview/page.slint
@@ -7,7 +7,9 @@ export component OverviewPage inherits VerticalLayout {
     in property <string> method;
     in-out property <bool> vi-enabled;
     in-out property <bool> launch-at-login;
+    in-out property <bool> auto-english-layout;
     callback set-enabled(bool);
+    callback set-auto-english-layout(bool);
     callback set-launch(bool);
     callback pick-method(string);
 
@@ -50,6 +52,16 @@ export component OverviewPage inherits VerticalLayout {
                 ];
                 current: root.method;
                 changed(value) => { root.pick-method(value); }
+            }
+        }
+        Rectangle { height: 1px; background: Theme.divider; }
+        Row {
+            title: "Tự tắt khi đổi bàn phím";
+            subtitle: "Chuyển sang EN khi dùng bàn phím tiếng Nhật, Hàn, Trung…";
+            icon: @image-url("../../icons/nav/primary/keyboard.svg");
+            AccentSwitch {
+                checked <=> root.auto-english-layout;
+                toggled => { root.set-auto-english-layout(self.checked); }
             }
         }
     }

--- a/platforms/windows/ui/shell/content.slint
+++ b/platforms/windows/ui/shell/content.slint
@@ -24,6 +24,7 @@ export component SettingsContent inherits ScrollView {
     in-out property <bool> eager-restore;
     in-out property <bool> spell-check;
     in-out property <bool> auto-capitalize;
+    in-out property <bool> auto-english-layout;
     in-out property <bool> launch-at-login;
     in property <[ShortcutEntry]> shortcuts;
     in property <bool> can-add-shortcut: true;
@@ -43,6 +44,7 @@ export component SettingsContent inherits ScrollView {
     callback set-eager(bool);
     callback set-spell(bool);
     callback set-auto-cap(bool);
+    callback set-auto-english-layout(bool);
     callback set-launch(bool);
     callback add-shortcut();
     callback set-shortcuts-enabled(bool);
@@ -74,8 +76,10 @@ export component SettingsContent inherits ScrollView {
                 method: root.method;
                 vi-enabled <=> root.vi-enabled;
                 launch-at-login <=> root.launch-at-login;
+                auto-english-layout <=> root.auto-english-layout;
                 set-enabled(v) => { root.set-enabled(v); }
                 set-launch(v) => { root.set-launch(v); }
+                set-auto-english-layout(v) => { root.set-auto-english-layout(v); }
                 pick-method(v) => { root.pick-method(v); }
             }
             if root.active == "typing": TypingPage {

--- a/platforms/windows/ui/shell/settings.slint
+++ b/platforms/windows/ui/shell/settings.slint
@@ -28,6 +28,7 @@ export component SettingsWindow inherits Window {
     in-out property <bool> eager-restore;
     in-out property <bool> spell-check;
     in-out property <bool> auto-capitalize;
+    in-out property <bool> auto-english-layout;
     in-out property <bool> launch-at-login;
     in property <[ShortcutEntry]> shortcuts;
     in property <bool> can-add-shortcut: true;
@@ -51,6 +52,7 @@ export component SettingsWindow inherits Window {
     callback set-eager(bool);
     callback set-spell(bool);
     callback set-auto-cap(bool);
+    callback set-auto-english-layout(bool);
     callback set-launch(bool);
     callback add-shortcut();
     callback set-shortcuts-enabled(bool);
@@ -97,6 +99,7 @@ export component SettingsWindow inherits Window {
             eager-restore <=> root.eager-restore;
             spell-check <=> root.spell-check;
             auto-capitalize <=> root.auto-capitalize;
+            auto-english-layout <=> root.auto-english-layout;
             launch-at-login <=> root.launch-at-login;
             shortcuts: root.shortcuts;
             can-add-shortcut: root.can-add-shortcut;
@@ -115,6 +118,7 @@ export component SettingsWindow inherits Window {
             set-eager(v) => { root.set-eager(v); }
             set-spell(v) => { root.set-spell(v); }
             set-auto-cap(v) => { root.set-auto-cap(v); }
+            set-auto-english-layout(v) => { root.set-auto-english-layout(v); }
             set-launch(v) => { root.set-launch(v); }
             add-shortcut() => { root.add-shortcut(); }
             set-shortcuts-enabled(v) => { root.set-shortcuts-enabled(v); }


### PR DESCRIPTION
Người dùng gõ tiếng Nhật (hoặc Trung, Hàn, Nga, Thái…) hiện phải tự nhớ tắt Funput mỗi lần đổi ngôn ngữ bàn phím. Quên là chữ hỏng: Funput vẫn nuốt phím và gõ đè lên phần IME đang dựng chữ.

Sau PR này Funput tự chuyển sang EN khi bàn phím đang dùng là một IME (Nhật/Trung/Hàn) hoặc một layout chữ không phải Latin, rồi tự bật tiếng Việt trở lại khi quay về bàn phím thường. Phím đầu tiên gõ sau khi đổi bàn phím đã đúng — không có ký tự nào bị hỏng ở lần chuyển.

Muốn gõ tiếng Việt trên chính bàn phím đó thì bấm phím tắt VI/EN như bình thường; Funput ghi nhận và không tự tắt lại cho tới khi bạn đổi sang bàn phím khác.

Công tắc ở **Cài đặt → Tổng quan → Chế độ gõ**, mặc định bật. Tắt đi là quay lại hành vi cũ.

## Ghi chú

- 6 commit chia theo cụm, mỗi commit compile độc lập, review tuần tự được.
- Icon khay hệ thống cập nhật khi có keystroke hoặc đổi app, không có timer riêng.
- Thiết kế chi tiết: `docs/features/foreign-layout.md`.
- Đã test tay với Microsoft IME Japanese trên máy có cài sẵn layout, chạy đúng.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
