### PR TITLE
ci: gate the Swift and Kotlin line budgets on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,36 @@ jobs:
       - name: Line budget
         run: bash scripts/check-loc.sh
 
+  # The line budgets for the three shell languages, none of which ran anywhere a
+  # pull request could see. The Swift ones were called from deploy-ios.yml
+  # (`workflow_dispatch`, a manual release) and build-macos.yml (`workflow_call`,
+  # from release.yml); the Kotlin ones were called from nothing at all. So an
+  # oversized file could sit in main until someone shipped, and two did: a Swift
+  # test file at 159 lines with twelve green pull requests stacked on it, and a
+  # Kotlin one at 162.
+  #
+  # Its own job rather than steps in `rust`, so a failure is named for what broke.
+  # Every script here is bash, find and wc, so none needs a toolchain and the whole
+  # job costs a checkout. It does not build or test either mobile shell — the
+  # Android module in particular has no CI at all, which is its own problem and a
+  # much larger one than this job.
+  shell-line-budget:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Swift, iOS
+        run: bash platforms/ios/Scripts/check-swift-loc.sh
+
+      - name: Swift, macOS
+        run: bash platforms/macos/scripts/check-swift-loc.sh
+
+      - name: Kotlin, line budget
+        run: bash platforms/android/scripts/check-kotlin-loc.sh
+
+      - name: Kotlin, directory layout
+        run: bash platforms/android/scripts/check-kotlin-layout.sh
+
   # The GTK4 Settings app, which also hosts the Chuyển mã window. Excluded from the
   # cargo workspace because it links system gtk4/libadwaita, so the `rust` job above —
   # which deliberately installs no system libraries — cannot see it. Before this job it


### PR DESCRIPTION
Four line-budget scripts existed, and **none of them ran anywhere a pull request could see**:

| Script | Called from | Trigger |
|---|---|---|
| `platforms/ios/Scripts/check-swift-loc.sh` | `deploy-ios.yml` | `workflow_dispatch` — manual release |
| `platforms/macos/scripts/check-swift-loc.sh` | `build-macos.yml` | `workflow_call` — from `release.yml` |
| `platforms/android/scripts/check-kotlin-loc.sh` | nothing | — |
| `platforms/android/scripts/check-kotlin-layout.sh` | nothing | — |

So an oversized file could sit in main until someone shipped. **Two did while this feature was being built:** `PersonalSuggestionServiceCreationTests.swift` at 159 lines with twelve green pull requests stacked on top of it, and `AuthoredTokenTrackerTest.kt` at 162. Both were caught by hand during review, not by CI.

## Review

Its own job rather than steps in `rust`, so a failure is named for what broke rather than reported under a job about Rust.

Every script is bash, `find` and `wc` — no Swift toolchain, no Android SDK, no macOS runner. The whole job runs in about six seconds against the fifty the other jobs take, in parallel with them.

All four pass on this branch; this PR only adds the gate. The violations it would have caught are already fixed in #288 and #293.

## What this does not close

It does not build or test either mobile shell. **The Android module has no CI at all** — 245 unit tests that have never run on a pull request, and the Rust JNI library it links is never built for Android either. That is a much larger gap than this job closes, needs a JDK and the Android SDK, and should be its own piece of work.