### PR TITLE
feat(windows,desktop): add the "Tự nhận diện hoa/thường" switch to Gõ tắt settings

### DIFF
--- a/crates/funput-desktop/src/shell/options.rs
+++ b/crates/funput-desktop/src/shell/options.rs
@@ -43,6 +43,13 @@ impl ShellState {
         self.update_config(|s| s.shortcuts_enabled = on);
     }
 
+    /// Turn smart-case trigger matching on or off. Off, only the trigger as stored
+    /// expands and the expansion is emitted verbatim — which is what a table
+    /// holding both `vn` and `VN` needs.
+    pub fn set_shortcut_smart_case(&mut self, on: bool) {
+        self.update_config(|s| s.shortcut_smart_case = on);
+    }
+
     /// Turn the foreign-layout auto-switch on or off. Re-judges the current layout
     /// straight away, so turning it off lifts a suspension already in place instead
     /// of leaving Vietnamese off until the user next changes keyboards.

--- a/crates/funput-desktop/src/shell/tests.rs
+++ b/crates/funput-desktop/src/shell/tests.rs
@@ -3,7 +3,7 @@
 //! tray binds to, and when composition is thrown away.
 
 use funput_config::{Method, Settings};
-use funput_engine::KeySource;
+use funput_engine::{Action, KeySource};
 
 use super::*;
 
@@ -263,6 +263,72 @@ fn pruning_drops_drafts_and_keeps_complete_rows() {
     assert_eq!(state.shortcuts()[0].trigger, "vn");
 }
 
+/// Type `keys` through the shell and rebuild what the app would be showing, the
+/// same way the hook applies an [`ImeResult`]: pass the key through, or eat the
+/// backspaces and inject.
+fn app_text(state: &mut ShellState, keys: &str) -> String {
+    let mut app = String::new();
+    for key in keys.chars() {
+        let result = state.process_key(key, KeySource::Standard);
+        match result.action {
+            Action::None => app.push(key),
+            Action::Send => {
+                for _ in 0..result.backspace {
+                    app.pop();
+                }
+                app.push_str(&result.output);
+            }
+            Action::Restore => unreachable!("Restore not implemented yet"),
+        }
+    }
+    app
+}
+
+/// A shell holding one finished row, `tp` → `TP. HCM`.
+fn shell_with_tp() -> ShellState {
+    let mut state = shell();
+    state.add_shortcut();
+    state.set_shortcut_trigger(0, "tp".into());
+    state.set_shortcut_expansion(0, "TP. HCM".into());
+    state
+}
+
+#[test]
+fn smart_case_is_on_by_default() {
+    let mut state = shell_with_tp();
+    assert_eq!(app_text(&mut state, "Tp "), "Tp. Hcm ");
+}
+
+/// The Settings switch has to reach the engine, not just the settings file — on
+/// this shell that is `update_config` re-syncing the whole `EngineConfig`, with no
+/// separate setter to forget.
+#[test]
+fn turning_smart_case_off_reaches_the_engine() {
+    let mut state = shell_with_tp();
+    state.set_shortcut_smart_case(false);
+
+    assert_eq!(
+        app_text(&mut state, "Tp "),
+        "Tp ",
+        "a differently cased trigger must be left alone"
+    );
+    assert_eq!(
+        app_text(&mut state, "tp "),
+        "TP. HCM ",
+        "the row itself is untouched — the exact trigger still expands"
+    );
+}
+
+/// Flipping it back must take effect without re-pushing the table.
+#[test]
+fn turning_smart_case_back_on_restores_matching() {
+    let mut state = shell_with_tp();
+    state.set_shortcut_smart_case(false);
+    state.set_shortcut_smart_case(true);
+
+    assert_eq!(app_text(&mut state, "Tp "), "Tp. Hcm ");
+}
+
 // --- keyboard layout -------------------------------------------------------
 
 /// Real Windows layout handles. `JAPANESE_IME` is what Microsoft IME reports;
@@ -388,10 +454,12 @@ fn settings_survive_a_restart() {
     let mut state = ShellState::new(Some(path.clone()));
     state.set_method(InputMethod::Vni);
     state.set_spell_check(true);
+    state.set_shortcut_smart_case(false);
 
     let reopened = ShellState::new(Some(path));
     assert_eq!(reopened.settings().method, Method::Vni);
     assert!(reopened.settings().spell_check);
+    assert!(!reopened.settings().shortcut_smart_case);
     let _ = std::fs::remove_dir_all(dir);
 }
 

--- a/platforms/windows/src/shared/commands/settings.rs
+++ b/platforms/windows/src/shared/commands/settings.rs
@@ -35,6 +35,10 @@ pub fn set_shortcuts_enabled(on: bool) {
     shell::set_shortcuts_enabled(on);
 }
 
+pub fn set_shortcut_smart_case(on: bool) {
+    shell::set_shortcut_smart_case(on);
+}
+
 pub fn set_auto_english_layout(on: bool) {
     shell::set_auto_english_on_foreign_layout(on);
 }

--- a/platforms/windows/src/shared/shell/settings.rs
+++ b/platforms/windows/src/shared/shell/settings.rs
@@ -78,6 +78,9 @@ pub fn set_auto_capitalize(on: bool) {
 pub fn set_shortcuts_enabled(on: bool) {
     with(|s| s.set_shortcuts_enabled(on));
 }
+pub fn set_shortcut_smart_case(on: bool) {
+    with(|s| s.set_shortcut_smart_case(on));
+}
 pub fn set_auto_english_on_foreign_layout(on: bool) {
     with(|s| s.set_auto_english_on_foreign_layout(on));
 }

--- a/platforms/windows/src/ui/settings_callbacks.rs
+++ b/platforms/windows/src/ui/settings_callbacks.rs
@@ -90,6 +90,7 @@ pub(super) fn wire(window: &SettingsWindow) {
     window.on_set_auto_cap(commands::set_auto_capitalize);
     window.on_set_auto_english_layout(commands::set_auto_english_layout);
     window.on_set_shortcuts_enabled(commands::set_shortcuts_enabled);
+    window.on_set_shortcut_smart_case(commands::set_shortcut_smart_case);
     window.on_set_launch(commands::set_launch_at_login);
 
     let weak = window.as_weak();

--- a/platforms/windows/src/ui/settings_window.rs
+++ b/platforms/windows/src/ui/settings_window.rs
@@ -104,6 +104,7 @@ pub(super) fn populate(window: &SettingsWindow) {
     window.set_update_message("".into());
     window.set_shortcuts(models::shortcuts(&shell::shortcuts()));
     window.set_shortcuts_enabled(settings.shortcuts_enabled);
+    window.set_shortcut_smart_case(settings.shortcut_smart_case);
     window.set_can_add_shortcut(commands::can_add_shortcut());
 }
 

--- a/platforms/windows/ui/pages/shortcuts/page.slint
+++ b/platforms/windows/ui/pages/shortcuts/page.slint
@@ -7,11 +7,13 @@ export component ShortcutsPage inherits VerticalLayout {
     in property <[ShortcutEntry]> shortcuts;
     in property <bool> can-add: true;
     in-out property <bool> shortcuts-enabled;
+    in-out property <bool> shortcut-smart-case;
     callback add-shortcut();
     callback remove-shortcut(int);
     callback edit-trigger(int, string);
     callback edit-expansion(int, string);
     callback set-shortcuts-enabled(bool);
+    callback set-shortcut-smart-case(bool);
 
     spacing: Theme.sp-lg;
     width: 100%;
@@ -19,7 +21,11 @@ export component ShortcutsPage inherits VerticalLayout {
 
     PageHeader {
         title: "Gõ tắt";
-        subtitle: "Bung chữ tắt khi gõ khoảng trắng hoặc dấu câu — tự nhận diện hoa/thường: vn → việt nam, Vn → Việt Nam, VN → VIỆT NAM.";
+        // The example only holds while smart case is on; with it off the page
+        // would otherwise promise matching that no longer happens.
+        subtitle: root.shortcut-smart-case
+            ? "Bung chữ tắt khi gõ khoảng trắng hoặc dấu câu — tự nhận diện hoa/thường: vn → việt nam, Vn → Việt Nam, VN → VIỆT NAM."
+            : "Bung chữ tắt khi gõ khoảng trắng hoặc dấu câu — đang tắt nhận diện hoa/thường, chỉ đúng chữ tắt đã lưu mới bung và nội dung giữ nguyên.";
     }
 
     Section {
@@ -32,6 +38,18 @@ export component ShortcutsPage inherits VerticalLayout {
             AccentSwitch {
                 checked <=> root.shortcuts-enabled;
                 toggled => { root.set-shortcuts-enabled(root.shortcuts-enabled); }
+            }
+        }
+        Rectangle { height: 1px; background: Theme.divider; }
+        Row {
+            icon: @image-url("../../icons/row/case.svg");
+            title: "Tự nhận diện hoa/thường";
+            subtitle: "Gõ vn, Vn hay VN đều bung và nội dung tự viết hoa theo. Tắt thì chỉ khớp đúng chuỗi tắt đã lưu.";
+            // Deliberately not gated on shortcuts-enabled: macOS leaves it live,
+            // and the two platforms must read the same.
+            AccentSwitch {
+                checked <=> root.shortcut-smart-case;
+                toggled => { root.set-shortcut-smart-case(root.shortcut-smart-case); }
             }
         }
     }

--- a/platforms/windows/ui/shell/content.slint
+++ b/platforms/windows/ui/shell/content.slint
@@ -29,6 +29,7 @@ export component SettingsContent inherits ScrollView {
     in property <[ShortcutEntry]> shortcuts;
     in property <bool> can-add-shortcut: true;
     in-out property <bool> shortcuts-enabled;
+    in-out property <bool> shortcut-smart-case;
     in property <string> version;
     in property <string> update-state: "idle";
     in property <string> update-version;
@@ -48,6 +49,7 @@ export component SettingsContent inherits ScrollView {
     callback set-launch(bool);
     callback add-shortcut();
     callback set-shortcuts-enabled(bool);
+    callback set-shortcut-smart-case(bool);
     callback remove-shortcut(int);
     callback edit-trigger(int, string);
     callback edit-expansion(int, string);
@@ -112,8 +114,10 @@ export component SettingsContent inherits ScrollView {
                 shortcuts: root.shortcuts;
                 can-add: root.can-add-shortcut;
                 shortcuts-enabled <=> root.shortcuts-enabled;
+                shortcut-smart-case <=> root.shortcut-smart-case;
                 add-shortcut() => { root.add-shortcut(); }
                 set-shortcuts-enabled(v) => { root.set-shortcuts-enabled(v); }
+                set-shortcut-smart-case(v) => { root.set-shortcut-smart-case(v); }
                 remove-shortcut(i) => { root.remove-shortcut(i); }
                 edit-trigger(i, t) => { root.edit-trigger(i, t); }
                 edit-expansion(i, t) => { root.edit-expansion(i, t); }

--- a/platforms/windows/ui/shell/settings.slint
+++ b/platforms/windows/ui/shell/settings.slint
@@ -33,6 +33,7 @@ export component SettingsWindow inherits Window {
     in property <[ShortcutEntry]> shortcuts;
     in property <bool> can-add-shortcut: true;
     in-out property <bool> shortcuts-enabled;
+    in-out property <bool> shortcut-smart-case;
     in property <string> version;
     in property <string> update-state: "idle";
     in property <string> update-version;
@@ -56,6 +57,7 @@ export component SettingsWindow inherits Window {
     callback set-launch(bool);
     callback add-shortcut();
     callback set-shortcuts-enabled(bool);
+    callback set-shortcut-smart-case(bool);
     callback remove-shortcut(int);
     callback edit-trigger(int, string);
     callback edit-expansion(int, string);
@@ -105,6 +107,7 @@ export component SettingsWindow inherits Window {
             shortcuts: root.shortcuts;
             can-add-shortcut: root.can-add-shortcut;
             shortcuts-enabled <=> root.shortcuts-enabled;
+            shortcut-smart-case <=> root.shortcut-smart-case;
             version: root.version;
             update-state: root.update-state;
             update-version: root.update-version;
@@ -123,6 +126,7 @@ export component SettingsWindow inherits Window {
             set-launch(v) => { root.set-launch(v); }
             add-shortcut() => { root.add-shortcut(); }
             set-shortcuts-enabled(v) => { root.set-shortcuts-enabled(v); }
+            set-shortcut-smart-case(v) => { root.set-shortcut-smart-case(v); }
             remove-shortcut(i) => { root.remove-shortcut(i); }
             edit-trigger(i, t) => { root.edit-trigger(i, t); }
             edit-expansion(i, t) => { root.edit-expansion(i, t); }


### PR DESCRIPTION
Brings the gõ tắt smart-case switch to Windows, matching the macOS pane on the base branch.

The shared layers already carried `shortcut_smart_case` to the engine; Windows had no way to reach it short of importing a config. Adds the missing `ShellState` setter, then walks the same six-step chain `shortcuts_enabled` already uses — Slint property and callback, the two shell forwarding hops, `populate`, and the passthrough pair.

No FFI involved: the Windows shell links funput-desktop directly and `sync_engine_config` pushes a whole `EngineConfig`, so the `funput_configure` clobbering fix does not apply here.

The switch is deliberately not gated on `shortcuts-enabled`, so it reads the same as macOS. The page header subtitle becomes conditional instead — it promised `vn → việt nam` unconditionally.

**Tests**: three new ones in `funput-desktop` drive real keystrokes through `ShellState` — default on expands `Tp ` to `Tp. Hcm `, off leaves `Tp ` alone while `tp ` still expands, and flipping back restores matching. `settings_survive_a_restart` now covers the flag too.

**Checks run locally**: root `cargo fmt --check`, `check-loc.sh`, `clippy --workspace -D warnings`, `cargo test --workspace`; and in `platforms/windows` (outside the workspace, so PR CI never sees it) `clippy --release --all-targets -D warnings`, `cargo test --release`, `cargo build --release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
