### PR TITLE
fix(suggestions): stop a journal that outlived its compact counting twice

### DIFF
--- a/crates/funput-suggestions/src/engine/durability.rs
+++ b/crates/funput-suggestions/src/engine/durability.rs
@@ -22,7 +22,7 @@ impl SuggestionEngine {
         };
         self.journal_bytes = self
             .journal_bytes
-            .saturating_add(store.append_journal(&self.pending)?);
+            .saturating_add(store.append_journal(&self.pending, self.sequence)?);
         self.pending.clear();
         if self.journal_bytes >= JOURNAL_COMPACT_BYTES
             && let Err(error) = self.compact()

--- a/crates/funput-suggestions/src/persistence/codec/journal.rs
+++ b/crates/funput-suggestions/src/persistence/codec/journal.rs
@@ -6,17 +6,33 @@
 //!
 //! v1 has no such byte and recorded no boundaries at all, so nothing in a v1
 //! frame can be believed as adjacent.
+//!
+//! From v3 a frame also records the engine sequence its last token was learned
+//! at. `compact` folds the journal into the snapshot and then truncates it, and
+//! those are two writes rather than one: a crash in between leaves a snapshot
+//! that already contains the frame next to a journal that still holds it. The
+//! sequence is what lets the reader tell, so replaying such a journal adds
+//! nothing rather than counting every token in it twice.
 
 use std::io;
 
-use super::binary::{Cursor, checksum, invalid_data, put_u16, put_u32};
+use super::binary::{Cursor, checksum, invalid_data, put_u16, put_u32, put_u64};
 use crate::persistence::schema::{self, JOURNAL_MAGIC, JOURNAL_WRITE_VERSION, Version};
 
 /// One learned token, and whether it followed the token written before it.
 pub(crate) type Entry = (String, bool);
 
-pub(crate) fn encode_frame(entries: &[Entry]) -> Vec<u8> {
+/// A decoded frame: its entries, and the sequence it ends at when the format
+/// recorded one. `None` is a frame from before v3, which has to be replayed
+/// because nothing in it says whether it already has been.
+pub(crate) struct Frame {
+    pub(crate) sequence: Option<u64>,
+    pub(crate) entries: Vec<Entry>,
+}
+
+pub(crate) fn encode_frame(entries: &[Entry], sequence: u64) -> Vec<u8> {
     let mut payload = Vec::new();
+    put_u64(&mut payload, sequence);
     put_u32(&mut payload, entries.len() as u32);
     for (token, chained) in entries {
         put_u16(&mut payload, token.len() as u16);
@@ -32,7 +48,7 @@ pub(crate) fn encode_frame(entries: &[Entry]) -> Vec<u8> {
     frame
 }
 
-pub(crate) fn decode_frame(cursor: &mut Cursor<'_>) -> io::Result<Vec<Entry>> {
+pub(crate) fn decode_frame(cursor: &mut Cursor<'_>) -> io::Result<Frame> {
     if cursor.take(JOURNAL_MAGIC.len())? != JOURNAL_MAGIC {
         return Err(invalid_data());
     }
@@ -56,6 +72,11 @@ pub(crate) fn decode_frame(cursor: &mut Cursor<'_>) -> io::Result<Vec<Entry>> {
         return Err(invalid_data());
     }
     let mut payload = Cursor::new(payload);
+    let sequence = if version >= 3 {
+        Some(payload.u64()?)
+    } else {
+        None
+    };
     let count = payload.u32()? as usize;
     if count > payload.remaining() / 2 {
         return Err(invalid_data());
@@ -73,5 +94,5 @@ pub(crate) fn decode_frame(cursor: &mut Cursor<'_>) -> io::Result<Vec<Entry>> {
     if !payload.is_empty() {
         return Err(invalid_data());
     }
-    Ok(entries)
+    Ok(Frame { sequence, entries })
 }

--- a/crates/funput-suggestions/src/persistence/mod.rs
+++ b/crates/funput-suggestions/src/persistence/mod.rs
@@ -45,7 +45,7 @@ impl Store {
             None => (Vec::new(), 0, false),
         };
         let (journal, journal_bytes) = if snapshot_valid {
-            store.load_journal()?
+            store.load_journal(sequence)?
         } else {
             // The snapshot was damaged, not absent. Repair both files now: leaving
             // the snapshot means every later open discards the journal again, and
@@ -66,11 +66,11 @@ impl Store {
         ))
     }
 
-    pub(crate) fn append_journal(&self, entries: &[Entry]) -> io::Result<u64> {
+    pub(crate) fn append_journal(&self, entries: &[Entry], sequence: u64) -> io::Result<u64> {
         if entries.is_empty() {
             return Ok(0);
         }
-        let frame = journal::encode_frame(entries);
+        let frame = journal::encode_frame(entries, sequence);
         let path = self.journal_path();
         // A brand new journal is a directory change, so the entry needs syncing
         // too — once, on the append that creates it, not on every later one.

--- a/crates/funput-suggestions/src/persistence/recovery.rs
+++ b/crates/funput-suggestions/src/persistence/recovery.rs
@@ -34,7 +34,16 @@ impl Store {
         snapshot::decode(&bytes)
     }
 
-    pub(super) fn load_journal(&self) -> io::Result<(Vec<super::JournalEntry>, u64)> {
+    /// Frames the snapshot already contains are skipped rather than replayed.
+    ///
+    /// `compact` writes the snapshot and truncates the journal as two separate
+    /// writes; a crash between them leaves a journal that has already been folded
+    /// in. Comparing the sequence each frame ends at against the snapshot's makes
+    /// replaying such a journal a no-op instead of counting every token twice.
+    pub(super) fn load_journal(
+        &self,
+        snapshot_sequence: u64,
+    ) -> io::Result<(Vec<super::JournalEntry>, u64)> {
         let path = self.journal_path();
         let bytes = match fs::metadata(&path) {
             // Far past the 64 KiB that triggers a compact, so this is not
@@ -54,7 +63,13 @@ impl Store {
         let mut entries = Vec::new();
         while !cursor.is_empty() {
             match journal::decode_frame(&mut cursor) {
-                Ok(frame) => entries.extend(frame),
+                // A frame from before v3 records no sequence, so nothing in it
+                // says whether it has been folded in; replay it, as every build
+                // before this one did.
+                Ok(frame) if frame.sequence.is_none_or(|at| at > snapshot_sequence) => {
+                    entries.extend(frame.entries);
+                }
+                Ok(_) => {}
                 Err(error) if error.kind() == io::ErrorKind::Unsupported => return Err(error),
                 Err(_) => break,
             }

--- a/crates/funput-suggestions/src/persistence/schema.rs
+++ b/crates/funput-suggestions/src/persistence/schema.rs
@@ -16,8 +16,10 @@ pub(super) const MAX_JOURNAL_BYTES: u64 = 1024 * 1024;
 pub(super) const SNAPSHOT_WRITE_VERSION: u16 = 2;
 pub(super) const SNAPSHOT_MIN_READ_VERSION: u16 = 1;
 
-/// v1 is a flat token list; v2 may carry context breaks between the tokens.
-pub(super) const JOURNAL_WRITE_VERSION: u16 = 2;
+/// v1 is a flat token list; v2 marks which tokens followed which; v3 records the
+/// sequence a frame ends at, which is what lets replay know it has already been
+/// folded into the snapshot.
+pub(super) const JOURNAL_WRITE_VERSION: u16 = 3;
 pub(super) const JOURNAL_MIN_READ_VERSION: u16 = 1;
 
 /// The oldest schema a build can still read. Raising one is how a format is

--- a/crates/funput-suggestions/src/tests/persistence/replay.rs
+++ b/crates/funput-suggestions/src/tests/persistence/replay.rs
@@ -88,6 +88,68 @@ fn a_version_one_journal_replays_its_words_and_no_pairs() {
     );
 }
 
+/// How often the engine has seen `word`, which is what a double replay inflates.
+fn uses(engine: &SuggestionEngine, word: &str) -> u32 {
+    engine
+        .words
+        .iter()
+        .find(|record| record.text == word)
+        .map(|record| record.uses)
+        .unwrap_or_default()
+}
+
+#[test]
+fn a_journal_that_outlived_its_compact_is_not_replayed_twice() {
+    let directory = tempdir().unwrap();
+    let journal = directory.path().join("personal-lexicon.journal");
+    {
+        let mut engine = opened(directory.path());
+        for _ in 0..3 {
+            engine.learn_after(None, "chào");
+        }
+        engine.flush().unwrap();
+        // Exactly what `compact` is about to fold into the snapshot.
+        let folded = fs::read(&journal).unwrap();
+        assert!(!folded.is_empty());
+        engine.compact().unwrap();
+        assert!(fs::read(&journal).unwrap().is_empty());
+
+        // The crash: the renamed snapshot reached the disk and the truncation
+        // did not, so the journal still holds what the snapshot already has.
+        fs::write(&journal, &folded).unwrap();
+    }
+
+    let reopened = opened(directory.path());
+    assert_eq!(
+        uses(&reopened, "chào"),
+        3,
+        "the snapshot already contained these tokens; replaying them again would \
+         inflate the ranking that decides what is offered and what is evicted"
+    );
+}
+
+#[test]
+fn a_journal_written_after_its_compact_still_replays() {
+    let directory = tempdir().unwrap();
+    {
+        let mut engine = opened(directory.path());
+        for _ in 0..3 {
+            engine.learn_after(None, "chào");
+        }
+        engine.compact().unwrap();
+        // Learned after the snapshot, so it is only in the journal.
+        engine.learn_after(None, "chào");
+        engine.flush().unwrap();
+    }
+
+    let reopened = opened(directory.path());
+    assert_eq!(
+        uses(&reopened, "chào"),
+        4,
+        "skipping is for folded frames only"
+    );
+}
+
 /// A valid v1 journal frame: a flat token list with no context breaks.
 fn version_one_frame(tokens: &[&str]) -> Vec<u8> {
     let mut payload = Vec::new();


### PR DESCRIPTION
Independent of #290 and #291; the three touch different files and can merge in any order.

## The window

`compact` folds the journal into the snapshot and then truncates it, and those are **two writes rather than one**:

```
1. write the new snapshot to .tmp, fsync it
2. rename .tmp → snapshot        ← the snapshot now contains everything
3. File::create(journal)         ← the journal is emptied
4. fsync the directory           ← only here do 2 and 3 become durable
```

A crash before step 4 can leave either write durable without the other. If the rename lands and the truncation does not, the next open replays a journal the snapshot already contains, and every token in it is counted a second time.

The window is the truncation's own fsync — a few milliseconds of a fourteen-millisecond compact — and `compact` runs about once per 5,000 words typed. Small, but iOS kills keyboard extensions freely, and this is a keyboard.

## What it costs when it happens

Nothing crashes and nothing is lost. `uses` decides the trie's top three and the order words are evicted in, so an inflated word crowds out one that deserved the slot and pushes another out of the lexicon early.

Prediction fares better than the rest — both sides of the dominance ratio inflate together — but not exactly, because only the pairs that were in the journal move.

## The fix

A frame now records the engine sequence its last token was learned at. The snapshot header has carried that number since v1, so replay can simply skip any frame the snapshot's sequence already covers. Eight bytes a frame, no new state anywhere, and replaying a folded journal becomes a no-op.

## Review

**Frames from before v3 are still replayed.** They record no sequence and so cannot say whether they have been folded in; a file already in the field keeps the semantics it was written with rather than being dropped on upgrade. `JOURNAL_MIN_READ_VERSION` stays at 1.

Two tests: one writes the exact crash state — capture the journal, compact, write it back — and fails without the comparison; the other checks a frame written *after* a compact still replays, so the skip does not overreach.

**Not fixed here:** the other half of the same window. If the truncation reaches disk and the rename does not, the tokens are lost rather than doubled, and no sequence number recovers them — that needs a barrier between the two writes, which costs another fsync per compact.