### PR TITLE
feat(linux): add the Arch recipe, fix the repository instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,3 +199,78 @@ jobs:
 
       - name: Test
         run: ctest --test-dir platforms/linux/build/tests --output-on-failure
+
+  # Does this pull request touch the AUR recipe? Its own tiny job so the Arch
+  # container below is only pulled when it will actually be used — otherwise every
+  # unrelated pull request would pay for the image and a full `pacman -Syu`.
+  aur-changed:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - id: check
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          # Pull requests only: a push to main has no base to diff against, and
+          # this is a review gate rather than a release check.
+          if [ -z "${BASE_REF:-}" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # No --depth here: checkout already unshallowed the clone, and a shallow
+          # fetch of the base would leave `...` without a merge base to work from.
+          git fetch origin "$BASE_REF"
+          if git diff --name-only "origin/${BASE_REF}...HEAD" \
+              | grep -q '^platforms/linux/packaging/aur/'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "AUR recipe untouched — skipping the makepkg build."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # The AUR recipe (platforms/linux/packaging/aur/PKGBUILD.in). publish-aur.yml only
+  # renders and lints it — a real makepkg run costs a full Rust + GTK4 build in an
+  # Arch container, far too much for every release — so the build happens here.
+  #
+  # It builds the LATEST RELEASED TAG, not this pull request's code: the recipe
+  # sources a published GitHub tarball, and a pull request has no tag. So this
+  # proves the recipe still works; a CMake-layout change that would break it needs
+  # a run against a release made after that change.
+  aur:
+    needs: aur-changed
+    if: needs.aur-changed.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    steps:
+      - name: Install tools
+        run: pacman -Syu --noconfirm --needed git namcap curl jq
+
+      - uses: actions/checkout@v5
+
+      - name: Render the recipe for the latest release
+        run: |
+          set -euo pipefail
+          TAG="$(curl -fsSL "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r .tag_name)"
+          VERSION="${TAG#v}"
+          URL="https://github.com/${{ github.repository }}/archive/refs/tags/${TAG}.tar.gz"
+          SHA="$(curl -fsSL "$URL" | sha256sum | cut -d' ' -f1)"
+          mkdir -p aur
+          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" \
+            platforms/linux/packaging/aur/PKGBUILD.in > aur/PKGBUILD
+
+      - name: makepkg
+        run: |
+          set -euo pipefail
+          # makepkg refuses to run as root, and `-s` shells out to pacman for the
+          # declared makedepends — so the build user needs passwordless sudo.
+          useradd -m builder
+          echo 'builder ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/builder
+          chown -R builder aur
+          su builder -c 'cd aur && makepkg -s --noconfirm'
+          namcap aur/*.pkg.tar.zst
+          ls -l aur/*.pkg.tar.zst

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -1,0 +1,111 @@
+name: Publish AUR package
+
+# Arch Linux channel: render platforms/linux/packaging/aur/PKGBUILD.in for the
+# current release and push it, with a regenerated .SRCINFO, to the AUR.
+#
+# Unlike the Homebrew tap and the Scoop bucket — separate GitHub repos, so
+# release.yml has to repository_dispatch into them with a PAT — the AUR template
+# lives in this repo, so this workflow follows publish-repo.yml instead: it fires
+# off the release itself and needs no dispatch job and no PAT.
+#
+# One pkgbase publishes all three packages (funput, funput-ibus, funput-settings),
+# so there is a single AUR repo to maintain.
+#
+# Prerequisites (one-time):
+#   - An AUR account owning the `funput` pkgbase, with a deploy SSH key uploaded.
+#   - Secret AUR_SSH_PRIVATE_KEY holding that key. Without it this workflow is a
+#     no-op rather than a failure, matching the homebrew/scoop dispatch jobs.
+#
+# The package is NOT built here: compiling Rust + GTK4 in an Arch container costs
+# far more than it proves for every release. ci.yml builds it for real, but only
+# on pull requests that touch the template.
+on:
+  release:
+    types: [released]   # full releases only, never a prerelease
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to publish (without the leading v)."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aur
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # base-devel carries makepkg; git/openssh/namcap are added below.
+    container: archlinux:base-devel
+    steps:
+      - name: Install tools
+        # git is also what actions/checkout needs; pacman pulls libcurl but not the
+        # curl binary the render step uses.
+        run: pacman -Syu --noconfirm --needed git openssh namcap curl
+
+      - uses: actions/checkout@v5
+
+      - name: Render PKGBUILD
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          # A release run has the tag; a manual run has the bare version.
+          VERSION="${INPUT_VERSION:-${TAG#v}}"
+          [ -n "$VERSION" ] || { echo "No version to publish." >&2; exit 1; }
+          URL="https://github.com/${{ github.repository }}/archive/refs/tags/v${VERSION}.tar.gz"
+
+          # Hash the tarball GitHub will serve to makepkg, not a local archive: the
+          # two are only byte-identical if the tag is untouched, and it is that
+          # served copy the sha256sums line has to match.
+          SHA="$(curl -fsSL "$URL" | sha256sum | cut -d' ' -f1)"
+
+          mkdir -p aur
+          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" \
+            platforms/linux/packaging/aur/PKGBUILD.in > aur/PKGBUILD
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          cat aur/PKGBUILD
+
+      - name: Generate .SRCINFO + lint
+        run: |
+          set -euo pipefail
+          # makepkg refuses to run as root, and the container has no other user.
+          # `--printsrcinfo` only parses the PKGBUILD, so no dependency is installed.
+          useradd -m builder
+          chown -R builder aur
+          su builder -c 'cd aur && makepkg --printsrcinfo > .SRCINFO'
+          namcap aur/PKGBUILD
+          cat aur/.SRCINFO
+
+      - name: Push to the AUR
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${AUR_SSH_PRIVATE_KEY:-}" ]; then
+            echo "AUR_SSH_PRIVATE_KEY not set — skipping the AUR push." >&2
+            exit 0
+          fi
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          # Pin the host key rather than disabling verification: this pushes signed
+          # package metadata, so a MITM here would ship arbitrary build steps.
+          ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/aur -o IdentitiesOnly=yes"
+
+          git clone ssh://aur@aur.archlinux.org/funput.git aur-repo
+          cp aur/PKGBUILD aur/.SRCINFO aur-repo/
+          cd aur-repo
+          # The AUR rejects a push whose .SRCINFO disagrees with the PKGBUILD, so
+          # the two are always committed together.
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add PKGBUILD .SRCINFO
+          git commit -m "funput ${VERSION}" || { echo "Already at ${VERSION}."; exit 0; }
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,9 @@ jobs:
       # Create the release as a DRAFT with all assets attached. This repo has
       # "immutable releases" enabled: a published release rejects asset uploads, so
       # we must attach everything while it is still a mutable draft, then publish.
+      # `out/*.tar.gz` are the portable Linux trees behind `install.sh --user`.
+      # They were built but never attached, so the no-sudo path could not resolve
+      # one and always died on "no matching asset".
       - uses: softprops/action-gh-release@v2
         with:
           files: |
@@ -135,6 +138,7 @@ jobs:
             out/*.zip
             out/*.deb
             out/*.rpm
+            out/*.tar.gz
             out/appcast.xml
             out/*.json
           body_path: notes.md

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -89,6 +89,23 @@ that is the part worth keeping: the Settings app rewrites `settings.json` from i
 struct, so a copy older than the addon deletes settings the addon has since learned.
 The package manager now refuses the mismatch that used to cause it.
 
+## Distribution
+
+Four channels, all fed by the same release:
+
+- **`repo.funput.app`** — signed apt + dnf/zypper repositories on GitHub Pages, built
+  by `.github/workflows/publish-repo.yml`. The only channel with automatic upgrades,
+  and what `install.sh` now configures by default. See `packaging/repo/README.md`.
+- **GitHub Releases** — the `.deb`/`.rpm` themselves, plus the portable `.tar.gz`
+  trees behind `install.sh --user`.
+- **`install.sh`** — detect-then-configure front end over the two above.
+- **AUR** — `packaging/aur/PKGBUILD.in`, pushed to `ssh://aur@aur.archlinux.org/funput.git`
+  by `.github/workflows/publish-aur.yml`. One `pkgbase` yielding the same three
+  packages, built from the release tag's source rather than repackaged binaries.
+  The recipe is only rendered and linted at release time; `ci.yml` runs a real
+  `makepkg` on pull requests that touch it, since a full Rust + GTK4 build in an
+  Arch container is far too slow to repeat per release.
+
 ## Tests
 
 `common/` is buildable and testable on its own, with **neither Fcitx5 nor IBus

--- a/platforms/linux/install.sh
+++ b/platforms/linux/install.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
-# Funput Linux installer: detect the distro + arch, pick the matching package from
-# the latest GitHub release, and install it with the native package manager.
+# Funput Linux installer: detect the distro + arch and install with the native
+# package manager.
 #
-# This is the "one command, auto-detect" front end over GitHub Releases — there is
-# no hosted apt/dnf repo yet, so it downloads a versioned asset and installs it
-# (no automatic upgrades; re-run this script to update). Apt and dnf are different
-# repo formats, so a single repo can never serve every distro — only this kind of
-# detect-then-fetch script gives the unified experience.
+# By default it adds the signed Funput repository (repo.funput.app) and installs
+# from it, so `apt/dnf/zypper upgrade` picks up later releases like any other
+# system package. Apt and rpm are different repo formats, so a single repo can
+# never serve every distro — only this kind of detect-then-configure script gives
+# the unified experience.
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/Funput/Funput/main/platforms/linux/install.sh | bash
-#   ./install.sh [--ibus | --fcitx5] [--version vX.Y.Z]
+#   ./install.sh [--ibus | --fcitx5] [--no-repo] [--version vX.Y.Z]
+#
+# --no-repo: skip the repository and install a versioned asset straight from
+# GitHub Releases instead. No automatic upgrades — re-run to update. Implied by
+# --version, because the repository only ever carries the newest release.
 #
 # No-sudo (user-local): install the engine into ~/.local — no root, no package
 # manager. Needs an already-installed IBus or Fcitx5 daemon. IBus works right
@@ -23,9 +27,11 @@
 set -euo pipefail
 
 REPO="Funput/Funput"
+REPO_URL="https://repo.funput.app"   # the signed apt/dnf/zypper repository
 FRAMEWORK=""        # "ibus" | "fcitx5"; empty = auto-detect
 VERSION="latest"    # "latest" or a tag like v1.2026.1
 USER_INSTALL=0      # 1 = no-sudo, user-local install into ~/.local (IBus only)
+USE_REPO=1          # 0 = --no-repo: fetch a release asset instead
 
 die() { echo "Error: $*" >&2; exit 1; }
 have() { command -v "$1" >/dev/null 2>&1; }
@@ -222,12 +228,83 @@ user_install_fcitx5() {
   echo "To update later: re-run this installer (grabs the latest release)."
 }
 
+# What to do once the package is on disk. Shared by the repository path and the
+# --no-repo one, which install the same package by different routes.
+post_install_hint() {
+  echo
+  echo "Installed. Next steps:"
+  if [ "$FRAMEWORK" = "ibus" ]; then
+    echo "  1. ibus restart            # load the newly registered engine"
+    echo "  2. Settings → Keyboard → Input Sources → + → Vietnamese → Funput"
+  else
+    echo "  1. fcitx5-configtool       # + → add Funput (Vietnamese group)"
+    echo "  2. log out/in if Fcitx5 was not already running"
+  fi
+  echo "  Open \"Funput\" from the app menu to switch Telex/VNI."
+  if [ "$USE_REPO" -eq 0 ]; then
+    echo
+    echo "Installed from a release asset, so this will not upgrade itself."
+    echo "For automatic updates, re-run without --version/--no-repo to add ${REPO_URL}."
+  fi
+}
+
+# --- The signed repository (the default path) ------------------------------
+# Adding the repo instead of dropping a downloaded package in is what buys the
+# user automatic upgrades; every other path here has to be re-run by hand. The
+# packages it serves are GPG-signed, so none of these needs an
+# unsigned-package escape hatch.
+
+# Debian/Ubuntu. The deb822 `.sources` format, not a one-line `.list`: apt 3.0
+# (Debian 13, Ubuntu 25.04) deprecates the latter and says so on every run. A flat
+# repository is spelled `Suites: ./` with no Components.
+repo_add_debian() {
+  local keyring="/usr/share/keyrings/funput.asc"
+  echo "Adding ${REPO_URL} (apt)…"
+  $SUDO install -d /usr/share/keyrings
+  curl -fsSL "${REPO_URL}/funput.asc" | $SUDO tee "$keyring" >/dev/null
+  printf 'Types: deb\nURIs: %s/deb\nSuites: ./\nSigned-By: %s\n' \
+    "$REPO_URL" "$keyring" | $SUDO tee /etc/apt/sources.list.d/funput.sources >/dev/null
+  $SUDO apt-get update
+}
+
+# Fedora/RHEL. Written straight into /etc/yum.repos.d rather than through
+# `dnf config-manager --add-repo`, which dnf5 (Fedora 41+) removed; a plain file
+# drop works on both dnf4 and dnf5. The key is not imported here — funput.repo
+# carries `gpgkey=` and dnf fetches it on first install.
+repo_add_fedora() {
+  echo "Adding ${REPO_URL} (dnf)…"
+  curl -fsSL "${REPO_URL}/funput.repo" | $SUDO tee /etc/yum.repos.d/funput.repo >/dev/null
+}
+
+# openSUSE. zypper wants the key in the rpm database up front, unlike dnf.
+repo_add_suse() {
+  echo "Adding ${REPO_URL} (zypper)…"
+  $SUDO rpm --import "${REPO_URL}/funput.asc"
+  $SUDO zypper --non-interactive addrepo -gf "${REPO_URL}/rpm/" funput
+  $SUDO zypper --non-interactive refresh
+}
+
+# Install (or upgrade to) the package for the chosen framework from the repo.
+repo_install() {
+  local pkg="funput"
+  [ "$FRAMEWORK" = "ibus" ] && pkg="funput-ibus"
+  echo "Installing ${pkg} from ${REPO_URL}…"
+  case "$FAMILY" in
+    debian) $SUDO apt-get install -y "$pkg" ;;
+    fedora) $SUDO dnf install -y "$pkg" ;;
+    suse)   $SUDO zypper --non-interactive install "$pkg" ;;
+  esac
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --ibus)    FRAMEWORK="ibus" ;;
     --fcitx5)  FRAMEWORK="fcitx5" ;;
     --user)    USER_INSTALL=1 ;;
-    --version) shift; VERSION="${1:?--version needs a tag}" ;;
+    --no-repo) USE_REPO=0 ;;
+    # Pinning a version means leaving the repository behind: it is rebuilt from
+    # the current release each time and serves nothing else.
+    --version) shift; VERSION="${1:?--version needs a tag}"; USE_REPO=0 ;;
     -h|--help)
       # Print the usage header (everything between line 2 and `set -euo …`).
       sed -n '2,/^set -euo/p' "$0" | sed -e '/^set -euo/d' -e 's/^# \{0,1\}//'
@@ -263,19 +340,42 @@ case " ${ID:-} ${ID_LIKE:-} " in
   *) die "unsupported distro (ID=${ID:-?}, ID_LIKE=${ID_LIKE:-?}). Build from source: platforms/linux/build.sh" ;;
 esac
 
-# Arch is community-packaged via the AUR, not a release asset.
+SUDO=""
+[ "$(id -u)" -eq 0 ] || SUDO="sudo"
+
+# Arch is community-packaged via the AUR (one pkgbase, three packages), which is
+# neither a release asset nor part of repo.funput.app — so there is nothing for
+# this script to install and it hands the user over rather than failing.
 if [ "$FAMILY" = "arch" ]; then
-  cat >&2 <<'EOF'
+  cat <<'EOF'
 Arch Linux is packaged through the AUR, not the GitHub release assets.
 Install with an AUR helper, e.g.:
   yay -S funput-ibus     # IBus (GNOME)
   yay -S funput          # Fcitx5 (KDE / full features)
+
+No AUR helper, or no sudo? The user-local install works here too:
+  ./install.sh --user    # into ~/.local, needs an IBus or Fcitx5 daemon already
 EOF
-  exit 1
+  exit 0
 fi
 
 # --- Framework -------------------------------------------------------------
 detect_framework
+
+# --- Repository path (the default) -----------------------------------------
+# Everything below this block is the --no-repo fallback: one versioned asset,
+# updated only by re-running the script.
+if [ "$USE_REPO" -eq 1 ]; then
+  have curl || die "curl is required"
+  case "$FAMILY" in
+    debian) repo_add_debian ;;
+    fedora) repo_add_fedora ;;
+    suse)   repo_add_suse ;;
+  esac
+  repo_install
+  post_install_hint
+  exit 0
+fi
 
 # --- Arch + package-name pattern -------------------------------------------
 # .deb uses amd64/arm64; .rpm uses x86_64/aarch64. The CPack file names are:
@@ -322,8 +422,6 @@ FILE="$TMP/$(basename "$URL")"
 download "$URL" "$FILE"
 
 # --- Install ---------------------------------------------------------------
-SUDO=""
-[ "$(id -u)" -eq 0 ] || SUDO="sudo"
 echo "Installing $(basename "$FILE")…"
 case "$FAMILY" in
   debian) $SUDO apt-get install -y "$FILE" ;;
@@ -331,14 +429,4 @@ case "$FAMILY" in
   suse)   $SUDO zypper --non-interactive install --allow-unsigned-rpm "$FILE" ;;
 esac
 
-# --- Post-install hint -----------------------------------------------------
-echo
-echo "Installed. Next steps:"
-if [ "$FRAMEWORK" = "ibus" ]; then
-  echo "  1. ibus restart            # load the newly registered engine"
-  echo "  2. Settings → Keyboard → Input Sources → + → Vietnamese → Funput"
-else
-  echo "  1. fcitx5-configtool       # + → add Funput (Vietnamese group)"
-  echo "  2. log out/in if Fcitx5 was not already running"
-fi
-echo "  Open \"Funput\" from the app menu to switch Telex/VNI."
+post_install_hint

--- a/platforms/linux/packaging/aur/PKGBUILD.in
+++ b/platforms/linux/packaging/aur/PKGBUILD.in
@@ -1,0 +1,119 @@
+# Maintainer: Funput <hello@funput.app>
+#
+# Template, not a working PKGBUILD: @VERSION@ and @SHA256@ are substituted by
+# .github/workflows/publish-aur.yml, which then pushes the rendered file plus a
+# regenerated .SRCINFO to ssh://aur@aur.archlinux.org/funput.git.
+#
+# One pkgbase, three packages — the same split the .deb and .rpm builds produce
+# (see platforms/linux/README.md). Splitting the Settings app out is what lets the
+# Fcitx5 and IBus packages be installed side by side: they used to ship a copy of
+# its binary, icons and .desktop files each, which no package manager will unpack
+# twice.
+pkgbase=funput
+pkgname=(funput funput-ibus funput-settings)
+pkgver=@VERSION@
+pkgrel=1
+pkgdesc="Vietnamese input method (Telex, Full Telex & VNI)"
+arch=('x86_64' 'aarch64')
+url="https://github.com/Funput/Funput"
+license=('MIT')
+# Arch does not split -devel packages: fcitx5 and ibus ship their own headers, so
+# they appear here and again in the runtime depends of the shell that needs them.
+# nlohmann-json is header-only and never becomes a runtime dependency.
+makedepends=('cargo' 'cmake' 'nlohmann-json' 'fcitx5' 'ibus' 'glib2'
+             'gtk4' 'libadwaita' 'librsvg')
+source=("$pkgbase-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('@SHA256@')
+# No debug package. makepkg's default `debug` writes one set of .build-id symlinks
+# for the whole pkgbase, but the binaries they name are split across the three
+# packages, so every symlink in it dangles and namcap fails the result. Nothing
+# here ships debug symbols anyway.
+options=('!debug')
+
+# The GitHub tarball unpacks to Funput-<pkgver>/, which is the Cargo workspace root
+# and holds platforms/ directly. (A local checkout nests the same tree under app/;
+# that directory is the git root, so it does not appear in the archive.)
+_srcdir="Funput-$pkgver"
+
+prepare() {
+  # Two independent lockfiles: the workspace (which owns funput-ffi) and the GTK
+  # Settings crate, excluded from that workspace so macOS/Windows
+  # `cargo test --workspace` stays green. Both must be fetched here so build() can
+  # run with the network off, the way a clean chroot expects.
+  cd "$_srcdir"
+  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+  cd platforms/linux/settings-gtk
+  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+}
+
+build() {
+  cd "$_srcdir"
+  # rust-toolchain.toml pins 1.97.1 so contributors and CI share one compiler. On
+  # a rustup host that pin would try to download the toolchain inside the chroot;
+  # Arch ships a single rolling stable, so use it.
+  export RUSTUP_TOOLCHAIN=stable
+  export CARGO_NET_OFFLINE=true
+  # CARGO_TARGET_DIR is deliberately left unset. common/CMakeLists.txt reads the
+  # cdylib from <workspace>/target/release/libfunput_ffi.so and
+  # settings-gtk/CMakeLists.txt reads the GUI from
+  # settings-gtk/target/release/funput-settings; both paths are hardcoded, so
+  # redirecting the target dir hides the artifacts from CMake.
+  cargo build --release --frozen \
+    --manifest-path platforms/linux/settings-gtk/Cargo.toml
+
+  # Each project is its own top-level CMake build (the two shells package
+  # independently, and settings-gtk only installs the binary cargo just built).
+  # Both shells build the Rust cdylib through common/, so cargo runs again here
+  # and hits its own cache. Separate build dirs, the same shape as build.sh.
+  #
+  # CMAKE_BUILD_TYPE=None keeps makepkg's CFLAGS/LDFLAGS instead of CMake's own
+  # optimisation set. CMAKE_INSTALL_PREFIX is passed explicitly because the shells
+  # force /usr only while the prefix still holds its default, and settings-gtk
+  # never forces it at all.
+  #
+  # CMAKE_INSTALL_LIBEXECDIR=lib is not cosmetic. The IBus project asks pkg-config
+  # for ibus-1.0's libexecdir, and on Arch that variable is empty, so CMake falls
+  # back to GNUInstallDirs' /usr/libexec — while Arch's own ibus keeps its engines
+  # in /usr/lib/ibus and namcap rejects /usr/libexec outright.
+  local proj
+  for proj in fcitx5 ibus settings-gtk; do
+    cmake -S "platforms/linux/$proj" -B "build/$proj" \
+      -DCMAKE_BUILD_TYPE=None \
+      -DCMAKE_INSTALL_PREFIX=/usr \
+      -DCMAKE_INSTALL_LIBEXECDIR=lib \
+      -DFUNPUT_VERSION="$pkgver"
+    cmake --build "build/$proj"
+  done
+}
+
+package_funput() {
+  pkgdesc="Vietnamese input method (Telex, Full Telex & VNI) — Fcitx5 addon"
+  # glibc/gcc-libs are what namcap detects from the ELF files; fcitx5 is the host
+  # that dlopens the addon. funput-settings is pinned to the exact version, not
+  # merely required: the Settings app rewrites settings.json by serializing its
+  # whole struct, so a copy older than this addon deletes any key the addon has
+  # learned since. The .deb and .rpm carry the same pin.
+  depends=('glibc' 'gcc-libs' 'fcitx5' "funput-settings=$pkgver-$pkgrel")
+  cd "$_srcdir"
+  DESTDIR="$pkgdir" cmake --install build/fcitx5
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+
+package_funput-ibus() {
+  pkgdesc="Vietnamese input method (Telex, Full Telex & VNI) — IBus engine"
+  depends=('glibc' 'gcc-libs' 'glib2' 'ibus' "funput-settings=$pkgver-$pkgrel")
+  cd "$_srcdir"
+  DESTDIR="$pkgdir" cmake --install build/ibus
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+
+package_funput-settings() {
+  pkgdesc="Vietnamese input method (Telex, Full Telex & VNI) — Settings app"
+  # hicolor-icon-theme owns the theme hierarchy the icons below install into.
+  # librsvg is deliberately absent: namcap finds nothing linking it, and the 512px
+  # PNG shipped beside the SVG covers any renderer that cannot read the SVG.
+  depends=('glibc' 'gcc-libs' 'glib2' 'gtk4' 'libadwaita' 'hicolor-icon-theme')
+  cd "$_srcdir"
+  DESTDIR="$pkgdir" cmake --install build/settings-gtk
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/platforms/linux/packaging/repo/index.html.in
+++ b/platforms/linux/packaging/repo/index.html.in
@@ -125,7 +125,12 @@
     <div class="step">1 · Thêm kho (làm một lần)</div>
     <div class="cmd"><button class="copy">Copy</button><pre><code>sudo install -d /usr/share/keyrings
 curl -fsSL @REPO_URL@funput.asc | sudo tee /usr/share/keyrings/funput.asc >/dev/null
-echo "deb [signed-by=/usr/share/keyrings/funput.asc] @REPO_URL@deb ./" | sudo tee /etc/apt/sources.list.d/funput.list
+sudo tee /etc/apt/sources.list.d/funput.sources >/dev/null &lt;&lt;'EOF'
+Types: deb
+URIs: @REPO_URL@deb
+Suites: ./
+Signed-By: /usr/share/keyrings/funput.asc
+EOF
 sudo apt update</code></pre></div>
 
     <div class="step">2 · Cài đặt</div>
@@ -146,7 +151,7 @@ sudo apt update</code></pre></div>
     <h2>🎩 Fedora <small style="color:var(--muted);font-weight:400;font-size:.9rem">(.rpm)</small></h2>
 
     <div class="step">1 · Thêm kho (làm một lần)</div>
-    <div class="cmd"><button class="copy">Copy</button><pre><code>sudo dnf config-manager --add-repo @REPO_URL@funput.repo</code></pre></div>
+    <div class="cmd"><button class="copy">Copy</button><pre><code>sudo curl -fsSL @REPO_URL@funput.repo -o /etc/yum.repos.d/funput.repo</code></pre></div>
 
     <div class="step">2 · Cài đặt</div>
     <div class="grid">


### PR DESCRIPTION
Three gaps in how Funput reaches Linux users, plus a one-line release bug found on the way.

## 1. AUR was a promise with nothing behind it

`install.sh` and the docs told Arch users to run `yay -S funput`, but no `PKGBUILD` existed anywhere in the tree and nothing published one — so the script's `exit 1` led straight to a dead end.

- `platforms/linux/packaging/aur/PKGBUILD.in` — one `pkgbase` yielding the same three packages the `.deb`/`.rpm` builds produce (`funput`, `funput-ibus`, `funput-settings`), built from the release tag's source, carrying the same exact-version pin on `funput-settings`.
- `.github/workflows/publish-aur.yml` — renders it, regenerates `.SRCINFO`, pushes to `ssh://aur@aur.archlinux.org/funput.git` on each full release. It follows `publish-repo.yml` rather than the homebrew/scoop dispatch pattern, because the template lives in this repo: no PAT and no dispatch job in `release.yml`. Soft-skips when the secret is unset.
- `ci.yml` — a real `makepkg` is far too slow to repeat per release, so it runs only on pull requests that touch the recipe, behind a cheap path-check job so unrelated PRs never pull the Arch image.

**Three bugs a real `makepkg` run caught that static review would not have:**

| | |
|---|---|
| `_srcdir` | The GitHub tarball has no `app/` level — that directory is the git root, so it never appears in the archive. The recipe died on its first `cd`. |
| ibus path | `pkg-config --variable=libexecdir ibus-1.0` is **empty** on Arch, so CMake fell back to `/usr/libexec` while Arch's ibus keeps engines in `/usr/lib/ibus`. Fixed with `-DCMAKE_INSTALL_LIBEXECDIR=lib`. |
| depends | namcap wanted `glibc`, `gcc-libs`, `glib2`, `hicolor-icon-theme` — and not `librsvg`. |

Plus `options=('!debug')`: one set of `.build-id` symlinks for a pkgbase whose binaries are split across three packages dangles in all of them.

## 2. The Fedora instructions were dead

`dnf config-manager --add-repo <url>` was removed in dnf5 (Fedora 41+). Dropping the `.repo` file in with `curl` works on both dnf4 and dnf5. The apt path moves to deb822 `.sources` at the same time, since apt 3.0 deprecates the one-line `.list` form.

## 3. `install.sh` was the only channel without automatic updates

…while its header still claimed no hosted repo existed. It now adds `repo.funput.app` by default and installs from it; `--no-repo` keeps the old release-asset path, and `--version` implies it because the repository only carries the newest release. The Arch branch hands over to the AUR instead of failing.

## 4. `install.sh --user` had never worked

`release.yml` never attached `out/*.tar.gz`, so the no-sudo path could not resolve its tarball and always died on `no matching asset`. One line.

## Verification

Run with Docker against the live repository:

- **AUR** — full `makepkg -s` builds all three packages; contents split with **no file overlap**, and `namcap` reports **no errors** on any of the three.
- **Fedora** — `install.sh` end to end on dnf5: `.repo` dropped in, GPG key auto-imported, `funput-ibus` + `funput-settings` installed at matching versions.
- **openSUSE** — `install.sh` end to end on Tumbleweed: repository added with GPG check, `funput` (Fcitx5) + `funput-settings` installed at matching versions.
- **Debian** — apt accepts the deb822 file and resolves all three packages from `repo.funput.app`. Full install not reachable here: `deb.debian.org` is unreachable from this network, so the dependencies cannot be fetched.

## Needs before merge

An AUR account owning the `funput` pkgbase, and the `AUR_SSH_PRIVATE_KEY` secret. Until it is set, `publish-aur.yml` is a green no-op.

Docs are a separate repo — paired PR: Funput/Docs#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

