### PR TITLE
fix(android): end a word at a digit, as iOS already does

### DIFF
--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/AuthoredTokenTracker.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/AuthoredTokenTracker.kt
@@ -106,8 +106,21 @@ internal class AuthoredTokenTracker {
 
     private fun scalarCount(text: String): Int = text.codePointCount(0, text.length)
 
+    /**
+     * Letters and their marks, and nothing else — a digit ends a word here as it
+     * does on iOS.
+     *
+     * The two trackers have to agree, or the same typing teaches two different
+     * lexicons. Letters is the rule that agrees with what is being learned:
+     * Vietnamese syllables contain no digits, so a run of them is never a word,
+     * and treating it as one spends a slot out of five thousand on a date or a
+     * price — and writes a phone number into the store on disk.
+     *
+     * It only comes up with the number row turned on. Otherwise digits are typed
+     * from the symbols panel, where nothing is learned at all.
+     */
     private fun isTokenScalar(codePoint: Int) =
-        Character.isLetterOrDigit(codePoint) || isCombiningMark(codePoint)
+        Character.isLetter(codePoint) || isCombiningMark(codePoint)
 
     private fun isCombiningMark(codePoint: Int): Boolean = when (Character.getType(codePoint)) {
         Character.NON_SPACING_MARK.toInt(),

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AuthoredTokenContextTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AuthoredTokenContextTest.kt
@@ -1,0 +1,100 @@
+package app.funput.funput.ime.editing
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * What the tracker records as the word a prefix is being typed after: which
+ * separators keep it, which end it, and what counts as a word in the first place.
+ *
+ * These read alongside the iOS `PersonalSuggestionTokenTests` on purpose — the two
+ * trackers describe the same keyboard, so a rule that differs between them is a
+ * bug in one of them.
+ */
+class AuthoredTokenContextTest {
+    @Test
+    fun `a space keeps the finished word as context and a full stop clears it`() {
+        val tracker = AuthoredTokenTracker()
+        tracker.update("", "xin", completedOnSpace = true)
+        assertEquals("xin", tracker.consume().context)
+
+        tracker.update("", "xin", completedOnSpace = false)
+        val ended = tracker.consume()
+        assertEquals("the word is still learned", "xin", ended.completedToken)
+        assertNull("but nothing follows it", ended.context)
+    }
+
+    @Test
+    fun `direct input decides the context from its own separator`() {
+        val tracker = AuthoredTokenTracker()
+        tracker.input("xin ")
+        assertEquals("xin", tracker.consume().context)
+
+        tracker.input("xin.")
+        assertNull(tracker.consume().context)
+    }
+
+    @Test
+    fun `the context survives while the next word is typed`() {
+        val tracker = AuthoredTokenTracker()
+        tracker.input("xin ")
+        tracker.consume()
+        tracker.input("ch")
+        val update = tracker.consume()
+        assertEquals("ch", update.prefix)
+        assertEquals("xin", update.context)
+    }
+
+    @Test
+    fun `accepting a candidate makes it the context`() {
+        val tracker = AuthoredTokenTracker()
+        tracker.accepted("bạn")
+        assertEquals("bạn", tracker.consume().context)
+    }
+
+    @Test
+    fun `reset and backspacing past the word abandon the context`() {
+        val tracker = AuthoredTokenTracker()
+        tracker.input("xin ")
+        tracker.consume()
+        tracker.backspace()
+        assertNull("the caret crossed back over the boundary", tracker.consume().context)
+
+        tracker.input("xin ")
+        tracker.consume()
+        tracker.reset()
+        assertNull(tracker.consume().context)
+    }
+
+    @Test
+    fun `a digit ends a word rather than joining it`() {
+        val tracker = AuthoredTokenTracker()
+        typed(tracker, "phòng ")
+        assertEquals("phòng", tracker.consume().context)
+
+        // "302" is not a word, and it is not part of one either.
+        typed(tracker, "302")
+
+        val afterDigits = tracker.consume()
+        assertEquals("digits never become a query prefix", "", afterDigits.prefix)
+        assertNull("and never become a learned word", afterDigits.completedToken)
+        assertNull("a digit is a boundary, and only a space chains", afterDigits.context)
+    }
+
+    @Test
+    fun `a digit inside a word cuts it there`() {
+        val tracker = AuthoredTokenTracker()
+
+        typed(tracker, "covid1")
+
+        val update = tracker.consume()
+        assertEquals("the letters are still worth learning", "covid", update.completedToken)
+        assertNull("a digit is a boundary, and only a space chains", update.context)
+    }
+
+    /** One call per key, which is how `ImeKeyActionHandler` drives the tracker. */
+    private fun typed(tracker: AuthoredTokenTracker, text: String) {
+        text.forEach { tracker.input(it.toString()) }
+    }
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AuthoredTokenTrackerTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AuthoredTokenTrackerTest.kt
@@ -65,37 +65,6 @@ class AuthoredTokenTrackerTest {
     }
 
     @Test
-    fun `a digit ends a word rather than joining it`() {
-        val tracker = AuthoredTokenTracker()
-        typed(tracker, "phòng ")
-        assertEquals("phòng", tracker.consume().context)
-
-        // "302" is not a word, and it is not part of one either.
-        typed(tracker, "302")
-
-        val afterDigits = tracker.consume()
-        assertEquals("digits never become a query prefix", "", afterDigits.prefix)
-        assertNull("and never become a learned word", afterDigits.completedToken)
-        assertNull("a digit is a boundary, and only a space chains", afterDigits.context)
-    }
-
-    @Test
-    fun `a digit inside a word cuts it there`() {
-        val tracker = AuthoredTokenTracker()
-
-        typed(tracker, "covid1")
-
-        val update = tracker.consume()
-        assertEquals("the letters are still worth learning", "covid", update.completedToken)
-        assertNull("a digit is a boundary, and only a space chains", update.context)
-    }
-
-    /** One call per key, which is how `ImeKeyActionHandler` drives the tracker. */
-    private fun typed(tracker: AuthoredTokenTracker, text: String) {
-        text.forEach { tracker.input(it.toString()) }
-    }
-
-    @Test
     fun `oversized direct token stays suppressed through its boundary`() {
         val tracker = AuthoredTokenTracker()
 
@@ -106,57 +75,4 @@ class AuthoredTokenTrackerTest {
         assertEquals(AuthoredSuggestionUpdate.Empty, tracker.consume())
     }
 
-    @Test
-    fun `a space keeps the finished word as context and a full stop clears it`() {
-        val tracker = AuthoredTokenTracker()
-        tracker.update("", "xin", completedOnSpace = true)
-        assertEquals("xin", tracker.consume().context)
-
-        tracker.update("", "xin", completedOnSpace = false)
-        val ended = tracker.consume()
-        assertEquals("the word is still learned", "xin", ended.completedToken)
-        assertNull("but nothing follows it", ended.context)
-    }
-
-    @Test
-    fun `direct input decides the context from its own separator`() {
-        val tracker = AuthoredTokenTracker()
-        tracker.input("xin ")
-        assertEquals("xin", tracker.consume().context)
-
-        tracker.input("xin.")
-        assertNull(tracker.consume().context)
-    }
-
-    @Test
-    fun `the context survives while the next word is typed`() {
-        val tracker = AuthoredTokenTracker()
-        tracker.input("xin ")
-        tracker.consume()
-        tracker.input("ch")
-        val update = tracker.consume()
-        assertEquals("ch", update.prefix)
-        assertEquals("xin", update.context)
-    }
-
-    @Test
-    fun `accepting a candidate makes it the context`() {
-        val tracker = AuthoredTokenTracker()
-        tracker.accepted("bạn")
-        assertEquals("bạn", tracker.consume().context)
-    }
-
-    @Test
-    fun `reset and backspacing past the word abandon the context`() {
-        val tracker = AuthoredTokenTracker()
-        tracker.input("xin ")
-        tracker.consume()
-        tracker.backspace()
-        assertNull("the caret crossed back over the boundary", tracker.consume().context)
-
-        tracker.input("xin ")
-        tracker.consume()
-        tracker.reset()
-        assertNull(tracker.consume().context)
-    }
 }

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AuthoredTokenTrackerTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/AuthoredTokenTrackerTest.kt
@@ -53,15 +53,46 @@ class AuthoredTokenTrackerTest {
     }
 
     @Test
-    fun `direct input tracks letters digits boundaries and backspace`() {
+    fun `direct input tracks letters boundaries and backspace`() {
         val tracker = AuthoredTokenTracker()
 
-        tracker.input("ab12")
+        tracker.input("abcd")
         tracker.backspace()
-        assertEquals("ab1", tracker.consume().prefix)
+        assertEquals("abc", tracker.consume().prefix)
         tracker.input(" ")
 
-        assertEquals(AuthoredSuggestionUpdate("", "ab1", context = "ab1"), tracker.consume())
+        assertEquals(AuthoredSuggestionUpdate("", "abc", context = "abc"), tracker.consume())
+    }
+
+    @Test
+    fun `a digit ends a word rather than joining it`() {
+        val tracker = AuthoredTokenTracker()
+        typed(tracker, "phòng ")
+        assertEquals("phòng", tracker.consume().context)
+
+        // "302" is not a word, and it is not part of one either.
+        typed(tracker, "302")
+
+        val afterDigits = tracker.consume()
+        assertEquals("digits never become a query prefix", "", afterDigits.prefix)
+        assertNull("and never become a learned word", afterDigits.completedToken)
+        assertNull("a digit is a boundary, and only a space chains", afterDigits.context)
+    }
+
+    @Test
+    fun `a digit inside a word cuts it there`() {
+        val tracker = AuthoredTokenTracker()
+
+        typed(tracker, "covid1")
+
+        val update = tracker.consume()
+        assertEquals("the letters are still worth learning", "covid", update.completedToken)
+        assertNull("a digit is a boundary, and only a space chains", update.context)
+    }
+
+    /** One call per key, which is how `ImeKeyActionHandler` drives the tracker. */
+    private fun typed(tracker: AuthoredTokenTracker, text: String) {
+        text.forEach { tracker.input(it.toString()) }
     }
 
     @Test


### PR DESCRIPTION
Independent of #290, #291 and #292.

The two trackers disagreed about what a word is. iOS asks `isLetter`; Android asked `isLetterOrDigit`, so a digit joined the token instead of ending it. **The same typing taught two different lexicons.**

| Typed | iOS learned | Android learned |
|---|---|---|
| `phòng 302 rộng` | `phòng`, `rộng` | `phòng`, **`302`**, `rộng` — plus the pairs `phòng → 302` and `302 → rộng` |
| `0912345678` in a chat | nothing | **the phone number**, written to the snapshot on disk |
| `covid19` | `covid` | `covid19` |

## Why letters is the right rule

The engine learns Vietnamese syllables and those contain no digits, so a run of them is never a word. Treating it as one spends a slot out of five thousand on a date, a price or a room number — strings that will almost never be typed identically again — and puts a phone number in a file.

What it costs: `covid19` is learned as `covid` rather than whole. In Vietnamese that shape is rare, the letters are still worth having, and it is a small price against not keeping phone numbers.

## Scope

This only arises **with the number row turned on**. Without it, digits come from the symbols panel, where neither platform learns anything at all (`eligible()` requires the letters panel on Android, `layoutMode == .letters` on iOS).

Existing Android lexicons keep whatever digit strings they already hold until those are evicted normally. Sweeping them on load is a separate question and not answered here.

## Review

Two tests, and they fail if the rule is put back. They drive the tracker **one key at a time**, which is how `ImeKeyActionHandler` drives it — my first version passed a whole string to `input()` and asserted the wrong thing as a result.

`AuthoredTokenTrackerTest` went over the Kotlin budget once the digit cases joined the context cases, so the context tests move to `AuthoredTokenContextTest`, which says out loud that it reads alongside the iOS `PersonalSuggestionTokenTests` — the divergence fixed here is exactly what happens when the two stop describing the same keyboard.

Nothing caught that overrun either: no workflow runs `check-kotlin-loc.sh`. #291 now does.