### PR TITLE
fix(ci): publish the release with github.token and dispatch the package repo

### DIFF
--- a/.github/workflows/publish-repo.yml
+++ b/.github/workflows/publish-repo.yml
@@ -12,7 +12,14 @@ name: Publish package repo
 #     The key's uid must be `Funput <hello@funput.app>` (matches %_gpg_name below).
 on:
   release:
-    types: [released]   # fires only for full (non-prerelease) releases
+    types: [released]   # a release published by hand, in the web UI
+  # How a *CI* release gets here. The `release` event above never fires for one:
+  # GitHub starts no workflow run for an event created by the default GITHUB_TOKEN,
+  # and release.yml publishes with that token so the release itself never depends on
+  # a PAT. Its `repo` job dispatches this workflow explicitly instead, passing the
+  # tag it just published.
+  repository_dispatch:
+    types: [publish-repo]
   # Fortnightly, for the pacman repo alone. Its packages are binaries on a rolling
   # distro: they link the Arch libraries of the build day, so an soname bump in
   # fcitx5, ibus or gtk4 breaks them until something rebuilds. Arch's fcitx5 and
@@ -57,7 +64,7 @@ jobs:
       - name: Download .deb assets from the release
         env:
           GH_REPO: ${{ github.repository }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || github.event.client_payload.tag }}
         run: |
           set -euo pipefail
           mkdir -p tree/deb
@@ -112,7 +119,7 @@ jobs:
       - name: Download .rpm assets from the release
         env:
           GH_REPO: ${{ github.repository }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || github.event.client_payload.tag }}
         run: |
           set -euo pipefail
           mkdir -p tree/rpm
@@ -185,7 +192,7 @@ jobs:
       - name: Build the packages from the Arch recipe
         env:
           GH_REPO: ${{ github.repository }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || github.event.client_payload.tag }}
         run: |
           set -euo pipefail
           [ -n "$TAG" ] || TAG="$(curl -fsSL "https://api.github.com/repos/$GH_REPO/releases/latest" | jq -r .tag_name)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,17 +153,18 @@ jobs:
           tag_name: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', needs.version.outputs.version) }}
 
       # Flip the draft to published. This bakes the already-attached assets into the
-      # now-immutable release, and is the event publish-repo.yml listens for.
+      # now-immutable release.
       #
-      # RELEASE_TOKEN, not github.token: GitHub does not start a workflow run for an
-      # event created by the default GITHUB_TOKEN, so publishing with it left
-      # `on: release: [released]` silently dead and the package repository stuck one
-      # release behind until someone dispatched it by hand. A PAT (contents: write on
-      # this repo) makes the event fire. Falls back to the default token when the
-      # secret is unset, so a release still publishes — just without the follow-on.
+      # github.token, deliberately: it is the one token guaranteed to see this draft.
+      # `gh release edit` resolves a tag through an endpoint that never returns
+      # drafts, then falls back to listing releases — and a token without write
+      # access here does not see drafts in that list either, so it fails with a bare
+      # "release not found" and takes the whole release down with it. Publishing the
+      # package repo needs a PAT, but that is the `repo` job's problem, not this
+      # step's.
       - name: Publish the draft release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
           # The publish job has no checkout, so tell gh which repo to act on instead
           # of letting it look for a local .git.
           GH_REPO: ${{ github.repository }}
@@ -177,6 +178,39 @@ jobs:
           else
             gh release edit "$TAG" --draft=false --latest
           fi
+
+  # ---- Trigger the apt/dnf/pacman package repository rebuild ----------------
+  # Fires only for a real public release. `publish-repo.yml` rebuilds the signed
+  # repositories from this release's .deb/.rpm assets. It also listens for the
+  # `release` event, but a release published by github.token raises no event GitHub
+  # acts on, so a CI release reaches it only through this dispatch. Requires a
+  # `RELEASE_TOKEN` secret (a PAT with `contents: write` on this repo); skipped
+  # automatically if absent. A job of its own, like the two dispatches below: a bad
+  # token then costs the package repository alone, not the release.
+  repo:
+    needs: [version, publish]
+    if: needs.version.outputs.prerelease == 'false'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Dispatch the package repo publish
+        env:
+          TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}', needs.version.outputs.version) }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${TOKEN:-}" ]]; then
+            echo "RELEASE_TOKEN not set — skipping the package repo publish." >&2
+            exit 0
+          fi
+          # --fail-with-body, not -f: a token that cannot write to this repo gets a
+          # 404 here, and the body is the only thing that says so.
+          curl -sS --fail-with-body -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            "https://api.github.com/repos/${REPO}/dispatches" \
+            -d "{\"event_type\":\"publish-repo\",\"client_payload\":{\"tag\":\"${TAG}\"}}"
 
   # ---- Trigger the Homebrew tap to build + publish bottles ------------------
   # Fires only for a real public release (not prereleases/smoke tests). The tap's

--- a/platforms/linux/packaging/repo/README.md
+++ b/platforms/linux/packaging/repo/README.md
@@ -42,6 +42,11 @@ gpg --armor --export-secret-keys hello@funput.app
 Settings → Secrets and variables → Actions:
 - `GPG_PRIVATE_KEY` — toàn bộ khối `-----BEGIN PGP PRIVATE KEY BLOCK----- … END …`.
 - `GPG_PASSPHRASE` — mật khẩu của khóa trên.
+- `RELEASE_TOKEN` — PAT có quyền **`contents: write`** trên chính repo này (fine-grained:
+  Repository access = repo này, Contents = Read and write). `release.yml` dùng nó để bắn
+  `repository_dispatch` gọi workflow này sau mỗi bản release chính thức; GitHub không kích
+  hoạt workflow từ sự kiện do `GITHUB_TOKEN` mặc định tạo ra nên phải là PAT. Thiếu secret
+  thì release vẫn ra bình thường, chỉ là kho phải chạy tay (mục 4).
 
 ### 3. Bật GitHub Pages + custom domain `repo.funput.app`
 Kho phục vụ dưới thương hiệu funput.app qua subdomain riêng (tách hẳn site marketing —
@@ -56,7 +61,11 @@ Kho phục vụ dưới thương hiệu funput.app qua subdomain riêng (tách h
 cuối**); workflow tự suy host cho `CNAME` từ đó. Không đặt thì mặc định `https://repo.funput.app/`.
 
 ### 4. Chạy
-Tự chạy khi release `released`. Chạy tay: Actions → **Publish package repo** → Run workflow.
+Tự chạy sau mỗi bản release chính thức: job `repo` trong `release.yml` bắn
+`repository_dispatch` (kèm tag vừa phát hành) ngay khi release được publish. Release publish
+bằng tay trong web UI thì sự kiện `released` cũng kích hoạt workflow này. Chạy tay:
+Actions → **Publish package repo** → Run workflow (khi đó workflow tự lấy tag của
+`releases/latest`).
 Xong, trang cài đặt nằm ở URL Pages (xem mục cuối `index.html.in` để biết các lệnh người dùng).
 
 ## Hoạt động thế nào (tóm tắt)


### PR DESCRIPTION
## Vấn đề

`v1.2026.75` build xanh cả 10 job rồi chết ở bước `Publish the draft release` với đúng một dòng: `release not found`.

Draft **vẫn tồn tại** (id `382977272`, đủ 22 asset). Khác biệt duy nhất là token: bước đó chạy bằng `RELEASE_TOKEN` — PAT thêm ngày 2026-09-02, không có quyền ghi trên repo này.

Cơ chế: `GET /repos/.../releases/tags/<tag>` không bao giờ trả về draft. Khi gặp 404, `gh` chuyển sang liệt kê `/releases` rồi lọc draft theo tag — nhưng token không có quyền ghi **cũng không thấy draft trong danh sách đó**, nên `gh` kết luận là không có release. Ngay trong cùng job, 3 giây trước đó, `softprops/action-gh-release` (chạy bằng token mặc định) đã in `Found release v1.2026.75 (with id=382977272)`.

Bản `v1.2026.74` không dính vì secret chưa tồn tại, workflow rơi vào nhánh dự phòng `|| github.token`. `v1.2026.75` là bản release đầu tiên thực sự dùng PAT — và hỏng ngay. Hệ quả: `homebrew` và `scoop` (`needs: publish`) bị skip theo.

## Thay đổi

- **`release.yml`** — lật draft bằng `github.token`, token duy nhất chắc chắn nhìn thấy draft. PAT chuyển sang job `repo` riêng, đứng cạnh `homebrew`/`scoop`, bắn `repository_dispatch` gọi `publish-repo.yml`. Luồng vẫn tự động (GitHub không kích hoạt workflow từ sự kiện do token mặc định tạo, nên riêng trigger `release: [released]` sẽ nằm im), nhưng PAT hỏng giờ chỉ làm mất kho apt/dnf — không kéo sập release lẫn hai job kia.
- **`publish-repo.yml`** — thêm trigger `repository_dispatch: [publish-repo]`, giữ `release: [released]` cho trường hợp publish tay trong web UI. Ba chỗ `TAG:` nhận thêm `client_payload.tag` nên dispatch truyền tag chính xác; fallback `releases/latest` vẫn còn cho `schedule` và Run workflow tay.
- **`packaging/repo/README.md`** — ghi rõ `RELEASE_TOKEN` cần quyền gì và luồng chạy mới.

`--fail-with-body` thay `-fsS` ở job mới: PAT thiếu quyền sẽ nhận 404 và body là thứ duy nhất nói ra điều đó — đúng bài học của sự cố này.

## Yêu cầu vận hành

`RELEASE_TOKEN` phải là PAT có **`contents: write`** trên `Funput/Funput` (fine-grained: Repository access = repo này, Contents = Read and write). Không cần quyền `Actions`. Thiếu secret thì release vẫn ra bình thường, chỉ là kho phải chạy tay.

## Kiểm tra

- YAML parse sạch cả hai workflow; `bash -n` sạch cho script của job mới; payload JSON dựng đúng.
- `repository_dispatch` chỉ có hiệu lực sau khi merge vào `main` (GitHub đọc workflow ở nhánh mặc định), và tag mới phải chứa bản sửa này.
- `v1.2026.75` đang kẹt vẫn phải xử lý riêng: re-run run cũ sẽ replay code ở commit `5f5ebb97`, nên cần sửa quyền token trước rồi `gh run rerun 33911545099 --failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)