### PR TITLE
ci: make the pull-request gate binding

### DIFF
--- a/.github/workflows/arch-recipe.yml
+++ b/.github/workflows/arch-recipe.yml
@@ -38,8 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     container: archlinux:base-devel
     # makepkg compiles the whole Rust + C++ tree from source with no cache, so the
-    # normal run is minutes rather than seconds. Generous, but bounded.
-    timeout-minutes: 45
+    # normal run is minutes rather than seconds — measured at 2m48s, pacman -Syu
+    # included. Wide enough for a slow runner, far short of the six-hour default.
+    timeout-minutes: 20
     steps:
       - name: Install tools
         run: pacman -Syu --noconfirm --needed git namcap curl jq

--- a/.github/workflows/arch-recipe.yml
+++ b/.github/workflows/arch-recipe.yml
@@ -1,0 +1,77 @@
+name: Arch recipe
+
+# Builds platforms/linux/packaging/arch/PKGBUILD.in with a real `makepkg`, so a
+# broken recipe is caught at review rather than at publish time.
+#
+# Its own workflow rather than a job in ci.yml, because it is the one check here
+# that does not apply to every pull request. GitHub filters paths per *workflow*,
+# never per job, so expressing "only when the recipe changes" inside ci.yml needed
+# a helper job that ran on every pull request — a whole runner and a full-history
+# checkout — to compute a diff whose answer was almost always "no". The `paths:`
+# filter below is the same condition with none of that machinery.
+#
+# NOT a required status check: a path-filtered workflow reports no status on the
+# pull requests it skips, and a required check that never reports blocks the merge
+# forever. ci.yml holds the checks that must pass on everything.
+#
+# It builds the LATEST RELEASED TAG, not this pull request's code: the recipe
+# sources a published GitHub tarball, and a pull request has no tag. So this
+# proves the recipe still works; a CMake-layout change that would break it needs
+# a run against a release made after that change. publish-repo.yml builds it for
+# real on every release and fortnightly — this is the cheaper, earlier signal.
+on:
+  pull_request:
+    paths:
+      - platforms/linux/packaging/arch/**
+      - .github/workflows/arch-recipe.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: arch-recipe-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  arch-recipe:
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    # makepkg compiles the whole Rust + C++ tree from source with no cache, so the
+    # normal run is minutes rather than seconds. Generous, but bounded.
+    timeout-minutes: 45
+    steps:
+      - name: Install tools
+        run: pacman -Syu --noconfirm --needed git namcap curl jq
+
+      - uses: actions/checkout@v5
+
+      - name: Render the recipe for the latest release
+        run: |
+          set -euo pipefail
+          TAG="$(curl -fsSL "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r .tag_name)"
+          VERSION="${TAG#v}"
+          URL="https://github.com/${{ github.repository }}/archive/refs/tags/${TAG}.tar.gz"
+          SHA="$(curl -fsSL "$URL" | sha256sum | cut -d' ' -f1)"
+          # makepkg refuses to run as root, and `-s` shells out to pacman for the
+          # declared makedepends — so the build user needs passwordless sudo.
+          useradd -m builder
+          echo 'builder ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/builder
+
+          # Build in the build user's home, NOT inside the checkout. makepkg unpacks
+          # the source under its build dir, and settings-gtk is a crate excluded from
+          # the root Cargo workspace by path — an unpacked copy nested under the
+          # repo's own Cargo.toml is not covered by that exclude, so cargo refuses it
+          # with "believes it's in a workspace when it's not".
+          install -d -o builder /home/builder/build
+          # pkgrel is irrelevant to this check — it only has to parse — so use 1.
+          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" -e "s/@PKGREL@/1/g" \
+            platforms/linux/packaging/arch/PKGBUILD.in > /home/builder/build/PKGBUILD
+          chown builder /home/builder/build/PKGBUILD
+
+      - name: makepkg
+        run: |
+          set -euo pipefail
+          su builder -c 'cd ~/build && makepkg -s --noconfirm'
+          namcap /home/builder/build/*.pkg.tar.zst
+          ls -l /home/builder/build/*.pkg.tar.zst

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -20,6 +20,13 @@ on:
 
 # Cargo network resilience (see release.yml). Workflow-level env does not cross the
 # workflow_call boundary, so each build workflow repeats it.
+# Called from release.yml, whose token is `contents: write` so it can publish the
+# Release. Nothing in here needs that: it builds, signs and uploads artifacts, and
+# the `publish` job in the caller is what writes. A reusable workflow may narrow
+# the caller's token but never widen it, so declaring it here is a real reduction.
+permissions:
+  contents: read
+
 env:
   CARGO_HTTP_MULTIPLEXING: "false"
   CARGO_NET_RETRY: "5"
@@ -35,6 +42,7 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
 
@@ -183,6 +191,7 @@ jobs:
           - arch: arm64
             runner: ubuntu-26.04-arm
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     container: fedora:latest
     steps:
       - name: Install build deps

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -14,6 +14,13 @@ on:
 
 # Cargo network resilience (see release.yml). Workflow-level env does not cross the
 # workflow_call boundary, so each build workflow repeats it.
+# Called from release.yml, whose token is `contents: write` so it can publish the
+# Release. Nothing in here needs that: it builds, signs and uploads artifacts, and
+# the `publish` job in the caller is what writes. A reusable workflow may narrow
+# the caller's token but never widen it, so declaring it here is a real reduction.
+permissions:
+  contents: read
+
 env:
   CARGO_HTTP_MULTIPLEXING: "false"
   CARGO_NET_RETRY: "5"
@@ -21,6 +28,7 @@ env:
 jobs:
   macos:
     runs-on: macos-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -15,6 +15,13 @@ on:
 
 # Cargo network resilience (see release.yml). Workflow-level env does not cross the
 # workflow_call boundary, so each build workflow repeats it.
+# Called from release.yml, whose token is `contents: write` so it can publish the
+# Release. Nothing in here needs that: it builds, signs and uploads artifacts, and
+# the `publish` job in the caller is what writes. A reusable workflow may narrow
+# the caller's token but never widen it, so declaring it here is a real reduction.
+permissions:
+  contents: read
+
 env:
   CARGO_HTTP_MULTIPLEXING: "false"
   CARGO_NET_RETRY: "5"
@@ -22,6 +29,7 @@ env:
 jobs:
   windows:
     runs-on: windows-latest
+    timeout-minutes: 45
     defaults:
       run:
         shell: bash
@@ -84,6 +92,7 @@ jobs:
   # the release asset is the distinctly-named zip below, never `Funput-<v>.exe`.
   windows-cli:
     runs-on: windows-latest
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash
@@ -130,6 +139,7 @@ jobs:
     needs: windows
     if: inputs.version != ''
     runs-on: macos-latest
+    timeout-minutes: 15
     steps:
       - name: Download Windows artifact
         uses: actions/download-artifact@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,36 @@
 name: CI
 
-# The pull-request gate. Nothing here builds or ships — the release workflows own
-# that. This only checks that the Rust workspace stays formatted, lint-clean,
-# tested and inside the per-file line budget.
+# The pull-request gate: the checks that must pass on **every** change, which is
+# why nothing here is path-filtered and nothing here builds or ships — the release
+# workflows own that. Its four jobs are the repository's required status checks
+# (`rust`, `shell-line-budget`, `settings-gtk`, `linux-common`), so renaming a job
+# here means updating the ruleset on `main` to match, or the rule silently stops
+# matching anything.
+#
+# A check that only applies to some pull requests belongs in its own workflow with
+# a `paths:` filter instead — see arch-recipe.yml — because GitHub filters paths
+# per workflow and never per job.
 #
 # The toolchain comes from rust-toolchain.toml (1.97.1 + rustfmt + clippy), so
-# bumping the pin moves CI with it. The two excluded shells need system libraries, so
-# neither is reachable from the `rust` job: the GTK4 Settings app gets a job of its own
-# below, and the Windows shell is covered by build-windows.yml, which runs clippy and
-# its tests there because nothing in this file can.
+# bumping the pin moves CI with it. The two excluded shells need system libraries,
+# so neither is reachable from the `rust` job: the GTK4 Settings app gets a job of
+# its own below.
+#
+# The Windows shell has no job here at all. build-windows.yml runs its clippy and
+# its tests, but that workflow is `workflow_call` only — it runs from release.yml,
+# at release time. So a lint or test failure in platforms/windows stops a release
+# rather than a pull request, and nothing on this list will catch it first.
 
 on:
   pull_request:
   push:
     branches: [main]
+
+# Read-only: nothing here writes to the repository, publishes an artifact, or
+# touches a release. Set explicitly rather than inherited from the repository
+# default, so widening that default never silently widens this workflow's token.
+permissions:
+  contents: read
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -25,6 +42,7 @@ env:
 jobs:
   rust:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
 
@@ -128,6 +146,7 @@ jobs:
   # much larger one than this job.
   shell-line-budget:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
 
@@ -155,6 +174,7 @@ jobs:
   # which is why formatting is checked here too.
   settings-gtk:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
 
@@ -183,6 +203,7 @@ jobs:
   # for the funput-ffi cdylib the tests call across the C ABI.
   linux-common:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
 
@@ -199,86 +220,3 @@ jobs:
 
       - name: Test
         run: ctest --test-dir platforms/linux/build/tests --output-on-failure
-
-  # Does this pull request touch the Arch recipe? Its own tiny job so the Arch
-  # container below is only pulled when it will actually be used — otherwise every
-  # unrelated pull request would pay for the image and a full `pacman -Syu`.
-  arch-recipe-changed:
-    runs-on: ubuntu-latest
-    outputs:
-      run: ${{ steps.check.outputs.run }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - id: check
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          set -euo pipefail
-          # Pull requests only: a push to main has no base to diff against, and
-          # this is a review gate rather than a release check.
-          if [ -z "${BASE_REF:-}" ]; then
-            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-          # No --depth here: checkout already unshallowed the clone, and a shallow
-          # fetch of the base would leave `...` without a merge base to work from.
-          git fetch origin "$BASE_REF"
-          if git diff --name-only "origin/${BASE_REF}...HEAD" \
-              | grep -q '^platforms/linux/packaging/arch/'; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Arch recipe untouched — skipping the makepkg build."
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  # The Arch recipe (platforms/linux/packaging/arch/PKGBUILD.in), which publish-repo.yml
-  # builds the pacman repository from. That workflow runs it for real on every release
-  # and every fortnight, but a break there costs a failed publish; catching it on the
-  # pull request is cheaper.
-  #
-  # It builds the LATEST RELEASED TAG, not this pull request's code: the recipe
-  # sources a published GitHub tarball, and a pull request has no tag. So this
-  # proves the recipe still works; a CMake-layout change that would break it needs
-  # a run against a release made after that change.
-  arch-recipe:
-    needs: arch-recipe-changed
-    if: needs.arch-recipe-changed.outputs.run == 'true'
-    runs-on: ubuntu-latest
-    container: archlinux:base-devel
-    steps:
-      - name: Install tools
-        run: pacman -Syu --noconfirm --needed git namcap curl jq
-
-      - uses: actions/checkout@v5
-
-      - name: Render the recipe for the latest release
-        run: |
-          set -euo pipefail
-          TAG="$(curl -fsSL "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r .tag_name)"
-          VERSION="${TAG#v}"
-          URL="https://github.com/${{ github.repository }}/archive/refs/tags/${TAG}.tar.gz"
-          SHA="$(curl -fsSL "$URL" | sha256sum | cut -d' ' -f1)"
-          # makepkg refuses to run as root, and `-s` shells out to pacman for the
-          # declared makedepends — so the build user needs passwordless sudo.
-          useradd -m builder
-          echo 'builder ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/builder
-
-          # Build in the build user's home, NOT inside the checkout. makepkg unpacks
-          # the source under its build dir, and settings-gtk is a crate excluded from
-          # the root Cargo workspace by path — an unpacked copy nested under the
-          # repo's own Cargo.toml is not covered by that exclude, so cargo refuses it
-          # with "believes it's in a workspace when it's not".
-          install -d -o builder /home/builder/build
-          # pkgrel is irrelevant to this check — it only has to parse — so use 1.
-          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@SHA256@/${SHA}/g" -e "s/@PKGREL@/1/g" \
-            platforms/linux/packaging/arch/PKGBUILD.in > /home/builder/build/PKGBUILD
-          chown builder /home/builder/build/PKGBUILD
-
-      - name: makepkg
-        run: |
-          set -euo pipefail
-          su builder -c 'cd ~/build && makepkg -s --noconfirm'
-          namcap /home/builder/build/*.pkg.tar.zst
-          ls -l /home/builder/build/*.pkg.tar.zst

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -52,6 +52,7 @@ env:
 jobs:
   ios:
     runs-on: macos-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/publish-repo.yml
+++ b/.github/workflows/publish-repo.yml
@@ -49,6 +49,7 @@ jobs:
   # ---- apt (flat) repo: signed Packages + InRelease -------------------------
   apt:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Install tools
         run: sudo apt-get update && sudo apt-get install -y apt-utils gnupg jq curl
@@ -102,6 +103,7 @@ jobs:
   # Runs in Fedora for native rpmsign + createrepo_c.
   rpm:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     container: fedora:latest
     steps:
       - name: Install tools
@@ -172,6 +174,7 @@ jobs:
   # a separate distribution with its own repositories).
   pacman:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     container: archlinux:base-devel
     steps:
       - name: Install tools
@@ -272,6 +275,7 @@ jobs:
   deploy:
     needs: [apt, rpm, pacman]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
   # ---- Single source of truth for the version -------------------------------
   version:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.v.outputs.version }}
       publish: ${{ steps.v.outputs.publish }}
@@ -96,6 +97,7 @@ jobs:
     needs: [version, macos, windows, linux]
     if: needs.version.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/download-artifact@v5
         with:
@@ -185,6 +187,7 @@ jobs:
     needs: [version, publish]
     if: needs.version.outputs.prerelease == 'false'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Dispatch bottle build to Funput/homebrew-tap
         env:
@@ -212,6 +215,7 @@ jobs:
     needs: [version, publish]
     if: needs.version.outputs.prerelease == 'false'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Dispatch manifest bump to Funput/scoop-funput
         env:

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -106,8 +106,8 @@ asset — a rolling source distro has no use for a `.deb` or `.rpm` — so the `
 in `publish-repo.yml` *builds* it, from `packaging/arch/PKGBUILD.in`, and serves the
 result under `arch/x86_64/`. The AUR would be the conventional home for that recipe and
 it is written to AUR conventions, but nothing uploads it: Arch has new-account
-registration paused. `ci.yml`'s `arch-recipe` job runs a real `makepkg` on pull requests
-that touch the recipe, so a break is caught before it fails a publish.
+registration paused. `arch-recipe.yml` runs a real `makepkg` on pull requests that
+touch the recipe, so a break is caught before it fails a publish.
 
 What binaries cost on a rolling distro is that they link the libraries of the build day,
 so a soname bump in fcitx5, ibus or gtk4 breaks them. A dependency cannot express that


### PR DESCRIPTION
Đợt 1 of the CI plan: make the checks that already exist actually binding, and stop paying for one that never runs. No new code is checked here — that is đợt 2.

## What changes

**`arch-recipe` moves to its own workflow.** It had never run once. The gate is a diff touching `platforms/linux/packaging/arch/` — one file, touched exactly once in the whole history, by the commit that created the gate. Paying for that was `arch-recipe-changed`: a full runner with a `fetch-depth: 0` checkout on every PR and every push, always answering "no", plus a `skipped` row on every checks list.

GitHub filters paths per *workflow*, never per job, which is why that helper job existed at all. As `arch-recipe.yml` it is a native `paths:` filter and nothing else — zero runners when the recipe is untouched.

It is deliberately **not** a required check: a path-filtered workflow reports no status on the PRs it skips, and a required check that never reports blocks the merge forever.

**Explicit `permissions: contents: read`** on `ci.yml` and the three `build-*.yml`, which had none and so inherited the repository default. All four are read-only in fact. The build workflows are reusable, and a reusable workflow may narrow the caller's token but never widen it, so this is a real reduction against `release.yml`'s `contents: write`.

**`timeout-minutes` on all 20 jobs.** There were none anywhere — the default is six hours, so one hung job (a `notarytool` wait, a cargo fetch that never returns) held a runner for a working day. Each limit is ~4x the job's observed runtime.

**The header comment stops overstating coverage.** It said the Windows shell was "covered by build-windows.yml" — true only at release time, since that workflow is `workflow_call` only. A clippy failure in `platforms/windows` stops a release, not a PR. The comment now says that rather than reading like coverage.

## Companion change, outside this diff

The ruleset on `main` gains require-a-PR and required status checks (`rust`, `shell-line-budget`, `settings-gtk`, `linux-common`). Until then the checks in this repo are advisory — nothing stops a push straight to `main`.

Renaming a job in `ci.yml` now means updating that ruleset to match, or the rule quietly stops matching anything. The header comment records this.

## Verification

All 8 workflows parse; every job that is not a `uses:` call has a timeout; every workflow has an explicit `permissions` block. This PR is itself the first live test of the required-checks rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)