### PR TITLE
fix(suggestions): stop the personal lexicon losing itself in silence

### DIFF
--- a/crates/funput-suggestions/src/persistence/codec/journal.rs
+++ b/crates/funput-suggestions/src/persistence/codec/journal.rs
@@ -3,7 +3,7 @@
 use std::io;
 
 use super::binary::{Cursor, checksum, invalid_data, put_u16, put_u32};
-use crate::persistence::schema::{JOURNAL_MAGIC, VERSION};
+use crate::persistence::schema::{self, JOURNAL_MAGIC, Version, WRITE_VERSION};
 
 pub(crate) fn encode_frame(tokens: &[String]) -> Vec<u8> {
     let mut payload = Vec::new();
@@ -14,7 +14,7 @@ pub(crate) fn encode_frame(tokens: &[String]) -> Vec<u8> {
     }
     let mut frame = Vec::with_capacity(14 + payload.len());
     frame.extend_from_slice(JOURNAL_MAGIC);
-    put_u16(&mut frame, VERSION);
+    put_u16(&mut frame, WRITE_VERSION);
     put_u32(&mut frame, payload.len() as u32);
     put_u32(&mut frame, checksum(&payload));
     frame.extend_from_slice(&payload);
@@ -25,8 +25,17 @@ pub(crate) fn decode_frame(cursor: &mut Cursor<'_>) -> io::Result<Vec<String>> {
     if cursor.take(JOURNAL_MAGIC.len())? != JOURNAL_MAGIC {
         return Err(invalid_data());
     }
-    if cursor.u16()? != VERSION {
-        return Err(io::Error::new(io::ErrorKind::Unsupported, "journal schema"));
+    match schema::accept(cursor.u16()?) {
+        Version::Readable => {}
+        Version::TooNew => {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "journal schema is newer than this build",
+            ));
+        }
+        // Not fatal: the reader stops at this frame and keeps the prefix it
+        // already decoded, the same as it does for a torn one.
+        Version::TooOld => return Err(invalid_data()),
     }
     let payload_len = cursor.u32()? as usize;
     let expected = cursor.u32()?;

--- a/crates/funput-suggestions/src/persistence/codec/snapshot.rs
+++ b/crates/funput-suggestions/src/persistence/codec/snapshot.rs
@@ -5,12 +5,12 @@ use std::io;
 use crate::types::WordRecord;
 
 use super::binary::{Cursor, checksum, invalid_data, put_u16, put_u32, put_u64};
-use crate::persistence::schema::{SNAPSHOT_MAGIC, VERSION};
+use crate::persistence::schema::{self, SNAPSHOT_MAGIC, Version, WRITE_VERSION};
 
 pub(crate) fn encode(words: &[WordRecord], sequence: u64) -> Vec<u8> {
     let mut bytes = Vec::new();
     bytes.extend_from_slice(SNAPSHOT_MAGIC);
-    put_u16(&mut bytes, VERSION);
+    put_u16(&mut bytes, WRITE_VERSION);
     put_u64(&mut bytes, sequence);
     put_u32(&mut bytes, words.len() as u32);
     for word in words {
@@ -36,11 +36,15 @@ pub(crate) fn decode(bytes: &[u8]) -> io::Result<Option<(Vec<WordRecord>, u64)>>
     if cursor.take(SNAPSHOT_MAGIC.len())? != SNAPSHOT_MAGIC {
         return Ok(None);
     }
-    if cursor.u16()? != VERSION {
-        return Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "personal lexicon schema is newer or unsupported",
-        ));
+    match schema::accept(cursor.u16()?) {
+        Version::Readable => {}
+        Version::TooNew => {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "personal lexicon schema is newer than this build",
+            ));
+        }
+        Version::TooOld => return Ok(None),
     }
     let sequence = cursor.u64()?;
     let count = cursor.u32()? as usize;

--- a/crates/funput-suggestions/src/persistence/fs.rs
+++ b/crates/funput-suggestions/src/persistence/fs.rs
@@ -1,0 +1,33 @@
+//! Filesystem calls that have to be durable, not merely successful.
+//!
+//! `write` + `sync_data` only promises the bytes reached the disk — not that the
+//! *name* pointing at them did. A rename or a create is a directory change, and
+//! it needs the directory itself synced before a power loss is survivable.
+
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+/// Flush the directory entry itself, so a rename or create that just happened
+/// survives a crash.
+///
+/// Opening a directory as a file is a POSIX facility; on other platforms this is
+/// a no-op, which is the same guarantee those platforms gave us before.
+#[cfg(unix)]
+pub(super) fn sync_dir(root: &Path) -> io::Result<()> {
+    File::open(root)?.sync_all()
+}
+
+#[cfg(not(unix))]
+pub(super) fn sync_dir(_root: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+/// Empty a file that exists, without caring whether it did.
+pub(super) fn truncate(path: &Path) -> io::Result<()> {
+    match File::create(path) {
+        Ok(file) => file.sync_all(),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}

--- a/crates/funput-suggestions/src/persistence/mod.rs
+++ b/crates/funput-suggestions/src/persistence/mod.rs
@@ -44,6 +44,12 @@ impl Store {
         let (journal, journal_bytes) = if snapshot_valid {
             store.load_journal()?
         } else {
+            // The snapshot was damaged, not absent. Repair both files now: leaving
+            // the snapshot means every later open discards the journal again, and
+            // leaving the journal means its unreadable head swallows every valid
+            // frame appended after it. Best effort — an empty engine works either
+            // way, and the next flush will try again.
+            let _ = store.compact(&[], 0);
             (Vec::new(), 0)
         };
         Ok((

--- a/crates/funput-suggestions/src/persistence/mod.rs
+++ b/crates/funput-suggestions/src/persistence/mod.rs
@@ -4,13 +4,15 @@
 //! - `schema` — the on-disk constants both records agree on.
 //! - `codec` — pure bytes to data translation, no filesystem.
 //! - `recovery` — reading a store that may be damaged.
+//! - `fs` — the filesystem calls that have to be durable, not merely successful.
 //! - here — paths, and the two write paths (`append_journal`, `compact`).
 
 mod codec;
+mod fs;
 mod recovery;
 mod schema;
 
-use std::fs::{self, File, OpenOptions};
+use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
@@ -30,7 +32,7 @@ pub(crate) struct Loaded {
 
 impl Store {
     pub(crate) fn open(root: &Path) -> io::Result<(Self, Loaded)> {
-        fs::create_dir_all(root)?;
+        std::fs::create_dir_all(root)?;
         let store = Self {
             root: root.to_owned(),
         };
@@ -60,12 +62,16 @@ impl Store {
             return Ok(0);
         }
         let frame = journal::encode_frame(tokens);
-        let mut file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(self.journal_path())?;
+        let path = self.journal_path();
+        // A brand new journal is a directory change, so the entry needs syncing
+        // too — once, on the append that creates it, not on every later one.
+        let created = !path.exists();
+        let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
         file.write_all(&frame)?;
         file.sync_data()?;
+        if created {
+            fs::sync_dir(&self.root)?;
+        }
         Ok(frame.len() as u64)
     }
 
@@ -75,9 +81,12 @@ impl Store {
         let mut file = File::create(&temporary)?;
         file.write_all(&bytes)?;
         file.sync_all()?;
-        fs::rename(&temporary, self.snapshot_path())?;
+        std::fs::rename(&temporary, self.snapshot_path())?;
         let journal = File::create(self.journal_path())?;
         journal.sync_all()?;
+        // Both the rename and the fresh journal are directory changes: without
+        // this the snapshot we just fsynced can still be the one lost.
+        fs::sync_dir(&self.root)?;
         Ok(bytes.len() as u64)
     }
 

--- a/crates/funput-suggestions/src/persistence/recovery.rs
+++ b/crates/funput-suggestions/src/persistence/recovery.rs
@@ -11,8 +11,9 @@ use std::io::{self, Read};
 use crate::types::WordRecord;
 
 use super::Store;
-use super::codec::binary::{Cursor, invalid_data};
+use super::codec::binary::Cursor;
 use super::codec::{journal, snapshot};
+use super::fs::{sync_dir, truncate};
 use super::schema::{MAX_JOURNAL_BYTES, MAX_SNAPSHOT_BYTES};
 
 impl Store {
@@ -36,7 +37,14 @@ impl Store {
     pub(super) fn load_journal(&self) -> io::Result<(Vec<String>, u64)> {
         let path = self.journal_path();
         let bytes = match fs::metadata(&path) {
-            Ok(metadata) if metadata.len() > MAX_JOURNAL_BYTES => return Err(invalid_data()),
+            // Far past the 64 KiB that triggers a compact, so this is not
+            // something we wrote. Dropping it costs the tokens since the last
+            // snapshot; returning an error costs the shells their persistence for
+            // the rest of the process.
+            Ok(metadata) if metadata.len() > MAX_JOURNAL_BYTES => {
+                self.discard_journal()?;
+                return Ok((Vec::new(), 0));
+            }
             Ok(_) => fs::read(path)?,
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok((Vec::new(), 0)),
             Err(error) => return Err(error),
@@ -52,5 +60,15 @@ impl Store {
             }
         }
         Ok((tokens, journal_bytes))
+    }
+
+    /// Empty a journal we have decided not to read.
+    ///
+    /// Leaving it in place is not neutral: `load_journal` stops at the first frame
+    /// that fails to decode, so garbage at the head silently swallows every valid
+    /// frame appended after it, for as long as the file survives.
+    pub(super) fn discard_journal(&self) -> io::Result<()> {
+        truncate(&self.journal_path())?;
+        sync_dir(&self.root)
     }
 }

--- a/crates/funput-suggestions/src/persistence/schema.rs
+++ b/crates/funput-suggestions/src/persistence/schema.rs
@@ -4,6 +4,66 @@
 
 pub(super) const SNAPSHOT_MAGIC: &[u8; 8] = b"FPSNAP01";
 pub(super) const JOURNAL_MAGIC: &[u8; 4] = b"FPJR";
-pub(super) const VERSION: u16 = 1;
 pub(super) const MAX_SNAPSHOT_BYTES: u64 = 2 * 1024 * 1024;
 pub(super) const MAX_JOURNAL_BYTES: u64 = 1024 * 1024;
+
+/// The schema every file this build writes is stamped with.
+pub(super) const WRITE_VERSION: u16 = 1;
+
+/// The oldest schema this build can still read. Raising it is how a format is
+/// retired: files below it are discarded and rebuilt rather than rejected.
+pub(super) const MIN_READ_VERSION: u16 = 1;
+
+pub(super) enum Version {
+    Readable,
+    /// Written by a newer build. Its meaning is unknown, so it must be left
+    /// untouched — the user may simply be running an older app for a moment.
+    TooNew,
+    /// Written by a build whose format we have retired. Safe to throw away and
+    /// rebuild from what the running engine knows.
+    TooOld,
+}
+
+pub(super) fn accept(version: u16) -> Version {
+    verdict(version, MIN_READ_VERSION, WRITE_VERSION)
+}
+
+/// The window is a parameter so the verdict can be exercised across ranges this
+/// build does not happen to have yet. A gate whose arms are unreachable today is
+/// a gate nobody has tested by the time a migration needs it.
+fn verdict(version: u16, min_read: u16, write: u16) -> Version {
+    if version > write {
+        Version::TooNew
+    } else if version < min_read {
+        Version::TooOld
+    } else {
+        Version::Readable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_shipped_window_reads_what_it_writes() {
+        assert!(matches!(accept(WRITE_VERSION), Version::Readable));
+        assert!(matches!(accept(MIN_READ_VERSION), Version::Readable));
+        assert!(MIN_READ_VERSION <= WRITE_VERSION);
+    }
+
+    #[test]
+    fn a_newer_schema_is_never_readable() {
+        assert!(matches!(accept(WRITE_VERSION + 1), Version::TooNew));
+        assert!(matches!(accept(u16::MAX), Version::TooNew));
+    }
+
+    #[test]
+    fn a_window_wider_than_one_reads_every_version_inside_it() {
+        for version in 2..=4 {
+            assert!(matches!(verdict(version, 2, 4), Version::Readable));
+        }
+        assert!(matches!(verdict(1, 2, 4), Version::TooOld));
+        assert!(matches!(verdict(5, 2, 4), Version::TooNew));
+    }
+}

--- a/crates/funput-suggestions/src/persistence/schema.rs
+++ b/crates/funput-suggestions/src/persistence/schema.rs
@@ -14,6 +14,10 @@ pub(super) const WRITE_VERSION: u16 = 1;
 /// retired: files below it are discarded and rebuilt rather than rejected.
 pub(super) const MIN_READ_VERSION: u16 = 1;
 
+/// A build that cannot read what it writes would discard every file on upgrade.
+/// Checked here so raising `MIN_READ_VERSION` too far fails the build, not a test.
+const _: () = assert!(MIN_READ_VERSION <= WRITE_VERSION);
+
 pub(super) enum Version {
     Readable,
     /// Written by a newer build. Its meaning is unknown, so it must be left
@@ -49,7 +53,6 @@ mod tests {
     fn the_shipped_window_reads_what_it_writes() {
         assert!(matches!(accept(WRITE_VERSION), Version::Readable));
         assert!(matches!(accept(MIN_READ_VERSION), Version::Readable));
-        assert!(MIN_READ_VERSION <= WRITE_VERSION);
     }
 
     #[test]

--- a/crates/funput-suggestions/src/tests/persistence/recovery.rs
+++ b/crates/funput-suggestions/src/tests/persistence/recovery.rs
@@ -63,3 +63,60 @@ fn newer_schema_is_rejected_without_overwriting_it() {
     assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
     assert_eq!(fs::read(snapshot).unwrap(), bytes);
 }
+
+#[test]
+fn a_discarded_snapshot_takes_its_journal_with_it() {
+    let directory = tempdir().unwrap();
+    let journal = directory.path().join("personal-lexicon.journal");
+    let mut engine = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    learned(&mut engine, "cũ", 2);
+    engine.flush().unwrap();
+    drop(engine);
+    assert!(fs::metadata(&journal).unwrap().len() > 0);
+
+    // The frames in that journal are perfectly good. It is the snapshot they were
+    // written against that is gone.
+    fs::write(
+        directory.path().join("personal-lexicon.snapshot"),
+        b"corrupt",
+    )
+    .unwrap();
+
+    let mut engine = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    assert_eq!(
+        fs::metadata(&journal).unwrap().len(),
+        0,
+        "a journal we refuse to read must not be left for the next open to append to"
+    );
+
+    learned(&mut engine, "mới", 2);
+    engine.flush().unwrap();
+    drop(engine);
+    let reopened = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    assert_eq!(texts(&reopened, "m"), ["mới"]);
+}
+
+#[test]
+fn an_oversized_journal_is_discarded_without_losing_persistence() {
+    let directory = tempdir().unwrap();
+    let journal = directory.path().join("personal-lexicon.journal");
+    let mut engine = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    learned(&mut engine, "cũ", 2);
+    engine.compact().unwrap();
+    drop(engine);
+    fs::write(&journal, vec![0u8; 2 * 1024 * 1024]).unwrap();
+
+    let mut engine = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    assert_eq!(fs::metadata(&journal).unwrap().len(), 0);
+    assert_eq!(
+        texts(&engine, "c"),
+        ["cũ"],
+        "the snapshot was never in doubt"
+    );
+
+    learned(&mut engine, "mới", 2);
+    engine.flush().unwrap();
+    drop(engine);
+    let reopened = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    assert_eq!(texts(&reopened, "m"), ["mới"]);
+}


### PR DESCRIPTION
**2 of 6** toward `feature/context-suggestion`. Base is PR #278; it retargets to the feature branch once that merges.

Three defects in the store, all of which lose the user's learned words with no error anywhere.

**A bump of the schema version would have wiped every lexicon.** `decode` rejected any version that was not the single `VERSION` constant, in *both* directions. Rejecting a newer file is deliberate and stays — the user may be running an older build for a moment. Rejecting an older one is not, and the consequence lands the moment we bump for the bigram work: `decode` returns `Unsupported`, `Store::open` fails, the keyboard shells fall back to an in-memory engine permanently, and every later flush is a no-op. The gate now spans a window.

**A discarded snapshot left its journal behind.** `load_journal` stops at the first frame it cannot decode, so the stale head silently swallowed every valid frame appended after it — flush after flush, open after open. An unreadable snapshot is now repaired on open: one `compact` of an empty store rewrites a valid snapshot and truncates the journal in the same atomic path.

**An oversized journal returned an error**, which propagated out of `Store::open` and cost the shells their persistence for the rest of the process. It is now discarded like every other damaged file.

Plus a durability gap: `compact` renamed the snapshot into place without fsyncing the directory, so a power loss could reorder the rename against the journal truncation that follows — leaving an empty journal and no snapshot to have folded it into.

## Review

No format change: `WRITE_VERSION` is still 1, so nothing in the field moves. The version verdict takes its window as a parameter so the arms this build cannot reach are still exercised.

`compact` is 9.83 ms → 13.69 ms from the directory fsync. Deliberate: it runs on the shells' background worker, never on the typing path.