### PR TITLE
fix(ios): commit the key a press landed on, not the one it lifted over

### DIFF
--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Touch/KeyboardTouchConfiguration.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Interaction/Touch/KeyboardTouchConfiguration.swift
@@ -19,7 +19,8 @@ extension KeyboardTouchCoordinator {
     static let arbiterConfiguration = PressArbiterConfiguration(rolloverWindow: 0.040)
 
     /// Every eligible role recovers from both kinds of drift. A fast two-thumb tap that slid
-    /// past the slop, or lifted off the tracked area, still meant the key it landed on.
+    /// past the slop, or lifted off the tracked area, still meant the key it landed on — and
+    /// `ContactResolver` is what makes that true of the key it commits.
     ///
     /// This includes Space, which the architecture document's Phase 2.5 note originally wanted
     /// cancelled: the swipe tracker already claims the contact at 32pt, so cancelling at the

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardTouchCore/Resolution/ContactResolver.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardTouchCore/Resolution/ContactResolver.swift
@@ -1,10 +1,25 @@
 import CoreGraphics
 import Foundation
 
+/// Turns a stream of contact samples into one decision per press.
+///
+/// A press commits the key the finger **landed** on. The finger moves between landing and
+/// lifting — it rolls as it comes off, and the roll carries the direction of whatever key is
+/// typed next — so the lift point is the noisiest moment of the whole gesture and the one the
+/// user has least control over. Resolving to it made a press near a key edge commit its
+/// neighbour without any signal that something had gone wrong: not far enough to trip the tap
+/// slop, and never visible to the person typing, who had pressed the right key.
+///
+/// The lift point still decides one thing: whether the finger lifted inside the tracked area
+/// at all. Where inside it lifted is not the resolver's business.
 public struct ContactResolver<Payload: Sendable>: Sendable {
     struct State: Sendable {
         let beganAt: TimeInterval
         let startLocation: CGPoint
+        /// What the finger was on when it landed. This is what a press commits.
+        let landedPayload: Payload
+        /// What it is on now, which decides only whether the lift happened inside the
+        /// tracked area — never which key the press meant.
         var currentPayload: Payload?
         var exceededTapSlop = false
     }
@@ -57,6 +72,7 @@ public struct ContactResolver<Payload: Sendable>: Sendable {
         states[sample.id] = State(
             beganAt: sample.timestamp,
             startLocation: sample.location,
+            landedPayload: payload,
             currentPayload: payload
         )
         return .began(sample.id)
@@ -84,12 +100,12 @@ public struct ContactResolver<Payload: Sendable>: Sendable {
         if duration > configuration.maximumTapDuration {
             return .cancelled(sample.id, .exceededDuration)
         }
-        guard let payload = state.currentPayload else {
+        guard state.currentPayload != nil else {
             return .cancelled(sample.id, .endedOutside)
         }
         return .resolved(
             sample.id,
-            payload,
+            state.landedPayload,
             ContactResolutionMetadata(exceededTapSlop: state.exceededTapSlop)
         )
     }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardTouchUIKit/Pipeline/KeyboardTouchPipeline+Contacts.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardTouchUIKit/Pipeline/KeyboardTouchPipeline+Contacts.swift
@@ -69,34 +69,23 @@ extension KeyboardTouchPipeline {
         return hit
     }
 
-    /// A fast two-thumb tap often lifts off the tracked geometry. Recovering it as the key the
-    /// finger landed on keeps the press instead of dropping it, mirroring how the resolver's
-    /// tap-slop recovery already treats a finger that merely drifted.
+    /// A fast two-thumb tap often lifts off the tracked geometry. Handing the resolver the key
+    /// the finger landed on keeps the press alive instead of dropping it as a lift outside.
+    ///
+    /// The resolver commits the landed key either way, so this decides only whether a press
+    /// that ended off the keys survives at all — never which key it produces.
     private func recoveredHit(
         for sample: ContactSample,
         current: KeyboardTouchHit?
     ) -> KeyboardTouchHit? {
-        let locked = lockedHit(for: sample.id, current: current)
         // `isTracking` keeps a contact already claimed by a gesture out of the counters, since
         // the resolver would ignore the hit anyway.
-        guard locked == nil,
+        guard current == nil,
               sample.phase == .ended,
               resolver.isTracking(sample.id),
-              let initial = initialHits[sample.id] else { return locked }
+              let initial = initialHits[sample.id] else { return current }
         let recovered = policy.recoversReleaseOutside(initial.key.role)
         counters.recordReleaseOutside(recovered: recovered)
         return recovered ? initial : nil
-    }
-
-    /// Keys with a horizontal swipe own the contact once it starts, so a finger sliding across
-    /// the spacebar never commits a neighbouring key.
-    private func lockedHit(
-        for id: ContactID,
-        current: KeyboardTouchHit?
-    ) -> KeyboardTouchHit? {
-        guard let initial = initialHits[id],
-              initial.key.horizontalSwipeAction != nil,
-              current != nil else { return current }
-        return initial
     }
 }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardTouchUIKit/Policy/KeyboardTouchRecoveryPolicy.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardTouchUIKit/Policy/KeyboardTouchRecoveryPolicy.swift
@@ -3,15 +3,16 @@ import KeyboardLayout
 /// Groups the per-role rules the pipeline applies while a contact is still recoverable.
 ///
 /// A fast two-thumb tap rarely lifts exactly where it landed, so the pipeline needs to know
-/// which roles may still commit after the finger drifted. Keeping the rules in one value type
-/// means a new rule is an added property here instead of another `KeyboardTouchPipeline.init`
-/// parameter.
+/// which roles survive a finger that drifted. What they commit is never in question — a press
+/// commits the key it landed on — so these rules decide only whether it commits at all.
+/// Keeping them in one value type means a new rule is an added property here instead of
+/// another `KeyboardTouchPipeline.init` parameter.
 public struct KeyboardTouchRecoveryPolicy: Equatable, Sendable {
     /// Roles the pipeline tracks at all; a touch-down on anything else is ignored.
     public let eligibleRoles: Set<KeyRole>
-    /// Roles that still commit after the finger travelled past the resolver's tap slop.
+    /// Roles that still commit their landed key after the finger travelled past the tap slop.
     public let tapSlopRecoveringRoles: Set<KeyRole>
-    /// Roles that still commit when the finger lifts outside the tracked geometry.
+    /// Roles that still commit their landed key when the finger lifts outside the geometry.
     public let releaseOutsideRecoveringRoles: Set<KeyRole>
 
     public init(
@@ -24,7 +25,8 @@ public struct KeyboardTouchRecoveryPolicy: Equatable, Sendable {
         self.releaseOutsideRecoveringRoles = releaseOutsideRecoveringRoles
     }
 
-    /// Every eligible role recovers from both drift cases, which is what slide-to-correct needs.
+    /// Every eligible role survives both drift cases, so a press is never lost to a finger
+    /// that moved on its way up.
     public static func recoveringAll(_ roles: Set<KeyRole>) -> Self {
         Self(
             eligibleRoles: roles,

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Touch/KeyboardTouchCoordinatorTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Touch/KeyboardTouchCoordinatorTests.swift
@@ -74,5 +74,32 @@ struct KeyboardTouchCoordinatorTests {
         #expect(fixture.coordinator.metrics.capturedContacts == 2)
         #expect(fixture.coordinator.metrics.timestampTieContacts == 0)
     }
+
+    /// The whole path, not just the resolver: `a` spans x 0...45 and `b` starts at 55, so a
+    /// press at 40 lands on `a` while a lift at 52 is over `b` — 12pt of travel, inside the
+    /// 16pt tap slop, which is the drift a finger makes on its way up without meaning
+    /// anything by it.
+    @Test("A press that drifts to the next key still types the key it landed on")
+    func driftCommitsTheKeyThatWasPressed() {
+        let fixture = KeyboardTouchFixture.adjacentKeys()
+        fixture.begin(x: 40, at: 0)
+        fixture.coordinator.consume(fixture.sample(.moved, id: 1, x: 52, at: 0.04))
+        fixture.end(x: 52, at: 0.05)
+
+        #expect(fixture.output.map(\.key.id) == ["a"])
+        #expect(fixture.coordinator.metrics.recoveredTapSlop == 0)
+    }
+
+    /// A slide the whole way across is no different. Landing on a key is the aim; everything
+    /// after it is the finger leaving.
+    @Test("A press that slides across the neighbour still types the key it landed on")
+    func longSlideCommitsTheKeyThatWasPressed() {
+        let fixture = KeyboardTouchFixture.adjacentKeys()
+        fixture.begin(x: 22, at: 0)
+        fixture.end(x: 77, at: 0.05)
+
+        #expect(fixture.output.map(\.key.id) == ["a"])
+        #expect(fixture.coordinator.metrics.recoveredTapSlop == 1)
+    }
 }
 #endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardTouchCoreTests/Resolution/ContactResolverTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardTouchCoreTests/Resolution/ContactResolverTests.swift
@@ -18,7 +18,10 @@ struct ContactResolverTests {
         #expect(resolver.activeContactCount == 0)
     }
 
-    @Test func slideToCorrectUsesTerminalHit() {
+    /// A finger that lands on one key and lifts over its neighbour typed the key it landed
+    /// on. This used to resolve to the neighbour, which is how a press dead centre on `h`
+    /// came out as `j` — the roll happens on the way up, after the aiming is over.
+    @Test func slidingKeepsTheKeyThatWasPressed() {
         var resolver = ContactResolver<String>(
             configuration: .init(tapSlop: 100, maximumTapDuration: 1)
         )
@@ -33,7 +36,24 @@ struct ContactResolverTests {
                 hit: "B"
             ) == .resolved(
                 .init(rawValue: 1),
-                "B",
+                "A",
+                .init(exceededTapSlop: false)
+            )
+        )
+    }
+
+    /// The drift that produced the reported mistypes never tripped anything: well inside the
+    /// tap slop, no metadata to show for it, and invisible to the person typing.
+    @Test func driftUnderTheTapSlopKeepsTheKeyThatWasPressed() {
+        var resolver = ContactResolver<String>()
+        _ = resolver.consume(contactSample(1, .began, at: 0), hit: "A")
+        #expect(
+            resolver.consume(
+                contactSample(1, .ended, at: 0.05, point: CGPoint(x: 12, y: 0)),
+                hit: "B"
+            ) == .resolved(
+                .init(rawValue: 1),
+                "A",
                 .init(exceededTapSlop: false)
             )
         )
@@ -48,7 +68,7 @@ struct ContactResolverTests {
                 hit: "B"
             ) == .resolved(
                 .init(rawValue: 1),
-                "B",
+                "A",
                 .init(exceededTapSlop: true)
             )
         )

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardTouchUIKitTests/Pipeline/KeyboardTouchPipelineTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardTouchUIKitTests/Pipeline/KeyboardTouchPipelineTests.swift
@@ -26,7 +26,9 @@ struct KeyboardTouchPipelineTests {
         #expect(fixture.emissions.keys == ["b"])
     }
 
-    @Test("Text drift resolves while duration and outside hand back")
+    /// Drift keeps the press alive and keeps the key it landed on: the slop is exceeded, so
+    /// the recovery policy is what saves it, and the resolver is what decides it is still `a`.
+    @Test("Text drift resolves to the key it landed on while duration hands back")
     func resolutionPolicy() {
         let fixture = makeTouchPipeline()
         fixture.consume(touchSample(1, .began, 0, .init(x: 10, y: 20)))
@@ -38,7 +40,7 @@ struct KeyboardTouchPipelineTests {
         } else {
             Issue.record("Expected recovered fast tap")
         }
-        #expect(fixture.emissions.keys == ["b"])
+        #expect(fixture.emissions.keys == ["a"])
 
         fixture.consume(touchSample(2, .began, 1, .init(x: 10, y: 20)))
         let long = fixture.consume(


### PR DESCRIPTION
`ContactResolver` overwrote its payload with every sample, so a press resolved to whatever key the finger was over at release. Landing dead centre on `h` and lifting 12pt to the right typed `j` — inside the 16pt tap slop, so nothing was flagged, and invisible to someone typing without looking, who had pressed the right key. A user reported exactly that: `h` after `k` coming out as `j`, and `s` and `f` both coming out as `d`. Both of those roll inward, which is what a finger does on its way up when the next key is on the other side.

The finger is not still between landing and lifting. It rolls off, and the roll carries the direction of whatever comes next, so the lift point is the noisiest moment of the gesture and the one the user controls least. Landing is the aim; everything after it is the finger leaving.

The resolver now freezes the landed payload and keeps tracking the current one only to answer whether the lift happened inside the tracked area at all. Commit timing is untouched — a press still resolves at release, which is what the arbiter needs to order overlapping contacts.

This reverses a deliberate choice: `slideToCorrectUsesTerminalHit` pinned the old behaviour. Slide-to-correct only helps someone who can see they pressed the wrong key, and it cannot tell a deliberate slide from a 12pt roll, so it charged every touch-typist for a feature only a hunt-and-peck typist can use. The comment on `recoveryPolicy` already claimed a drifted tap "still meant the key it landed on"; that is now true of the key it commits.

`lockedHit` pinned the spacebar to its landed key so a slide across it could not commit a neighbour. Every key has that now, so it was a nil-preserving no-op — deleted rather than left looking load-bearing.