### PR TITLE
feat(android): offer a prediction after a space, and let it be tapped

### DIFF
--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/ImeEditingSession.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/ImeEditingSession.kt
@@ -112,9 +112,8 @@ internal fun createImeEditingSession(
         enterCommand = { editorRuntime.policy.editorAction.command },
     )
     val suggestionService = PersonalSuggestionService(
-        context = context,
-        show = showSuggestions,
-        acknowledgeReset = acknowledgeReset,
+        context = context, show = showSuggestions,
+        capitalized = { currentShiftState().isActive }, acknowledgeReset = acknowledgeReset,
     )
     val clipboardPreferences = ClipboardSettings(context).preferences
     val clipboardController = ImeClipboardController(

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/suggestions/PersonalSuggestionCasing.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/suggestions/PersonalSuggestionCasing.kt
@@ -5,13 +5,18 @@ import java.util.Locale
 internal object PersonalSuggestionCasing {
     private val Vietnamese = Locale.forLanguageTag("vi-VN")
 
-    fun apply(candidate: String, prefix: String): String = when {
+    /**
+     * A prediction has no prefix to take its shape from, so [capitalized] — the
+     * keyboard's own Shift state — is the only thing left to ask.
+     */
+    fun apply(candidate: String, prefix: String, capitalized: Boolean = false): String = when {
+        prefix.isEmpty() -> if (capitalized) candidate.titlecased() else candidate
         prefix.hasLetters() && prefix == prefix.uppercase(Vietnamese) -> candidate.uppercase(Vietnamese)
-        prefix.firstOrNull()?.isUpperCase() == true -> candidate.replaceFirstChar { char ->
-            char.titlecase(Vietnamese)
-        }
+        prefix.firstOrNull()?.isUpperCase() == true -> candidate.titlecased()
         else -> candidate.lowercase(Vietnamese)
     }
+
+    private fun String.titlecased() = replaceFirstChar { char -> char.titlecase(Vietnamese) }
 
     private fun String.hasLetters() = any(Char::isLetter)
 }

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/suggestions/PersonalSuggestionService.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/suggestions/PersonalSuggestionService.kt
@@ -13,6 +13,7 @@ import app.funput.funput.keyboard.ui.KeyboardPanel
 internal class PersonalSuggestionService(
     context: Context,
     private val show: (List<String>) -> Unit,
+    private val capitalized: () -> Boolean = { false },
     private val acknowledgeReset: (String) -> Unit,
 ) {
     private val worker = runCatching {
@@ -29,6 +30,8 @@ internal class PersonalSuggestionService(
     private var prefix = ""
     /** The word the next one follows, when the tracker can vouch for one. */
     private var previousWord: String? = null
+    /** Whether the bar is currently answering a context rather than a prefix. */
+    private var predicting = false
     private var candidates = emptyList<String>()
     private var pendingReset: String? = null
 
@@ -69,11 +72,15 @@ internal class PersonalSuggestionService(
             ?.takeIf { eligible() && policy.allowsPersonalizedLearning }
             ?.let { worker?.learn(it, previousWord) }
         previousWord = update.context
-        if (update.completedToken == null && update.prefix == prefix) return
+        // A prediction answers a context with no prefix at all. One character is
+        // neither a prefix worth completing nor a word boundary, and stays out.
+        val predicts = eligible() && update.prefix.isEmpty() && previousWord != null
+        if (update.completedToken == null && update.prefix == prefix && predicts == predicting) return
         prefix = update.prefix
-        // Never queried without a prefix: without one every follower matches, and
-        // that is prediction without the threshold that has to guard it.
-        if (!eligible() || prefix.codePointCount(0, prefix.length) < MinimumPrefix) return clear()
+        predicting = predicts
+        if (!eligible() || (!predicts && prefix.codePointCount(0, prefix.length) < MinimumPrefix)) {
+            return clear()
+        }
         generation += 1
         clearCandidates()
         worker?.query(PersonalSuggestionRequest(prefix, generation, session, previousWord))
@@ -81,7 +88,9 @@ internal class PersonalSuggestionService(
 
     fun select(selection: SuggestionSelection, handler: ImeKeyActionHandler): Boolean {
         val candidate = candidates.getOrNull(selection.index) ?: return reject()
-        if (candidate != selection.text || !eligible() || prefix.isEmpty()) return reject()
+        // An empty prefix is the ordinary shape of accepting a prediction: it
+        // replaces nothing and inserts a word.
+        if (candidate != selection.text || !eligible()) return reject()
         if (!handler.acceptSuggestion(candidate, prefix)) return reject()
         consume(handler.takeSuggestionUpdate())
         return true
@@ -93,8 +102,11 @@ internal class PersonalSuggestionService(
     private fun publish(request: PersonalSuggestionRequest, values: List<String>) {
         if (request.generation != generation || request.session != session || request.prefix != prefix) return
         if (!eligible()) return
-        candidates = values.map { PersonalSuggestionCasing.apply(it, prefix) }
-        runCatching { show(candidates) }
+        val next = values.map { PersonalSuggestionCasing.apply(it, prefix, capitalized()) }
+        if (next != candidates) {
+            candidates = next
+            runCatching { show(candidates) }
+        }
         suggestionCounter("SuggestionQueryToToolbarUs", (System.nanoTime() - request.startedNanos) / 1_000)
     }
 
@@ -108,6 +120,7 @@ internal class PersonalSuggestionService(
         generation += 1
         prefix = ""
         previousWord = null
+        predicting = false
         worker?.clearQueries()
         clearCandidates()
     }

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/suggestions/PersonalSuggestionCasingTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/suggestions/PersonalSuggestionCasingTest.kt
@@ -10,4 +10,10 @@ class PersonalSuggestionCasingTest {
         assertEquals("Việt", PersonalSuggestionCasing.apply("việt", "Vi"))
         assertEquals("VIỆT", PersonalSuggestionCasing.apply("việt", "VI"))
     }
+
+    @Test
+    fun `a prediction takes its case from shift, having no prefix to take it from`() {
+        assertEquals("chào", PersonalSuggestionCasing.apply("chào", "", capitalized = false))
+        assertEquals("Chào", PersonalSuggestionCasing.apply("chào", "", capitalized = true))
+    }
 }


### PR DESCRIPTION
**12 of 12** toward `feature/context-suggestion`. Base is PR #288.

The mirror of the iOS change, with the same three parts — and the same third one that would otherwise have shipped broken: `select` rejected an empty prefix, so tapping a prediction did nothing, silently. Everything under it was already correct (`acceptDirect` deletes nothing and commits the word with a space) and only the guard above it was wrong.

An empty prefix reaches the engine when there is a context; one character stays blocked. The bar stops redrawing when the candidates have not changed.

## Review

Casing is passed in as a `capitalized: () -> Boolean` lambda alongside `show`, rather than added to each of the four `consume` call sites. `ImeEditingSession` already had `currentShiftState` in hand.

`ImeEditingSession` went one line over the Kotlin budget from the new argument; the constructor call now pairs its named arguments two to a line.

This completes the crate and both platforms. What remains is calibration: `AGING_AFTER`, `context_dominance_percent` and `context_predict_uses` are all guesses, and measuring them against real typing is the last step.