### PR TITLE
fix(ios): correct swapped tone style descriptions

### DIFF
--- a/platforms/ios/Funput/Settings/SettingsPicker.swift
+++ b/platforms/ios/Funput/Settings/SettingsPicker.swift
@@ -83,7 +83,8 @@ extension SettingsPicker {
             ToneStyleOption.allCases.map { value in
                 SettingsChoice(
                     id: value.rawValue, title: value.settingsTitle,
-                    summary: value == .traditional ? "Đặt dấu như “hoà”." : "Đặt dấu như “hòa”.",
+                    summary: value == .traditional
+                        ? "Dấu kiểu cũ — hòa, khỏe, thúy." : "Dấu kiểu mới — hoà, khoẻ, thuý.",
                     isSelected: model.configuration.toneStyle == value,
                     select: { model.update(\.toneStyle, to: value) }
                 )

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Models/ToneStyleOption.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Models/ToneStyleOption.swift
@@ -3,8 +3,8 @@
 /// Kept independent of the Rust engine's `FunputToneStyle` so shared
 /// configuration never links `FunputCore`; `KeyboardInput` bridges the two.
 public enum ToneStyleOption: String, CaseIterable, Hashable, Sendable, Codable {
-    /// Classic placement (e.g. `hoà`).
+    /// Classic placement (e.g. `hòa`).
     case traditional
-    /// Modern placement (e.g. `hòa`).
+    /// Modern placement (e.g. `hoà`).
     case modern
 }


### PR DESCRIPTION
Mô tả của hai lựa chọn trong "Kiểu đặt dấu" bị đảo: Truyền thống ghi ví dụ "hoà", Hiện đại ghi "hòa".

Hành vi engine vốn đã đúng (`compose("hoaf", .traditional) == "hòa"`), chỉ phần chữ hiển thị sai. Sửa lại theo cách diễn đạt sẵn có bên macOS:

- Truyền thống → "Dấu kiểu cũ — hòa, khỏe, thúy."
- Hiện đại → "Dấu kiểu mới — hoà, khoẻ, thuý."

Doc comment của `ToneStyleOption` cũng bị đảo y hệt, đã sửa cùng.

Chỉ đổi chuỗi hiển thị và comment, không đụng logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)