### PR TITLE
feat: let gõ tắt smart-case matching be switched off

### DIFF
--- a/crates/funput-config/src/settings/model.rs
+++ b/crates/funput-config/src/settings/model.rs
@@ -66,6 +66,12 @@ pub struct Settings {
     /// would otherwise find it silently dead after an update.
     #[serde(default = "shortcuts_enabled_default")]
     pub shortcuts_enabled: bool,
+    /// Whether a gõ tắt trigger matches regardless of how it was capitalized, with
+    /// the expansion re-cased to match. Defaults to **on**, including for a file
+    /// written before this field existed — that is how gõ tắt has always behaved,
+    /// and an update must not silently change what a table expands to.
+    #[serde(default = "shortcut_smart_case_default")]
+    pub shortcut_smart_case: bool,
     /// Whether focusing a keyboard layout Vietnamese cannot be typed on — a CJK
     /// IME, or a non-Latin script — suspends Vietnamese for as long as it is
     /// active. Defaults to **on**, including for a file written before this field
@@ -77,6 +83,10 @@ pub struct Settings {
 }
 
 fn shortcuts_enabled_default() -> bool {
+    true
+}
+
+fn shortcut_smart_case_default() -> bool {
     true
 }
 
@@ -118,6 +128,7 @@ impl Default for Settings {
             excluded_apps: Vec::new(),
             shortcuts: Vec::new(),
             shortcuts_enabled: true,
+            shortcut_smart_case: true,
             auto_english_on_foreign_layout: true,
         }
     }

--- a/crates/funput-config/src/settings/model/tests.rs
+++ b/crates/funput-config/src/settings/model/tests.rs
@@ -138,6 +138,36 @@ fn the_shortcut_switch_round_trips_when_turned_off() {
     assert!(!back.shortcuts_enabled);
 }
 
+/// Same rule, same reason: a file written before the smart-case switch existed comes
+/// from someone whose triggers already match every capitalization. Defaulting off
+/// would change what their table expands to, out of nowhere, on an update.
+#[test]
+fn a_file_without_the_smart_case_switch_still_matches_any_capitalization() {
+    let legacy = r#"{
+      "method": "vni",
+      "enabled": true,
+      "smartRestore": true,
+      "eagerRestore": true,
+      "toggleHotkey": "ctrl_backtick",
+      "launchAtLogin": false,
+      "hasCompletedOnboarding": false
+    }"#;
+    let s: Settings = serde_json::from_str(legacy).expect("legacy settings.json must decode");
+
+    assert!(s.shortcut_smart_case);
+}
+
+#[test]
+fn the_smart_case_switch_round_trips_when_turned_off() {
+    let s = Settings {
+        shortcut_smart_case: false,
+        ..Settings::default()
+    };
+    let text = serde_json::to_string(&s).expect("serialize");
+    let back: Settings = serde_json::from_str(&text).expect("deserialize");
+    assert!(!back.shortcut_smart_case);
+}
+
 /// Same rule as the gõ tắt switch: absent means on. Someone who has been fighting
 /// Funput inside a Japanese IME upgrades into the fix without going looking for it.
 #[test]

--- a/crates/funput-config/src/transfer/apply.rs
+++ b/crates/funput-config/src/transfer/apply.rs
@@ -1,4 +1,5 @@
-//! Building a document from settings, and merging one back in.
+//! Merging an interchange document back into the settings (export lives in
+//! [`super::export`]).
 //!
 //! Import is **non-destructive**: it overwrites the fields the file carries and
 //! leaves everything else alone. Nothing is ever deleted — an absent field means
@@ -8,50 +9,9 @@
 use crate::settings::{FlipHotkey, Hotkey, Method, Settings, Shortcut, ToneStyle};
 
 use super::document::{
-    CURRENT_VERSION, ConfigDocument, Platform, PortableShortcut, Preferences, SCHEMA_ID, Source,
-    WindowsBlock,
+    CURRENT_VERSION, ConfigDocument, PortableShortcut, Preferences, WindowsBlock,
 };
 use super::error::ImportSummary;
-use super::time::iso8601_now;
-
-/// Snapshot `s` into an interchange document. `source` names the app that wrote
-/// it — the caller supplies it because only the shell knows the app's version.
-pub fn to_document(s: &Settings, source: Source) -> ConfigDocument {
-    ConfigDocument {
-        schema: SCHEMA_ID.to_string(),
-        version: CURRENT_VERSION,
-        exported_at: Some(iso8601_now()),
-        source: Some(source),
-        preferences: Some(Preferences {
-            input_method: Some(s.method.id().to_string()),
-            tone_style: Some(s.tone_style.id().to_string()),
-            smart_english_restore: Some(s.smart_restore),
-            eager_restore: Some(s.eager_restore),
-            spell_check: Some(s.spell_check),
-            auto_capitalize: Some(s.auto_capitalize),
-            shortcuts_enabled: Some(s.shortcuts_enabled),
-        }),
-        shortcuts: Some(
-            s.shortcuts
-                .iter()
-                .map(|sc| PortableShortcut {
-                    trigger: sc.trigger.clone(),
-                    expansion: sc.expansion.clone(),
-                })
-                .collect(),
-        ),
-        platform: Some(Platform {
-            windows: Some(WindowsBlock {
-                toggle_hotkey: Some(s.toggle_hotkey.id().to_string()),
-                toggle_combo: s.toggle_combo.clone(),
-                flip_hotkey: Some(s.flip_hotkey.id().to_string()),
-                flip_combo: s.flip_combo.clone(),
-                app_language_memory: Some(s.app_language_memory.clone()),
-                excluded_apps: None,
-            }),
-        }),
-    }
-}
 
 /// Merge `doc` into `s`, reporting what changed.
 pub fn apply(s: &mut Settings, doc: &ConfigDocument) -> ImportSummary {

--- a/crates/funput-config/src/transfer/apply.rs
+++ b/crates/funput-config/src/transfer/apply.rs
@@ -56,6 +56,9 @@ fn apply_preferences(s: &mut Settings, prefs: &Preferences) {
     if let Some(v) = prefs.shortcuts_enabled {
         s.shortcuts_enabled = v;
     }
+    if let Some(v) = prefs.shortcut_smart_case {
+        s.shortcut_smart_case = v;
+    }
 }
 
 /// Merge by `trigger`: a matching trigger takes the incoming expansion, a new one

--- a/crates/funput-config/src/transfer/document.rs
+++ b/crates/funput-config/src/transfer/document.rs
@@ -68,6 +68,10 @@ pub struct Preferences {
     /// because it is a typing preference, not a per-OS one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shortcuts_enabled: Option<bool>,
+    /// Whether a gõ tắt trigger matches regardless of capitalization, with the
+    /// expansion re-cased to match. Portable for the same reason.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shortcut_smart_case: Option<bool>,
 }
 
 /// Comparable and printable because it is also what [`crate::unikey`] parses a

--- a/crates/funput-config/src/transfer/export.rs
+++ b/crates/funput-config/src/transfer/export.rs
@@ -1,0 +1,51 @@
+//! Building an interchange document from the current settings.
+//!
+//! The import half lives in [`super::apply`] — the two directions are separate
+//! because only one of them has a rule to enforce (import never deletes).
+
+use crate::settings::Settings;
+
+use super::document::{
+    CURRENT_VERSION, ConfigDocument, Platform, PortableShortcut, Preferences, SCHEMA_ID, Source,
+    WindowsBlock,
+};
+use super::time::iso8601_now;
+
+/// Snapshot `s` into an interchange document. `source` names the app that wrote
+/// it — the caller supplies it because only the shell knows the app's version.
+pub fn to_document(s: &Settings, source: Source) -> ConfigDocument {
+    ConfigDocument {
+        schema: SCHEMA_ID.to_string(),
+        version: CURRENT_VERSION,
+        exported_at: Some(iso8601_now()),
+        source: Some(source),
+        preferences: Some(Preferences {
+            input_method: Some(s.method.id().to_string()),
+            tone_style: Some(s.tone_style.id().to_string()),
+            smart_english_restore: Some(s.smart_restore),
+            eager_restore: Some(s.eager_restore),
+            spell_check: Some(s.spell_check),
+            auto_capitalize: Some(s.auto_capitalize),
+            shortcuts_enabled: Some(s.shortcuts_enabled),
+        }),
+        shortcuts: Some(
+            s.shortcuts
+                .iter()
+                .map(|sc| PortableShortcut {
+                    trigger: sc.trigger.clone(),
+                    expansion: sc.expansion.clone(),
+                })
+                .collect(),
+        ),
+        platform: Some(Platform {
+            windows: Some(WindowsBlock {
+                toggle_hotkey: Some(s.toggle_hotkey.id().to_string()),
+                toggle_combo: s.toggle_combo.clone(),
+                flip_hotkey: Some(s.flip_hotkey.id().to_string()),
+                flip_combo: s.flip_combo.clone(),
+                app_language_memory: Some(s.app_language_memory.clone()),
+                excluded_apps: None,
+            }),
+        }),
+    }
+}

--- a/crates/funput-config/src/transfer/export.rs
+++ b/crates/funput-config/src/transfer/export.rs
@@ -27,6 +27,7 @@ pub fn to_document(s: &Settings, source: Source) -> ConfigDocument {
             spell_check: Some(s.spell_check),
             auto_capitalize: Some(s.auto_capitalize),
             shortcuts_enabled: Some(s.shortcuts_enabled),
+            shortcut_smart_case: Some(s.shortcut_smart_case),
         }),
         shortcuts: Some(
             s.shortcuts

--- a/crates/funput-config/src/transfer/mod.rs
+++ b/crates/funput-config/src/transfer/mod.rs
@@ -8,6 +8,7 @@
 mod apply;
 mod document;
 mod error;
+mod export;
 mod time;
 
 use std::fs;
@@ -15,12 +16,13 @@ use std::path::Path;
 
 use crate::settings::Settings;
 
-pub use apply::{apply, to_document};
+pub use apply::apply;
 pub use document::{
     CURRENT_VERSION, ConfigDocument, Platform, PortableShortcut, Preferences, SCHEMA_ID, Source,
     WindowsBlock,
 };
 pub use error::{ConfigError, ImportSummary};
+pub use export::to_document;
 pub use time::iso8601_now;
 
 /// Write the current settings as a pretty-printed interchange file.

--- a/crates/funput-config/src/transfer/tests.rs
+++ b/crates/funput-config/src/transfer/tests.rs
@@ -46,6 +46,7 @@ fn round_trip_preserves_state() {
             expansion: "Việt Nam".into(),
         }],
         app_language_memory: BTreeMap::from([("code.exe".to_string(), false)]),
+        shortcut_smart_case: false,
         ..Settings::default()
     };
 
@@ -63,6 +64,8 @@ fn round_trip_preserves_state() {
     assert_eq!(b.shortcuts.len(), 1);
     assert_eq!(b.shortcuts[0].expansion, "Việt Nam");
     assert_eq!(b.app_language_memory.get("code.exe"), Some(&false));
+    assert!(!b.shortcut_smart_case, "both gõ tắt switches are portable");
+    assert!(b.shortcuts_enabled);
 }
 
 /// Import never rewrites a choice this machine's user made — the same

--- a/crates/funput-desktop/src/shell/config.rs
+++ b/crates/funput-desktop/src/shell/config.rs
@@ -30,6 +30,7 @@ impl ShellState {
             spell_check: self.settings.spell_check,
             auto_capitalize: self.settings.auto_capitalize,
             shortcuts_enabled: self.settings.shortcuts_enabled,
+            shortcut_smart_case: self.settings.shortcut_smart_case,
         });
     }
 

--- a/crates/funput-desktop/src/shell/options.rs
+++ b/crates/funput-desktop/src/shell/options.rs
@@ -43,6 +43,13 @@ impl ShellState {
         self.update_config(|s| s.shortcuts_enabled = on);
     }
 
+    /// Turn smart-case trigger matching on or off. Off, only the trigger as stored
+    /// expands and the expansion is emitted verbatim — which is what a table
+    /// holding both `vn` and `VN` needs.
+    pub fn set_shortcut_smart_case(&mut self, on: bool) {
+        self.update_config(|s| s.shortcut_smart_case = on);
+    }
+
     /// Turn the foreign-layout auto-switch on or off. Re-judges the current layout
     /// straight away, so turning it off lifts a suspension already in place instead
     /// of leaving Vietnamese off until the user next changes keyboards.

--- a/crates/funput-desktop/src/shell/tests.rs
+++ b/crates/funput-desktop/src/shell/tests.rs
@@ -3,7 +3,7 @@
 //! tray binds to, and when composition is thrown away.
 
 use funput_config::{Method, Settings};
-use funput_engine::KeySource;
+use funput_engine::{Action, KeySource};
 
 use super::*;
 
@@ -263,6 +263,72 @@ fn pruning_drops_drafts_and_keeps_complete_rows() {
     assert_eq!(state.shortcuts()[0].trigger, "vn");
 }
 
+/// Type `keys` through the shell and rebuild what the app would be showing, the
+/// same way the hook applies an [`ImeResult`]: pass the key through, or eat the
+/// backspaces and inject.
+fn app_text(state: &mut ShellState, keys: &str) -> String {
+    let mut app = String::new();
+    for key in keys.chars() {
+        let result = state.process_key(key, KeySource::Standard);
+        match result.action {
+            Action::None => app.push(key),
+            Action::Send => {
+                for _ in 0..result.backspace {
+                    app.pop();
+                }
+                app.push_str(&result.output);
+            }
+            Action::Restore => unreachable!("Restore not implemented yet"),
+        }
+    }
+    app
+}
+
+/// A shell holding one finished row, `tp` → `TP. HCM`.
+fn shell_with_tp() -> ShellState {
+    let mut state = shell();
+    state.add_shortcut();
+    state.set_shortcut_trigger(0, "tp".into());
+    state.set_shortcut_expansion(0, "TP. HCM".into());
+    state
+}
+
+#[test]
+fn smart_case_is_on_by_default() {
+    let mut state = shell_with_tp();
+    assert_eq!(app_text(&mut state, "Tp "), "Tp. Hcm ");
+}
+
+/// The Settings switch has to reach the engine, not just the settings file — on
+/// this shell that is `update_config` re-syncing the whole `EngineConfig`, with no
+/// separate setter to forget.
+#[test]
+fn turning_smart_case_off_reaches_the_engine() {
+    let mut state = shell_with_tp();
+    state.set_shortcut_smart_case(false);
+
+    assert_eq!(
+        app_text(&mut state, "Tp "),
+        "Tp ",
+        "a differently cased trigger must be left alone"
+    );
+    assert_eq!(
+        app_text(&mut state, "tp "),
+        "TP. HCM ",
+        "the row itself is untouched — the exact trigger still expands"
+    );
+}
+
+/// Flipping it back must take effect without re-pushing the table.
+#[test]
+fn turning_smart_case_back_on_restores_matching() {
+    let mut state = shell_with_tp();
+    state.set_shortcut_smart_case(false);
+    state.set_shortcut_smart_case(true);
+
+    assert_eq!(app_text(&mut state, "Tp "), "Tp. Hcm ");
+}
+
 // --- keyboard layout -------------------------------------------------------
 
 /// Real Windows layout handles. `JAPANESE_IME` is what Microsoft IME reports;
@@ -388,10 +454,12 @@ fn settings_survive_a_restart() {
     let mut state = ShellState::new(Some(path.clone()));
     state.set_method(InputMethod::Vni);
     state.set_spell_check(true);
+    state.set_shortcut_smart_case(false);
 
     let reopened = ShellState::new(Some(path));
     assert_eq!(reopened.settings().method, Method::Vni);
     assert!(reopened.settings().spell_check);
+    assert!(!reopened.settings().shortcut_smart_case);
     let _ = std::fs::remove_dir_all(dir);
 }
 

--- a/crates/funput-engine/src/compose/boundary/shortcut.rs
+++ b/crates/funput-engine/src/compose/boundary/shortcut.rs
@@ -1,11 +1,13 @@
-//! Shortcut expansion at a word boundary, including case propagation.
+//! Shortcut expansion at a word boundary, including case propagation when
+//! `shortcut_smart_case` is on.
 
 use crate::ImeResult;
 use crate::model::Session;
 
 /// The letter-casing pattern of typed keys, used to mirror the expansion's case
 /// (`vn` → lowercase, `Vn` → Title Case, `VN` → UPPERCASE) — the same "propagate
-/// case" convention used by common text expanders like Espanso.
+/// case" convention used by common text expanders like Espanso. Only consulted while
+/// `shortcut_smart_case` is on.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum ShortcutCase {
     Lower,
@@ -16,7 +18,8 @@ enum ShortcutCase {
 /// Classify the case pattern of `keys` from its cased characters (letters), ignoring
 /// digits and punctuation. Returns `None` when the keys don't fit a clean pattern
 /// (e.g. `vNa`), so the caller falls back to an exact, unmodified lookup — this keeps
-/// deliberately mixed-case triggers (like `iOS`) working exactly as defined.
+/// deliberately mixed-case triggers (like `iOS`) working exactly as defined. That same
+/// `None` path is what the smart-case switch reuses when it is off.
 fn classify_case(keys: &str) -> Option<ShortcutCase> {
     let mut letters = keys.chars().filter(|c| c.is_alphabetic());
     let first = letters.next()?;
@@ -67,7 +70,14 @@ pub(super) fn expansion(session: &Session, boundary_key: char) -> Option<ImeResu
     if !session.config.shortcuts_enabled || session.keys.is_empty() {
         return None;
     }
-    let case = classify_case(&session.keys);
+    // Off, every trigger takes the exact-match path below: `tp` expands, `Tp`/`TP` do
+    // not, and the expansion is never re-cased. Reusing the mixed-case fallback rather
+    // than adding a second lookup keeps one description of "no case propagation".
+    let case = if session.config.shortcut_smart_case {
+        classify_case(&session.keys)
+    } else {
+        None
+    };
     let lookup_key = match case {
         Some(_) => session.keys.to_lowercase(),
         None => session.keys.clone(),

--- a/crates/funput-engine/src/compose/boundary/tests/mod.rs
+++ b/crates/funput-engine/src/compose/boundary/tests/mod.rs
@@ -15,6 +15,7 @@ fn session(method: InputMethod, buffer: &str, keys: &str) -> Session {
             spell_check: false,
             auto_capitalize: false,
             shortcuts_enabled: true,
+            shortcut_smart_case: true,
         },
         buffer: buffer.into(),
         keys: keys.into(),

--- a/crates/funput-engine/src/model/config.rs
+++ b/crates/funput-engine/src/model/config.rs
@@ -1,9 +1,9 @@
 //! User-configurable engine options, grouped out of the per-word [`super::Session`]
 //! state so adding a feature toggle touches one struct instead of the god-object.
 //!
-//! These six options map 1:1 to the public `Engine::set_*` methods (and, over the
-//! FFI, to `funput_set_*`). Keeping them together is also the seam for a future
-//! `Engine::configure(EngineConfig)` API — this type would simply become `pub`.
+//! Every option here is reachable from the public `Engine::configure` /
+//! `Engine::update_config` API (and, over the FFI, from `funput_configure` plus the
+//! `funput_set_*` functions for the ones that do not ride the by-value C struct).
 
 use funput_core::{InputMethod, ToneStyle};
 
@@ -32,6 +32,13 @@ pub struct EngineConfig {
     /// — to type a word that collides with a trigger — costs nothing and gives the
     /// rows back untouched.
     pub shortcuts_enabled: bool,
+    /// Smart-case matching for gõ tắt ("Tự nhận diện hoa/thường"). On by default.
+    ///
+    /// On, a trigger typed lowercase, Title Case, or UPPERCASE all resolve to the same
+    /// entry and the expansion is re-cased to match (`tp`/`Tp`/`TP` → `TP. HCM`/
+    /// `Tp. Hcm`/`TP. HCM`). Off, only the exact trigger matches and the expansion
+    /// comes out verbatim — for users whose expansions have a casing of their own.
+    pub shortcut_smart_case: bool,
 }
 
 impl Default for EngineConfig {
@@ -44,6 +51,7 @@ impl Default for EngineConfig {
             spell_check: false,
             auto_capitalize: false,
             shortcuts_enabled: true,
+            shortcut_smart_case: true,
         }
     }
 }

--- a/crates/funput-engine/tests/engine_api.rs
+++ b/crates/funput-engine/tests/engine_api.rs
@@ -470,6 +470,7 @@ fn configure_applies_all_options() {
         spell_check: true,
         auto_capitalize: true,
         shortcuts_enabled: false,
+        shortcut_smart_case: false,
     });
     assert_eq!(engine.method(), InputMethod::Vni);
     assert_eq!(engine.tone_style(), ToneStyle::Modern);
@@ -477,7 +478,7 @@ fn configure_applies_all_options() {
     assert_eq!(config.method, InputMethod::Vni);
     assert!(config.spell_check && config.auto_capitalize);
     assert!(!config.smart_restore && !config.eager_restore);
-    assert!(!config.shortcuts_enabled);
+    assert!(!config.shortcuts_enabled && !config.shortcut_smart_case);
 }
 
 /// `configure` keeps the `set_*` side effect: switching method mid-word clears the

--- a/crates/funput-engine/tests/words/shortcut.rs
+++ b/crates/funput-engine/tests/words/shortcut.rs
@@ -10,14 +10,9 @@
 use funput_core::InputMethod;
 use funput_engine::{Action, Engine};
 
-/// Drive `keys` through an engine seeded with `shortcuts`, reconstructing the
-/// resulting app text from the inject stream (None → append, Send → delete + append).
-fn app_text_with_shortcuts(method: InputMethod, shortcuts: &[(&str, &str)], keys: &str) -> String {
-    let mut engine = Engine::new();
-    engine.set_method(method);
-    for (trigger, expansion) in shortcuts {
-        engine.add_shortcut(*trigger, *expansion);
-    }
+/// Type `keys` into `engine`, reconstructing the resulting app text from the inject
+/// stream (None → append, Send → delete + append).
+fn drive(engine: &mut Engine, keys: &str) -> String {
     let mut app = String::new();
     for key in keys.chars() {
         let r = engine.process_char(key);
@@ -33,6 +28,22 @@ fn app_text_with_shortcuts(method: InputMethod, shortcuts: &[(&str, &str)], keys
         }
     }
     app
+}
+
+/// An engine seeded with `shortcuts`, everything else at its default.
+fn engine_with(shortcuts: &[(&str, &str)]) -> Engine {
+    let mut engine = Engine::new();
+    for (trigger, expansion) in shortcuts {
+        engine.add_shortcut(*trigger, *expansion);
+    }
+    engine
+}
+
+/// Drive `keys` through an engine seeded with `shortcuts`.
+fn app_text_with_shortcuts(method: InputMethod, shortcuts: &[(&str, &str)], keys: &str) -> String {
+    let mut engine = engine_with(shortcuts);
+    engine.set_method(method);
+    drive(&mut engine, keys)
 }
 
 #[test]
@@ -153,26 +164,9 @@ fn re_adding_trigger_overwrites() {
 /// Drive `keys` with gõ tắt switched off, otherwise identical to
 /// [`app_text_with_shortcuts`].
 fn app_text_with_shortcuts_off(shortcuts: &[(&str, &str)], keys: &str) -> String {
-    let mut engine = Engine::new();
+    let mut engine = engine_with(shortcuts);
     engine.update_config(|config| config.shortcuts_enabled = false);
-    for (trigger, expansion) in shortcuts {
-        engine.add_shortcut(*trigger, *expansion);
-    }
-    let mut app = String::new();
-    for key in keys.chars() {
-        let r = engine.process_char(key);
-        match r.action {
-            Action::None => app.push(key),
-            Action::Send => {
-                for _ in 0..r.backspace {
-                    app.pop();
-                }
-                app.push_str(&r.output);
-            }
-            Action::Restore => unreachable!("Restore not implemented yet"),
-        }
-    }
-    app
+    drive(&mut engine, keys)
 }
 
 #[test]
@@ -203,4 +197,58 @@ fn the_table_survives_the_switch_so_flipping_back_costs_nothing() {
         engine.process_char(key);
     }
     assert_eq!(engine.shortcuts().len(), 1);
+}
+
+// ---- the smart-case switch ("Tự nhận diện hoa/thường") ----
+
+/// Drive `keys` with smart case off but gõ tắt itself still on.
+fn app_text_without_smart_case(shortcuts: &[(&str, &str)], keys: &str) -> String {
+    let mut engine = engine_with(shortcuts);
+    engine.update_config(|config| config.shortcut_smart_case = false);
+    drive(&mut engine, keys)
+}
+
+#[test]
+fn smart_case_off_expands_only_the_exact_trigger() {
+    let text = app_text_without_smart_case(&[("tp", "TP. HCM")], "tp ");
+    assert_eq!(text, "TP. HCM ");
+}
+
+#[test]
+fn smart_case_off_leaves_a_differently_cased_trigger_alone() {
+    // Neither the Title Case nor the UPPERCASE spelling is the stored trigger, so
+    // nothing expands and the keys stay exactly as typed.
+    assert_eq!(
+        app_text_without_smart_case(&[("tp", "TP. HCM")], "Tp "),
+        "Tp "
+    );
+    assert_eq!(
+        app_text_without_smart_case(&[("tp", "TP. HCM")], "TP "),
+        "TP "
+    );
+}
+
+#[test]
+fn smart_case_off_keeps_the_expansion_verbatim() {
+    // The whole point of the switch: an expansion with a casing of its own comes out
+    // untouched, where smart case would have re-cased it to `Tp. Hcm`.
+    let text = app_text_without_smart_case(&[("tp", "TP. HCM")], "tp ");
+    assert_eq!(text, "TP. HCM ");
+    let smart = app_text_with_shortcuts(InputMethod::Telex, &[("tp", "TP. HCM")], "Tp ");
+    assert_eq!(smart, "Tp. Hcm ", "smart case still re-cases when it is on");
+}
+
+#[test]
+fn flipping_smart_case_back_on_restores_matching() {
+    let mut engine = engine_with(&[("tp", "TP. HCM")]);
+    engine.update_config(|config| config.shortcut_smart_case = false);
+    assert_eq!(drive(&mut engine, "TP "), "TP ");
+    engine.update_config(|config| config.shortcut_smart_case = true);
+    assert_eq!(drive(&mut engine, "TP "), "TP. HCM ");
+}
+
+#[test]
+fn smart_case_off_still_leaves_ordinary_composition_alone() {
+    let text = app_text_without_smart_case(&[("tp", "TP. HCM")], "chaof ");
+    assert_eq!(text, "chào ");
 }

--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -698,6 +698,20 @@ void funput_add_shortcut(FunputEngine *engine,
 void funput_clear_shortcuts(FunputEngine *engine);
 
 /**
+ * Turn gõ tắt expansion on or off ("Bật gõ tắt"). Off, a trigger is typed out as
+ * itself and nothing expands; the table is left loaded, so the switch is instant in
+ * both directions and hosts need not re-push their rows around it.
+ *
+ * Its own function rather than a [`crate::FunputConfig`] field, for the ABI reason
+ * documented there; [`crate::funput_configure`] leaves this setting alone, so the
+ * two may be called in either order.
+ *
+ * # Safety
+ * `engine` must be a valid handle or null.
+ */
+void funput_set_shortcuts_enabled(FunputEngine *engine, bool on);
+
+/**
  * Turn smart-case matching on or off ("Tự nhận diện hoa/thường"). On (the default),
  * a trigger typed lowercase, Title Case, or UPPERCASE all resolve to the same entry
  * and the expansion is re-cased to match (`tp`/`Tp`/`TP` → `TP. HCM`/`Tp. Hcm`/

--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -697,6 +697,22 @@ void funput_add_shortcut(FunputEngine *engine,
  */
 void funput_clear_shortcuts(FunputEngine *engine);
 
+/**
+ * Turn smart-case matching on or off ("Tự nhận diện hoa/thường"). On (the default),
+ * a trigger typed lowercase, Title Case, or UPPERCASE all resolve to the same entry
+ * and the expansion is re-cased to match (`tp`/`Tp`/`TP` → `TP. HCM`/`Tp. Hcm`/
+ * `TP. HCM`). Off, only the exact trigger expands and the expansion comes out
+ * verbatim.
+ *
+ * Its own function rather than a [`crate::FunputConfig`] field, for the ABI reason
+ * documented there; [`crate::funput_configure`] leaves this setting alone, so the
+ * two may be called in either order.
+ *
+ * # Safety
+ * `engine` must be a valid handle or null.
+ */
+void funput_set_shortcut_smart_case(FunputEngine *engine, bool on);
+
 FunputSuggestionEngine *funput_suggestion_engine_new_in_memory(void);
 
 /**

--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -181,7 +181,9 @@ typedef struct {
 
 /**
  * A whole engine configuration passed by value over the C ABI — the six user
- * options. `enabled` and the gõ tắt shortcut table have their own functions.
+ * options. `enabled` and the gõ tắt options have their own functions: this struct
+ * crosses the ABI by value and the hosts declaring it are built separately from the
+ * header, so growing it would mismatch silently until every consumer is rebuilt.
  */
 typedef struct {
     /**
@@ -643,8 +645,12 @@ void funput_set_method(FunputEngine *engine, uint8_t method);
 /**
  * Apply a whole [`FunputConfig`] at once — the batch equivalent of the individual
  * `funput_set_*` functions, with the same side effects (a method change clears the
- * composition; auto-capitalize off resets its tracking). `funput_set_enabled` and
- * the shortcut table are separate and left untouched.
+ * composition; auto-capitalize off resets its tracking). `funput_set_enabled`, the
+ * shortcut table, and the gõ tắt options are separate and left untouched.
+ *
+ * Edits the live config rather than replacing it, so an option that is not on the
+ * wire keeps whatever its own setter last put there, whichever order the two are
+ * called in.
  *
  * # Safety
  * `engine` must be a valid handle or null.

--- a/crates/funput-ffi/src/engine/config.rs
+++ b/crates/funput-ffi/src/engine/config.rs
@@ -5,7 +5,6 @@
 //! boundary rule "every FFI call goes through the guard" holds uniformly.
 
 use funput_core::{InputMethod, ToneStyle};
-use funput_engine::EngineConfig;
 
 use super::FunputEngine;
 use crate::abi;
@@ -45,7 +44,9 @@ pub unsafe extern "C" fn funput_set_method(engine: *mut FunputEngine, method: u8
 }
 
 /// A whole engine configuration passed by value over the C ABI — the six user
-/// options. `enabled` and the gõ tắt shortcut table have their own functions.
+/// options. `enabled` and the gõ tắt options have their own functions: this struct
+/// crosses the ABI by value and the hosts declaring it are built separately from the
+/// header, so growing it would mismatch silently until every consumer is rebuilt.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct FunputConfig {
@@ -61,28 +62,29 @@ pub struct FunputConfig {
 
 /// Apply a whole [`FunputConfig`] at once — the batch equivalent of the individual
 /// `funput_set_*` functions, with the same side effects (a method change clears the
-/// composition; auto-capitalize off resets its tracking). `funput_set_enabled` and
-/// the shortcut table are separate and left untouched.
+/// composition; auto-capitalize off resets its tracking). `funput_set_enabled`, the
+/// shortcut table, and the gõ tắt options are separate and left untouched.
+///
+/// Edits the live config rather than replacing it, so an option that is not on the
+/// wire keeps whatever its own setter last put there, whichever order the two are
+/// called in.
 ///
 /// # Safety
 /// `engine` must be a valid handle or null.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn funput_configure(engine: *mut FunputEngine, config: FunputConfig) {
-    let cfg = EngineConfig {
-        method: decode_method(config.method),
-        tone_style: decode_tone_style(config.tone_style),
-        smart_restore: config.smart_restore,
-        eager_restore: config.eager_restore,
-        spell_check: config.spell_check,
-        auto_capitalize: config.auto_capitalize,
-        // Not in `FunputConfig`: this struct crosses the C ABI by value, and the
-        // Swift side declaring it is built separately, so growing it here would
-        // mismatch silently until every consumer is rebuilt. The hosts on this ABI
-        // have no gõ tắt switch yet, and `true` is what they behaved as before —
-        // give them a dedicated setter when one of them grows the feature.
-        shortcuts_enabled: true,
-    };
-    unsafe { abi::with_engine_mut(engine, |e| e.configure(cfg)) }
+    unsafe {
+        abi::with_engine_mut(engine, |e| {
+            e.update_config(|cfg| {
+                cfg.method = decode_method(config.method);
+                cfg.tone_style = decode_tone_style(config.tone_style);
+                cfg.smart_restore = config.smart_restore;
+                cfg.eager_restore = config.eager_restore;
+                cfg.spell_check = config.spell_check;
+                cfg.auto_capitalize = config.auto_capitalize;
+            })
+        })
+    }
 }
 
 /// Enable or disable Vietnamese composition.

--- a/crates/funput-ffi/src/engine/mod.rs
+++ b/crates/funput-ffi/src/engine/mod.rs
@@ -26,7 +26,10 @@ pub use config::{
     funput_set_enabled, funput_set_method,
 };
 pub use result::{ACTION_NONE, ACTION_RESTORE, ACTION_SEND, CHARS_CAP, FunputResult};
-pub use shortcuts::{funput_add_shortcut, funput_clear_shortcuts, funput_set_shortcut_smart_case};
+pub use shortcuts::{
+    funput_add_shortcut, funput_clear_shortcuts, funput_set_shortcut_smart_case,
+    funput_set_shortcuts_enabled,
+};
 
 /// Opaque IME engine handle for C callers. Create with [`funput_engine_new`],
 /// release with [`funput_engine_free`]. cbindgen emits this as an opaque struct.

--- a/crates/funput-ffi/src/engine/mod.rs
+++ b/crates/funput-ffi/src/engine/mod.rs
@@ -26,7 +26,7 @@ pub use config::{
     funput_set_enabled, funput_set_method,
 };
 pub use result::{ACTION_NONE, ACTION_RESTORE, ACTION_SEND, CHARS_CAP, FunputResult};
-pub use shortcuts::{funput_add_shortcut, funput_clear_shortcuts};
+pub use shortcuts::{funput_add_shortcut, funput_clear_shortcuts, funput_set_shortcut_smart_case};
 
 /// Opaque IME engine handle for C callers. Create with [`funput_engine_new`],
 /// release with [`funput_engine_free`]. cbindgen emits this as an opaque struct.

--- a/crates/funput-ffi/src/engine/shortcuts.rs
+++ b/crates/funput-ffi/src/engine/shortcuts.rs
@@ -44,3 +44,20 @@ pub unsafe extern "C" fn funput_add_shortcut(
 pub unsafe extern "C" fn funput_clear_shortcuts(engine: *mut FunputEngine) {
     unsafe { abi::with_engine_mut(engine, |e| e.clear_shortcuts()) }
 }
+
+/// Turn smart-case matching on or off ("Tự nhận diện hoa/thường"). On (the default),
+/// a trigger typed lowercase, Title Case, or UPPERCASE all resolve to the same entry
+/// and the expansion is re-cased to match (`tp`/`Tp`/`TP` → `TP. HCM`/`Tp. Hcm`/
+/// `TP. HCM`). Off, only the exact trigger expands and the expansion comes out
+/// verbatim.
+///
+/// Its own function rather than a [`crate::FunputConfig`] field, for the ABI reason
+/// documented there; [`crate::funput_configure`] leaves this setting alone, so the
+/// two may be called in either order.
+///
+/// # Safety
+/// `engine` must be a valid handle or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_set_shortcut_smart_case(engine: *mut FunputEngine, on: bool) {
+    unsafe { abi::with_engine_mut(engine, |e| e.update_config(|c| c.shortcut_smart_case = on)) }
+}

--- a/crates/funput-ffi/src/engine/shortcuts.rs
+++ b/crates/funput-ffi/src/engine/shortcuts.rs
@@ -45,6 +45,21 @@ pub unsafe extern "C" fn funput_clear_shortcuts(engine: *mut FunputEngine) {
     unsafe { abi::with_engine_mut(engine, |e| e.clear_shortcuts()) }
 }
 
+/// Turn gõ tắt expansion on or off ("Bật gõ tắt"). Off, a trigger is typed out as
+/// itself and nothing expands; the table is left loaded, so the switch is instant in
+/// both directions and hosts need not re-push their rows around it.
+///
+/// Its own function rather than a [`crate::FunputConfig`] field, for the ABI reason
+/// documented there; [`crate::funput_configure`] leaves this setting alone, so the
+/// two may be called in either order.
+///
+/// # Safety
+/// `engine` must be a valid handle or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_set_shortcuts_enabled(engine: *mut FunputEngine, on: bool) {
+    unsafe { abi::with_engine_mut(engine, |e| e.update_config(|c| c.shortcuts_enabled = on)) }
+}
+
 /// Turn smart-case matching on or off ("Tự nhận diện hoa/thường"). On (the default),
 /// a trigger typed lowercase, Title Case, or UPPERCASE all resolve to the same entry
 /// and the expansion is re-cased to match (`tp`/`Tp`/`TP` → `TP. HCM`/`Tp. Hcm`/

--- a/crates/funput-ffi/src/lib.rs
+++ b/crates/funput-ffi/src/lib.rs
@@ -65,7 +65,7 @@ pub use engine::{
     funput_add_shortcut, funput_adopt, funput_arm_capitalization, funput_backspace, funput_buffer,
     funput_clear, funput_clear_shortcuts, funput_configure, funput_engine_free, funput_engine_new,
     funput_flip_composing, funput_process_char, funput_process_key, funput_set_enabled,
-    funput_set_method,
+    funput_set_method, funput_set_shortcut_smart_case,
 };
 pub use suggestion::{
     FunputSuggestionCandidate, FunputSuggestionEngine, FunputSuggestionResult,

--- a/crates/funput-ffi/src/lib.rs
+++ b/crates/funput-ffi/src/lib.rs
@@ -65,7 +65,7 @@ pub use engine::{
     funput_add_shortcut, funput_adopt, funput_arm_capitalization, funput_backspace, funput_buffer,
     funput_clear, funput_clear_shortcuts, funput_configure, funput_engine_free, funput_engine_new,
     funput_flip_composing, funput_process_char, funput_process_key, funput_set_enabled,
-    funput_set_method, funput_set_shortcut_smart_case,
+    funput_set_method, funput_set_shortcut_smart_case, funput_set_shortcuts_enabled,
 };
 pub use suggestion::{
     FunputSuggestionCandidate, FunputSuggestionEngine, FunputSuggestionResult,

--- a/crates/funput-ffi/tests/round_trip.rs
+++ b/crates/funput-ffi/tests/round_trip.rs
@@ -4,7 +4,7 @@ use funput_ffi::{
     ACTION_NONE, ACTION_SEND, FunputConfig, FunputResult, SOURCE_NUMPAD, funput_add_shortcut,
     funput_adopt, funput_backspace, funput_buffer, funput_clear, funput_clear_shortcuts,
     funput_configure, funput_engine_free, funput_engine_new, funput_process_char,
-    funput_process_key, funput_set_method,
+    funput_process_key, funput_set_method, funput_set_shortcut_smart_case,
 };
 
 fn output(result: &FunputResult) -> String {
@@ -304,4 +304,78 @@ fn shortcut_null_safe() {
         funput_add_shortcut(engine, std::ptr::null(), 0, std::ptr::null(), 0);
         funput_engine_free(engine);
     }
+}
+
+/// Type `keys` through the C API, applying each result to an app-text model.
+unsafe fn app_text(engine: *mut funput_ffi::FunputEngine, keys: &str) -> String {
+    let mut app = String::new();
+    for ch in keys.chars() {
+        let r = unsafe { funput_process_char(engine, ch as u32) };
+        if r.action == ACTION_NONE {
+            app.push(ch);
+        } else {
+            for _ in 0..r.backspace {
+                app.pop();
+            }
+            app.push_str(&output(&r));
+        }
+    }
+    app
+}
+
+#[test]
+fn smart_case_is_on_by_default_and_the_setter_turns_it_off() {
+    unsafe {
+        let engine = funput_engine_new();
+        funput_set_method(engine, 0); // Telex
+        add_shortcut(engine, "tp", "TP. HCM");
+
+        assert_eq!(
+            app_text(engine, "Tp "),
+            "Tp. Hcm ",
+            "default is smart case on"
+        );
+
+        funput_set_shortcut_smart_case(engine, false);
+        assert_eq!(app_text(engine, "Tp "), "Tp ", "no longer matches");
+        assert_eq!(
+            app_text(engine, "tp "),
+            "TP. HCM ",
+            "exact trigger, verbatim"
+        );
+
+        funput_engine_free(engine);
+    }
+}
+
+/// `funput_configure` carries only the six wire options, so it must edit the config
+/// rather than replace it — a host that configures after calling the setter would
+/// otherwise silently get smart case back.
+#[test]
+fn configure_does_not_clobber_the_smart_case_setting() {
+    unsafe {
+        let engine = funput_engine_new();
+        add_shortcut(engine, "tp", "TP. HCM");
+        funput_set_shortcut_smart_case(engine, false);
+
+        funput_configure(
+            engine,
+            FunputConfig {
+                method: 0, // Telex
+                tone_style: 0,
+                smart_restore: true,
+                eager_restore: true,
+                spell_check: false,
+                auto_capitalize: false,
+            },
+        );
+
+        assert_eq!(app_text(engine, "Tp "), "Tp ", "the setter must survive");
+        funput_engine_free(engine);
+    }
+}
+
+#[test]
+fn smart_case_setter_is_null_safe() {
+    unsafe { funput_set_shortcut_smart_case(std::ptr::null_mut(), false) };
 }

--- a/crates/funput-ffi/tests/round_trip.rs
+++ b/crates/funput-ffi/tests/round_trip.rs
@@ -5,6 +5,7 @@ use funput_ffi::{
     funput_adopt, funput_backspace, funput_buffer, funput_clear, funput_clear_shortcuts,
     funput_configure, funput_engine_free, funput_engine_new, funput_process_char,
     funput_process_key, funput_set_method, funput_set_shortcut_smart_case,
+    funput_set_shortcuts_enabled,
 };
 
 fn output(result: &FunputResult) -> String {
@@ -378,4 +379,58 @@ fn configure_does_not_clobber_the_smart_case_setting() {
 #[test]
 fn smart_case_setter_is_null_safe() {
     unsafe { funput_set_shortcut_smart_case(std::ptr::null_mut(), false) };
+}
+
+#[test]
+fn shortcuts_are_on_by_default_and_the_setter_turns_them_off() {
+    unsafe {
+        let engine = funput_engine_new();
+        funput_set_method(engine, 0); // Telex
+        add_shortcut(engine, "vn", "Việt Nam");
+
+        assert_eq!(app_text(engine, "vn "), "Việt Nam ", "default is on");
+
+        funput_set_shortcuts_enabled(engine, false);
+        assert_eq!(
+            app_text(engine, "vn "),
+            "vn ",
+            "the trigger types out as itself"
+        );
+
+        // The table was never re-pushed, so turning the switch back on must be
+        // enough on its own — that is what lets a host toggle it without resyncing.
+        funput_set_shortcuts_enabled(engine, true);
+        assert_eq!(app_text(engine, "vn "), "Việt Nam ", "rows were kept");
+
+        funput_engine_free(engine);
+    }
+}
+
+/// The two gõ tắt setters write the same config, so each must edit it rather than
+/// replace it — turning smart case off must not switch expansion back on.
+#[test]
+fn the_two_shortcut_setters_do_not_clobber_each_other() {
+    unsafe {
+        let engine = funput_engine_new();
+        funput_set_method(engine, 0); // Telex
+        add_shortcut(engine, "tp", "TP. HCM");
+
+        funput_set_shortcuts_enabled(engine, false);
+        funput_set_shortcut_smart_case(engine, false);
+        assert_eq!(app_text(engine, "tp "), "tp ", "still switched off");
+
+        funput_set_shortcuts_enabled(engine, true);
+        assert_eq!(
+            app_text(engine, "Tp "),
+            "Tp ",
+            "smart case stayed off across the other setter"
+        );
+
+        funput_engine_free(engine);
+    }
+}
+
+#[test]
+fn shortcuts_enabled_setter_is_null_safe() {
+    unsafe { funput_set_shortcuts_enabled(std::ptr::null_mut(), false) };
 }

--- a/crates/funput-jni/src/engine/settings.rs
+++ b/crates/funput-jni/src/engine/settings.rs
@@ -5,7 +5,6 @@
 //! separate: VI/EN is runtime state, flipped per field and by the language key.
 
 use funput_core::{InputMethod, ToneStyle};
-use funput_engine::EngineConfig;
 use jni::EnvUnowned;
 use jni::sys::{jboolean, jint, jlong};
 
@@ -27,20 +26,21 @@ pub extern "system" fn Java_app_funput_funput_ime_nativebridge_FunputNative_nati
     spell_check: jboolean,
     auto_capitalize: jboolean,
 ) {
-    let config = EngineConfig {
-        method: decode_method(method),
-        tone_style: decode_tone_style(tone_style),
-        smart_restore,
-        eager_restore,
-        spell_check,
-        auto_capitalize,
-        // Not a parameter: the JNI symbol name encodes the Java signature, so an
-        // extra argument would stop Kotlin finding this function at all until the
-        // `external fun` is changed to match. Android has no gõ tắt switch yet, and
-        // `true` is how it behaved before there was one.
-        shortcuts_enabled: true,
-    };
-    update(handle, |engine| engine.configure(config));
+    // Edits rather than replaces the config: the JNI symbol name encodes the Java
+    // signature, so the gõ tắt options cannot ride along here without breaking the
+    // `external fun` — and replacing the whole config would reset them behind the
+    // back of whatever set them. Android has no gõ tắt switch yet, so they simply
+    // stay at their defaults.
+    update(handle, |engine| {
+        engine.update_config(|config| {
+            config.method = decode_method(method);
+            config.tone_style = decode_tone_style(tone_style);
+            config.smart_restore = smart_restore;
+            config.eager_restore = eager_restore;
+            config.spell_check = spell_check;
+            config.auto_capitalize = auto_capitalize;
+        });
+    });
 }
 
 pub(crate) fn decode_method(method: jint) -> InputMethod {

--- a/crates/funput-term/src/config/mod.rs
+++ b/crates/funput-term/src/config/mod.rs
@@ -45,8 +45,11 @@ pub struct TermConfig {
     pub auto_capitalize: bool,
     pub shortcuts: Vec<(String, String)>,
     /// Whether those shortcuts expand. Read from the same `settings.json` the GUI
-    /// writes, so turning gõ tắt off there turns it off here too.
+    /// writes, so turning gõ tắt off there turns it off here too — as does
+    /// `shortcut_smart_case` below.
     pub shortcuts_enabled: bool,
+    /// Whether a trigger matches regardless of capitalization, expansion re-cased.
+    pub shortcut_smart_case: bool,
     /// The byte that toggles VI/EN.
     pub toggle: u8,
     /// The byte that cycles Telex↔VNI at runtime, or `None` to disable.
@@ -79,6 +82,7 @@ impl From<FileSettings> for TermConfig {
                 .map(|s| (s.trigger, s.expansion))
                 .collect(),
             shortcuts_enabled: f.shortcuts_enabled,
+            shortcut_smart_case: f.shortcut_smart_case,
             toggle: DEFAULT_TOGGLE,
             cycle_method: DEFAULT_CYCLE_METHOD,
             vi_cursor_color: DEFAULT_VI_CURSOR_COLOR.to_string(),
@@ -107,6 +111,7 @@ impl TermConfig {
             spell_check: self.spell_check,
             auto_capitalize: self.auto_capitalize,
             shortcuts_enabled: self.shortcuts_enabled,
+            shortcut_smart_case: self.shortcut_smart_case,
         });
         engine.clear_shortcuts();
         for (trigger, expansion) in &self.shortcuts {

--- a/crates/funput-term/src/config/schema.rs
+++ b/crates/funput-term/src/config/schema.rs
@@ -75,6 +75,8 @@ pub(super) struct FileSettings {
     pub(super) shortcuts: Vec<Shortcut>,
     #[serde(default = "default_true")]
     pub(super) shortcuts_enabled: bool,
+    #[serde(default = "default_true")]
+    pub(super) shortcut_smart_case: bool,
 }
 
 fn default_true() -> bool {

--- a/platforms/CONFIG_FORMAT.md
+++ b/platforms/CONFIG_FORMAT.md
@@ -68,8 +68,8 @@ one machine imports on another. macOS is the first implementation
 | `source` | — | `platform` + `appVersion` that produced the file. Metadata only. |
 | `preferences.inputMethod` | ✅ | `telex`, `telex_advanced`, or `vni`. Exposed on macOS, Windows, Linux, iOS, and Android; unsupported consumers keep their current selection. |
 | `preferences.*` | ✅ | Other typing options; each is optional and applied only if present. |
-| `shortcuts[]` | ✅ | `{ trigger, expansion }`. Local UUIDs are dropped; recreated on import. Whether they expand is `preferences.shortcutsEnabled`, which defaults to `true` when absent — an older file carries a working table and must not arrive switched off. |
-| `preferences.shortcutSmartCase` | ✅ | Whether a trigger matches regardless of how it was capitalized, with the expansion re-cased to match (`tp`/`Tp`/`TP` → `TP. HCM`/`Tp. Hcm`/`TP. HCM`). Off, only the exact trigger expands and the expansion is verbatim. Defaults to `true` when absent, for the same reason as `shortcutsEnabled`. |
+| `shortcuts[]` | ✅ | `{ trigger, expansion }`. Local UUIDs are dropped; recreated on import. Whether they expand is `preferences.shortcutsEnabled`, which defaults to `true` when absent — an older file carries a working table and must not arrive switched off. Exposed as a switch on Windows and Linux; macOS reads it but shows no control. |
+| `preferences.shortcutSmartCase` | ✅ | Whether a trigger matches regardless of how it was capitalized, with the expansion re-cased to match (`tp`/`Tp`/`TP` → `TP. HCM`/`Tp. Hcm`/`TP. HCM`). Off, only the exact trigger expands and the expansion is verbatim. Defaults to `true` when absent, for the same reason as `shortcutsEnabled`. Exposed as a switch on macOS, Windows and Linux. |
 | `platform.macos.toggleShortcut` | ❌ | `KeyCombo` (`keyCode` is AppKit-specific). Applied only on macOS, only if present. |
 | `platform.macos.flipShortcut` | ❌ | `KeyCombo` or `null`. Applied only on macOS, only if present. |
 | `platform.macos.appLanguageMemory` | ❌ | `{ bundleId: rememberedIsVietnamese }`. macOS-only per-app VI/EN memory; merged by key, existing entries win. |

--- a/platforms/CONFIG_FORMAT.md
+++ b/platforms/CONFIG_FORMAT.md
@@ -68,7 +68,7 @@ one machine imports on another. macOS is the first implementation
 | `source` | — | `platform` + `appVersion` that produced the file. Metadata only. |
 | `preferences.inputMethod` | ✅ | `telex`, `telex_advanced`, or `vni`. Exposed on macOS, Windows, Linux, iOS, and Android; unsupported consumers keep their current selection. |
 | `preferences.*` | ✅ | Other typing options; each is optional and applied only if present. |
-| `shortcuts[]` | ✅ | `{ trigger, expansion }`. Local UUIDs are dropped; recreated on import. Whether they expand is `preferences.shortcutsEnabled`, which defaults to `true` when absent — an older file carries a working table and must not arrive switched off. Exposed as a switch on Windows and Linux; macOS reads it but shows no control. |
+| `shortcuts[]` | ✅ | `{ trigger, expansion }`. Local UUIDs are dropped; recreated on import. Whether they expand is `preferences.shortcutsEnabled`, which defaults to `true` when absent — an older file carries a working table and must not arrive switched off. Exposed as a switch on macOS, Windows and Linux. |
 | `preferences.shortcutSmartCase` | ✅ | Whether a trigger matches regardless of how it was capitalized, with the expansion re-cased to match (`tp`/`Tp`/`TP` → `TP. HCM`/`Tp. Hcm`/`TP. HCM`). Off, only the exact trigger expands and the expansion is verbatim. Defaults to `true` when absent, for the same reason as `shortcutsEnabled`. Exposed as a switch on macOS, Windows and Linux. |
 | `platform.macos.toggleShortcut` | ❌ | `KeyCombo` (`keyCode` is AppKit-specific). Applied only on macOS, only if present. |
 | `platform.macos.flipShortcut` | ❌ | `KeyCombo` or `null`. Applied only on macOS, only if present. |

--- a/platforms/CONFIG_FORMAT.md
+++ b/platforms/CONFIG_FORMAT.md
@@ -40,7 +40,8 @@ one machine imports on another. macOS is the first implementation
     "eagerRestore": true,
     "spellCheck": false,
     "autoCapitalize": false,
-    "shortcutsEnabled": true
+    "shortcutsEnabled": true,
+    "shortcutSmartCase": true
   },
 
   "shortcuts": [
@@ -68,6 +69,7 @@ one machine imports on another. macOS is the first implementation
 | `preferences.inputMethod` | ✅ | `telex`, `telex_advanced`, or `vni`. Exposed on macOS, Windows, Linux, iOS, and Android; unsupported consumers keep their current selection. |
 | `preferences.*` | ✅ | Other typing options; each is optional and applied only if present. |
 | `shortcuts[]` | ✅ | `{ trigger, expansion }`. Local UUIDs are dropped; recreated on import. Whether they expand is `preferences.shortcutsEnabled`, which defaults to `true` when absent — an older file carries a working table and must not arrive switched off. |
+| `preferences.shortcutSmartCase` | ✅ | Whether a trigger matches regardless of how it was capitalized, with the expansion re-cased to match (`tp`/`Tp`/`TP` → `TP. HCM`/`Tp. Hcm`/`TP. HCM`). Off, only the exact trigger expands and the expansion is verbatim. Defaults to `true` when absent, for the same reason as `shortcutsEnabled`. |
 | `platform.macos.toggleShortcut` | ❌ | `KeyCombo` (`keyCode` is AppKit-specific). Applied only on macOS, only if present. |
 | `platform.macos.flipShortcut` | ❌ | `KeyCombo` or `null`. Applied only on macOS, only if present. |
 | `platform.macos.appLanguageMemory` | ❌ | `{ bundleId: rememberedIsVietnamese }`. macOS-only per-app VI/EN memory; merged by key, existing entries win. |

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -21,7 +21,7 @@ common/                 Framework-free C++ shared by both shells
       nonpreedit.h            Commit-as-you-type: the mode, and judging a client
       nonpreedit.cpp          What the composer does with that judgement
   settings/               ~/.config/Funput/settings.json
-    settings.h              The model every shell reads
+    settings.h              The model every shell reads, gõ tắt switches included
     lookup.cpp              Where the file lives; app exclusion
     io.cpp                  Parse and save (JSON)
     watch.h/.cpp            inotify watcher for live reload
@@ -38,6 +38,7 @@ ibus/src/               IBus engine -> ibus-engine-funput
 settings-gtk/           GTK4 + libadwaita Settings app (its own cargo crate,
                         and its own package — see Build)
   src/settings_window/    one submodule per preferences page
+    shortcuts/              the gõ tắt switches, the rows, the empty state
   src/convert/            the Chuyển mã window — see below
 packaging/              two .desktop files, apt/dnf repo metadata
 ```

--- a/platforms/linux/common/compose/composer/state.cpp
+++ b/platforms/linux/common/compose/composer/state.cpp
@@ -46,6 +46,10 @@ void Composer::applySettings() {
     // than left for the other mode to finish in a way it cannot.
     setNonPreedit(settings_.nonPreedit);
     handle_.setEnabled(effectiveEnabled_);
+    // The two gõ tắt options ride separately from `configure` (see handle.h), and
+    // ahead of the table itself only for reading order — neither one clears it.
+    handle_.setShortcutsEnabled(settings_.shortcutsEnabled);
+    handle_.setShortcutSmartCase(settings_.shortcutSmartCase);
     // The engine holds a runtime mirror of the gõ tắt table: replace it wholesale
     // rather than diffing, since the table is small and the source of truth is the
     // settings file.

--- a/platforms/linux/common/ffi/handle.h
+++ b/platforms/linux/common/ffi/handle.h
@@ -29,7 +29,8 @@ enum class KeySource : uint32_t {
 
 // The engine-affecting options of `settings`, as the C ABI's by-value config. The
 // runtime VI/EN state is deliberately absent: that is the live toggle
-// (`setEnabled`), not a persisted engine option.
+// (`setEnabled`), not a persisted engine option. So are the two gõ tắt options,
+// which the C ABI keeps as their own functions — see `setShortcutsEnabled` below.
 inline FunputConfig engineConfig(const Settings &s) {
     return FunputConfig{
         static_cast<uint8_t>(s.method),
@@ -70,6 +71,15 @@ public:
     // Text-expansion shortcuts (gõ tắt). Replace the whole table by clearing then
     // re-adding each entry (the engine is a runtime mirror of settings.json).
     void clearShortcuts() { funput_clear_shortcuts(engine_); }
+
+    // The two gõ tắt options. Their own FFI calls rather than `FunputConfig` fields:
+    // that struct crosses the ABI by value and this addon is built separately from
+    // the committed header, so growing it would mismatch silently. `configure` leaves
+    // both alone, so the calls may come in any order.
+    //
+    // Neither touches the table, so toggling either is instant and needs no re-push.
+    void setShortcutsEnabled(bool on) { funput_set_shortcuts_enabled(engine_, on); }
+    void setShortcutSmartCase(bool on) { funput_set_shortcut_smart_case(engine_, on); }
     void addShortcut(const std::string &trigger, const std::string &expansion) {
         const std::vector<uint32_t> t = decodeUtf8(trigger);
         const std::vector<uint32_t> e = decodeUtf8(expansion);

--- a/platforms/linux/common/settings/io.cpp
+++ b/platforms/linux/common/settings/io.cpp
@@ -91,6 +91,8 @@ bool Settings::reload() {
     spellCheck = data.value("spellCheck", spellCheck);
     autoCapitalize = data.value("autoCapitalize", autoCapitalize);
     nonPreedit = data.value("nonPreedit", nonPreedit);
+    shortcutsEnabled = data.value("shortcutsEnabled", shortcutsEnabled);
+    shortcutSmartCase = data.value("shortcutSmartCase", shortcutSmartCase);
     toggleHotkey = parseHotkey(data.value("toggleHotkey", std::string(hotkeyString(toggleHotkey))));
     flipHotkey = parseFlip(data.value("flipHotkey", std::string(flipString(flipHotkey))));
     shortcuts.clear();
@@ -108,7 +110,8 @@ bool Settings::reload() {
            eagerRestore != previous.eagerRestore || spellCheck != previous.spellCheck ||
            autoCapitalize != previous.autoCapitalize || nonPreedit != previous.nonPreedit ||
            toggleHotkey != previous.toggleHotkey || flipHotkey != previous.flipHotkey ||
-           shortcuts != previous.shortcuts;
+           shortcuts != previous.shortcuts || shortcutsEnabled != previous.shortcutsEnabled ||
+           shortcutSmartCase != previous.shortcutSmartCase;
 }
 
 void Settings::save() const {
@@ -127,6 +130,8 @@ void Settings::save() const {
     data["spellCheck"] = spellCheck;
     data["autoCapitalize"] = autoCapitalize;
     data["nonPreedit"] = nonPreedit;
+    data["shortcutsEnabled"] = shortcutsEnabled;
+    data["shortcutSmartCase"] = shortcutSmartCase;
     data["toggleHotkey"] = hotkeyString(toggleHotkey);
     data["flipHotkey"] = flipString(flipHotkey);
     std::ofstream output(file, std::ios::trunc);

--- a/platforms/linux/common/settings/settings.h
+++ b/platforms/linux/common/settings/settings.h
@@ -44,6 +44,17 @@ struct Settings {
     // Text-expansion shortcuts (gõ tắt): (trigger, expansion) pairs. Owned by the
     // Settings UI; the addon only reads them and pushes them into the engine.
     std::vector<std::pair<std::string, std::string>> shortcuts;
+    // Whether the table above expands at all ("Bật gõ tắt"). The rows stay loaded
+    // either way, so the switch is instant in both directions.
+    bool shortcutsEnabled = true;
+    // Whether a trigger matches however it was capitalized, with the expansion
+    // re-cased to match ("Tự nhận diện hoa/thường"). Off, only the exact trigger
+    // expands and the expansion is verbatim.
+    //
+    // Both default to **on**, including for a file written before they existed:
+    // that is how gõ tắt has always behaved, and an update must not silently change
+    // what an existing table expands to.
+    bool shortcutSmartCase = true;
 
     // Absolute path to ~/.config/Funput/settings.json (XDG-aware).
     static std::string path();

--- a/platforms/linux/common/tests/CMakeLists.txt
+++ b/platforms/linux/common/tests/CMakeLists.txt
@@ -27,7 +27,9 @@ add_executable(funput_linux_tests
     compose/composer/retone_tests.cpp
     compose/composer/verify_tests.cpp
     ffi/utf8_tests.cpp
-    settings/settings_tests.cpp)
+    settings/lookup_tests.cpp
+    settings/io_tests.cpp
+    settings/save_tests.cpp)
 
 target_link_libraries(funput_linux_tests PRIVATE funput_linux_common doctest::doctest)
 # So the nested test files can reach support.h by its bare name.

--- a/platforms/linux/common/tests/compose/composer/state_tests.cpp
+++ b/platforms/linux/common/tests/compose/composer/state_tests.cpp
@@ -110,3 +110,29 @@ TEST_CASE("gõ tắt expansions survive a settings push") {
     CHECK(plan.effect == Effect::Commit);
     CHECK(plan.text == "Việt Nam ");
 }
+
+// The matching rules themselves belong to the engine and are tested there
+// (crates/funput-engine/tests/words/shortcut.rs). What only this layer can prove is
+// that applySettings() pushes each switch across the C ABI at all — before it did,
+// neither field reached the engine however the user set it.
+TEST_CASE("shortcutsEnabled off is pushed to the engine") {
+    Settings settings;
+    settings.method = Method::Telex;
+    settings.shortcuts = {{"vn", "Việt Nam"}};
+    settings.shortcutsEnabled = false;
+    Composer composer(settings);
+
+    CHECK(typeDocument(composer, "vn ") == "vn ");
+}
+
+TEST_CASE("shortcutSmartCase off is pushed to the engine") {
+    Settings settings;
+    settings.method = Method::Telex;
+    settings.shortcuts = {{"vn", "Việt Nam"}};
+    settings.shortcutSmartCase = false;
+    Composer composer(settings);
+
+    // The stored trigger still expands; a differently-cased one no longer does.
+    CHECK(typeDocument(composer, "vn ") == "Việt Nam ");
+    CHECK(typeDocument(composer, "Vn ") == "Vn ");
+}

--- a/platforms/linux/common/tests/settings/io_tests.cpp
+++ b/platforms/linux/common/tests/settings/io_tests.cpp
@@ -1,32 +1,13 @@
-// The settings bridge. Every case writes the file it then reads, so the tests do
-// not depend on each other's leftovers (the composer's VI/EN toggle persists into
-// the same sandbox file).
+// Reading settings.json: every wire name, the defaults a key's absence must leave in
+// place, and what a file the reader cannot make sense of does *not* do.
 
 #include <doctest/doctest.h>
 
-#include <cstdlib>
-#include <fstream>
-#include <string>
-
 #include "settings/settings.h"
+#include "settings/support.h"
 
 using namespace funput;
-
-namespace {
-
-void writeSettingsFile(const std::string &json) {
-    std::ofstream out(Settings::path(), std::ios::trunc);
-    REQUIRE(out.good());
-    out << json;
-}
-
-} // namespace
-
-TEST_CASE("path follows XDG_CONFIG_HOME") {
-    const std::string path = Settings::path();
-    CHECK(path.rfind("/Funput/settings.json") != std::string::npos);
-    CHECK(path.rfind(std::getenv("XDG_CONFIG_HOME"), 0) == 0);
-}
+using namespace funput::test;
 
 TEST_CASE("reload parses every field from its wire name") {
     writeSettingsFile(R"({
@@ -40,6 +21,8 @@ TEST_CASE("reload parses every field from its wire name") {
         "nonPreedit": true,
         "toggleHotkey": "ctrl_space",
         "flipHotkey": "ctrl_shift_x",
+        "shortcutsEnabled": false,
+        "shortcutSmartCase": false,
         "shortcuts": [{"trigger": "vn", "expansion": "Việt Nam"}]
     })");
 
@@ -55,9 +38,26 @@ TEST_CASE("reload parses every field from its wire name") {
     CHECK(settings.nonPreedit);
     CHECK(settings.toggleHotkey == Hotkey::CtrlSpace);
     CHECK(settings.flipHotkey == FlipHotkey::CtrlShiftX);
+    CHECK_FALSE(settings.shortcutsEnabled);
+    CHECK_FALSE(settings.shortcutSmartCase);
     REQUIRE(settings.shortcuts.size() == 1);
     CHECK(settings.shortcuts[0].first == "vn");
     CHECK(settings.shortcuts[0].second == "Việt Nam");
+}
+
+// The compatibility guarantee behind both gõ tắt switches: a settings.json written
+// before they existed describes a table that expands, smart-cased. An update that
+// read those absences as "off" would silently change what the table expands to.
+TEST_CASE("the gõ tắt switches default to on when the file predates them") {
+    writeSettingsFile(R"({
+        "method": "telex",
+        "shortcuts": [{"trigger": "vn", "expansion": "Việt Nam"}]
+    })");
+
+    Settings settings;
+    REQUIRE(settings.reload());
+    CHECK(settings.shortcutsEnabled);
+    CHECK(settings.shortcutSmartCase);
 }
 
 TEST_CASE("reload reports whether anything actually changed") {
@@ -67,15 +67,6 @@ TEST_CASE("reload reports whether anything actually changed") {
     CHECK(settings.reload()); // method moved
 
     CHECK_FALSE(settings.reload()); // same file, same values
-}
-
-TEST_CASE("reloadIfChanged skips a file whose mtime has not moved") {
-    // "telex" differs from the Method::Vni default, so the first read reports a
-    // change — the return value is "did any value move", not "did I read the file".
-    writeSettingsFile(R"({"method": "telex"})");
-    Settings settings;
-    REQUIRE(settings.reloadIfChanged());
-    CHECK_FALSE(settings.reloadIfChanged());
 }
 
 TEST_CASE("a corrupt or missing file leaves the current values alone") {
@@ -98,35 +89,6 @@ TEST_CASE("unknown wire values fall back to the current setting") {
     settings.reload();
     CHECK(settings.method == Method::Vni);
     CHECK(settings.toggleHotkey == Hotkey::CtrlBacktick);
-}
-
-TEST_CASE("save round-trips and preserves keys it does not own") {
-    // shortcuts belong to the Settings UI: the addon reads them but must never
-    // write them back, or a toggle would wipe the user's list. Leftover keys
-    // (including a retired excludedApps list) must survive a merge save too.
-    writeSettingsFile(R"({
-        "method": "vni",
-        "excludedApps": [{"id": "firefox"}],
-        "shortcuts": [{"trigger": "vn", "expansion": "Việt Nam"}],
-        "someFutureKey": 42
-    })");
-
-    Settings settings;
-    REQUIRE(settings.reload());
-    settings.method = Method::Telex;
-    settings.enabled = false;
-    settings.save();
-
-    Settings reloaded;
-    REQUIRE(reloaded.reload());
-    CHECK(reloaded.method == Method::Telex);
-    CHECK_FALSE(reloaded.enabled);
-    REQUIRE(reloaded.shortcuts.size() == 1);
-
-    std::ifstream in(Settings::path());
-    const std::string raw((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    CHECK(raw.find("someFutureKey") != std::string::npos);
-    CHECK(raw.find("excludedApps") != std::string::npos);
 }
 
 TEST_CASE("toggleHotkey parses the extra presets") {

--- a/platforms/linux/common/tests/settings/lookup_tests.cpp
+++ b/platforms/linux/common/tests/settings/lookup_tests.cpp
@@ -1,0 +1,16 @@
+// Where settings.json lives (settings/lookup.cpp).
+
+#include <doctest/doctest.h>
+
+#include <cstdlib>
+#include <string>
+
+#include "settings/settings.h"
+
+using namespace funput;
+
+TEST_CASE("path follows XDG_CONFIG_HOME") {
+    const std::string path = Settings::path();
+    CHECK(path.rfind("/Funput/settings.json") != std::string::npos);
+    CHECK(path.rfind(std::getenv("XDG_CONFIG_HOME"), 0) == 0);
+}

--- a/platforms/linux/common/tests/settings/save_tests.cpp
+++ b/platforms/linux/common/tests/settings/save_tests.cpp
@@ -1,0 +1,68 @@
+// Writing settings.json, and the mtime shortcut that decides whether to read it.
+
+#include <doctest/doctest.h>
+
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#include "settings/settings.h"
+#include "settings/support.h"
+
+using namespace funput;
+using namespace funput::test;
+
+TEST_CASE("reloadIfChanged skips a file whose mtime has not moved") {
+    // "telex" differs from the Method::Vni default, so the first read reports a
+    // change — the return value is "did any value move", not "did I read the file".
+    writeSettingsFile(R"({"method": "telex"})");
+    Settings settings;
+    REQUIRE(settings.reloadIfChanged());
+    CHECK_FALSE(settings.reloadIfChanged());
+}
+
+TEST_CASE("save round-trips and preserves keys it does not own") {
+    // shortcuts belong to the Settings UI: the addon reads them but must never
+    // write them back, or a toggle would wipe the user's list. Leftover keys
+    // (including a retired excludedApps list) must survive a merge save too.
+    writeSettingsFile(R"({
+        "method": "vni",
+        "excludedApps": [{"id": "firefox"}],
+        "shortcuts": [{"trigger": "vn", "expansion": "Việt Nam"}],
+        "someFutureKey": 42
+    })");
+
+    Settings settings;
+    REQUIRE(settings.reload());
+    settings.method = Method::Telex;
+    settings.enabled = false;
+    settings.save();
+
+    Settings reloaded;
+    REQUIRE(reloaded.reload());
+    CHECK(reloaded.method == Method::Telex);
+    CHECK_FALSE(reloaded.enabled);
+    REQUIRE(reloaded.shortcuts.size() == 1);
+
+    std::ifstream in(Settings::path());
+    const std::string raw((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    CHECK(raw.find("someFutureKey") != std::string::npos);
+    CHECK(raw.find("excludedApps") != std::string::npos);
+}
+
+// The gõ tắt switches are options the addon reads, so — unlike the table itself —
+// they ride along on a save. A VI/EN toggle must not drop the user's choice.
+TEST_CASE("save keeps the gõ tắt switches") {
+    writeSettingsFile(R"({"method": "telex"})");
+
+    Settings settings;
+    REQUIRE(settings.reload());
+    settings.shortcutsEnabled = false;
+    settings.shortcutSmartCase = false;
+    settings.save();
+
+    Settings reloaded;
+    REQUIRE(reloaded.reload());
+    CHECK_FALSE(reloaded.shortcutsEnabled);
+    CHECK_FALSE(reloaded.shortcutSmartCase);
+}

--- a/platforms/linux/common/tests/settings/support.h
+++ b/platforms/linux/common/tests/settings/support.h
@@ -1,0 +1,26 @@
+// Shared helper for the settings-bridge tests. Every case writes the file it then
+// reads, so the tests do not depend on each other's leftovers (the composer's VI/EN
+// toggle persists into the same sandbox file). The sandbox itself is
+// XDG_CONFIG_HOME, set by main.cpp — the user's real settings.json is never touched.
+
+#ifndef FUNPUT_TESTS_SETTINGS_SUPPORT_H
+#define FUNPUT_TESTS_SETTINGS_SUPPORT_H
+
+#include <doctest/doctest.h>
+
+#include <fstream>
+#include <string>
+
+#include "settings/settings.h"
+
+namespace funput::test {
+
+inline void writeSettingsFile(const std::string &json) {
+    std::ofstream out(Settings::path(), std::ios::trunc);
+    REQUIRE(out.good());
+    out << json;
+}
+
+} // namespace funput::test
+
+#endif // FUNPUT_TESTS_SETTINGS_SUPPORT_H

--- a/platforms/linux/settings-gtk/src/config_transfer/document.rs
+++ b/platforms/linux/settings-gtk/src/config_transfer/document.rs
@@ -43,6 +43,10 @@ pub(super) struct Preferences {
     pub spell_check: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_capitalize: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shortcuts_enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shortcut_smart_case: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/platforms/linux/settings-gtk/src/config_transfer/tests.rs
+++ b/platforms/linux/settings-gtk/src/config_transfer/tests.rs
@@ -12,6 +12,8 @@ fn round_trip_preserves_state() {
             expansion: "Việt Nam".into(),
         }],
         non_preedit: true,
+        shortcuts_enabled: false,
+        shortcut_smart_case: false,
         ..Settings::default()
     };
     assert_eq!(
@@ -26,6 +28,28 @@ fn round_trip_preserves_state() {
     assert_eq!(imported.toggle_hotkey, Hotkey::AltShift);
     assert_eq!(imported.shortcuts.len(), 1);
     assert!(imported.non_preedit);
+    assert!(!imported.shortcuts_enabled);
+    assert!(!imported.shortcut_smart_case);
+}
+
+#[test]
+fn a_document_without_the_gõ_tắt_switches_leaves_them_alone() {
+    // Both default to on, so a file predating them describes a table that expands,
+    // smart-cased. Reading their absence as "off" would silently change what an
+    // imported table expands to — the same rule non_preedit follows above.
+    let mut settings = Settings {
+        shortcuts_enabled: false,
+        shortcut_smart_case: false,
+        ..Settings::default()
+    };
+    let doc = serde_json::from_str(
+        r#"{"schema":"app.funput.config","version":1,"preferences":{"inputMethod":"telex"}}"#,
+    )
+    .unwrap();
+    apply(&mut settings, &doc);
+    assert_eq!(settings.method, Method::Telex); // the block was read
+    assert!(!settings.shortcuts_enabled); // and these survived it
+    assert!(!settings.shortcut_smart_case);
 }
 
 #[test]

--- a/platforms/linux/settings-gtk/src/config_transfer/transfer.rs
+++ b/platforms/linux/settings-gtk/src/config_transfer/transfer.rs
@@ -24,6 +24,8 @@ pub(super) fn to_document(settings: &Settings) -> ConfigDocument {
             eager_restore: Some(settings.eager_restore),
             spell_check: Some(settings.spell_check),
             auto_capitalize: Some(settings.auto_capitalize),
+            shortcuts_enabled: Some(settings.shortcuts_enabled),
+            shortcut_smart_case: Some(settings.shortcut_smart_case),
         }),
         shortcuts: Some(
             settings
@@ -72,6 +74,15 @@ pub(super) fn apply(settings: &mut Settings, doc: &ConfigDocument) -> ImportSumm
         }
         if let Some(value) = prefs.auto_capitalize {
             settings.auto_capitalize = value;
+        }
+        // Absent means the exporter had nothing to say, not "off" — the format's
+        // non-destructive-import rule. A file predating these two fields carries a
+        // table that expands, smart-cased, and importing it must not change that.
+        if let Some(value) = prefs.shortcuts_enabled {
+            settings.shortcuts_enabled = value;
+        }
+        if let Some(value) = prefs.shortcut_smart_case {
+            settings.shortcut_smart_case = value;
         }
     }
     merge_shortcuts(settings, doc, &mut summary);

--- a/platforms/linux/settings-gtk/src/settings/model.rs
+++ b/platforms/linux/settings-gtk/src/settings/model.rs
@@ -106,6 +106,21 @@ pub struct Settings {
     pub has_completed_onboarding: bool,
     #[serde(default)]
     pub shortcuts: Vec<Shortcut>,
+    /// Whether the table above expands at all. The rows stay stored either way.
+    #[serde(default = "on")]
+    pub shortcuts_enabled: bool,
+    /// Whether a trigger matches however it was capitalized, with the expansion
+    /// re-cased to match.
+    ///
+    /// Both default to **on**, including for a file written before they existed:
+    /// that is how gõ tắt has always behaved, and an update must not silently change
+    /// what an existing table expands to. The addon's C++ model says the same.
+    #[serde(default = "on")]
+    pub shortcut_smart_case: bool,
+}
+
+fn on() -> bool {
+    true
 }
 
 impl Default for Settings {
@@ -124,6 +139,8 @@ impl Default for Settings {
             launch_at_login: false,
             has_completed_onboarding: false,
             shortcuts: Vec::new(),
+            shortcuts_enabled: true,
+            shortcut_smart_case: true,
         }
     }
 }

--- a/platforms/linux/settings-gtk/src/settings_window/shortcuts.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/shortcuts.rs
@@ -1,7 +1,11 @@
-//! "Gõ tắt" page: manage text-expansion shortcuts (`vn` → `việt nam`, smart-cased to
-//! `Vn` → `Việt Nam` / `VN` → `VIỆT NAM` at expansion time). Each shortcut
-//! is an expander with two editable fields; edits persist by index and update the
-//! header live, while add/delete rebuild the list.
+//! "Gõ tắt" page: the two switches governing expansion, then the shortcuts
+//! themselves (`vn` → `việt nam`, smart-cased to `Vn` → `Việt Nam` / `VN` →
+//! `VIỆT NAM` at expansion time). Each shortcut is an expander with two editable
+//! fields; edits persist by index and update the header live, while add/delete
+//! rebuild the list.
+//!
+//! One page rather than a stack of empty/list states: the switches in `options` are
+//! shown either way, which a swapped-out empty page could not do.
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -13,6 +17,7 @@ use gtk::{Align, Button};
 use crate::settings::{Settings, Shortcut};
 
 mod empty;
+mod options;
 mod row;
 
 /// The "throw the list away and build it again" closure, held so the rows it builds
@@ -24,27 +29,29 @@ mod row;
 pub(super) type Rebuild = Rc<RefCell<Option<Rc<dyn Fn()>>>>;
 
 pub(super) fn page() -> gtk::Widget {
-    let list_page = PreferencesPage::builder()
+    let settings = Settings::load();
+    let page = PreferencesPage::builder()
         .title("Gõ tắt")
         .icon_name("edit-find-replace-symbolic")
         .build();
     let group = PreferencesGroup::builder()
-        .title("Gõ tắt")
-        .description(
-            "Gõ chữ tắt rồi dấu cách để bung — ví dụ vn → việt nam. Tự nhận diện hoa/thường: \
-             Vn → Việt Nam, VN → VIỆT NAM.",
-        )
+        .title("Danh sách gõ tắt")
         .build();
-    list_page.add(&group);
+    // The empty state is a group of its own rather than a separate page, so the
+    // switches above it stay on screen while the table has no rows.
+    let blank = PreferencesGroup::new();
 
-    let pages = gtk::Stack::new();
+    page.add(&options::group(&settings));
+    page.add(&group);
+    page.add(&blank);
+
     let rows: Rc<RefCell<Vec<gtk::Widget>>> = Rc::new(RefCell::new(Vec::new()));
     let focus_new = Rc::new(Cell::new(false));
     let rebuild: Rebuild = Rc::new(RefCell::new(None));
 
     let rebuild_impl: Rc<dyn Fn()> = {
         let group = group.clone();
-        let pages = pages.clone();
+        let blank = blank.clone();
         let rows = rows.clone();
         let focus_new = focus_new.clone();
         let rebuild = rebuild.clone();
@@ -53,11 +60,8 @@ pub(super) fn page() -> gtk::Widget {
                 group.remove(&r);
             }
             let s = Settings::load();
-            if s.shortcuts.is_empty() {
-                pages.set_visible_child_name("empty");
-                return;
-            }
-            pages.set_visible_child_name("list");
+            group.set_visible(!s.shortcuts.is_empty());
+            blank.set_visible(s.shortcuts.is_empty());
             let mut last: Option<(ExpanderRow, EntryRow)> = None;
             for (i, sc) in s.shortcuts.iter().enumerate() {
                 let (expander, trigger) = row::build(i, sc, &rebuild);
@@ -101,8 +105,7 @@ pub(super) fn page() -> gtk::Widget {
     add_btn.connect_clicked(move |_| add_header());
     group.set_header_suffix(Some(&add_btn));
 
-    pages.add_named(&empty::page(move || add()), Some("empty"));
-    pages.add_named(&list_page, Some("list"));
+    blank.add(&empty::page(move || add()));
     rebuild_impl();
-    pages.upcast()
+    page.upcast()
 }

--- a/platforms/linux/settings-gtk/src/settings_window/shortcuts/options.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/shortcuts/options.rs
@@ -1,0 +1,62 @@
+//! The two switches governing the gõ tắt table, above the rows themselves.
+//!
+//! Kept visible whether or not the table has any rows — an empty table is exactly
+//! when a user is most likely to be reading this page — and mirroring the Windows
+//! page (`platforms/windows/ui/pages/shortcuts/page.slint`) row for row.
+
+use adw::prelude::*;
+use adw::{PreferencesGroup, SwitchRow};
+
+use crate::settings::Settings;
+
+/// This group's description, which has to follow the smart-case switch: the example
+/// stops being true the moment case matching is off. It sits here rather than on the
+/// list below because the list is hidden while the table is empty, and a switch
+/// whose explanation vanishes with the rows explains nothing.
+fn description(smart_case: bool) -> &'static str {
+    if smart_case {
+        "Gõ chữ tắt rồi dấu cách để bung — ví dụ vn → việt nam. Tự nhận diện hoa/thường: \
+         Vn → Việt Nam, VN → VIỆT NAM."
+    } else {
+        "Gõ chữ tắt rồi dấu cách để bung — ví dụ vn → việt nam. Đang tắt nhận diện \
+         hoa/thường: chỉ đúng chữ tắt đã lưu mới bung, nội dung giữ nguyên."
+    }
+}
+
+pub(super) fn group(settings: &Settings) -> PreferencesGroup {
+    let group = PreferencesGroup::builder()
+        .title("Gõ tắt")
+        .description(description(settings.shortcut_smart_case))
+        .build();
+
+    let enabled_row = SwitchRow::builder()
+        .title("Bật gõ tắt")
+        .subtitle("Tắt để tạm gõ nguyên chữ tắt — bảng bên dưới vẫn giữ nguyên.")
+        .active(settings.shortcuts_enabled)
+        .build();
+    enabled_row.connect_active_notify(|row| {
+        let on = row.is_active();
+        Settings::update(|settings| settings.shortcuts_enabled = on);
+    });
+
+    let smart_row = SwitchRow::builder()
+        .title("Tự nhận diện hoa/thường")
+        .subtitle(
+            "Gõ vn, Vn hay VN đều bung và nội dung tự viết hoa theo. Tắt thì chỉ khớp \
+             đúng chuỗi tắt đã lưu.",
+        )
+        .active(settings.shortcut_smart_case)
+        .build();
+    // Deliberately not desensitized when "Bật gõ tắt" is off, even though it depends
+    // on it: macOS leaves the switch live, and the platforms must read the same.
+    let group_for_smart = group.clone();
+    smart_row.connect_active_notify(move |row| {
+        let on = row.is_active();
+        Settings::update(|settings| settings.shortcut_smart_case = on);
+        group_for_smart.set_description(Some(description(on)));
+    });
+
+    group.add(&enabled_row);
+    group.add(&smart_row);
+    group
+}

--- a/platforms/macos/Funput/IME/ComposerConfiguration.swift
+++ b/platforms/macos/Funput/IME/ComposerConfiguration.swift
@@ -10,6 +10,7 @@ struct ComposerConfiguration: Equatable {
     let eagerRestore: Bool
     let spellCheckEnabled: Bool
     let autoCapitalizeEnabled: Bool
+    let shortcutsEnabled: Bool
     let shortcutSmartCase: Bool
 
     init(settings: AppSettings) {
@@ -20,6 +21,7 @@ struct ComposerConfiguration: Equatable {
         eagerRestore = settings.eagerRestore
         spellCheckEnabled = settings.spellCheckEnabled
         autoCapitalizeEnabled = settings.autoCapitalizeEnabled
+        shortcutsEnabled = settings.shortcutsEnabled
         shortcutSmartCase = settings.shortcutSmartCase
     }
 
@@ -31,6 +33,7 @@ struct ComposerConfiguration: Equatable {
         eagerRestore: Bool = true,
         spellCheckEnabled: Bool = false,
         autoCapitalizeEnabled: Bool = false,
+        shortcutsEnabled: Bool = true,
         shortcutSmartCase: Bool = true
     ) {
         self.inputMethod = inputMethod
@@ -40,6 +43,7 @@ struct ComposerConfiguration: Equatable {
         self.eagerRestore = eagerRestore
         self.spellCheckEnabled = spellCheckEnabled
         self.autoCapitalizeEnabled = autoCapitalizeEnabled
+        self.shortcutsEnabled = shortcutsEnabled
         self.shortcutSmartCase = shortcutSmartCase
     }
 }
@@ -56,9 +60,10 @@ extension FunputComposer {
                 auto_capitalize: configuration.autoCapitalizeEnabled
             )
         )
-        // Neither of these rides the by-value `FunputConfig`: `enabled` is a runtime
-        // toggle, and smart case is kept off the C struct for ABI stability. Order does
-        // not matter — `configure` edits the engine config rather than replacing it.
+        // None of these ride the by-value `FunputConfig`: `enabled` is a runtime
+        // toggle, and the gõ tắt switches are kept off the C struct for ABI stability.
+        // Order does not matter — `configure` edits the engine config, never replaces it.
+        setShortcutsEnabled(configuration.shortcutsEnabled)
         setShortcutSmartCase(configuration.shortcutSmartCase)
         setEnabled(configuration.enabled)
     }

--- a/platforms/macos/Funput/IME/ComposerConfiguration.swift
+++ b/platforms/macos/Funput/IME/ComposerConfiguration.swift
@@ -10,6 +10,7 @@ struct ComposerConfiguration: Equatable {
     let eagerRestore: Bool
     let spellCheckEnabled: Bool
     let autoCapitalizeEnabled: Bool
+    let shortcutSmartCase: Bool
 
     init(settings: AppSettings) {
         inputMethod = settings.inputMethod
@@ -19,6 +20,7 @@ struct ComposerConfiguration: Equatable {
         eagerRestore = settings.eagerRestore
         spellCheckEnabled = settings.spellCheckEnabled
         autoCapitalizeEnabled = settings.autoCapitalizeEnabled
+        shortcutSmartCase = settings.shortcutSmartCase
     }
 
     init(
@@ -28,7 +30,8 @@ struct ComposerConfiguration: Equatable {
         smartEnglishRestore: Bool = true,
         eagerRestore: Bool = true,
         spellCheckEnabled: Bool = false,
-        autoCapitalizeEnabled: Bool = false
+        autoCapitalizeEnabled: Bool = false,
+        shortcutSmartCase: Bool = true
     ) {
         self.inputMethod = inputMethod
         self.toneStyle = toneStyle
@@ -37,6 +40,7 @@ struct ComposerConfiguration: Equatable {
         self.eagerRestore = eagerRestore
         self.spellCheckEnabled = spellCheckEnabled
         self.autoCapitalizeEnabled = autoCapitalizeEnabled
+        self.shortcutSmartCase = shortcutSmartCase
     }
 }
 
@@ -52,7 +56,10 @@ extension FunputComposer {
                 auto_capitalize: configuration.autoCapitalizeEnabled
             )
         )
-        // `enabled` is a runtime toggle, not part of the batch config.
+        // Neither of these rides the by-value `FunputConfig`: `enabled` is a runtime
+        // toggle, and smart case is kept off the C struct for ABI stability. Order does
+        // not matter — `configure` edits the engine config rather than replacing it.
+        setShortcutSmartCase(configuration.shortcutSmartCase)
         setEnabled(configuration.enabled)
     }
 }

--- a/platforms/macos/Funput/IME/FunputComposer.swift
+++ b/platforms/macos/Funput/IME/FunputComposer.swift
@@ -43,6 +43,15 @@ final class FunputComposer {
         funput_clear_shortcuts(handle)
     }
 
+    /// Smart-case matching for gõ tắt: on, `tp`/`Tp`/`TP` all find the `tp` entry and
+    /// the expansion is re-cased to match; off, only the exact trigger expands and the
+    /// expansion is verbatim. Its own FFI call rather than a `FunputConfig` field —
+    /// that struct crosses the C ABI by value and this app is built separately from the
+    /// header, so growing it would mismatch silently. `configure` leaves it alone.
+    func setShortcutSmartCase(_ on: Bool) {
+        funput_set_shortcut_smart_case(handle, on)
+    }
+
     /// Define a text-expansion shortcut: typing `trigger` then a word boundary injects
     /// `expansion` (`vn` → `Việt Nam`). Both strings cross the C ABI as UTF-32.
     func addShortcut(trigger: String, expansion: String) {

--- a/platforms/macos/Funput/IME/FunputComposer.swift
+++ b/platforms/macos/Funput/IME/FunputComposer.swift
@@ -43,6 +43,13 @@ final class FunputComposer {
         funput_clear_shortcuts(handle)
     }
 
+    /// The gõ tắt master switch: off, nothing expands and the table is left loaded, so
+    /// hosts need not re-push their rows around it. Its own FFI call for the same ABI
+    /// reason as `setShortcutSmartCase` below.
+    func setShortcutsEnabled(_ on: Bool) {
+        funput_set_shortcuts_enabled(handle, on)
+    }
+
     /// Smart-case matching for gõ tắt: on, `tp`/`Tp`/`TP` all find the `tp` entry and
     /// the expansion is re-cased to match; off, only the exact trigger expands and the
     /// expansion is verbatim. Its own FFI call rather than a `FunputConfig` field —

--- a/platforms/macos/Funput/Model/AppSettings+Config.swift
+++ b/platforms/macos/Funput/Model/AppSettings+Config.swift
@@ -41,6 +41,7 @@ extension AppSettings {
                 eagerRestore: eagerRestore,
                 spellCheck: spellCheckEnabled,
                 autoCapitalize: autoCapitalizeEnabled,
+                shortcutsEnabled: shortcutsEnabled,
                 shortcutSmartCase: shortcutSmartCase
             ),
             shortcuts: shortcuts.map { .init(trigger: $0.trigger, expansion: $0.expansion) },
@@ -86,6 +87,7 @@ extension AppSettings {
             if let value = prefs.eagerRestore { eagerRestore = value }
             if let value = prefs.spellCheck { spellCheckEnabled = value }
             if let value = prefs.autoCapitalize { autoCapitalizeEnabled = value }
+            if let value = prefs.shortcutsEnabled { shortcutsEnabled = value }
             if let value = prefs.shortcutSmartCase { shortcutSmartCase = value }
         }
 

--- a/platforms/macos/Funput/Model/AppSettings+Config.swift
+++ b/platforms/macos/Funput/Model/AppSettings+Config.swift
@@ -40,7 +40,8 @@ extension AppSettings {
                 smartEnglishRestore: smartEnglishRestore,
                 eagerRestore: eagerRestore,
                 spellCheck: spellCheckEnabled,
-                autoCapitalize: autoCapitalizeEnabled
+                autoCapitalize: autoCapitalizeEnabled,
+                shortcutSmartCase: shortcutSmartCase
             ),
             shortcuts: shortcuts.map { .init(trigger: $0.trigger, expansion: $0.expansion) },
             platform: .init(macos: .init(
@@ -85,6 +86,7 @@ extension AppSettings {
             if let value = prefs.eagerRestore { eagerRestore = value }
             if let value = prefs.spellCheck { spellCheckEnabled = value }
             if let value = prefs.autoCapitalize { autoCapitalizeEnabled = value }
+            if let value = prefs.shortcutSmartCase { shortcutSmartCase = value }
         }
 
         if let incoming = document.shortcuts {

--- a/platforms/macos/Funput/Model/AppSettings.swift
+++ b/platforms/macos/Funput/Model/AppSettings.swift
@@ -80,6 +80,11 @@ final class AppSettings {
             shortcutsRevision &+= 1
         }
     }
+    /// Smart-case gõ tắt ("Tự nhận diện hoa/thường"): a trigger matches however it was
+    /// capitalized and the expansion is re-cased to match. On by default.
+    var shortcutSmartCase: Bool {
+        didSet { defaults.set(shortcutSmartCase, forKey: Keys.shortcutSmartCase) }
+    }
     /// Bumped on every `shortcuts` mutation so the controller knows when to re-marshal
     /// the table to the engine (instead of doing it on every keystroke). Not persisted.
     @ObservationIgnored private(set) var shortcutsRevision = 0
@@ -106,6 +111,7 @@ final class AppSettings {
             Keys.showMenuBarIcon: true,
             Keys.vietnameseEnabled: true,
             Keys.retoneAfterBackspace: true,
+            Keys.shortcutSmartCase: true,
         ])
         inputMethod = InputMethod.persisted(defaults.object(forKey: Keys.inputMethod))
         toneStyle = ToneStyle(rawValue: defaults.integer(forKey: Keys.toneStyle)) ?? .traditional
@@ -115,6 +121,7 @@ final class AppSettings {
         spellCheckEnabled = defaults.bool(forKey: Keys.spellCheckEnabled)
         autoCapitalizeEnabled = defaults.bool(forKey: Keys.autoCapitalizeEnabled)
         retoneAfterBackspace = defaults.bool(forKey: Keys.retoneAfterBackspace)
+        shortcutSmartCase = defaults.bool(forKey: Keys.shortcutSmartCase)
         toggleShortcut = defaults.data(forKey: Keys.toggleShortcut)
             .flatMap { try? JSONDecoder().decode(KeyCombo.self, from: $0) } ?? .defaultToggle
         flipShortcut = defaults.data(forKey: Keys.flipShortcut)

--- a/platforms/macos/Funput/Model/AppSettings.swift
+++ b/platforms/macos/Funput/Model/AppSettings.swift
@@ -80,6 +80,11 @@ final class AppSettings {
             shortcutsRevision &+= 1
         }
     }
+    /// Master gõ tắt switch ("Bật gõ tắt"). Off, nothing expands; the table stays
+    /// loaded, so flipping it back costs nothing. On by default.
+    var shortcutsEnabled: Bool {
+        didSet { defaults.set(shortcutsEnabled, forKey: Keys.shortcutsEnabled) }
+    }
     /// Smart-case gõ tắt ("Tự nhận diện hoa/thường"): a trigger matches however it was
     /// capitalized and the expansion is re-cased to match. On by default.
     var shortcutSmartCase: Bool {
@@ -111,6 +116,7 @@ final class AppSettings {
             Keys.showMenuBarIcon: true,
             Keys.vietnameseEnabled: true,
             Keys.retoneAfterBackspace: true,
+            Keys.shortcutsEnabled: true,
             Keys.shortcutSmartCase: true,
         ])
         inputMethod = InputMethod.persisted(defaults.object(forKey: Keys.inputMethod))
@@ -121,6 +127,7 @@ final class AppSettings {
         spellCheckEnabled = defaults.bool(forKey: Keys.spellCheckEnabled)
         autoCapitalizeEnabled = defaults.bool(forKey: Keys.autoCapitalizeEnabled)
         retoneAfterBackspace = defaults.bool(forKey: Keys.retoneAfterBackspace)
+        shortcutsEnabled = defaults.bool(forKey: Keys.shortcutsEnabled)
         shortcutSmartCase = defaults.bool(forKey: Keys.shortcutSmartCase)
         toggleShortcut = defaults.data(forKey: Keys.toggleShortcut)
             .flatMap { try? JSONDecoder().decode(KeyCombo.self, from: $0) } ?? .defaultToggle

--- a/platforms/macos/Funput/Model/AppSettingsKeys.swift
+++ b/platforms/macos/Funput/Model/AppSettingsKeys.swift
@@ -14,5 +14,6 @@ extension AppSettings {
         static let showMenuBarIcon = "showMenuBarIcon"
         static let hasCompletedOnboarding = "hasCompletedOnboarding"
         static let shortcuts = "shortcuts"
+        static let shortcutSmartCase = "shortcutSmartCase"
     }
 }

--- a/platforms/macos/Funput/Model/AppSettingsKeys.swift
+++ b/platforms/macos/Funput/Model/AppSettingsKeys.swift
@@ -14,6 +14,7 @@ extension AppSettings {
         static let showMenuBarIcon = "showMenuBarIcon"
         static let hasCompletedOnboarding = "hasCompletedOnboarding"
         static let shortcuts = "shortcuts"
+        static let shortcutsEnabled = "shortcutsEnabled"
         static let shortcutSmartCase = "shortcutSmartCase"
     }
 }

--- a/platforms/macos/Funput/Model/ConfigDocument.swift
+++ b/platforms/macos/Funput/Model/ConfigDocument.swift
@@ -35,6 +35,9 @@ struct ConfigDocument: Codable {
         var eagerRestore: Bool?
         var spellCheck: Bool?
         var autoCapitalize: Bool?
+        /// Whether the gõ tắt rows in `shortcuts` expand at all. Absent means on —
+        /// see `CONFIG_FORMAT.md`.
+        var shortcutsEnabled: Bool?
         /// Whether a gõ tắt trigger matches however it was capitalized, expansion
         /// re-cased to match. Absent means on — see `CONFIG_FORMAT.md`.
         var shortcutSmartCase: Bool?

--- a/platforms/macos/Funput/Model/ConfigDocument.swift
+++ b/platforms/macos/Funput/Model/ConfigDocument.swift
@@ -35,6 +35,9 @@ struct ConfigDocument: Codable {
         var eagerRestore: Bool?
         var spellCheck: Bool?
         var autoCapitalize: Bool?
+        /// Whether a gõ tắt trigger matches however it was capitalized, expansion
+        /// re-cased to match. Absent means on — see `CONFIG_FORMAT.md`.
+        var shortcutSmartCase: Bool?
     }
 
     /// A text-expansion shortcut without the local UUID (recreated on import).

--- a/platforms/macos/Funput/Settings/Panes/OverviewPane.swift
+++ b/platforms/macos/Funput/Settings/Panes/OverviewPane.swift
@@ -26,7 +26,9 @@ struct OverviewPane: View {
                         }
                         SettingsMetric(
                             title: "Gõ tắt",
-                            value: "\(settings.shortcuts.count)",
+                            // The count would otherwise promise expansions that the
+                            // master switch is currently stopping.
+                            value: settings.shortcutsEnabled ? "\(settings.shortcuts.count)" : "Tắt",
                             systemImage: "text.append"
                         ) {
                             selection = .textShortcuts

--- a/platforms/macos/Funput/Settings/Panes/ShortcutsPane+Row.swift
+++ b/platforms/macos/Funput/Settings/Panes/ShortcutsPane+Row.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// Rendering of one gõ tắt row, split out of `ShortcutsPane` to keep both files
+/// inside the 150-line budget.
+extension ShortcutsPane {
+    func row(_ shortcut: Binding<TextShortcut>) -> some View {
+        let isDuplicate = !shortcut.wrappedValue.trigger.isEmpty
+            && duplicateTriggers.contains(shortcut.wrappedValue.trigger)
+
+        return VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            HStack(spacing: Theme.Spacing.md) {
+                field(text: shortcut.trigger, placeholder: "vn", monospaced: true, invalid: isDuplicate)
+                    .frame(width: 130)
+                    .focused($focusedTrigger, equals: shortcut.wrappedValue.id)
+
+                Image(systemName: "arrow.right")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                field(text: shortcut.expansion, placeholder: "Việt Nam", monospaced: false, invalid: false)
+                    .frame(maxWidth: .infinity)
+
+                Button {
+                    settings.removeShortcut(shortcut.wrappedValue.id)
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.borderless)
+                .foregroundStyle(.secondary)
+                .help("Xoá gõ tắt này")
+            }
+
+            if isDuplicate {
+                Text("Trùng trigger — dòng dưới sẽ được dùng.")
+                    .font(.caption2)
+                    .foregroundStyle(Theme.accent)
+            }
+        }
+        .padding(.vertical, Theme.Spacing.xs)
+    }
+
+    func field(text: Binding<String>, placeholder: String, monospaced: Bool, invalid: Bool) -> some View {
+        TextField("", text: text, prompt: Text(placeholder))
+            .labelsHidden()
+            .textFieldStyle(.plain)
+            .font(.system(.body, design: monospaced ? .monospaced : .default))
+            .padding(.horizontal, Theme.Spacing.sm)
+            .padding(.vertical, 6)
+            .background(.quaternary, in: RoundedRectangle(cornerRadius: Theme.Radius.control))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.Radius.control)
+                    .strokeBorder(invalid ? Theme.accent : .clear, lineWidth: 1)
+            )
+    }
+}

--- a/platforms/macos/Funput/Settings/Panes/ShortcutsPane.swift
+++ b/platforms/macos/Funput/Settings/Panes/ShortcutsPane.swift
@@ -3,8 +3,8 @@ import SwiftUI
 /// Manage text-expansion shortcuts (gõ tắt): type a short trigger, then a space or
 /// punctuation, and Funput expands it (`vn` → `Việt Nam`). Rows are edited inline.
 struct ShortcutsPane: View {
-    @Environment(AppSettings.self) private var settings
-    @FocusState private var focusedTrigger: UUID?
+    @Environment(AppSettings.self) var settings
+    @FocusState var focusedTrigger: UUID?
 
     var body: some View {
         @Bindable var settings = settings
@@ -54,58 +54,6 @@ struct ShortcutsPane: View {
         }
     }
 
-    // MARK: - Row
-
-    private func row(_ shortcut: Binding<TextShortcut>) -> some View {
-        let isDuplicate = !shortcut.wrappedValue.trigger.isEmpty
-            && duplicateTriggers.contains(shortcut.wrappedValue.trigger)
-
-        return VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
-            HStack(spacing: Theme.Spacing.md) {
-                field(text: shortcut.trigger, placeholder: "vn", monospaced: true, invalid: isDuplicate)
-                    .frame(width: 130)
-                    .focused($focusedTrigger, equals: shortcut.wrappedValue.id)
-
-                Image(systemName: "arrow.right")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                field(text: shortcut.expansion, placeholder: "Việt Nam", monospaced: false, invalid: false)
-                    .frame(maxWidth: .infinity)
-
-                Button {
-                    settings.removeShortcut(shortcut.wrappedValue.id)
-                } label: {
-                    Image(systemName: "trash")
-                }
-                .buttonStyle(.borderless)
-                .foregroundStyle(.secondary)
-                .help("Xoá gõ tắt này")
-            }
-
-            if isDuplicate {
-                Text("Trùng trigger — dòng dưới sẽ được dùng.")
-                    .font(.caption2)
-                    .foregroundStyle(Theme.accent)
-            }
-        }
-        .padding(.vertical, Theme.Spacing.xs)
-    }
-
-    private func field(text: Binding<String>, placeholder: String, monospaced: Bool, invalid: Bool) -> some View {
-        TextField("", text: text, prompt: Text(placeholder))
-            .labelsHidden()
-            .textFieldStyle(.plain)
-            .font(.system(.body, design: monospaced ? .monospaced : .default))
-            .padding(.horizontal, Theme.Spacing.sm)
-            .padding(.vertical, 6)
-            .background(.quaternary, in: RoundedRectangle(cornerRadius: Theme.Radius.control))
-            .overlay(
-                RoundedRectangle(cornerRadius: Theme.Radius.control)
-                    .strokeBorder(invalid ? Theme.accent : .clear, lineWidth: 1)
-            )
-    }
-
     // MARK: - Helpers
 
     /// "Thêm" is only enabled when the list is empty, or the last row already
@@ -118,7 +66,7 @@ struct ShortcutsPane: View {
 
     /// Triggers (non-empty) that appear on more than one row — flagged so the user
     /// knows the engine map keeps only the last one.
-    private var duplicateTriggers: Set<String> {
+    var duplicateTriggers: Set<String> {
         var seen = Set<String>()
         var duplicates = Set<String>()
         for shortcut in settings.shortcuts where !shortcut.trigger.isEmpty {

--- a/platforms/macos/Funput/Settings/Panes/ShortcutsPane.swift
+++ b/platforms/macos/Funput/Settings/Panes/ShortcutsPane.swift
@@ -28,6 +28,19 @@ struct ShortcutsPane: View {
                         )
                     }
 
+                    Divider()
+
+                    SettingsRow(
+                        title: "Tự nhận diện hoa/thường",
+                        subtitle: "Gõ vn, Vn hay VN đều bung và nội dung tự viết hoa theo. Tắt thì chỉ khớp đúng chuỗi tắt đã lưu.",
+                        systemImage: "textformat"
+                    ) {
+                        Toggle("Tự nhận diện hoa/thường", isOn: $settings.shortcutSmartCase)
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                            .tint(Theme.accent)
+                    }
+
                     if settings.shortcuts.isEmpty {
                         Divider()
                         Text("Chưa có gõ tắt nào. Bấm “Thêm” để tạo — ví dụ vn → Việt Nam, kg → không.")
@@ -45,7 +58,9 @@ struct ShortcutsPane: View {
 
             Section("Mẹo") {
                 VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-                    Text("Trigger tự nhận diện hoa/thường — gõ `vn`, `Vn` hay `VN` đều bung, expansion tự viết hoa tương ứng. Gõ tắt được ưu tiên hơn tự động khôi phục tiếng Anh.")
+                    Text(settings.shortcutSmartCase
+                        ? "Trigger tự nhận diện hoa/thường — gõ `vn`, `Vn` hay `VN` đều bung, expansion tự viết hoa tương ứng. Gõ tắt được ưu tiên hơn tự động khôi phục tiếng Anh."
+                        : "Đang tắt nhận diện hoa/thường — chỉ gõ đúng chuỗi tắt đã lưu mới bung, và nội dung giữ nguyên như đã nhập. Gõ tắt được ưu tiên hơn tự động khôi phục tiếng Anh.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/platforms/macos/Funput/Settings/Panes/ShortcutsPane.swift
+++ b/platforms/macos/Funput/Settings/Panes/ShortcutsPane.swift
@@ -10,12 +10,44 @@ struct ShortcutsPane: View {
         @Bindable var settings = settings
 
         Group {
+            Section("Gõ tắt") {
+                VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+                    // The pane's own sidebar mark, so the switch reads as governing the
+                    // whole feature rather than one option among several.
+                    SettingsRow(
+                        title: "Bật gõ tắt",
+                        subtitle: "Tắt để tạm gõ nguyên chữ tắt — bảng bên dưới vẫn giữ nguyên.",
+                        systemImage: "text.append"
+                    ) {
+                        Toggle("Bật gõ tắt", isOn: $settings.shortcutsEnabled)
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                            .tint(Theme.accent)
+                    }
+
+                    Divider()
+
+                    // Deliberately live while "Bật gõ tắt" is off, even though it only
+                    // matters when that is on: Windows and Linux leave it live too.
+                    SettingsRow(
+                        title: "Tự nhận diện hoa/thường",
+                        subtitle: "Gõ vn, Vn hay VN đều bung và nội dung tự viết hoa theo. Tắt thì chỉ khớp đúng chuỗi tắt đã lưu.",
+                        systemImage: "textformat"
+                    ) {
+                        Toggle("Tự nhận diện hoa/thường", isOn: $settings.shortcutSmartCase)
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                            .tint(Theme.accent)
+                    }
+                }
+            }
+
             Section("Danh sách gõ tắt") {
                 VStack(alignment: .leading, spacing: Theme.Spacing.md) {
                     SettingsRow(
-                        title: "Gõ tắt",
+                        title: countLabel,
                         subtitle: "Gõ chuỗi tắt rồi dấu cách để bung — ví dụ vn → Việt Nam",
-                        systemImage: "text.append"
+                        systemImage: "list.bullet"
                     ) {
                         Button(action: addRow) {
                             Label("Thêm", systemImage: "plus")
@@ -28,22 +60,9 @@ struct ShortcutsPane: View {
                         )
                     }
 
-                    Divider()
-
-                    SettingsRow(
-                        title: "Tự nhận diện hoa/thường",
-                        subtitle: "Gõ vn, Vn hay VN đều bung và nội dung tự viết hoa theo. Tắt thì chỉ khớp đúng chuỗi tắt đã lưu.",
-                        systemImage: "textformat"
-                    ) {
-                        Toggle("Tự nhận diện hoa/thường", isOn: $settings.shortcutSmartCase)
-                            .labelsHidden()
-                            .toggleStyle(.switch)
-                            .tint(Theme.accent)
-                    }
-
                     if settings.shortcuts.isEmpty {
                         Divider()
-                        Text("Chưa có gõ tắt nào. Bấm “Thêm” để tạo — ví dụ vn → Việt Nam, kg → không.")
+                        Text("Bấm “Thêm” để tạo — ví dụ vn → Việt Nam, kg → không.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -70,6 +89,10 @@ struct ShortcutsPane: View {
     }
 
     // MARK: - Helpers
+
+    private var countLabel: String {
+        settings.shortcuts.isEmpty ? "Chưa có gõ tắt nào" : "\(settings.shortcuts.count) gõ tắt"
+    }
 
     /// "Thêm" is only enabled when the list is empty, or the last row already
     /// has both a trigger and an expansion — avoids piling up empty/half-filled

--- a/platforms/macos/FunputTests/ComposerConfigurationTests.swift
+++ b/platforms/macos/FunputTests/ComposerConfigurationTests.swift
@@ -16,6 +16,7 @@ final class ComposerConfigurationTests: XCTestCase {
         settings.eagerRestore = false
         settings.spellCheckEnabled = true
         settings.autoCapitalizeEnabled = true
+        settings.shortcutSmartCase = false
 
         let configuration = ComposerConfiguration(settings: settings)
 
@@ -26,5 +27,20 @@ final class ComposerConfigurationTests: XCTestCase {
         XCTAssertFalse(configuration.eagerRestore)
         XCTAssertTrue(configuration.spellCheckEnabled)
         XCTAssertTrue(configuration.autoCapitalizeEnabled)
+        XCTAssertFalse(configuration.shortcutSmartCase)
+    }
+
+    /// Smart-case gõ tắt is on by default, which only holds because the key is in
+    /// `defaults.register` — `UserDefaults.bool` reads a missing key as `false`, so
+    /// forgetting that line would silently change what everyone's table expands to.
+    func testSmartCaseShortcutsDefaultToOn() {
+        let suiteName = "app.funput.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settings = AppSettings(defaults: defaults)
+
+        XCTAssertTrue(settings.shortcutSmartCase)
+        XCTAssertTrue(ComposerConfiguration(settings: settings).shortcutSmartCase)
     }
 }

--- a/platforms/macos/FunputTests/ComposerConfigurationTests.swift
+++ b/platforms/macos/FunputTests/ComposerConfigurationTests.swift
@@ -16,6 +16,7 @@ final class ComposerConfigurationTests: XCTestCase {
         settings.eagerRestore = false
         settings.spellCheckEnabled = true
         settings.autoCapitalizeEnabled = true
+        settings.shortcutsEnabled = false
         settings.shortcutSmartCase = false
 
         let configuration = ComposerConfiguration(settings: settings)
@@ -27,20 +28,25 @@ final class ComposerConfigurationTests: XCTestCase {
         XCTAssertFalse(configuration.eagerRestore)
         XCTAssertTrue(configuration.spellCheckEnabled)
         XCTAssertTrue(configuration.autoCapitalizeEnabled)
+        XCTAssertFalse(configuration.shortcutsEnabled)
         XCTAssertFalse(configuration.shortcutSmartCase)
     }
 
-    /// Smart-case gõ tắt is on by default, which only holds because the key is in
-    /// `defaults.register` — `UserDefaults.bool` reads a missing key as `false`, so
-    /// forgetting that line would silently change what everyone's table expands to.
-    func testSmartCaseShortcutsDefaultToOn() {
+    /// Both gõ tắt switches are on by default, which only holds because their keys are
+    /// in `defaults.register` — `UserDefaults.bool` reads a missing key as `false`, so
+    /// forgetting a line there would silently kill everyone's shortcuts on update.
+    func testShortcutSwitchesDefaultToOn() {
         let suiteName = "app.funput.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let settings = AppSettings(defaults: defaults)
 
+        XCTAssertTrue(settings.shortcutsEnabled)
         XCTAssertTrue(settings.shortcutSmartCase)
-        XCTAssertTrue(ComposerConfiguration(settings: settings).shortcutSmartCase)
+
+        let configuration = ComposerConfiguration(settings: settings)
+        XCTAssertTrue(configuration.shortcutsEnabled)
+        XCTAssertTrue(configuration.shortcutSmartCase)
     }
 }

--- a/platforms/macos/FunputTests/ConfigDocumentTests.swift
+++ b/platforms/macos/FunputTests/ConfigDocumentTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import Funput
+
+@MainActor
+final class ConfigDocumentTests: XCTestCase {
+    private func makeSettings() -> (AppSettings, String) {
+        let suiteName = "app.funput.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        return (AppSettings(defaults: defaults), suiteName)
+    }
+
+    /// Both gõ tắt switches are portable preferences, so an export has to carry them
+    /// and an import has to apply them. A field missing from `Preferences` decodes
+    /// silently as `nil`, which is why this asserts the values rather than the shape.
+    func testShortcutSwitchesSurviveExportAndImport() throws {
+        let (source, sourceSuite) = makeSettings()
+        defer { UserDefaults().removePersistentDomain(forName: sourceSuite) }
+        source.shortcutsEnabled = false
+        source.shortcutSmartCase = false
+
+        let data = try source.exportData()
+
+        let (destination, destinationSuite) = makeSettings()
+        defer { UserDefaults().removePersistentDomain(forName: destinationSuite) }
+        XCTAssertTrue(destination.shortcutsEnabled, "starts at the default")
+        XCTAssertTrue(destination.shortcutSmartCase)
+
+        try destination.importData(data)
+
+        XCTAssertFalse(destination.shortcutsEnabled)
+        XCTAssertFalse(destination.shortcutSmartCase)
+    }
+
+    /// Import is a merge: a file written before these fields existed must leave the
+    /// local switches alone rather than resetting them to the format's default.
+    func testAFileWithoutTheSwitchesLeavesLocalOnesAlone() throws {
+        let (settings, suite) = makeSettings()
+        defer { UserDefaults().removePersistentDomain(forName: suite) }
+        settings.shortcutsEnabled = false
+        settings.shortcutSmartCase = false
+
+        let legacy = """
+        { "schema": "app.funput.config", "version": 1,
+          "preferences": { "inputMethod": "vni" } }
+        """
+        try settings.importData(Data(legacy.utf8))
+
+        XCTAssertFalse(settings.shortcutsEnabled)
+        XCTAssertFalse(settings.shortcutSmartCase)
+    }
+}

--- a/platforms/windows/src/shared/commands/settings.rs
+++ b/platforms/windows/src/shared/commands/settings.rs
@@ -35,6 +35,10 @@ pub fn set_shortcuts_enabled(on: bool) {
     shell::set_shortcuts_enabled(on);
 }
 
+pub fn set_shortcut_smart_case(on: bool) {
+    shell::set_shortcut_smart_case(on);
+}
+
 pub fn set_auto_english_layout(on: bool) {
     shell::set_auto_english_on_foreign_layout(on);
 }

--- a/platforms/windows/src/shared/shell/settings.rs
+++ b/platforms/windows/src/shared/shell/settings.rs
@@ -78,6 +78,9 @@ pub fn set_auto_capitalize(on: bool) {
 pub fn set_shortcuts_enabled(on: bool) {
     with(|s| s.set_shortcuts_enabled(on));
 }
+pub fn set_shortcut_smart_case(on: bool) {
+    with(|s| s.set_shortcut_smart_case(on));
+}
 pub fn set_auto_english_on_foreign_layout(on: bool) {
     with(|s| s.set_auto_english_on_foreign_layout(on));
 }

--- a/platforms/windows/src/ui/settings_callbacks.rs
+++ b/platforms/windows/src/ui/settings_callbacks.rs
@@ -90,6 +90,7 @@ pub(super) fn wire(window: &SettingsWindow) {
     window.on_set_auto_cap(commands::set_auto_capitalize);
     window.on_set_auto_english_layout(commands::set_auto_english_layout);
     window.on_set_shortcuts_enabled(commands::set_shortcuts_enabled);
+    window.on_set_shortcut_smart_case(commands::set_shortcut_smart_case);
     window.on_set_launch(commands::set_launch_at_login);
 
     let weak = window.as_weak();

--- a/platforms/windows/src/ui/settings_window.rs
+++ b/platforms/windows/src/ui/settings_window.rs
@@ -104,6 +104,7 @@ pub(super) fn populate(window: &SettingsWindow) {
     window.set_update_message("".into());
     window.set_shortcuts(models::shortcuts(&shell::shortcuts()));
     window.set_shortcuts_enabled(settings.shortcuts_enabled);
+    window.set_shortcut_smart_case(settings.shortcut_smart_case);
     window.set_can_add_shortcut(commands::can_add_shortcut());
 }
 

--- a/platforms/windows/ui/pages/shortcuts/page.slint
+++ b/platforms/windows/ui/pages/shortcuts/page.slint
@@ -7,11 +7,13 @@ export component ShortcutsPage inherits VerticalLayout {
     in property <[ShortcutEntry]> shortcuts;
     in property <bool> can-add: true;
     in-out property <bool> shortcuts-enabled;
+    in-out property <bool> shortcut-smart-case;
     callback add-shortcut();
     callback remove-shortcut(int);
     callback edit-trigger(int, string);
     callback edit-expansion(int, string);
     callback set-shortcuts-enabled(bool);
+    callback set-shortcut-smart-case(bool);
 
     spacing: Theme.sp-lg;
     width: 100%;
@@ -19,7 +21,11 @@ export component ShortcutsPage inherits VerticalLayout {
 
     PageHeader {
         title: "Gõ tắt";
-        subtitle: "Bung chữ tắt khi gõ khoảng trắng hoặc dấu câu — tự nhận diện hoa/thường: vn → việt nam, Vn → Việt Nam, VN → VIỆT NAM.";
+        // The example only holds while smart case is on; with it off the page
+        // would otherwise promise matching that no longer happens.
+        subtitle: root.shortcut-smart-case
+            ? "Bung chữ tắt khi gõ khoảng trắng hoặc dấu câu — tự nhận diện hoa/thường: vn → việt nam, Vn → Việt Nam, VN → VIỆT NAM."
+            : "Bung chữ tắt khi gõ khoảng trắng hoặc dấu câu — đang tắt nhận diện hoa/thường, chỉ đúng chữ tắt đã lưu mới bung và nội dung giữ nguyên.";
     }
 
     Section {
@@ -32,6 +38,18 @@ export component ShortcutsPage inherits VerticalLayout {
             AccentSwitch {
                 checked <=> root.shortcuts-enabled;
                 toggled => { root.set-shortcuts-enabled(root.shortcuts-enabled); }
+            }
+        }
+        Rectangle { height: 1px; background: Theme.divider; }
+        Row {
+            icon: @image-url("../../icons/row/case.svg");
+            title: "Tự nhận diện hoa/thường";
+            subtitle: "Gõ vn, Vn hay VN đều bung và nội dung tự viết hoa theo. Tắt thì chỉ khớp đúng chuỗi tắt đã lưu.";
+            // Deliberately not gated on shortcuts-enabled: macOS leaves it live,
+            // and the two platforms must read the same.
+            AccentSwitch {
+                checked <=> root.shortcut-smart-case;
+                toggled => { root.set-shortcut-smart-case(root.shortcut-smart-case); }
             }
         }
     }

--- a/platforms/windows/ui/shell/content.slint
+++ b/platforms/windows/ui/shell/content.slint
@@ -29,6 +29,7 @@ export component SettingsContent inherits ScrollView {
     in property <[ShortcutEntry]> shortcuts;
     in property <bool> can-add-shortcut: true;
     in-out property <bool> shortcuts-enabled;
+    in-out property <bool> shortcut-smart-case;
     in property <string> version;
     in property <string> update-state: "idle";
     in property <string> update-version;
@@ -48,6 +49,7 @@ export component SettingsContent inherits ScrollView {
     callback set-launch(bool);
     callback add-shortcut();
     callback set-shortcuts-enabled(bool);
+    callback set-shortcut-smart-case(bool);
     callback remove-shortcut(int);
     callback edit-trigger(int, string);
     callback edit-expansion(int, string);
@@ -112,8 +114,10 @@ export component SettingsContent inherits ScrollView {
                 shortcuts: root.shortcuts;
                 can-add: root.can-add-shortcut;
                 shortcuts-enabled <=> root.shortcuts-enabled;
+                shortcut-smart-case <=> root.shortcut-smart-case;
                 add-shortcut() => { root.add-shortcut(); }
                 set-shortcuts-enabled(v) => { root.set-shortcuts-enabled(v); }
+                set-shortcut-smart-case(v) => { root.set-shortcut-smart-case(v); }
                 remove-shortcut(i) => { root.remove-shortcut(i); }
                 edit-trigger(i, t) => { root.edit-trigger(i, t); }
                 edit-expansion(i, t) => { root.edit-expansion(i, t); }

--- a/platforms/windows/ui/shell/settings.slint
+++ b/platforms/windows/ui/shell/settings.slint
@@ -33,6 +33,7 @@ export component SettingsWindow inherits Window {
     in property <[ShortcutEntry]> shortcuts;
     in property <bool> can-add-shortcut: true;
     in-out property <bool> shortcuts-enabled;
+    in-out property <bool> shortcut-smart-case;
     in property <string> version;
     in property <string> update-state: "idle";
     in property <string> update-version;
@@ -56,6 +57,7 @@ export component SettingsWindow inherits Window {
     callback set-launch(bool);
     callback add-shortcut();
     callback set-shortcuts-enabled(bool);
+    callback set-shortcut-smart-case(bool);
     callback remove-shortcut(int);
     callback edit-trigger(int, string);
     callback edit-expansion(int, string);
@@ -105,6 +107,7 @@ export component SettingsWindow inherits Window {
             shortcuts: root.shortcuts;
             can-add-shortcut: root.can-add-shortcut;
             shortcuts-enabled <=> root.shortcuts-enabled;
+            shortcut-smart-case <=> root.shortcut-smart-case;
             version: root.version;
             update-state: root.update-state;
             update-version: root.update-version;
@@ -123,6 +126,7 @@ export component SettingsWindow inherits Window {
             set-launch(v) => { root.set-launch(v); }
             add-shortcut() => { root.add-shortcut(); }
             set-shortcuts-enabled(v) => { root.set-shortcuts-enabled(v); }
+            set-shortcut-smart-case(v) => { root.set-shortcut-smart-case(v); }
             remove-shortcut(i) => { root.remove-shortcut(i); }
             edit-trigger(i, t) => { root.edit-trigger(i, t); }
             edit-expansion(i, t) => { root.edit-expansion(i, t); }


### PR DESCRIPTION
Gõ tắt giờ có **hai công tắc**, đủ trên cả ba nền tảng desktop.

| Công tắc | Engine | macOS | Windows | Linux |
|---|:---:|:---:|:---:|:---:|
| **Bật gõ tắt** — tạm ngưng bung chữ tắt | ✅ | ✅ | ✅ | ✅ |
| **Tự nhận diện hoa/thường** — khớp trigger bất kể hoa thường | ✅ | ✅ | ✅ | ✅ |

## Bật gõ tắt

Tắt để gõ nguyên chữ tắt trong chốc lát — ví dụ khi cần viết đúng chữ `vn` mà không muốn nó bung thành `Việt Nam`. **Bảng gõ tắt vẫn giữ nguyên**, vẫn sửa được, nên bật lại là dùng ngay.

## Tự nhận diện hoa/thường

Với bảng `tp → TP. HCM`:

| Gõ | Bật *(mặc định)* | Tắt |
|---|---|---|
| `tp` | `TP. HCM` | `TP. HCM` |
| `Tp` | `Tp. Hcm` | `Tp` — không bung |
| `TP` | `TP. HCM` | `TP` — không bung |

Tắt nghĩa là chỉ khớp đúng chữ tắt đã lưu, nội dung ra nguyên văn — dành cho người có expansion mang cách viết hoa riêng.

## Ba nền tảng đọc như nhau

- Cùng chuỗi tiếng Việt, cùng thứ tự: công tắc tổng trước, hoa/thường sau, cả hai nằm trên bảng
- **Không làm mờ gì cả** khi tắt công tắc tổng — công tắc hoa/thường vẫn bấm được, các dòng vẫn sửa được
- Mỗi nền tảng dùng control gốc của mình: SwiftUI `Form(.grouped)` trên macOS, `AccentSwitch` Slint trên Windows, `AdwSwitchRow` trên Linux
- Cả hai công tắc đi theo file cấu hình khi xuất/nhập, nên chuyển máy là giữ nguyên

Mặc định **bật cả hai**, kể cả với file cấu hình viết trước khi có chúng — cập nhật bản mới không được đổi thứ mà bảng gõ tắt của người dùng đang bung ra.

## Hai lỗi sửa kèm

**`configure` xoá mất tuỳ chọn không nằm trên wire.** `funput_configure` và `nativeConfigure` chỉ mang được sáu tuỳ chọn qua chữ ký của mình, nhưng lại dựng lại toàn bộ config — âm thầm reset mọi thứ còn lại. Hệ quả: `shortcuts_enabled` bị ép về `true` sau **mỗi lần** đồng bộ cài đặt. Nay cả hai chỉ sửa config chứ không thay thế.

**macOS làm rớt công tắc khi xuất/nhập cấu hình.** `ConfigDocument.Preferences` thiếu hẳn `shortcutsEnabled`, nên file từ Windows đang tắt gõ tắt về Mac lại thành bật, và Mac không bao giờ ghi field đó ra. Tài liệu `CONFIG_FORMAT.md` thì đang mô tả là macOS *có* đọc — đã sửa lại cho khớp thực tế.

## Kiểm thử

Từng commit đều tự build và tự chạy test xanh — đã kiểm bằng cách checkout lần lượt ra worktree riêng. CI xanh toàn bộ: `rust`, `linux-common`, `settings-gtk`, `shell-line-budget`.

Test round-trip xuất/nhập cấu hình đã được xác minh là bắt được lỗi thật: gỡ phần sửa ra thì test đỏ.

Các commit `refactor:` là **thuần túy dời code**, không kèm thay đổi hành vi — chúng dọn chỗ dưới trần 150 dòng (`transfer/apply.rs` đang đúng 150, `ShortcutsPane.swift` 148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)