### PR TITLE
fix(ci): drop the release trigger that Pages can never deploy

### DIFF
--- a/.github/workflows/publish-repo.yml
+++ b/.github/workflows/publish-repo.yml
@@ -10,14 +10,18 @@ name: Publish package repo
 #   - Settings → Pages → Source = GitHub Actions.
 #   - Secrets GPG_PRIVATE_KEY (ASCII-armored private key) and GPG_PASSPHRASE.
 #     The key's uid must be `Funput <hello@funput.app>` (matches %_gpg_name below).
+#
+# Every trigger below runs on the default branch, and that is a requirement, not a
+# coincidence: the `github-pages` environment allows deployments from `main` alone.
+# A run at any other ref builds all three repositories and is then rejected at
+# `deploy`. `on: release: [released]` was exactly that — a release event always sits
+# at `refs/tags/v*` — so the one time it ever fired (v1.2026.75) it rebuilt all three
+# and was refused at the last step. It is gone; release.yml's `repo` job dispatches
+# this workflow instead, and every path in still lands on `main`.
 on:
-  release:
-    types: [released]   # a release published by hand, in the web UI
-  # How a *CI* release gets here. The `release` event above never fires for one:
-  # GitHub starts no workflow run for an event created by the default GITHUB_TOKEN,
-  # and release.yml publishes with that token so the release itself never depends on
-  # a PAT. Its `repo` job dispatches this workflow explicitly instead, passing the
-  # tag it just published.
+  # How a release gets here. release.yml publishes with the default GITHUB_TOKEN, and
+  # GitHub starts no workflow run for an event that token creates, so the dispatch is
+  # also what makes this run at all. It carries the tag it just published.
   repository_dispatch:
     types: [publish-repo]
   # Fortnightly, for the pacman repo alone. Its packages are binaries on a rolling
@@ -64,7 +68,7 @@ jobs:
       - name: Download .deb assets from the release
         env:
           GH_REPO: ${{ github.repository }}
-          TAG: ${{ github.event.release.tag_name || github.event.client_payload.tag }}
+          TAG: ${{ github.event.client_payload.tag }}
         run: |
           set -euo pipefail
           mkdir -p tree/deb
@@ -119,7 +123,7 @@ jobs:
       - name: Download .rpm assets from the release
         env:
           GH_REPO: ${{ github.repository }}
-          TAG: ${{ github.event.release.tag_name || github.event.client_payload.tag }}
+          TAG: ${{ github.event.client_payload.tag }}
         run: |
           set -euo pipefail
           mkdir -p tree/rpm
@@ -192,7 +196,7 @@ jobs:
       - name: Build the packages from the Arch recipe
         env:
           GH_REPO: ${{ github.repository }}
-          TAG: ${{ github.event.release.tag_name || github.event.client_payload.tag }}
+          TAG: ${{ github.event.client_payload.tag }}
         run: |
           set -euo pipefail
           [ -n "$TAG" ] || TAG="$(curl -fsSL "https://api.github.com/repos/$GH_REPO/releases/latest" | jq -r .tag_name)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,9 +181,10 @@ jobs:
 
   # ---- Trigger the apt/dnf/pacman package repository rebuild ----------------
   # Fires only for a real public release. `publish-repo.yml` rebuilds the signed
-  # repositories from this release's .deb/.rpm assets. It also listens for the
-  # `release` event, but a release published by github.token raises no event GitHub
-  # acts on, so a CI release reaches it only through this dispatch. Requires a
+  # repositories from this release's .deb/.rpm assets. This dispatch is the only way
+  # a release reaches it: GitHub starts no run for an event the default GITHUB_TOKEN
+  # creates, and a `release`-triggered run would sit at a tag ref, which the
+  # `github-pages` environment refuses to deploy from. Requires a
   # `RELEASE_TOKEN` secret (a PAT with `contents: write` on this repo); skipped
   # automatically if absent. A job of its own, like the two dispatches below: a bad
   # token then costs the package repository alone, not the release.

--- a/platforms/linux/packaging/repo/README.md
+++ b/platforms/linux/packaging/repo/README.md
@@ -62,10 +62,14 @@ cuối**); workflow tự suy host cho `CNAME` từ đó. Không đặt thì mặ
 
 ### 4. Chạy
 Tự chạy sau mỗi bản release chính thức: job `repo` trong `release.yml` bắn
-`repository_dispatch` (kèm tag vừa phát hành) ngay khi release được publish. Release publish
-bằng tay trong web UI thì sự kiện `released` cũng kích hoạt workflow này. Chạy tay:
+`repository_dispatch` (kèm tag vừa phát hành) ngay khi release được publish. Chạy tay:
 Actions → **Publish package repo** → Run workflow (khi đó workflow tự lấy tag của
 `releases/latest`).
+
+> **Mọi cách kích hoạt đều phải chạy từ nhánh `main`.** Environment `github-pages` chỉ cho
+> phép deploy từ `main`, nên run ở ref tag sẽ dựng xong cả ba kho rồi bị chặn ở job `deploy`.
+> Đó là lý do workflow **không** dùng trigger `release: [released]`: sự kiện release luôn nằm
+> ở `refs/tags/v*`. Publish release bằng tay trong web UI thì phải bấm Run workflow ở đây.
 Xong, trang cài đặt nằm ở URL Pages (xem mục cuối `index.html.in` để biết các lệnh người dùng).
 
 ## Hoạt động thế nào (tóm tắt)


### PR DESCRIPTION
Tiếp nối #328. Sau khi #328 được merge và `RELEASE_TOKEN` được cấp lại quyền, bản `v1.2026.75` publish thành công — và lộ ra lỗi thứ hai, độc lập với token.

## Vấn đề

Environment `github-pages` chỉ cho phép deploy từ nhánh **`main`** (`deployment_branch_policy` custom, danh sách đúng một mục). Run ở ref khác sẽ dựng xong cả ba kho apt/rpm/pacman rồi bị chặn ở job `deploy`:

> Tag "v1.2026.75" is not allowed to deploy to github-pages due to environment protection rules.

Mà run kích hoạt bởi sự kiện `release` **luôn** nằm ở `refs/tags/v*`. Nghĩa là `on: release: [released]` không bao giờ hoàn tất được.

Lỗi này ẩn suốt vì workflow xưa nay chỉ được chạy tay từ `main` (10 run gần nhất đều là `workflow_dispatch`). Lần đầu tiên sự kiện thực sự kích hoạt được — sau khi token đủ quyền — nó chạy hết ~10 phút rồi đỏ ở bước cuối: [run 33935373831](https://github.com/Funput/Funput/actions/runs/33935373831).

## Thay đổi

- Gỡ trigger `release: [released]` khỏi `publish-repo.yml`. Ba đường còn lại — `repository_dispatch` (do job `repo` của `release.yml` bắn), `schedule`, `workflow_dispatch` — đều chạy trên nhánh mặc định nên không thể chạm vào rule này.
- `TAG:` rút gọn còn `client_payload.tag` (nhánh `github.event.release.tag_name` giờ là code chết). Fallback `releases/latest` giữ nguyên cho run theo lịch và chạy tay.
- Ghi lại ràng buộc "mọi trigger phải ở `main`" ngay đầu workflow và trong README vận hành, vì rule nằm trong cài đặt environment của GitHub chứ không có trong file nào của repo — không ghi thì lần sau lại mất công truy.

**Vì sao gỡ trigger chứ không nới rule:** thêm pattern `v*` vào danh sách ref được phép của `github-pages` cũng chữa được lỗi, nhưng đánh đổi một lớp bảo vệ deploy thật để cứu một đường đi giờ đã thừa. Đánh đổi không đáng.

Đổi lại: release publish bằng tay trong web UI sẽ không tự dựng kho nữa, phải bấm Run workflow — README đã ghi rõ.

## Kiểm chứng

Đường `repository_dispatch` đã chạy thật trên `main` và xanh cả 4 job, kể cả `deploy`: [run 33935611279](https://github.com/Funput/Funput/actions/runs/33935611279). Kho công khai đang phục vụ đúng bản mới:

```
Package: funput           Version: 1.2026.75
Package: funput-ibus      Version: 1.2026.75
Package: funput-settings  Version: 1.2026.75
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)