### PR TITLE
feat(linux): serve Arch from repo.funput.app as a pacman repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,20 +259,26 @@ jobs:
           VERSION="${TAG#v}"
           URL="https://github.com/${{ github.repository }}/archive/refs/tags/${TAG}.tar.gz"
           SHA="$(curl -fsSL "$URL" | sha256sum | cut -d' ' -f1)"
-          mkdir -p aur
-          # pkgrel 1: the AUR compiles on the user's machine, so a rebuild without a
-          # new pkgver has nothing to fix.
-          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" -e "s/@PKGREL@/1/g" \
-            platforms/linux/packaging/aur/PKGBUILD.in > aur/PKGBUILD
-
-      - name: makepkg
-        run: |
-          set -euo pipefail
           # makepkg refuses to run as root, and `-s` shells out to pacman for the
           # declared makedepends — so the build user needs passwordless sudo.
           useradd -m builder
           echo 'builder ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/builder
-          chown -R builder aur
-          su builder -c 'cd aur && makepkg -s --noconfirm'
-          namcap aur/*.pkg.tar.zst
-          ls -l aur/*.pkg.tar.zst
+
+          # Build in the build user's home, NOT inside the checkout. makepkg unpacks
+          # the source under its build dir, and settings-gtk is a crate excluded from
+          # the root Cargo workspace by path — an unpacked copy nested under the
+          # repo's own Cargo.toml is not covered by that exclude, so cargo refuses it
+          # with "believes it's in a workspace when it's not".
+          install -d -o builder /home/builder/build
+          # pkgrel 1: the AUR compiles on the user's machine, so a rebuild without a
+          # new pkgver has nothing to fix.
+          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" -e "s/@PKGREL@/1/g" \
+            platforms/linux/packaging/aur/PKGBUILD.in > /home/builder/build/PKGBUILD
+          chown builder /home/builder/build/PKGBUILD
+
+      - name: makepkg
+        run: |
+          set -euo pipefail
+          su builder -c 'cd ~/build && makepkg -s --noconfirm'
+          namcap /home/builder/build/*.pkg.tar.zst
+          ls -l /home/builder/build/*.pkg.tar.zst

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,9 @@ jobs:
           URL="https://github.com/${{ github.repository }}/archive/refs/tags/${TAG}.tar.gz"
           SHA="$(curl -fsSL "$URL" | sha256sum | cut -d' ' -f1)"
           mkdir -p aur
-          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" \
+          # pkgrel 1: the AUR compiles on the user's machine, so a rebuild without a
+          # new pkgver has nothing to fix.
+          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" -e "s/@PKGREL@/1/g" \
             platforms/linux/packaging/aur/PKGBUILD.in > aur/PKGBUILD
 
       - name: makepkg

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -66,7 +66,9 @@ jobs:
           SHA="$(curl -fsSL "$URL" | sha256sum | cut -d' ' -f1)"
 
           mkdir -p aur
-          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" \
+          # pkgrel 1: the AUR compiles on the user's machine, so a rebuild without a
+          # new pkgver has nothing to fix.
+          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" -e "s/@PKGREL@/1/g" \
             platforms/linux/packaging/aur/PKGBUILD.in > aur/PKGBUILD
           echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
           cat aur/PKGBUILD

--- a/.github/workflows/publish-repo.yml
+++ b/.github/workflows/publish-repo.yml
@@ -13,6 +13,17 @@ name: Publish package repo
 on:
   release:
     types: [released]   # fires only for full (non-prerelease) releases
+  # Weekly, for the pacman repo alone. Its packages are binaries on a rolling
+  # distro: they link the Arch libraries of the build day, so an soname bump in
+  # fcitx5, ibus or gtk4 breaks them until something rebuilds. Arch's fcitx5 and
+  # ibus packages declare no soname `provides`, so a dependency cannot express
+  # that constraint and pacman cannot warn — rebuilding on a schedule is the only
+  # thing that actually repairs it, within a week rather than at the next release.
+  #
+  # The run is stateless and rebuilds every tree from the current release, so the
+  # apt and rpm halves simply re-publish what they already had.
+  schedule:
+    - cron: "0 3 * * 1"   # Mondays, 03:00 UTC
   workflow_dispatch: {}
 
 permissions:
@@ -177,7 +188,13 @@ jobs:
           mkdir -p build
           # The same template the AUR would consume, so the two channels can never
           # describe different packages.
-          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" \
+          # pkgrel is the build date, not 1. These are binaries, and the scheduled
+          # rebuild below produces the same pkgver every time — pacman only offers
+          # an upgrade when pkgver-pkgrel moves, so the date is what makes a rebuild
+          # reach users. All three packages share this run's value, which keeps the
+          # exact-version dependency between them satisfiable.
+          PKGREL="$(date -u +%Y%m%d)"
+          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" -e "s/@PKGREL@/${PKGREL}/g" \
             platforms/linux/packaging/aur/PKGBUILD.in > build/PKGBUILD
           # makepkg refuses to run as root, and `-s` shells out to pacman for the
           # declared makedepends, so the build user needs passwordless sudo.

--- a/.github/workflows/publish-repo.yml
+++ b/.github/workflows/publish-repo.yml
@@ -13,17 +13,20 @@ name: Publish package repo
 on:
   release:
     types: [released]   # fires only for full (non-prerelease) releases
-  # Weekly, for the pacman repo alone. Its packages are binaries on a rolling
+  # Fortnightly, for the pacman repo alone. Its packages are binaries on a rolling
   # distro: they link the Arch libraries of the build day, so an soname bump in
   # fcitx5, ibus or gtk4 breaks them until something rebuilds. Arch's fcitx5 and
   # ibus packages declare no soname `provides`, so a dependency cannot express
   # that constraint and pacman cannot warn — rebuilding on a schedule is the only
-  # thing that actually repairs it, within a week rather than at the next release.
+  # thing that actually repairs it, in about two weeks rather than at the next
+  # release.
   #
   # The run is stateless and rebuilds every tree from the current release, so the
   # apt and rpm halves simply re-publish what they already had.
+  # cron has no "every two weeks", so this is the 1st and 15th: gaps of 14-17 days
+  # rather than exactly 14, which is close enough for what it guards against.
   schedule:
-    - cron: "0 3 * * 1"   # Mondays, 03:00 UTC
+    - cron: "0 3 1,15 * *"   # 1st and 15th, 03:00 UTC
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/publish-repo.yml
+++ b/.github/workflows/publish-repo.yml
@@ -188,25 +188,33 @@ jobs:
           VERSION="${TAG#v}"
           URL="https://github.com/$GH_REPO/archive/refs/tags/${TAG}.tar.gz"
           SHA="$(curl -fsSL "$URL" | sha256sum | cut -d' ' -f1)"
-          mkdir -p build
-          # The same template the AUR would consume, so the two channels can never
-          # describe different packages.
-          # pkgrel is the build date, not 1. These are binaries, and the scheduled
-          # rebuild below produces the same pkgver every time — pacman only offers
-          # an upgrade when pkgver-pkgrel moves, so the date is what makes a rebuild
-          # reach users. All three packages share this run's value, which keeps the
-          # exact-version dependency between them satisfiable.
-          PKGREL="$(date -u +%Y%m%d)"
-          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" -e "s/@PKGREL@/${PKGREL}/g" \
-            platforms/linux/packaging/aur/PKGBUILD.in > build/PKGBUILD
           # makepkg refuses to run as root, and `-s` shells out to pacman for the
           # declared makedepends, so the build user needs passwordless sudo.
           useradd -m builder
           echo 'builder ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/builder
-          chown -R builder build
-          su builder -c 'cd build && makepkg -s --noconfirm'
+
+          # Build in the build user's home, NOT inside the checkout. makepkg unpacks
+          # the source under its build dir, and settings-gtk is a crate excluded from
+          # the root Cargo workspace by path — an unpacked copy nested under the
+          # repo's own Cargo.toml is not covered by that exclude, so cargo refuses it
+          # with "believes it's in a workspace when it's not".
+          install -d -o builder /home/builder/build
+
+          # The same template the AUR would consume, so the two channels can never
+          # describe different packages.
+          # pkgrel is the build date, not 1. These are binaries, and the scheduled
+          # rebuild produces the same pkgver every time — pacman only offers an
+          # upgrade when pkgver-pkgrel moves, so the date is what makes a rebuild
+          # reach users. All three packages share this run's value, which keeps the
+          # exact-version dependency between them satisfiable.
+          PKGREL="$(date -u +%Y%m%d)"
+          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" -e "s/@PKGREL@/${PKGREL}/g" \
+            platforms/linux/packaging/aur/PKGBUILD.in > /home/builder/build/PKGBUILD
+          chown builder /home/builder/build/PKGBUILD
+
+          su builder -c 'cd ~/build && makepkg -s --noconfirm'
           echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
-          ls -l build/*.pkg.tar.zst
+          ls -l /home/builder/build/*.pkg.tar.zst
 
       - name: Import GPG key
         env:
@@ -224,7 +232,7 @@ jobs:
           printf '%s' "$GPG_PASSPHRASE" > "$HOME/.gpg-pass"
 
           mkdir -p tree/arch/x86_64
-          cp build/*.pkg.tar.zst tree/arch/x86_64/
+          cp /home/builder/build/*.pkg.tar.zst tree/arch/x86_64/
 
           sign() {
             gpg --batch --yes --pinentry-mode loopback --passphrase-file "$HOME/.gpg-pass" \

--- a/.github/workflows/publish-repo.yml
+++ b/.github/workflows/publish-repo.yml
@@ -142,9 +142,108 @@ jobs:
           name: rpm-tree
           path: tree/rpm
 
+  # ---- pacman repo: signed packages + signed database ------------------------
+  # Arch is the one distro with no package in the release assets: it is a rolling
+  # source distro, so the .deb/.rpm builds have nothing to offer it. The AUR is the
+  # conventional answer and the recipe for it lives in packaging/aur/ — but an AUR
+  # upload needs an AUR account, so this serves the same three packages as a binary
+  # pacman repo under the same domain and the same GPG key.
+  #
+  # The trade-off is inherent and worth knowing: these are binaries linked against
+  # the Arch libraries of the build day, on a distro that moves continuously. A
+  # soname bump in fcitx5, ibus or gtk4 breaks them until the next release rebuilds.
+  #
+  # x86_64 only — Arch officially supports no other architecture (Arch Linux ARM is
+  # a separate distribution with its own repositories).
+  pacman:
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    steps:
+      - name: Install tools
+        run: pacman -Syu --noconfirm --needed git jq curl
+
+      - uses: actions/checkout@v5
+
+      - name: Build the packages from the AUR recipe
+        env:
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          [ -n "$TAG" ] || TAG="$(curl -fsSL "https://api.github.com/repos/$GH_REPO/releases/latest" | jq -r .tag_name)"
+          VERSION="${TAG#v}"
+          URL="https://github.com/$GH_REPO/archive/refs/tags/${TAG}.tar.gz"
+          SHA="$(curl -fsSL "$URL" | sha256sum | cut -d' ' -f1)"
+          mkdir -p build
+          # The same template the AUR would consume, so the two channels can never
+          # describe different packages.
+          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" \
+            platforms/linux/packaging/aur/PKGBUILD.in > build/PKGBUILD
+          # makepkg refuses to run as root, and `-s` shells out to pacman for the
+          # declared makedepends, so the build user needs passwordless sudo.
+          useradd -m builder
+          echo 'builder ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/builder
+          chown -R builder build
+          su builder -c 'cd build && makepkg -s --noconfirm'
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          ls -l build/*.pkg.tar.zst
+
+      - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+      - name: Sign packages + build the database
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.gnupg" && chmod 700 "$HOME/.gnupg"
+          echo 'allow-loopback-pinentry' >> "$HOME/.gnupg/gpg-agent.conf"
+          gpgconf --kill gpg-agent || true
+          printf '%s' "$GPG_PASSPHRASE" > "$HOME/.gpg-pass"
+
+          mkdir -p tree/arch/x86_64
+          cp build/*.pkg.tar.zst tree/arch/x86_64/
+
+          sign() {
+            gpg --batch --yes --pinentry-mode loopback --passphrase-file "$HOME/.gpg-pass" \
+              --detach-sign --no-armor "$1"
+          }
+
+          # pacman verifies a detached .sig beside each package. Unlike apt and dnf,
+          # signing the database alone is not enough: SigLevel applies per package.
+          for f in tree/arch/x86_64/*.pkg.tar.zst; do sign "$f"; done
+
+          # repo-add picks up the .sig files and records them in the database. Its
+          # own --sign is not used: it shells out to gpg without a loopback
+          # pinentry, so it cannot take a passphrase in CI.
+          repo-add tree/arch/x86_64/funput.db.tar.gz tree/arch/x86_64/*.pkg.tar.zst
+
+          # repo-add leaves `funput.db` and `funput.files` as symlinks to the
+          # .tar.gz files. pacman fetches those names, and the Pages artifact does
+          # not carry symlinks, so materialise them as real files — then sign the
+          # names pacman actually downloads.
+          cd tree/arch/x86_64
+          for n in db files; do
+            rm -f "funput.$n"
+            cp "funput.$n.tar.gz" "funput.$n"
+          done
+          cd - >/dev/null
+          sign tree/arch/x86_64/funput.db
+          sign tree/arch/x86_64/funput.files
+
+          rm -f "$HOME/.gpg-pass"
+          ls -l tree/arch/x86_64
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: pacman-tree
+          path: tree/arch
+
   # ---- Assemble + deploy to Pages -------------------------------------------
   deploy:
-    needs: [apt, rpm]
+    needs: [apt, rpm, pacman]
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -156,6 +255,8 @@ jobs:
         with: { name: apt-tree, path: public/deb }
       - uses: actions/download-artifact@v5
         with: { name: rpm-tree, path: public/rpm }
+      - uses: actions/download-artifact@v5
+        with: { name: pacman-tree, path: public/arch }
 
       - name: Assemble site (index, .repo, public key)
         run: |

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -110,12 +110,18 @@ Four channels, all fed by the same release:
 Arch is served twice, deliberately. The `pacman` job in `publish-repo.yml` builds
 **the same `PKGBUILD.in`** into binaries under `arch/x86_64/`, so a user needs no AUR
 helper and no compiler — which is also the only channel available while AUR account
-registration is closed. What that costs is what binaries always cost on a rolling
-distro: the packages link the Arch libraries of the build day, so a soname bump in
-fcitx5, ibus or gtk4 breaks them until the next release rebuilds. The AUR path has no
-such problem because it compiles on the user's machine, which is why both exist rather
-than one replacing the other. Sharing the recipe is what keeps them describing the
-same packages.
+registration is closed. The AUR path compiles on the user's machine, which is why both
+exist rather than one replacing the other; sharing the recipe is what keeps them
+describing the same packages.
+
+What binaries cost on a rolling distro is that they link the libraries of the build day,
+so a soname bump in fcitx5, ibus or gtk4 breaks them. A dependency cannot express that
+constraint: Arch's `fcitx5` and `ibus` packages declare no soname `provides` at all
+(only gtk4, libadwaita and glib2 do), so pacman has nothing to check and cannot warn.
+The repair is therefore a schedule, not a dependency — `publish-repo.yml` also runs
+weekly, rebuilding the current release against current Arch, with `pkgrel` rendered as
+the build date so pacman sees an upgrade even though `pkgver` has not moved. That is
+what `@PKGREL@` in the template is for; the AUR renders it as `1`.
 
 ## Tests
 

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -118,9 +118,10 @@ What binaries cost on a rolling distro is that they link the libraries of the bu
 so a soname bump in fcitx5, ibus or gtk4 breaks them. A dependency cannot express that
 constraint: Arch's `fcitx5` and `ibus` packages declare no soname `provides` at all
 (only gtk4, libadwaita and glib2 do), so pacman has nothing to check and cannot warn.
-The repair is therefore a schedule, not a dependency — `publish-repo.yml` also runs
-weekly, rebuilding the current release against current Arch, with `pkgrel` rendered as
-the build date so pacman sees an upgrade even though `pkgver` has not moved. That is
+The repair is therefore a schedule, not a dependency — `publish-repo.yml` also runs on
+the 1st and 15th, rebuilding the current release against current Arch, with `pkgrel`
+rendered as the build date so pacman sees an upgrade even though `pkgver` has not
+moved. That is
 what `@PKGREL@` in the template is for; the AUR renders it as `1`.
 
 ## Tests

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -93,9 +93,10 @@ The package manager now refuses the mismatch that used to cause it.
 
 Four channels, all fed by the same release:
 
-- **`repo.funput.app`** — signed apt + dnf/zypper repositories on GitHub Pages, built
-  by `.github/workflows/publish-repo.yml`. The only channel with automatic upgrades,
-  and what `install.sh` now configures by default. See `packaging/repo/README.md`.
+- **`repo.funput.app`** — signed apt, dnf/zypper and pacman repositories on GitHub
+  Pages, built by `.github/workflows/publish-repo.yml`. The only channel with
+  automatic upgrades, and what `install.sh` configures by default. See
+  `packaging/repo/README.md`.
 - **GitHub Releases** — the `.deb`/`.rpm` themselves, plus the portable `.tar.gz`
   trees behind `install.sh --user`.
 - **`install.sh`** — detect-then-configure front end over the two above.
@@ -105,6 +106,16 @@ Four channels, all fed by the same release:
   The recipe is only rendered and linted at release time; `ci.yml` runs a real
   `makepkg` on pull requests that touch it, since a full Rust + GTK4 build in an
   Arch container is far too slow to repeat per release.
+
+Arch is served twice, deliberately. The `pacman` job in `publish-repo.yml` builds
+**the same `PKGBUILD.in`** into binaries under `arch/x86_64/`, so a user needs no AUR
+helper and no compiler — which is also the only channel available while AUR account
+registration is closed. What that costs is what binaries always cost on a rolling
+distro: the packages link the Arch libraries of the build day, so a soname bump in
+fcitx5, ibus or gtk4 breaks them until the next release rebuilds. The AUR path has no
+such problem because it compiles on the user's machine, which is why both exist rather
+than one replacing the other. Sharing the recipe is what keeps them describing the
+same packages.
 
 ## Tests
 

--- a/platforms/linux/install.sh
+++ b/platforms/linux/install.sh
@@ -14,7 +14,8 @@
 #
 # --no-repo: skip the repository and install a versioned asset straight from
 # GitHub Releases instead. No automatic upgrades — re-run to update. Implied by
-# --version, because the repository only ever carries the newest release.
+# --version, because the repository only ever carries the newest release. Not
+# available on Arch, which has no release asset — use the repository or --user.
 #
 # No-sudo (user-local): install the engine into ~/.local — no root, no package
 # manager. Needs an already-installed IBus or Fcitx5 daemon. IBus works right
@@ -284,6 +285,30 @@ repo_add_suse() {
   $SUDO zypper --non-interactive refresh
 }
 
+# Arch. Two steps no other package manager needs: pacman keeps its own keyring,
+# so the key has to be imported and locally signed before any signature verifies,
+# and the repo section goes into pacman.conf itself rather than a drop-in file.
+# x86_64 only, which is all Arch officially supports.
+repo_add_arch() {
+  [ "$(uname -m)" = "x86_64" ] || die "the Funput pacman repo is x86_64 only (Arch Linux ARM is a separate distribution). Try --user."
+  echo "Adding ${REPO_URL} (pacman)…"
+  local tmp; tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' RETURN
+  curl -fsSL "${REPO_URL}/funput.asc" -o "$tmp/funput.asc"
+  $SUDO pacman-key --add "$tmp/funput.asc"
+  # Local signing is what promotes the key from "known" to "trusted"; without it
+  # pacman reports every package as signed by an unknown key.
+  $SUDO pacman-key --lsign-key hello@funput.app
+
+  # Appended, not written: pacman.conf is one file holding every repo, and the
+  # order of sections is the priority order. Skip if it is already there so
+  # re-running does not stack duplicate sections.
+  if ! grep -q '^\[funput\]' /etc/pacman.conf; then
+    printf '\n[funput]\nServer = %s/arch/$arch\n' "$REPO_URL" \
+      | $SUDO tee -a /etc/pacman.conf >/dev/null
+  fi
+  $SUDO pacman -Sy
+}
+
 # Install (or upgrade to) the package for the chosen framework from the repo.
 repo_install() {
   local pkg="funput"
@@ -293,6 +318,7 @@ repo_install() {
     debian) $SUDO apt-get install -y "$pkg" ;;
     fedora) $SUDO dnf install -y "$pkg" ;;
     suse)   $SUDO zypper --non-interactive install "$pkg" ;;
+    arch)   $SUDO pacman -S --noconfirm "$pkg" ;;
   esac
 }
 
@@ -343,21 +369,10 @@ esac
 SUDO=""
 [ "$(id -u)" -eq 0 ] || SUDO="sudo"
 
-# Arch is community-packaged via the AUR (one pkgbase, three packages), which is
-# neither a release asset nor part of repo.funput.app — so there is nothing for
-# this script to install and it hands the user over rather than failing.
-if [ "$FAMILY" = "arch" ]; then
-  cat <<'EOF'
-Arch Linux is packaged through the AUR, not the GitHub release assets.
-Install with an AUR helper, e.g.:
-  yay -S funput-ibus     # IBus (GNOME)
-  yay -S funput          # Fcitx5 (KDE / full features)
-
-No AUR helper, or no sudo? The user-local install works here too:
-  ./install.sh --user    # into ~/.local, needs an IBus or Fcitx5 daemon already
-EOF
-  exit 0
-fi
+# Arch has no release asset: it is a rolling source distro, so the .deb/.rpm
+# builds have nothing to offer it. What repo.funput.app serves instead is a
+# pacman repository of the same three packages, under the same key. Handled
+# entirely by repo_add_arch below, so it falls through with the others.
 
 # --- Framework -------------------------------------------------------------
 detect_framework
@@ -371,13 +386,20 @@ if [ "$USE_REPO" -eq 1 ]; then
     debian) repo_add_debian ;;
     fedora) repo_add_fedora ;;
     suse)   repo_add_suse ;;
+    arch)   repo_add_arch ;;
   esac
   repo_install
   post_install_hint
   exit 0
 fi
 
-# --- Arch + package-name pattern -------------------------------------------
+# Past this point every path resolves a release asset, and Arch has none — the
+# rpm branch below would otherwise pick up a Fedora package for it.
+if [ "$FAMILY" = "arch" ]; then
+  die "Arch has no release asset to install (--no-repo / --version cannot work here). Use the repository (re-run without those flags), or --user for a no-sudo install into ~/.local."
+fi
+
+# --- CPU arch + package-name pattern ---------------------------------------
 # .deb uses amd64/arm64; .rpm uses x86_64/aarch64. The CPack file names are:
 #   deb  funput_<v>_<arch>.deb        funput-ibus_<v>_<arch>.deb
 #   rpm  funput-<v>.<arch>.rpm        funput-ibus-<v>.<arch>.rpm

--- a/platforms/linux/packaging/aur/PKGBUILD.in
+++ b/platforms/linux/packaging/aur/PKGBUILD.in
@@ -12,7 +12,11 @@
 pkgbase=funput
 pkgname=(funput funput-ibus funput-settings)
 pkgver=@VERSION@
-pkgrel=1
+# @PKGREL@ is 1 for the AUR, where every install compiles against the machine's own
+# libraries. The pacman repo renders a build date instead: it ships binaries, so it
+# rebuilds on a schedule to follow Arch's libraries, and each rebuild has to look
+# like an upgrade to pacman even though pkgver has not moved.
+pkgrel=@PKGREL@
 pkgdesc="Vietnamese input method (Telex, Full Telex & VNI)"
 arch=('x86_64' 'aarch64')
 url="https://github.com/Funput/Funput"

--- a/platforms/linux/packaging/repo/README.md
+++ b/platforms/linux/packaging/repo/README.md
@@ -8,7 +8,8 @@
 Phân phối Phase 2: biến `.deb`/`.rpm` của bản release mới nhất — cộng gói Arch dựng tại
 chỗ — thành **kho apt + dnf + pacman có ký GPG**, host trên **GitHub Pages**, để người dùng `apt/dnf/zypper upgrade` thay vì
 tải lại tay. Build bởi [`.github/workflows/publish-repo.yml`](../../../../.github/workflows/publish-repo.yml),
-tự chạy mỗi khi có release chính thức (không phải prerelease).
+tự chạy mỗi khi có release chính thức (không phải prerelease), **và hàng tuần** (thứ Hai
+03:00 UTC) để dựng lại phần Arch — xem mục giới hạn bên dưới.
 
 > Đây là kho "bên thứ ba" (như Docker/VS Code): người dùng tin **khóa của bạn** và URL
 > Pages. Khác với kênh *official* của distro (OBS/COPR/PPA) — cái đó để Phase 3.
@@ -81,6 +82,9 @@ phiên bản mới nhất để chào upgrade, nên không cần giữ lịch s�
 - RPM ký gói + ký repomd; APT ký Release; pacman ký từng gói **và** `funput.db` (pacman áp
   `SigLevel` theo từng gói, nên ký mình database là không đủ).
 - Gói pacman là **binary trên distro rolling**: link vào thư viện Arch tại thời điểm dựng, nên
-  một đợt bump soname (fcitx5, ibus, gtk4) sẽ làm gãy cho tới bản release kế tiếp. Kênh AUR
-  (`packaging/aur/`) không dính vì build trên máy người dùng — hai kênh bổ sung cho nhau. Khóa hết hạn = `Expire-Date: 0` (vô hạn) để khỏi gãy
+  một đợt bump soname (fcitx5, ibus, gtk4) làm gãy gói. Không khai dependency để pacman cảnh
+  báo trước được: gói `fcitx5` và `ibus` của Arch **không khai soname `provides`** nào (chỉ
+  gtk4/libadwaita/glib2 có), nên ràng buộc đó không diễn đạt được. Cách vá duy nhất là **dựng
+  lại theo lịch** — cron hàng tuần ở trên, với `pkgrel` = ngày dựng để pacman coi đó là bản
+  nâng cấp dù `pkgver` không đổi. Kênh AUR không dính vì build trên máy người dùng. Khóa hết hạn = `Expire-Date: 0` (vô hạn) để khỏi gãy
   kho; nếu đặt hạn, nhớ gia hạn và chạy lại workflow trước khi hết hạn.

--- a/platforms/linux/packaging/repo/README.md
+++ b/platforms/linux/packaging/repo/README.md
@@ -8,7 +8,7 @@
 Phân phối Phase 2: biến `.deb`/`.rpm` của bản release mới nhất — cộng gói Arch dựng tại
 chỗ — thành **kho apt + dnf + pacman có ký GPG**, host trên **GitHub Pages**, để người dùng `apt/dnf/zypper upgrade` thay vì
 tải lại tay. Build bởi [`.github/workflows/publish-repo.yml`](../../../../.github/workflows/publish-repo.yml),
-tự chạy mỗi khi có release chính thức (không phải prerelease), **và hàng tuần** (thứ Hai
+tự chạy mỗi khi có release chính thức (không phải prerelease), **và hai tuần một lần** (ngày 1 và 15,
 03:00 UTC) để dựng lại phần Arch — xem mục giới hạn bên dưới.
 
 > Đây là kho "bên thứ ba" (như Docker/VS Code): người dùng tin **khóa của bạn** và URL
@@ -85,6 +85,6 @@ phiên bản mới nhất để chào upgrade, nên không cần giữ lịch s�
   một đợt bump soname (fcitx5, ibus, gtk4) làm gãy gói. Không khai dependency để pacman cảnh
   báo trước được: gói `fcitx5` và `ibus` của Arch **không khai soname `provides`** nào (chỉ
   gtk4/libadwaita/glib2 có), nên ràng buộc đó không diễn đạt được. Cách vá duy nhất là **dựng
-  lại theo lịch** — cron hàng tuần ở trên, với `pkgrel` = ngày dựng để pacman coi đó là bản
-  nâng cấp dù `pkgver` không đổi. Kênh AUR không dính vì build trên máy người dùng. Khóa hết hạn = `Expire-Date: 0` (vô hạn) để khỏi gãy
+  lại theo lịch** — cron hai tuần một lần ở trên, với `pkgrel` = ngày dựng để pacman coi đó
+  là bản nâng cấp dù `pkgver` không đổi. Kênh AUR không dính vì build trên máy người dùng. Khóa hết hạn = `Expire-Date: 0` (vô hạn) để khỏi gãy
   kho; nếu đặt hạn, nhớ gia hạn và chạy lại workflow trước khi hết hạn.

--- a/platforms/linux/packaging/repo/README.md
+++ b/platforms/linux/packaging/repo/README.md
@@ -5,8 +5,8 @@
 > mục cài đặt trong [`platforms/linux/README.md`](../../README.md). File này ghi cách
 > *dựng* và *bảo trì* kho (khóa GPG, secrets, Pages, DNS).
 
-Phân phối Phase 2: biến `.deb`/`.rpm` của bản release mới nhất thành **kho apt + dnf
-có ký GPG**, host trên **GitHub Pages**, để người dùng `apt/dnf/zypper upgrade` thay vì
+Phân phối Phase 2: biến `.deb`/`.rpm` của bản release mới nhất — cộng gói Arch dựng tại
+chỗ — thành **kho apt + dnf + pacman có ký GPG**, host trên **GitHub Pages**, để người dùng `apt/dnf/zypper upgrade` thay vì
 tải lại tay. Build bởi [`.github/workflows/publish-repo.yml`](../../../../.github/workflows/publish-repo.yml),
 tự chạy mỗi khi có release chính thức (không phải prerelease).
 
@@ -63,7 +63,12 @@ Xong, trang cài đặt nằm ở URL Pages (xem mục cuối `index.html.in` đ
   ký `InRelease` + `Release.gpg`. Kho **phẳng** (`deb … ./`).
 - **dnf/zypper** (job `rpm`, container Fedora): `rpm --addsign` từng gói → `createrepo_c` →
   ký `repodata/repomd.xml`. Người dùng đặt `gpgcheck=1` + `repo_gpgcheck=1`.
-- **deploy**: gộp `public/{deb,rpm}` + `funput.asc` + `index.html` + `funput.repo`, đẩy lên Pages.
+- **pacman** (job `pacman`, container Arch): Arch không có asset nào trong release (distro
+  rolling, build từ nguồn), nên job này *dựng* gói từ chính `packaging/aur/PKGBUILD.in` —
+  cùng một công thức với kênh AUR, để hai kênh không bao giờ mô tả khác nhau — rồi ký từng
+  gói, `repo-add`, ký luôn `funput.db`. Chỉ **x86_64** (Arch chỉ hỗ trợ chính thức kiến
+  trúc này). Đây là job duy nhất phải biên dịch, nên cũng là job lâu nhất.
+- **deploy**: gộp `public/{deb,rpm,arch}` + `funput.asc` + `index.html` + `funput.repo`, đẩy lên Pages.
 
 Mỗi lần chạy **dựng lại toàn bộ** từ release hiện tại (stateless) — package manager chỉ cần
 phiên bản mới nhất để chào upgrade, nên không cần giữ lịch sử gh-pages.
@@ -73,5 +78,9 @@ phiên bản mới nhất để chào upgrade, nên không cần giữ lịch s�
   của distro thì cần OBS/COPR/PPA (Phase 3).
 - Kho chỉ chứa **bản mới nhất**; không phục vụ cài lại phiên bản cũ qua kho (vẫn tải được từ
   GitHub Releases).
-- RPM ký gói + ký repomd; APT ký Release. Khóa hết hạn = `Expire-Date: 0` (vô hạn) để khỏi gãy
+- RPM ký gói + ký repomd; APT ký Release; pacman ký từng gói **và** `funput.db` (pacman áp
+  `SigLevel` theo từng gói, nên ký mình database là không đủ).
+- Gói pacman là **binary trên distro rolling**: link vào thư viện Arch tại thời điểm dựng, nên
+  một đợt bump soname (fcitx5, ibus, gtk4) sẽ làm gãy cho tới bản release kế tiếp. Kênh AUR
+  (`packaging/aur/`) không dính vì build trên máy người dùng — hai kênh bổ sung cho nhau. Khóa hết hạn = `Expire-Date: 0` (vô hạn) để khỏi gãy
   kho; nếu đặt hạn, nhớ gia hạn và chạy lại workflow trước khi hết hạn.

--- a/platforms/linux/packaging/repo/index.html.in
+++ b/platforms/linux/packaging/repo/index.html.in
@@ -190,18 +190,36 @@ sudo zypper refresh</code></pre></div>
 
   <!-- Arch -->
   <div class="card">
-    <h2>🏛️ Arch Linux <small style="color:var(--muted);font-weight:400;font-size:.9rem">(AUR)</small></h2>
-    <div class="step">Cài qua AUR helper (vd <code class="inline">yay</code>)</div>
+    <h2>🏛️ Arch Linux <small style="color:var(--muted);font-weight:400;font-size:.9rem">(pacman · x86_64)</small></h2>
+
+    <div class="step">1 · Nhập khóa (làm một lần)</div>
+    <div class="cmd"><button class="copy">Copy</button><pre><code>curl -fsSL @REPO_URL@funput.asc | sudo pacman-key --add -
+sudo pacman-key --lsign-key hello@funput.app</code></pre></div>
+
+    <div class="step">2 · Thêm kho vào <code class="inline">/etc/pacman.conf</code></div>
+    <div class="cmd"><button class="copy">Copy</button><pre><code>sudo tee -a /etc/pacman.conf &lt;&lt;'EOF'
+
+[funput]
+Server = @REPO_URL@arch/$arch
+EOF
+sudo pacman -Sy</code></pre></div>
+
+    <div class="step">3 · Cài đặt</div>
     <div class="grid">
       <div>
         <div class="lbl"><span class="badge ibus">IBus</span></div>
-        <div class="cmd"><button class="copy">Copy</button><pre><code>yay -S funput-ibus</code></pre></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo pacman -S funput-ibus</code></pre></div>
       </div>
       <div>
         <div class="lbl"><span class="badge fcitx">Fcitx5</span></div>
-        <div class="cmd"><button class="copy">Copy</button><pre><code>yay -S funput</code></pre></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo pacman -S funput</code></pre></div>
       </div>
     </div>
+
+    <p style="color:var(--muted);font-size:.9rem;margin:.9rem 0 0">
+      Gói dựng sẵn cho <b>x86_64</b>. Arch cập nhật liên tục, nên sau một đợt bump
+      soname lớn (fcitx5, ibus, gtk4) gói có thể cần đợi bản phát hành kế tiếp.
+    </p>
   </div>
 
   <div class="note">


### PR DESCRIPTION
**Stacked on #302** — review that first; this branch adds commits on top of it.

## Why

The AUR recipe in #302 cannot be published: Arch has **paused new account registration** while it deals with a wave of automated signups, and an AUR upload needs an account. Arch users would keep having no working channel for however long that lasts.

## What

`repo.funput.app` now serves Arch as well. `publish-repo.yml` gains a `pacman` job that:

- builds the same three packages from **the very same `packaging/aur/PKGBUILD.in`** — sharing the recipe is what stops the two channels from ever describing different packages,
- signs each package **and** the database with the existing release key,
- deploys them under `arch/x86_64/` beside the existing `deb/` and `rpm/` trees.

`install.sh` stops handing Arch users off and installs for them: import the key into pacman's keyring, locally sign it, append the `[funput]` section to `pacman.conf` if absent, then `pacman -S`. `--no-repo` and `--version` now fail with a clear message on Arch rather than falling through to the rpm branch and fetching a Fedora package.

## Two things pacman needs that apt and dnf do not

Both learned by running it, not from documentation:

| | |
|---|---|
| Per-package signatures | `SigLevel` applies per package, so signing the database alone leaves every package unverified. |
| `repo-add` symlinks | It leaves `funput.db` as a symlink to the `.tar.gz`, which a Pages artifact does not carry. The files are materialised, then signed under the names pacman actually fetches. |

`repo-add --sign` is unused: it shells out to gpg without a loopback pinentry, so it cannot take a passphrase in CI.

## Weekly rebuild, because no dependency can guard these packages

These are binaries on a rolling distro: they link the Arch libraries of the build day, so a soname bump in fcitx5, ibus or gtk4 stops them loading.

The obvious guard is a soname dependency — `libfcitx5core.so=7-64` rather than `fcitx5` — so pacman refuses the breaking upgrade instead of leaving the user to discover it mid-sentence. **It does not work here.** Checked against the live packages:

```
fcitx5       provides: None
ibus         provides: None
gtk4         provides: libgtk-4.so=1-64
libadwaita   provides: libadwaita-1.so=0-64
glib2        provides: libglib-2.0.so=0-64  libgio-2.0.so=0-64  …
```

fcitx5 and ibus declare no soname `provides` at all — and those two are exactly the libraries at risk. Only gtk4/libadwaita/glib2 declare any, and they cover just the Settings app. There is nothing for pacman to check, so it cannot warn.

So the workflow **rebuilds fortnightly** instead (the 1st and 15th — cron cannot say "every two weeks"): a soname bump costs about two weeks, rather than waiting for the next Funput release. The whole workflow runs on that schedule, since `deploy` needs all three trees; the Arch half is the only one that compiles anything. `pkgrel` becomes `@PKGREL@` in the template — a rebuild has the same `pkgver`, and pacman only offers an upgrade when `pkgver-pkgrel` moves — rendered as the build date here, and as `1` for the AUR and the CI recipe check, where compiling on the user's machine has nothing to repair.

This still does not replace the AUR channel: that path compiles on the user's machine and cannot have the problem at all. x86_64 only, all Arch officially supports.

## Verification

In an Arch container, against the packages the recipe actually builds:

- `repo-add` plus the documented `pacman.conf` stanza produce a repository `pacman -Sl funput` lists all three packages from.
- `pacman -S funput-ibus` **verifies the signatures** and pulls in `funput-settings` through the exact-version dependency.
- `install.sh` dry-run: key import → lsign → `pacman.conf` append → `pacman -S`, with the `[funput]` section written correctly (`$arch` stays literal) and not duplicated on a second run. The x86_64 guard and the `--no-repo` refusal both fire as intended.

Docs are a separate repo — paired PR: Funput/Docs#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

