### PR TITLE
feat(ios,android): QWERTY editors follow the number row preference

### DIFF
--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/CompactDigitAlternates.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/CompactDigitAlternates.kt
@@ -8,9 +8,9 @@ import app.funput.funput.keyboard.popover.model.KeyAlternate
 /**
  * Digit hints and long-press digits for the top character row.
  *
- * The compact letters page hides the number row, which leaves the symbols page as the only
- * way to reach a digit. Printing the digit on the keycap and offering it as the pre-selected
- * long-press alternate restores that reach without spending a row.
+ * A compact page — letters, search, email or URL — hides the number row, which leaves the symbols
+ * page as the only way to reach a digit. Printing the digit on the keycap and offering it as the
+ * pre-selected long-press alternate restores that reach without spending a row.
  */
 internal object CompactDigitAlternates {
     private const val RowCharacters = "qwertyuiop"

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/CompactLetterRows.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/CompactLetterRows.kt
@@ -6,15 +6,22 @@ import app.funput.funput.keyboard.model.KeyboardInputMethod
 /**
  * Single source of truth for "this keyboard drops its top number row".
  *
- * Only the plain-text letters layout honours the preference: the web/mail editors build their own
- * leading number row unconditionally, and VNI needs the digits for its tone marks. Layout and
- * measured height must agree on this, otherwise a five-row keyboard gets squeezed into a four-row
- * panel.
+ * Only the pages that can hand the digits to [CompactDigitAlternates] honour the preference: the
+ * QWERTY pages — text, search, email and URL. The keypads and the secure pages have no such row to
+ * give them, and VNI needs the digits for its tone marks. Layout and measured height must agree on
+ * this, otherwise a five-row keyboard gets squeezed into a four-row panel.
  */
 internal fun usesCompactLetterRows(
     inputMethod: KeyboardInputMethod,
     editorMode: KeyboardEditorMode,
     showsNumberRow: Boolean,
-): Boolean = editorMode == KeyboardEditorMode.TEXT &&
+): Boolean = editorMode in CompactCapableEditorModes &&
     inputMethod.isTelexFamily &&
     !showsNumberRow
+
+private val CompactCapableEditorModes = setOf(
+    KeyboardEditorMode.TEXT,
+    KeyboardEditorMode.SEARCH,
+    KeyboardEditorMode.EMAIL,
+    KeyboardEditorMode.URL,
+)

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/EditorKeyboardLayouts.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/EditorKeyboardLayouts.kt
@@ -1,6 +1,7 @@
 package app.funput.funput.keyboard.layout
 
 import app.funput.funput.keyboard.model.KeyRole
+import app.funput.funput.keyboard.model.KeySpec
 import app.funput.funput.keyboard.model.KeyboardEditorMode
 import app.funput.funput.keyboard.model.KeyboardInputMethod
 import app.funput.funput.keyboard.model.KeyboardLayout
@@ -14,9 +15,10 @@ internal object EditorKeyboardLayouts {
     ): KeyboardLayout {
         val layout = when (editorMode) {
             KeyboardEditorMode.TEXT -> KeyboardLayouts.forInputMethod(inputMethod, showsNumberRow)
-            KeyboardEditorMode.SEARCH -> searchLayouts.getValue(inputMethod)
-            KeyboardEditorMode.EMAIL -> emailLayouts.getValue(inputMethod)
-            KeyboardEditorMode.URL -> urlLayouts.getValue(inputMethod)
+            KeyboardEditorMode.SEARCH,
+            KeyboardEditorMode.EMAIL,
+            KeyboardEditorMode.URL,
+            -> webLayout(editorMode, inputMethod, showsNumberRow)
             KeyboardEditorMode.PHONE -> PhoneKeyboardLayouts.resolve(inputMethod, suggestionsEnabled)
             KeyboardEditorMode.PASSWORD -> PasswordKeyboardLayouts.text(inputMethod)
             KeyboardEditorMode.PIN -> PasswordKeyboardLayouts.pin(inputMethod)
@@ -36,71 +38,63 @@ internal object EditorKeyboardLayouts {
         }
     }
 
-    private val emailLayouts = KeyboardInputMethod.entries.associateWith { method ->
-        qwertyLayout(
-            id = "qwerty-email-${method.name.lowercase()}",
-            inputMethod = method,
-            leadingRows = listOf(
-                topNumberRow(TopNumberRowMode.PLAIN_CHARACTER, pageId = "email-${method.name.lowercase()}"),
-            ),
-            actionKeys = webActionKeys(
-                middleId = "at",
-                middleLabel = "@",
-                middleAccessibilityLabel = "A còng",
-            ),
-        )
-    }
-
-    private val searchLayouts = KeyboardInputMethod.entries.associateWith { method ->
-        webNavigationLayout(
-            idPrefix = "search",
-            inputMethod = method,
-        )
-    }
-
-    private val urlLayouts = KeyboardInputMethod.entries.associateWith { method ->
-        webNavigationLayout(
-            idPrefix = "url",
-            inputMethod = method,
-        )
-    }
-
-    private fun webNavigationLayout(
-        idPrefix: String,
+    /**
+     * The QWERTY page behind search, email and URL: one shape, one action row, and one answer to
+     * the number row preference.
+     *
+     * Search composes Vietnamese, so it keeps the tone hints and the VNI modifier row of the
+     * letters page; email and URL do not compose, so their row stays plain digits. All three
+     * follow the letters page on the preference — with the row hidden, the digits come back as
+     * long-press alternates on the top row.
+     */
+    private fun webLayout(
+        editorMode: KeyboardEditorMode,
         inputMethod: KeyboardInputMethod,
+        showsNumberRow: Boolean,
     ): KeyboardLayout {
-        val supportsVietnamese = idPrefix == "search"
-        return qwertyLayout(
-            id = "qwerty-$idPrefix-${inputMethod.name.lowercase()}",
+        val composesVietnamese = editorMode.supportsVietnameseComposition
+        val pageId = "${editorMode.name.lowercase()}-${inputMethod.name.lowercase()}"
+        val isCompact = usesCompactLetterRows(inputMethod, editorMode, showsNumberRow)
+        val layout = qwertyLayout(
+            id = if (isCompact) "qwerty-$pageId-compact" else "qwerty-$pageId",
             inputMethod = inputMethod,
-            leadingRows = listOf(
-                topNumberRowFor(
-                    inputMethod,
-                    pageId = "$idPrefix-${inputMethod.name.lowercase()}",
-                    composesVietnamese = supportsVietnamese,
-                ),
-            ),
-            actionKeys = webActionKeys(
-                middleId = "slash",
-                middleLabel = "/",
-                middleAccessibilityLabel = "Dấu gạch chéo",
-                supportsVietnamese = supportsVietnamese,
-            ),
-            supportsVietnameseAlternates = supportsVietnamese,
-            showsTelexHints = supportsVietnamese && inputMethod.isTelexFamily,
+            leadingRows = if (isCompact) {
+                emptyList()
+            } else {
+                listOf(topNumberRowFor(inputMethod, pageId, composesVietnamese))
+            },
+            actionKeys = webActionKeys(editorMode),
+            supportsVietnameseAlternates = composesVietnamese,
+            showsTelexHints = composesVietnamese && inputMethod.isTelexFamily,
         )
+        return if (isCompact) CompactDigitAlternates.decorate(layout) else layout
     }
 
-    private fun webActionKeys(
-        middleId: String,
-        middleLabel: String,
-        middleAccessibilityLabel: String,
-        supportsVietnamese: Boolean = false,
-    ) = listOf(
-        specialKey("symbols", "?123", KeyRole.SYMBOLS, 1.7f, "Ký hiệu"),
-        specialKey(middleId, middleLabel, KeyRole.PUNCTUATION, accessibilityLabel = middleAccessibilityLabel),
-        if (supportsVietnamese) standardSpaceKey(5.8f) else asciiSpaceKey(5.8f),
-        specialKey("period", ".", KeyRole.PUNCTUATION, accessibilityLabel = "Dấu chấm"),
-        specialKey("enter", "", KeyRole.ENTER, 1.7f, "Enter"),
-    )
+    /**
+     * Email reaches for `@`; search and URL reach for `/`. Only search keeps the language swipe on
+     * the space bar, because only search composes.
+     */
+    private fun webActionKeys(editorMode: KeyboardEditorMode): List<KeySpec> {
+        val middle = if (editorMode == KeyboardEditorMode.EMAIL) {
+            Triple("at", "@", "A còng")
+        } else {
+            Triple("slash", "/", "Dấu gạch chéo")
+        }
+        return listOf(
+            specialKey("symbols", "?123", KeyRole.SYMBOLS, 1.7f, "Ký hiệu"),
+            specialKey(
+                id = middle.first,
+                label = middle.second,
+                role = KeyRole.PUNCTUATION,
+                accessibilityLabel = middle.third,
+            ),
+            if (editorMode.supportsVietnameseComposition) {
+                standardSpaceKey(5.8f)
+            } else {
+                asciiSpaceKey(5.8f)
+            },
+            specialKey("period", ".", KeyRole.PUNCTUATION, accessibilityLabel = "Dấu chấm"),
+            specialKey("enter", "", KeyRole.ENTER, 1.7f, "Enter"),
+        )
+    }
 }

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayouts.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardLayouts.kt
@@ -1,6 +1,7 @@
 package app.funput.funput.keyboard.layout
 
 import app.funput.funput.keyboard.model.KeyRole
+import app.funput.funput.keyboard.model.KeyboardEditorMode
 import app.funput.funput.keyboard.model.KeyboardInputMethod
 import app.funput.funput.keyboard.model.KeyboardLayout
 
@@ -30,22 +31,21 @@ object KeyboardLayouts {
         inputMethod: KeyboardInputMethod,
         showsNumberRow: Boolean,
     ): KeyboardLayout {
-        val hasNumberRow = inputMethod == KeyboardInputMethod.VNI || showsNumberRow
+        val isCompact = usesCompactLetterRows(inputMethod, KeyboardEditorMode.TEXT, showsNumberRow)
         val layout = qwertyLayout(
-            id = if (hasNumberRow) id else "$id-compact",
+            id = if (isCompact) "$id-compact" else id,
             inputMethod = inputMethod,
-            leadingRows = if (hasNumberRow) {
-                listOf(topNumberRowForLetters(inputMethod))
-            } else {
+            leadingRows = if (isCompact) {
                 emptyList()
+            } else {
+                listOf(topNumberRowForLetters(inputMethod))
             },
             actionKeys = standardActionKeys(),
             supportsVietnameseAlternates = true,
             showsTelexHints = inputMethod.isTelexFamily,
         )
         // Digits move onto the top row only when no row of their own is on screen.
-        if (hasNumberRow || !inputMethod.isTelexFamily) return layout
-        return CompactDigitAlternates.decorate(layout)
+        return if (isCompact) CompactDigitAlternates.decorate(layout) else layout
     }
 
     private fun standardActionKeys() = listOf(

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/CompactDigitAlternatesTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/CompactDigitAlternatesTest.kt
@@ -85,22 +85,18 @@ class CompactDigitAlternatesTest {
             assertEquals(reference.accessibilityLabel, key.accessibilityLabel)
             assertEquals(reference.alternates, key.alternates)
         }
-        listOf(
-            KeyboardEditorMode.SEARCH,
-            KeyboardEditorMode.EMAIL,
-            KeyboardEditorMode.URL,
-        ).forEach { editorMode ->
-            val row = topRow(
-                KeyboardLayoutResolver.resolve(
-                    inputMethod = KeyboardInputMethod.TELEX,
-                    mode = KeyboardLayoutMode.LETTERS,
-                    editorMode = editorMode,
-                    showsNumberRow = false,
-                ),
-            )
-            assertEquals("$editorMode", null, row.keys[0].secondaryLabel)
-            assertTrue("$editorMode", row.keys[0].alternates.isEmpty())
-        }
+        // The QWERTY editors follow the preference too — WebEditorNumberRowLayoutTest covers
+        // them. A page with no number row to trade keeps its top row exactly as it was.
+        val password = topRow(
+            KeyboardLayoutResolver.resolve(
+                inputMethod = KeyboardInputMethod.TELEX,
+                mode = KeyboardLayoutMode.LETTERS,
+                editorMode = KeyboardEditorMode.PASSWORD,
+                showsNumberRow = false,
+            ),
+        )
+        assertEquals(null, password.keys[0].secondaryLabel)
+        assertTrue(password.keys[0].alternates.isEmpty())
     }
 
     private fun compactRow(method: KeyboardInputMethod): KeyboardRow =

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/NumberRowLayoutTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/NumberRowLayoutTest.kt
@@ -80,33 +80,32 @@ class NumberRowLayoutTest {
     }
 
     @Test
-    fun webEditorsKeepFullHeightWhenNumberRowIsOff() {
-        for (editorMode in listOf(
-            KeyboardEditorMode.URL,
-            KeyboardEditorMode.SEARCH,
-            KeyboardEditorMode.EMAIL,
-        )) {
-            val layout = KeyboardLayoutResolver.resolve(
-                inputMethod = KeyboardInputMethod.TELEX,
-                mode = KeyboardLayoutMode.LETTERS,
-                editorMode = editorMode,
-                showsNumberRow = false,
-            )
-            val height = KeyboardDimensions.recommendedHeightDp(
-                KeyboardInputMethod.TELEX,
-                editorMode,
-                showsNumberRow = false,
-            )
+    fun securePagesKeepFullHeightWhenNumberRowIsOff() {
+        // A secure page has no number row to trade for long-press digits, so the preference
+        // cannot shrink it. The QWERTY editors do follow it — WebEditorNumberRowLayoutTest.
+        for (editorMode in listOf(KeyboardEditorMode.PASSWORD, KeyboardEditorMode.PIN)) {
+            val rows = { showsNumberRow: Boolean ->
+                KeyboardLayoutResolver.resolve(
+                    inputMethod = KeyboardInputMethod.TELEX,
+                    mode = KeyboardLayoutMode.LETTERS,
+                    editorMode = editorMode,
+                    showsNumberRow = showsNumberRow,
+                ).rows.size
+            }
 
-            assertEquals("$editorMode keeps its own number row", 5, layout.rows.size)
+            assertEquals("$editorMode keeps its own rows", rows(true), rows(false))
             assertEquals(
-                "$editorMode height must fit $editorMode rows",
+                "$editorMode height must not follow the preference",
                 KeyboardDimensions.recommendedHeightDp(
                     KeyboardInputMethod.TELEX,
                     editorMode,
                     showsNumberRow = true,
                 ),
-                height,
+                KeyboardDimensions.recommendedHeightDp(
+                    KeyboardInputMethod.TELEX,
+                    editorMode,
+                    showsNumberRow = false,
+                ),
                 0.001f,
             )
         }

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/ToneHintInvariantTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/ToneHintInvariantTest.kt
@@ -43,8 +43,13 @@ class ToneHintInvariantTest {
         }
     }
 
+    /**
+     * A compact page prints the long-press digit in the same slot, and a digit promises nothing
+     * about tones — only the rest of the hint counts as one.
+     */
     private fun KeyboardLayout.hasTelexHints(): Boolean = rows.flatMap { it.keys }.any { key ->
-        key.role == KeyRole.CHARACTER && key.secondaryLabel != null
+        key.role == KeyRole.CHARACTER &&
+            key.secondaryLabel.orEmpty().any { !it.isDigit() && !it.isWhitespace() }
     }
 
     private fun KeyboardLayout.hasVniModifiers(): Boolean = rows.flatMap { it.keys }.any { key ->

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/WebEditorNumberRowLayoutTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/WebEditorNumberRowLayoutTest.kt
@@ -1,0 +1,148 @@
+package app.funput.funput.keyboard.layout
+
+import app.funput.funput.keyboard.KeyboardDimensions
+import app.funput.funput.keyboard.model.KeyRole
+import app.funput.funput.keyboard.model.KeySpec
+import app.funput.funput.keyboard.model.KeyboardEditorMode
+import app.funput.funput.keyboard.model.KeyboardInputMethod
+import app.funput.funput.keyboard.model.KeyboardLayout
+import app.funput.funput.keyboard.model.KeyboardLayoutMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Search, email and URL answer the number-row preference exactly as the letters page does. */
+class WebEditorNumberRowLayoutTest {
+    @Test
+    fun `telex web pages drop the number row when the preference is off`() {
+        forEachWebEditor { editorMode ->
+            listOf(KeyboardInputMethod.TELEX, KeyboardInputMethod.TELEX_ADVANCED).forEach { method ->
+                val layout = resolve(editorMode, method, showsNumberRow = false)
+                val name = "${editorMode.name.lowercase()}-${method.name.lowercase()}"
+
+                assertEquals("qwerty-$name-compact", layout.id)
+                assertEquals("$name rows", 4, layout.rows.size)
+                assertFalse("$name digit row", layout.rows.any { row -> row.keys.all(::isDigitKey) })
+            }
+        }
+    }
+
+    @Test
+    fun `hidden digits come back as long-press alternates, beside any tone hint`() {
+        forEachWebEditor { editorMode ->
+            val compact = topRow(resolve(editorMode, showsNumberRow = false))
+            val standard = topRow(resolve(editorMode, showsNumberRow = true))
+
+            assertEquals(Digits, compact.keys.map { it.alternates.first().text })
+            compact.keys.forEachIndexed { index, key ->
+                // Search composes, so its tone hint keeps its slot and the digit joins it on the
+                // right; email and URL never had one, so the digit stands alone.
+                val tone = standard.keys[index].secondaryLabel
+                assertEquals(
+                    "$editorMode hint $index",
+                    tone?.let { "$it ${Digits[index]}" } ?: Digits[index],
+                    key.secondaryLabel,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the preference on leaves every web page exactly as it was`() {
+        forEachWebEditor { editorMode ->
+            KeyboardInputMethod.entries.forEach { method ->
+                val layout = resolve(editorMode, method, showsNumberRow = true)
+                val name = "${editorMode.name.lowercase()}-${method.name.lowercase()}"
+
+                assertEquals("qwerty-$name", layout.id)
+                assertEquals("$name rows", 5, layout.rows.size)
+                assertTrue("$name digit row", layout.rows.first().keys.all(::isDigitKey))
+            }
+        }
+    }
+
+    @Test
+    fun `vni keeps its digit row whatever the preference is`() {
+        forEachWebEditor { editorMode ->
+            val layout = resolve(editorMode, KeyboardInputMethod.VNI, showsNumberRow = false)
+            // Only a composing page spends that row on tone modifiers.
+            val role = if (editorMode.supportsVietnameseComposition) {
+                KeyRole.VNI_MODIFIER
+            } else {
+                KeyRole.CHARACTER
+            }
+
+            assertEquals("qwerty-${editorMode.name.lowercase()}-vni", layout.id)
+            assertEquals(5, layout.rows.size)
+            assertTrue("$editorMode row role", layout.rows.first().keys.all { it.role == role })
+            assertTrue("$editorMode alternates", topRow(layout).keys[0].alternates.none { it.text == "1" })
+        }
+    }
+
+    @Test
+    fun `the symbols page still shows the digits, in the same panel height`() {
+        forEachWebEditor { editorMode ->
+            val letters = resolve(editorMode, showsNumberRow = false)
+            val symbols = KeyboardLayoutResolver.resolve(
+                inputMethod = KeyboardInputMethod.TELEX,
+                mode = KeyboardLayoutMode.SYMBOLS_PRIMARY,
+                editorMode = editorMode,
+                showsNumberRow = false,
+            )
+
+            assertTrue("$editorMode compact symbols", symbols.id.contains("compact"))
+            assertEquals("$editorMode rows", letters.rows.size, symbols.rows.size)
+            assertTrue("$editorMode digits", symbols.rows.first().keys.all(::isDigitKey))
+        }
+    }
+
+    @Test
+    fun `the measured height follows the row the page dropped`() {
+        forEachWebEditor { editorMode ->
+            val compact = height(editorMode, showsNumberRow = false)
+
+            assertTrue("$editorMode shorter", compact < height(editorMode, showsNumberRow = true))
+            assertEquals(
+                "$editorMode matches the letters page",
+                height(KeyboardEditorMode.TEXT, showsNumberRow = false),
+                compact,
+                0.001f,
+            )
+        }
+    }
+
+    private fun forEachWebEditor(block: (KeyboardEditorMode) -> Unit) = listOf(
+        KeyboardEditorMode.SEARCH,
+        KeyboardEditorMode.EMAIL,
+        KeyboardEditorMode.URL,
+    ).forEach(block)
+
+    private fun resolve(
+        editorMode: KeyboardEditorMode,
+        method: KeyboardInputMethod = KeyboardInputMethod.TELEX,
+        showsNumberRow: Boolean,
+    ): KeyboardLayout = KeyboardLayoutResolver.resolve(
+        inputMethod = method,
+        mode = KeyboardLayoutMode.LETTERS,
+        editorMode = editorMode,
+        showsNumberRow = showsNumberRow,
+    )
+
+    private fun height(editorMode: KeyboardEditorMode, showsNumberRow: Boolean): Float =
+        KeyboardDimensions.recommendedHeightDp(
+            KeyboardInputMethod.TELEX,
+            editorMode,
+            showsNumberRow = showsNumberRow,
+        )
+
+    private fun topRow(layout: KeyboardLayout) =
+        layout.rows.first { row -> row.keys.map { it.label } == TopRow.map(Char::toString) }
+
+    private companion object {
+        const val TopRow = "qwertyuiop"
+        val Digits = "1234567890".map(Char::toString)
+    }
+}
+
+private fun isDigitKey(key: KeySpec): Boolean = key.label.singleOrNull()?.isDigit() == true

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Alternates/CompactDigitAlternates.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Alternates/CompactDigitAlternates.swift
@@ -1,8 +1,9 @@
 /// Digit hints and long-press digits for the top character row.
 ///
-/// The compact letters page hides the number row, which leaves the symbols page as the
-/// only way to reach a digit. Printing the digit on the keycap and offering it as the
-/// pre-selected long-press alternate restores that reach without spending a row.
+/// A compact page — letters, search, email or URL — hides the number row, which leaves the
+/// symbols page as the only way to reach a digit. Printing the digit on the keycap and
+/// offering it as the pre-selected long-press alternate restores that reach without
+/// spending a row.
 public enum CompactDigitAlternates {
     private static let rowCharacters = "qwertyuiop"
     private static let digits = "1234567890"

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Models/KeyboardEditorMode.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Models/KeyboardEditorMode.swift
@@ -27,6 +27,15 @@ public enum KeyboardEditorMode: String, CaseIterable, Hashable, Sendable {
     public var allowsSigned: Bool { self == .numberSigned || self == .numberSignedDecimal }
     public var usesKeypad: Bool { isNumber || self == .phone || self == .pin }
 
+    /// Whether this page can hide its number row and carry the digits as long-press
+    /// alternates on the top character row instead. See `usesCompactLetterRows`.
+    public var supportsCompactLetterRows: Bool {
+        switch self {
+        case .text, .search, .email, .url: true
+        default: false
+        }
+    }
+
     /// Whether `KeyboardLayoutPreset.system` describes this mode's keyboard.
     ///
     /// The stock keyboard renders text and search identically — the magnifying glass on

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/CompactLetterRows.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/CompactLetterRows.swift
@@ -1,0 +1,15 @@
+/// Single source of truth for "this page drops its top number row".
+///
+/// Only pages that can put the digits back on the letters row honour the preference: the
+/// QWERTY pages — text, search, email and URL — hand them to `CompactDigitAlternates`. The
+/// keypads and the secure pages have no such row to give them, and VNI spends the row on
+/// tone modifiers, so neither ever goes compact. Layout, symbol page and measured height
+/// must all agree on this answer, otherwise a five-row keyboard gets squeezed into a
+/// four-row panel.
+func usesCompactLetterRows(
+    inputMethod: KeyboardInputMethod,
+    editorMode: KeyboardEditorMode,
+    showsNumberRow: Bool
+) -> Bool {
+    editorMode.supportsCompactLetterRows && inputMethod.isTelexFamily && !showsNumberRow
+}

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/EditorKeyboardLayouts.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/EditorKeyboardLayouts.swift
@@ -7,12 +7,8 @@ public enum EditorKeyboardLayouts {
         switch editorMode {
         case .text:
             StandardKeyboardLayouts.letters(inputMethod, showsNumberRow: showsNumberRow)
-        case .search:
-            searchLayout(inputMethod)
-        case .email:
-            emailLayout(inputMethod)
-        case .url:
-            webLayout(prefix: "url", inputMethod: inputMethod)
+        case .search, .email, .url:
+            webLayout(editorMode, inputMethod: inputMethod, showsNumberRow: showsNumberRow)
         case .phone:
             PhoneKeyboardLayouts.resolve(inputMethod)
         case .password:
@@ -24,69 +20,60 @@ public enum EditorKeyboardLayouts {
         }
     }
 
-    private static func emailLayout(_ method: KeyboardInputMethod) -> KeyboardLayout {
-        qwertyLayout(
-            id: "qwerty-email-\(method.rawValue)",
-            inputMethod: method,
-            leadingRows: [topNumberRow(.plainCharacter, pageID: "email-\(method.rawValue)")],
-            actionKeys: webActionKeys(middleID: "at", middleLabel: "@", middleAccessibility: "A còng")
-        )
-    }
-
+    /// The QWERTY page behind search, email and URL: one shape, one action row, and one
+    /// answer to the number row preference.
+    ///
     /// Search composes Vietnamese, so it carries the same tone hints and the same VNI
     /// modifier row as the letters page — a field where the tones work but their hints are
     /// hidden, and where Shift is eaten by a tone key, just behaves differently for no
-    /// reason the user can see. Only the action row keeps the web shape.
-    private static func searchLayout(_ method: KeyboardInputMethod) -> KeyboardLayout {
-        qwertyLayout(
-            id: "qwerty-search-\(method.rawValue)",
-            inputMethod: method,
-            leadingRows: [topNumberRow(for: method, pageID: "search-\(method.rawValue)")],
-            actionKeys: webActionKeys(
-                middleID: "slash",
-                middleLabel: "/",
-                middleAccessibility: "Dấu gạch chéo",
-                supportsLanguageSwipe: true
-            ),
-            showsTelexHints: method.isTelexFamily,
-            supportsVietnameseAlternates: true
-        )
-    }
-
-    /// URL fields do not compose Vietnamese, so no tone hints and plain digits.
+    /// reason the user can see. Email and URL do not compose: no tone hints, plain digits.
+    ///
+    /// All three follow the letters page on the number row: a Telex typist who turned it
+    /// off gets the four-row page here too, with the digits one long press away on the top
+    /// row. VNI keeps the row, which is where its tone modifiers live.
     private static func webLayout(
-        prefix: String,
-        inputMethod: KeyboardInputMethod
+        _ editorMode: KeyboardEditorMode,
+        inputMethod: KeyboardInputMethod,
+        showsNumberRow: Bool
     ) -> KeyboardLayout {
-        qwertyLayout(
-            id: "qwerty-\(prefix)-\(inputMethod.rawValue)",
+        let composes = editorMode.supportsVietnameseComposition
+        let pageID = "\(editorMode.rawValue)-\(inputMethod.rawValue)"
+        let isCompact = usesCompactLetterRows(
             inputMethod: inputMethod,
-            leadingRows: [
-                topNumberRow(.plainCharacter, pageID: "\(prefix)-\(inputMethod.rawValue)"),
-            ],
-            actionKeys: webActionKeys(
-                middleID: "slash",
-                middleLabel: "/",
-                middleAccessibility: "Dấu gạch chéo"
-            )
+            editorMode: editorMode,
+            showsNumberRow: showsNumberRow
         )
+        let numberRow = composes
+            ? topNumberRow(for: inputMethod, pageID: pageID)
+            : topNumberRow(.plainCharacter, pageID: pageID)
+        let layout = qwertyLayout(
+            id: "qwerty-\(pageID)\(isCompact ? "-compact" : "")",
+            inputMethod: inputMethod,
+            leadingRows: isCompact ? [] : [numberRow],
+            actionKeys: webActionKeys(editorMode),
+            showsTelexHints: composes,
+            supportsVietnameseAlternates: composes
+        )
+        return isCompact ? CompactDigitAlternates.decorate(layout) : layout
     }
 
-    private static func webActionKeys(
-        middleID: String,
-        middleLabel: String,
-        middleAccessibility: String,
-        supportsLanguageSwipe: Bool = false
-    ) -> [KeySpec] {
-        [
+    /// Email reaches for `@`; search and URL reach for `/`. Only search keeps the language
+    /// swipe on the space bar, because only search composes.
+    private static func webActionKeys(_ editorMode: KeyboardEditorMode) -> [KeySpec] {
+        let middle = editorMode == .email
+            ? (id: "at", label: "@", accessibility: "A còng")
+            : (id: "slash", label: "/", accessibility: "Dấu gạch chéo")
+        return [
             specialKey("symbols", "?123", .symbols, weight: 1.7, accessibilityLabel: "Ký hiệu"),
             specialKey(
-                middleID,
-                middleLabel,
+                middle.id,
+                middle.label,
                 .punctuation,
-                accessibilityLabel: middleAccessibility
+                accessibilityLabel: middle.accessibility
             ),
-            supportsLanguageSwipe ? standardSpaceKey() : asciiSpaceKey(weight: 5.8),
+            editorMode.supportsVietnameseComposition
+                ? standardSpaceKey()
+                : asciiSpaceKey(weight: 5.8),
             specialKey("period", ".", .punctuation, accessibilityLabel: "Dấu chấm"),
             specialKey("enter", "", .enter, weight: 1.7, accessibilityLabel: "Enter"),
         ]

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/KeyboardLayoutResolver.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/KeyboardLayoutResolver.swift
@@ -57,9 +57,11 @@ public enum KeyboardLayoutResolver {
         editorMode: KeyboardEditorMode,
         showsNumberRow: Bool
     ) -> KeyboardLayout {
-        let usesCompactLayout = editorMode == .text
-            && inputMethod.isTelexFamily
-            && !showsNumberRow
+        let usesCompactLayout = usesCompactLetterRows(
+            inputMethod: inputMethod,
+            editorMode: editorMode,
+            showsNumberRow: showsNumberRow
+        )
         return switch mode {
         case .letters:
             EditorKeyboardLayouts.resolve(

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/StandardKeyboardLayouts.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/Presets/StandardKeyboardLayouts.swift
@@ -3,18 +3,21 @@ public enum StandardKeyboardLayouts {
         _ inputMethod: KeyboardInputMethod,
         showsNumberRow: Bool = true
     ) -> KeyboardLayout {
-        let hasNumberRow = inputMethod == .vni || showsNumberRow
-        let layout = qwertyLayout(
-            id: "qwerty-\(inputMethod.rawValue)\(hasNumberRow ? "" : "-compact")",
+        let isCompact = usesCompactLetterRows(
             inputMethod: inputMethod,
-            leadingRows: hasNumberRow ? [topNumberRowForLetters(inputMethod)] : [],
+            editorMode: .text,
+            showsNumberRow: showsNumberRow
+        )
+        let layout = qwertyLayout(
+            id: "qwerty-\(inputMethod.rawValue)\(isCompact ? "-compact" : "")",
+            inputMethod: inputMethod,
+            leadingRows: isCompact ? [] : [topNumberRowForLetters(inputMethod)],
             actionKeys: standardActionRow().keys,
             showsTelexHints: inputMethod.isTelexFamily,
             supportsVietnameseAlternates: true
         )
         // Digits move onto the top row only when no row of their own is on screen.
-        guard !hasNumberRow, inputMethod.isTelexFamily else { return layout }
-        return CompactDigitAlternates.decorate(layout)
+        return isCompact ? CompactDigitAlternates.decorate(layout) : layout
     }
 }
 

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardLayoutTests/Alternates/CompactDigitAlternatesTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardLayoutTests/Alternates/CompactDigitAlternatesTests.swift
@@ -70,13 +70,13 @@ struct CompactDigitAlternatesTests {
             #expect(key.accessibilityLabel == reference.accessibilityLabel)
             #expect(key.alternates == reference.alternates)
         }
-        for mode in [KeyboardEditorMode.search, .email, .url] {
-            let row = Self.topRow(
-                EditorKeyboardLayouts.resolve(.telex, editorMode: mode, showsNumberRow: false)
-            )
-            #expect(row.keys[0].secondaryLabel == nil)
-            #expect(row.keys[0].alternates.isEmpty)
-        }
+        // The QWERTY editors follow the preference too — CompactWebPageTests covers them.
+        // A page with no number row to trade keeps its top row exactly as it was.
+        let password = Self.topRow(
+            EditorKeyboardLayouts.resolve(.telex, editorMode: .password, showsNumberRow: false)
+        )
+        #expect(password.keys[0].secondaryLabel == nil)
+        #expect(password.keys[0].alternates.isEmpty)
         let system = KeyboardLayoutResolver.resolve(
             inputMethod: .telex,
             mode: .letters,

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardLayoutTests/Alternates/CompactWebPageTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardLayoutTests/Alternates/CompactWebPageTests.swift
@@ -1,0 +1,86 @@
+import KeyboardLayout
+import Testing
+
+/// Search, email and URL answer the number row preference exactly as the letters page does.
+@Suite("Compact web pages")
+struct CompactWebPageTests {
+    static let modes: [KeyboardEditorMode] = [.search, .email, .url]
+
+    @Test("Telex drops the number row and keeps the digits a long press away", arguments: modes)
+    func compact(mode: KeyboardEditorMode) throws {
+        for method in [KeyboardInputMethod.telex, .telexAdvanced] {
+            let layout = Self.resolve(mode, method: method, showsNumberRow: false)
+            #expect(layout.id == "qwerty-\(mode.rawValue)-\(method.rawValue)-compact")
+            #expect(layout.rows.count == 4)
+            #expect(!layout.rows.contains { $0.keys.map(\.label).joined() == "1234567890" })
+
+            let row = try #require(Self.topRow(layout))
+            #expect(row.keys.map { $0.alternates.first?.text } == Self.digits)
+            #expect(row.keys.allSatisfy { $0.secondaryLabel?.hasSuffix($0.alternates[0].text) == true })
+        }
+    }
+
+    @Test("A hidden row does not change what the page says about tones", arguments: modes)
+    func hints(mode: KeyboardEditorMode) throws {
+        let compact = try #require(Self.topRow(Self.resolve(mode, showsNumberRow: false)))
+        let standard = try #require(Self.topRow(Self.resolve(mode, showsNumberRow: true)))
+        for (index, key) in compact.keys.enumerated() {
+            // Search composes, so its tone hint keeps its slot and the digit joins it;
+            // email and URL never had one, so the digit stands alone.
+            let tone = standard.keys[index].secondaryLabel
+            #expect(key.secondaryLabel == tone.map { "\($0) \(Self.digits[index])" }
+                ?? Self.digits[index])
+        }
+        #expect(mode.supportsVietnameseComposition == (standard.keys[3].secondaryLabel != nil))
+    }
+
+    @Test("VNI keeps its digit row whatever the preference is", arguments: modes)
+    func vni(mode: KeyboardEditorMode) throws {
+        let layout = Self.resolve(mode, method: .vni, showsNumberRow: false)
+        #expect(layout.id == "qwerty-\(mode.rawValue)-vni")
+        #expect(layout.rows.count == 5)
+        #expect(layout.rows[0].keys.map(\.label).joined() == "1234567890")
+        // Only a composing page spends that row on tone modifiers.
+        let role: KeyRole = mode.supportsVietnameseComposition ? .vniModifier : .character
+        #expect(layout.rows[0].keys.allSatisfy { $0.role == role })
+        let row = try #require(Self.topRow(layout))
+        #expect(!row.keys[0].alternates.contains { $0.text == "1" })
+    }
+
+    @Test("The symbols page still shows the digits, in the same panel height", arguments: modes)
+    func symbols(mode: KeyboardEditorMode) {
+        let letters = Self.resolve(mode, showsNumberRow: false)
+        let symbols = KeyboardLayoutResolver.resolve(
+            inputMethod: .telex,
+            mode: .symbolsPrimary,
+            editorMode: mode,
+            showsNumberRow: false
+        )
+        #expect(symbols.rows.count == letters.rows.count)
+        #expect(symbols.rows[0].keys.map(\.label).joined() == "1234567890")
+    }
+
+    @Test("The preference on leaves every page exactly as it was", arguments: modes)
+    func preferenceOn(mode: KeyboardEditorMode) {
+        for method in KeyboardInputMethod.allCases {
+            let layout = Self.resolve(mode, method: method, showsNumberRow: true)
+            #expect(layout.id == "qwerty-\(mode.rawValue)-\(method.rawValue)")
+            #expect(layout.rows.count == 5)
+            #expect(layout.rows[0].keys.map(\.label).joined() == "1234567890")
+        }
+    }
+
+    private static let digits = "1234567890".map(String.init)
+
+    private static func resolve(
+        _ mode: KeyboardEditorMode,
+        method: KeyboardInputMethod = .telex,
+        showsNumberRow: Bool
+    ) -> KeyboardLayout {
+        EditorKeyboardLayouts.resolve(method, editorMode: mode, showsNumberRow: showsNumberRow)
+    }
+
+    private static func topRow(_ layout: KeyboardLayout) -> KeyboardRow? {
+        layout.rows.first { $0.keys.map(\.label) == "qwertyuiop".map(String.init) }
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardLayoutTests/LayoutParity/CompactSymbolLayoutParityTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardLayoutTests/LayoutParity/CompactSymbolLayoutParityTests.swift
@@ -4,8 +4,12 @@ import Testing
 struct CompactSymbolLayoutParityTests {
     @Test("Compact Telex pages keep a stable four-row family")
     func stableFamily() {
-        for mode in KeyboardLayoutMode.allCases {
-            #expect(resolve(mode).rows.count == 4)
+        // Every QWERTY page honours the preference, so each keeps the four-row shape on
+        // every page it can switch to.
+        for editor in [KeyboardEditorMode.text, .search, .email, .url] {
+            for mode in KeyboardLayoutMode.allCases {
+                #expect(resolve(mode, editorMode: editor).rows.count == 4)
+            }
         }
     }
 
@@ -38,13 +42,13 @@ struct CompactSymbolLayoutParityTests {
     @Test("VNI and specialized editors ignore the compact preference")
     func standardOnlyContexts() {
         for mode in KeyboardLayoutMode.allCases {
-            #expect(resolve(mode, method: .vni).rows.count == 5)
-        }
-        for editor in [KeyboardEditorMode.search, .email, .url, .password] {
-            for mode in KeyboardLayoutMode.allCases {
-                let layout = resolve(mode, editorMode: editor)
-                #expect(layout.rows.count == 5)
+            for editor in [KeyboardEditorMode.text, .search, .email, .url] {
+                #expect(resolve(mode, method: .vni, editorMode: editor).rows.count == 5)
             }
+        }
+        // A secure page has no number row to trade, so it never goes compact either.
+        for mode in KeyboardLayoutMode.allCases {
+            #expect(resolve(mode, editorMode: .password).rows.count == 5)
         }
     }
 


### PR DESCRIPTION
## Vấn đề

Toggle **Hàng phím số** chỉ có tác dụng trên trang chữ. Search, email và URL đều tự dựng hàng số của riêng chúng, nên người gõ Telex/Telex+ đã tắt toggle vẫn thấy bàn phím 5 hàng ngay khi focus vào ô địa chỉ trình duyệt hay ô email — bàn phím đổi hình dạng mà không có lý do nào người dùng thấy được.

## Thay đổi

Cả bốn trang QWERTY (text, search, email, url) giờ trả lời toggle giống nhau:

- **Telex/Telex+ + toggle tắt** → 4 hàng, id `...-compact`, chữ số quay lại dưới dạng nhấn giữ trên hàng `qwertyuiop` (`CompactDigitAlternates`).
- **Search** vẫn giữ gợi ý dấu; chữ số đứng cạnh nó (`"̉ 4"`) đúng như trang chữ. Email/URL không bỏ dấu nên keycap chỉ có số.
- **VNI** luôn giữ hàng số — đó là nơi phím bổ trợ dấu của VNI sống.
- **Trang ký hiệu (?123)** vẫn đủ 0–9, và cũng 4 hàng nên chiều cao bàn phím không nhảy khi chuyển trang.
- **Toggle bật**: id và layout y hệt trước, không đổi gì.
- Trang bảo mật và keypad không có hàng nào để đánh đổi nên không bị ảnh hưởng.

## Cấu trúc

- Quy tắc "trang này có bỏ hàng số không" gom về một hàm `usesCompactLetterRows` trên cả hai nền tảng, để layout, trang ký hiệu và chiều cao đo được không thể lệch nhau (`KeyboardDimensions` bên Android dùng chung hàm này).
- Ba builder web gần giống nhau gộp thành một, đọc khác biệt từ `supportsVietnameseComposition` thay vì từ chuỗi id: iOS `EditorKeyboardLayouts.swift` 94 → 79 dòng, Android `EditorKeyboardLayouts.kt` 106 → 96 dòng (bỏ luôn 3 map dựng sẵn — resolve chỉ chạy khi state đổi).

## Kiểm chứng

- iOS: toàn bộ FunputKit suite xanh (`Scripts/test-funput-kit.sh`). File mới `CompactWebPageTests.swift` — 5 test × 3 editor.
- Android: `:keyboard-renderer:`, `:keyboard-ui:`, `:ime:` xanh. File mới `WebEditorNumberRowLayoutTest.kt` phủ cả ba editor, gồm cả chiều cao đo được.
- LOC/layout gate của cả Swift lẫn Kotlin đều pass.
- Hai test cũ bị chính thay đổi này thay thế nên được viết lại thay vì nới lỏng: `NumberRowLayoutTest` nay khẳng định trang bảo mật *không* theo toggle, và `ToneHintInvariantTest` phân biệt chữ số với gợi ý dấu trong cùng một slot.

## Cần mắt người review

Việc thêm chữ số vào nhấn giữ cho search/email/url là suy luận theo trang chữ, không phải yêu cầu ban đầu — nếu muốn các trang này chỉ ẩn hàng số mà không có nhấn giữ ra số thì gỡ ra rất gọn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)