### PR TITLE
feat(ffi,jni): expose the context-aware learn and query

### DIFF
--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -718,6 +718,23 @@ bool funput_suggestion_learn(FunputSuggestionEngine *engine,
                              uintptr_t token_len);
 
 /**
+ * Record one completed token and that it followed `previous`.
+ *
+ * A null `previous`, or a zero length, means there was no context to vouch for —
+ * a sentence boundary, a moved caret, a fresh editor — and behaves exactly like
+ * `funput_suggestion_learn`.
+ *
+ * # Safety
+ * `previous` and `token` must each point to their stated number of readable
+ * codepoints, or be null.
+ */
+bool funput_suggestion_learn_after(FunputSuggestionEngine *engine,
+                                   const uint32_t *previous,
+                                   uintptr_t previous_len,
+                                   const uint32_t *token,
+                                   uintptr_t token_len);
+
+/**
  * Return at most three UTF-32 candidates by value. Any failure returns empty.
  *
  * # Safety
@@ -726,6 +743,20 @@ bool funput_suggestion_learn(FunputSuggestionEngine *engine,
 FunputSuggestionResult funput_suggestion_query(const FunputSuggestionEngine *engine,
                                                const uint32_t *prefix,
                                                uintptr_t prefix_len);
+
+/**
+ * Return at most three UTF-32 candidates, with the words that have followed
+ * `previous` before moved to the front. Any failure returns empty.
+ *
+ * # Safety
+ * `previous` and `prefix` must each point to their stated number of readable
+ * codepoints, or be null.
+ */
+FunputSuggestionResult funput_suggestion_query_with(const FunputSuggestionEngine *engine,
+                                                    const uint32_t *previous,
+                                                    uintptr_t previous_len,
+                                                    const uint32_t *prefix,
+                                                    uintptr_t prefix_len);
 
 /**
  * Flush pending learned tokens to the journal.

--- a/crates/funput-ffi/src/lib.rs
+++ b/crates/funput-ffi/src/lib.rs
@@ -72,5 +72,6 @@ pub use suggestion::{
     FunputSuggestionStats, SUGGESTION_CAP, SUGGESTION_CHARS_CAP, funput_suggestion_compact,
     funput_suggestion_engine_free, funput_suggestion_engine_new_in_memory,
     funput_suggestion_engine_open, funput_suggestion_flush, funput_suggestion_learn,
-    funput_suggestion_query, funput_suggestion_reset, funput_suggestion_stats,
+    funput_suggestion_learn_after, funput_suggestion_query, funput_suggestion_query_with,
+    funput_suggestion_reset, funput_suggestion_stats,
 };

--- a/crates/funput-ffi/src/suggestion/mod.rs
+++ b/crates/funput-ffi/src/suggestion/mod.rs
@@ -12,7 +12,10 @@ pub use engine::{
     FunputSuggestionEngine, funput_suggestion_engine_free, funput_suggestion_engine_new_in_memory,
     funput_suggestion_engine_open,
 };
-pub use query::{funput_suggestion_learn, funput_suggestion_query};
+pub use query::{
+    funput_suggestion_learn, funput_suggestion_learn_after, funput_suggestion_query,
+    funput_suggestion_query_with,
+};
 pub use store::{
     funput_suggestion_compact, funput_suggestion_flush, funput_suggestion_reset,
     funput_suggestion_stats,

--- a/crates/funput-ffi/src/suggestion/query.rs
+++ b/crates/funput-ffi/src/suggestion/query.rs
@@ -29,6 +29,41 @@ pub unsafe extern "C" fn funput_suggestion_learn(
     })
 }
 
+/// Record one completed token and that it followed `previous`.
+///
+/// A null `previous`, or a zero length, means there was no context to vouch for —
+/// a sentence boundary, a moved caret, a fresh editor — and behaves exactly like
+/// `funput_suggestion_learn`.
+///
+/// # Safety
+/// `previous` and `token` must each point to their stated number of readable
+/// codepoints, or be null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_suggestion_learn_after(
+    engine: *mut FunputSuggestionEngine,
+    previous: *const u32,
+    previous_len: usize,
+    token: *const u32,
+    token_len: usize,
+) -> bool {
+    safe(false, || {
+        let Some(engine) = (unsafe { engine.as_mut() }) else {
+            return false;
+        };
+        let Some(context) = context_from_raw(previous, previous_len) else {
+            return false;
+        };
+        let Some(codepoints) = codepoints_from_raw(token, token_len) else {
+            return false;
+        };
+        let Some(text) = decode_valid_codepoints(codepoints) else {
+            return false;
+        };
+        let outcome = engine.inner.learn_after(context.as_deref(), &text);
+        !matches!(outcome, LearnOutcome::Ignored)
+    })
+}
+
 /// Return at most three UTF-32 candidates by value. Any failure returns empty.
 ///
 /// # Safety
@@ -51,6 +86,46 @@ pub unsafe extern "C" fn funput_suggestion_query(
         };
         FunputSuggestionResult::from_set(engine.inner.suggest(&text))
     })
+}
+
+/// Return at most three UTF-32 candidates, with the words that have followed
+/// `previous` before moved to the front. Any failure returns empty.
+///
+/// # Safety
+/// `previous` and `prefix` must each point to their stated number of readable
+/// codepoints, or be null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_suggestion_query_with(
+    engine: *const FunputSuggestionEngine,
+    previous: *const u32,
+    previous_len: usize,
+    prefix: *const u32,
+    prefix_len: usize,
+) -> FunputSuggestionResult {
+    safe(FunputSuggestionResult::default(), || {
+        let Some(engine) = (unsafe { engine.as_ref() }) else {
+            return FunputSuggestionResult::default();
+        };
+        let Some(context) = context_from_raw(previous, previous_len) else {
+            return FunputSuggestionResult::default();
+        };
+        let Some(codepoints) = codepoints_from_raw(prefix, prefix_len) else {
+            return FunputSuggestionResult::default();
+        };
+        let Some(text) = decode_valid_codepoints(codepoints) else {
+            return FunputSuggestionResult::default();
+        };
+        FunputSuggestionResult::from_set(engine.inner.suggest_with(context.as_deref(), &text))
+    })
+}
+
+/// `None` when the call is malformed; `Some(None)` when the caller had no context
+/// to offer, which is a normal thing to say and not an error.
+fn context_from_raw(previous: *const u32, len: usize) -> Option<Option<String>> {
+    if len == 0 {
+        return Some(None);
+    }
+    decode_valid_codepoints(codepoints_from_raw(previous, len)?).map(Some)
 }
 
 fn decode_valid_codepoints(codepoints: &[u32]) -> Option<String> {

--- a/crates/funput-ffi/tests/suggestions.rs
+++ b/crates/funput-ffi/tests/suggestions.rs
@@ -1,7 +1,8 @@
 use funput_ffi::{
     FunputSuggestionResult, funput_suggestion_engine_free, funput_suggestion_engine_new_in_memory,
     funput_suggestion_engine_open, funput_suggestion_flush, funput_suggestion_learn,
-    funput_suggestion_query, funput_suggestion_reset, funput_suggestion_stats,
+    funput_suggestion_learn_after, funput_suggestion_query, funput_suggestion_query_with,
+    funput_suggestion_reset, funput_suggestion_stats,
 };
 
 fn codepoints(text: &str) -> Vec<u32> {
@@ -19,6 +20,42 @@ fn query(
 ) -> FunputSuggestionResult {
     let prefix = codepoints(prefix);
     unsafe { funput_suggestion_query(engine, prefix.as_ptr(), prefix.len()) }
+}
+
+fn learn_after(
+    engine: *mut funput_ffi::FunputSuggestionEngine,
+    previous: &str,
+    text: &str,
+) -> bool {
+    let previous = codepoints(previous);
+    let text = codepoints(text);
+    unsafe {
+        funput_suggestion_learn_after(
+            engine,
+            previous.as_ptr(),
+            previous.len(),
+            text.as_ptr(),
+            text.len(),
+        )
+    }
+}
+
+fn query_with(
+    engine: *const funput_ffi::FunputSuggestionEngine,
+    previous: &str,
+    prefix: &str,
+) -> FunputSuggestionResult {
+    let previous = codepoints(previous);
+    let prefix = codepoints(prefix);
+    unsafe {
+        funput_suggestion_query_with(
+            engine,
+            previous.as_ptr(),
+            previous.len(),
+            prefix.as_ptr(),
+            prefix.len(),
+        )
+    }
 }
 
 fn candidate(result: &FunputSuggestionResult, index: usize) -> String {
@@ -77,4 +114,45 @@ fn persistent_handle_round_trips_without_owned_results() {
     assert_eq!(result.count, 1);
     assert_eq!(candidate(&result, 0), "đường");
     unsafe { funput_suggestion_engine_free(reopened) };
+}
+
+#[test]
+fn a_context_reorders_the_candidates_through_c_abi() {
+    let engine = funput_suggestion_engine_new_in_memory();
+    assert!(!engine.is_null());
+    // "chúc" is used more, so frequency alone puts it first.
+    for _ in 0..5 {
+        assert!(learn(engine, "chúc"));
+    }
+    assert!(learn(engine, "xin"));
+    assert!(learn_after(engine, "xin", "chào"));
+    assert!(learn_after(engine, "xin", "chào"));
+
+    let plain = query(engine, "ch");
+    assert_eq!(candidate(&plain, 0), "chúc");
+
+    let contextual = query_with(engine, "xin", "ch");
+    assert_eq!(candidate(&contextual, 0), "chào");
+
+    // An empty context is a normal thing to say, not a malformed call.
+    let none = query_with(engine, "", "ch");
+    assert_eq!(candidate(&none, 0), "chúc");
+    assert_eq!(none.count, plain.count);
+
+    unsafe { funput_suggestion_engine_free(engine) };
+}
+
+#[test]
+fn a_null_context_is_the_same_as_no_context() {
+    let engine = funput_suggestion_engine_new_in_memory();
+    assert!(unsafe {
+        funput_suggestion_learn_after(engine, std::ptr::null(), 0, [99u32, 104].as_ptr(), 2)
+    });
+    assert!(unsafe {
+        funput_suggestion_learn_after(engine, std::ptr::null(), 0, [99u32, 104].as_ptr(), 2)
+    });
+    let result =
+        unsafe { funput_suggestion_query_with(engine, std::ptr::null(), 0, [99u32].as_ptr(), 1) };
+    assert_eq!(candidate(&result, 0), "ch");
+    unsafe { funput_suggestion_engine_free(engine) };
 }

--- a/crates/funput-jni/src/suggestion/query.rs
+++ b/crates/funput-jni/src/suggestion/query.rs
@@ -27,14 +27,38 @@ pub extern "system" fn Java_app_funput_funput_ime_nativebridge_PersonalSuggestio
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
-                let initial =
-                    JString::from_str(env, words.first().map(String::as_str).unwrap_or(""))?;
-                let array = JObjectArray::<JString>::new(env, words.len(), &initial)?;
-                for (index, word) in words.iter().enumerate().skip(1) {
-                    let value = JString::from_str(env, word)?;
-                    array.set_element(env, index, &value)?;
-                }
-                Ok(array.into_raw())
+                candidates(env, &words)
+            })
+            .into_outcome();
+        neutral(result)
+    })
+}
+
+/// As `nativeQuery`, with the words that have followed `previous` before moved to
+/// the front. A null or empty `previous` means there was no context to vouch for.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_app_funput_funput_ime_nativebridge_PersonalSuggestionNative_nativeQueryWith(
+    mut env: EnvUnowned<'_>,
+    _this: JavaObject<'_>,
+    handle: jlong,
+    previous: JString<'_>,
+    prefix: JString<'_>,
+) -> jobjectArray {
+    safe(std::ptr::null_mut(), || {
+        let result = env
+            .with_env(|env| -> jni::errors::Result<_> {
+                let context = previous.try_to_string(env)?;
+                let text = prefix.try_to_string(env)?;
+                let words = registry::with(handle, |engine| {
+                    engine
+                        .suggest_with(Some(context.as_str()).filter(|it| !it.is_empty()), &text)
+                        .iter()
+                        .take(3)
+                        .map(str::to_owned)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+                candidates(env, &words)
             })
             .into_outcome();
         neutral(result)
@@ -71,4 +95,14 @@ pub extern "system" fn Java_app_funput_funput_ime_nativebridge_PersonalSuggestio
             .into_outcome();
         neutral(result)
     })
+}
+
+fn candidates(env: &mut jni::Env<'_>, words: &[String]) -> jni::errors::Result<jobjectArray> {
+    let initial = JString::from_str(env, words.first().map(String::as_str).unwrap_or(""))?;
+    let array = JObjectArray::<JString>::new(env, words.len(), &initial)?;
+    for (index, word) in words.iter().enumerate().skip(1) {
+        let value = JString::from_str(env, word)?;
+        array.set_element(env, index, &value)?;
+    }
+    Ok(array.into_raw())
 }

--- a/crates/funput-jni/src/suggestion/store.rs
+++ b/crates/funput-jni/src/suggestion/store.rs
@@ -27,6 +27,35 @@ pub extern "system" fn Java_app_funput_funput_ime_nativebridge_PersonalSuggestio
     })
 }
 
+/// A null or empty `previous` means there was no context to vouch for, and this
+/// behaves exactly like `nativeLearn`.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_app_funput_funput_ime_nativebridge_PersonalSuggestionNative_nativeLearnAfter(
+    mut env: EnvUnowned<'_>,
+    _this: JavaObject<'_>,
+    handle: jlong,
+    previous: JString<'_>,
+    token: JString<'_>,
+) -> jboolean {
+    safe(false, || {
+        let (context, text) = neutral(
+            env.with_env(|env| -> jni::errors::Result<_> {
+                Ok((previous.try_to_string(env)?, token.try_to_string(env)?))
+            })
+            .into_outcome(),
+        );
+        if text.is_empty() {
+            return false;
+        }
+        registry::with_mut(handle, |engine| {
+            let outcome =
+                engine.learn_after(Some(context.as_str()).filter(|it| !it.is_empty()), &text);
+            !matches!(outcome, LearnOutcome::Ignored)
+        })
+        .unwrap_or(false)
+    })
+}
+
 macro_rules! store_operation {
     ($name:ident, $operation:ident) => {
         #[unsafe(no_mangle)]


### PR DESCRIPTION
**7 of 9** toward `feature/context-suggestion`. Base is PR #283.

The engine has taken a context since the bigram work landed, but no shell could say one: the C ABI and the JNI bridge carried only `learn` and `query`. This adds the pair each was missing.

- `funput_suggestion_learn_after` / `funput_suggestion_query_with`
- `nativeLearnAfter` / `nativeQueryWith`

A null or zero-length context is a normal thing for a caller to say — a sentence boundary, a moved caret, a fresh editor — and behaves exactly like the calls that never took one. That is separate from a malformed call, and tested as such.

## Review

Nothing existing changes shape. The old four functions keep their signatures, so a shell built against the previous library still links, and `FunputSuggestionResult` is untouched, so the Swift and Kotlin decoders need no work.

`include/funput.h` is regenerated; CI checks it against cbindgen.

Both `suggestion/` directories were already at the five-file limit, so the new functions join existing files rather than adding any. `nativeQuery` and `nativeQueryWith` now share the array building instead of keeping a copy each.