### PR TITLE
feat(ios,android): shrink the suggestion toolbar to a Gboard-compact band

### DIFF
--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/KeyboardDimensions.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/KeyboardDimensions.kt
@@ -1,6 +1,7 @@
 package app.funput.funput.keyboard
 
 import app.funput.funput.keyboard.layout.KeyboardSizingProfile
+import app.funput.funput.keyboard.layout.ToolbarMetrics
 import app.funput.funput.keyboard.layout.usesCompactLetterRows
 import app.funput.funput.keyboard.model.KeyboardEditorMode
 import app.funput.funput.keyboard.model.KeyboardInputMethod
@@ -9,8 +10,6 @@ object KeyboardDimensions {
     const val DefaultWidthDp = 360f
 
     private const val CanonicalColumnCount = 10
-    private const val SuggestionBarHeightDp = 42f
-    private const val SuggestionBarGapDp = 6f
 
     fun recommendedHeightDp(
         inputMethod: KeyboardInputMethod,
@@ -55,11 +54,7 @@ object KeyboardDimensions {
         val rowHeight = canonicalUnit / profile.keyAspectRatio
         val verticalGap = rowHeight * profile.verticalGapRatio
         val rowsBlockHeight = rowCount * rowHeight + (rowCount - 1) * verticalGap
-        val suggestionBarBlock = if (hasSuggestionBar) {
-            SuggestionBarHeightDp + SuggestionBarGapDp
-        } else {
-            0f
-        }
+        val suggestionBarBlock = if (hasSuggestionBar) ToolbarMetrics.ChromeDp else 0f
         return (profile.verticalPaddingDp * 2f + suggestionBarBlock + rowsBlockHeight) * profile.heightScale
     }
 }

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/accessibility/KeyboardAccessibilitySnapshot.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/accessibility/KeyboardAccessibilitySnapshot.kt
@@ -31,15 +31,19 @@ internal class KeyboardAccessibilitySnapshot(
                 customActions = SmartGestureAccessibility.actions(key.spec.role, smartGesturesEnabled),
             ).let(::add)
         }
-        val bounds = keyboard.suggestionBar?.suggestionsBounds
-        if (bounds != null && suggestions.isNotEmpty()) {
+        val bar = keyboard.suggestionBar
+        val bounds = bar?.suggestionsBounds
+        // Explore-by-touch follows the same generous region a finger does, not the drawn band.
+        val hit = bar?.suggestionsHitBounds
+        if (bounds != null && hit != null && suggestions.isNotEmpty()) {
             val width = bounds.width / suggestions.size
             suggestions.forEachIndexed { index, text ->
                 val segment = KeyBounds(bounds.left + width * index, bounds.top, bounds.left + width * (index + 1), bounds.bottom)
-                add(KeyboardAccessibilityNode(size, SuggestionTargetIds.id(index), "Gợi ý, $text", segment, segment, false))
+                val target = KeyBounds(segment.left, hit.top, segment.right, hit.bottom)
+                add(KeyboardAccessibilityNode(size, SuggestionTargetIds.id(index), "Gợi ý, $text", segment, target, false))
             }
-        } else if (bounds != null && clipboardLabel != null) {
-            add(KeyboardAccessibilityNode(size, ClipboardTargetId, clipboardLabel, bounds, bounds, false))
+        } else if (bounds != null && hit != null && clipboardLabel != null) {
+            add(KeyboardAccessibilityNode(size, ClipboardTargetId, clipboardLabel, bounds, hit, false))
         }
     }
 

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/interaction/KeyboardInteractionTargets.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/interaction/KeyboardInteractionTargets.kt
@@ -24,10 +24,10 @@ internal fun ResolvedKeyboard.interactionTargetAt(
 ): String? {
     keyAt(x, y)?.let { return it.spec.id }
     val bar = suggestionBar ?: return null
-    if (!bar.suggestionsBounds.contains(x, y)) return null
+    if (!bar.suggestionsHitBounds.contains(x, y)) return null
     if (suggestionCount <= 0) return ClipboardTargetId.takeIf { clipboardVisible }
 
-    val bounds = bar.suggestionsBounds
+    val bounds = bar.suggestionsHitBounds
     val segmentWidth = bounds.width / suggestionCount
     val index = ((x - bounds.left) / segmentWidth).toInt().coerceIn(0, suggestionCount - 1)
     return SuggestionTargetIds.id(index)

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardGeometrySpec.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardGeometrySpec.kt
@@ -39,8 +39,8 @@ data class KeyboardGeometrySpec(
                 horizontalGapRatio = profile.horizontalGapRatio,
                 verticalGapRatio = profile.verticalGapRatio,
                 keyAspectRatio = profile.keyAspectRatio,
-                suggestionBarHeight = 42f * density * heightScale,
-                suggestionBarGap = 6f * density * heightScale,
+                suggestionBarHeight = ToolbarMetrics.SuggestionBarHeightDp * density * heightScale,
+                suggestionBarGap = ToolbarMetrics.SuggestionBarGapDp * density * heightScale,
                 heightScale = heightScale,
             )
         }

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardHitTargetResolver.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/KeyboardHitTargetResolver.kt
@@ -33,6 +33,7 @@ internal object KeyboardHitTargetResolver {
         val controls = listOfNotNull(
             bar.systemInputMethodKey, bar.clipboardKey, bar.emojiKey,
         )
+        val hitBottom = midpoint(bar.bounds.bottom, keyboard.rows.first().first().bounds.top)
         val resolvedControls = controls.mapIndexed { index, key ->
             val left = if (index > 0) {
                 midpoint(controls[index - 1].bounds.right, key.bounds.left)
@@ -43,11 +44,17 @@ internal object KeyboardHitTargetResolver {
             }
             val right = controls.getOrNull(index + 1)
                 ?.let { midpoint(key.bounds.right, it.bounds.left) } ?: keyboard.width
-            resolveToolbarKey(keyboard, key, left, right)
+            resolveToolbarKey(key, left, right, hitBottom)
         }
         fun lookup(key: ResolvedKey?): ResolvedKey? =
             key?.let { target -> resolvedControls.first { it.spec.id == target.spec.id } }
         return bar.copy(
+            suggestionsHitBounds = KeyBounds(
+                left = bar.suggestionsBounds.left,
+                top = 0f,
+                right = bar.suggestionsBounds.right,
+                bottom = hitBottom,
+            ),
             systemInputMethodKey = lookup(bar.systemInputMethodKey),
             clipboardKey = lookup(bar.clipboardKey),
             emojiKey = requireNotNull(lookup(bar.emojiKey)),
@@ -55,17 +62,12 @@ internal object KeyboardHitTargetResolver {
     }
 
     private fun resolveToolbarKey(
-        keyboard: ResolvedKeyboard,
         key: ResolvedKey,
         left: Float,
         right: Float,
+        bottom: Float,
     ): ResolvedKey = key.copy(
-        hitBounds = KeyBounds(
-            left = left,
-            top = 0f,
-            right = right,
-            bottom = midpoint(key.bounds.bottom, keyboard.rows.first().first().bounds.top),
-        ),
+        hitBounds = KeyBounds(left = left, top = 0f, right = right, bottom = bottom),
     )
 
     private fun rowHitTop(keyboard: ResolvedKeyboard, rowIndex: Int): Float {

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/ResolvedKeyboard.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/ResolvedKeyboard.kt
@@ -26,6 +26,12 @@ data class ResolvedSuggestionBar(
     val bounds: KeyBounds,
     val logoBounds: KeyBounds,
     val suggestionsBounds: KeyBounds,
+    /**
+     * Where a tap still counts as a suggestion. Wider than what is drawn: the band is only
+     * as tall as the text needs, so the slack above it and half the gap below it belong to
+     * the suggestions rather than to nothing at all. [KeyboardHitTargetResolver] fills it in.
+     */
+    val suggestionsHitBounds: KeyBounds = suggestionsBounds,
     val systemInputMethodKey: ResolvedKey?,
     val clipboardKey: ResolvedKey? = null,
     val emojiKey: ResolvedKey,

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/ToolbarBrandMetrics.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/ToolbarBrandMetrics.kt
@@ -1,6 +1,0 @@
-package app.funput.funput.keyboard.layout
-
-/** Density-independent toolbar branding geometry shared by layout and renderer. */
-internal object ToolbarBrandMetrics {
-    const val LogoSizeRatio = 0.68f
-}

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/ToolbarGeometry.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/ToolbarGeometry.kt
@@ -29,7 +29,7 @@ internal object ToolbarGeometry {
         val systemAnchor = clipboard?.left ?: emoji.left
         val system = bar.systemInputMethodKey?.let { boundsBefore(systemAnchor, top, bottom, spec) }
         val controlsLeft = system?.left ?: clipboard?.left ?: emoji.left
-        val logoSize = spec.suggestionBarHeight * ToolbarBrandMetrics.LogoSizeRatio
+        val logoSize = spec.suggestionBarHeight * ToolbarMetrics.LogoSizeRatio
         val logoTop = top + (spec.suggestionBarHeight - logoSize) / 2f
         val logo = KeyBounds(spec.horizontalPadding, logoTop, spec.horizontalPadding + logoSize, logoTop + logoSize)
         val suggestionsLeft = logo.right + spec.horizontalGap

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/ToolbarMetrics.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/ToolbarMetrics.kt
@@ -1,0 +1,29 @@
+package app.funput.funput.keyboard.layout
+
+/**
+ * Density-independent toolbar geometry, shared by the layout, the renderer and the panel
+ * height budget.
+ *
+ * One copy on purpose: [KeyboardDimensions][app.funput.funput.keyboard.KeyboardDimensions]
+ * reserves this strip when it measures the panel and [KeyboardGeometry] lays the band out
+ * inside it. Two copies that drift leave the keyboard either squeezing its rows or showing
+ * a blank gap above them.
+ */
+internal object ToolbarMetrics {
+    /**
+     * The suggestion band, sized like Gboard's strip rather than like a key row: the toolbar
+     * carries one line of text and two icons, so anything taller is keyboard height spent on
+     * padding. The utility keys still take the full band and widen into their neighbours'
+     * slack (see [KeyboardHitTargetResolver]), so the shorter band costs no tap area.
+     */
+    const val SuggestionBarHeightDp = 36f
+
+    /** Separates the band from the first key row. */
+    const val SuggestionBarGapDp = 4f
+
+    /** The vertical strip the toolbar claims in total. */
+    const val ChromeDp = SuggestionBarHeightDp + SuggestionBarGapDp
+
+    /** The brand mark is decorative, so it sits inside the band instead of filling it. */
+    const val LogoSizeRatio = 0.68f
+}

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/rendering/SuggestionBarRenderer.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/rendering/SuggestionBarRenderer.kt
@@ -90,18 +90,15 @@ internal class SuggestionBarRenderer(private val metrics: RenderMetrics) {
     }
 
     private fun drawDivider(canvas: Canvas, bounds: KeyBounds, x: Float) {
-        canvas.drawLine(
-            x,
-            bounds.top + metrics.dp(DividerInsetDp),
-            x,
-            bounds.bottom - metrics.dp(DividerInsetDp),
-            dividerPaint,
-        )
+        // Taken from the band rather than in dp so the divider keeps its proportions at
+        // every keyboard size setting instead of swallowing a short band.
+        val inset = bounds.height * DividerInsetRatio
+        canvas.drawLine(x, bounds.top + inset, x, bounds.bottom - inset, dividerPaint)
     }
 
     private companion object {
         const val SuggestionLabelSizeSp = 14f
-        const val DividerInsetDp = 9f
+        const val DividerInsetRatio = 0.22f
         const val LabelHorizontalInsetDp = 8f
     }
 }

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/interaction/KeyboardInteractionTargetsTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/interaction/KeyboardInteractionTargetsTest.kt
@@ -53,6 +53,21 @@ class KeyboardInteractionTargetsTest {
     }
 
     @Test
+    fun suggestionsClaimThePaddingAroundTheirBand() {
+        val bar = requireNotNull(keyboard.suggestionBar)
+        val x = bar.suggestionsBounds.centerX
+        // The band is drawn no taller than its text, so a thumb landing in the padding above
+        // it or in the top half of the gap below it still means "take that suggestion".
+        for (y in listOf(0f, bar.bounds.top - 1f, bar.bounds.bottom + spec.suggestionBarGap / 4f)) {
+            assertEquals(
+                "tap at y=$y",
+                SuggestionTargetIds.id(1),
+                keyboard.interactionTargetAt(x, y, SuggestionCount),
+            )
+        }
+    }
+
+    @Test
     fun emptySuggestionListLeavesBarNonInteractive() {
         val bounds = requireNotNull(keyboard.suggestionBar).suggestionsBounds
 

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/KeyboardSizingProfile.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardLayout/KeyboardSizingProfile.swift
@@ -5,6 +5,9 @@ public struct KeyboardSizingProfile: Hashable, Sendable {
     public var verticalPadding: CGFloat
     public var horizontalGap: CGFloat
     public var verticalGap: CGFloat
+    /// The suggestion band, sized like Gboard's strip rather than like a key row:
+    /// the toolbar carries one line of text and two icons, so anything taller is
+    /// keyboard height spent on padding.
     public var toolbarHeight: CGFloat
     public var toolbarGap: CGFloat
     public var heightScale: CGFloat
@@ -15,8 +18,8 @@ public struct KeyboardSizingProfile: Hashable, Sendable {
         verticalPadding: CGFloat = 6,
         horizontalGap: CGFloat = 5,
         verticalGap: CGFloat = 7,
-        toolbarHeight: CGFloat = 44,
-        toolbarGap: CGFloat = 6,
+        toolbarHeight: CGFloat = 36,
+        toolbarGap: CGFloat = 4,
         heightScale: CGFloat = 1,
         labelScale: CGFloat = 1
     ) {
@@ -38,6 +41,11 @@ public struct KeyboardSizingProfile: Hashable, Sendable {
         self.heightScale = heightScale
         self.labelScale = labelScale
     }
+
+    /// The vertical strip the toolbar claims: its band plus the gap down to the first
+    /// key row. Height budgets reserve exactly this much, so nothing has to restate the
+    /// sum and drift away from what the geometry actually lays out.
+    public var toolbarChrome: CGFloat { toolbarHeight + toolbarGap }
 
     public static let `default` = KeyboardSizingProfile()
 }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Presentation/KeyboardPresentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Presentation/KeyboardPresentation.swift
@@ -73,9 +73,9 @@ public struct KeyboardKeyEvent: Sendable {
 
 @MainActor
 public enum KeyboardMetrics {
-    public static let phonePortraitBaseHeight: CGFloat = 304
-    public static let phoneLandscapeBaseHeight: CGFloat = 236
-    public static let padBaseHeight: CGFloat = 324
+    public static let phonePortraitBaseHeight: CGFloat = 294
+    public static let phoneLandscapeBaseHeight: CGFloat = 226
+    public static let padBaseHeight: CGFloat = 314
 
     public static func recommendedHeight(
         for traits: UITraitCollection,
@@ -113,7 +113,9 @@ public enum KeyboardMetrics {
         scale: CGFloat
     ) -> CGFloat {
         let verticalPadding: CGFloat = 12
-        let toolbarChrome: CGFloat = 50
+        // Read from the profile the geometry lays out with, so the strip reserved here
+        // and the band actually drawn can never disagree.
+        let toolbarChrome = KeyboardSizingProfile.default.toolbarChrome
         let rowGap: CGFloat = 7
         let standardRows: CGFloat = 5
         let standardRowHeight = (

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Toolbar/KeyboardClipboardChipView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Toolbar/KeyboardClipboardChipView.swift
@@ -37,9 +37,9 @@ final class KeyboardClipboardChipView: UIView {
         super.layoutSubviews()
         guard let pasteControl else { return }
         let intrinsic = pasteControl.intrinsicContentSize
-        // At the smallest keyboard height the toolbar is ~37pt while the control
-        // wants 38.33pt, so it is scaled rather than clipped. Under a transform the
-        // frame is meaningless — position with bounds and center.
+        // The compact toolbar band is shorter than the 38.33pt the control asks for,
+        // so it is scaled down rather than clipped. Under a transform the frame is
+        // meaningless — position with bounds and center.
         let scale = min(1, bounds.height / max(intrinsic.height, 1))
         pasteControl.transform = .identity
         pasteControl.bounds = CGRect(origin: .zero, size: intrinsic)

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Toolbar/KeyboardSuggestionBarView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Toolbar/KeyboardSuggestionBarView.swift
@@ -8,6 +8,19 @@ final class KeyboardSuggestionBarView: UIView {
 
     private static let maximumCount = 3
     private static let minimumWidth: CGFloat = 64
+    /// Sized for the compact band: body text would fill it edge to edge, and a
+    /// suggestion is a glance target rather than something the user reads. Dynamic Type
+    /// still moves it, but only up to what the band can show without clipping the
+    /// stacked Vietnamese diacritics.
+    private static var labelFont: UIFont {
+        UIFontMetrics(forTextStyle: .body).scaledFont(
+            for: .systemFont(ofSize: 15),
+            maximumPointSize: 17
+        )
+    }
+    /// The divider's share of the band height, so it keeps its proportions at any
+    /// keyboard size setting.
+    private static let separatorInsetRatio: CGFloat = 0.24
     private let buttons = (0..<maximumCount).map { _ in UIButton(type: .system) }
     private let separators = (0..<(maximumCount - 1)).map { _ in UIView() }
     private var candidates: [KeyboardSuggestionCandidate] = []
@@ -16,7 +29,7 @@ final class KeyboardSuggestionBarView: UIView {
         super.init(frame: frame)
         buttons.enumerated().forEach { index, button in
             button.tag = index
-            button.titleLabel?.font = .preferredFont(forTextStyle: .body)
+            button.titleLabel?.font = Self.labelFont
             button.titleLabel?.lineBreakMode = .byTruncatingTail
             button.accessibilityTraits = .keyboardKey
             button.addTarget(self, action: #selector(selectCandidate(_:)), for: .touchUpInside)
@@ -41,11 +54,17 @@ final class KeyboardSuggestionBarView: UIView {
                 ? CGRect(x: CGFloat(index) * width, y: 0, width: width, height: bounds.height)
                 : .zero
         }
+        let separatorInset = (bounds.height * Self.separatorInsetRatio).rounded()
         for index in separators.indices {
             let visible = index + 1 < count
             separators[index].isHidden = !visible
             separators[index].frame = visible
-                ? CGRect(x: CGFloat(index + 1) * width, y: 10, width: 0.5, height: bounds.height - 20)
+                ? CGRect(
+                    x: CGFloat(index + 1) * width,
+                    y: separatorInset,
+                    width: 0.5,
+                    height: bounds.height - separatorInset * 2
+                )
                 : .zero
         }
     }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Toolbar/KeyboardToolbarView+Layout.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Toolbar/KeyboardToolbarView+Layout.swift
@@ -1,0 +1,71 @@
+#if canImport(UIKit)
+import UIKit
+
+extension KeyboardToolbarView {
+    enum Metrics {
+        /// Utility keys take the band's full height and a fixed width. The compact band
+        /// has no height to give away to an inset, and a wider key buys back what the
+        /// shorter band costs the tap target.
+        static let controlWidth: CGFloat = 40
+        /// Separates two adjacent utility keys.
+        static let controlSpacing: CGFloat = 2
+        /// The brand mark is decorative, so it sits inside the band instead of filling it.
+        static let logoRatio: CGFloat = 0.82
+        /// Keeps the shared content region clear of the logo and the utility keys.
+        static let contentInset: CGFloat = 6
+        /// How far above the band a tap still counts, covering the keyboard's top padding.
+        /// Nothing else owns that strip: the keycap touch surface starts below the band.
+        static let topTouchOutset: CGFloat = 6
+    }
+
+    /// Places the brand mark, the utility keys and the shared content region
+    /// across the toolbar band.
+    func layoutContents() {
+        let logoSize = (bounds.height * Metrics.logoRatio).rounded()
+        logoView.frame = CGRect(
+            x: 0,
+            y: (bounds.height - logoSize) / 2,
+            width: logoSize,
+            height: logoSize
+        )
+        // The right-hand controls stack inwards from the trailing edge, and either of
+        // them can step aside — the clipboard key while the user is typing, the emoji
+        // key when the layout already carries one in its rows.
+        var trailing = bounds.width
+        var placedAControl = false
+        if !emojiButton.isHidden {
+            emojiButton.frame = controlFrame(endingAt: trailing)
+            trailing = emojiButton.frame.minX
+            placedAControl = true
+        }
+        if !clipboardButton.isHidden {
+            // The separator belongs *between* two controls, so it only applies when
+            // something was placed before this one — otherwise the content region would
+            // silently lose those points whenever the clipboard key is the one to step aside.
+            clipboardButton.frame = controlFrame(
+                endingAt: trailing - (placedAControl ? Metrics.controlSpacing : 0)
+            )
+            trailing = clipboardButton.frame.minX
+        }
+        // Suggestions and the clipboard chip share one region and never show at the
+        // same time, so they get the same frame. It ends wherever the controls begin.
+        let contentRegion = CGRect(
+            x: logoView.frame.maxX + Metrics.contentInset,
+            y: 0,
+            width: max(0, trailing - logoView.frame.maxX - Metrics.contentInset * 2),
+            height: bounds.height
+        )
+        suggestionBar.frame = contentRegion
+        clipboardChip.frame = contentRegion
+    }
+
+    private func controlFrame(endingAt trailing: CGFloat) -> CGRect {
+        CGRect(
+            x: trailing - Metrics.controlWidth,
+            y: 0,
+            width: Metrics.controlWidth,
+            height: bounds.height
+        )
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Toolbar/KeyboardToolbarView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Toolbar/KeyboardToolbarView.swift
@@ -9,11 +9,12 @@ final class KeyboardToolbarView: UIView {
     var onSuggestionSelected: ((KeyboardSuggestionCandidate) -> Void)?
     var onClipboardPaste: ((String) -> Void)?
 
-    private let logoView = KeyboardBrandLogoView()
-    private let clipboardButton = UIButton(type: .system)
+    // Laid out across the band by `layoutContents()` in KeyboardToolbarView+Layout.
+    let logoView = KeyboardBrandLogoView()
+    let clipboardButton = UIButton(type: .system)
     let emojiButton = UIButton(type: .system)
     let suggestionBar = KeyboardSuggestionBarView()
-    private let clipboardChip = KeyboardClipboardChipView()
+    let clipboardChip = KeyboardClipboardChipView()
     private var clipboardHint: KeyboardClipboardHint?
     private var hasSuggestions = false
     private var allowsClipboardKey = true
@@ -39,46 +40,17 @@ final class KeyboardToolbarView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        let itemSize = min(36, bounds.height)
-        let originY = (bounds.height - itemSize) / 2
-        logoView.frame = CGRect(x: 0, y: originY, width: itemSize, height: itemSize)
-        // The right-hand controls stack inwards from the trailing edge, and either of
-        // them can step aside — the clipboard key while the user is typing, the emoji
-        // key when the layout already carries one in its rows.
-        var trailing = bounds.width
-        var placedAControl = false
-        if !emojiButton.isHidden {
-            emojiButton.frame = CGRect(
-                x: trailing - itemSize,
-                y: originY,
-                width: itemSize,
-                height: itemSize
-            )
-            trailing = emojiButton.frame.minX
-            placedAControl = true
+        layoutContents()
+    }
+
+    /// Folds a tap in the padding above the band onto the band itself. The band is drawn
+    /// no taller than the text and icons it carries, so its touch target has to reach past
+    /// what is painted for a suggestion to stay as easy to hit as a key.
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard point.y < 0, point.y >= -Metrics.topTouchOutset else {
+            return super.hitTest(point, with: event)
         }
-        if !clipboardButton.isHidden {
-            // The 2pt separator belongs *between* two controls, so it only applies when
-            // something was placed before this one — otherwise the content region would
-            // silently lose those 2pt whenever the clipboard key is the one to step aside.
-            clipboardButton.frame = CGRect(
-                x: trailing - itemSize - (placedAControl ? 2 : 0),
-                y: originY,
-                width: itemSize,
-                height: itemSize
-            )
-            trailing = clipboardButton.frame.minX
-        }
-        // Suggestions and the clipboard chip share one region and never show at the
-        // same time, so they get the same frame. It ends wherever the controls begin.
-        let contentRegion = CGRect(
-            x: logoView.frame.maxX + 6,
-            y: 0,
-            width: max(0, trailing - logoView.frame.maxX - 12),
-            height: bounds.height
-        )
-        suggestionBar.frame = contentRegion
-        clipboardChip.frame = contentRegion
+        return super.hitTest(CGPoint(x: point.x, y: 0), with: event)
     }
 
     func apply(

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardMetricsTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardMetricsTests.swift
@@ -9,9 +9,9 @@ struct KeyboardMetricsTests {
     @Test("Device traits select the correct standard height")
     func deviceBaseHeights() {
         let layout = StandardKeyboardLayouts.letters(.telex)
-        expectHeight(layout, traits: phonePortrait, expected: 304)
-        expectHeight(layout, traits: phoneLandscape, expected: 236)
-        expectHeight(layout, traits: padPortrait, expected: 324)
+        expectHeight(layout, traits: phonePortrait, expected: 294)
+        expectHeight(layout, traits: phoneLandscape, expected: 226)
+        expectHeight(layout, traits: padPortrait, expected: 314)
     }
 
     @Test("Toolbar and row count determine variant heights")
@@ -48,10 +48,10 @@ struct KeyboardMetricsTests {
     @Test("Height scale stays within supported bounds")
     func scaleBounds() {
         let layout = StandardKeyboardLayouts.letters(.telex)
-        expectHeight(layout, traits: phonePortrait, scale: 0.5, expected: 304 * 0.85)
-        expectHeight(layout, traits: phonePortrait, scale: 0.85, expected: 304 * 0.85)
-        expectHeight(layout, traits: phonePortrait, scale: 1.2, expected: 304 * 1.2)
-        expectHeight(layout, traits: phonePortrait, scale: 2, expected: 304 * 1.2)
+        expectHeight(layout, traits: phonePortrait, scale: 0.5, expected: 294 * 0.85)
+        expectHeight(layout, traits: phonePortrait, scale: 0.85, expected: 294 * 0.85)
+        expectHeight(layout, traits: phonePortrait, scale: 1.2, expected: 294 * 1.2)
+        expectHeight(layout, traits: phonePortrait, scale: 2, expected: 294 * 1.2)
     }
 
     @Test("Compact Telex pages share one height below the standard family")

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/PersonalSuggestionToolbarTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/PersonalSuggestionToolbarTests.swift
@@ -10,7 +10,7 @@ import UIKit
 struct PersonalSuggestionToolbarTests {
     @Test("Keeps logo utilities and emits one candidate")
     func contentAndSelection() {
-        let toolbar = KeyboardToolbarView(frame: CGRect(x: 0, y: 0, width: 360, height: 44))
+        let toolbar = KeyboardToolbarView(frame: CGRect(x: 0, y: 0, width: 360, height: bandHeight))
         toolbar.apply(spec: .standard, theme: .funputGlass, traits: .init())
         let values = candidates(3)
         toolbar.updateSuggestions(values)
@@ -37,7 +37,7 @@ struct PersonalSuggestionToolbarTests {
 
     @Test("Narrow toolbar keeps highest-ranked candidates that fit")
     func adaptiveWidth() {
-        let toolbar = KeyboardToolbarView(frame: CGRect(x: 0, y: 0, width: 220, height: 44))
+        let toolbar = KeyboardToolbarView(frame: CGRect(x: 0, y: 0, width: 220, height: bandHeight))
         toolbar.apply(spec: .standard, theme: .funputGlass, traits: .init())
         toolbar.updateSuggestions(candidates(3))
         toolbar.layoutIfNeeded()
@@ -45,6 +45,10 @@ struct PersonalSuggestionToolbarTests {
         #expect(labels.contains("Gợi ý, từ0"))
         #expect(!labels.contains("Gợi ý, từ2"))
     }
+
+    /// The band the shipping geometry lays out, so the fitting rules are exercised at
+    /// the size users actually get.
+    private var bandHeight: CGFloat { KeyboardSizingProfile.default.toolbarHeight }
 
     private func candidates(_ count: Int) -> [KeyboardSuggestionCandidate] {
         (0..<count).map { KeyboardSuggestionCandidate(text: "từ\($0)", generation: 7) }

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/SystemPresetRenderingTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/SystemPresetRenderingTests.swift
@@ -33,17 +33,23 @@ struct SystemPresetRenderingTests {
     @Test("Hiding a control does not resize the suggestion region for other layouts")
     func toolbarRegionIsUnchangedForFunput() {
         let toolbar = KeyboardToolbarView()
-        toolbar.frame = CGRect(x: 0, y: 0, width: 390, height: 44)
+        toolbar.frame = CGRect(
+            x: 0,
+            y: 0,
+            width: 390,
+            height: KeyboardSizingProfile.default.toolbarHeight
+        )
         toolbar.apply(spec: .standard, theme: .funputGlass, traits: traits)
         toolbar.layoutIfNeeded()
         let both = toolbar.suggestionBar.frame.width
 
         // While typing, the clipboard key steps aside and the region grows by exactly
-        // that key plus the 2pt between the two — no more, no less.
+        // that key plus the spacing between the two — no more, no less.
         toolbar.updateSuggestions([KeyboardSuggestionCandidate(text: "chào", generation: 1)])
         toolbar.layoutIfNeeded()
-        let itemSize = min(36, toolbar.bounds.height)
-        #expect(abs(toolbar.suggestionBar.frame.width - (both + itemSize + 2)) <= 0.01)
+        let reclaimed = KeyboardToolbarView.Metrics.controlWidth
+            + KeyboardToolbarView.Metrics.controlSpacing
+        #expect(abs(toolbar.suggestionBar.frame.width - (both + reclaimed)) <= 0.01)
         #expect(toolbar.emojiButton.frame.maxX == toolbar.bounds.width)
     }
 

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/ToolbarChromeTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/ToolbarChromeTests.swift
@@ -1,0 +1,46 @@
+#if canImport(UIKit)
+import KeyboardLayout
+@testable import KeyboardRenderer
+import Testing
+import ThemeSchema
+import UIKit
+
+/// The toolbar band is described twice — once by the sizing profile the geometry lays
+/// out with, once by the height budget that reserves room for it. They have to agree,
+/// or the keyboard either clips its first key row or leaves a blank strip above it.
+@MainActor
+struct ToolbarChromeTests {
+    @Test("The toolbar costs exactly the band the geometry draws plus its gap")
+    func toolbarCostsItsChrome() {
+        let shown = KeyboardLayoutResolver.resolve(inputMethod: .telex, mode: .letters)
+        let hidden = KeyboardLayoutResolver.resolve(
+            inputMethod: .telex,
+            mode: .letters,
+            showsToolbar: false
+        )
+        expectClose(
+            KeyboardMetrics.phonePortraitHeight(for: shown)
+                - KeyboardMetrics.phonePortraitHeight(for: hidden),
+            KeyboardSizingProfile.default.toolbarChrome
+        )
+    }
+
+    @Test("A tap in the padding above the band still reaches the toolbar")
+    func paddingAboveTheBandIsTappable() {
+        let toolbar = KeyboardToolbarView(
+            frame: CGRect(x: 0, y: 0, width: 360, height: KeyboardSizingProfile.default.toolbarHeight)
+        )
+        toolbar.apply(spec: .standard, theme: .funputGlass, traits: .init())
+        toolbar.layoutIfNeeded()
+        let x = toolbar.emojiButton.frame.midX
+
+        #expect(toolbar.hitTest(CGPoint(x: x, y: -4), with: nil) === toolbar.emojiButton)
+        // Only the padding, though — the keycap touch surface owns everything further out.
+        #expect(toolbar.hitTest(CGPoint(x: x, y: -40), with: nil) == nil)
+    }
+
+    private func expectClose(_ actual: CGFloat, _ expected: CGFloat) {
+        #expect(abs(actual - expected) <= 0.01)
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardTouchUIKitTests/Geometry/KeyboardRowBandsTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardTouchUIKitTests/Geometry/KeyboardRowBandsTests.swift
@@ -36,21 +36,39 @@ struct KeyboardRowBandsTests {
     @Test("The gap above the inset row is split at its midpoint")
     func upperRowGapIsSplit() {
         let snapshot = makeSnapshot()
+        let split = gapMidpoint(in: snapshot, above: homeRowIndex(in: snapshot))
 
-        #expect(snapshot.touchHit(at: CGPoint(x: 2, y: 151))?.key.id == "character-q")
-        #expect(snapshot.touchHit(at: CGPoint(x: 2, y: 153))?.key.id == "character-a")
-        #expect(snapshot.touchHit(at: CGPoint(x: 388, y: 151))?.key.id == "character-p")
-        #expect(snapshot.touchHit(at: CGPoint(x: 388, y: 153))?.key.id == "character-l")
+        #expect(snapshot.touchHit(at: CGPoint(x: 2, y: split - 1))?.key.id == "character-q")
+        #expect(snapshot.touchHit(at: CGPoint(x: 2, y: split + 1))?.key.id == "character-a")
+        #expect(snapshot.touchHit(at: CGPoint(x: 388, y: split - 1))?.key.id == "character-p")
+        #expect(snapshot.touchHit(at: CGPoint(x: 388, y: split + 1))?.key.id == "character-l")
     }
 
     @Test("The gap below the inset row is split at its midpoint")
     func lowerRowGapIsSplit() {
         let snapshot = makeSnapshot()
+        let split = gapMidpoint(in: snapshot, above: homeRowIndex(in: snapshot) + 1)
 
-        #expect(snapshot.touchHit(at: CGPoint(x: 2, y: 200))?.key.id == "character-a")
-        #expect(snapshot.touchHit(at: CGPoint(x: 2, y: 204))?.key.id == "shift")
-        #expect(snapshot.touchHit(at: CGPoint(x: 388, y: 200))?.key.id == "character-l")
-        #expect(snapshot.touchHit(at: CGPoint(x: 388, y: 204))?.key.id == "backspace")
+        #expect(snapshot.touchHit(at: CGPoint(x: 2, y: split - 1))?.key.id == "character-a")
+        #expect(snapshot.touchHit(at: CGPoint(x: 2, y: split + 1))?.key.id == "shift")
+        #expect(snapshot.touchHit(at: CGPoint(x: 388, y: split - 1))?.key.id == "character-l")
+        #expect(snapshot.touchHit(at: CGPoint(x: 388, y: split + 1))?.key.id == "backspace")
+    }
+
+    private func homeRowIndex(in snapshot: KeyboardGeometrySnapshot) -> Int {
+        snapshot.geometry.rows.firstIndex { row in
+            row.contains { $0.spec.id == "character-a" }
+        } ?? 0
+    }
+
+    /// Where two rows' touch bands meet. Read off the resolved geometry rather than written
+    /// down as a coordinate, so re-sizing the toolbar moves the probe with the rows instead
+    /// of leaving it testing the wrong strip.
+    private func gapMidpoint(in snapshot: KeyboardGeometrySnapshot, above index: Int) -> CGFloat {
+        let rows = snapshot.geometry.rows
+        let upper = rows[index - 1].map(\.frame.maxY).max() ?? 0
+        let lower = rows[index].map(\.frame.minY).min() ?? 0
+        return upper + (lower - upper) / 2
     }
 
     @Test("Every alphabetic editor gives its side runway to A and L", arguments: [


### PR DESCRIPTION
## Vấn đề

Toolbar gợi ý cao gần bằng một hàng phím trong khi chỉ chứa một dòng chữ và hai icon, nên bàn phím Funput chiếm nhiều diện tích màn hình hơn cần thiết.

## Thay đổi

| | iOS | Android |
|---|---|---|
| Chiều cao dải gợi ý | 44 → **36** pt | 42 → **36** dp |
| Khoảng cách xuống hàng phím | 6 → **4** pt | 6 → **4** dp |
| Toolbar chiếm tổng cộng | 50 → **40** | 48 → **40** |
| Tổng chiều cao bàn phím (dọc, 100%) | 304 → **294** pt | 329 → **320,3** dp |

Hàng phím **không đổi** (42,8pt / 46,8dp). Base height của iOS giảm đúng bằng phần chrome tiết kiệm được, nên toàn bộ mức giảm lấy từ toolbar chứ không phải bóp phím; các bố cục không có toolbar (mật khẩu, keypad) giữ nguyên chiều cao tuyệt đối.

**Chữ gợi ý** — iOS: `.preferredFont(.body)` (17pt) → 15pt, vẫn theo Dynamic Type nhưng chặn trần 17pt để dấu tiếng Việt xếp chồng không bị cắt. Android giữ 14sp vì đã đúng cỡ compact. Vạch phân cách trên cả hai nền tảng đổi từ inset cứng sang tỉ lệ chiều cao dải.

## Dải thấp hơn nhưng vùng chạm rộng hơn trước

- **iOS**: phím clipboard/emoji từ 36×36 → 40×36pt — trước đây chúng nằm gọn trong dải 44pt, 8pt còn lại là vùng chết. `KeyboardToolbarView` thêm `hitTest` gấp cú chạm rơi vào 6pt padding phía trên dải về lại dải; vùng đó trước giờ không thuộc về ai vì `KeyboardTrackingBounds` cắt bề mặt phím từ `toolbar.maxY` xuống. Tổng vùng chạm 42pt.
- **Android**: gợi ý trước đây hit-test đúng bằng khung vẽ. Nay có `suggestionsHitBounds` trải từ mép trên bàn phím xuống điểm giữa khe dưới — cùng cách `KeyboardHitTargetResolver` vốn đã nới cho phím toolbar (~47dp, so với 45dp cũ). `KeyboardAccessibilitySnapshot` dùng cùng vùng này nên explore-by-touch của TalkBack khớp với ngón tay.

## Dọn dẹp kèm theo

- Dải toolbar được mô tả hai nơi trên mỗi nền tảng — một bởi geometry vẽ nó, một bởi ngân sách chiều cao dành chỗ cho nó. Giờ cả hai đọc từ một nguồn: `KeyboardSizingProfile.toolbarChrome` (iOS) và `ToolbarMetrics` (Android, gộp từ `ToolbarBrandMetrics`). Lệch nhau thì hoặc bóp hàng phím đầu, hoặc chừa một dải trống phía trên.
- `KeyboardToolbarView.swift` sẽ vượt hạn mức 150 dòng nên tách phần bố cục sang `KeyboardToolbarView+Layout.swift`.
- Hai test touch-band iOS đang ghi cứng toạ độ pixel; nay tính điểm giữa khe từ geometry nên lần sau đổi số đo chúng không vỡ.

## Test

- `ToolbarChromeTests` (mới): khoá bất biến "toolbar tốn đúng bằng dải + khe" và việc padding phía trên dải vẫn bấm được.
- `KeyboardInteractionTargetsTest` (Android): thêm ca gợi ý nhận cú chạm ở padding quanh dải.
- iOS `FunputKit` full suite xanh, trừ một lỗi **có sẵn trên `main`** (`KeyboardInputConfigurationTests` — đặt dấu `hoà` vs `hòa`); đã chạy lại trên cây sạch để xác nhận không liên quan.
- Android `testDebugUnitTest` + `lintDebug` xanh; `check-swift-loc.sh`, `check-kotlin-loc.sh`, `check-kotlin-layout.sh` xanh.

## Lưu ý

Icon toolbar Android vẽ theo `min(width, height)` của phím nên nhỏ đi ~14% cùng với dải (iOS dùng SF Symbol cố định 17pt nên không đổi). Vẫn rõ trong ảnh xem trước, nhưng có thể chỉnh ratio riêng cho phím toolbar nếu thấy nhỏ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)