### PR TITLE
feat(android): carry the previous word into learn and query

### DIFF
--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/AndroidCompositionSession.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/AndroidCompositionSession.kt
@@ -17,7 +17,8 @@ internal class AndroidCompositionSession(
     private var renderMode = CompositionRenderMode.COMPOSING
     var composingText: String = ""
         private set
-    private var completedToken: String? = null
+    /** The word a boundary just finished, and whether that boundary was a space. */
+    private var completed: Pair<String, Boolean>? = null
 
     val isComposing: Boolean get() = composingText.isNotEmpty()
 
@@ -28,7 +29,7 @@ internal class AndroidCompositionSession(
     }
 
     fun input(connection: InputConnection?, text: String): Boolean {
-        completedToken = null
+        completed = null
         if (connection == null || text.isEmpty()) return false
         val codePoint = text.singleCodePointOrNull() ?: return commitRaw(connection, text)
         return if (CompositionBoundary.isBoundary(codePoint, engine.inputMethod)) {
@@ -39,7 +40,7 @@ internal class AndroidCompositionSession(
     }
 
     fun backspace(connection: InputConnection?): Boolean {
-        completedToken = null
+        completed = null
         if (connection == null || !isComposing) return false
         val previous = composingText
         composingText = engine.backspace()
@@ -53,19 +54,19 @@ internal class AndroidCompositionSession(
 
     fun reset() {
         composingText = ""
-        completedToken = null
+        completed = null
         committedTail.clear()
         engine.clear()
     }
 
-    fun takeCompletedToken(): String? = completedToken.also { completedToken = null }
+    fun takeCompleted(): Pair<String, Boolean>? = completed.also { completed = null }
 
     fun acceptSuggestion(connection: InputConnection, prefix: String, candidate: String): Boolean {
         if (composingText != prefix) return false
         val accepted = documentEditor.acceptSuggestion(connection, renderMode, prefix, candidate)
         if (accepted) committedTail.record("$candidate ")
         composingText = ""
-        completedToken = null
+        completed = null
         engine.clear()
         return accepted
     }
@@ -77,7 +78,10 @@ internal class AndroidCompositionSession(
     ): Boolean {
         val previous = composingText
         val replacement = engine.processBoundary(codePoint)
-        completedToken = replacement?.removeSuffix(text)?.ifEmpty { null } ?: previous.ifEmpty { null }
+        // Only a space leaves the words either side of it adjacent; the tracker
+        // has no other way to know which boundary this was.
+        val token = replacement?.removeSuffix(text)?.ifEmpty { null } ?: previous.ifEmpty { null }
+        completed = token?.let { it to (codePoint == ' '.code) }
         committedTail.record(replacement ?: previous + text)
         composingText = ""
         return documentEditor.commitBoundary(connection, renderMode, previous, replacement, text)

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/AuthoredTokenTracker.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/AuthoredTokenTracker.kt
@@ -3,6 +3,8 @@ package app.funput.funput.ime.editing
 internal data class AuthoredSuggestionUpdate(
     val prefix: String,
     val completedToken: String?,
+    /** The word [prefix] is being typed after, when one can be vouched for. */
+    val context: String? = null,
 ) {
     companion object {
         val Empty = AuthoredSuggestionUpdate("", null)
@@ -12,18 +14,31 @@ internal data class AuthoredSuggestionUpdate(
 internal class AuthoredTokenTracker {
     private var prefix = ""
     private var completedToken: String? = null
+
+    /**
+     * The word the next one will be recorded as following, or null when nothing
+     * here can vouch for what came before.
+     *
+     * It lives in the tracker because the tracker is the only thing that sees
+     * every edit — which separator ended a word, when the caret left, when the
+     * prefix was abandoned. Everything downstream sees the result, not the reason.
+     */
+    private var context: String? = null
     private var directOverflow = false
 
-    fun update(composingText: String, completed: String?) {
+    fun update(composingText: String, completed: String?, completedOnSpace: Boolean) {
         directOverflow = false
         prefix = composingText.takeIf(::isValidToken).orEmpty()
         completedToken = completed?.takeIf { isValidToken(it) && scalarCount(it) >= MinimumLength }
+        if (completed != null) context = completedToken.takeIf { completedOnSpace }
     }
 
     fun accepted(candidate: String) {
         directOverflow = false
         prefix = ""
         completedToken = candidate.takeIf(::isValidToken)
+        // Accepting a candidate writes the word and a space after it.
+        context = completedToken
     }
 
     fun input(text: String) {
@@ -42,6 +57,10 @@ internal class AuthoredTokenTracker {
                 completedToken = prefix.takeIf {
                     !directOverflow && scalarCount(it) >= MinimumLength
                 }
+                // A space continues the sentence, so the word just finished is
+                // what the next one follows. Anything else ends it, and the two
+                // words either side were never adjacent.
+                context = completedToken.takeIf { codePoint == ' '.code }
                 prefix = ""
                 directOverflow = false
             }
@@ -50,14 +69,18 @@ internal class AuthoredTokenTracker {
     }
 
     fun backspace() {
-        if (directOverflow || prefix.isEmpty()) return
+        if (directOverflow || prefix.isEmpty()) {
+            // Nothing left of this word to delete, so the caret has crossed back
+            // over a boundary and what precedes it is no longer known.
+            context = null
+            return
+        }
         prefix = prefix.dropLast(Character.charCount(prefix.codePointBefore(prefix.length)))
         completedToken = null
     }
 
-    fun consume(): AuthoredSuggestionUpdate = AuthoredSuggestionUpdate(prefix, completedToken).also {
-        completedToken = null
-    }
+    fun consume(): AuthoredSuggestionUpdate =
+        AuthoredSuggestionUpdate(prefix, completedToken, context).also { completedToken = null }
 
     fun currentPrefix(): String = prefix
 
@@ -65,6 +88,7 @@ internal class AuthoredTokenTracker {
         directOverflow = false
         prefix = ""
         completedToken = null
+        context = null
     }
 
     private fun isValidToken(text: String): Boolean {

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/ImeSuggestionSession.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/ImeSuggestionSession.kt
@@ -10,7 +10,8 @@ internal class ImeSuggestionSession(
     private val tracker = AuthoredTokenTracker()
 
     fun updateComposition() {
-        tracker.update(composition.composingText, composition.takeCompletedToken())
+        val completed = composition.takeCompleted()
+        tracker.update(composition.composingText, completed?.first, completed?.second == true)
     }
 
     fun inputDirect(text: String) = tracker.input(text)

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/nativebridge/PersonalSuggestionNative.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/nativebridge/PersonalSuggestionNative.kt
@@ -9,7 +9,9 @@ internal object PersonalSuggestionNative {
     external fun nativeOpen(path: String): Long
     external fun nativeDestroy(handle: Long)
     external fun nativeLearn(handle: Long, token: String): Boolean
+    external fun nativeLearnAfter(handle: Long, previous: String, token: String): Boolean
     external fun nativeQuery(handle: Long, prefix: String): Array<String>?
+    external fun nativeQueryWith(handle: Long, previous: String, prefix: String): Array<String>?
     external fun nativeFlush(handle: Long): Boolean
     external fun nativeCompact(handle: Long): Boolean
     external fun nativeReset(handle: Long): Boolean

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/suggestions/PersonalSuggestionEngine.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/suggestions/PersonalSuggestionEngine.kt
@@ -7,9 +7,13 @@ import java.io.File
 internal class PersonalSuggestionEngine private constructor(private var handle: Long) : Closeable {
     private val ownerThread = Thread.currentThread()
 
-    fun learn(token: String): Boolean = call(false) { PersonalSuggestionNative.nativeLearn(it, token) }
-    fun query(prefix: String): List<String> = call(emptyList()) { value ->
-        PersonalSuggestionNative.nativeQuery(value, prefix)?.take(MaxCandidates).orEmpty()
+    fun learn(token: String, after: String? = null): Boolean = call(false) {
+        PersonalSuggestionNative.nativeLearnAfter(it, after.orEmpty(), token)
+    }
+    fun query(prefix: String, after: String? = null): List<String> = call(emptyList()) { value ->
+        PersonalSuggestionNative.nativeQueryWith(value, after.orEmpty(), prefix)
+            ?.take(MaxCandidates)
+            .orEmpty()
     }
     fun flush(): Boolean = call(false, PersonalSuggestionNative::nativeFlush)
     fun compact(): Boolean = call(false, PersonalSuggestionNative::nativeCompact)

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/suggestions/PersonalSuggestionRequestSlot.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/suggestions/PersonalSuggestionRequestSlot.kt
@@ -7,6 +7,8 @@ internal data class PersonalSuggestionRequest(
     val prefix: String,
     val generation: Long,
     val session: Long,
+    /** The word [prefix] is being typed after, when one can be vouched for. */
+    val context: String? = null,
     val startedNanos: Long = System.nanoTime(),
 )
 

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/suggestions/PersonalSuggestionService.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/suggestions/PersonalSuggestionService.kt
@@ -27,6 +27,8 @@ internal class PersonalSuggestionService(
     private var session = 0L
     private var generation = 0L
     private var prefix = ""
+    /** The word the next one follows, when the tracker can vouch for one. */
+    private var previousWord: String? = null
     private var candidates = emptyList<String>()
     private var pendingReset: String? = null
 
@@ -63,13 +65,18 @@ internal class PersonalSuggestionService(
     }
 
     fun consume(update: AuthoredSuggestionUpdate) {
-        update.completedToken?.takeIf { eligible() && policy.allowsPersonalizedLearning }?.let { worker?.learn(it) }
+        update.completedToken
+            ?.takeIf { eligible() && policy.allowsPersonalizedLearning }
+            ?.let { worker?.learn(it, previousWord) }
+        previousWord = update.context
         if (update.completedToken == null && update.prefix == prefix) return
         prefix = update.prefix
+        // Never queried without a prefix: without one every follower matches, and
+        // that is prediction without the threshold that has to guard it.
         if (!eligible() || prefix.codePointCount(0, prefix.length) < MinimumPrefix) return clear()
         generation += 1
         clearCandidates()
-        worker?.query(PersonalSuggestionRequest(prefix, generation, session))
+        worker?.query(PersonalSuggestionRequest(prefix, generation, session, previousWord))
     }
 
     fun select(selection: SuggestionSelection, handler: ImeKeyActionHandler): Boolean {
@@ -100,6 +107,7 @@ internal class PersonalSuggestionService(
     private fun clear() {
         generation += 1
         prefix = ""
+        previousWord = null
         worker?.clearQueries()
         clearCandidates()
     }

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/suggestions/PersonalSuggestionWorker.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/suggestions/PersonalSuggestionWorker.kt
@@ -28,8 +28,8 @@ internal class PersonalSuggestionWorker(
         if (requests.submit(request)) worker.post(drain)
     }
 
-    fun learn(token: String) = worker.post {
-        if (engine?.learn(token) != true) return@post
+    fun learn(token: String, after: String?) = worker.post {
+        if (engine?.learn(token, after) != true) return@post
         learnedSinceFlush += 1
         worker.removeCallbacks(idleFlush)
         if (learnedSinceFlush >= FlushWordCount) flushNow() else worker.postDelayed(idleFlush, IdleFlushMillis)
@@ -66,7 +66,7 @@ internal class PersonalSuggestionWorker(
         while (true) {
             val request = requests.takeLatest() ?: break
             suggestionCounter("SuggestionGeneration", request.generation)
-            val result = suggestionTrace("SuggestionJNIQuery") { engine?.query(request.prefix).orEmpty() }
+            val result = suggestionTrace("SuggestionJNIQuery") { engine?.query(request.prefix, request.context).orEmpty() }
             main.post { runCatching { publish(request, result) } }
         }
         if (requests.finishDrain()) worker.post(drain)

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AndroidSuggestionCompositionSessionTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AndroidSuggestionCompositionSessionTest.kt
@@ -26,7 +26,18 @@ class AndroidSuggestionCompositionSessionTest {
 
         session.input(connection.proxy, " ")
 
-        assertEquals("tiếng", session.takeCompletedToken())
-        assertEquals(null, session.takeCompletedToken())
+        assertEquals("tiếng" to true, session.takeCompleted())
+        assertEquals(null, session.takeCompleted())
+    }
+
+    @Test
+    fun `a full stop finishes the word without leaving it as context`() {
+        val connection = RecordingConnection()
+        val session = testSession(ScriptedEngine(ArrayDeque(listOf("tiếng"))))
+        session.input(connection.proxy, "g")
+
+        session.input(connection.proxy, ".")
+
+        assertEquals("tiếng" to false, session.takeCompleted())
     }
 }

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AuthoredTokenTrackerTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AuthoredTokenTrackerTest.kt
@@ -9,9 +9,9 @@ class AuthoredTokenTrackerTest {
     fun `tracks final composed output and completed token`() {
         val tracker = AuthoredTokenTracker()
 
-        tracker.update("tiếng", null)
+        tracker.update("tiếng", null, completedOnSpace = true)
         assertEquals("tiếng", tracker.consume().prefix)
-        tracker.update("", "tiếng")
+        tracker.update("", "tiếng", completedOnSpace = true)
 
         val update = tracker.consume()
         assertEquals("", update.prefix)
@@ -23,9 +23,9 @@ class AuthoredTokenTrackerTest {
     fun `supports decomposed marks and rejects boundaries`() {
         val tracker = AuthoredTokenTracker()
 
-        tracker.update("tie\u0302\u0301ng", null)
+        tracker.update("tie\u0302\u0301ng", null, completedOnSpace = true)
         assertEquals("tie\u0302\u0301ng", tracker.consume().prefix)
-        tracker.update("xin chào", "a!")
+        tracker.update("xin chào", "a!", completedOnSpace = true)
 
         assertEquals(AuthoredSuggestionUpdate.Empty, tracker.consume())
     }
@@ -35,9 +35,9 @@ class AuthoredTokenTrackerTest {
         val tracker = AuthoredTokenTracker()
         val valid = "a".repeat(32)
 
-        tracker.update(valid, valid)
+        tracker.update(valid, valid, completedOnSpace = true)
         assertEquals(valid, tracker.consume().prefix)
-        tracker.update("a".repeat(33), "a".repeat(33))
+        tracker.update("a".repeat(33), "a".repeat(33), completedOnSpace = true)
 
         assertEquals(AuthoredSuggestionUpdate.Empty, tracker.consume())
     }
@@ -61,7 +61,7 @@ class AuthoredTokenTrackerTest {
         assertEquals("ab1", tracker.consume().prefix)
         tracker.input(" ")
 
-        assertEquals(AuthoredSuggestionUpdate("", "ab1"), tracker.consume())
+        assertEquals(AuthoredSuggestionUpdate("", "ab1", context = "ab1"), tracker.consume())
     }
 
     @Test
@@ -73,5 +73,59 @@ class AuthoredTokenTrackerTest {
         tracker.input(" ")
 
         assertEquals(AuthoredSuggestionUpdate.Empty, tracker.consume())
+    }
+
+    @Test
+    fun `a space keeps the finished word as context and a full stop clears it`() {
+        val tracker = AuthoredTokenTracker()
+        tracker.update("", "xin", completedOnSpace = true)
+        assertEquals("xin", tracker.consume().context)
+
+        tracker.update("", "xin", completedOnSpace = false)
+        val ended = tracker.consume()
+        assertEquals("the word is still learned", "xin", ended.completedToken)
+        assertNull("but nothing follows it", ended.context)
+    }
+
+    @Test
+    fun `direct input decides the context from its own separator`() {
+        val tracker = AuthoredTokenTracker()
+        tracker.input("xin ")
+        assertEquals("xin", tracker.consume().context)
+
+        tracker.input("xin.")
+        assertNull(tracker.consume().context)
+    }
+
+    @Test
+    fun `the context survives while the next word is typed`() {
+        val tracker = AuthoredTokenTracker()
+        tracker.input("xin ")
+        tracker.consume()
+        tracker.input("ch")
+        val update = tracker.consume()
+        assertEquals("ch", update.prefix)
+        assertEquals("xin", update.context)
+    }
+
+    @Test
+    fun `accepting a candidate makes it the context`() {
+        val tracker = AuthoredTokenTracker()
+        tracker.accepted("bạn")
+        assertEquals("bạn", tracker.consume().context)
+    }
+
+    @Test
+    fun `reset and backspacing past the word abandon the context`() {
+        val tracker = AuthoredTokenTracker()
+        tracker.input("xin ")
+        tracker.consume()
+        tracker.backspace()
+        assertNull("the caret crossed back over the boundary", tracker.consume().context)
+
+        tracker.input("xin ")
+        tracker.consume()
+        tracker.reset()
+        assertNull(tracker.consume().context)
     }
 }


### PR DESCRIPTION
**9 of 9** toward `feature/context-suggestion`. Base is PR #285.

The mirror of the iOS change. The rules match it line for line, because they have to describe the same keyboard.

**Neither Android path could tell a space from a full stop.** The direct path had the separator in hand and threw it away. The composed path never saw it at all: `commitBoundary` knows the code point, but `takeCompletedToken` returned only the word. The word and how it ended are now one value, so the two cannot drift apart and every reset clears both by construction.

Accepting a candidate is an explicit call here rather than an ordinary insertion as on iOS, so it sets the context itself — it writes the word and a space.

## Review

Three tests fail if every boundary is allowed to chain.

The service field is `previousWord`, not `context`: the class already takes an Android `Context`, and two things called context in one file is one too many.

`AndroidCompositionSession` went four lines over the Kotlin budget while carrying the separator in a second field. Collapsing the word and its separator into one value came in under it and removed the way they could have disagreed.

Known and unchanged: Android counts digits as part of a word (`isLetterOrDigit`) while iOS does not (`isLetter`). A pre-existing divergence between the two trackers, not introduced here.