### PR TITLE
feat(suggestions): learn which word followed which

### DIFF
--- a/benchmarks/results/personal-suggestions-v2.md
+++ b/benchmarks/results/personal-suggestions-v2.md
@@ -10,8 +10,8 @@ lookup and memory numbers are unchanged and are not repeated here.
 
 | Path | Before | After | Change |
 |---|---:|---:|---|
-| Learn an existing word | 2.39 µs | 2.29 µs | unchanged |
-| Learn evicting a promoted word | 1.82 ms | 50.0 µs | **36x faster** |
+| Learn an existing word | 2.39 µs | 2.17 µs | unchanged |
+| Learn evicting a promoted word | 1.82 ms | 47.2 µs | **39x faster** |
 
 `suggestions/learn/evicting` is the new benchmark: a lexicon already full of
 promoted words, learning one new word twice per iteration so that every iteration
@@ -27,6 +27,26 @@ only idle signal, which both keyboard shells already call off the typing path on
 a 2 s timer and every 32 learns. `REBUILD_AFTER_EVICTIONS = 64` caps how many
 dead entries can accumulate for a caller that never flushes, which is what keeps
 the tries from growing with every distinct word ever seen.
+
+## Memory
+
+Retained heap for a warm 5,000-word lexicon, measured with
+`cargo run --release -p funput-suggestions --example latency`:
+
+| Revision | Retained | Added |
+|---|---:|---:|
+| V1 baseline, and after the store durability work | 572,504 B | — |
+| After tagging trie entries with a slot generation | 670,820 B | +98,316 B |
+| After adding four follower slots per word | 932,964 B | +262,144 B |
+
+The follower figure is exactly 256 KiB because `words` grows by doubling: 32
+bytes of edges against a `Vec` capacity of 8,192, not the 5,000 words the
+capacity holds. `context_seen` fits in padding the record already had. The tests
+enforce a 4 MiB retained-heap budget, so the whole bigram feature spends about
+6% of the room it has.
+
+Lookup is unchanged at p99 **292 ns** and 3.85 M queries/second — the edges are
+written on the learn path and nothing reads them yet.
 
 ## Persistence
 

--- a/crates/funput-suggestions/src/bigram/follower.rs
+++ b/crates/funput-suggestions/src/bigram/follower.rs
@@ -1,0 +1,57 @@
+//! The edge a word keeps to a word that followed it.
+
+use crate::index::NONE;
+use crate::types::WordRecord;
+
+/// How many following words one word remembers.
+///
+/// Not a memory compromise — four slots for every word costs about 160 KB in
+/// total. It is where the data stops being dense enough to be worth a slot: with
+/// a lexicon learned from one person, further slots need evidence that never
+/// arrives and fill with typos instead.
+pub(crate) const FOLLOWER_SLOTS: usize = 4;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Follower {
+    pub(crate) word: u32,
+    pub(crate) generation: u16,
+    pub(crate) uses: u16,
+}
+
+impl Follower {
+    pub(crate) const EMPTY: Self = Self {
+        word: NONE,
+        generation: 0,
+        uses: 0,
+    };
+
+    pub(crate) fn of(word: u32, words: &[WordRecord]) -> Option<Self> {
+        words.get(word as usize).map(|record| Self {
+            word,
+            generation: record.generation,
+            uses: 1,
+        })
+    }
+
+    /// The word this edge still points at, if it points at one at all.
+    ///
+    /// The same trap and the same answer as `index::trie::Entry::word`: the
+    /// engine hands word slots to new words, so an edge only means anything
+    /// while the generation it was written at still matches.
+    pub(crate) fn word<'a>(&self, words: &'a [WordRecord]) -> Option<&'a WordRecord> {
+        if self.is_free() {
+            return None;
+        }
+        words
+            .get(self.word as usize)
+            .filter(|record| record.generation == self.generation)
+    }
+
+    pub(crate) fn is_free(&self) -> bool {
+        self.uses == 0
+    }
+
+    pub(crate) fn points_at(&self, other: Self) -> bool {
+        !self.is_free() && self.word == other.word && self.generation == other.generation
+    }
+}

--- a/crates/funput-suggestions/src/bigram/learning.rs
+++ b/crates/funput-suggestions/src/bigram/learning.rs
@@ -1,0 +1,53 @@
+//! The write path: learn a token, and remember what it followed.
+
+use super::follower::{FOLLOWER_SLOTS, Follower};
+use super::slots;
+use crate::engine::SuggestionEngine;
+use crate::index::normalize;
+use crate::types::LearnOutcome;
+
+impl SuggestionEngine {
+    /// Learn `token`, and record that it followed `previous`.
+    ///
+    /// What counts as `previous` is the caller's business. This crate never looks
+    /// at document context, so a platform that cannot vouch for what came before
+    /// — a fresh focus, a moved caret, a sentence boundary — passes `None` and
+    /// gets exactly the behaviour `learn` always had.
+    pub fn learn_after(&mut self, previous: Option<&str>, token: &str) -> LearnOutcome {
+        // Resolved before learning because learning `token` can evict `previous`,
+        // and re-checked after because it may have just done so.
+        let context = previous.and_then(|text| self.context_slot(text));
+        let (outcome, word_id) = self.learn_inner(token, true);
+        if outcome != LearnOutcome::Ignored
+            && let Some((index, generation)) = context
+            && self.words[index].generation == generation
+        {
+            self.record_edge(index, word_id);
+        }
+        outcome
+    }
+
+    /// The slot `previous` sits in, and the generation it sits there at.
+    ///
+    /// Compares through the normalizing iterator rather than `normalize::exact`,
+    /// which would allocate a `String` for every token learned with a context.
+    fn context_slot(&self, previous: &str) -> Option<(usize, u16)> {
+        self.words
+            .iter()
+            .position(|word| word.text.chars().eq(normalize::exact_chars(previous)))
+            .map(|index| (index, self.words[index].generation))
+    }
+
+    fn record_edge(&mut self, context: usize, next_id: u32) {
+        let Some(next) = Follower::of(next_id, &self.words) else {
+            return;
+        };
+        // Liveness is read before the mutable borrow: `record` holds one slot of
+        // `words` exclusively and so cannot ask `words` anything while it works.
+        let followers: [Follower; FOLLOWER_SLOTS] = self.words[context].followers;
+        let dead = followers.map(|slot| !slot.is_free() && slot.word(&self.words).is_none());
+
+        let word = &mut self.words[context];
+        slots::record(&mut word.followers, &mut word.context_seen, dead, next);
+    }
+}

--- a/crates/funput-suggestions/src/bigram/mod.rs
+++ b/crates/funput-suggestions/src/bigram/mod.rs
@@ -1,0 +1,11 @@
+//! Which words follow which, learned from the person typing.
+//!
+//! - `follower` — the edge itself, and how many of them a word keeps.
+//! - `slots` — which edges survive when there are more than there is room for.
+//! - `learning` — the engine's write path, [`SuggestionEngine::learn_after`].
+//!
+//! Nothing reads these edges yet; querying arrives with `suggest_with`.
+
+pub(crate) mod follower;
+mod learning;
+mod slots;

--- a/crates/funput-suggestions/src/bigram/slots.rs
+++ b/crates/funput-suggestions/src/bigram/slots.rs
@@ -1,0 +1,107 @@
+//! Which few following words a word keeps, and how a newcomer gets in.
+//!
+//! Pure on the slot array: no allocation, no `words`, O(`FOLLOWER_SLOTS`). What
+//! liveness a caller knows, it passes in.
+
+use super::follower::{FOLLOWER_SLOTS, Follower};
+
+pub(crate) fn record(
+    followers: &mut [Follower; FOLLOWER_SLOTS],
+    seen: &mut u16,
+    dead: [bool; FOLLOWER_SLOTS],
+    next: Follower,
+) {
+    *seen = seen.saturating_add(1);
+
+    if let Some(index) = (0..FOLLOWER_SLOTS).find(|&index| followers[index].points_at(next)) {
+        followers[index].uses = followers[index].uses.saturating_add(1);
+        return;
+    }
+    if let Some(index) =
+        (0..FOLLOWER_SLOTS).find(|&index| followers[index].is_free() || dead[index])
+    {
+        followers[index] = next;
+        return;
+    }
+
+    // Every slot is taken by a living word, so the newcomer has to buy its way
+    // in: the weakest pays a point for the challenge and only yields once it has
+    // nothing left. A one-off typo never gets in; a pair typed a few times does.
+    // Without this the first four words to follow a context would hold it for
+    // good, and "xin" would answer with four typos forever.
+    let weakest = (0..FOLLOWER_SLOTS)
+        .min_by_key(|&index| followers[index].uses)
+        .unwrap_or(0);
+    followers[weakest].uses -= 1;
+    if followers[weakest].is_free() {
+        followers[weakest] = next;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALIVE: [bool; FOLLOWER_SLOTS] = [false; FOLLOWER_SLOTS];
+
+    fn follower(word: u32, uses: u16) -> Follower {
+        Follower {
+            word,
+            generation: 0,
+            uses,
+        }
+    }
+
+    fn set(counts: [u16; FOLLOWER_SLOTS]) -> [Follower; FOLLOWER_SLOTS] {
+        std::array::from_fn(|index| follower(index as u32, counts[index]))
+    }
+
+    #[test]
+    fn a_repeat_counts_up_rather_than_taking_a_second_slot() {
+        let mut followers = set([3, 2, 1, 1]);
+        let mut seen = 7;
+        record(&mut followers, &mut seen, ALIVE, follower(1, 1));
+        assert_eq!(followers[1].uses, 3);
+        assert_eq!(seen, 8);
+    }
+
+    #[test]
+    fn a_free_slot_takes_the_newcomer_outright() {
+        let mut followers = set([3, 0, 0, 0]);
+        let mut seen = 3;
+        record(&mut followers, &mut seen, ALIVE, follower(9, 1));
+        assert_eq!(followers[1].word, 9);
+        assert_eq!(followers[1].uses, 1);
+    }
+
+    #[test]
+    fn a_dead_slot_is_reused_before_anyone_is_charged() {
+        let mut followers = set([3, 2, 2, 2]);
+        let mut seen = 9;
+        let mut dead = ALIVE;
+        dead[2] = true;
+        record(&mut followers, &mut seen, dead, follower(9, 1));
+        assert_eq!(followers[2].word, 9);
+        assert_eq!(
+            [followers[0].uses, followers[1].uses, followers[3].uses],
+            [3, 2, 2],
+            "nobody should pay while a dead slot is going spare"
+        );
+    }
+
+    #[test]
+    fn a_full_set_charges_the_weakest_and_only_yields_at_zero() {
+        let mut followers = set([3, 2, 2, 2]);
+        let mut seen = 9;
+        record(&mut followers, &mut seen, ALIVE, follower(9, 1));
+        assert_eq!(followers[1].uses, 1, "the weakest pays for the challenge");
+        assert!(
+            followers.iter().all(|slot| slot.word != 9),
+            "one sighting must not be enough to displace an established pair"
+        );
+
+        record(&mut followers, &mut seen, ALIVE, follower(9, 1));
+        assert_eq!(followers[1].word, 9, "persistence eventually wins the slot");
+        assert_eq!(followers[1].uses, 1);
+    }
+}

--- a/crates/funput-suggestions/src/bigram/slots.rs
+++ b/crates/funput-suggestions/src/bigram/slots.rs
@@ -5,6 +5,17 @@
 
 use super::follower::{FOLLOWER_SLOTS, Follower};
 
+/// After this many sightings of one context word, every count it holds is halved.
+///
+/// Two jobs in one constant. It bounds `uses`, which can never exceed `seen`, so
+/// the `u16` counts cannot overflow. And it is what lets a habit change: the
+/// challenge rule below removes one point at a time, so a slot that got far
+/// enough ahead would be unreachable forever without something that decays it.
+///
+/// Not in `SuggestionConfig` yet — the value is a guess until there is a reader
+/// to calibrate it against.
+pub(crate) const AGING_AFTER: u16 = 256;
+
 pub(crate) fn record(
     followers: &mut [Follower; FOLLOWER_SLOTS],
     seen: &mut u16,
@@ -12,7 +23,13 @@ pub(crate) fn record(
     next: Follower,
 ) {
     *seen = seen.saturating_add(1);
+    admit(followers, dead, next);
+    if *seen >= AGING_AFTER {
+        age(followers, seen);
+    }
+}
 
+fn admit(followers: &mut [Follower; FOLLOWER_SLOTS], dead: [bool; FOLLOWER_SLOTS], next: Follower) {
     if let Some(index) = (0..FOLLOWER_SLOTS).find(|&index| followers[index].points_at(next)) {
         followers[index].uses = followers[index].uses.saturating_add(1);
         return;
@@ -35,6 +52,18 @@ pub(crate) fn record(
     followers[weakest].uses -= 1;
     if followers[weakest].is_free() {
         followers[weakest] = next;
+    }
+}
+
+fn age(followers: &mut [Follower; FOLLOWER_SLOTS], seen: &mut u16) {
+    *seen /= 2;
+    for slot in followers {
+        slot.uses /= 2;
+        if slot.is_free() {
+            // Halved out of existence: a word seen once here is noise, and its
+            // slot is worth more to whatever comes next.
+            *slot = Follower::EMPTY;
+        }
     }
 }
 
@@ -87,6 +116,34 @@ mod tests {
             [3, 2, 2],
             "nobody should pay while a dead slot is going spare"
         );
+    }
+
+    #[test]
+    fn aging_halves_every_count_and_drops_the_one_offs() {
+        let mut followers = set([8, 5, 2, 1]);
+        let mut seen = AGING_AFTER - 1;
+        record(&mut followers, &mut seen, ALIVE, follower(0, 1));
+
+        assert_eq!(seen, AGING_AFTER / 2);
+        assert_eq!(
+            [followers[0].uses, followers[1].uses, followers[2].uses],
+            [4, 2, 1]
+        );
+        assert!(
+            followers[3].is_free(),
+            "a single sighting should not survive an aging pass"
+        );
+    }
+
+    #[test]
+    fn aging_keeps_an_entrenched_slot_reachable() {
+        // The challenge rule removes one point per sighting, so without decay a
+        // set that got this far ahead could never be displaced at all.
+        let mut followers = set([250, 250, 250, 250]);
+        let mut seen = AGING_AFTER - 1;
+        record(&mut followers, &mut seen, ALIVE, follower(9, 1));
+
+        assert!(followers.iter().all(|slot| slot.uses <= 125));
     }
 
     #[test]

--- a/crates/funput-suggestions/src/engine/learning.rs
+++ b/crates/funput-suggestions/src/engine/learning.rs
@@ -1,20 +1,24 @@
 use super::{PENDING_LIMIT, REBUILD_AFTER_EVICTIONS, SuggestionEngine};
-use crate::index::normalize;
+use crate::bigram::follower::{FOLLOWER_SLOTS, Follower};
+use crate::index::{NONE, normalize};
 use crate::types::{LearnOutcome, WordRecord};
 
 impl SuggestionEngine {
     pub fn learn(&mut self, token: &str) -> LearnOutcome {
-        self.learn_inner(token, true)
+        self.learn_after(None, token)
     }
 
-    pub(crate) fn learn_inner(&mut self, token: &str, record_pending: bool) -> LearnOutcome {
+    /// Returns the outcome and the slot the token landed in; the slot is `NONE`
+    /// when the token was ignored. `learn_after` needs the slot to hang an edge
+    /// off, and it is the only thing that reads it.
+    pub(crate) fn learn_inner(&mut self, token: &str, record_pending: bool) -> (LearnOutcome, u32) {
         let normalized = normalize::exact(token);
         let length = normalized.chars().count();
         if length == 0
             || length > self.config.max_token_scalars
             || normalized.chars().any(char::is_whitespace)
         {
-            return LearnOutcome::Ignored;
+            return (LearnOutcome::Ignored, NONE);
         }
 
         self.sequence = self.sequence.saturating_add(1);
@@ -40,13 +44,14 @@ impl SuggestionEngine {
         }
 
         let uses = self.words[word_id as usize].uses;
-        if previous_uses == 0 {
+        let outcome = if previous_uses == 0 {
             LearnOutcome::Recorded
         } else if previous_uses < self.config.promotion_uses && uses >= self.config.promotion_uses {
             LearnOutcome::Promoted
         } else {
             LearnOutcome::Updated
-        }
+        };
+        (outcome, word_id)
     }
 
     fn upsert_word(&mut self, normalized: String) -> (u32, u32, bool) {
@@ -62,6 +67,8 @@ impl SuggestionEngine {
             uses: 1,
             last_used: self.sequence,
             generation: 0,
+            context_seen: 0,
+            followers: [Follower::EMPTY; FOLLOWER_SLOTS],
         };
         if self.words.len() < self.config.max_words {
             let index = self.words.len() as u32;

--- a/crates/funput-suggestions/src/lib.rs
+++ b/crates/funput-suggestions/src/lib.rs
@@ -5,12 +5,14 @@
 //!
 //! # Layout
 //!
+//! - `bigram/` — which words follow which, and the write path that learns them.
 //! - `engine/` — the [`SuggestionEngine`] facade, its [`SuggestionConfig`], and the
 //!   learn / query / durability behaviours.
 //! - `index/` — the in-memory search index (prefix trie, ranking, key normalization).
 //! - `persistence/` — the crash-safe on-disk snapshot + journal store.
 //! - `types` — the shared vocabulary (`WordRecord` and the public result types).
 
+mod bigram;
 mod engine;
 mod index;
 mod persistence;

--- a/crates/funput-suggestions/src/persistence/codec/snapshot.rs
+++ b/crates/funput-suggestions/src/persistence/codec/snapshot.rs
@@ -2,6 +2,7 @@
 
 use std::io;
 
+use crate::bigram::follower::{FOLLOWER_SLOTS, Follower};
 use crate::types::WordRecord;
 
 use super::binary::{Cursor, checksum, invalid_data, put_u16, put_u32, put_u64};
@@ -61,9 +62,12 @@ pub(crate) fn decode(bytes: &[u8]) -> io::Result<Option<(Vec<WordRecord>, u64)>>
             text,
             uses: cursor.u32()?,
             last_used: cursor.u64()?,
-            // Not serialized: generations only mean something to the trie
-            // entries of one run, and those are rebuilt on open.
+            // None of these three are serialized. Generations only mean
+            // something to the entries of one run, and the followers that depend
+            // on them are not persisted yet either.
             generation: 0,
+            context_seen: 0,
+            followers: [Follower::EMPTY; FOLLOWER_SLOTS],
         });
     }
     Ok(cursor.is_empty().then_some((words, sequence)))

--- a/crates/funput-suggestions/src/tests/bigram/learning.rs
+++ b/crates/funput-suggestions/src/tests/bigram/learning.rs
@@ -1,0 +1,88 @@
+use super::{edge, followers_of};
+use crate::{LearnOutcome, SuggestionConfig, SuggestionEngine};
+
+fn bounded(max_words: usize) -> SuggestionEngine {
+    SuggestionEngine::in_memory(SuggestionConfig {
+        max_words,
+        ..SuggestionConfig::default()
+    })
+}
+
+#[test]
+fn a_pair_is_recorded_and_counted_up() {
+    let mut engine = bounded(16);
+    engine.learn_after(None, "xin");
+    engine.learn_after(Some("xin"), "chào");
+    assert_eq!(followers_of(&engine, "xin"), [edge("chào", 1)]);
+
+    engine.learn_after(Some("xin"), "chào");
+    assert_eq!(followers_of(&engine, "xin"), [edge("chào", 2)]);
+}
+
+#[test]
+fn learning_without_a_context_records_no_edge() {
+    let mut engine = bounded(16);
+    engine.learn_after(None, "xin");
+    engine.learn_after(None, "chào");
+    assert!(followers_of(&engine, "xin").is_empty());
+}
+
+#[test]
+fn an_ignored_token_records_no_edge() {
+    let mut engine = bounded(16);
+    engine.learn_after(None, "xin");
+    assert_eq!(
+        engine.learn_after(Some("xin"), "hai từ"),
+        LearnOutcome::Ignored
+    );
+    assert_eq!(engine.learn_after(Some("xin"), ""), LearnOutcome::Ignored);
+    assert!(followers_of(&engine, "xin").is_empty());
+}
+
+#[test]
+fn an_unknown_context_records_no_edge() {
+    let mut engine = bounded(16);
+    engine.learn_after(Some("chưa gặp"), "chào");
+    assert!(followers_of(&engine, "chào").is_empty());
+}
+
+#[test]
+fn a_context_evicted_by_its_own_token_records_no_edge() {
+    // One slot, so learning "chào" can only take the slot "xin" is sitting in.
+    let mut engine = bounded(1);
+    engine.learn_after(None, "xin");
+    engine.learn_after(Some("xin"), "chào");
+
+    assert_eq!(engine.stats().words, 1);
+    assert!(
+        followers_of(&engine, "chào").is_empty(),
+        "the context was evicted by the very token that would follow it; the edge \
+         would land on whatever moved into its slot"
+    );
+}
+
+#[test]
+fn an_edge_to_an_evicted_word_reads_as_dead() {
+    let mut engine = bounded(3);
+    engine.learn_after(None, "aaa");
+    engine.learn_after(None, "aaa");
+    engine.learn_after(Some("aaa"), "bbb");
+    assert_eq!(followers_of(&engine, "aaa"), [edge("bbb", 1)]);
+
+    // "bbb" is the lowest ranked, so filling the lexicon pushes it out.
+    engine.learn_after(None, "ccc");
+    engine.learn_after(None, "ddd");
+    assert!(
+        followers_of(&engine, "aaa").is_empty(),
+        "an edge outlives its target, and must read as dead rather than point at \
+         the word that took the slot"
+    );
+}
+
+#[test]
+fn a_word_may_follow_itself() {
+    let mut engine = bounded(16);
+    engine.learn_after(None, "ha");
+    engine.learn_after(Some("ha"), "ha");
+    assert_eq!(followers_of(&engine, "ha"), [edge("ha", 1)]);
+}

--- a/crates/funput-suggestions/src/tests/bigram/mod.rs
+++ b/crates/funput-suggestions/src/tests/bigram/mod.rs
@@ -1,0 +1,27 @@
+//! What the engine remembers about which word followed which.
+
+mod learning;
+
+use crate::SuggestionEngine;
+
+/// The *living* followers of `word`, strongest first. Edges whose target has
+/// been evicted are filtered out here exactly as a reader would filter them.
+fn followers_of(engine: &SuggestionEngine, word: &str) -> Vec<(String, u16)> {
+    let Some(record) = engine.words.iter().find(|record| record.text == word) else {
+        return Vec::new();
+    };
+    let mut edges: Vec<_> = record
+        .followers
+        .iter()
+        .filter_map(|slot| {
+            slot.word(&engine.words)
+                .map(|next| (next.text.clone(), slot.uses))
+        })
+        .collect();
+    edges.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+    edges
+}
+
+fn edge(text: &str, uses: u16) -> (String, u16) {
+    (text.to_owned(), uses)
+}

--- a/crates/funput-suggestions/src/tests/mod.rs
+++ b/crates/funput-suggestions/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod bigram;
 mod eviction;
 mod learning;
 mod persistence;

--- a/crates/funput-suggestions/src/types.rs
+++ b/crates/funput-suggestions/src/types.rs
@@ -1,3 +1,4 @@
+use crate::bigram::follower::{FOLLOWER_SLOTS, Follower};
 use crate::index::TOP_K;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -50,4 +51,11 @@ pub(crate) struct WordRecord {
     /// invalidates those references instead of silently renaming what they point
     /// at. In memory only — a reloaded store starts everyone back at zero.
     pub(crate) generation: u16,
+    /// How many times this word has been seen *as a context* — the denominator
+    /// the dominance threshold will divide by once anything reads these edges.
+    pub(crate) context_seen: u16,
+    /// The words seen following this one. Inline rather than in a table of their
+    /// own: the edges then cost no allocation, and a word losing its slot takes
+    /// its edges with it instead of leaving a table to go stale.
+    pub(crate) followers: [Follower; FOLLOWER_SLOTS],
 }


### PR DESCRIPTION
**4 of 6** toward `feature/context-suggestion`. Base is PR #280.

The edge data and the path that writes it — steps 1 and 2 of the design doc. Nothing reads these edges yet, so no caller can see a difference.

Each word keeps four `Follower` slots inline in its own record rather than in a table of its own. That buys three things: no allocation per edge, a word that loses its slot takes its edges with it instead of leaving a table to go stale, and a fixed ceiling for the whole feature.

`learn_after(previous, token)` is the write path and `learn` is now `learn_after(None, token)` — same signature, so the C ABI and JNI see nothing.

**Order is the subtle part.** The context slot is resolved *before* the token is learned, because learning it can evict the very word it followed, and re-checked *after*, because it may have just done so. Two tests fail without those generation checks, one of them by recording "chào" as following itself.

Admission is Space-Saving rather than first-come: four slots filled by four typos would otherwise hold a context word for good. A newcomer charges the weakest slot a point and takes it only once that slot has nothing left. Every 256 sightings the counts are halved, which both bounds them and lets a habit change.

## Review

Followers are **not persisted yet** — reopening a store drops every edge. Harmless while nothing reads them; PR 5 is the storage work.

Measured cost is 256 KiB for 5,000 words, not the ~160 KB planned: `words` grows by doubling, so 32 bytes of edges are paid against a capacity of 8,192. Retained heap goes 670,820 B → 932,964 B against a 4 MiB test budget.