### PR TITLE
feat(suggestions): let the previous word reorder the completions

### DIFF
--- a/benchmarks/results/personal-suggestions-v2.md
+++ b/benchmarks/results/personal-suggestions-v2.md
@@ -28,6 +28,31 @@ a 2 s timer and every 32 learns. `REBUILD_AFTER_EVICTIONS = 64` caps how many
 dead entries can accumulate for a caller that never flushes, which is what keeps
 the tries from growing with every distinct word ever seen.
 
+## Lookup with a context
+
+| Path | Prefix only | With a context |
+|---|---:|---:|
+| Exact prefix, 5 scalars | 220 ns | 444 ns |
+| Miss | 146 ns | 340 ns |
+
+The context costs roughly 200 ns: normalizing the previous word, finding its slot,
+and walking four follower entries. Nearly all of it is finding the slot — a scan
+of up to 5,000 words — and it stays this cheap only because the word is
+normalized onto the stack once and then compared with `==`, which reads the
+length out of the record and rejects almost every candidate without touching its
+heap buffer. Comparing through a normalizing iterator inside the loop instead
+rebuilt an NFC iterator per word and took a cache miss on each; that was
+affordable when the call only ran once per learned token, and would not have been
+here. An O(1) index over `words` was left unbuilt: 200 ns on a background worker
+does not justify roughly 200 KB and a second copy of every word.
+
+Prefix-only lookup is 72.6 ns to 76.7 ns on the shortest prefix, about 6%. That is
+the cost of `suggest` becoming `suggest_with(None, ...)` and the merge moving
+behind two reusable calls; `#[inline]` recovers part of it, and the alternative is
+the same merge written twice. Both figures are around 13 million lookups a second.
+
+Warm lookup still makes zero heap allocations, with and without a context.
+
 ## Memory
 
 Retained heap for a warm 5,000-word lexicon, measured with
@@ -45,8 +70,8 @@ capacity holds. `context_seen` fits in padding the record already had. The tests
 enforce a 4 MiB retained-heap budget, so the whole bigram feature spends about
 6% of the room it has.
 
-Lookup is unchanged at p99 **292 ns** and 3.85 M queries/second — the edges are
-written on the learn path and nothing reads them yet.
+Lookup was p99 **292 ns** and 3.85 M queries/second while nothing read the edges;
+see above for what reading them costs.
 
 ## Persistence
 

--- a/crates/funput-suggestions/benches/suggestions.rs
+++ b/crates/funput-suggestions/benches/suggestions.rs
@@ -20,7 +20,11 @@ fn populated() -> SuggestionEngine {
 }
 
 fn bench_lookup(c: &mut Criterion) {
-    let engine = populated();
+    let mut engine = populated();
+    engine.learn_after(None, "xin");
+    engine.learn_after(Some("xin"), "word1234");
+    engine.learn_after(Some("xin"), "word1234");
+    let engine = engine;
     let mut group = c.benchmark_group("suggestions/lookup");
     group.throughput(Throughput::Elements(1));
     for (name, prefix) in [
@@ -33,6 +37,19 @@ fn bench_lookup(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("top3", name), prefix, |b, prefix| {
             b.iter(|| black_box(engine.suggest(black_box(prefix))).len());
         });
+    }
+    // The context path resolves the previous word against the whole lexicon and
+    // then walks four follower slots, on every keystroke.
+    for (name, prefix) in [("exact-medium", "word1"), ("miss", "zzzz")] {
+        group.bench_with_input(
+            BenchmarkId::new("with-context", name),
+            prefix,
+            |b, prefix| {
+                b.iter(|| {
+                    black_box(engine.suggest_with(black_box(Some("xin")), black_box(prefix))).len()
+                });
+            },
+        );
     }
     group.finish();
 }

--- a/crates/funput-suggestions/src/bigram/learning.rs
+++ b/crates/funput-suggestions/src/bigram/learning.rs
@@ -2,7 +2,7 @@
 
 use super::follower::{FOLLOWER_SLOTS, Follower};
 use super::slots;
-use crate::engine::SuggestionEngine;
+use crate::engine::{MAX_TOKEN_SCALARS, SuggestionEngine};
 use crate::index::normalize;
 use crate::types::LearnOutcome;
 
@@ -53,12 +53,26 @@ impl SuggestionEngine {
 
     /// The slot `previous` sits in, and the generation it sits there at.
     ///
-    /// Compares through the normalizing iterator rather than `normalize::exact`,
-    /// which would allocate a `String` for every token learned with a context.
-    fn context_slot(&self, previous: &str) -> Option<(u32, u16)> {
+    /// Normalizes onto the stack and then compares with `==`, which is the same
+    /// shape `upsert_word` uses: the length check reads out of the record itself
+    /// and rejects almost every word without touching its heap buffer. Comparing
+    /// through `normalize::exact_chars` inside the loop instead would rebuild an
+    /// NFC iterator per word and take a cache miss on each one — affordable on
+    /// the learn path, and this now runs on every keystroke.
+    pub(super) fn context_slot(&self, previous: &str) -> Option<(u32, u16)> {
+        let mut buffer = [0u8; MAX_TOKEN_SCALARS * 4];
+        let mut len = 0;
+        for scalar in normalize::exact_chars(previous) {
+            if len + scalar.len_utf8() > buffer.len() {
+                // Longer than anything `learn` would have accepted.
+                return None;
+            }
+            len += scalar.encode_utf8(&mut buffer[len..]).len();
+        }
+        let key = std::str::from_utf8(&buffer[..len]).ok()?;
         self.words
             .iter()
-            .position(|word| word.text.chars().eq(normalize::exact_chars(previous)))
+            .position(|word| word.text == key)
             .map(|index| (index as u32, self.words[index].generation))
     }
 

--- a/crates/funput-suggestions/src/bigram/mod.rs
+++ b/crates/funput-suggestions/src/bigram/mod.rs
@@ -4,8 +4,9 @@
 //! - `slots` — which edges survive when there are more than there is room for.
 //! - `learning` — the engine's write path, [`SuggestionEngine::learn_after`].
 //!
-//! Nothing reads these edges yet; querying arrives with `suggest_with`.
+//! - `query` — the read path, [`SuggestionEngine::suggest_with`].
 
 pub(crate) mod follower;
 mod learning;
+mod query;
 mod slots;

--- a/crates/funput-suggestions/src/bigram/query.rs
+++ b/crates/funput-suggestions/src/bigram/query.rs
@@ -1,0 +1,104 @@
+//! The read path: letting what came before reorder what comes next.
+//!
+//! A trie node remembers only its best few words by frequency, so a pair can be
+//! sharp — "xin" is almost always followed by "chào" — while its target is rare
+//! enough overall never to reach the reranker. The context is therefore allowed
+//! to *add* a candidate, not only to move one. Everything it adds still matches
+//! the prefix, so it is still a completion of what the user is typing.
+
+use super::follower::{FOLLOWER_SLOTS, Follower};
+use crate::engine::SuggestionEngine;
+use crate::index::{NONE, TOP_K, normalize};
+use crate::types::SuggestionSet;
+
+impl SuggestionEngine {
+    /// The words `prefix` could become, with the ones that have followed
+    /// `previous` before moved to the front.
+    ///
+    /// `previous` is the caller's business, as it is for `learn_after`: a
+    /// platform that cannot vouch for what came before passes `None` and gets
+    /// exactly what `suggest` has always returned.
+    pub fn suggest_with(&self, previous: Option<&str>, prefix: &str) -> SuggestionSet<'_> {
+        let (ids, len) = self.prefix_candidates(prefix);
+        let Some((context, _)) = previous.and_then(|text| self.context_slot(text)) else {
+            return self.assemble(ids, len);
+        };
+        let (ids, len) = self.with_context(context, prefix, ids, len);
+        self.assemble(ids, len)
+    }
+
+    fn with_context(
+        &self,
+        context: u32,
+        prefix: &str,
+        ids: [u32; TOP_K],
+        len: usize,
+    ) -> ([u32; TOP_K], usize) {
+        let mut ranked = [NONE; FOLLOWER_SLOTS];
+        let ranked_len = self.matching_followers(context, prefix, &mut ranked);
+        if ranked_len == 0 {
+            return (ids, len);
+        }
+
+        let mut merged = [NONE; TOP_K];
+        let mut merged_len = 0;
+        for id in ranked[..ranked_len].iter().chain(&ids[..len]) {
+            if *id != NONE && !merged[..merged_len].contains(id) && merged_len < TOP_K {
+                merged[merged_len] = *id;
+                merged_len += 1;
+            }
+        }
+        (merged, merged_len)
+    }
+
+    /// The live followers of `context` that `prefix` could still become, most
+    /// used first. Four slots, so the ordering is done in place.
+    fn matching_followers(
+        &self,
+        context: u32,
+        prefix: &str,
+        out: &mut [u32; FOLLOWER_SLOTS],
+    ) -> usize {
+        let Some(word) = self.words.get(context as usize) else {
+            return 0;
+        };
+        let folded_allowed = normalize::folded_chars(prefix).eq(normalize::exact_chars(prefix));
+
+        let mut slots = word.followers;
+        let mut len = 0;
+        for index in 0..FOLLOWER_SLOTS {
+            let Some(strongest) = (index..FOLLOWER_SLOTS).max_by_key(|&at| slots[at].uses) else {
+                break;
+            };
+            slots.swap(index, strongest);
+            let follower = slots[index];
+            if follower.uses < self.config.context_rerank_uses {
+                // Sorted by uses, so nothing after this one clears the bar either.
+                break;
+            }
+            if self.completes(follower, prefix, folded_allowed) {
+                out[len] = follower.word;
+                len += 1;
+            }
+        }
+        len
+    }
+
+    fn completes(&self, follower: Follower, prefix: &str, folded_allowed: bool) -> bool {
+        let Some(word) = follower.word(&self.words) else {
+            return false;
+        };
+        if starts_with(word.text.chars(), normalize::exact_chars(prefix)) {
+            return true;
+        }
+        folded_allowed
+            && starts_with(
+                normalize::folded_chars(&word.text),
+                normalize::folded_chars(prefix),
+            )
+    }
+}
+
+fn starts_with(mut word: impl Iterator<Item = char>, prefix: impl Iterator<Item = char>) -> bool {
+    prefix.into_iter().all(|scalar| word.next() == Some(scalar))
+}

--- a/crates/funput-suggestions/src/bigram/query.rs
+++ b/crates/funput-suggestions/src/bigram/query.rs
@@ -18,6 +18,7 @@ impl SuggestionEngine {
     /// `previous` is the caller's business, as it is for `learn_after`: a
     /// platform that cannot vouch for what came before passes `None` and gets
     /// exactly what `suggest` has always returned.
+    #[inline]
     pub fn suggest_with(&self, previous: Option<&str>, prefix: &str) -> SuggestionSet<'_> {
         let (ids, len) = self.prefix_candidates(prefix);
         let Some((context, _)) = previous.and_then(|text| self.context_slot(text)) else {

--- a/crates/funput-suggestions/src/engine/config.rs
+++ b/crates/funput-suggestions/src/engine/config.rs
@@ -1,3 +1,8 @@
+/// The longest token the engine will look at, and so the size of any fixed
+/// buffer that has to hold one. `sanitize` clamps to it, which is what lets a
+/// caller-supplied word be normalized onto the stack.
+pub(crate) const MAX_TOKEN_SCALARS: usize = 32;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SuggestionConfig {
     pub max_words: usize,
@@ -18,7 +23,7 @@ impl Default for SuggestionConfig {
 pub(crate) fn sanitize(config: SuggestionConfig) -> SuggestionConfig {
     SuggestionConfig {
         max_words: config.max_words.max(1),
-        max_token_scalars: config.max_token_scalars.clamp(1, 32),
+        max_token_scalars: config.max_token_scalars.clamp(1, MAX_TOKEN_SCALARS),
         promotion_uses: config.promotion_uses.max(1),
     }
 }

--- a/crates/funput-suggestions/src/engine/config.rs
+++ b/crates/funput-suggestions/src/engine/config.rs
@@ -8,6 +8,10 @@ pub struct SuggestionConfig {
     pub max_words: usize,
     pub max_token_scalars: usize,
     pub promotion_uses: u32,
+    /// How often a pair must have been seen before the context may reorder the
+    /// prefix results. One is deliberate: the prefix has already filtered the
+    /// field, so the cost of being wrong is the order of three slots.
+    pub context_rerank_uses: u16,
 }
 
 impl Default for SuggestionConfig {
@@ -16,6 +20,7 @@ impl Default for SuggestionConfig {
             max_words: 5_000,
             max_token_scalars: 32,
             promotion_uses: 2,
+            context_rerank_uses: 1,
         }
     }
 }
@@ -25,5 +30,6 @@ pub(crate) fn sanitize(config: SuggestionConfig) -> SuggestionConfig {
         max_words: config.max_words.max(1),
         max_token_scalars: config.max_token_scalars.clamp(1, MAX_TOKEN_SCALARS),
         promotion_uses: config.promotion_uses.max(1),
+        context_rerank_uses: config.context_rerank_uses.max(1),
     }
 }

--- a/crates/funput-suggestions/src/engine/mod.rs
+++ b/crates/funput-suggestions/src/engine/mod.rs
@@ -7,6 +7,7 @@ mod durability;
 mod learning;
 mod query;
 
+pub(crate) use config::MAX_TOKEN_SCALARS;
 pub use config::SuggestionConfig;
 
 use std::io;

--- a/crates/funput-suggestions/src/engine/query.rs
+++ b/crates/funput-suggestions/src/engine/query.rs
@@ -6,12 +6,15 @@ use crate::types::{SuggestionSet, SuggestionStats, WordRecord};
 
 impl SuggestionEngine {
     pub fn suggest(&self, prefix: &str) -> SuggestionSet<'_> {
+        self.suggest_with(None, prefix)
+    }
+
+    /// The words the prefix alone would offer, best first. Split out so the
+    /// context-aware path can reorder and extend the same set.
+    pub(crate) fn prefix_candidates(&self, prefix: &str) -> ([u32; TOP_K], usize) {
         let scalar_count = normalize::exact_chars(prefix).count();
         if scalar_count == 0 || scalar_count > self.config.max_token_scalars {
-            return SuggestionSet {
-                items: [None; TOP_K],
-                len: 0,
-            };
+            return ([NONE; TOP_K], 0);
         }
         let exact = self.exact.find(normalize::exact_chars(prefix), &self.words);
         let differs = normalize::folded_chars(prefix).ne(normalize::exact_chars(prefix));
@@ -30,6 +33,10 @@ impl SuggestionEngine {
                 len += 1;
             }
         }
+        (ids, len)
+    }
+
+    pub(crate) fn assemble(&self, ids: [u32; TOP_K], len: usize) -> SuggestionSet<'_> {
         let items = array::from_fn(|index| {
             ids.get(index)
                 .copied()

--- a/crates/funput-suggestions/src/engine/query.rs
+++ b/crates/funput-suggestions/src/engine/query.rs
@@ -11,6 +11,7 @@ impl SuggestionEngine {
 
     /// The words the prefix alone would offer, best first. Split out so the
     /// context-aware path can reorder and extend the same set.
+    #[inline]
     pub(crate) fn prefix_candidates(&self, prefix: &str) -> ([u32; TOP_K], usize) {
         let scalar_count = normalize::exact_chars(prefix).count();
         if scalar_count == 0 || scalar_count > self.config.max_token_scalars {
@@ -36,6 +37,7 @@ impl SuggestionEngine {
         (ids, len)
     }
 
+    #[inline]
     pub(crate) fn assemble(&self, ids: [u32; TOP_K], len: usize) -> SuggestionSet<'_> {
         let items = array::from_fn(|index| {
             ids.get(index)

--- a/crates/funput-suggestions/src/tests/bigram/mod.rs
+++ b/crates/funput-suggestions/src/tests/bigram/mod.rs
@@ -1,6 +1,7 @@
 //! What the engine remembers about which word followed which.
 
 mod learning;
+mod query;
 
 use crate::SuggestionEngine;
 

--- a/crates/funput-suggestions/src/tests/bigram/query.rs
+++ b/crates/funput-suggestions/src/tests/bigram/query.rs
@@ -1,0 +1,154 @@
+use crate::tests::texts;
+use crate::{SuggestionConfig, SuggestionEngine};
+
+fn engine(config: SuggestionConfig) -> SuggestionEngine {
+    SuggestionEngine::in_memory(config)
+}
+
+fn with(engine: &SuggestionEngine, previous: &str, prefix: &str) -> Vec<String> {
+    engine
+        .suggest_with(Some(previous), prefix)
+        .iter()
+        .map(str::to_owned)
+        .collect()
+}
+
+#[test]
+fn a_follower_of_the_context_takes_the_first_slot() {
+    let mut engine = engine(SuggestionConfig::default());
+    // "chúc" is used more often, so frequency alone puts it first.
+    for _ in 0..5 {
+        engine.learn_after(None, "chúc");
+    }
+    engine.learn_after(None, "xin");
+    engine.learn_after(Some("xin"), "chào");
+    engine.learn_after(Some("xin"), "chào");
+
+    assert_eq!(texts(&engine, "ch"), ["chúc", "chào"]);
+    assert_eq!(with(&engine, "xin", "ch"), ["chào", "chúc"]);
+}
+
+#[test]
+fn a_follower_outside_the_prefix_top_three_is_still_offered() {
+    let mut engine = engine(SuggestionConfig::default());
+    for word in ["chăm", "chân", "chậm", "chợ"] {
+        for _ in 0..5 {
+            engine.learn_after(None, word);
+        }
+    }
+    engine.learn_after(None, "xin");
+    engine.learn_after(Some("xin"), "chào");
+
+    let plain = texts(&engine, "ch");
+    assert_eq!(plain.len(), 3);
+    assert!(
+        !plain.contains(&"chào".to_owned()),
+        "the trie keeps only three per node, and \"chào\" is not one of them: {plain:?}"
+    );
+    assert_eq!(
+        with(&engine, "xin", "ch")[0],
+        "chào",
+        "a sharp pair whose target is globally rare is exactly what the context is for"
+    );
+}
+
+#[test]
+fn a_follower_that_does_not_match_the_prefix_is_not_offered() {
+    let mut engine = engine(SuggestionConfig::default());
+    for _ in 0..2 {
+        engine.learn_after(None, "cảm");
+    }
+    engine.learn_after(None, "xin");
+    engine.learn_after(Some("xin"), "chào");
+    engine.learn_after(Some("xin"), "chào");
+
+    assert_eq!(
+        with(&engine, "xin", "cả"),
+        texts(&engine, "cả"),
+        "the context may reorder completions, never replace them"
+    );
+}
+
+#[test]
+fn an_unknown_or_absent_context_changes_nothing() {
+    let mut engine = engine(SuggestionConfig::default());
+    engine.learn_after(None, "xin");
+    engine.learn_after(Some("xin"), "chào");
+    engine.learn_after(Some("xin"), "chào");
+
+    let plain = texts(&engine, "ch");
+    assert_eq!(with(&engine, "chưa", "ch"), plain);
+    assert_eq!(
+        engine
+            .suggest_with(None, "ch")
+            .iter()
+            .map(str::to_owned)
+            .collect::<Vec<_>>(),
+        plain
+    );
+}
+
+#[test]
+fn an_edge_to_an_evicted_word_does_not_promote_its_replacement() {
+    let mut engine = engine(SuggestionConfig {
+        max_words: 4,
+        ..SuggestionConfig::default()
+    });
+    for _ in 0..5 {
+        engine.learn_after(None, "xin");
+    }
+    engine.learn_after(Some("xin"), "chào");
+    engine.learn_after(Some("xin"), "chào");
+    for _ in 0..4 {
+        engine.learn_after(None, "chúc");
+    }
+    for _ in 0..4 {
+        engine.learn_after(None, "aaa");
+    }
+    assert_eq!(with(&engine, "xin", "ch")[0], "chào");
+
+    // "chào" is now the weakest, so "chăm" takes the very slot the edge points
+    // at — and "chăm" is itself a completion of "ch".
+    engine.learn_after(None, "chăm");
+    engine.learn_after(None, "chăm");
+
+    assert_eq!(
+        with(&engine, "xin", "ch"),
+        texts(&engine, "ch"),
+        "the edge died with the word it pointed at; it must not promote whichever \
+         word inherited the slot"
+    );
+    assert_eq!(with(&engine, "xin", "ch")[0], "chúc");
+}
+
+#[test]
+fn a_follower_below_the_threshold_stays_where_it_was() {
+    let mut engine = engine(SuggestionConfig {
+        context_rerank_uses: 2,
+        ..SuggestionConfig::default()
+    });
+    for _ in 0..5 {
+        engine.learn_after(None, "chúc");
+    }
+    engine.learn_after(None, "xin");
+    engine.learn_after(Some("xin"), "chào");
+    engine.learn_after(None, "chào");
+
+    assert_eq!(with(&engine, "xin", "ch"), ["chúc", "chào"]);
+    engine.learn_after(Some("xin"), "chào");
+    assert_eq!(with(&engine, "xin", "ch"), ["chào", "chúc"]);
+}
+
+#[test]
+fn a_folded_prefix_still_reranks() {
+    let mut engine = engine(SuggestionConfig::default());
+    for _ in 0..5 {
+        engine.learn_after(None, "hôm");
+    }
+    engine.learn_after(None, "xin");
+    engine.learn_after(Some("xin"), "hòa");
+    engine.learn_after(Some("xin"), "hòa");
+
+    assert_eq!(texts(&engine, "ho"), ["hôm", "hòa"]);
+    assert_eq!(with(&engine, "xin", "ho"), ["hòa", "hôm"]);
+}

--- a/crates/funput-suggestions/tests/alloc_budget.rs
+++ b/crates/funput-suggestions/tests/alloc_budget.rs
@@ -48,13 +48,48 @@ fn warm_lookup_does_not_allocate() {
         engine.learn(word);
     }
 
-    MEASURING.set(true);
-    let before = ALLOCATIONS.get();
-    for _ in 0..100_000 {
-        std::hint::black_box(engine.suggest(std::hint::black_box("kh")));
-    }
-    let allocations = ALLOCATIONS.get() - before;
-    MEASURING.set(false);
+    let allocations = measure(|| {
+        for _ in 0..100_000 {
+            std::hint::black_box(engine.suggest(std::hint::black_box("kh")));
+        }
+    });
 
     assert_eq!(allocations, 0, "warm lookup allocated {allocations} times");
+}
+
+/// The context path normalizes the previous word and walks its follower slots on
+/// every keystroke, so it has to hold the same budget the plain lookup does.
+#[test]
+fn warm_lookup_with_a_context_does_not_allocate() {
+    let mut engine = SuggestionEngine::in_memory(SuggestionConfig::default());
+    for word in ["không", "khỏe", "khoa", "hòa"] {
+        engine.learn(word);
+        engine.learn(word);
+    }
+    engine.learn_after(None, "xin");
+    engine.learn_after(Some("xin"), "khỏe");
+    engine.learn_after(Some("xin"), "khỏe");
+
+    let allocations = measure(|| {
+        for _ in 0..100_000 {
+            std::hint::black_box(engine.suggest_with(
+                std::hint::black_box(Some("xin")),
+                std::hint::black_box("kh"),
+            ));
+        }
+    });
+
+    assert_eq!(
+        allocations, 0,
+        "warm lookup with a context allocated {allocations} times"
+    );
+}
+
+fn measure(body: impl FnOnce()) -> usize {
+    MEASURING.set(true);
+    let before = ALLOCATIONS.get();
+    body();
+    let allocations = ALLOCATIONS.get() - before;
+    MEASURING.set(false);
+    allocations
 }


### PR DESCRIPTION
**6 of 6** toward `feature/context-suggestion`. Base is PR #282.

Step 4 of the design doc, and the first reader of the follower edges. `suggest_with(previous, prefix)` puts the words that have followed `previous` before at the front of what the prefix would have offered; `suggest` is now `suggest_with(None, ...)`.

**The context may add a candidate, not only move one**, and that is where most of the value is. A trie node remembers three words by frequency, so a pair can be sharp — "xin" is nearly always followed by "chào" — while its target is rare enough overall never to reach the reranker at all. A test builds exactly that shape and fails if the context may only reorder.

Nothing added is a word the user could not be typing: a follower has to match the prefix on the same terms the trie does, exact against exact and folded only when the prefix carries no diacritics.

`context_rerank_uses` defaults to 1. Reordering is cheap to get wrong — the prefix has already filtered the field, so the cost is the order of three slots.

| | prefix only | with a context |
|---|---:|---:|
| Exact prefix, 5 scalars | 220 ns | 444 ns |
| Miss | 146 ns | 340 ns |

## Review

The context costs ~200 ns, nearly all of it finding the previous word's slot. It stays that cheap only because of the first commit here: the word is normalized onto the stack once and compared with `==`, the shape `upsert_word` already uses. The previous form rebuilt an NFC iterator per word and took a cache miss on each — affordable when it ran once per learned token, not on a path that now runs per keystroke. That is also why the O(1) index over `words` is still unbuilt; this is the second measurement arguing against it.

Prefix-only lookup went 72.6 ns → 76.7 ns on the shortest prefix, about 6%, from `suggest` sharing its merge with `suggest_with` rather than the two paths keeping a copy each. Real, small, and recorded.

Warm lookup still allocates zero times, with and without a context.

**Known, and deliberately not addressed here:** an empty prefix already returns followers, because an empty prefix trivially matches every one of them. Harmless while nothing calls this, but it is prediction without the dominance threshold that guards it — the platform wiring must either withhold an empty prefix or wait for step 6.