### PR TITLE
feat(macos): add the "Bật gõ tắt" switch to Gõ tắt settings

### DIFF
--- a/platforms/CONFIG_FORMAT.md
+++ b/platforms/CONFIG_FORMAT.md
@@ -68,7 +68,7 @@ one machine imports on another. macOS is the first implementation
 | `source` | — | `platform` + `appVersion` that produced the file. Metadata only. |
 | `preferences.inputMethod` | ✅ | `telex`, `telex_advanced`, or `vni`. Exposed on macOS, Windows, Linux, iOS, and Android; unsupported consumers keep their current selection. |
 | `preferences.*` | ✅ | Other typing options; each is optional and applied only if present. |
-| `shortcuts[]` | ✅ | `{ trigger, expansion }`. Local UUIDs are dropped; recreated on import. Whether they expand is `preferences.shortcutsEnabled`, which defaults to `true` when absent — an older file carries a working table and must not arrive switched off. Exposed as a switch on Windows and Linux; macOS reads it but shows no control. |
+| `shortcuts[]` | ✅ | `{ trigger, expansion }`. Local UUIDs are dropped; recreated on import. Whether they expand is `preferences.shortcutsEnabled`, which defaults to `true` when absent — an older file carries a working table and must not arrive switched off. Exposed as a switch on macOS, Windows and Linux. |
 | `preferences.shortcutSmartCase` | ✅ | Whether a trigger matches regardless of how it was capitalized, with the expansion re-cased to match (`tp`/`Tp`/`TP` → `TP. HCM`/`Tp. Hcm`/`TP. HCM`). Off, only the exact trigger expands and the expansion is verbatim. Defaults to `true` when absent, for the same reason as `shortcutsEnabled`. Exposed as a switch on macOS, Windows and Linux. |
 | `platform.macos.toggleShortcut` | ❌ | `KeyCombo` (`keyCode` is AppKit-specific). Applied only on macOS, only if present. |
 | `platform.macos.flipShortcut` | ❌ | `KeyCombo` or `null`. Applied only on macOS, only if present. |

--- a/platforms/macos/Funput/IME/ComposerConfiguration.swift
+++ b/platforms/macos/Funput/IME/ComposerConfiguration.swift
@@ -10,6 +10,7 @@ struct ComposerConfiguration: Equatable {
     let eagerRestore: Bool
     let spellCheckEnabled: Bool
     let autoCapitalizeEnabled: Bool
+    let shortcutsEnabled: Bool
     let shortcutSmartCase: Bool
 
     init(settings: AppSettings) {
@@ -20,6 +21,7 @@ struct ComposerConfiguration: Equatable {
         eagerRestore = settings.eagerRestore
         spellCheckEnabled = settings.spellCheckEnabled
         autoCapitalizeEnabled = settings.autoCapitalizeEnabled
+        shortcutsEnabled = settings.shortcutsEnabled
         shortcutSmartCase = settings.shortcutSmartCase
     }
 
@@ -31,6 +33,7 @@ struct ComposerConfiguration: Equatable {
         eagerRestore: Bool = true,
         spellCheckEnabled: Bool = false,
         autoCapitalizeEnabled: Bool = false,
+        shortcutsEnabled: Bool = true,
         shortcutSmartCase: Bool = true
     ) {
         self.inputMethod = inputMethod
@@ -40,6 +43,7 @@ struct ComposerConfiguration: Equatable {
         self.eagerRestore = eagerRestore
         self.spellCheckEnabled = spellCheckEnabled
         self.autoCapitalizeEnabled = autoCapitalizeEnabled
+        self.shortcutsEnabled = shortcutsEnabled
         self.shortcutSmartCase = shortcutSmartCase
     }
 }
@@ -56,9 +60,10 @@ extension FunputComposer {
                 auto_capitalize: configuration.autoCapitalizeEnabled
             )
         )
-        // Neither of these rides the by-value `FunputConfig`: `enabled` is a runtime
-        // toggle, and smart case is kept off the C struct for ABI stability. Order does
-        // not matter — `configure` edits the engine config rather than replacing it.
+        // None of these ride the by-value `FunputConfig`: `enabled` is a runtime
+        // toggle, and the gõ tắt switches are kept off the C struct for ABI stability.
+        // Order does not matter — `configure` edits the engine config, never replaces it.
+        setShortcutsEnabled(configuration.shortcutsEnabled)
         setShortcutSmartCase(configuration.shortcutSmartCase)
         setEnabled(configuration.enabled)
     }

--- a/platforms/macos/Funput/IME/FunputComposer.swift
+++ b/platforms/macos/Funput/IME/FunputComposer.swift
@@ -43,6 +43,13 @@ final class FunputComposer {
         funput_clear_shortcuts(handle)
     }
 
+    /// The gõ tắt master switch: off, nothing expands and the table is left loaded, so
+    /// hosts need not re-push their rows around it. Its own FFI call for the same ABI
+    /// reason as `setShortcutSmartCase` below.
+    func setShortcutsEnabled(_ on: Bool) {
+        funput_set_shortcuts_enabled(handle, on)
+    }
+
     /// Smart-case matching for gõ tắt: on, `tp`/`Tp`/`TP` all find the `tp` entry and
     /// the expansion is re-cased to match; off, only the exact trigger expands and the
     /// expansion is verbatim. Its own FFI call rather than a `FunputConfig` field —

--- a/platforms/macos/Funput/Model/AppSettings+Config.swift
+++ b/platforms/macos/Funput/Model/AppSettings+Config.swift
@@ -41,6 +41,7 @@ extension AppSettings {
                 eagerRestore: eagerRestore,
                 spellCheck: spellCheckEnabled,
                 autoCapitalize: autoCapitalizeEnabled,
+                shortcutsEnabled: shortcutsEnabled,
                 shortcutSmartCase: shortcutSmartCase
             ),
             shortcuts: shortcuts.map { .init(trigger: $0.trigger, expansion: $0.expansion) },
@@ -86,6 +87,7 @@ extension AppSettings {
             if let value = prefs.eagerRestore { eagerRestore = value }
             if let value = prefs.spellCheck { spellCheckEnabled = value }
             if let value = prefs.autoCapitalize { autoCapitalizeEnabled = value }
+            if let value = prefs.shortcutsEnabled { shortcutsEnabled = value }
             if let value = prefs.shortcutSmartCase { shortcutSmartCase = value }
         }
 

--- a/platforms/macos/Funput/Model/AppSettings.swift
+++ b/platforms/macos/Funput/Model/AppSettings.swift
@@ -80,6 +80,11 @@ final class AppSettings {
             shortcutsRevision &+= 1
         }
     }
+    /// Master gõ tắt switch ("Bật gõ tắt"). Off, nothing expands; the table stays
+    /// loaded, so flipping it back costs nothing. On by default.
+    var shortcutsEnabled: Bool {
+        didSet { defaults.set(shortcutsEnabled, forKey: Keys.shortcutsEnabled) }
+    }
     /// Smart-case gõ tắt ("Tự nhận diện hoa/thường"): a trigger matches however it was
     /// capitalized and the expansion is re-cased to match. On by default.
     var shortcutSmartCase: Bool {
@@ -111,6 +116,7 @@ final class AppSettings {
             Keys.showMenuBarIcon: true,
             Keys.vietnameseEnabled: true,
             Keys.retoneAfterBackspace: true,
+            Keys.shortcutsEnabled: true,
             Keys.shortcutSmartCase: true,
         ])
         inputMethod = InputMethod.persisted(defaults.object(forKey: Keys.inputMethod))
@@ -121,6 +127,7 @@ final class AppSettings {
         spellCheckEnabled = defaults.bool(forKey: Keys.spellCheckEnabled)
         autoCapitalizeEnabled = defaults.bool(forKey: Keys.autoCapitalizeEnabled)
         retoneAfterBackspace = defaults.bool(forKey: Keys.retoneAfterBackspace)
+        shortcutsEnabled = defaults.bool(forKey: Keys.shortcutsEnabled)
         shortcutSmartCase = defaults.bool(forKey: Keys.shortcutSmartCase)
         toggleShortcut = defaults.data(forKey: Keys.toggleShortcut)
             .flatMap { try? JSONDecoder().decode(KeyCombo.self, from: $0) } ?? .defaultToggle

--- a/platforms/macos/Funput/Model/AppSettingsKeys.swift
+++ b/platforms/macos/Funput/Model/AppSettingsKeys.swift
@@ -14,6 +14,7 @@ extension AppSettings {
         static let showMenuBarIcon = "showMenuBarIcon"
         static let hasCompletedOnboarding = "hasCompletedOnboarding"
         static let shortcuts = "shortcuts"
+        static let shortcutsEnabled = "shortcutsEnabled"
         static let shortcutSmartCase = "shortcutSmartCase"
     }
 }

--- a/platforms/macos/Funput/Model/ConfigDocument.swift
+++ b/platforms/macos/Funput/Model/ConfigDocument.swift
@@ -35,6 +35,9 @@ struct ConfigDocument: Codable {
         var eagerRestore: Bool?
         var spellCheck: Bool?
         var autoCapitalize: Bool?
+        /// Whether the gõ tắt rows in `shortcuts` expand at all. Absent means on —
+        /// see `CONFIG_FORMAT.md`.
+        var shortcutsEnabled: Bool?
         /// Whether a gõ tắt trigger matches however it was capitalized, expansion
         /// re-cased to match. Absent means on — see `CONFIG_FORMAT.md`.
         var shortcutSmartCase: Bool?

--- a/platforms/macos/Funput/Settings/Panes/OverviewPane.swift
+++ b/platforms/macos/Funput/Settings/Panes/OverviewPane.swift
@@ -26,7 +26,9 @@ struct OverviewPane: View {
                         }
                         SettingsMetric(
                             title: "Gõ tắt",
-                            value: "\(settings.shortcuts.count)",
+                            // The count would otherwise promise expansions that the
+                            // master switch is currently stopping.
+                            value: settings.shortcutsEnabled ? "\(settings.shortcuts.count)" : "Tắt",
                             systemImage: "text.append"
                         ) {
                             selection = .textShortcuts

--- a/platforms/macos/Funput/Settings/Panes/ShortcutsPane.swift
+++ b/platforms/macos/Funput/Settings/Panes/ShortcutsPane.swift
@@ -10,12 +10,44 @@ struct ShortcutsPane: View {
         @Bindable var settings = settings
 
         Group {
+            Section("Gõ tắt") {
+                VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+                    // The pane's own sidebar mark, so the switch reads as governing the
+                    // whole feature rather than one option among several.
+                    SettingsRow(
+                        title: "Bật gõ tắt",
+                        subtitle: "Tắt để tạm gõ nguyên chữ tắt — bảng bên dưới vẫn giữ nguyên.",
+                        systemImage: "text.append"
+                    ) {
+                        Toggle("Bật gõ tắt", isOn: $settings.shortcutsEnabled)
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                            .tint(Theme.accent)
+                    }
+
+                    Divider()
+
+                    // Deliberately live while "Bật gõ tắt" is off, even though it only
+                    // matters when that is on: Windows and Linux leave it live too.
+                    SettingsRow(
+                        title: "Tự nhận diện hoa/thường",
+                        subtitle: "Gõ vn, Vn hay VN đều bung và nội dung tự viết hoa theo. Tắt thì chỉ khớp đúng chuỗi tắt đã lưu.",
+                        systemImage: "textformat"
+                    ) {
+                        Toggle("Tự nhận diện hoa/thường", isOn: $settings.shortcutSmartCase)
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                            .tint(Theme.accent)
+                    }
+                }
+            }
+
             Section("Danh sách gõ tắt") {
                 VStack(alignment: .leading, spacing: Theme.Spacing.md) {
                     SettingsRow(
-                        title: "Gõ tắt",
+                        title: countLabel,
                         subtitle: "Gõ chuỗi tắt rồi dấu cách để bung — ví dụ vn → Việt Nam",
-                        systemImage: "text.append"
+                        systemImage: "list.bullet"
                     ) {
                         Button(action: addRow) {
                             Label("Thêm", systemImage: "plus")
@@ -28,22 +60,9 @@ struct ShortcutsPane: View {
                         )
                     }
 
-                    Divider()
-
-                    SettingsRow(
-                        title: "Tự nhận diện hoa/thường",
-                        subtitle: "Gõ vn, Vn hay VN đều bung và nội dung tự viết hoa theo. Tắt thì chỉ khớp đúng chuỗi tắt đã lưu.",
-                        systemImage: "textformat"
-                    ) {
-                        Toggle("Tự nhận diện hoa/thường", isOn: $settings.shortcutSmartCase)
-                            .labelsHidden()
-                            .toggleStyle(.switch)
-                            .tint(Theme.accent)
-                    }
-
                     if settings.shortcuts.isEmpty {
                         Divider()
-                        Text("Chưa có gõ tắt nào. Bấm “Thêm” để tạo — ví dụ vn → Việt Nam, kg → không.")
+                        Text("Bấm “Thêm” để tạo — ví dụ vn → Việt Nam, kg → không.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -70,6 +89,10 @@ struct ShortcutsPane: View {
     }
 
     // MARK: - Helpers
+
+    private var countLabel: String {
+        settings.shortcuts.isEmpty ? "Chưa có gõ tắt nào" : "\(settings.shortcuts.count) gõ tắt"
+    }
 
     /// "Thêm" is only enabled when the list is empty, or the last row already
     /// has both a trigger and an expansion — avoids piling up empty/half-filled

--- a/platforms/macos/FunputTests/ComposerConfigurationTests.swift
+++ b/platforms/macos/FunputTests/ComposerConfigurationTests.swift
@@ -16,6 +16,7 @@ final class ComposerConfigurationTests: XCTestCase {
         settings.eagerRestore = false
         settings.spellCheckEnabled = true
         settings.autoCapitalizeEnabled = true
+        settings.shortcutsEnabled = false
         settings.shortcutSmartCase = false
 
         let configuration = ComposerConfiguration(settings: settings)
@@ -27,20 +28,25 @@ final class ComposerConfigurationTests: XCTestCase {
         XCTAssertFalse(configuration.eagerRestore)
         XCTAssertTrue(configuration.spellCheckEnabled)
         XCTAssertTrue(configuration.autoCapitalizeEnabled)
+        XCTAssertFalse(configuration.shortcutsEnabled)
         XCTAssertFalse(configuration.shortcutSmartCase)
     }
 
-    /// Smart-case gõ tắt is on by default, which only holds because the key is in
-    /// `defaults.register` — `UserDefaults.bool` reads a missing key as `false`, so
-    /// forgetting that line would silently change what everyone's table expands to.
-    func testSmartCaseShortcutsDefaultToOn() {
+    /// Both gõ tắt switches are on by default, which only holds because their keys are
+    /// in `defaults.register` — `UserDefaults.bool` reads a missing key as `false`, so
+    /// forgetting a line there would silently kill everyone's shortcuts on update.
+    func testShortcutSwitchesDefaultToOn() {
         let suiteName = "app.funput.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let settings = AppSettings(defaults: defaults)
 
+        XCTAssertTrue(settings.shortcutsEnabled)
         XCTAssertTrue(settings.shortcutSmartCase)
-        XCTAssertTrue(ComposerConfiguration(settings: settings).shortcutSmartCase)
+
+        let configuration = ComposerConfiguration(settings: settings)
+        XCTAssertTrue(configuration.shortcutsEnabled)
+        XCTAssertTrue(configuration.shortcutSmartCase)
     }
 }

--- a/platforms/macos/FunputTests/ConfigDocumentTests.swift
+++ b/platforms/macos/FunputTests/ConfigDocumentTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import Funput
+
+@MainActor
+final class ConfigDocumentTests: XCTestCase {
+    private func makeSettings() -> (AppSettings, String) {
+        let suiteName = "app.funput.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        return (AppSettings(defaults: defaults), suiteName)
+    }
+
+    /// Both gõ tắt switches are portable preferences, so an export has to carry them
+    /// and an import has to apply them. A field missing from `Preferences` decodes
+    /// silently as `nil`, which is why this asserts the values rather than the shape.
+    func testShortcutSwitchesSurviveExportAndImport() throws {
+        let (source, sourceSuite) = makeSettings()
+        defer { UserDefaults().removePersistentDomain(forName: sourceSuite) }
+        source.shortcutsEnabled = false
+        source.shortcutSmartCase = false
+
+        let data = try source.exportData()
+
+        let (destination, destinationSuite) = makeSettings()
+        defer { UserDefaults().removePersistentDomain(forName: destinationSuite) }
+        XCTAssertTrue(destination.shortcutsEnabled, "starts at the default")
+        XCTAssertTrue(destination.shortcutSmartCase)
+
+        try destination.importData(data)
+
+        XCTAssertFalse(destination.shortcutsEnabled)
+        XCTAssertFalse(destination.shortcutSmartCase)
+    }
+
+    /// Import is a merge: a file written before these fields existed must leave the
+    /// local switches alone rather than resetting them to the format's default.
+    func testAFileWithoutTheSwitchesLeavesLocalOnesAlone() throws {
+        let (settings, suite) = makeSettings()
+        defer { UserDefaults().removePersistentDomain(forName: suite) }
+        settings.shortcutsEnabled = false
+        settings.shortcutSmartCase = false
+
+        let legacy = """
+        { "schema": "app.funput.config", "version": 1,
+          "preferences": { "inputMethod": "vni" } }
+        """
+        try settings.importData(Data(legacy.utf8))
+
+        XCTAssertFalse(settings.shortcutsEnabled)
+        XCTAssertFalse(settings.shortcutSmartCase)
+    }
+}


### PR DESCRIPTION
Gõ tắt có hai công tắc. Windows và Linux đã có cả hai, macOS mới chỉ có một — PR này bù ô trống đó.

| Công tắc | Engine | macOS | Windows | Linux |
|---|:---:|:---:|:---:|:---:|
| **Bật gõ tắt** | ✅ | ✅ *(mới)* | ✅ | ✅ |
| **Tự nhận diện hoa/thường** | ✅ | ✅ | ✅ | ✅ |

Không sửa dòng Rust nào — `funput_set_shortcuts_enabled` đã có sẵn trong `funput.h`.

## Giao diện

Hai công tắc chuyển lên một nhóm riêng phía trên bảng, đúng thứ tự và đúng chuỗi tiếng Việt như Windows/Linux:

```
Gõ tắt
  ⌨  Bật gõ tắt                       [●]
  ─────────────────────────────────────
  Aa  Tự nhận diện hoa/thường         [●]

Danh sách gõ tắt
  ☰  2 gõ tắt                    [+ Thêm]
     vn  →  Việt Nam                  🗑

Mẹo
```

Dùng `Form(.grouped)` + `SettingsRow` + `Toggle(.switch)` sẵn có, nên vẫn là control macOS chuẩn như các màn khác.

**Tắt gõ tắt không làm mờ thứ gì** — không mờ công tắc hoa/thường, không khoá các dòng. Comment bên Windows và Linux đều ghi macOS là bản tham chiếu cho điểm này. Bảng cũng không bị xoá: engine chặn ở tầng compose, nên bật lại là dùng được ngay, không cần đẩy lại dữ liệu.

Thẻ **Gõ tắt** ở màn Tổng quan hiện `Tắt` thay vì con số khi công tắc đang tắt, để không hứa hẹn những dòng không bung.

## Sửa kèm một lỗ hổng có sẵn

`ConfigDocument.Preferences` bên macOS **thiếu hẳn** `shortcutsEnabled`, nên `Codable` âm thầm bỏ qua:

- File cấu hình xuất từ Windows đang **tắt** gõ tắt, nhập vào Mac thì thành **bật**
- Mac xuất ra không bao giờ ghi field đó, nên đi vòng nào cũng mất giá trị

`CONFIG_FORMAT.md` lại đang mô tả là macOS *có* đọc field này — đã sửa lại cho đúng.

## Kiểm thử

Hai commit, dựng worktree riêng cho từng commit: `xcodebuild test` xanh và `check-swift-loc.sh` sạch ở cả hai.

Test round-trip export/import đã được xác minh là **bắt được bug thật**: gỡ phần sửa ra thì test đỏ.

Còn lại cần thử tay (phải cài IME): tắt công tắc → gõ `vn ` phải ra `vn ` và các dòng trong bảng vẫn còn, vẫn sửa được; bật lại thì ăn ngay không cần khởi động lại.

🤖 Generated with [Claude Code](https://claude.com/claude-code)