### PR TITLE
fix(android): type Vietnamese into WPS Office PC through KeyEvents

### DIFF
--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CompositionCompatibilityPolicy.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CompositionCompatibilityPolicy.kt
@@ -1,11 +1,15 @@
 package app.funput.funput.ime.editing
 
+import app.funput.funput.ime.editing.keyevent.KeyEventHosts
+
 /**
- * Selects editors that need committed buffer replacement instead of composing spans.
+ * Selects editors that cannot host composing spans, without changing the default pipeline.
+ *
+ * Each render mode owns its host table. KEY_EVENT packages live in [KeyEventHosts] so
+ * OEM sandbox engines can be added without growing this dispatcher.
  *
  * Prefixes cover release variants such as Firefox Beta, Facebook Lite, Messenger, Instagram,
- * Threads, Reddit, and ONLYOFFICE Documents builds without coupling the editing pipeline to
- * individual product names.
+ * Threads, Reddit, and ONLYOFFICE Documents without coupling the pipeline to product names.
  */
 internal object CompositionCompatibilityPolicy {
     private val committedPackagePrefixes = listOf(
@@ -19,11 +23,19 @@ internal object CompositionCompatibilityPolicy {
         "com.onlyoffice.",
     )
 
-    fun renderMode(packageName: String?): CompositionRenderMode = when {
-        keyDeletePackagePrefixes.any { packageName?.startsWith(it) == true } ->
-            CompositionRenderMode.COMMITTED_KEY_DELETE
-        committedPackagePrefixes.any { packageName?.startsWith(it) == true } ->
-            CompositionRenderMode.COMMITTED
-        else -> CompositionRenderMode.COMPOSING
-    }
+    fun renderMode(packageName: String?): CompositionRenderMode =
+        KeyEventHosts.modeFor(packageName)
+            ?: keyDeleteMode(packageName)
+            ?: committedMode(packageName)
+            ?: CompositionRenderMode.COMPOSING
+
+    private fun keyDeleteMode(packageName: String?) =
+        CompositionRenderMode.COMMITTED_KEY_DELETE.takeIf {
+            keyDeletePackagePrefixes.any { packageName?.startsWith(it) == true }
+        }
+
+    private fun committedMode(packageName: String?) =
+        CompositionRenderMode.COMMITTED.takeIf {
+            committedPackagePrefixes.any { packageName?.startsWith(it) == true }
+        }
 }

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CompositionDocumentEditor.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CompositionDocumentEditor.kt
@@ -1,15 +1,17 @@
 package app.funput.funput.ime.editing
 
 import android.view.inputmethod.InputConnection
+import app.funput.funput.ime.editing.keyevent.KeyEventBufferWriter
 
 /**
  * Applies the engine buffer without exposing host-specific behavior to the engine session.
  *
  * Most editors get Android composing text. Broken hosts get committed replacements because they
- * ignore or decorate composing regions incorrectly.
+ * ignore or decorate composing regions incorrectly. Sandbox hosts get KeyEvents only.
  */
 internal class CompositionDocumentEditor(
     private val composingTextFactory: (String) -> CharSequence,
+    private val keyEventWriter: KeyEventBufferWriter = KeyEventBufferWriter(),
 ) {
     private val committedWriter = CommittedBufferWriter()
     private var committedSelection: Int? = null
@@ -20,16 +22,14 @@ internal class CompositionDocumentEditor(
         mode: CompositionRenderMode,
         previous: String,
         current: String,
-    ): Boolean = when (mode) {
-        CompositionRenderMode.COMPOSING ->
-            connection.setComposingText(composingTextFactory(current), CursorAfterText)
-        CompositionRenderMode.COMMITTED,
-        CompositionRenderMode.COMMITTED_KEY_DELETE,
-        -> replaceBeforeCursor(connection, mode, previous, current)
+    ): Boolean = if (mode.usesComposingSpans) {
+        connection.setComposingText(composingTextFactory(current), CursorAfterText)
+    } else {
+        replaceBeforeCursor(connection, mode, previous, current)
     }
 
     fun finish(connection: InputConnection?, mode: CompositionRenderMode, active: Boolean) {
-        if (active && mode == CompositionRenderMode.COMPOSING) connection?.finishComposingText()
+        if (active && mode.usesComposingSpans) connection?.finishComposingText()
     }
 
     fun commitBoundary(
@@ -38,23 +38,16 @@ internal class CompositionDocumentEditor(
         previous: String,
         replacement: String?,
         boundary: String,
-    ): Boolean = when (mode) {
-        CompositionRenderMode.COMPOSING -> {
-            if (replacement != null) connection.commitText(replacement, CursorAfterText)
-            else {
-                connection.finishComposingText()
-                connection.commitText(boundary, CursorAfterText)
-            }
+    ): Boolean = if (mode.usesComposingSpans) {
+        if (replacement != null) connection.commitText(replacement, CursorAfterText)
+        else {
+            connection.finishComposingText()
+            connection.commitText(boundary, CursorAfterText)
         }
-        CompositionRenderMode.COMMITTED,
-        CompositionRenderMode.COMMITTED_KEY_DELETE,
-        -> {
-            if (replacement != null) replaceBeforeCursor(connection, mode, previous, replacement)
-            else {
-                expectCommittedSelection(previousLength = 0, currentLength = boundary.length)
-                connection.commitText(boundary, CursorAfterText)
-            }
-        }
+    } else if (replacement != null) {
+        replaceBeforeCursor(connection, mode, previous, replacement)
+    } else {
+        replaceBeforeCursor(connection, mode, "", boundary)
     }
 
     fun acceptSuggestion(
@@ -62,28 +55,22 @@ internal class CompositionDocumentEditor(
         mode: CompositionRenderMode,
         prefix: String,
         candidate: String,
-    ): Boolean = when (mode) {
-        CompositionRenderMode.COMPOSING ->
-            connection.commitText("$candidate ", CursorAfterText)
-        CompositionRenderMode.COMMITTED,
-        CompositionRenderMode.COMMITTED_KEY_DELETE,
-        -> replaceBeforeCursor(connection, mode, prefix, "$candidate ")
+    ): Boolean = if (mode.usesComposingSpans) {
+        connection.commitText("$candidate ", CursorAfterText)
+    } else {
+        replaceBeforeCursor(connection, mode, prefix, "$candidate ")
     }
 
     fun reopenWord(
         connection: InputConnection,
         mode: CompositionRenderMode,
         word: String,
-    ): Boolean = when (mode) {
-        CompositionRenderMode.COMPOSING ->
-            connection.deleteSurroundingText(word.length, 0) &&
-                connection.setComposingText(composingTextFactory(word), CursorAfterText)
-        CompositionRenderMode.COMMITTED,
-        CompositionRenderMode.COMMITTED_KEY_DELETE,
-        -> true.also {
-            committedSelection = null
-            expectedCommittedSelection = null
-        }
+    ): Boolean = if (mode.usesComposingSpans) {
+        connection.deleteSurroundingText(word.length, 0) &&
+            connection.setComposingText(composingTextFactory(word), CursorAfterText)
+    } else true.also {
+        committedSelection = null
+        expectedCommittedSelection = null
     }
 
     fun ownsSelection(
@@ -93,12 +80,10 @@ internal class CompositionDocumentEditor(
         selectionStart: Int,
         selectionEnd: Int,
         composingEnd: Int,
-    ): Boolean = when (mode) {
-        CompositionRenderMode.COMPOSING ->
-            selectionStart == composingEnd && selectionEnd == composingEnd
-        CompositionRenderMode.COMMITTED,
-        CompositionRenderMode.COMMITTED_KEY_DELETE,
-        -> ownsCommittedSelection(connection, text, selectionStart, selectionEnd)
+    ): Boolean = if (mode.usesComposingSpans) {
+        selectionStart == composingEnd && selectionEnd == composingEnd
+    } else {
+        ownsCommittedSelection(connection, text, selectionStart, selectionEnd)
     }
 
     private fun replaceBeforeCursor(
@@ -108,12 +93,11 @@ internal class CompositionDocumentEditor(
         replacement: String,
     ): Boolean {
         expectCommittedSelection(previous.length, replacement.length)
-        return committedWriter.replace(
-            connection,
-            previous,
-            replacement,
-            deleteWithKeyEvents = mode.deleteWithKeyEvents,
-        )
+        return if (mode.writesKeyEvents) {
+            keyEventWriter.replace(connection, previous, replacement)
+        } else {
+            committedWriter.replace(connection, previous, replacement, mode.deleteWithKeyEvents)
+        }
     }
 
     private fun ownsCommittedSelection(

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CompositionRenderMode.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CompositionRenderMode.kt
@@ -5,7 +5,18 @@ internal enum class CompositionRenderMode {
     COMMITTED,
     /** Like [COMMITTED], but shrink/replace via KEYCODE_DEL (ONLYOFFICE-style hosts). */
     COMMITTED_KEY_DELETE,
+    /**
+     * Linux-sandbox / PC-framework hosts (WPS Office PC). They ignore InputConnection
+     * text APIs; the engine buffer is written only as KeyEvents.
+     */
+    KEY_EVENT,
 }
 
 internal val CompositionRenderMode.deleteWithKeyEvents: Boolean
     get() = this == CompositionRenderMode.COMMITTED_KEY_DELETE
+
+internal val CompositionRenderMode.usesComposingSpans: Boolean
+    get() = this == CompositionRenderMode.COMPOSING
+
+internal val CompositionRenderMode.writesKeyEvents: Boolean
+    get() = this == CompositionRenderMode.KEY_EVENT

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/keyevent/KeyEventBufferWriter.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/keyevent/KeyEventBufferWriter.kt
@@ -1,0 +1,47 @@
+package app.funput.funput.ime.editing.keyevent
+
+import android.os.SystemClock
+import android.view.KeyCharacterMap
+import android.view.KeyEvent
+import android.view.inputmethod.InputConnection
+
+/**
+ * Performs a [KeyEventTextPlan] against hosts that ignore composing and commitText.
+ *
+ * [send] is injectable so JVM tests never construct KeyEvent (android.jar getters throw).
+ */
+internal class KeyEventBufferWriter(
+    private val send: (InputConnection, KeyEventStroke) -> Boolean = ::sendAndroidKeyEventStroke,
+) {
+    fun replace(
+        connection: InputConnection,
+        previous: String,
+        replacement: String,
+    ): Boolean {
+        connection.beginBatchEdit()
+        return try {
+            KeyEventTextPlan.replace(previous, replacement).strokes()
+                .all { send(connection, it) }
+        } finally {
+            connection.endBatchEdit()
+        }
+    }
+}
+
+internal fun sendAndroidKeyEventStroke(
+    connection: InputConnection,
+    stroke: KeyEventStroke,
+): Boolean = when (stroke) {
+    KeyEventStroke.Delete -> {
+        connection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL)) &&
+            connection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_DEL))
+    }
+    is KeyEventStroke.Text -> connection.sendKeyEvent(
+        KeyEvent(
+            SystemClock.uptimeMillis(),
+            stroke.characters,
+            KeyCharacterMap.VIRTUAL_KEYBOARD,
+            0,
+        ),
+    )
+}

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/keyevent/KeyEventHosts.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/keyevent/KeyEventHosts.kt
@@ -1,0 +1,26 @@
+package app.funput.funput.ime.editing.keyevent
+
+import app.funput.funput.ime.editing.CompositionRenderMode
+
+/**
+ * Linux-sandbox / PC-framework packages that only accept KeyEvents.
+ *
+ * Prefixes, not product names. Add a constant here when a new OEM engine is confirmed;
+ * split this object into `keyevent/hosts/` if a vendor needs its own notes.
+ *
+ * Huawei WPS, CAJViewer, and Edraw share [HUAWEI_PC_ENGINE] — matching the engine
+ * covers every guest without naming each shortcut activity.
+ */
+internal object KeyEventHosts {
+    private const val XIAOMI_WPS = "com.xiaomi.wps"
+    private const val HUAWEI_PC_ENGINE = "com.huawei.hsl"
+    private const val HUAWEI_WPS = "cn.wps.huawei"
+
+    private val prefixes = listOf(XIAOMI_WPS, HUAWEI_PC_ENGINE, HUAWEI_WPS)
+
+    fun matches(packageName: String?): Boolean =
+        prefixes.any { packageName?.startsWith(it) == true }
+
+    fun modeFor(packageName: String?): CompositionRenderMode? =
+        CompositionRenderMode.KEY_EVENT.takeIf { matches(packageName) }
+}

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/keyevent/KeyEventStroke.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/keyevent/KeyEventStroke.kt
@@ -1,0 +1,12 @@
+package app.funput.funput.ime.editing.keyevent
+
+/**
+ * One write a Linux-sandbox host can receive. Text APIs stay off this path.
+ *
+ * [Delete] is KEYCODE_DEL. [Text] is an ACTION_MULTIPLE unicode payload — the only KeyEvent
+ * that can carry Vietnamese after Telex/VNI has already composed it.
+ */
+internal sealed interface KeyEventStroke {
+    data object Delete : KeyEventStroke
+    data class Text(val characters: String) : KeyEventStroke
+}

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/keyevent/KeyEventTextPlan.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/keyevent/KeyEventTextPlan.kt
@@ -1,0 +1,26 @@
+package app.funput.funput.ime.editing.keyevent
+
+/**
+ * The same prefix arithmetic as committed replacement, without touching InputConnection.
+ *
+ * Grow by appending the suffix, shrink by deleting the tail, and rewrite by delete-then-insert
+ * when a tone transform changes a character in the middle.
+ */
+internal data class KeyEventTextPlan(val deleteCount: Int, val insert: String) {
+    fun strokes(): List<KeyEventStroke> = buildList {
+        repeat(deleteCount) { add(KeyEventStroke.Delete) }
+        if (insert.isNotEmpty()) add(KeyEventStroke.Text(insert))
+    }
+
+    companion object {
+        fun replace(previous: String, replacement: String): KeyEventTextPlan = when {
+            previous == replacement -> KeyEventTextPlan(0, "")
+            previous.isEmpty() -> KeyEventTextPlan(0, replacement)
+            replacement.startsWith(previous) ->
+                KeyEventTextPlan(0, replacement.substring(previous.length))
+            previous.startsWith(replacement) ->
+                KeyEventTextPlan(previous.length - replacement.length, "")
+            else -> KeyEventTextPlan(previous.length, replacement)
+        }
+    }
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CompositionCompatibilityPolicyTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CompositionCompatibilityPolicyTest.kt
@@ -37,7 +37,7 @@ class CompositionCompatibilityPolicyTest {
 
     @Test
     fun `unlisted and missing packages keep native composition`() {
-        listOf(null, "com.android.chrome", "com.whatsapp").forEach { packageName ->
+        listOf(null, "com.android.chrome", "com.whatsapp", "cn.wps.moffice_eng").forEach { packageName ->
             assertEquals(
                 CompositionRenderMode.COMPOSING,
                 CompositionCompatibilityPolicy.renderMode(packageName),

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/keyevent/KeyEventBufferWriterTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/keyevent/KeyEventBufferWriterTest.kt
@@ -1,0 +1,61 @@
+package app.funput.funput.ime.editing.keyevent
+
+import android.view.inputmethod.InputConnection
+import java.lang.reflect.Proxy
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class KeyEventBufferWriterTest {
+    @Test
+    fun prefixGrowthSendsOnlyTheSuffix() {
+        val host = RecordingHost()
+        val writer = KeyEventBufferWriter(host::record)
+
+        writer.replace(host.connection, "", "p")
+        writer.replace(host.connection, "p", "ph")
+        writer.replace(host.connection, "ph", "phu")
+
+        assertEquals(
+            listOf(
+                KeyEventStroke.Text("p"),
+                KeyEventStroke.Text("h"),
+                KeyEventStroke.Text("u"),
+            ),
+            host.strokes,
+        )
+    }
+
+    @Test
+    fun toneTransformDeletesThenInsertsUnicode() {
+        val host = RecordingHost()
+        val writer = KeyEventBufferWriter(host::record)
+
+        writer.replace(host.connection, "", "a")
+        writer.replace(host.connection, "a", "á")
+
+        assertEquals(
+            listOf(KeyEventStroke.Text("a"), KeyEventStroke.Delete, KeyEventStroke.Text("á")),
+            host.strokes,
+        )
+    }
+}
+
+private class RecordingHost {
+    val strokes = mutableListOf<KeyEventStroke>()
+    val connection: InputConnection = Proxy.newProxyInstance(
+        InputConnection::class.java.classLoader,
+        arrayOf(InputConnection::class.java),
+    ) { _, method, _ ->
+        when (method.name) {
+            "beginBatchEdit", "endBatchEdit" -> true
+            "toString" -> "RecordingHost"
+            else -> false
+        }
+    } as InputConnection
+
+    fun record(connection: InputConnection, stroke: KeyEventStroke): Boolean {
+        check(connection === this.connection)
+        strokes += stroke
+        return true
+    }
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/keyevent/KeyEventDocumentEditorTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/keyevent/KeyEventDocumentEditorTest.kt
@@ -1,0 +1,69 @@
+package app.funput.funput.ime.editing.keyevent
+
+import android.view.inputmethod.InputConnection
+import app.funput.funput.ime.editing.CompositionDocumentEditor
+import app.funput.funput.ime.editing.CompositionRenderMode
+import java.lang.reflect.Proxy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KeyEventDocumentEditorTest {
+    @Test
+    fun keyEventModeNeverUsesInputConnectionTextApis() {
+        val host = SandboxHost()
+        val editor = CompositionDocumentEditor(
+            composingTextFactory = { it },
+            keyEventWriter = KeyEventBufferWriter(host::record),
+        )
+
+        assertTrue(editor.update(host.connection, CompositionRenderMode.KEY_EVENT, "", "a"))
+        assertTrue(editor.update(host.connection, CompositionRenderMode.KEY_EVENT, "a", "á"))
+        assertTrue(
+            editor.commitBoundary(
+                host.connection,
+                CompositionRenderMode.KEY_EVENT,
+                "á",
+                replacement = null,
+                boundary = " ",
+            ),
+        )
+
+        assertEquals(0, host.commitTextCount)
+        assertEquals(0, host.setComposingCount)
+        assertEquals(
+            listOf(
+                KeyEventStroke.Text("a"),
+                KeyEventStroke.Delete,
+                KeyEventStroke.Text("á"),
+                KeyEventStroke.Text(" "),
+            ),
+            host.strokes,
+        )
+    }
+}
+
+private class SandboxHost {
+    val strokes = mutableListOf<KeyEventStroke>()
+    var commitTextCount = 0
+    var setComposingCount = 0
+    val connection: InputConnection = Proxy.newProxyInstance(
+        InputConnection::class.java.classLoader,
+        arrayOf(InputConnection::class.java),
+    ) { _, method, _ ->
+        when (method.name) {
+            "beginBatchEdit", "endBatchEdit" -> true
+            "commitText" -> true.also { commitTextCount += 1 }
+            "setComposingText" -> true.also { setComposingCount += 1 }
+            "finishComposingText" -> true
+            "toString" -> "SandboxHost"
+            else -> false
+        }
+    } as InputConnection
+
+    fun record(connection: InputConnection, stroke: KeyEventStroke): Boolean {
+        check(connection === this.connection)
+        strokes += stroke
+        return true
+    }
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/keyevent/KeyEventHostsTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/keyevent/KeyEventHostsTest.kt
@@ -1,0 +1,37 @@
+package app.funput.funput.ime.editing.keyevent
+
+import app.funput.funput.ime.editing.CompositionCompatibilityPolicy
+import app.funput.funput.ime.editing.CompositionRenderMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KeyEventHostsTest {
+    @Test
+    fun sandboxEnginesSelectKeyEventMode() {
+        listOf(
+            "com.xiaomi.wpslauncher",
+            "com.huawei.hsl",
+            "cn.wps.huawei",
+        ).forEach { packageName ->
+            assertTrue(packageName, KeyEventHosts.matches(packageName))
+            assertEquals(
+                packageName,
+                CompositionRenderMode.KEY_EVENT,
+                CompositionCompatibilityPolicy.renderMode(packageName),
+            )
+        }
+    }
+
+    @Test
+    fun nativeWpsAndOtherHuaweiAppsStayOffThisHandle() {
+        listOf(
+            "cn.wps.moffice_eng",
+            "cn.wps.moffice",
+            "com.huawei.android.launcher",
+        ).forEach { packageName ->
+            assertFalse(packageName, KeyEventHosts.matches(packageName))
+        }
+    }
+}

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/keyevent/KeyEventTextPlanTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/keyevent/KeyEventTextPlanTest.kt
@@ -1,0 +1,41 @@
+package app.funput.funput.ime.editing.keyevent
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class KeyEventTextPlanTest {
+    @Test
+    fun emptyPreviousInsertsTheWholeReplacement() {
+        assertEquals(KeyEventTextPlan(0, "a"), KeyEventTextPlan.replace("", "a"))
+        assertEquals(
+            listOf(KeyEventStroke.Text("a")),
+            KeyEventTextPlan.replace("", "a").strokes(),
+        )
+    }
+
+    @Test
+    fun prefixGrowthInsertsOnlyTheSuffix() {
+        assertEquals(KeyEventTextPlan(0, "h"), KeyEventTextPlan.replace("p", "ph"))
+        assertEquals(KeyEventTextPlan(0, "u"), KeyEventTextPlan.replace("ph", "phu"))
+    }
+
+    @Test
+    fun shrinkDeletesTheDroppedTail() {
+        assertEquals(KeyEventTextPlan(1, ""), KeyEventTextPlan.replace("phu", "ph"))
+        assertEquals(listOf(KeyEventStroke.Delete), KeyEventTextPlan.replace("phu", "ph").strokes())
+    }
+
+    @Test
+    fun toneTransformDeletesThenInserts() {
+        assertEquals(KeyEventTextPlan(1, "á"), KeyEventTextPlan.replace("a", "á"))
+        assertEquals(
+            listOf(KeyEventStroke.Delete, KeyEventStroke.Text("á")),
+            KeyEventTextPlan.replace("a", "á").strokes(),
+        )
+    }
+
+    @Test
+    fun identicalBuffersEmitNothing() {
+        assertEquals(emptyList<KeyEventStroke>(), KeyEventTextPlan.replace("á", "á").strokes())
+    }
+}

--- a/platforms/android/scripts/check-kotlin-layout.sh
+++ b/platforms/android/scripts/check-kotlin-layout.sh
@@ -24,9 +24,11 @@ readonly roots=(
     "$ime_main/editing/caret"
     "$ime_main/editing/gestures"
     "$ime_main/editing/typing"
+    "$ime_main/editing/keyevent"
     "$ime_main/settings/gestures"
     "$ime_test/editing/caret"
     "$ime_test/editing/gestures"
+    "$ime_test/editing/keyevent"
     "$ime_test/settings/gestures"
 )
 violations=0


### PR DESCRIPTION
## Tóm tắt

WPS Office PC trên tablet Xiaomi/Huawei chạy Linux trong sandbox, nên không nhận `setComposingText` / `commitText`. Funput thêm handle **`KEY_EVENT`** riêng: Telex/VNI vẫn compose trong engine, rồi ghi ra host bằng KeyEvent. Các app khác (Chrome, OnlyOffice, Firefox…) không đổi.

## App được hỗ trợ

- **Xiaomi:** `com.xiaomi.wpslauncher`
- **Huawei PC Engine:** `com.huawei.hsl` (WPS, CAJViewer, Edraw trong cùng process)
- **Huawei WPS (nếu tách APK):** `cn.wps.huawei`

WPS Android thường (`cn.wps.moffice*`) vẫn dùng composing như trước.

## Cách thử

1. Bật Funput, mở **WPS Office PC** trên tablet Xiaomi (bàn phím Bluetooth cũng được).
2. Gõ Telex có dấu, ví dụ `aas` → **á**.
3. Backspace trong từ đang gõ, rồi gõ tiếp để đổi dấu.

OEM sandbox mới: thêm prefix vào `KeyEventHosts`, không sửa pipeline cũ.


Made with [Cursor](https://cursor.com)