### PR TITLE
docs(ci): explain changes_not_sent_for_review where its input points

### DIFF
--- a/.github/workflows/deploy-android.yml
+++ b/.github/workflows/deploy-android.yml
@@ -25,6 +25,15 @@ name: Deploy Android
 #
 # One-time, outside this repo: the app must already exist in the Play Console with a
 # first bundle uploaded by hand. Google will not create an app from an API upload.
+#
+# About `changes_not_sent_for_review`: committing an edit normally submits its
+# changes to Google for review. Some apps cannot do that automatically — one with no
+# reviewed release yet, or one carrying unsubmitted Console changes (store listing,
+# content rating, data safety) — and Google refuses the commit saying so in as many
+# words. Re-running with this input checked commits the edit *without* submitting
+# anything: the build is attached to its track, and you press "Send for review" in
+# the Play Console yourself. Leave it off otherwise — a release nobody submits sits
+# there and never reaches a tester.
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Ô `changes_not_sent_for_review` trên form Run workflow ghi *"see the workflow header"*, nhưng header lại không nói gì về nó — giải thích duy nhất nằm trong comment cạnh lệnh commit, tức là chỗ người đang đứng ở form không nhìn thấy. Con trỏ trỏ vào chỗ trống là lỗi của #330, PR này vá lại.

Header giờ nói rõ ba điều: cờ đó làm gì, khi nào Google đòi nó, và vì sao bật thừa còn tệ hơn không bật — edit commit mà không gửi duyệt sẽ nằm im, không tới tay tester nào.

Chỉ sửa comment, không đụng logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)