### PR TITLE
feat(linux): add the Gõ tắt switches to the addon and Settings

### DIFF
--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -698,6 +698,20 @@ void funput_add_shortcut(FunputEngine *engine,
 void funput_clear_shortcuts(FunputEngine *engine);
 
 /**
+ * Turn gõ tắt expansion on or off ("Bật gõ tắt"). Off, a trigger is typed out as
+ * itself and nothing expands; the table is left loaded, so the switch is instant in
+ * both directions and hosts need not re-push their rows around it.
+ *
+ * Its own function rather than a [`crate::FunputConfig`] field, for the ABI reason
+ * documented there; [`crate::funput_configure`] leaves this setting alone, so the
+ * two may be called in either order.
+ *
+ * # Safety
+ * `engine` must be a valid handle or null.
+ */
+void funput_set_shortcuts_enabled(FunputEngine *engine, bool on);
+
+/**
  * Turn smart-case matching on or off ("Tự nhận diện hoa/thường"). On (the default),
  * a trigger typed lowercase, Title Case, or UPPERCASE all resolve to the same entry
  * and the expansion is re-cased to match (`tp`/`Tp`/`TP` → `TP. HCM`/`Tp. Hcm`/

--- a/crates/funput-ffi/src/engine/mod.rs
+++ b/crates/funput-ffi/src/engine/mod.rs
@@ -26,7 +26,10 @@ pub use config::{
     funput_set_enabled, funput_set_method,
 };
 pub use result::{ACTION_NONE, ACTION_RESTORE, ACTION_SEND, CHARS_CAP, FunputResult};
-pub use shortcuts::{funput_add_shortcut, funput_clear_shortcuts, funput_set_shortcut_smart_case};
+pub use shortcuts::{
+    funput_add_shortcut, funput_clear_shortcuts, funput_set_shortcut_smart_case,
+    funput_set_shortcuts_enabled,
+};
 
 /// Opaque IME engine handle for C callers. Create with [`funput_engine_new`],
 /// release with [`funput_engine_free`]. cbindgen emits this as an opaque struct.

--- a/crates/funput-ffi/src/engine/shortcuts.rs
+++ b/crates/funput-ffi/src/engine/shortcuts.rs
@@ -45,6 +45,21 @@ pub unsafe extern "C" fn funput_clear_shortcuts(engine: *mut FunputEngine) {
     unsafe { abi::with_engine_mut(engine, |e| e.clear_shortcuts()) }
 }
 
+/// Turn gõ tắt expansion on or off ("Bật gõ tắt"). Off, a trigger is typed out as
+/// itself and nothing expands; the table is left loaded, so the switch is instant in
+/// both directions and hosts need not re-push their rows around it.
+///
+/// Its own function rather than a [`crate::FunputConfig`] field, for the ABI reason
+/// documented there; [`crate::funput_configure`] leaves this setting alone, so the
+/// two may be called in either order.
+///
+/// # Safety
+/// `engine` must be a valid handle or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_set_shortcuts_enabled(engine: *mut FunputEngine, on: bool) {
+    unsafe { abi::with_engine_mut(engine, |e| e.update_config(|c| c.shortcuts_enabled = on)) }
+}
+
 /// Turn smart-case matching on or off ("Tự nhận diện hoa/thường"). On (the default),
 /// a trigger typed lowercase, Title Case, or UPPERCASE all resolve to the same entry
 /// and the expansion is re-cased to match (`tp`/`Tp`/`TP` → `TP. HCM`/`Tp. Hcm`/

--- a/crates/funput-ffi/src/lib.rs
+++ b/crates/funput-ffi/src/lib.rs
@@ -65,7 +65,7 @@ pub use engine::{
     funput_add_shortcut, funput_adopt, funput_arm_capitalization, funput_backspace, funput_buffer,
     funput_clear, funput_clear_shortcuts, funput_configure, funput_engine_free, funput_engine_new,
     funput_flip_composing, funput_process_char, funput_process_key, funput_set_enabled,
-    funput_set_method, funput_set_shortcut_smart_case,
+    funput_set_method, funput_set_shortcut_smart_case, funput_set_shortcuts_enabled,
 };
 pub use suggestion::{
     FunputSuggestionCandidate, FunputSuggestionEngine, FunputSuggestionResult,

--- a/crates/funput-ffi/tests/round_trip.rs
+++ b/crates/funput-ffi/tests/round_trip.rs
@@ -5,6 +5,7 @@ use funput_ffi::{
     funput_adopt, funput_backspace, funput_buffer, funput_clear, funput_clear_shortcuts,
     funput_configure, funput_engine_free, funput_engine_new, funput_process_char,
     funput_process_key, funput_set_method, funput_set_shortcut_smart_case,
+    funput_set_shortcuts_enabled,
 };
 
 fn output(result: &FunputResult) -> String {
@@ -378,4 +379,58 @@ fn configure_does_not_clobber_the_smart_case_setting() {
 #[test]
 fn smart_case_setter_is_null_safe() {
     unsafe { funput_set_shortcut_smart_case(std::ptr::null_mut(), false) };
+}
+
+#[test]
+fn shortcuts_are_on_by_default_and_the_setter_turns_them_off() {
+    unsafe {
+        let engine = funput_engine_new();
+        funput_set_method(engine, 0); // Telex
+        add_shortcut(engine, "vn", "Việt Nam");
+
+        assert_eq!(app_text(engine, "vn "), "Việt Nam ", "default is on");
+
+        funput_set_shortcuts_enabled(engine, false);
+        assert_eq!(
+            app_text(engine, "vn "),
+            "vn ",
+            "the trigger types out as itself"
+        );
+
+        // The table was never re-pushed, so turning the switch back on must be
+        // enough on its own — that is what lets a host toggle it without resyncing.
+        funput_set_shortcuts_enabled(engine, true);
+        assert_eq!(app_text(engine, "vn "), "Việt Nam ", "rows were kept");
+
+        funput_engine_free(engine);
+    }
+}
+
+/// The two gõ tắt setters write the same config, so each must edit it rather than
+/// replace it — turning smart case off must not switch expansion back on.
+#[test]
+fn the_two_shortcut_setters_do_not_clobber_each_other() {
+    unsafe {
+        let engine = funput_engine_new();
+        funput_set_method(engine, 0); // Telex
+        add_shortcut(engine, "tp", "TP. HCM");
+
+        funput_set_shortcuts_enabled(engine, false);
+        funput_set_shortcut_smart_case(engine, false);
+        assert_eq!(app_text(engine, "tp "), "tp ", "still switched off");
+
+        funput_set_shortcuts_enabled(engine, true);
+        assert_eq!(
+            app_text(engine, "Tp "),
+            "Tp ",
+            "smart case stayed off across the other setter"
+        );
+
+        funput_engine_free(engine);
+    }
+}
+
+#[test]
+fn shortcuts_enabled_setter_is_null_safe() {
+    unsafe { funput_set_shortcuts_enabled(std::ptr::null_mut(), false) };
 }

--- a/platforms/CONFIG_FORMAT.md
+++ b/platforms/CONFIG_FORMAT.md
@@ -68,8 +68,8 @@ one machine imports on another. macOS is the first implementation
 | `source` | — | `platform` + `appVersion` that produced the file. Metadata only. |
 | `preferences.inputMethod` | ✅ | `telex`, `telex_advanced`, or `vni`. Exposed on macOS, Windows, Linux, iOS, and Android; unsupported consumers keep their current selection. |
 | `preferences.*` | ✅ | Other typing options; each is optional and applied only if present. |
-| `shortcuts[]` | ✅ | `{ trigger, expansion }`. Local UUIDs are dropped; recreated on import. Whether they expand is `preferences.shortcutsEnabled`, which defaults to `true` when absent — an older file carries a working table and must not arrive switched off. |
-| `preferences.shortcutSmartCase` | ✅ | Whether a trigger matches regardless of how it was capitalized, with the expansion re-cased to match (`tp`/`Tp`/`TP` → `TP. HCM`/`Tp. Hcm`/`TP. HCM`). Off, only the exact trigger expands and the expansion is verbatim. Defaults to `true` when absent, for the same reason as `shortcutsEnabled`. |
+| `shortcuts[]` | ✅ | `{ trigger, expansion }`. Local UUIDs are dropped; recreated on import. Whether they expand is `preferences.shortcutsEnabled`, which defaults to `true` when absent — an older file carries a working table and must not arrive switched off. Exposed as a switch on Windows and Linux; macOS reads it but shows no control. |
+| `preferences.shortcutSmartCase` | ✅ | Whether a trigger matches regardless of how it was capitalized, with the expansion re-cased to match (`tp`/`Tp`/`TP` → `TP. HCM`/`Tp. Hcm`/`TP. HCM`). Off, only the exact trigger expands and the expansion is verbatim. Defaults to `true` when absent, for the same reason as `shortcutsEnabled`. Exposed as a switch on macOS, Windows and Linux. |
 | `platform.macos.toggleShortcut` | ❌ | `KeyCombo` (`keyCode` is AppKit-specific). Applied only on macOS, only if present. |
 | `platform.macos.flipShortcut` | ❌ | `KeyCombo` or `null`. Applied only on macOS, only if present. |
 | `platform.macos.appLanguageMemory` | ❌ | `{ bundleId: rememberedIsVietnamese }`. macOS-only per-app VI/EN memory; merged by key, existing entries win. |

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -21,7 +21,7 @@ common/                 Framework-free C++ shared by both shells
       nonpreedit.h            Commit-as-you-type: the mode, and judging a client
       nonpreedit.cpp          What the composer does with that judgement
   settings/               ~/.config/Funput/settings.json
-    settings.h              The model every shell reads
+    settings.h              The model every shell reads, gõ tắt switches included
     lookup.cpp              Where the file lives; app exclusion
     io.cpp                  Parse and save (JSON)
     watch.h/.cpp            inotify watcher for live reload
@@ -38,6 +38,7 @@ ibus/src/               IBus engine -> ibus-engine-funput
 settings-gtk/           GTK4 + libadwaita Settings app (its own cargo crate,
                         and its own package — see Build)
   src/settings_window/    one submodule per preferences page
+    shortcuts/              the gõ tắt switches, the rows, the empty state
   src/convert/            the Chuyển mã window — see below
 packaging/              two .desktop files, apt/dnf repo metadata
 ```

--- a/platforms/linux/common/compose/composer/state.cpp
+++ b/platforms/linux/common/compose/composer/state.cpp
@@ -46,6 +46,10 @@ void Composer::applySettings() {
     // than left for the other mode to finish in a way it cannot.
     setNonPreedit(settings_.nonPreedit);
     handle_.setEnabled(effectiveEnabled_);
+    // The two gõ tắt options ride separately from `configure` (see handle.h), and
+    // ahead of the table itself only for reading order — neither one clears it.
+    handle_.setShortcutsEnabled(settings_.shortcutsEnabled);
+    handle_.setShortcutSmartCase(settings_.shortcutSmartCase);
     // The engine holds a runtime mirror of the gõ tắt table: replace it wholesale
     // rather than diffing, since the table is small and the source of truth is the
     // settings file.

--- a/platforms/linux/common/ffi/handle.h
+++ b/platforms/linux/common/ffi/handle.h
@@ -29,7 +29,8 @@ enum class KeySource : uint32_t {
 
 // The engine-affecting options of `settings`, as the C ABI's by-value config. The
 // runtime VI/EN state is deliberately absent: that is the live toggle
-// (`setEnabled`), not a persisted engine option.
+// (`setEnabled`), not a persisted engine option. So are the two gõ tắt options,
+// which the C ABI keeps as their own functions — see `setShortcutsEnabled` below.
 inline FunputConfig engineConfig(const Settings &s) {
     return FunputConfig{
         static_cast<uint8_t>(s.method),
@@ -70,6 +71,15 @@ public:
     // Text-expansion shortcuts (gõ tắt). Replace the whole table by clearing then
     // re-adding each entry (the engine is a runtime mirror of settings.json).
     void clearShortcuts() { funput_clear_shortcuts(engine_); }
+
+    // The two gõ tắt options. Their own FFI calls rather than `FunputConfig` fields:
+    // that struct crosses the ABI by value and this addon is built separately from
+    // the committed header, so growing it would mismatch silently. `configure` leaves
+    // both alone, so the calls may come in any order.
+    //
+    // Neither touches the table, so toggling either is instant and needs no re-push.
+    void setShortcutsEnabled(bool on) { funput_set_shortcuts_enabled(engine_, on); }
+    void setShortcutSmartCase(bool on) { funput_set_shortcut_smart_case(engine_, on); }
     void addShortcut(const std::string &trigger, const std::string &expansion) {
         const std::vector<uint32_t> t = decodeUtf8(trigger);
         const std::vector<uint32_t> e = decodeUtf8(expansion);

--- a/platforms/linux/common/settings/io.cpp
+++ b/platforms/linux/common/settings/io.cpp
@@ -91,6 +91,8 @@ bool Settings::reload() {
     spellCheck = data.value("spellCheck", spellCheck);
     autoCapitalize = data.value("autoCapitalize", autoCapitalize);
     nonPreedit = data.value("nonPreedit", nonPreedit);
+    shortcutsEnabled = data.value("shortcutsEnabled", shortcutsEnabled);
+    shortcutSmartCase = data.value("shortcutSmartCase", shortcutSmartCase);
     toggleHotkey = parseHotkey(data.value("toggleHotkey", std::string(hotkeyString(toggleHotkey))));
     flipHotkey = parseFlip(data.value("flipHotkey", std::string(flipString(flipHotkey))));
     shortcuts.clear();
@@ -108,7 +110,8 @@ bool Settings::reload() {
            eagerRestore != previous.eagerRestore || spellCheck != previous.spellCheck ||
            autoCapitalize != previous.autoCapitalize || nonPreedit != previous.nonPreedit ||
            toggleHotkey != previous.toggleHotkey || flipHotkey != previous.flipHotkey ||
-           shortcuts != previous.shortcuts;
+           shortcuts != previous.shortcuts || shortcutsEnabled != previous.shortcutsEnabled ||
+           shortcutSmartCase != previous.shortcutSmartCase;
 }
 
 void Settings::save() const {
@@ -127,6 +130,8 @@ void Settings::save() const {
     data["spellCheck"] = spellCheck;
     data["autoCapitalize"] = autoCapitalize;
     data["nonPreedit"] = nonPreedit;
+    data["shortcutsEnabled"] = shortcutsEnabled;
+    data["shortcutSmartCase"] = shortcutSmartCase;
     data["toggleHotkey"] = hotkeyString(toggleHotkey);
     data["flipHotkey"] = flipString(flipHotkey);
     std::ofstream output(file, std::ios::trunc);

--- a/platforms/linux/common/settings/settings.h
+++ b/platforms/linux/common/settings/settings.h
@@ -44,6 +44,17 @@ struct Settings {
     // Text-expansion shortcuts (gõ tắt): (trigger, expansion) pairs. Owned by the
     // Settings UI; the addon only reads them and pushes them into the engine.
     std::vector<std::pair<std::string, std::string>> shortcuts;
+    // Whether the table above expands at all ("Bật gõ tắt"). The rows stay loaded
+    // either way, so the switch is instant in both directions.
+    bool shortcutsEnabled = true;
+    // Whether a trigger matches however it was capitalized, with the expansion
+    // re-cased to match ("Tự nhận diện hoa/thường"). Off, only the exact trigger
+    // expands and the expansion is verbatim.
+    //
+    // Both default to **on**, including for a file written before they existed:
+    // that is how gõ tắt has always behaved, and an update must not silently change
+    // what an existing table expands to.
+    bool shortcutSmartCase = true;
 
     // Absolute path to ~/.config/Funput/settings.json (XDG-aware).
     static std::string path();

--- a/platforms/linux/common/tests/CMakeLists.txt
+++ b/platforms/linux/common/tests/CMakeLists.txt
@@ -27,7 +27,9 @@ add_executable(funput_linux_tests
     compose/composer/retone_tests.cpp
     compose/composer/verify_tests.cpp
     ffi/utf8_tests.cpp
-    settings/settings_tests.cpp)
+    settings/lookup_tests.cpp
+    settings/io_tests.cpp
+    settings/save_tests.cpp)
 
 target_link_libraries(funput_linux_tests PRIVATE funput_linux_common doctest::doctest)
 # So the nested test files can reach support.h by its bare name.

--- a/platforms/linux/common/tests/compose/composer/state_tests.cpp
+++ b/platforms/linux/common/tests/compose/composer/state_tests.cpp
@@ -110,3 +110,29 @@ TEST_CASE("gõ tắt expansions survive a settings push") {
     CHECK(plan.effect == Effect::Commit);
     CHECK(plan.text == "Việt Nam ");
 }
+
+// The matching rules themselves belong to the engine and are tested there
+// (crates/funput-engine/tests/words/shortcut.rs). What only this layer can prove is
+// that applySettings() pushes each switch across the C ABI at all — before it did,
+// neither field reached the engine however the user set it.
+TEST_CASE("shortcutsEnabled off is pushed to the engine") {
+    Settings settings;
+    settings.method = Method::Telex;
+    settings.shortcuts = {{"vn", "Việt Nam"}};
+    settings.shortcutsEnabled = false;
+    Composer composer(settings);
+
+    CHECK(typeDocument(composer, "vn ") == "vn ");
+}
+
+TEST_CASE("shortcutSmartCase off is pushed to the engine") {
+    Settings settings;
+    settings.method = Method::Telex;
+    settings.shortcuts = {{"vn", "Việt Nam"}};
+    settings.shortcutSmartCase = false;
+    Composer composer(settings);
+
+    // The stored trigger still expands; a differently-cased one no longer does.
+    CHECK(typeDocument(composer, "vn ") == "Việt Nam ");
+    CHECK(typeDocument(composer, "Vn ") == "Vn ");
+}

--- a/platforms/linux/common/tests/settings/io_tests.cpp
+++ b/platforms/linux/common/tests/settings/io_tests.cpp
@@ -1,32 +1,13 @@
-// The settings bridge. Every case writes the file it then reads, so the tests do
-// not depend on each other's leftovers (the composer's VI/EN toggle persists into
-// the same sandbox file).
+// Reading settings.json: every wire name, the defaults a key's absence must leave in
+// place, and what a file the reader cannot make sense of does *not* do.
 
 #include <doctest/doctest.h>
 
-#include <cstdlib>
-#include <fstream>
-#include <string>
-
 #include "settings/settings.h"
+#include "settings/support.h"
 
 using namespace funput;
-
-namespace {
-
-void writeSettingsFile(const std::string &json) {
-    std::ofstream out(Settings::path(), std::ios::trunc);
-    REQUIRE(out.good());
-    out << json;
-}
-
-} // namespace
-
-TEST_CASE("path follows XDG_CONFIG_HOME") {
-    const std::string path = Settings::path();
-    CHECK(path.rfind("/Funput/settings.json") != std::string::npos);
-    CHECK(path.rfind(std::getenv("XDG_CONFIG_HOME"), 0) == 0);
-}
+using namespace funput::test;
 
 TEST_CASE("reload parses every field from its wire name") {
     writeSettingsFile(R"({
@@ -40,6 +21,8 @@ TEST_CASE("reload parses every field from its wire name") {
         "nonPreedit": true,
         "toggleHotkey": "ctrl_space",
         "flipHotkey": "ctrl_shift_x",
+        "shortcutsEnabled": false,
+        "shortcutSmartCase": false,
         "shortcuts": [{"trigger": "vn", "expansion": "Việt Nam"}]
     })");
 
@@ -55,9 +38,26 @@ TEST_CASE("reload parses every field from its wire name") {
     CHECK(settings.nonPreedit);
     CHECK(settings.toggleHotkey == Hotkey::CtrlSpace);
     CHECK(settings.flipHotkey == FlipHotkey::CtrlShiftX);
+    CHECK_FALSE(settings.shortcutsEnabled);
+    CHECK_FALSE(settings.shortcutSmartCase);
     REQUIRE(settings.shortcuts.size() == 1);
     CHECK(settings.shortcuts[0].first == "vn");
     CHECK(settings.shortcuts[0].second == "Việt Nam");
+}
+
+// The compatibility guarantee behind both gõ tắt switches: a settings.json written
+// before they existed describes a table that expands, smart-cased. An update that
+// read those absences as "off" would silently change what the table expands to.
+TEST_CASE("the gõ tắt switches default to on when the file predates them") {
+    writeSettingsFile(R"({
+        "method": "telex",
+        "shortcuts": [{"trigger": "vn", "expansion": "Việt Nam"}]
+    })");
+
+    Settings settings;
+    REQUIRE(settings.reload());
+    CHECK(settings.shortcutsEnabled);
+    CHECK(settings.shortcutSmartCase);
 }
 
 TEST_CASE("reload reports whether anything actually changed") {
@@ -67,15 +67,6 @@ TEST_CASE("reload reports whether anything actually changed") {
     CHECK(settings.reload()); // method moved
 
     CHECK_FALSE(settings.reload()); // same file, same values
-}
-
-TEST_CASE("reloadIfChanged skips a file whose mtime has not moved") {
-    // "telex" differs from the Method::Vni default, so the first read reports a
-    // change — the return value is "did any value move", not "did I read the file".
-    writeSettingsFile(R"({"method": "telex"})");
-    Settings settings;
-    REQUIRE(settings.reloadIfChanged());
-    CHECK_FALSE(settings.reloadIfChanged());
 }
 
 TEST_CASE("a corrupt or missing file leaves the current values alone") {
@@ -98,35 +89,6 @@ TEST_CASE("unknown wire values fall back to the current setting") {
     settings.reload();
     CHECK(settings.method == Method::Vni);
     CHECK(settings.toggleHotkey == Hotkey::CtrlBacktick);
-}
-
-TEST_CASE("save round-trips and preserves keys it does not own") {
-    // shortcuts belong to the Settings UI: the addon reads them but must never
-    // write them back, or a toggle would wipe the user's list. Leftover keys
-    // (including a retired excludedApps list) must survive a merge save too.
-    writeSettingsFile(R"({
-        "method": "vni",
-        "excludedApps": [{"id": "firefox"}],
-        "shortcuts": [{"trigger": "vn", "expansion": "Việt Nam"}],
-        "someFutureKey": 42
-    })");
-
-    Settings settings;
-    REQUIRE(settings.reload());
-    settings.method = Method::Telex;
-    settings.enabled = false;
-    settings.save();
-
-    Settings reloaded;
-    REQUIRE(reloaded.reload());
-    CHECK(reloaded.method == Method::Telex);
-    CHECK_FALSE(reloaded.enabled);
-    REQUIRE(reloaded.shortcuts.size() == 1);
-
-    std::ifstream in(Settings::path());
-    const std::string raw((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    CHECK(raw.find("someFutureKey") != std::string::npos);
-    CHECK(raw.find("excludedApps") != std::string::npos);
 }
 
 TEST_CASE("toggleHotkey parses the extra presets") {

--- a/platforms/linux/common/tests/settings/lookup_tests.cpp
+++ b/platforms/linux/common/tests/settings/lookup_tests.cpp
@@ -1,0 +1,16 @@
+// Where settings.json lives (settings/lookup.cpp).
+
+#include <doctest/doctest.h>
+
+#include <cstdlib>
+#include <string>
+
+#include "settings/settings.h"
+
+using namespace funput;
+
+TEST_CASE("path follows XDG_CONFIG_HOME") {
+    const std::string path = Settings::path();
+    CHECK(path.rfind("/Funput/settings.json") != std::string::npos);
+    CHECK(path.rfind(std::getenv("XDG_CONFIG_HOME"), 0) == 0);
+}

--- a/platforms/linux/common/tests/settings/save_tests.cpp
+++ b/platforms/linux/common/tests/settings/save_tests.cpp
@@ -1,0 +1,68 @@
+// Writing settings.json, and the mtime shortcut that decides whether to read it.
+
+#include <doctest/doctest.h>
+
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#include "settings/settings.h"
+#include "settings/support.h"
+
+using namespace funput;
+using namespace funput::test;
+
+TEST_CASE("reloadIfChanged skips a file whose mtime has not moved") {
+    // "telex" differs from the Method::Vni default, so the first read reports a
+    // change — the return value is "did any value move", not "did I read the file".
+    writeSettingsFile(R"({"method": "telex"})");
+    Settings settings;
+    REQUIRE(settings.reloadIfChanged());
+    CHECK_FALSE(settings.reloadIfChanged());
+}
+
+TEST_CASE("save round-trips and preserves keys it does not own") {
+    // shortcuts belong to the Settings UI: the addon reads them but must never
+    // write them back, or a toggle would wipe the user's list. Leftover keys
+    // (including a retired excludedApps list) must survive a merge save too.
+    writeSettingsFile(R"({
+        "method": "vni",
+        "excludedApps": [{"id": "firefox"}],
+        "shortcuts": [{"trigger": "vn", "expansion": "Việt Nam"}],
+        "someFutureKey": 42
+    })");
+
+    Settings settings;
+    REQUIRE(settings.reload());
+    settings.method = Method::Telex;
+    settings.enabled = false;
+    settings.save();
+
+    Settings reloaded;
+    REQUIRE(reloaded.reload());
+    CHECK(reloaded.method == Method::Telex);
+    CHECK_FALSE(reloaded.enabled);
+    REQUIRE(reloaded.shortcuts.size() == 1);
+
+    std::ifstream in(Settings::path());
+    const std::string raw((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    CHECK(raw.find("someFutureKey") != std::string::npos);
+    CHECK(raw.find("excludedApps") != std::string::npos);
+}
+
+// The gõ tắt switches are options the addon reads, so — unlike the table itself —
+// they ride along on a save. A VI/EN toggle must not drop the user's choice.
+TEST_CASE("save keeps the gõ tắt switches") {
+    writeSettingsFile(R"({"method": "telex"})");
+
+    Settings settings;
+    REQUIRE(settings.reload());
+    settings.shortcutsEnabled = false;
+    settings.shortcutSmartCase = false;
+    settings.save();
+
+    Settings reloaded;
+    REQUIRE(reloaded.reload());
+    CHECK_FALSE(reloaded.shortcutsEnabled);
+    CHECK_FALSE(reloaded.shortcutSmartCase);
+}

--- a/platforms/linux/common/tests/settings/support.h
+++ b/platforms/linux/common/tests/settings/support.h
@@ -1,0 +1,26 @@
+// Shared helper for the settings-bridge tests. Every case writes the file it then
+// reads, so the tests do not depend on each other's leftovers (the composer's VI/EN
+// toggle persists into the same sandbox file). The sandbox itself is
+// XDG_CONFIG_HOME, set by main.cpp — the user's real settings.json is never touched.
+
+#ifndef FUNPUT_TESTS_SETTINGS_SUPPORT_H
+#define FUNPUT_TESTS_SETTINGS_SUPPORT_H
+
+#include <doctest/doctest.h>
+
+#include <fstream>
+#include <string>
+
+#include "settings/settings.h"
+
+namespace funput::test {
+
+inline void writeSettingsFile(const std::string &json) {
+    std::ofstream out(Settings::path(), std::ios::trunc);
+    REQUIRE(out.good());
+    out << json;
+}
+
+} // namespace funput::test
+
+#endif // FUNPUT_TESTS_SETTINGS_SUPPORT_H

--- a/platforms/linux/settings-gtk/src/config_transfer/document.rs
+++ b/platforms/linux/settings-gtk/src/config_transfer/document.rs
@@ -43,6 +43,10 @@ pub(super) struct Preferences {
     pub spell_check: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_capitalize: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shortcuts_enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shortcut_smart_case: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/platforms/linux/settings-gtk/src/config_transfer/tests.rs
+++ b/platforms/linux/settings-gtk/src/config_transfer/tests.rs
@@ -12,6 +12,8 @@ fn round_trip_preserves_state() {
             expansion: "Việt Nam".into(),
         }],
         non_preedit: true,
+        shortcuts_enabled: false,
+        shortcut_smart_case: false,
         ..Settings::default()
     };
     assert_eq!(
@@ -26,6 +28,28 @@ fn round_trip_preserves_state() {
     assert_eq!(imported.toggle_hotkey, Hotkey::AltShift);
     assert_eq!(imported.shortcuts.len(), 1);
     assert!(imported.non_preedit);
+    assert!(!imported.shortcuts_enabled);
+    assert!(!imported.shortcut_smart_case);
+}
+
+#[test]
+fn a_document_without_the_gõ_tắt_switches_leaves_them_alone() {
+    // Both default to on, so a file predating them describes a table that expands,
+    // smart-cased. Reading their absence as "off" would silently change what an
+    // imported table expands to — the same rule non_preedit follows above.
+    let mut settings = Settings {
+        shortcuts_enabled: false,
+        shortcut_smart_case: false,
+        ..Settings::default()
+    };
+    let doc = serde_json::from_str(
+        r#"{"schema":"app.funput.config","version":1,"preferences":{"inputMethod":"telex"}}"#,
+    )
+    .unwrap();
+    apply(&mut settings, &doc);
+    assert_eq!(settings.method, Method::Telex); // the block was read
+    assert!(!settings.shortcuts_enabled); // and these survived it
+    assert!(!settings.shortcut_smart_case);
 }
 
 #[test]

--- a/platforms/linux/settings-gtk/src/config_transfer/transfer.rs
+++ b/platforms/linux/settings-gtk/src/config_transfer/transfer.rs
@@ -24,6 +24,8 @@ pub(super) fn to_document(settings: &Settings) -> ConfigDocument {
             eager_restore: Some(settings.eager_restore),
             spell_check: Some(settings.spell_check),
             auto_capitalize: Some(settings.auto_capitalize),
+            shortcuts_enabled: Some(settings.shortcuts_enabled),
+            shortcut_smart_case: Some(settings.shortcut_smart_case),
         }),
         shortcuts: Some(
             settings
@@ -72,6 +74,15 @@ pub(super) fn apply(settings: &mut Settings, doc: &ConfigDocument) -> ImportSumm
         }
         if let Some(value) = prefs.auto_capitalize {
             settings.auto_capitalize = value;
+        }
+        // Absent means the exporter had nothing to say, not "off" — the format's
+        // non-destructive-import rule. A file predating these two fields carries a
+        // table that expands, smart-cased, and importing it must not change that.
+        if let Some(value) = prefs.shortcuts_enabled {
+            settings.shortcuts_enabled = value;
+        }
+        if let Some(value) = prefs.shortcut_smart_case {
+            settings.shortcut_smart_case = value;
         }
     }
     merge_shortcuts(settings, doc, &mut summary);

--- a/platforms/linux/settings-gtk/src/settings/model.rs
+++ b/platforms/linux/settings-gtk/src/settings/model.rs
@@ -106,6 +106,21 @@ pub struct Settings {
     pub has_completed_onboarding: bool,
     #[serde(default)]
     pub shortcuts: Vec<Shortcut>,
+    /// Whether the table above expands at all. The rows stay stored either way.
+    #[serde(default = "on")]
+    pub shortcuts_enabled: bool,
+    /// Whether a trigger matches however it was capitalized, with the expansion
+    /// re-cased to match.
+    ///
+    /// Both default to **on**, including for a file written before they existed:
+    /// that is how gõ tắt has always behaved, and an update must not silently change
+    /// what an existing table expands to. The addon's C++ model says the same.
+    #[serde(default = "on")]
+    pub shortcut_smart_case: bool,
+}
+
+fn on() -> bool {
+    true
 }
 
 impl Default for Settings {
@@ -124,6 +139,8 @@ impl Default for Settings {
             launch_at_login: false,
             has_completed_onboarding: false,
             shortcuts: Vec::new(),
+            shortcuts_enabled: true,
+            shortcut_smart_case: true,
         }
     }
 }

--- a/platforms/linux/settings-gtk/src/settings_window/shortcuts.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/shortcuts.rs
@@ -1,7 +1,11 @@
-//! "Gõ tắt" page: manage text-expansion shortcuts (`vn` → `việt nam`, smart-cased to
-//! `Vn` → `Việt Nam` / `VN` → `VIỆT NAM` at expansion time). Each shortcut
-//! is an expander with two editable fields; edits persist by index and update the
-//! header live, while add/delete rebuild the list.
+//! "Gõ tắt" page: the two switches governing expansion, then the shortcuts
+//! themselves (`vn` → `việt nam`, smart-cased to `Vn` → `Việt Nam` / `VN` →
+//! `VIỆT NAM` at expansion time). Each shortcut is an expander with two editable
+//! fields; edits persist by index and update the header live, while add/delete
+//! rebuild the list.
+//!
+//! One page rather than a stack of empty/list states: the switches in `options` are
+//! shown either way, which a swapped-out empty page could not do.
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
@@ -13,6 +17,7 @@ use gtk::{Align, Button};
 use crate::settings::{Settings, Shortcut};
 
 mod empty;
+mod options;
 mod row;
 
 /// The "throw the list away and build it again" closure, held so the rows it builds
@@ -24,27 +29,29 @@ mod row;
 pub(super) type Rebuild = Rc<RefCell<Option<Rc<dyn Fn()>>>>;
 
 pub(super) fn page() -> gtk::Widget {
-    let list_page = PreferencesPage::builder()
+    let settings = Settings::load();
+    let page = PreferencesPage::builder()
         .title("Gõ tắt")
         .icon_name("edit-find-replace-symbolic")
         .build();
     let group = PreferencesGroup::builder()
-        .title("Gõ tắt")
-        .description(
-            "Gõ chữ tắt rồi dấu cách để bung — ví dụ vn → việt nam. Tự nhận diện hoa/thường: \
-             Vn → Việt Nam, VN → VIỆT NAM.",
-        )
+        .title("Danh sách gõ tắt")
         .build();
-    list_page.add(&group);
+    // The empty state is a group of its own rather than a separate page, so the
+    // switches above it stay on screen while the table has no rows.
+    let blank = PreferencesGroup::new();
 
-    let pages = gtk::Stack::new();
+    page.add(&options::group(&settings));
+    page.add(&group);
+    page.add(&blank);
+
     let rows: Rc<RefCell<Vec<gtk::Widget>>> = Rc::new(RefCell::new(Vec::new()));
     let focus_new = Rc::new(Cell::new(false));
     let rebuild: Rebuild = Rc::new(RefCell::new(None));
 
     let rebuild_impl: Rc<dyn Fn()> = {
         let group = group.clone();
-        let pages = pages.clone();
+        let blank = blank.clone();
         let rows = rows.clone();
         let focus_new = focus_new.clone();
         let rebuild = rebuild.clone();
@@ -53,11 +60,8 @@ pub(super) fn page() -> gtk::Widget {
                 group.remove(&r);
             }
             let s = Settings::load();
-            if s.shortcuts.is_empty() {
-                pages.set_visible_child_name("empty");
-                return;
-            }
-            pages.set_visible_child_name("list");
+            group.set_visible(!s.shortcuts.is_empty());
+            blank.set_visible(s.shortcuts.is_empty());
             let mut last: Option<(ExpanderRow, EntryRow)> = None;
             for (i, sc) in s.shortcuts.iter().enumerate() {
                 let (expander, trigger) = row::build(i, sc, &rebuild);
@@ -101,8 +105,7 @@ pub(super) fn page() -> gtk::Widget {
     add_btn.connect_clicked(move |_| add_header());
     group.set_header_suffix(Some(&add_btn));
 
-    pages.add_named(&empty::page(move || add()), Some("empty"));
-    pages.add_named(&list_page, Some("list"));
+    blank.add(&empty::page(move || add()));
     rebuild_impl();
-    pages.upcast()
+    page.upcast()
 }

--- a/platforms/linux/settings-gtk/src/settings_window/shortcuts/options.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/shortcuts/options.rs
@@ -1,0 +1,62 @@
+//! The two switches governing the gõ tắt table, above the rows themselves.
+//!
+//! Kept visible whether or not the table has any rows — an empty table is exactly
+//! when a user is most likely to be reading this page — and mirroring the Windows
+//! page (`platforms/windows/ui/pages/shortcuts/page.slint`) row for row.
+
+use adw::prelude::*;
+use adw::{PreferencesGroup, SwitchRow};
+
+use crate::settings::Settings;
+
+/// This group's description, which has to follow the smart-case switch: the example
+/// stops being true the moment case matching is off. It sits here rather than on the
+/// list below because the list is hidden while the table is empty, and a switch
+/// whose explanation vanishes with the rows explains nothing.
+fn description(smart_case: bool) -> &'static str {
+    if smart_case {
+        "Gõ chữ tắt rồi dấu cách để bung — ví dụ vn → việt nam. Tự nhận diện hoa/thường: \
+         Vn → Việt Nam, VN → VIỆT NAM."
+    } else {
+        "Gõ chữ tắt rồi dấu cách để bung — ví dụ vn → việt nam. Đang tắt nhận diện \
+         hoa/thường: chỉ đúng chữ tắt đã lưu mới bung, nội dung giữ nguyên."
+    }
+}
+
+pub(super) fn group(settings: &Settings) -> PreferencesGroup {
+    let group = PreferencesGroup::builder()
+        .title("Gõ tắt")
+        .description(description(settings.shortcut_smart_case))
+        .build();
+
+    let enabled_row = SwitchRow::builder()
+        .title("Bật gõ tắt")
+        .subtitle("Tắt để tạm gõ nguyên chữ tắt — bảng bên dưới vẫn giữ nguyên.")
+        .active(settings.shortcuts_enabled)
+        .build();
+    enabled_row.connect_active_notify(|row| {
+        let on = row.is_active();
+        Settings::update(|settings| settings.shortcuts_enabled = on);
+    });
+
+    let smart_row = SwitchRow::builder()
+        .title("Tự nhận diện hoa/thường")
+        .subtitle(
+            "Gõ vn, Vn hay VN đều bung và nội dung tự viết hoa theo. Tắt thì chỉ khớp \
+             đúng chuỗi tắt đã lưu.",
+        )
+        .active(settings.shortcut_smart_case)
+        .build();
+    // Deliberately not desensitized when "Bật gõ tắt" is off, even though it depends
+    // on it: macOS leaves the switch live, and the platforms must read the same.
+    let group_for_smart = group.clone();
+    smart_row.connect_active_notify(move |row| {
+        let on = row.is_active();
+        Settings::update(|settings| settings.shortcut_smart_case = on);
+        group_for_smart.set_description(Some(description(on)));
+    });
+
+    group.add(&enabled_row);
+    group.add(&smart_row);
+    group
+}


### PR DESCRIPTION
Đưa Linux ngang bằng Windows ở trang Gõ tắt: **Bật gõ tắt** và **Tự nhận diện hoa/thường** giờ là hai công tắc người dùng chạm tới được.

## Vì sao

Linux là nền tảng bị bỏ sót khi công tắc smart-case ra đời. Cả struct `Settings` C++ mà addon Fcitx5/IBus đọc lẫn app Settings GTK đều không biết trường này, nên người dùng Linux không tắt được — và sửa tay `settings.json` cũng vô ích, vì addon chưa từng đọc khoá đó. `shortcutsEnabled` thiếu y hệt.

Tệ hơn cả thiếu: app Settings ghi đè **nguyên** struct của nó lên `settings.json`, nên khoá nào vắng mặt trong model sẽ bị xoá ở lần lưu kế tiếp. Một `shortcutsEnabled: false` đến từ import config chỉ sống được đúng tới lúc người dùng đổi bất kỳ cài đặt nào.

## Thay đổi những gì

| Tầng | Thay đổi |
|---|---|
| **C ABI** | Thêm `funput_set_shortcuts_enabled`, theo đúng khuôn setter smart-case đã có. `shortcuts_enabled` trước giờ chưa có setter — macOS không có UI cho nó, còn Windows link thẳng `funput-desktop`. Linux chỉ chạm tới engine qua ABI này. |
| **Addon** | Hai trường đi xuyên qua struct `Settings` C++, phần đọc/ghi JSON, `handle.h` và `applySettings()`. |
| **App Settings** | Hai trường vào model GTK và vào export/import config; hai `SwitchRow` trên trang Gõ tắt. |

Cả hai mặc định **bật**, kể cả với file được ghi trước khi hai trường này tồn tại — gõ tắt xưa nay vẫn hoạt động như vậy, và một bản cập nhật không được lặng lẽ đổi kết quả bung của bảng đang có.

## Ghi chú cho người review

- **Trang được cấu trúc lại, không chỉ thêm hai dòng.** Nó vốn là `GtkStack` đổi qua lại giữa trang trạng thái rỗng và danh sách, nên công tắc sẽ bị ẩn mỗi khi bảng trống — đúng lúc người dùng dễ đọc trang này nhất. Giờ là một `AdwPreferencesPage`, nhóm danh sách và nhóm trạng thái rỗng bật/tắt visibility bên dưới một nhóm công tắc luôn hiện, giống Windows. Mô tả của nhóm đi theo công tắc smart-case, vì ví dụ `vn → việt nam, Vn → Việt Nam` hết đúng ngay khi tắt nó.
- **Smart-case cố ý để sống khi "Bật gõ tắt" đang tắt**, không làm mờ — macOS để sống, và các nền tảng nên đọc giống nhau.
- **Test settings được tách làm ba** (lookup / io / save). File cũ 143 dòng so với hạn mức 150, mà C++ đếm cả file kể cả phần test, nên phần coverage mới không nhét vừa; cách tách theo đúng quy ước một-file-test-cho-một-file-nguồn mà CMakeLists đã ghi sẵn.
- **Test composer vẫn ở `state_tests.cpp`** — `common/tests/compose/composer/` đã chạm trần năm file — và chỉ chứng minh phần thuộc về tầng này: `applySettings()` có đẩy từng công tắc qua ABI hay không. Luật khớp hoa/thường vẫn được test trong `funput-engine`.

## Kiểm thử

Chạy tại máy, tất cả đều xanh:

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`
- `cargo test -p funput-ffi -p funput-engine -p funput-config`
- `gen-header.sh --check`, `scripts/check-loc.sh` (373 file trong hạn mức)
- settings-gtk: fmt + clippy + test
- `ctest` **84/84** — bộ này link `libfunput_ffi.so` thật, nên các case composer chạy đúng chuỗi settings → `Handle` → C ABI mới → engine Rust, y như addon chạy thật
- Addon Fcitx5 và engine IBus đều build được (cả hai dùng `handle.h` đã sửa)
- Đã cài đè lên bản Fcitx5 đang chạy và test tay: hai công tắc hoạt động đúng như mô tả, ăn ngay qua settings watcher

## Ngoài phạm vi

macOS vẫn chưa có công tắc "Bật gõ tắt", nên sau PR này Linux và Windows có cả hai, macOS có một. Hàm `save()` ghi đè nguyên file của app GTK cũng vẫn mong manh về mặt cấu trúc — PR này bịt hai lỗ đã biết chứ không đổi cơ chế đó.

🤖 Generated with [Claude Code](https://claude.com/claude-code)