### PR TITLE
feat(suggestions): persist the follower edges

### DIFF
--- a/benchmarks/results/personal-suggestions-v2.md
+++ b/benchmarks/results/personal-suggestions-v2.md
@@ -52,8 +52,10 @@ written on the learn path and nothing reads them yet.
 
 | Operation | V1 | V2 | Note |
 |---|---:|---:|---|
-| Flush 256 mutations | 5.19 ms | 5.42 ms | first append to a new journal only |
-| Compact 5,000 words | 9.83 ms | 13.51 ms | +4.1 ms, deliberate |
+| Open a 5,000-word snapshot | 2.17 ms | 2.31 ms | reads a follower section per word |
+| Open + replay 100 journal tokens | 3.98 ms | 2.92 ms | replay no longer rebuilds the tries |
+| Flush 256 mutations | 5.19 ms | 5.37 ms | first append to a new journal only |
+| Compact 5,000 words | 9.83 ms | 13.69 ms | +3.9 ms, deliberate |
 
 `compact` now fsyncs the directory after renaming the snapshot into place. A
 rename is a directory change, and without that sync a power loss can reorder it
@@ -64,6 +66,28 @@ worker, never on the typing path.
 The `flush_256` figure covers the append that *creates* the journal, which is the
 only append that syncs the directory; steady-state appends add one `stat` and no
 sync.
+
+## Storage format
+
+The snapshot is at v2 and the journal at v2; the two are versioned apart, because
+they are separate formats that happened to share a number. Both still read v1, so
+upgrading loses nothing, and a v1 file is rewritten at the current schema on its
+first compact.
+
+Costs are fixed by the format rather than measured. A snapshot word grows by
+three bytes for its context count and follower count, plus six per occupied
+follower slot — so a word nobody has followed costs three bytes and a word with
+all four slots taken costs twenty-seven. Against the V1 record of twenty-two
+bytes plus the word itself, a lexicon with no edges grows about 14%, and one with
+every slot filled roughly doubles. The 2 MiB snapshot budget the tests enforce is
+an order of magnitude away either way.
+
+A journal token grows by exactly one byte: a flag saying whether it followed the
+token before it. Recording pairs any other way was measurably worse — writing a
+separate break record doubled the entries for every token learned without a
+context, which is every token until the platforms pass one, and pushed `pending`
+past its 256-entry limit after 128 learns, turning every flush into a full
+compact. `flush_256` went to 9.97 ms before the flag byte replaced it.
 
 ## Measured and deliberately not changed
 

--- a/crates/funput-suggestions/src/bigram/learning.rs
+++ b/crates/funput-suggestions/src/bigram/learning.rs
@@ -14,16 +14,40 @@ impl SuggestionEngine {
     /// — a fresh focus, a moved caret, a sentence boundary — passes `None` and
     /// gets exactly the behaviour `learn` always had.
     pub fn learn_after(&mut self, previous: Option<&str>, token: &str) -> LearnOutcome {
+        self.learn_after_inner(previous, token, true)
+    }
+
+    pub(crate) fn learn_after_inner(
+        &mut self,
+        previous: Option<&str>,
+        token: &str,
+        record_pending: bool,
+    ) -> LearnOutcome {
         // Resolved before learning because learning `token` can evict `previous`,
         // and re-checked after because it may have just done so.
         let context = previous.and_then(|text| self.context_slot(text));
-        let (outcome, word_id) = self.learn_inner(token, true);
-        if outcome != LearnOutcome::Ignored
-            && let Some((index, generation)) = context
-            && self.words[index].generation == generation
-        {
-            self.record_edge(index, word_id);
+
+        // Replay reads pairs off adjacency, so a token may only be marked as
+        // chained when its context really is what the journal wrote last.
+        // Anything else — a sentence boundary, an ignored token in between, a
+        // context evicted since — is left unchained, and replay then misses an
+        // edge instead of inventing one.
+        let chained = context.is_some() && context == self.journalled_previous;
+
+        let (outcome, word_id) = self.learn_inner(token);
+        if outcome == LearnOutcome::Ignored {
+            return outcome;
         }
+        if record_pending {
+            let token = self.words[word_id as usize].text.clone();
+            self.push_pending((token, chained));
+        }
+        if let Some((index, generation)) = context
+            && self.words[index as usize].generation == generation
+        {
+            self.record_edge(index as usize, word_id);
+        }
+        self.journalled_previous = Some((word_id, self.words[word_id as usize].generation));
         outcome
     }
 
@@ -31,11 +55,11 @@ impl SuggestionEngine {
     ///
     /// Compares through the normalizing iterator rather than `normalize::exact`,
     /// which would allocate a `String` for every token learned with a context.
-    fn context_slot(&self, previous: &str) -> Option<(usize, u16)> {
+    fn context_slot(&self, previous: &str) -> Option<(u32, u16)> {
         self.words
             .iter()
             .position(|word| word.text.chars().eq(normalize::exact_chars(previous)))
-            .map(|index| (index, self.words[index].generation))
+            .map(|index| (index as u32, self.words[index].generation))
     }
 
     fn record_edge(&mut self, context: usize, next_id: u32) {

--- a/crates/funput-suggestions/src/engine/durability.rs
+++ b/crates/funput-suggestions/src/engine/durability.rs
@@ -34,6 +34,9 @@ impl SuggestionEngine {
     }
 
     pub fn compact(&mut self) -> io::Result<u64> {
+        // The journal is replaced wholesale below, so nothing already written is
+        // adjacent to whatever is learned next.
+        self.journalled_previous = None;
         let Some(store) = &self.store else {
             self.pending.clear();
             self.pending_overflow = false;
@@ -52,6 +55,7 @@ impl SuggestionEngine {
     pub fn reset(&mut self) -> io::Result<()> {
         self.words.clear();
         self.evictions_since_rebuild = 0;
+        self.journalled_previous = None;
         self.exact.clear();
         self.folded.clear();
         self.sequence = 0;

--- a/crates/funput-suggestions/src/engine/learning.rs
+++ b/crates/funput-suggestions/src/engine/learning.rs
@@ -1,6 +1,7 @@
 use super::{PENDING_LIMIT, REBUILD_AFTER_EVICTIONS, SuggestionEngine};
 use crate::bigram::follower::{FOLLOWER_SLOTS, Follower};
 use crate::index::{NONE, normalize};
+use crate::persistence::JournalEntry;
 use crate::types::{LearnOutcome, WordRecord};
 
 impl SuggestionEngine {
@@ -8,10 +9,10 @@ impl SuggestionEngine {
         self.learn_after(None, token)
     }
 
-    /// Returns the outcome and the slot the token landed in; the slot is `NONE`
-    /// when the token was ignored. `learn_after` needs the slot to hang an edge
-    /// off, and it is the only thing that reads it.
-    pub(crate) fn learn_inner(&mut self, token: &str, record_pending: bool) -> (LearnOutcome, u32) {
+    /// Learn one token, returning the outcome and the slot it landed in — `NONE`
+    /// when it was ignored. Appending it to the journal is `learn_after_inner`'s
+    /// job, because only that knows whether it followed what came before.
+    pub(crate) fn learn_inner(&mut self, token: &str) -> (LearnOutcome, u32) {
         let normalized = normalize::exact(token);
         let length = normalized.chars().count();
         if length == 0
@@ -22,14 +23,7 @@ impl SuggestionEngine {
         }
 
         self.sequence = self.sequence.saturating_add(1);
-        let (word_id, previous_uses, evicted_indexed) = self.upsert_word(normalized.clone());
-        if record_pending {
-            if self.pending.len() < PENDING_LIMIT {
-                self.pending.push(normalized);
-            } else {
-                self.pending_overflow = true;
-            }
-        }
+        let (word_id, previous_uses, evicted_indexed) = self.upsert_word(normalized);
         if evicted_indexed {
             // The evicted word's entries are stale, not wrong: its slot's
             // generation moved on, so they already read as dead. Sweeping them is
@@ -52,6 +46,17 @@ impl SuggestionEngine {
             LearnOutcome::Updated
         };
         (outcome, word_id)
+    }
+
+    /// Overflow is not a gap in the journal: `flush` turns it into a compact,
+    /// which replaces the journal outright rather than appending a chain with a
+    /// hole nothing marked.
+    pub(crate) fn push_pending(&mut self, entry: JournalEntry) {
+        if self.pending.len() < PENDING_LIMIT {
+            self.pending.push(entry);
+        } else {
+            self.pending_overflow = true;
+        }
     }
 
     fn upsert_word(&mut self, normalized: String) -> (u32, u32, bool) {

--- a/crates/funput-suggestions/src/engine/mod.rs
+++ b/crates/funput-suggestions/src/engine/mod.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use config::sanitize;
 
 use crate::index::ArenaTrie;
-use crate::persistence::Store;
+use crate::persistence::{JournalEntry, Store};
 use crate::types::WordRecord;
 
 pub(crate) const PENDING_LIMIT: usize = 256;
@@ -38,7 +38,7 @@ pub struct SuggestionEngine {
     pub(crate) exact: ArenaTrie,
     pub(crate) folded: ArenaTrie,
     pub(crate) sequence: u64,
-    pub(crate) pending: Vec<String>,
+    pub(crate) pending: Vec<JournalEntry>,
     pub(crate) pending_overflow: bool,
     pub(crate) store: Option<Store>,
     pub(crate) last_snapshot_bytes: u64,
@@ -51,6 +51,12 @@ pub struct SuggestionEngine {
     /// Indexed words evicted since the last rebuild — that is, how many dead
     /// entries the tries are currently carrying.
     pub(crate) evictions_since_rebuild: u32,
+    /// The slot and generation of the last token appended to the journal.
+    ///
+    /// Replay rebuilds pairs from adjacency, so the writer has to know whether
+    /// the context it was handed really is what it wrote last. When it is not, a
+    /// break goes in and replay loses an edge rather than inventing one.
+    pub(crate) journalled_previous: Option<(u32, u16)>,
 }
 
 impl SuggestionEngine {
@@ -68,6 +74,7 @@ impl SuggestionEngine {
             journal_bytes: 0,
             rebuilds: 0,
             evictions_since_rebuild: 0,
+            journalled_previous: None,
         }
     }
 
@@ -81,8 +88,11 @@ impl SuggestionEngine {
         engine.journal_bytes = loaded.journal_bytes;
         engine.enforce_capacity();
         engine.rebuild_tries();
-        for token in loaded.journal {
-            engine.learn_inner(&token, false);
+        let mut previous: Option<String> = None;
+        for (token, chained) in loaded.journal {
+            let context = chained.then_some(previous.as_deref()).flatten();
+            engine.learn_after_inner(context, &token, false);
+            previous = Some(token);
         }
         engine.pending.clear();
         engine.pending_overflow = false;

--- a/crates/funput-suggestions/src/engine/mod.rs
+++ b/crates/funput-suggestions/src/engine/mod.rs
@@ -112,6 +112,15 @@ impl SuggestionEngine {
                 break;
             };
             self.words.swap_remove(index);
+            // `swap_remove` hands this slot to whatever was last in the list, so
+            // anything still holding the old index has to stop resolving — the
+            // same reuse `upsert_word` bumps for. It matters here because a
+            // freshly loaded store has every record at generation 0, so a
+            // follower read off disk would otherwise match its new tenant and
+            // read as perfectly alive.
+            if let Some(word) = self.words.get_mut(index) {
+                word.generation = word.generation.wrapping_add(1);
+            }
         }
     }
 }

--- a/crates/funput-suggestions/src/engine/query.rs
+++ b/crates/funput-suggestions/src/engine/query.rs
@@ -47,8 +47,12 @@ impl SuggestionEngine {
                 .iter()
                 .map(|word| word.text.capacity())
                 .sum::<usize>();
-        let pending_bytes = self.pending.capacity() * size_of::<String>()
-            + self.pending.iter().map(String::capacity).sum::<usize>();
+        let pending_bytes = self.pending.capacity() * size_of::<crate::persistence::JournalEntry>()
+            + self
+                .pending
+                .iter()
+                .map(|(token, _)| token.capacity())
+                .sum::<usize>();
         SuggestionStats {
             words: self.words.len(),
             promoted_words: self

--- a/crates/funput-suggestions/src/persistence/codec/binary.rs
+++ b/crates/funput-suggestions/src/persistence/codec/binary.rs
@@ -20,6 +20,10 @@ impl<'a> Cursor<'a> {
         Ok(value)
     }
 
+    pub(crate) fn u8(&mut self) -> io::Result<u8> {
+        Ok(self.take(1)?[0])
+    }
+
     pub(crate) fn u16(&mut self) -> io::Result<u16> {
         Ok(u16::from_le_bytes(
             self.take(2)?.try_into().map_err(|_| invalid_data())?,

--- a/crates/funput-suggestions/src/persistence/codec/journal.rs
+++ b/crates/funput-suggestions/src/persistence/codec/journal.rs
@@ -1,15 +1,26 @@
 //! The journal record: one checksummed frame per batch of learned tokens.
+//!
+//! The frame is already in typing order, so a pair is simply two adjacent
+//! tokens and the pairs themselves never need writing. What each token carries
+//! is one byte saying whether it really did follow the token before it.
+//!
+//! v1 has no such byte and recorded no boundaries at all, so nothing in a v1
+//! frame can be believed as adjacent.
 
 use std::io;
 
 use super::binary::{Cursor, checksum, invalid_data, put_u16, put_u32};
 use crate::persistence::schema::{self, JOURNAL_MAGIC, JOURNAL_WRITE_VERSION, Version};
 
-pub(crate) fn encode_frame(tokens: &[String]) -> Vec<u8> {
+/// One learned token, and whether it followed the token written before it.
+pub(crate) type Entry = (String, bool);
+
+pub(crate) fn encode_frame(entries: &[Entry]) -> Vec<u8> {
     let mut payload = Vec::new();
-    put_u32(&mut payload, tokens.len() as u32);
-    for token in tokens {
+    put_u32(&mut payload, entries.len() as u32);
+    for (token, chained) in entries {
         put_u16(&mut payload, token.len() as u16);
+        payload.push(u8::from(*chained));
         payload.extend_from_slice(token.as_bytes());
     }
     let mut frame = Vec::with_capacity(14 + payload.len());
@@ -21,11 +32,12 @@ pub(crate) fn encode_frame(tokens: &[String]) -> Vec<u8> {
     frame
 }
 
-pub(crate) fn decode_frame(cursor: &mut Cursor<'_>) -> io::Result<Vec<String>> {
+pub(crate) fn decode_frame(cursor: &mut Cursor<'_>) -> io::Result<Vec<Entry>> {
     if cursor.take(JOURNAL_MAGIC.len())? != JOURNAL_MAGIC {
         return Err(invalid_data());
     }
-    match schema::accept_journal(cursor.u16()?) {
+    let version = cursor.u16()?;
+    match schema::accept_journal(version) {
         Version::Readable => {}
         Version::TooNew => {
             return Err(io::Error::new(
@@ -48,17 +60,18 @@ pub(crate) fn decode_frame(cursor: &mut Cursor<'_>) -> io::Result<Vec<String>> {
     if count > payload.remaining() / 2 {
         return Err(invalid_data());
     }
-    let mut tokens = Vec::with_capacity(count);
+    let mut entries = Vec::with_capacity(count);
     for _ in 0..count {
         let len = payload.u16()? as usize;
-        tokens.push(
-            std::str::from_utf8(payload.take(len)?)
-                .map_err(|_| invalid_data())?
-                .to_owned(),
-        );
+        // A v1 frame has no flag byte, and nothing in it may be read as adjacent.
+        let chained = version >= 2 && payload.u8()? != 0;
+        let token = std::str::from_utf8(payload.take(len)?)
+            .map_err(|_| invalid_data())?
+            .to_owned();
+        entries.push((token, chained));
     }
     if !payload.is_empty() {
         return Err(invalid_data());
     }
-    Ok(tokens)
+    Ok(entries)
 }

--- a/crates/funput-suggestions/src/persistence/codec/journal.rs
+++ b/crates/funput-suggestions/src/persistence/codec/journal.rs
@@ -3,7 +3,7 @@
 use std::io;
 
 use super::binary::{Cursor, checksum, invalid_data, put_u16, put_u32};
-use crate::persistence::schema::{self, JOURNAL_MAGIC, Version, WRITE_VERSION};
+use crate::persistence::schema::{self, JOURNAL_MAGIC, JOURNAL_WRITE_VERSION, Version};
 
 pub(crate) fn encode_frame(tokens: &[String]) -> Vec<u8> {
     let mut payload = Vec::new();
@@ -14,7 +14,7 @@ pub(crate) fn encode_frame(tokens: &[String]) -> Vec<u8> {
     }
     let mut frame = Vec::with_capacity(14 + payload.len());
     frame.extend_from_slice(JOURNAL_MAGIC);
-    put_u16(&mut frame, WRITE_VERSION);
+    put_u16(&mut frame, JOURNAL_WRITE_VERSION);
     put_u32(&mut frame, payload.len() as u32);
     put_u32(&mut frame, checksum(&payload));
     frame.extend_from_slice(&payload);
@@ -25,7 +25,7 @@ pub(crate) fn decode_frame(cursor: &mut Cursor<'_>) -> io::Result<Vec<String>> {
     if cursor.take(JOURNAL_MAGIC.len())? != JOURNAL_MAGIC {
         return Err(invalid_data());
     }
-    match schema::accept(cursor.u16()?) {
+    match schema::accept_journal(cursor.u16()?) {
         Version::Readable => {}
         Version::TooNew => {
             return Err(io::Error::new(

--- a/crates/funput-suggestions/src/persistence/codec/snapshot.rs
+++ b/crates/funput-suggestions/src/persistence/codec/snapshot.rs
@@ -1,4 +1,9 @@
 //! The snapshot record: the whole word list in one checksummed frame.
+//!
+//! v1 is the word list alone. v2 appends each word's context count and its
+//! follower edges. The generation is never written: it means something only
+//! within one run, and every record comes back at zero, so the edges written
+//! against it come back matching.
 
 use std::io;
 
@@ -6,12 +11,12 @@ use crate::bigram::follower::{FOLLOWER_SLOTS, Follower};
 use crate::types::WordRecord;
 
 use super::binary::{Cursor, checksum, invalid_data, put_u16, put_u32, put_u64};
-use crate::persistence::schema::{self, SNAPSHOT_MAGIC, Version, WRITE_VERSION};
+use crate::persistence::schema::{self, SNAPSHOT_MAGIC, SNAPSHOT_WRITE_VERSION, Version};
 
 pub(crate) fn encode(words: &[WordRecord], sequence: u64) -> Vec<u8> {
     let mut bytes = Vec::new();
     bytes.extend_from_slice(SNAPSHOT_MAGIC);
-    put_u16(&mut bytes, WRITE_VERSION);
+    put_u16(&mut bytes, SNAPSHOT_WRITE_VERSION);
     put_u64(&mut bytes, sequence);
     put_u32(&mut bytes, words.len() as u32);
     for word in words {
@@ -19,10 +24,43 @@ pub(crate) fn encode(words: &[WordRecord], sequence: u64) -> Vec<u8> {
         bytes.extend_from_slice(word.text.as_bytes());
         put_u32(&mut bytes, word.uses);
         put_u64(&mut bytes, word.last_used);
+        encode_followers(&mut bytes, word);
     }
     let sum = checksum(&bytes);
     put_u32(&mut bytes, sum);
     bytes
+}
+
+/// Only the occupied slots go out, so a word nobody has followed costs three
+/// bytes rather than twenty-seven.
+fn encode_followers(bytes: &mut Vec<u8>, word: &WordRecord) {
+    put_u16(bytes, word.context_seen);
+    let live = word.followers.iter().filter(|slot| !slot.is_free());
+    bytes.push(live.clone().count() as u8);
+    for follower in live {
+        put_u32(bytes, follower.word);
+        put_u16(bytes, follower.uses);
+    }
+}
+
+fn decode_followers(cursor: &mut Cursor<'_>) -> io::Result<(u16, [Follower; FOLLOWER_SLOTS])> {
+    let context_seen = cursor.u16()?;
+    let count = cursor.u8()? as usize;
+    if count > FOLLOWER_SLOTS {
+        return Err(invalid_data());
+    }
+    let mut followers = [Follower::EMPTY; FOLLOWER_SLOTS];
+    for slot in followers.iter_mut().take(count) {
+        // Generation zero to match the records this file is being read into. An
+        // id past the end of the list needs no check of its own: `Follower::word`
+        // reads it as dead, and the checksum has already ruled out real damage.
+        *slot = Follower {
+            word: cursor.u32()?,
+            generation: 0,
+            uses: cursor.u16()?,
+        };
+    }
+    Ok((context_seen, followers))
 }
 
 pub(crate) fn decode(bytes: &[u8]) -> io::Result<Option<(Vec<WordRecord>, u64)>> {
@@ -37,7 +75,8 @@ pub(crate) fn decode(bytes: &[u8]) -> io::Result<Option<(Vec<WordRecord>, u64)>>
     if cursor.take(SNAPSHOT_MAGIC.len())? != SNAPSHOT_MAGIC {
         return Ok(None);
     }
-    match schema::accept(cursor.u16()?) {
+    let version = cursor.u16()?;
+    match schema::accept_snapshot(version) {
         Version::Readable => {}
         Version::TooNew => {
             return Err(io::Error::new(
@@ -58,16 +97,23 @@ pub(crate) fn decode(bytes: &[u8]) -> io::Result<Option<(Vec<WordRecord>, u64)>>
         let text = std::str::from_utf8(cursor.take(len)?)
             .map_err(|_| invalid_data())?
             .to_owned();
+        let uses = cursor.u32()?;
+        let last_used = cursor.u64()?;
+        let (context_seen, followers) = if version >= 2 {
+            decode_followers(&mut cursor)?
+        } else {
+            (0, [Follower::EMPTY; FOLLOWER_SLOTS])
+        };
         words.push(WordRecord {
             text,
-            uses: cursor.u32()?,
-            last_used: cursor.u64()?,
-            // None of these three are serialized. Generations only mean
-            // something to the entries of one run, and the followers that depend
-            // on them are not persisted yet either.
+            uses,
+            last_used,
+            // Never serialized: a generation means something only inside the run
+            // that issued it, and starting everyone at zero is what makes the
+            // edges above line up again.
             generation: 0,
-            context_seen: 0,
-            followers: [Follower::EMPTY; FOLLOWER_SLOTS],
+            context_seen,
+            followers,
         });
     }
     Ok(cursor.is_empty().then_some((words, sequence)))

--- a/crates/funput-suggestions/src/persistence/mod.rs
+++ b/crates/funput-suggestions/src/persistence/mod.rs
@@ -17,7 +17,10 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use crate::types::WordRecord;
+use codec::journal::Entry;
 use codec::{journal, snapshot};
+
+pub(crate) use codec::journal::Entry as JournalEntry;
 
 pub(crate) struct Store {
     pub(super) root: PathBuf,
@@ -26,7 +29,7 @@ pub(crate) struct Store {
 pub(crate) struct Loaded {
     pub(crate) words: Vec<WordRecord>,
     pub(crate) sequence: u64,
-    pub(crate) journal: Vec<String>,
+    pub(crate) journal: Vec<Entry>,
     pub(crate) journal_bytes: u64,
 }
 
@@ -63,11 +66,11 @@ impl Store {
         ))
     }
 
-    pub(crate) fn append_journal(&self, tokens: &[String]) -> io::Result<u64> {
-        if tokens.is_empty() {
+    pub(crate) fn append_journal(&self, entries: &[Entry]) -> io::Result<u64> {
+        if entries.is_empty() {
             return Ok(0);
         }
-        let frame = journal::encode_frame(tokens);
+        let frame = journal::encode_frame(entries);
         let path = self.journal_path();
         // A brand new journal is a directory change, so the entry needs syncing
         // too — once, on the append that creates it, not on every later one.

--- a/crates/funput-suggestions/src/persistence/recovery.rs
+++ b/crates/funput-suggestions/src/persistence/recovery.rs
@@ -34,7 +34,7 @@ impl Store {
         snapshot::decode(&bytes)
     }
 
-    pub(super) fn load_journal(&self) -> io::Result<(Vec<String>, u64)> {
+    pub(super) fn load_journal(&self) -> io::Result<(Vec<super::JournalEntry>, u64)> {
         let path = self.journal_path();
         let bytes = match fs::metadata(&path) {
             // Far past the 64 KiB that triggers a compact, so this is not
@@ -51,15 +51,15 @@ impl Store {
         };
         let journal_bytes = bytes.len() as u64;
         let mut cursor = Cursor::new(&bytes);
-        let mut tokens = Vec::new();
+        let mut entries = Vec::new();
         while !cursor.is_empty() {
             match journal::decode_frame(&mut cursor) {
-                Ok(frame) => tokens.extend(frame),
+                Ok(frame) => entries.extend(frame),
                 Err(error) if error.kind() == io::ErrorKind::Unsupported => return Err(error),
                 Err(_) => break,
             }
         }
-        Ok((tokens, journal_bytes))
+        Ok((entries, journal_bytes))
     }
 
     /// Empty a journal we have decided not to read.

--- a/crates/funput-suggestions/src/persistence/schema.rs
+++ b/crates/funput-suggestions/src/persistence/schema.rs
@@ -7,16 +7,26 @@ pub(super) const JOURNAL_MAGIC: &[u8; 4] = b"FPJR";
 pub(super) const MAX_SNAPSHOT_BYTES: u64 = 2 * 1024 * 1024;
 pub(super) const MAX_JOURNAL_BYTES: u64 = 1024 * 1024;
 
-/// The schema every file this build writes is stamped with.
-pub(super) const WRITE_VERSION: u16 = 1;
+// The two records are separate formats that happened to share a number. They are
+// versioned apart so one can move without claiming anything about the other —
+// stamping a journal as v2 because the snapshot grew would tell the reader it
+// contains context breaks it does not have.
 
-/// The oldest schema this build can still read. Raising it is how a format is
+/// v2 carries each word's follower edges; v1 is the word list alone.
+pub(super) const SNAPSHOT_WRITE_VERSION: u16 = 2;
+pub(super) const SNAPSHOT_MIN_READ_VERSION: u16 = 1;
+
+/// v1 is a flat token list. Bumped when context breaks arrive.
+pub(super) const JOURNAL_WRITE_VERSION: u16 = 1;
+pub(super) const JOURNAL_MIN_READ_VERSION: u16 = 1;
+
+/// The oldest schema a build can still read. Raising one is how a format is
 /// retired: files below it are discarded and rebuilt rather than rejected.
-pub(super) const MIN_READ_VERSION: u16 = 1;
-
-/// A build that cannot read what it writes would discard every file on upgrade.
-/// Checked here so raising `MIN_READ_VERSION` too far fails the build, not a test.
-const _: () = assert!(MIN_READ_VERSION <= WRITE_VERSION);
+///
+/// A build that cannot read what it writes would discard every file on upgrade,
+/// so the windows are checked here — a bad one fails the build, not a test.
+const _: () = assert!(SNAPSHOT_MIN_READ_VERSION <= SNAPSHOT_WRITE_VERSION);
+const _: () = assert!(JOURNAL_MIN_READ_VERSION <= JOURNAL_WRITE_VERSION);
 
 pub(super) enum Version {
     Readable,
@@ -28,8 +38,12 @@ pub(super) enum Version {
     TooOld,
 }
 
-pub(super) fn accept(version: u16) -> Version {
-    verdict(version, MIN_READ_VERSION, WRITE_VERSION)
+pub(super) fn accept_snapshot(version: u16) -> Version {
+    verdict(version, SNAPSHOT_MIN_READ_VERSION, SNAPSHOT_WRITE_VERSION)
+}
+
+pub(super) fn accept_journal(version: u16) -> Version {
+    verdict(version, JOURNAL_MIN_READ_VERSION, JOURNAL_WRITE_VERSION)
 }
 
 /// The window is a parameter so the verdict can be exercised across ranges this
@@ -50,15 +64,40 @@ mod tests {
     use super::*;
 
     #[test]
-    fn the_shipped_window_reads_what_it_writes() {
-        assert!(matches!(accept(WRITE_VERSION), Version::Readable));
-        assert!(matches!(accept(MIN_READ_VERSION), Version::Readable));
+    fn each_shipped_window_reads_what_it_writes() {
+        assert!(matches!(
+            accept_snapshot(SNAPSHOT_WRITE_VERSION),
+            Version::Readable
+        ));
+        assert!(matches!(
+            accept_snapshot(SNAPSHOT_MIN_READ_VERSION),
+            Version::Readable
+        ));
+        assert!(matches!(
+            accept_journal(JOURNAL_WRITE_VERSION),
+            Version::Readable
+        ));
     }
 
     #[test]
     fn a_newer_schema_is_never_readable() {
-        assert!(matches!(accept(WRITE_VERSION + 1), Version::TooNew));
-        assert!(matches!(accept(u16::MAX), Version::TooNew));
+        assert!(matches!(
+            accept_snapshot(SNAPSHOT_WRITE_VERSION + 1),
+            Version::TooNew
+        ));
+        assert!(matches!(accept_snapshot(u16::MAX), Version::TooNew));
+        assert!(matches!(
+            accept_journal(JOURNAL_WRITE_VERSION + 1),
+            Version::TooNew
+        ));
+    }
+
+    #[test]
+    fn the_two_records_are_versioned_apart() {
+        // The snapshot has moved and the journal has not; a build that shared one
+        // number would have to move both or neither.
+        assert!(matches!(accept_snapshot(1), Version::Readable));
+        assert!(matches!(accept_journal(2), Version::TooNew));
     }
 
     #[test]

--- a/crates/funput-suggestions/src/persistence/schema.rs
+++ b/crates/funput-suggestions/src/persistence/schema.rs
@@ -16,8 +16,8 @@ pub(super) const MAX_JOURNAL_BYTES: u64 = 1024 * 1024;
 pub(super) const SNAPSHOT_WRITE_VERSION: u16 = 2;
 pub(super) const SNAPSHOT_MIN_READ_VERSION: u16 = 1;
 
-/// v1 is a flat token list. Bumped when context breaks arrive.
-pub(super) const JOURNAL_WRITE_VERSION: u16 = 1;
+/// v1 is a flat token list; v2 may carry context breaks between the tokens.
+pub(super) const JOURNAL_WRITE_VERSION: u16 = 2;
 pub(super) const JOURNAL_MIN_READ_VERSION: u16 = 1;
 
 /// The oldest schema a build can still read. Raising one is how a format is
@@ -94,10 +94,10 @@ mod tests {
 
     #[test]
     fn the_two_records_are_versioned_apart() {
-        // The snapshot has moved and the journal has not; a build that shared one
-        // number would have to move both or neither.
+        // They move independently. What matters is that each still reads the
+        // version below it, which is every file already in the field.
         assert!(matches!(accept_snapshot(1), Version::Readable));
-        assert!(matches!(accept_journal(2), Version::TooNew));
+        assert!(matches!(accept_journal(1), Version::Readable));
     }
 
     #[test]

--- a/crates/funput-suggestions/src/tests/bigram/mod.rs
+++ b/crates/funput-suggestions/src/tests/bigram/mod.rs
@@ -6,7 +6,7 @@ use crate::SuggestionEngine;
 
 /// The *living* followers of `word`, strongest first. Edges whose target has
 /// been evicted are filtered out here exactly as a reader would filter them.
-fn followers_of(engine: &SuggestionEngine, word: &str) -> Vec<(String, u16)> {
+pub(super) fn followers_of(engine: &SuggestionEngine, word: &str) -> Vec<(String, u16)> {
     let Some(record) = engine.words.iter().find(|record| record.text == word) else {
         return Vec::new();
     };

--- a/crates/funput-suggestions/src/tests/persistence/mod.rs
+++ b/crates/funput-suggestions/src/tests/persistence/mod.rs
@@ -2,4 +2,5 @@
 //! `round_trip`, and everything to do with damaged or foreign files in `recovery`.
 
 mod recovery;
+mod replay;
 mod round_trip;

--- a/crates/funput-suggestions/src/tests/persistence/recovery.rs
+++ b/crates/funput-suggestions/src/tests/persistence/recovery.rs
@@ -52,7 +52,10 @@ fn newer_schema_is_rejected_without_overwriting_it() {
     engine.compact().unwrap();
     drop(engine);
     let mut bytes = fs::read(&snapshot).unwrap();
-    bytes[8..10].copy_from_slice(&2u16.to_le_bytes());
+    // One past whatever this build writes, read out of the file rather than
+    // written in here, so the test keeps meaning the same thing after a bump.
+    let version = u16::from_le_bytes(bytes[8..10].try_into().unwrap());
+    bytes[8..10].copy_from_slice(&(version + 1).to_le_bytes());
     let content_len = bytes.len() - 4;
     let sum = crate::persistence::checksum(&bytes[..content_len]);
     bytes[content_len..].copy_from_slice(&sum.to_le_bytes());
@@ -119,4 +122,45 @@ fn an_oversized_journal_is_discarded_without_losing_persistence() {
     drop(engine);
     let reopened = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
     assert_eq!(texts(&reopened, "m"), ["mới"]);
+}
+
+/// A valid v1 snapshot: the word list alone, with no follower section.
+fn version_one_snapshot(words: &[(&str, u32, u64)], sequence: u64) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"FPSNAP01");
+    bytes.extend_from_slice(&1u16.to_le_bytes());
+    bytes.extend_from_slice(&sequence.to_le_bytes());
+    bytes.extend_from_slice(&(words.len() as u32).to_le_bytes());
+    for (text, uses, last_used) in words {
+        bytes.extend_from_slice(&(text.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(text.as_bytes());
+        bytes.extend_from_slice(&uses.to_le_bytes());
+        bytes.extend_from_slice(&last_used.to_le_bytes());
+    }
+    let sum = crate::persistence::checksum(&bytes);
+    bytes.extend_from_slice(&sum.to_le_bytes());
+    bytes
+}
+
+#[test]
+fn a_version_one_snapshot_upgrades_without_losing_a_word() {
+    let directory = tempdir().unwrap();
+    let snapshot = directory.path().join("personal-lexicon.snapshot");
+    let original = version_one_snapshot(&[("chào", 4, 1), ("chúc", 2, 2)], 2);
+    fs::write(&snapshot, &original).unwrap();
+
+    let mut engine = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    assert_eq!(texts(&engine, "ch"), ["chào", "chúc"]);
+    assert_eq!(engine.stats().words, 2);
+
+    engine.compact().unwrap();
+    drop(engine);
+    assert_ne!(
+        fs::read(&snapshot).unwrap(),
+        original,
+        "the first compact should have rewritten the file at the current schema"
+    );
+
+    let reopened = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    assert_eq!(texts(&reopened, "ch"), ["chào", "chúc"]);
 }

--- a/crates/funput-suggestions/src/tests/persistence/replay.rs
+++ b/crates/funput-suggestions/src/tests/persistence/replay.rs
@@ -1,0 +1,106 @@
+//! Rebuilding pairs from the journal: what survives a crash before a compact,
+//! and what must never be invented on the way back.
+
+use std::fs;
+
+use tempfile::tempdir;
+
+use crate::tests::bigram::followers_of;
+use crate::tests::texts;
+use crate::{SuggestionConfig, SuggestionEngine};
+
+fn opened(directory: &std::path::Path) -> SuggestionEngine {
+    SuggestionEngine::open(directory, SuggestionConfig::default()).unwrap()
+}
+
+#[test]
+fn adjacent_tokens_come_back_as_a_pair() {
+    let directory = tempdir().unwrap();
+    {
+        let mut engine = opened(directory.path());
+        engine.learn_after(None, "xin");
+        engine.learn_after(Some("xin"), "chào");
+        engine.flush().unwrap();
+    }
+    let reopened = opened(directory.path());
+    assert_eq!(followers_of(&reopened, "xin"), [("chào".to_owned(), 1)]);
+}
+
+#[test]
+fn a_context_break_stops_two_tokens_being_read_as_a_pair() {
+    let directory = tempdir().unwrap();
+    {
+        let mut engine = opened(directory.path());
+        engine.learn_after(None, "xin");
+        // A sentence ended here: the platform has no context to vouch for.
+        engine.learn_after(None, "chào");
+        engine.flush().unwrap();
+    }
+    let reopened = opened(directory.path());
+    assert!(
+        followers_of(&reopened, "xin").is_empty(),
+        "the two tokens are adjacent in the file but were never adjacent in the text"
+    );
+}
+
+#[test]
+fn a_context_that_is_not_what_the_journal_wrote_last_invents_nothing() {
+    let directory = tempdir().unwrap();
+    {
+        let mut engine = opened(directory.path());
+        engine.learn_after(None, "aaa");
+        engine.learn_after(None, "bbb");
+        // "aaa" is a real context and the edge is real, but the journal's chain
+        // runs through "bbb", so adjacency would reconstruct the wrong pair.
+        engine.learn_after(Some("aaa"), "ccc");
+        assert_eq!(followers_of(&engine, "aaa"), [("ccc".to_owned(), 1)]);
+        engine.flush().unwrap();
+    }
+    let reopened = opened(directory.path());
+    assert!(
+        followers_of(&reopened, "bbb").is_empty(),
+        "replay must never report a pair that was not typed"
+    );
+    assert!(followers_of(&reopened, "aaa").is_empty());
+}
+
+#[test]
+fn a_version_one_journal_replays_its_words_and_no_pairs() {
+    let directory = tempdir().unwrap();
+    let journal = directory.path().join("personal-lexicon.journal");
+    {
+        // A valid current snapshot, so the journal is read at all.
+        let mut engine = opened(directory.path());
+        engine.compact().unwrap();
+    }
+    fs::write(&journal, version_one_frame(&["xin", "chào"])).unwrap();
+
+    let reopened = opened(directory.path());
+    assert_eq!(texts(&reopened, "ch"), Vec::<String>::new());
+    assert_eq!(
+        reopened.stats().words,
+        2,
+        "both words must still be learned"
+    );
+    assert!(
+        followers_of(&reopened, "xin").is_empty(),
+        "a v1 journal records no boundaries, so none of it can be trusted as adjacent"
+    );
+}
+
+/// A valid v1 journal frame: a flat token list with no context breaks.
+fn version_one_frame(tokens: &[&str]) -> Vec<u8> {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&(tokens.len() as u32).to_le_bytes());
+    for token in tokens {
+        payload.extend_from_slice(&(token.len() as u16).to_le_bytes());
+        payload.extend_from_slice(token.as_bytes());
+    }
+    let mut frame = Vec::new();
+    frame.extend_from_slice(b"FPJR");
+    frame.extend_from_slice(&1u16.to_le_bytes());
+    frame.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    frame.extend_from_slice(&crate::persistence::checksum(&payload).to_le_bytes());
+    frame.extend_from_slice(&payload);
+    frame
+}

--- a/crates/funput-suggestions/src/tests/persistence/round_trip.rs
+++ b/crates/funput-suggestions/src/tests/persistence/round_trip.rs
@@ -1,5 +1,6 @@
 use tempfile::tempdir;
 
+use crate::tests::bigram::followers_of;
 use crate::tests::{learned, texts};
 use crate::{SuggestionConfig, SuggestionEngine};
 
@@ -34,4 +35,69 @@ fn abandoned_temporary_snapshot_keeps_last_good_state() {
     drop(engine);
     let reopened = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
     assert_eq!(texts(&reopened, "an"), ["antoàn"]);
+}
+
+#[test]
+fn follower_edges_survive_a_compact() {
+    let directory = tempdir().unwrap();
+    {
+        let mut engine =
+            SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+        engine.learn_after(None, "xin");
+        engine.learn_after(Some("xin"), "chào");
+        engine.learn_after(Some("xin"), "chào");
+        engine.learn_after(Some("xin"), "lỗi");
+        engine.compact().unwrap();
+    }
+    let reopened = SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+    assert_eq!(
+        followers_of(&reopened, "xin"),
+        [("chào".to_owned(), 2), ("lỗi".to_owned(), 1)]
+    );
+    assert_eq!(context_seen(&reopened, "xin"), 3);
+}
+
+#[test]
+fn a_shrunk_capacity_does_not_leave_edges_pointing_at_the_wrong_word() {
+    let directory = tempdir().unwrap();
+    {
+        let mut engine =
+            SuggestionEngine::open(directory.path(), SuggestionConfig::default()).unwrap();
+        // Laid out so the trim is forced to hand a live slot to another word:
+        // "bbb" is the weakest and sits at index 1, "ddd" is last and survives,
+        // so `swap_remove` moves "ddd" into the slot "aaa" has an edge to.
+        learned(&mut engine, "aaa", 4);
+        engine.learn_after(Some("aaa"), "bbb");
+        learned(&mut engine, "ccc", 3);
+        learned(&mut engine, "ddd", 4);
+        engine.compact().unwrap();
+    }
+    let reopened = SuggestionEngine::open(
+        directory.path(),
+        SuggestionConfig {
+            max_words: 2,
+            ..SuggestionConfig::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        texts(&reopened, "a"),
+        ["aaa"],
+        "the edge holder must survive"
+    );
+    assert!(
+        followers_of(&reopened, "aaa").is_empty(),
+        "the edge pointed at a word the trim deleted; it must not resolve to \
+         whichever word took over that slot"
+    );
+}
+
+fn context_seen(engine: &SuggestionEngine, word: &str) -> u16 {
+    engine
+        .words
+        .iter()
+        .find(|record| record.text == word)
+        .map(|record| record.context_seen)
+        .unwrap_or_default()
 }


### PR DESCRIPTION
**5 of 6** toward `feature/context-suggestion`. Base is PR #281.

Step 3 of the design doc. Until now, reopening a store dropped every edge the previous session learned. It comes before the query work on purpose: no version may exist in the field that writes a file a later version reads wrongly.

**Snapshot v2** carries each word's context count and its occupied follower slots. This is the first time the multi-version read window from PR #279 carries a real migration — v1 files load with empty edges and the next compact rewrites them.

The generation is deliberately not written. It means something only inside the run that issued it, and every record comes back at zero, which is what makes the edges written against it line up again.

**Journal v2** puts one byte on each token saying whether it really followed the token before it. Adjacency alone is not trustworthy — the token in between may have been ignored, or the context evicted since — so the engine tracks where the chain ends and marks a token chained only when the caller's context matches. Replay then *misses* an edge rather than reporting one that was never typed.

Also fixes a defect this PR activates: `enforce_capacity` uses `swap_remove`, which hands a slot to another word without bumping its generation. Harmless while nothing cached a word index off disk; after this, an edge to the deleted word would match its replacement and read as alive.

## Review

Three checks were each removed temporarily to confirm the test that guards them turns red. The shrink test needed rebuilding to do so — the first version deleted the edge holder before the hazard could be reached.

A flag byte rather than a separate break record, which this was written as first: a break entry doubled the journal entries for every token learned without a context — which is every token until the platforms pass one — so `pending` hit its 256 limit after 128 learns and every flush became a full compact. `flush_256` went 5.42 ms → 9.97 ms, and is 5.37 ms with the flag.

Downgrade behaviour is now real rather than hypothetical: a v2 file reads as `TooNew` to an older build, which falls back to an in-memory engine but leaves the file untouched, so re-upgrading restores everything. That is the behaviour PR #279 chose and tested.