### PR TITLE
fix(suggestions): make the snapshot durable before emptying the journal

### DIFF
--- a/crates/funput-suggestions/src/persistence/mod.rs
+++ b/crates/funput-suggestions/src/persistence/mod.rs
@@ -91,11 +91,24 @@ impl Store {
         file.write_all(&bytes)?;
         file.sync_all()?;
         std::fs::rename(&temporary, self.snapshot_path())?;
+
+        // The barrier, and the reason it sits here rather than at the end.
+        //
+        // Emptying the journal is only safe once the snapshot that replaces it is
+        // durable. Nothing orders a rename against the truncation that follows it,
+        // so with one sync at the end a crash could leave the journal empty while
+        // the *old* snapshot is still the one on disk — and everything learned
+        // since the last compact would be gone. Syncing here makes that ordering
+        // impossible rather than unlikely.
+        //
+        // The truncation needs no directory sync of its own. `sync_all` below
+        // makes the emptied file durable, and if the journal was being created
+        // rather than truncated then losing its directory entry leaves no journal
+        // at all, which reads exactly like the empty one it would have been.
+        fs::sync_dir(&self.root)?;
+
         let journal = File::create(self.journal_path())?;
         journal.sync_all()?;
-        // Both the rename and the fresh journal are directory changes: without
-        // this the snapshot we just fsynced can still be the one lost.
-        fs::sync_dir(&self.root)?;
         Ok(bytes.len() as u64)
     }
 


### PR DESCRIPTION
The other half of the crash window #292 only half closed. Base is #292; it retargets to `feature/context-suggestion` once that merges.

## The remaining case

`compact` renames the new snapshot into place and then truncates the journal, and **nothing orders those two against each other**. With one directory sync at the end, either can reach disk without the other:

| Rename durable | Truncation durable | Outcome |
|---|---|---|
| ✓ | ✗ | the journal is replayed on top of a snapshot that already holds it — **fixed by #292** |
| ✗ | ✓ | the journal is empty and the **old** snapshot is still on disk — everything since the last compact is gone |

Sequence numbers cannot help with the second: there is nothing left to skip or replay. It needs the two writes ordered.

## The fix costs nothing

The sync that was already there, moved from after both writes to between them. The rename is durable before the truncation can happen, so the order cannot invert.

The truncation needs no directory sync of its own — which is why this is a move rather than an addition. `sync_all` makes the emptied file durable, and in the one case that does change the directory (a journal being *created* rather than truncated) losing that entry leaves no journal at all, which reads exactly like the empty one it would have been.

Measured back to back on the same machine: `compact_5000` 13.73 ms → 13.86 ms, `flush_256` 7.04 ms → 6.91 ms. Noise.

## Review

**No test.** Partial durability is not something the unit tests can stage, and a test that staged the *outcome* would assert only what the code plainly does. The argument here is the ordering itself, and it is written down beside the code rather than in a test that could not fail for the right reason.

With this and #292, both halves of that window are closed: one write is ordered against the other, and a journal that survives its compact anyway is replayed as a no-op.