### PR TITLE
feat(ios): carry the previous word into learn and query

### DIFF
--- a/platforms/ios/FunputTests/Suggestions/Service/PersonalSuggestionServiceCreationTests.swift
+++ b/platforms/ios/FunputTests/Suggestions/Service/PersonalSuggestionServiceCreationTests.swift
@@ -43,7 +43,7 @@ struct PersonalSuggestionServiceCreationTests {
         )
 
         let worker = try #require(factory.workers.first)
-        #expect(worker.events == [.configure(configuration), .learn("chào")])
+        #expect(worker.events == [.configure(configuration), .learn("chào", context: nil)])
     }
 
     @Test("Disabled suggestions never create a worker")
@@ -59,6 +59,42 @@ struct PersonalSuggestionServiceCreationTests {
         service.flush()
 
         #expect(factory.workers.isEmpty)
+    }
+
+    @Test("The context reaches both the learn and the query")
+    func forwardsContext() throws {
+        let factory = SuggestionWorkerFactorySpy()
+        let service = factory.makeService()
+        _ = factory.configure(service)
+
+        // "xin" finishes on a space, so it is what the next word follows.
+        service.update(.init(prefix: "", completedToken: "xin", context: "xin"), canQuery: true)
+        service.update(.init(prefix: "ch", completedToken: nil, context: "xin"), canQuery: true)
+
+        let worker = try #require(factory.workers.first)
+        #expect(worker.events.compactMap(\.learned).last?.context == nil)
+        #expect(worker.events.compactMap(\.query).last?.context == "xin")
+
+        // The word that follows is learned against the context, not after it.
+        service.update(.init(prefix: "", completedToken: "chào", context: "chào"), canQuery: true)
+        let learned = try #require(worker.events.compactMap(\.learned).last)
+        #expect(learned.token == "chào")
+        #expect(learned.context == "xin")
+    }
+
+    @Test("A prefix shorter than the query threshold never reaches the worker")
+    func neverQueriesWithoutAPrefix() throws {
+        let factory = SuggestionWorkerFactorySpy()
+        let service = factory.makeService()
+        _ = factory.configure(service)
+
+        service.update(.init(prefix: "", completedToken: "xin", context: "xin"), canQuery: true)
+        service.update(.init(prefix: "c", completedToken: nil, context: "xin"), canQuery: true)
+
+        let worker = try #require(factory.workers.first)
+        // Without a prefix every follower matches, which is prediction without
+        // the threshold that has to guard it.
+        #expect(worker.events.compactMap(\.query).isEmpty)
     }
 
     private func update(prefix: String) -> KeyboardSuggestionInputUpdate {

--- a/platforms/ios/FunputTests/Suggestions/Service/SuggestionWorkerSpy.swift
+++ b/platforms/ios/FunputTests/Suggestions/Service/SuggestionWorkerSpy.swift
@@ -42,9 +42,14 @@ final class SuggestionWorkerFactorySpy {
 final class SuggestionWorkerSpy: PersonalSuggestionWorking, @unchecked Sendable {
     enum Event: Equatable {
         case configure(PersonalSuggestionWorkerConfiguration)
-        case learn(String)
+        case learn(String, context: String?)
         case query(PersonalSuggestionQueryRequest)
         case flush
+
+        var learned: (token: String, context: String?)? {
+            guard case .learn(let token, let context) = self else { return nil }
+            return (token, context)
+        }
 
         var query: PersonalSuggestionQueryRequest? {
             guard case .query(let value) = self else { return nil }
@@ -68,7 +73,9 @@ final class SuggestionWorkerSpy: PersonalSuggestionWorking, @unchecked Sendable 
         events.append(.configure(configuration))
     }
 
-    func learn(_ token: String) { events.append(.learn(token)) }
+    func learn(_ token: String, after previous: String?) {
+        events.append(.learn(token, context: previous))
+    }
 
     func query(_ request: PersonalSuggestionQueryRequest) {
         events.append(.query(request))

--- a/platforms/ios/Keyboard/Suggestions/PersonalSuggestionWorker.swift
+++ b/platforms/ios/Keyboard/Suggestions/PersonalSuggestionWorker.swift
@@ -36,11 +36,11 @@ final class PersonalSuggestionWorker: PersonalSuggestionWorking, @unchecked Send
         }
     }
 
-    func learn(_ token: String) {
+    func learn(_ token: String, after previous: String?) {
         queue.async { [weak self] in
             guard let self, enabled else { return }
             ensureEngine()
-            guard engine?.learn(token) == true else { return }
+            guard engine?.learn(token, after: previous) == true else { return }
             learnedSinceFlush += 1
             if learnedSinceFlush >= 32 { flushWhenIdle() }
             else { flushTimer.schedule(deadline: .now() + 2) }
@@ -89,7 +89,7 @@ final class PersonalSuggestionWorker: PersonalSuggestionWorking, @unchecked Send
                 request.generation
             )
             ensureEngine()
-            let result = enabled ? engine?.query(request.prefix) ?? [] : []
+            let result = enabled ? engine?.query(request.prefix, after: request.context) ?? [] : []
             os_signpost(
                 .end,
                 log: PersonalSuggestionSignposts.log,

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/PersonalSuggestions/AuthoredTokenTracker.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardInput/PersonalSuggestions/AuthoredTokenTracker.swift
@@ -4,6 +4,14 @@ struct AuthoredTokenTracker {
 
     private(set) var prefix = ""
     private(set) var completedToken: String?
+    /// The word the next one will be recorded as following, or nil when nothing
+    /// here can vouch for what came before.
+    ///
+    /// This lives in the tracker because the tracker is the only thing that sees
+    /// every mutation — which separator ended a word, when the caret left, when
+    /// the prefix was abandoned. Anything downstream sees the result and not the
+    /// reason.
+    private(set) var context: String?
     private var prefixLength = 0
     private var overflowCount = 0
 
@@ -12,7 +20,7 @@ struct AuthoredTokenTracker {
             if byte >= 65 && byte <= 90 || byte >= 97 && byte <= 122 {
                 append(text)
             } else {
-                complete()
+                complete(separator: Character(UnicodeScalar(byte)))
             }
             return
         }
@@ -20,7 +28,7 @@ struct AuthoredTokenTracker {
             if character.isLetter || isCombiningMark(character) && (!prefix.isEmpty || overflowCount > 0) {
                 append(String(character))
             } else {
-                complete()
+                complete(separator: character)
             }
         }
     }
@@ -32,6 +40,10 @@ struct AuthoredTokenTracker {
         } else if !prefix.isEmpty {
             prefix.removeLast()
             prefixLength -= 1
+        } else {
+            // Nothing left of this word to delete, so the caret has crossed back
+            // over a boundary and what precedes it is no longer known.
+            context = nil
         }
     }
 
@@ -53,7 +65,8 @@ struct AuthoredTokenTracker {
     mutating func consume() -> KeyboardSuggestionInputUpdate {
         let update = KeyboardSuggestionInputUpdate(
             prefix: overflowCount == 0 ? prefix : "",
-            completedToken: completedToken
+            completedToken: completedToken,
+            context: context
         )
         completedToken = nil
         return update
@@ -62,6 +75,7 @@ struct AuthoredTokenTracker {
     mutating func reset() {
         prefix.removeAll(keepingCapacity: true)
         completedToken = nil
+        context = nil
         prefixLength = 0
         overflowCount = 0
     }
@@ -76,10 +90,15 @@ struct AuthoredTokenTracker {
         }
     }
 
-    private mutating func complete() {
+    /// A space continues the sentence, so the word just finished becomes the
+    /// context for the next one. Anything else — a full stop, a newline, a comma
+    /// — ends it, and two words either side of that were never adjacent. Guessing
+    /// the other way would teach pairs nobody typed.
+    private mutating func complete(separator: Character) {
         if overflowCount == 0, prefixLength >= Self.minimumLength {
             completedToken = prefix
         }
+        context = separator == " " ? completedToken : nil
         prefix.removeAll(keepingCapacity: true)
         prefixLength = 0
         overflowCount = 0
@@ -98,10 +117,13 @@ struct AuthoredTokenTracker {
 public struct KeyboardSuggestionInputUpdate: Equatable, Sendable {
     public let prefix: String
     public let completedToken: String?
+    /// The word `prefix` is being typed after, when one can be vouched for.
+    public let context: String?
 
-    public init(prefix: String, completedToken: String?) {
+    public init(prefix: String, completedToken: String?, context: String? = nil) {
         self.prefix = prefix
         self.completedToken = completedToken
+        self.context = context
     }
 
     public static let empty = KeyboardSuggestionInputUpdate(prefix: "", completedToken: nil)

--- a/platforms/ios/Packages/FunputKit/Sources/PersonalSuggestions/PersonalSuggestionEngine.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/PersonalSuggestions/PersonalSuggestionEngine.swift
@@ -36,17 +36,35 @@ public final class PersonalSuggestionEngine: @unchecked Sendable {
     }
 
     @discardableResult
-    public func learn(_ token: String) -> Bool {
+    public func learn(_ token: String, after previous: String? = nil) -> Bool {
+        let context = (previous ?? "").unicodeScalars.map(\.value)
         let codepoints = token.unicodeScalars.map(\.value)
-        return codepoints.withUnsafeBufferPointer {
-            funput_suggestion_learn(handle, $0.baseAddress, UInt($0.count))
+        return context.withUnsafeBufferPointer { context in
+            codepoints.withUnsafeBufferPointer { token in
+                funput_suggestion_learn_after(
+                    handle,
+                    context.baseAddress,
+                    UInt(context.count),
+                    token.baseAddress,
+                    UInt(token.count)
+                )
+            }
         }
     }
 
-    public func query(_ prefix: String) -> [PersonalSuggestionCandidate] {
+    public func query(_ prefix: String, after previous: String? = nil) -> [PersonalSuggestionCandidate] {
+        let context = (previous ?? "").unicodeScalars.map(\.value)
         let codepoints = prefix.unicodeScalars.map(\.value)
-        let result = codepoints.withUnsafeBufferPointer {
-            funput_suggestion_query(handle, $0.baseAddress, UInt($0.count))
+        let result = context.withUnsafeBufferPointer { context in
+            codepoints.withUnsafeBufferPointer { prefix in
+                funput_suggestion_query_with(
+                    handle,
+                    context.baseAddress,
+                    UInt(context.count),
+                    prefix.baseAddress,
+                    UInt(prefix.count)
+                )
+            }
         }
         return PersonalSuggestionDecoder.candidates(result)
     }

--- a/platforms/ios/Packages/FunputKit/Sources/PersonalSuggestions/PersonalSuggestionQuerySlot.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/PersonalSuggestions/PersonalSuggestionQuerySlot.swift
@@ -4,10 +4,13 @@ import os
 public struct PersonalSuggestionQueryRequest: Equatable, Sendable {
     public let prefix: String
     public let generation: UInt64
+    /// The word `prefix` is being typed after, when the caller can vouch for one.
+    public let context: String?
 
-    public init(prefix: String, generation: UInt64) {
+    public init(prefix: String, generation: UInt64, context: String? = nil) {
         self.prefix = prefix
         self.generation = generation
+        self.context = context
     }
 }
 

--- a/platforms/ios/Packages/FunputKit/Sources/PersonalSuggestions/Service/PersonalSuggestionService.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/PersonalSuggestions/Service/PersonalSuggestionService.swift
@@ -15,6 +15,7 @@ public final class PersonalSuggestionService {
     private var generation: UInt64 = 0
     private var activationGeneration: UInt64 = 0
     private var prefix = ""
+    private var context: String?
     private var visibleCandidates: [KeyboardSuggestionCandidate] = []
 
     public init(workerFactory: @escaping PersonalSuggestionWorkerFactory) {
@@ -46,8 +47,9 @@ public final class PersonalSuggestionService {
             )
         }
         if let token = update.completedToken, workerConfiguration.enabled {
-            ensureWorker()?.learn(token)
+            ensureWorker()?.learn(token, after: context)
         }
+        context = update.context
         let next = canQuery && workerConfiguration.enabled && update.prefix.count >= 2
             ? update.prefix : ""
         if update.completedToken == nil, next == prefix { return }
@@ -55,8 +57,10 @@ public final class PersonalSuggestionService {
         prefix = next
         visibleCandidates = []
         publish([])
+        // Never queried with an empty prefix: without one every follower matches,
+        // and that is prediction without the threshold that has to guard it.
         guard !prefix.isEmpty else { return }
-        ensureWorker()?.query(.init(prefix: prefix, generation: generation))
+        ensureWorker()?.query(.init(prefix: prefix, generation: generation, context: context))
     }
 
     public func acceptance(
@@ -89,6 +93,7 @@ public final class PersonalSuggestionService {
         let needsPublish = !prefix.isEmpty || !visibleCandidates.isEmpty
         generation &+= 1
         prefix = ""
+        context = nil
         visibleCandidates = []
         if needsPublish { publish([]) }
     }

--- a/platforms/ios/Packages/FunputKit/Sources/PersonalSuggestions/Service/PersonalSuggestionWorking.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/PersonalSuggestions/Service/PersonalSuggestionWorking.swift
@@ -14,7 +14,7 @@ public struct PersonalSuggestionWorkerConfiguration: Equatable, Sendable {
 
 public protocol PersonalSuggestionWorking: AnyObject, Sendable {
     func configure(_ configuration: PersonalSuggestionWorkerConfiguration)
-    func learn(_ token: String)
+    func learn(_ token: String, after previous: String?)
     func query(_ request: PersonalSuggestionQueryRequest)
     func flush()
 }

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Suggestions/PersonalSuggestionTokenTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Suggestions/PersonalSuggestionTokenTests.swift
@@ -51,6 +51,66 @@ struct PersonalSuggestionTokenTests {
         #expect(coordinator.takePersonalSuggestionUpdate() == .empty)
     }
 
+    @Test("A space keeps the finished word as context, a full stop does not")
+    func separatorDecidesContext() {
+        let coordinator = KeyboardInputCoordinator(inputMethod: .vni)
+        let document = TestKeyboardWriter()
+        type("xin", with: coordinator, into: document)
+        coordinator.handle(testKey(.space, label: " "), writer: document)
+        #expect(coordinator.takePersonalSuggestionUpdate().context == "xin")
+
+        type("xin", with: coordinator, into: document)
+        type(".", role: .punctuation, with: coordinator, into: document)
+        let ended = coordinator.takePersonalSuggestionUpdate()
+        #expect(ended.completedToken == "xin", "the word is still learned")
+        #expect(ended.context == nil, "but nothing follows it")
+    }
+
+    @Test("A newline ends the sentence too")
+    func newlineEndsContext() {
+        let coordinator = KeyboardInputCoordinator(inputMethod: .vni)
+        let document = TestKeyboardWriter()
+        type("xin", with: coordinator, into: document)
+        type("\n", role: .punctuation, with: coordinator, into: document)
+        #expect(coordinator.takePersonalSuggestionUpdate().context == nil)
+    }
+
+    @Test("The context survives while the next word is being typed")
+    func contextSpansTheNextWord() {
+        let coordinator = KeyboardInputCoordinator(inputMethod: .vni)
+        let document = TestKeyboardWriter()
+        type("xin", with: coordinator, into: document)
+        coordinator.handle(testKey(.space, label: " "), writer: document)
+        _ = coordinator.takePersonalSuggestionUpdate()
+        type("ch", with: coordinator, into: document)
+        let update = coordinator.takePersonalSuggestionUpdate()
+        #expect(update.prefix == "ch")
+        #expect(update.context == "xin")
+    }
+
+    @Test("Accepting a candidate makes it the context")
+    func acceptedCandidateBecomesContext() {
+        let coordinator = KeyboardInputCoordinator(inputMethod: .vni)
+        let document = TestKeyboardWriter()
+        type("ban", with: coordinator, into: document)
+        #expect(
+            coordinator.acceptSuggestion("bạn", replacing: "ban", writer: document) != nil
+        )
+        #expect(coordinator.takePersonalSuggestionUpdate().context == "bạn")
+    }
+
+    @Test("A caret that leaves the word abandons the context")
+    func caretMoveClearsContext() {
+        let coordinator = KeyboardInputCoordinator(inputMethod: .vni)
+        let document = TestKeyboardWriter()
+        type("xin", with: coordinator, into: document)
+        coordinator.handle(testKey(.space, label: " "), writer: document)
+        _ = coordinator.takePersonalSuggestionUpdate()
+        document.replaceTextExternally(with: "một câu khác ")
+        coordinator.synchronizeDocument(document, event: .textChanged)
+        #expect(coordinator.takePersonalSuggestionUpdate().context == nil)
+    }
+
     @Test("Oversized words do not expose a query prefix")
     func boundedPrefix() {
         let coordinator = KeyboardInputCoordinator(inputMethod: .vni)


### PR DESCRIPTION
**8 of 9** toward `feature/context-suggestion`. Base is PR #284.

The first change a user can see: typing "xin", a space, then "ch" now puts "chào" first.

The context lives in `AuthoredTokenTracker`, because that is the only thing that sees every mutation — which separator ended a word, when the caret left, when the prefix was abandoned. Everything downstream sees the result and not the reason.

**The tracker could not tell a space from a full stop.** Both were a non-letter, both ended the word, and nothing recorded which. A space now keeps the finished word as the context for the next one; anything else — a full stop, a newline, a comma — clears it. Two words either side of a sentence boundary were never adjacent, and guessing otherwise would teach pairs nobody typed.

| Event | Context |
|---|---|
| word ends on a space | the word just finished |
| word ends on anything else | cleared |
| `reset` — caret moved, focus or panel changed | cleared |
| backspace past an empty prefix | cleared |

Accepting a candidate needs no special case: it inserts the word and a space, travels the ordinary insertion path, and ends with the accepted word as the context.

## Review

Two tests fail if every separator is allowed to chain.

The service never queries without a prefix. Without one every follower matches, which is prediction without the threshold that has to guard it (step 6). The two-character rule already enforced it; a test now pins it rather than leaving it to a coincidence.

Verified by `Scripts/test-funput-kit.sh` and the `FunputTests` suggestion suites on the simulator, after rebuilding the xcframework against the new ABI.