### PR TITLE
ci: add cargo-deny and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+# Dependency updates, grouped and weekly.
+#
+# Grouped on purpose: ungrouped, the four ecosystems below would open a dozen
+# single-crate pull requests a week, each burning a full CI run — and every one of
+# them now costs a Windows and an Android job. One pull request per ecosystem per
+# week is reviewable; twelve are not, and the ones that are not get ignored, which
+# is the failure mode this is meant to prevent.
+#
+# No npm entry: docs/ and website/ live outside this repository.
+version: 2
+updates:
+  # The workflows themselves. Actions are pinned by major tag here, so this is
+  # what notices a v6 -> v7; it is also the channel through which a compromised
+  # action's fix would arrive.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # Three separate Cargo trees, each with its own Cargo.lock: the root workspace
+  # and the two packages excluded from it. Dependabot needs one entry per lockfile
+  # — it will not discover the excluded ones from the root manifest.
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      cargo:
+        patterns: ["*"]
+
+  - package-ecosystem: cargo
+    directory: /platforms/windows
+    schedule:
+      interval: weekly
+    groups:
+      cargo-windows:
+        patterns: ["*"]
+
+  - package-ecosystem: cargo
+    directory: /platforms/linux/settings-gtk
+    schedule:
+      interval: weekly
+    groups:
+      cargo-settings-gtk:
+        patterns: ["*"]
+
+  # Gradle, read from gradle/libs.versions.toml. AGP and Kotlin are split out of
+  # the group: those two move compileSdk, the Kotlin language version and the
+  # jvmTarget together, and a failure there needs reading on its own rather than
+  # buried in a bump of fifteen androidx artifacts.
+  - package-ecosystem: gradle
+    directory: /platforms/android
+    schedule:
+      interval: weekly
+    groups:
+      androidx:
+        patterns: ["*"]
+        exclude-patterns:
+          - "com.android.*"
+          - "org.jetbrains.kotlin*"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,57 @@
+name: Audit
+
+# The half of cargo-deny that is not deterministic.
+#
+# `bans`, `licenses` and `sources` answer the same way until a dependency changes,
+# so ci.yml gates pull requests on them. Advisories do not: RUSTSEC publishes
+# continuously, and a entry filed overnight would turn every open pull request red
+# for a reason that has nothing to do with any of them. Someone would then either
+# fix an unrelated vulnerability under merge pressure, or — far likelier — learn to
+# merge past a red check. Both are worse than hearing about it a day later here.
+#
+# Daily rather than weekly: dependabot's cadence is weekly, and an advisory that
+# lands the day after a dependency bump should not wait six days to be noticed.
+on:
+  schedule:
+    - cron: "0 4 * * *"   # 04:00 UTC daily
+  pull_request:
+    # Only when the answer can have changed. A lockfile edit is the one thing on a
+    # pull request that moves this check, and the policy file itself is the other.
+    paths:
+      - "**/Cargo.lock"
+      - deny.toml
+      - .github/workflows/audit.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  advisories:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      # Every tree gets checked even when an earlier one fails; a vulnerability in
+      # the Windows shell should not hide one in the engine.
+      fail-fast: false
+      matrix:
+        tree:
+          - .
+          - platforms/windows
+          - platforms/linux/settings-gtk
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+
+      # One policy file for all three trees, so a licence accepted for the engine
+      # is accepted for the shells. cargo-deny would otherwise look for a deny.toml
+      # beside each manifest and find none.
+      - name: cargo-deny advisories
+        run: cargo deny --manifest-path ${{ matrix.tree }}/Cargo.toml --config deny.toml check advisories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 # The pull-request gate: the checks that must pass on **every** change, which is
 # why nothing here is path-filtered and nothing here builds or ships — the release
 # workflows own that. Its six jobs are the repository's required status checks
-# (`rust`, `shell-line-budget`, `settings-gtk`, `linux-common`, `windows`,
-# `android`), so renaming a job here means updating the ruleset on `main` to
+# (`rust`, `shell-line-budget`, `settings-gtk`, `linux-common`, `cargo-deny`,
+# `windows`, `android`), so renaming a job here means updating the ruleset on
+# `main` to
 # match, or the rule silently stops matching anything and the gate quietly opens.
 #
 # A check that only applies to some pull requests belongs in its own workflow with
@@ -226,6 +227,38 @@ jobs:
 
       - name: Test
         run: ctest --test-dir platforms/linux/build/tests --output-on-failure
+
+  # The deterministic half of cargo-deny: what the dependency graph is allowed to
+  # contain, which only changes when a dependency changes. Advisories are NOT here
+  # — RUSTSEC publishes continuously and a new entry would redden every open pull
+  # request over something none of them touched. audit.yml runs those on a schedule.
+  #
+  # `licenses` is the reason this job earns its place. Slint is tri-licensed
+  # (GPL-3.0-only OR Royalty-free-2.0 OR Software-3.0) and the Windows shell links
+  # it; deny.toml allows exactly one of the three, which is what picks one. Without
+  # this check that choice is a comment nobody enforces, and a dependency arriving
+  # under GPL-3.0 would ship inside an MIT release with nothing to say so.
+  #
+  # Three trees because there are three lockfiles: the workspace, and the two
+  # packages excluded from it. One deny.toml governs all three.
+  cargo-deny:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+
+      - name: Workspace
+        run: cargo deny --config deny.toml check bans licenses sources
+
+      - name: Windows shell
+        run: cargo deny --manifest-path platforms/windows/Cargo.toml --config deny.toml check bans licenses sources
+
+      - name: GTK Settings app
+        run: cargo deny --manifest-path platforms/linux/settings-gtk/Cargo.toml --config deny.toml check bans licenses sources
 
   # The Windows shell (platforms/windows): the Slint IME GUI. Excluded from the
   # cargo workspace because it links the `windows` crate and slint/skia, so the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,12 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 authors = ["Funput"]
+# These are application crates, not library releases: none has been published and
+# the shells consume them by path. Saying so prevents an accidental `cargo publish`
+# and lets cargo-deny's wildcard rule work — it refuses to accept versionless path
+# dependencies for a crate that claims to be publishable, because crates.io would
+# reject that crate anyway. Remove this from any crate genuinely bound for crates.io.
+publish = false
 
 # Shared lint policy — every member opts in via `[lints] workspace = true`.
 # CI escalates warnings to errors (`cargo clippy -- -D warnings`); the denies

--- a/crates/funput-cli/Cargo.toml
+++ b/crates/funput-cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "funput-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/funput-config/Cargo.toml
+++ b/crates/funput-config/Cargo.toml
@@ -3,6 +3,7 @@ name = "funput-config"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 description = "Persisted Funput settings and the cross-platform config interchange document."
 
 [lints]

--- a/crates/funput-convert/Cargo.toml
+++ b/crates/funput-convert/Cargo.toml
@@ -3,6 +3,7 @@ name = "funput-convert"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 description = "The Chuyển mã window's logic: reading a batch, naming what a conversion costs, writing copies out."
 
 [lints]

--- a/crates/funput-core/Cargo.toml
+++ b/crates/funput-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "funput-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/funput-desktop/Cargo.toml
+++ b/crates/funput-desktop/Cargo.toml
@@ -3,6 +3,7 @@ name = "funput-desktop"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 description = "Platform-agnostic logic for hook-based desktop input shells (Windows now)."
 
 [lints]

--- a/crates/funput-engine/Cargo.toml
+++ b/crates/funput-engine/Cargo.toml
@@ -3,6 +3,7 @@ name = "funput-engine"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/funput-ffi/Cargo.toml
+++ b/crates/funput-ffi/Cargo.toml
@@ -3,6 +3,7 @@ name = "funput-ffi"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/funput-jni/Cargo.toml
+++ b/crates/funput-jni/Cargo.toml
@@ -3,6 +3,7 @@ name = "funput-jni"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 authors.workspace = true
 
 [lints]

--- a/crates/funput-suggestions/Cargo.toml
+++ b/crates/funput-suggestions/Cargo.toml
@@ -3,6 +3,7 @@ name = "funput-suggestions"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/crates/funput-term/Cargo.toml
+++ b/crates/funput-term/Cargo.toml
@@ -3,6 +3,7 @@ name = "funput-term"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 
 [lints]
 workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,98 @@
+# cargo-deny policy for every Rust tree in the repository: the root workspace and
+# the two packages excluded from it (platforms/windows, platforms/linux/settings-gtk),
+# each of which has its own Cargo.lock. CI runs cargo-deny once per tree against
+# this one file, so a licence accepted for the engine is accepted for the shells.
+#
+# Split by how the answer changes over time:
+#   - bans / licenses / sources are deterministic. They change only when a
+#     dependency changes, so they gate pull requests.
+#   - advisories are not. A new RUSTSEC entry published overnight would turn every
+#     open pull request red for a reason unrelated to any of them, so those run on
+#     a schedule instead (audit.yml).
+
+[graph]
+# Evaluate every target the lockfiles cover. The shells' locks include Linux-only
+# and UEFI-only crates that their own builds never compile; excluding targets here
+# would hide them, and a licence obligation is not something to hide from.
+all-features = true
+
+# ---------------------------------------------------------------------------
+[advisories]
+version = 2
+# Unmaintained is a maintenance signal, not a vulnerability, and almost all of it
+# here is transitive: slint pulls gtk3 bindings, rustybuzz and ttf-parser; the
+# proc-macro crates come from further down still. Flagging what the workspace
+# depends on DIRECTLY is actionable; flagging the rest is noise nobody can act on.
+unmaintained = "workspace"
+yanked = "deny"
+
+ignore = [
+  # quick-xml 0.39.4, reached only through wayland-scanner and zbus_xml. Both are
+  # Linux-only crates that appear in platforms/windows/Cargo.lock because a lockfile
+  # covers every target, and neither is compiled into any shipped Windows binary.
+  # The fix has to come from those two crates bumping to quick-xml >=0.41; there is
+  # no version of this tree that resolves it from here.
+  # Revisit when either publishes a release that moves off 0.39.
+  { id = "RUSTSEC-2026-0194", reason = "quick-xml via wayland-scanner/zbus_xml; Linux-only, not compiled on Windows; no fix available from this tree" },
+  { id = "RUSTSEC-2026-0195", reason = "same quick-xml 0.39.4 path as RUSTSEC-2026-0194" },
+]
+
+# ---------------------------------------------------------------------------
+[licenses]
+version = 2
+# Permissive licences plus MPL-2.0, whose copyleft is per-file and so places no
+# obligation on Funput's own sources.
+allow = [
+  "0BSD",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-1-Clause",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "CC0-1.0",
+  "CDLA-Permissive-2.0",
+  "ISC",
+  "MIT",
+  "MPL-2.0",
+  "NCSA",
+  "Unicode-3.0",
+  "Unlicense",
+  "Zlib",
+  # Slint is tri-licensed: GPL-3.0-only OR Royalty-free-2.0 OR Software-3.0.
+  # Allowing exactly one of the three is what PICKS one, and this file is the only
+  # place that choice is written down. Royalty-free 2.0 is the desktop-application
+  # licence: it costs nothing and asks for attribution.
+  #
+  # GPL-3.0-only is deliberately NOT on this list. Taking Slint under it would make
+  # the Windows shell GPL-3.0 and put it at odds with the MIT licence the rest of
+  # the repository ships under. Adding "GPL-3.0-only" here would silently make that
+  # choice instead, because cargo-deny resolves an OR expression against this list.
+  "LicenseRef-Slint-Royalty-free-2.0",
+]
+
+# Per-crate, because the licence is acceptable for this crate's role rather than
+# in general.
+[[licenses.exceptions]]
+# UEFI boot-services bindings, reached through getrandom's UEFI target support.
+# LGPL-2.1-or-later is not on the allow list and should not be: it is granted here
+# for a crate that no Funput target compiles — there is no UEFI build of an input
+# method. Linking obligations never arise because linking never happens.
+name = "r-efi"
+allow = ["LGPL-2.1-or-later"]
+
+# ---------------------------------------------------------------------------
+[bans]
+multiple-versions = "allow"   # a lockfile this wide always has some; not a gate
+wildcards = "deny"
+# The crates in this repository depend on each other by path and carry no version
+# requirement, which is a wildcard by cargo-deny's reading. That is how a workspace
+# is meant to look; the rule exists to catch `version = "*"` on a crates.io
+# dependency, and this keeps it aimed at that.
+allow-wildcard-paths = true
+
+# ---------------------------------------------------------------------------
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/platforms/linux/settings-gtk/Cargo.toml
+++ b/platforms/linux/settings-gtk/Cargo.toml
@@ -3,6 +3,9 @@ name = "funput-settings"
 version = "1.2026.1"
 edition = "2021"
 description = "Funput Settings & Onboarding (GTK4 + libadwaita) for Linux"
+# Outside the root workspace, so [workspace.package] gives it nothing. See the
+# same note in platforms/windows/Cargo.toml.
+license = "MIT"
 publish = false
 
 # Single binary; the name is the contract with packaging — both CMakeLists and the

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -6,6 +6,13 @@ name = "funput-windows"
 version = "1.2026.1"
 edition = "2021"
 description = "Funput for Windows — global keyboard hook + tray + native Slint UI."
+# Stated explicitly: this package is outside the root workspace, so it inherits
+# nothing from [workspace.package] — including the MIT licence every other crate
+# in the repository carries. Without this line cargo-deny reports the shipped
+# Windows binary as unlicensed, which it effectively was.
+license = "MIT"
+# A shipped binary, never a crates.io release — same as funput-settings.
+publish = false
 
 [workspace]
 


### PR DESCRIPTION
Phương án 1 of the follow-up: supply-chain checks. No `SECURITY.md`/`CONTRIBUTING.md` — those wait until Funput is stable enough to take outside PRs.

Switching cargo-deny on produced four real findings, all fixed here.

## 1. Three vulnerabilities, fixed by lockfile bumps

| Advisory | Crate | Fix |
|---|---|---|
| RUSTSEC-2026-0204 | `crossbeam-epoch` 0.9.18 | → 0.9.20 (workspace) |
| RUSTSEC-2026-0194/0195 | `quick-xml` 0.39.4 | not fixable here — see below |
| — | `webbrowser` 1.2.1 | → 1.2.4 (Windows shell) |

No source changed. These were simply never being looked for.

## 2. Two shipped binaries were unlicensed

`platforms/windows` and `platforms/linux/settings-gtk` sit outside the root workspace, so they inherit nothing from `[workspace.package]` — including the MIT licence every other crate carries. cargo-deny reported both as `unlicensed`, which they effectively were. Fixed.

## 3. Nothing recorded which Slint licence Funput uses ← the one worth reading

Slint is **tri-licensed**: `GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0`, and the Windows shell links 10 of its crates.

cargo-deny resolves an `OR` expression against the allow list, so **allowing exactly one of the three is what picks one**. `deny.toml` allows Royalty-free 2.0 and deliberately omits GPL-3.0-only — taking Slint under the GPL would make the Windows shell GPL-3.0 and put it at odds with the MIT licence the rest of the repo ships under.

That choice now lives in a file CI enforces, instead of in nobody's head.

## 4. The crates claimed to be publishable

None has been published and the shells consume them by path, but no manifest said `publish = false` — so cargo-deny refused their versionless path dependencies, correctly, since crates.io would reject such a crate. Saying it also prevents an accidental `cargo publish`.

**Judgment call worth your review:** if you intend to publish `funput-core` (or any crate) to crates.io later, drop `publish.workspace = true` from that manifest.

## Why two workflows

- **`ci.yml` → `cargo-deny` job**: `bans`, `licenses`, `sources`. Deterministic — they answer the same way until a dependency changes, so they gate PRs.
- **`audit.yml` → daily + on lockfile changes**: `advisories`. RUSTSEC publishes continuously; an entry filed overnight would redden every open PR over something none of them touched. That teaches people to merge past a red check, which is worse than hearing about it a day later.

Two `quick-xml` advisories are ignored with a written reason and a revisit condition: they arrive via `wayland-scanner` and `zbus_xml`, Linux-only crates present in the Windows lockfile because a lockfile covers every target, and that no Windows build compiles.

## Dependabot

Five entries — github-actions, three Cargo trees (one per lockfile; it will not discover the excluded ones from the root manifest), and Gradle. All grouped weekly: ungrouped this would open a dozen PRs a week, each now costing a Windows and an Android job. AGP and Kotlin are split out of the Gradle group since those move `compileSdk`, the language version and `jvmTarget` together.

## Verified locally

All four checks green on all three trees; `cargo fmt --check` and `cargo test --workspace` still pass after the lockfile bumps.

**Ruleset:** `cargo-deny` is a new required-check candidate — the update command now needs 7 contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)