### PR TITLE
feat(ios): let the user pin the keyboard's light/dark appearance

### DIFF
--- a/platforms/ios/Funput/Appearance/AppearanceModel+KeyboardAppearance.swift
+++ b/platforms/ios/Funput/Appearance/AppearanceModel+KeyboardAppearance.swift
@@ -1,0 +1,20 @@
+import FunputShared
+import SwiftUI
+
+extension AppearanceModel {
+    var keyboardAppearanceBinding: Binding<KeyboardAppearanceOption> {
+        Binding(
+            get: { self.configuration.keyboardAppearance },
+            set: { self.commit(keyboardAppearance: $0) }
+        )
+    }
+
+    /// A failed save leaves `configuration` untouched, so the picker reads back the old
+    /// value on the next pass and the shared save-error alert explains why.
+    func commit(keyboardAppearance: KeyboardAppearanceOption) {
+        var candidate = configuration
+        candidate.keyboardAppearance = keyboardAppearance
+        guard persistConfiguration(candidate) else { return }
+        acceptPersistedConfiguration(candidate, updatesPreview: false)
+    }
+}

--- a/platforms/ios/Funput/Appearance/AppearanceModel.swift
+++ b/platforms/ios/Funput/Appearance/AppearanceModel.swift
@@ -79,9 +79,16 @@ final class AppearanceModel {
         previewThemeID = appliedThemeID
     }
 
+    /// Seeds the preview from the appearance the keyboard will actually render in, which
+    /// is the pinned one when the user pinned it and the system's otherwise. It stays a
+    /// free toggle: the theme editor uses it to pick which half of each color pair to edit.
     func setInitialMode(for colorScheme: ColorScheme) {
         guard !didSetInitialMode else { return }
-        previewMode = colorScheme == .dark ? .dark : .light
+        switch configuration.keyboardAppearance {
+        case .light: previewMode = .light
+        case .dark: previewMode = .dark
+        case .system: previewMode = colorScheme == .dark ? .dark : .light
+        }
         didSetInitialMode = true
     }
 

--- a/platforms/ios/Funput/Appearance/AppearanceScreen.swift
+++ b/platforms/ios/Funput/Appearance/AppearanceScreen.swift
@@ -58,6 +58,7 @@ struct AppearanceScreen: View {
                     confirmsDelete = true
                 }
             )
+            KeyboardAppearanceCard(appearance: model.keyboardAppearanceBinding)
             AppearanceResetCard(isDefault: model.appliedThemeID == FunputConfiguration.defaultThemeID) {
                 confirmsReset = true
             }

--- a/platforms/ios/Funput/Appearance/KeyboardAppearanceCard.swift
+++ b/platforms/ios/Funput/Appearance/KeyboardAppearanceCard.swift
@@ -1,0 +1,33 @@
+import FunputShared
+import SwiftUI
+
+struct KeyboardAppearanceCard: View {
+    @Binding var appearance: KeyboardAppearanceOption
+
+    var body: some View {
+        ContentCard {
+            Label("Giao diện bàn phím", systemImage: "circle.lefthalf.filled")
+                .font(.headline)
+            Text("Bàn phím mặc định đi theo ứng dụng bạn đang gõ, nên ứng dụng chỉ có nền sáng sẽ giữ bàn phím sáng. Chọn Sáng hoặc Tối để cố định.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Picker("Giao diện bàn phím", selection: $appearance) {
+                ForEach(KeyboardAppearanceOption.allCases, id: \.self) { option in
+                    Text(option.title).tag(option)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityIdentifier("appearance.keyboardAppearance")
+        }
+    }
+}
+
+extension KeyboardAppearanceOption {
+    var title: String {
+        switch self {
+        case .system: "Theo ứng dụng"
+        case .light: "Sáng"
+        case .dark: "Tối"
+        }
+    }
+}

--- a/platforms/ios/FunputTests/Appearance/KeyboardAppearanceTests.swift
+++ b/platforms/ios/FunputTests/Appearance/KeyboardAppearanceTests.swift
@@ -1,0 +1,75 @@
+import FunputShared
+import SwiftUI
+import Testing
+@testable import Funput
+
+@MainActor
+struct KeyboardAppearanceTests {
+    @Test("Choosing an appearance persists it without touching the theme")
+    func commitPersists() {
+        let store = SettingsTestStore(configuration: .default)
+        let model = AppearanceModel(store: store, customStore: ThemeTestStore())
+
+        model.commit(keyboardAppearance: .dark)
+
+        #expect(model.configuration.keyboardAppearance == .dark)
+        #expect(store.configuration.keyboardAppearance == .dark)
+        #expect(model.appliedThemeID == FunputConfiguration.defaultThemeID)
+        #expect(!model.showsSaveError)
+    }
+
+    @Test("A failed save keeps the previous appearance and reports the error")
+    func commitFailureKeepsPrevious() {
+        var configuration = FunputConfiguration.default
+        configuration.keyboardAppearance = .light
+        let store = SettingsTestStore(configuration: configuration, acceptsSaves: false)
+        let model = AppearanceModel(store: store, customStore: ThemeTestStore())
+
+        model.commit(keyboardAppearance: .dark)
+
+        #expect(model.configuration.keyboardAppearance == .light)
+        #expect(model.showsSaveError)
+    }
+
+    /// The picker reads straight off the stored configuration, so a rejected write has to
+    /// leave the binding showing what is actually saved.
+    @Test("The picker binding follows the stored configuration")
+    func bindingReflectsConfiguration() {
+        var configuration = FunputConfiguration.default
+        configuration.keyboardAppearance = .dark
+        let model = AppearanceModel(
+            store: SettingsTestStore(configuration: configuration),
+            customStore: ThemeTestStore()
+        )
+
+        #expect(model.keyboardAppearanceBinding.wrappedValue == .dark)
+        model.keyboardAppearanceBinding.wrappedValue = .light
+        #expect(model.keyboardAppearanceBinding.wrappedValue == .light)
+    }
+
+    @Test("A pinned appearance seeds the preview instead of the system scheme")
+    func pinnedAppearanceSeedsPreview() {
+        var configuration = FunputConfiguration.default
+        configuration.keyboardAppearance = .dark
+        let model = AppearanceModel(
+            store: SettingsTestStore(configuration: configuration),
+            customStore: ThemeTestStore()
+        )
+
+        model.setInitialMode(for: .light)
+
+        #expect(model.previewMode == .dark)
+    }
+
+    @Test("Following the host app leaves the preview on the system scheme")
+    func systemAppearanceSeedsFromColorScheme() {
+        let model = AppearanceModel(
+            store: SettingsTestStore(configuration: .default),
+            customStore: ThemeTestStore()
+        )
+
+        model.setInitialMode(for: .dark)
+
+        #expect(model.previewMode == .dark)
+    }
+}

--- a/platforms/ios/Keyboard/Controller/Activation/KeyboardViewController+Activation.swift
+++ b/platforms/ios/Keyboard/Controller/Activation/KeyboardViewController+Activation.swift
@@ -74,6 +74,7 @@ extension KeyboardViewController {
     /// Folds the adopted configuration and the live input state onto the surfaces.
     func applyAdoptedPresentation() {
         launchTrace.measure("SurfaceApply") {
+            applyKeyboardAppearance()
             applyInputPresentation()
             keyboardView.updateClipboardKeyVisible(configuration.clipboardEnabled)
             // A theme swap changes the backdrop without changing the layout, which on
@@ -82,5 +83,21 @@ extension KeyboardViewController {
             resolvedBackgroundRequest = nil
             refreshBackgroundImage()
         }
+    }
+
+    /// Pins the whole surface to the user's chosen appearance.
+    ///
+    /// Every color the renderer resolves reads the view's own trait collection, and so
+    /// does the Liquid Glass material — glass adapts from the trait environment, not from
+    /// the theme. Carrying a resolved style through `KeyboardPresentation` instead would
+    /// flip the tints while leaving the glass on the host app's appearance.
+    ///
+    /// This runs on every activation rather than once in `viewDidLoad` because the
+    /// setting can change between two keyboard sessions; the guard keeps an unchanged
+    /// appearance from spending a trait-change pass.
+    private func applyKeyboardAppearance() {
+        let style = configuration.keyboardAppearance.interfaceStyle
+        guard view.overrideUserInterfaceStyle != style else { return }
+        view.overrideUserInterfaceStyle = style
     }
 }

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Configuration/FunputConfiguration+Codable.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Configuration/FunputConfiguration+Codable.swift
@@ -22,6 +22,7 @@ extension FunputConfiguration {
         config.showsNumberRow = try container.decodeIfPresent(Bool.self, forKey: .showsNumberRow) ?? config.showsNumberRow
         config.layoutPreset = try container.decodeIfPresent(KeyboardLayoutPreset.self, forKey: .layoutPreset) ?? config.layoutPreset
         config.heightScale = try container.decodeIfPresent(Double.self, forKey: .heightScale) ?? config.heightScale
+        config.keyboardAppearance = try container.decodeIfPresent(KeyboardAppearanceOption.self, forKey: .keyboardAppearance) ?? config.keyboardAppearance
         config.personalSuggestionsEnabled = try container.decodeIfPresent(Bool.self, forKey: .personalSuggestionsEnabled) ?? config.personalSuggestionsEnabled
         config.personalSuggestionResetToken = try container.decodeIfPresent(UUID.self, forKey: .personalSuggestionResetToken)
         config.clipboardEnabled = try container.decodeIfPresent(Bool.self, forKey: .clipboardEnabled) ?? config.clipboardEnabled
@@ -67,6 +68,11 @@ extension FunputConfiguration {
         // it covers are what iOS users already expect from the system keyboard.
         if config.schemaVersion < 11 {
             config.schemaVersion = 11
+        }
+        // v12 added `keyboardAppearance`. `.system` is the trait-following behaviour every
+        // earlier build had, so like the `< 10` rung there is nothing to fix up.
+        if config.schemaVersion < 12 {
+            config.schemaVersion = 12
         }
         self = config
     }

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Configuration/FunputConfiguration.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Configuration/FunputConfiguration.swift
@@ -23,6 +23,8 @@ public struct FunputConfiguration: Codable, Hashable, Sendable {
     public var smartGesturesEnabled: Bool
     public var showsNumberRow: Bool
     public var layoutPreset: KeyboardLayoutPreset
+    /// Overrides the light/dark appearance the host app would otherwise impose.
+    public var keyboardAppearance: KeyboardAppearanceOption
     public var heightScale: Double
     public var personalSuggestionsEnabled: Bool
     public var clipboardEnabled: Bool
@@ -35,7 +37,7 @@ public struct FunputConfiguration: Codable, Hashable, Sendable {
         case eagerRestore, autoCapitalize, selectedThemeID
         case isHapticFeedbackEnabled, isKeySoundEnabled, showsKeyPreviews
         case smartGesturesEnabled
-        case showsNumberRow, layoutPreset, heightScale
+        case showsNumberRow, layoutPreset, heightScale, keyboardAppearance
         case personalSuggestionsEnabled, personalSuggestionResetToken
         case clipboardEnabled, clipboardExpiry, schemaVersion
     }
@@ -55,6 +57,7 @@ public struct FunputConfiguration: Codable, Hashable, Sendable {
         smartGesturesEnabled: Bool = true,
         showsNumberRow: Bool = false,
         layoutPreset: KeyboardLayoutPreset = .funput,
+        keyboardAppearance: KeyboardAppearanceOption = .system,
         heightScale: Double = 1.1,
         personalSuggestionsEnabled: Bool = true,
         clipboardEnabled: Bool = true,
@@ -76,6 +79,7 @@ public struct FunputConfiguration: Codable, Hashable, Sendable {
         self.smartGesturesEnabled = smartGesturesEnabled
         self.showsNumberRow = showsNumberRow
         self.layoutPreset = layoutPreset
+        self.keyboardAppearance = keyboardAppearance
         self.heightScale = heightScale
         self.personalSuggestionsEnabled = personalSuggestionsEnabled
         self.clipboardEnabled = clipboardEnabled
@@ -89,5 +93,5 @@ public struct FunputConfiguration: Codable, Hashable, Sendable {
     public static let defaultThemeID = "app.funput.theme.glass"
 
     /// Schema version emitted by this build. Bump when the stored shape changes.
-    public static let currentSchemaVersion = 11
+    public static let currentSchemaVersion = 12
 }

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Models/KeyboardAppearanceOption.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Models/KeyboardAppearanceOption.swift
@@ -1,0 +1,27 @@
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Which appearance the keyboard renders in, independent of the host app.
+///
+/// A keyboard extension inherits its trait collection from whichever app is being
+/// typed into, so an app that pins itself to light mode also pins the keyboard.
+/// This option lets the user override that.
+public enum KeyboardAppearanceOption: String, CaseIterable, Hashable, Sendable, Codable {
+    /// Follow the host app's trait collection — the behaviour before this option existed.
+    case system
+    case light
+    case dark
+}
+
+#if canImport(UIKit)
+public extension KeyboardAppearanceOption {
+    var interfaceStyle: UIUserInterfaceStyle {
+        switch self {
+        case .system: .unspecified
+        case .light: .light
+        case .dark: .dark
+        }
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardConfiguration/Presentation/KeyboardPresentationFactory.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardConfiguration/Presentation/KeyboardPresentationFactory.swift
@@ -37,7 +37,8 @@ public enum KeyboardPresentationFactory {
             isHapticFeedbackEnabled: configuration.isHapticFeedbackEnabled,
             isKeySoundEnabled: configuration.isKeySoundEnabled,
             showsKeyPreviews: configuration.showsKeyPreviews,
-            areSmartGesturesEnabled: configuration.smartGesturesEnabled
+            areSmartGesturesEnabled: configuration.smartGesturesEnabled,
+            pinsAppearance: configuration.keyboardAppearance != .system
         )
     }
 

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Clipboard/ClipboardKeyboardView+Presentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Clipboard/ClipboardKeyboardView+Presentation.swift
@@ -52,7 +52,8 @@ extension ClipboardKeyboardView {
             theme: theme,
             traits: traitCollection,
             image: backgroundImage,
-            blendsSystemEdge: presentation.blendsSystemEdge
+            blendsSystemEdge: presentation.blendsSystemEdge,
+            pinsAppearance: presentation.pinsAppearance
         )
         let isEmpty = groups.isEmpty
         emptyStateView.isHidden = !isEmpty

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Emoji/Browser/EmojiKeyboardView+Presentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Emoji/Browser/EmojiKeyboardView+Presentation.swift
@@ -64,7 +64,8 @@ extension EmojiKeyboardView {
             theme: theme,
             traits: traitCollection,
             image: backgroundImage,
-            blendsSystemEdge: presentation.blendsSystemEdge
+            blendsSystemEdge: presentation.blendsSystemEdge,
+            pinsAppearance: presentation.pinsAppearance
         )
         bottomBar.apply(color: label, selected: selectedCategory)
         searchHeader.apply(

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Kaomoji/Browser/KaomojiKeyboardView+Presentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Kaomoji/Browser/KaomojiKeyboardView+Presentation.swift
@@ -56,7 +56,8 @@ extension KaomojiKeyboardView {
             theme: theme,
             traits: traitCollection,
             image: backgroundImage,
-            blendsSystemEdge: presentation.blendsSystemEdge
+            blendsSystemEdge: presentation.blendsSystemEdge,
+            pinsAppearance: presentation.pinsAppearance
         )
         bottomBar.apply(color: theme.label.uiColor(for: traitCollection), selected: selectedCategory)
         collectionView.reloadData()

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Presentation/KeyboardPresentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Presentation/KeyboardPresentation.swift
@@ -16,6 +16,8 @@ public struct KeyboardPresentation: Hashable, Sendable {
     public var showsKeyPreviews: Bool
     /// Double-tap space, spacebar cursor panning and swipe-to-delete-word.
     public var areSmartGesturesEnabled: Bool
+    /// Whether the user pinned the keyboard's appearance instead of following the host app.
+    public var pinsAppearance: Bool
 
     public init(
         layout: KeyboardLayout = .funputQWERTY,
@@ -28,7 +30,8 @@ public struct KeyboardPresentation: Hashable, Sendable {
         isHapticFeedbackEnabled: Bool = true,
         isKeySoundEnabled: Bool = false,
         showsKeyPreviews: Bool = true,
-        areSmartGesturesEnabled: Bool = true
+        areSmartGesturesEnabled: Bool = true,
+        pinsAppearance: Bool = false
     ) {
         self.layout = layout
         self.sizing = sizing
@@ -41,6 +44,7 @@ public struct KeyboardPresentation: Hashable, Sendable {
         self.isKeySoundEnabled = isKeySoundEnabled
         self.showsKeyPreviews = showsKeyPreviews
         self.areSmartGesturesEnabled = areSmartGesturesEnabled
+        self.pinsAppearance = pinsAppearance
     }
 }
 

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView+Presentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView+Presentation.swift
@@ -85,10 +85,9 @@ extension KeyboardSurfaceView {
 
     func applyBackdropPresentation() {
         backdropView.apply(
-            theme: presentation.theme,
-            traits: traitCollection,
-            image: backgroundImage,
-            blendsSystemEdge: presentation.blendsSystemEdge
+            theme: presentation.theme, traits: traitCollection, image: backgroundImage,
+            blendsSystemEdge: presentation.blendsSystemEdge,
+            pinsAppearance: presentation.pinsAppearance
         )
     }
 

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Presentation/KeyboardBackdropView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Presentation/KeyboardBackdropView.swift
@@ -51,7 +51,8 @@ final class KeyboardBackdropView: UIView {
         theme: ResolvedTheme,
         traits: UITraitCollection,
         image: UIImage? = nil,
-        blendsSystemEdge: Bool = false
+        blendsSystemEdge: Bool = false,
+        pinsAppearance: Bool = false
     ) {
         self.theme = theme
         self.blendsSystemEdge = blendsSystemEdge
@@ -60,7 +61,7 @@ final class KeyboardBackdropView: UIView {
         imageView.isHidden = !usesImage
         overlayView.isHidden = !usesImage
         gradientView.isHidden = usesImage
-        configureMaterial(theme: theme, usesImage: usesImage)
+        configureMaterial(theme: theme, usesImage: usesImage, pinsAppearance: pinsAppearance)
         gradientLayer.isHidden = gradientView.isHidden
         if usesImage {
             overlayView.backgroundColor = theme.backgroundEffects.overlay.uiColor(for: traits)
@@ -72,9 +73,13 @@ final class KeyboardBackdropView: UIView {
         updateEdgeMask()
     }
 
-    private func configureMaterial(theme: ResolvedTheme, usesImage: Bool) {
+    /// The host material is the *app's* glass, and it stays on that app's appearance no
+    /// matter what this keyboard overrides. A keyboard pinned to dark inside a light app
+    /// would draw dark-mode labels straight onto light glass, so once the appearance is
+    /// pinned the backdrop has to bring its own material.
+    private func configureMaterial(theme: ResolvedTheme, usesImage: Bool, pinsAppearance: Bool) {
         let reducesTransparency = UIAccessibility.isReduceTransparencyEnabled
-        if #available(iOS 26.0, *), theme.material == .glass, !reducesTransparency {
+        if #available(iOS 26.0, *), theme.material == .glass, !reducesTransparency, !pinsAppearance {
             usesHostMaterial = true
             materialView.effect = nil
         } else {

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/AdvancedTelex/AdvancedTelexConfigurationTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/AdvancedTelex/AdvancedTelexConfigurationTests.swift
@@ -19,7 +19,7 @@ struct AdvancedTelexConfigurationTests {
         let decoded = try JSONDecoder().decode(FunputConfiguration.self, from: data)
 
         #expect(decoded.inputMethod == .telexAdvanced)
-        #expect(decoded.schemaVersion == 11)
+        #expect(decoded.schemaVersion == 12)
     }
 
     @Test("Legacy schema preserves its input method while migrating")
@@ -30,6 +30,6 @@ struct AdvancedTelexConfigurationTests {
         let decoded = try JSONDecoder().decode(FunputConfiguration.self, from: data)
 
         #expect(decoded.inputMethod == .telex)
-        #expect(decoded.schemaVersion == 11)
+        #expect(decoded.schemaVersion == 12)
     }
 }

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/FunputConfigurationTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/FunputConfigurationTests.swift
@@ -24,7 +24,8 @@ struct FunputConfigurationTests {
         #expect(config.clipboardEnabled)
         #expect(config.clipboardExpiry == .hour)
         #expect(config.layoutPreset == .funput)
-        #expect(config.schemaVersion == 11)
+        #expect(config.keyboardAppearance == .system) // follow the host app, as before v12
+        #expect(config.schemaVersion == 12)
     }
 
     @Test("Configuration survives a JSON round-trip")
@@ -61,7 +62,7 @@ struct FunputConfigurationTests {
         #expect(!decoded.isHapticFeedbackEnabled)
         #expect(!decoded.isKeySoundEnabled)
         #expect(!decoded.showsNumberRow)
-        #expect(decoded.schemaVersion == 11)
+        #expect(decoded.schemaVersion == 12)
     }
 
     @Test("Schema 3 migrates to the compact Telex default")
@@ -69,7 +70,7 @@ struct FunputConfigurationTests {
         let data = Data(#"{"showsNumberRow":true,"schemaVersion":3}"#.utf8)
         let decoded = try JSONDecoder().decode(FunputConfiguration.self, from: data)
         #expect(!decoded.showsNumberRow)
-        #expect(decoded.schemaVersion == 11)
+        #expect(decoded.schemaVersion == 12)
     }
 
     /// v8 dropped `showsGlobeKey` entirely. A stored payload still carrying it must
@@ -79,7 +80,7 @@ struct FunputConfigurationTests {
         let data = Data(#"{"showsGlobeKey":true,"showsNumberRow":true,"schemaVersion":4}"#.utf8)
         let decoded = try JSONDecoder().decode(FunputConfiguration.self, from: data)
         #expect(decoded.showsNumberRow)
-        #expect(decoded.schemaVersion == 11)
+        #expect(decoded.schemaVersion == 12)
     }
 
     /// v10 added `layoutPreset`. Unlike the `< 4` rung it must not touch stored values:
@@ -92,6 +93,18 @@ struct FunputConfigurationTests {
         #expect(decoded.layoutPreset == .funput)
         #expect(decoded.inputMethod == .telex)
         #expect(decoded.showsNumberRow)
-        #expect(decoded.schemaVersion == 11)
+        #expect(decoded.schemaVersion == 12)
+    }
+
+    /// v12 added `keyboardAppearance`. `.system` reproduces how every earlier build
+    /// rendered, so an upgrading payload must land there with nothing else disturbed.
+    @Test("Schema 11 payloads keep following the host app's appearance")
+    func migratesKeyboardAppearanceDefault() throws {
+        let data = Data(#"{"inputMethod":"telex","layoutPreset":"system","schemaVersion":11}"#.utf8)
+        let decoded = try JSONDecoder().decode(FunputConfiguration.self, from: data)
+        #expect(decoded.keyboardAppearance == .system)
+        #expect(decoded.inputMethod == .telex)
+        #expect(decoded.layoutPreset == .system)
+        #expect(decoded.schemaVersion == 12)
     }
 }

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/LiquidGlassSurfaceTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/LiquidGlassSurfaceTests.swift
@@ -51,6 +51,21 @@ struct LiquidGlassSurfaceTests {
         #expect((backdrop?.backgroundColor?.cgColor.alpha ?? 0) == 0)
     }
 
+    /// A pinned appearance cannot borrow the host app's glass: that material stays on the
+    /// host app's own light/dark setting, so a keyboard pinned to dark inside a light app
+    /// would end up drawing dark-mode labels onto light glass.
+    @Test("A pinned appearance brings its own material instead of the host's")
+    func pinnedAppearanceDropsHostMaterial() {
+        guard #available(iOS 26.0, *) else { return }
+        let surface = KeyboardSurfaceView(
+            presentation: KeyboardPresentation(pinsAppearance: true)
+        )
+        let backdrop = surface.subviews.compactMap { $0 as? KeyboardBackdropView }.first
+
+        #expect(backdrop?.usesHostMaterial == false)
+        #expect(backdrop?.effect is UIBlurEffect)
+    }
+
     private func accessibleControls(in view: UIView) -> [UIControl] {
         view.subviews.flatMap { child -> [UIControl] in
             let own = (child as? UIControl).map {


### PR DESCRIPTION
## Vấn đề

Bàn phím extension thừa hưởng `UITraitCollection` từ app đang được gõ, nên app nào ép sáng toàn cục (Shopee và khá nhiều app Việt) thì bàn phím luôn sáng, kể cả khi iOS đang ở dark mode. Người dùng không có cách nào ép được.

## Thay đổi

Thêm tuỳ chọn **Giao diện bàn phím** ở màn Giao diện: **Theo ứng dụng** (đúng hành vi cũ, mặc định) / **Sáng** / **Tối**.

Toàn bộ renderer resolve màu qua đúng một hàm đọc trait của chính view (`AdaptiveThemeColor.uiColor(for:)`, 41 call site), nên chỉ cần đặt `overrideUserInterfaceStyle` trên view của `KeyboardViewController` là mọi surface, overlay và cache `appliedInterfaceStyle` đi theo. Cách này cũng giữ Liquid Glass đồng bộ: kính thích ứng theo trait environment, nếu nhét một "style đã resolve" vào `KeyboardPresentation` thì màu lật mà kính vẫn theo app chủ.

**Ngoại lệ là backdrop** — và đây là lỗi phát hiện khi test tay, không phải qua test tự động. Theme glass mượn *host material* của app đang gõ, mà material đó luôn giữ giao diện của app chủ dù ta override gì đi nữa. Kết quả: bàn phím ép tối trong app sáng vẽ chữ chế độ tối lên kính sáng — tiêu đề bảng emoji gần như tàng hình. Nay khi người dùng đã ép giao diện thì backdrop tự vẽ material của mình (`pinsAppearance` đi qua `KeyboardPresentation` tới cả 4 surface).

Schema config 11 → 12. Field mới mặc định `.system` — đúng cách mọi bản cũ vẫn render, nên nấc migration không ghi đè gì.

## Kiểm chứng

Chạy thật trên iPhone 17 Pro (iOS 27):
- Pin **Tối**, mở Safari đang sáng → bàn phím tối, kính và chữ cùng tối.
- Đổi lại **Theo ứng dụng** → sáng lại ngay ở lần activation kế tiếp.
- Bảng emoji: trước khi sửa backdrop thì tiêu đề mục gần như không đọc được; sau khi sửa thì rõ.

Tự động:
- `./Scripts/test-funput-kit.sh` xanh toàn bộ (renderer 167 test, thêm 1 test mới cho quy tắc backdrop).
- `./Scripts/check-swift-loc.sh` pass. Không thêm file vào thư mục nào đang chạm trần 5 file.
- 5 test mới trong `FunputTests/Appearance/KeyboardAppearanceTests.swift` chạy riêng đều pass.

## Còn chưa xác minh

Chạy **toàn bộ** target `FunputTests` thì `xcodebuild` báo `TEST FAILED`, nhưng mình chưa kịp đọc danh sách test nào đỏ và **chưa đối chiếu với `main`** xem có đỏ sẵn từ trước không. Nhờ để ý khi review; nếu cần mình chạy lại và báo cụ thể.

Ngoài ra `Scripts/Quality/check-keyboard-touch-layout.sh` đang fail ở `Packages/FunputKit/Tests/KeyboardInputTests/Coordinator` (6 file > 5) — lỗi này **có sẵn trên `main`**, không liên quan PR này, và script đó cũng không chạy trong CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)