### PR TITLE
feat(suggestions): predict the next word, but only when the context is sharp

### DIFF
--- a/crates/funput-suggestions/src/bigram/mod.rs
+++ b/crates/funput-suggestions/src/bigram/mod.rs
@@ -4,7 +4,7 @@
 //! - `slots` — which edges survive when there are more than there is room for.
 //! - `learning` — the engine's write path, [`SuggestionEngine::learn_after`].
 //!
-//! - `query` — the read path, [`SuggestionEngine::suggest_with`].
+//! - `query/` — the read path, [`SuggestionEngine::suggest_with`], in its two modes.
 
 pub(crate) mod follower;
 mod learning;

--- a/crates/funput-suggestions/src/bigram/query/mod.rs
+++ b/crates/funput-suggestions/src/bigram/query/mod.rs
@@ -23,7 +23,13 @@ impl SuggestionEngine {
         let Some((context, _)) = previous.and_then(|text| self.context_slot(text)) else {
             return self.assemble(ids, len);
         };
-        let (ids, len) = self.with_context(context, prefix, ids, len);
+        // No prefix means no candidates to reorder, so the context is all there
+        // is to go on and a much stricter question applies.
+        let (ids, len) = if len == 0 && prefix.is_empty() {
+            self.predict(context)
+        } else {
+            self.with_context(context, prefix, ids, len)
+        };
         self.assemble(ids, len)
     }
 }

--- a/crates/funput-suggestions/src/bigram/query/mod.rs
+++ b/crates/funput-suggestions/src/bigram/query/mod.rs
@@ -1,0 +1,29 @@
+//! The read path, in its two modes.
+//!
+//! - `rerank` — a prefix is being typed, and the context reorders and extends
+//!   what that prefix could become.
+//! - `predict` — no prefix yet, so the context is all there is to go on.
+
+mod predict;
+mod rerank;
+
+use crate::engine::SuggestionEngine;
+use crate::types::SuggestionSet;
+
+impl SuggestionEngine {
+    /// The words `prefix` could become, with the ones that have followed
+    /// `previous` before moved to the front.
+    ///
+    /// `previous` is the caller's business, as it is for `learn_after`: a
+    /// platform that cannot vouch for what came before passes `None` and gets
+    /// exactly what `suggest` has always returned.
+    #[inline]
+    pub fn suggest_with(&self, previous: Option<&str>, prefix: &str) -> SuggestionSet<'_> {
+        let (ids, len) = self.prefix_candidates(prefix);
+        let Some((context, _)) = previous.and_then(|text| self.context_slot(text)) else {
+            return self.assemble(ids, len);
+        };
+        let (ids, len) = self.with_context(context, prefix, ids, len);
+        self.assemble(ids, len)
+    }
+}

--- a/crates/funput-suggestions/src/bigram/query/predict.rs
+++ b/crates/funput-suggestions/src/bigram/query/predict.rs
@@ -1,0 +1,3 @@
+//! Deciding whether the context is worth speaking about on its own.
+//!
+//! Nothing here yet; the thresholds arrive with the prediction mode.

--- a/crates/funput-suggestions/src/bigram/query/predict.rs
+++ b/crates/funput-suggestions/src/bigram/query/predict.rs
@@ -1,3 +1,49 @@
 //! Deciding whether the context is worth speaking about on its own.
 //!
-//! Nothing here yet; the thresholds arrive with the prediction mode.
+//! With no prefix, every follower of the context is a candidate, so the question
+//! stops being "which of these" and becomes "should anything be offered at all".
+//!
+//! Vietnamese splits sharply here. "cảm" is nearly always followed by "ơn" and
+//! "bởi" by "vì"; "của" and "và" can be followed by anything, and those are the
+//! syllables that come up most. No amount of memory helps the second group, so
+//! the value of this mode is in staying quiet for it.
+
+use crate::engine::SuggestionEngine;
+use crate::index::{NONE, TOP_K};
+
+impl SuggestionEngine {
+    /// The one word most likely to follow `context`, or nothing.
+    ///
+    /// Only the leader is ever offered. The dominance test below is a statement
+    /// that the rest of the distribution is noise, so filling the other two slots
+    /// with it would contradict the reason this spoke at all.
+    pub(super) fn predict(&self, context: u32) -> ([u32; TOP_K], usize) {
+        let silent = ([NONE; TOP_K], 0);
+        let Some(word) = self.words.get(context as usize) else {
+            return silent;
+        };
+        let Some(leader) = word
+            .followers
+            .iter()
+            .filter(|slot| slot.word(&self.words).is_some())
+            .max_by_key(|slot| slot.uses)
+        else {
+            return silent;
+        };
+        if leader.uses < self.config.context_predict_uses
+            || !self.dominates(leader.uses, word.context_seen)
+        {
+            return silent;
+        }
+        let mut ids = [NONE; TOP_K];
+        ids[0] = leader.word;
+        (ids, 1)
+    }
+
+    /// Both sides are bounded by the aging threshold, so `u32` cannot overflow
+    /// and the comparison needs no division.
+    fn dominates(&self, uses: u16, context_seen: u16) -> bool {
+        u32::from(uses) * 100
+            >= u32::from(context_seen) * u32::from(self.config.context_dominance_percent)
+    }
+}

--- a/crates/funput-suggestions/src/bigram/query/rerank.rs
+++ b/crates/funput-suggestions/src/bigram/query/rerank.rs
@@ -1,4 +1,4 @@
-//! The read path: letting what came before reorder what comes next.
+//! Letting what came before reorder what comes next.
 //!
 //! A trie node remembers only its best few words by frequency, so a pair can be
 //! sharp — "xin" is almost always followed by "chào" — while its target is rare
@@ -6,29 +6,12 @@
 //! to *add* a candidate, not only to move one. Everything it adds still matches
 //! the prefix, so it is still a completion of what the user is typing.
 
-use super::follower::{FOLLOWER_SLOTS, Follower};
+use crate::bigram::follower::{FOLLOWER_SLOTS, Follower};
 use crate::engine::SuggestionEngine;
 use crate::index::{NONE, TOP_K, normalize};
-use crate::types::SuggestionSet;
 
 impl SuggestionEngine {
-    /// The words `prefix` could become, with the ones that have followed
-    /// `previous` before moved to the front.
-    ///
-    /// `previous` is the caller's business, as it is for `learn_after`: a
-    /// platform that cannot vouch for what came before passes `None` and gets
-    /// exactly what `suggest` has always returned.
-    #[inline]
-    pub fn suggest_with(&self, previous: Option<&str>, prefix: &str) -> SuggestionSet<'_> {
-        let (ids, len) = self.prefix_candidates(prefix);
-        let Some((context, _)) = previous.and_then(|text| self.context_slot(text)) else {
-            return self.assemble(ids, len);
-        };
-        let (ids, len) = self.with_context(context, prefix, ids, len);
-        self.assemble(ids, len)
-    }
-
-    fn with_context(
+    pub(super) fn with_context(
         &self,
         context: u32,
         prefix: &str,

--- a/crates/funput-suggestions/src/engine/config.rs
+++ b/crates/funput-suggestions/src/engine/config.rs
@@ -12,6 +12,15 @@ pub struct SuggestionConfig {
     /// prefix results. One is deliberate: the prefix has already filtered the
     /// field, so the cost of being wrong is the order of three slots.
     pub context_rerank_uses: u16,
+    /// How often a pair must have been seen before it may be offered with no
+    /// prefix at all. Higher than the rerank threshold, because here being wrong
+    /// costs a slot rather than an order.
+    pub context_predict_uses: u16,
+    /// What share of a context word's sightings its strongest follower has to
+    /// account for before the bar says anything. This is the whole of the
+    /// feature's judgement: "cảm" is nearly always followed by "ơn" and clears it
+    /// at once, while "của" can be followed by anything and never will.
+    pub context_dominance_percent: u8,
 }
 
 impl Default for SuggestionConfig {
@@ -21,6 +30,8 @@ impl Default for SuggestionConfig {
             max_token_scalars: 32,
             promotion_uses: 2,
             context_rerank_uses: 1,
+            context_predict_uses: 2,
+            context_dominance_percent: 40,
         }
     }
 }
@@ -31,5 +42,7 @@ pub(crate) fn sanitize(config: SuggestionConfig) -> SuggestionConfig {
         max_token_scalars: config.max_token_scalars.clamp(1, MAX_TOKEN_SCALARS),
         promotion_uses: config.promotion_uses.max(1),
         context_rerank_uses: config.context_rerank_uses.max(1),
+        context_predict_uses: config.context_predict_uses.max(1),
+        context_dominance_percent: config.context_dominance_percent.min(100),
     }
 }

--- a/crates/funput-suggestions/src/tests/bigram/query.rs
+++ b/crates/funput-suggestions/src/tests/bigram/query.rs
@@ -152,3 +152,92 @@ fn a_folded_prefix_still_reranks() {
     assert_eq!(texts(&engine, "ho"), ["hôm", "hòa"]);
     assert_eq!(with(&engine, "xin", "ho"), ["hòa", "hôm"]);
 }
+
+fn predicted(engine: &SuggestionEngine, previous: &str) -> Vec<String> {
+    with(engine, previous, "")
+}
+
+#[test]
+fn a_dominant_pair_speaks_after_a_space() {
+    let mut engine = engine(SuggestionConfig::default());
+    engine.learn_after(None, "cảm");
+    engine.learn_after(Some("cảm"), "ơn");
+    engine.learn_after(Some("cảm"), "ơn");
+    assert_eq!(predicted(&engine, "cảm"), ["ơn"]);
+}
+
+#[test]
+fn a_flat_context_stays_silent() {
+    let mut engine = engine(SuggestionConfig::default());
+    engine.learn_after(None, "của");
+    // Four followers sharing the sightings evenly. Every one of them clears the
+    // use threshold; none of them accounts for enough of "của" to be worth
+    // saying, which is the whole distinction this mode rests on.
+    for word in ["tôi", "bạn", "anh", "chị"] {
+        for _ in 0..3 {
+            engine.learn_after(Some("của"), word);
+        }
+    }
+    assert!(
+        predicted(&engine, "của").is_empty(),
+        "a context that can be followed by anything must not offer one of them"
+    );
+}
+
+#[test]
+fn only_the_leader_is_offered() {
+    let mut engine = engine(SuggestionConfig::default());
+    engine.learn_after(None, "xin");
+    for _ in 0..8 {
+        engine.learn_after(Some("xin"), "chào");
+    }
+    for _ in 0..2 {
+        engine.learn_after(Some("xin"), "lỗi");
+    }
+    assert_eq!(predicted(&engine, "xin"), ["chào"]);
+}
+
+#[test]
+fn a_pair_below_the_use_threshold_stays_silent() {
+    let mut engine = engine(SuggestionConfig::default());
+    engine.learn_after(None, "xin");
+    engine.learn_after(Some("xin"), "chào");
+    assert!(
+        predicted(&engine, "xin").is_empty(),
+        "seen once is not a habit"
+    );
+
+    engine.learn_after(Some("xin"), "chào");
+    assert_eq!(predicted(&engine, "xin"), ["chào"]);
+}
+
+#[test]
+fn without_a_context_nothing_is_predicted() {
+    let mut engine = engine(SuggestionConfig::default());
+    engine.learn_after(None, "xin");
+    engine.learn_after(Some("xin"), "chào");
+    engine.learn_after(Some("xin"), "chào");
+
+    assert!(engine.suggest_with(None, "").is_empty());
+    assert!(predicted(&engine, "chưa").is_empty());
+}
+
+#[test]
+fn a_dead_leader_does_not_speak() {
+    let mut engine = engine(SuggestionConfig {
+        max_words: 3,
+        ..SuggestionConfig::default()
+    });
+    engine.learn_after(None, "xin");
+    engine.learn_after(None, "xin");
+    engine.learn_after(Some("xin"), "chào");
+    engine.learn_after(Some("xin"), "chào");
+    assert_eq!(predicted(&engine, "xin"), ["chào"]);
+
+    // "chào" is the weakest, so filling the lexicon pushes it out.
+    engine.learn_after(None, "aaa");
+    engine.learn_after(None, "aaa");
+    engine.learn_after(None, "bbb");
+    engine.learn_after(None, "bbb");
+    assert!(predicted(&engine, "xin").is_empty());
+}

--- a/crates/funput-suggestions/tests/alloc_budget.rs
+++ b/crates/funput-suggestions/tests/alloc_budget.rs
@@ -85,6 +85,29 @@ fn warm_lookup_with_a_context_does_not_allocate() {
     );
 }
 
+/// Prediction runs after every space, so it is on the same budget: it normalizes
+/// the previous word and walks four follower slots with no heap in sight.
+#[test]
+fn warm_prediction_does_not_allocate() {
+    let mut engine = SuggestionEngine::in_memory(SuggestionConfig::default());
+    engine.learn_after(None, "xin");
+    engine.learn_after(Some("xin"), "chào");
+    engine.learn_after(Some("xin"), "chào");
+
+    let allocations = measure(|| {
+        for _ in 0..100_000 {
+            std::hint::black_box(
+                engine.suggest_with(std::hint::black_box(Some("xin")), std::hint::black_box("")),
+            );
+        }
+    });
+
+    assert_eq!(
+        allocations, 0,
+        "warm prediction allocated {allocations} times"
+    );
+}
+
 fn measure(body: impl FnOnce()) -> usize {
     MEASURING.set(true);
     let before = ALLOCATIONS.get();


### PR DESCRIPTION
**10 of 12** toward `feature/context-suggestion`. Base is PR #286.

With no prefix, every follower of the context is a candidate, so the question stops being "which of these" and becomes "should anything be offered at all".

This also closes the door the rerank work left open: an empty prefix already returned followers, because an empty prefix matches every one of them, and only the platforms' two-character rule kept it out of sight.

Vietnamese splits sharply here. "cảm" is nearly always followed by "ơn" and "bởi" by "vì"; "của" and "và" can be followed by anything, and those are the syllables that come up most. No amount of memory helps the second group, so the value of this mode is in staying quiet for it.

`context_dominance_percent` is that judgement: the strongest follower must account for 40% of the context word's sightings before the bar says anything. `context_seen` — written since the learn path landed, persisted since the snapshot work — is finally divided by.

**Only the leader is ever offered.** The dominance test is a statement that the rest of the distribution is noise, so filling the other two slots with it would contradict the reason this spoke at all.

## Review

The test that matters is `a_flat_context_stays_silent`: a context with four followers sharing its sightings evenly, every one of them past the use threshold, none of them worth saying. It is the only test that separates dominance from a simple count, and it fails without the comparison.

No ABI change — `query_with` has taken an empty prefix since PR #284. No format change, no `SuggestionStats` change.

Both thresholds are guesses; calibrating them against real typing is the last step. Prediction holds the same allocation budget as the other two paths.