### PR TITLE
fix(ios): refresh emoji recents after leaving the panel

### DIFF
--- a/platforms/ios/Keyboard/Controller/KeyboardViewController.swift
+++ b/platforms/ios/Keyboard/Controller/KeyboardViewController.swift
@@ -92,6 +92,7 @@ final class KeyboardViewController: UIInputViewController {
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+        emojiView?.reset()
 #if DEBUG
         touchDiagnosticsReporter.finish()
 #endif

--- a/platforms/ios/Keyboard/Controller/Surfaces/KeyboardViewController+Emoji.swift
+++ b/platforms/ios/Keyboard/Controller/Surfaces/KeyboardViewController+Emoji.swift
@@ -14,9 +14,6 @@ extension KeyboardViewController {
         emojiView.onEmojiSelected = { [weak self] item in
             self?.insertEmoji(item)
         }
-        emojiView.onRecentEmojiSelected = { [weak self] item in
-            self?.insertEmoji(item, recordRecent: false)
-        }
         emojiView.onDelete = { [weak self] in
             self?.deleteFromEmojiKeyboard()
         }
@@ -43,7 +40,6 @@ extension KeyboardViewController {
     }
 
     func showFunput() {
-        emojiView?.reset()
         kaomojiView?.reset()
         clipboardPanelView?.reset()
         switchSurface(to: .funput)
@@ -56,17 +52,15 @@ extension KeyboardViewController {
         )
     }
 
-    private func insertEmoji(_ item: EmojiItem, recordRecent: Bool = true) {
+    private func insertEmoji(_ item: EmojiItem) {
         let effects = inputCoordinator.insertLiteral(
             item.glyph,
             writer: makeDocumentWriter()
         )
-        if recordRecent {
-            _ = emojiRecentsStore.record(
-                EmojiRecent(glyph: item.glyph, name: item.name, category: item.category.rawValue)
-            )
-            refreshEmojiPresentation()
-        }
+        _ = emojiRecentsStore.record(
+            EmojiRecent(glyph: item.glyph, name: item.name, category: item.category.rawValue)
+        )
+        refreshEmojiPresentation()
         applyPostCommitEffects(effects)
     }
 

--- a/platforms/ios/Keyboard/Controller/Surfaces/KeyboardViewController+SurfaceLifecycle.swift
+++ b/platforms/ios/Keyboard/Controller/Surfaces/KeyboardViewController+SurfaceLifecycle.swift
@@ -1,3 +1,4 @@
+import KeyboardRenderer
 import UIKit
 
 extension KeyboardViewController {
@@ -14,6 +15,9 @@ extension KeyboardViewController {
     }
 
     func switchSurface(to surface: KeyboardSurface) {
+        if displayedSurface == .emoji, surface != .emoji {
+            emojiView?.reset()
+        }
         displayedSurface = surface
         keyboardView.isHidden = surface != .funput
         emojiView?.isHidden = surface != .emoji

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Persistence/UserData/EmojiRecentsStore.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Persistence/UserData/EmojiRecentsStore.swift
@@ -13,7 +13,7 @@ public struct EmojiRecent: Codable, Equatable, Sendable {
 }
 
 public struct EmojiRecentsStore {
-    public static let limit = 30
+    public static let limit = 8
     private let defaults: UserDefaults
     private let key: String
 

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Emoji/Browser/EmojiKeyboardView+Collection.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Emoji/Browser/EmojiKeyboardView+Collection.swift
@@ -1,7 +1,7 @@
 #if canImport(UIKit)
 import UIKit
 
-extension EmojiKeyboardView: UICollectionViewDataSource, UICollectionViewDelegate {
+extension EmojiKeyboardView: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     public func numberOfSections(in collectionView: UICollectionView) -> Int {
         sections.count
     }
@@ -43,10 +43,20 @@ extension EmojiKeyboardView: UICollectionViewDataSource, UICollectionViewDelegat
         let section = sections[indexPath.section]
         let item = section.items[indexPath.item]
         if section.category == .recent {
+            freezesRecents = true
             (onRecentEmojiSelected ?? onEmojiSelected)?(item)
         } else {
             onEmojiSelected?(item)
         }
+    }
+
+    public func collectionView(
+        _ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
+        let width = sections[indexPath.section].category == .recent
+            ? min(44, max(1, floor((collectionView.bounds.width - 16) / CGFloat(Self.recentLimit)))) : 44
+        return CGSize(width: width, height: 44)
     }
 
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Emoji/Browser/EmojiKeyboardView+Presentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Emoji/Browser/EmojiKeyboardView+Presentation.swift
@@ -48,8 +48,11 @@ extension EmojiKeyboardView {
     }
 
     func reload(recent: [EmojiItem]) {
+        latestRecents = Array(recent.prefix(Self.recentLimit))
+        let visibleRecents = freezesRecents
+            ? sections.first(where: { $0.category == .recent })?.items ?? [] : latestRecents
         sections = EmojiCategory.allCases.compactMap { category in
-            let items = category == .recent ? recent : catalog.items(in: category)
+            let items = category == .recent ? visibleRecents : catalog.items(in: category)
             return items.isEmpty ? nil : (category, items)
         }
         collectionView.reloadData()

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Emoji/Browser/EmojiKeyboardView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Emoji/Browser/EmojiKeyboardView.swift
@@ -18,6 +18,10 @@ public final class EmojiKeyboardView: UIView {
     let searchResults = EmojiSearchResultsView()
     let searchKeyboard = KeyboardSurfaceView()
     var sections: [(category: EmojiCategory, items: [EmojiItem])] = []
+    static let recentLimit = 8
+    var latestRecents: [EmojiItem] = []
+    // Keep tap targets stable while retaining the latest history for the next visit.
+    var freezesRecents = false
     var selectedCategory = EmojiCategory.smileysPeople
     var presentation = KeyboardPresentation()
     var searchState = EmojiSearchState.browsing
@@ -51,6 +55,8 @@ public final class EmojiKeyboardView: UIView {
     }
 
     public func reset() {
+        freezesRecents = false
+        reload(recent: latestRecents)
         resetSearch()
     }
 

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/EmojiRecentsStoreTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/EmojiRecentsStoreTests.swift
@@ -21,8 +21,18 @@ struct EmojiRecentsStoreTests {
             for index in 0...EmojiRecentsStore.limit {
                 _ = store.record(item("emoji-\(index)"))
             }
-            #expect(store.load().count == EmojiRecentsStore.limit)
-            #expect(store.load().first?.glyph == "emoji-30")
+            #expect(EmojiRecentsStore.limit == 8)
+            #expect(store.load().count == 8)
+            #expect(store.load().first?.glyph == "emoji-8")
+        }
+    }
+
+    @Test("Existing history is limited to the newest eight entries")
+    func legacyHistory() throws {
+        let data = try JSONEncoder().encode((0..<30).map { item("emoji-\($0)") })
+        withStore { store, defaults in
+            defaults.set(data, forKey: FunputAppGroup.emojiRecentsKey)
+            #expect(store.load().map(\.glyph) == (0..<8).map { "emoji-\($0)" })
         }
     }
 

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/EmojiSearch/EmojiRecentsPresentationTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/EmojiSearch/EmojiRecentsPresentationTests.swift
@@ -1,0 +1,52 @@
+#if canImport(UIKit)
+@testable import KeyboardRenderer
+import Testing
+import UIKit
+
+@MainActor
+@Suite("Emoji recent presentation")
+struct EmojiRecentsPresentationTests {
+    @Test("Repeated recent selections stay in place until the panel resets")
+    func deferredOrdering() {
+        let items = makeItems(count: 3)
+        let view = EmojiKeyboardView(catalog: EmojiCatalog(version: "test", emojis: items))
+        view.apply(theme: .funputGlass, recent: items)
+        var selected: [EmojiItem] = []
+        view.onRecentEmojiSelected = { item in
+            selected.append(item)
+            view.apply(theme: .funputGlass, recent: [item] + items.filter { $0 != item })
+        }
+        for index in [2, 2, 1] {
+            view.collectionView(view.collectionView, didSelectItemAt: IndexPath(item: index, section: 0))
+            #expect(view.sections[0].items == items)
+        }
+        #expect(selected == [items[2], items[2], items[1]])
+        view.reset()
+        #expect(view.sections[0].items == [items[1], items[0], items[2]])
+        view.apply(theme: .funputGlass, recent: items)
+        #expect(view.sections[0].items == items)
+    }
+
+    @Test("Recents fit one row on narrow and wide keyboards", arguments: [320.0, 343.0, 375.0, 430.0, 768.0])
+    func singleRow(width: Double) throws {
+        let items = makeItems(count: 30)
+        let view = EmojiKeyboardView(catalog: EmojiCatalog(version: "test", emojis: items))
+        view.frame = CGRect(x: 0, y: 0, width: width, height: 304)
+        view.apply(theme: .funputGlass, recent: items)
+        view.layoutIfNeeded()
+        view.collectionView.layoutIfNeeded()
+        #expect(view.sections[0].items == Array(items.prefix(8)))
+        let frames = try (0..<8).map { index in
+            try #require(view.collectionView.layoutAttributesForItem(
+                at: IndexPath(item: index, section: 0)
+            )).frame
+        }
+        #expect(Set(frames.map(\.minY)).count == 1)
+        #expect(frames.allSatisfy { $0.maxX <= width - 8 })
+    }
+
+    private func makeItems(count: Int) -> [EmojiItem] {
+        (0..<count).map { EmojiItem(glyph: "emoji-\($0)", name: "Item \($0)", category: .symbols) }
+    }
+}
+#endif

--- a/platforms/ios/Scripts/check-swift-loc.sh
+++ b/platforms/ios/Scripts/check-swift-loc.sh
@@ -16,7 +16,7 @@ while IFS= read -r -d '' file; do
 done < <(
     find "$ios_root" -type f \( -name '*.swift' -o -name 'Package.swift' \) \
         -not -path '*/.agents/*' \
-        -not -path '*/.build/*' -print0
+        -not -path '*/.build/*' -not -path "$ios_root/build/*" -print0
 )
 
 if (( violations != 0 )); then


### PR DESCRIPTION
Nhấn emoji trong **Gần đây** hiện giữ nguyên vị trí bằng cách bỏ qua việc ghi lịch sử, nên sau khi quay về bàn phím text rồi mở lại, thứ tự vẫn không phản ánh lần chọn mới nhất.

PR ghi lịch sử cho mọi lần chọn, đồng thời giữ nguyên các vị trí đang hiển thị sau khi nhấn trong Gần đây. Khi chuyển sang text, kaomoji, bề mặt khác hoặc đóng bàn phím, bảng emoji cập nhật theo lịch sử mới nhất.

Danh sách giới hạn **8 emoji**, kể cả dữ liệu cũ từng lưu tới 30 mục. Kích thước ô Gần đây được tính theo chiều rộng bàn phím để luôn vừa một hàng.

Script kiểm tra Swift LOC bỏ qua thư mục output `platforms/ios/build`, tránh tính file Xcode tự sinh; giới hạn mã nguồn vẫn là **150 dòng/file**.

## Kiểm chứng

- **13 test pass** trên iOS Simulator: lịch sử mới nhất, loại trùng, giới hạn 8 mục, dữ liệu cũ, nhấn lặp giữ vị trí và cập nhật sau reset.
- Kiểm tra bố cục một hàng ở 5 chiều rộng: 320, 343, 375, 430 và 768 pt.
- Build scheme `Funput` thành công, gồm app và keyboard extension.
- `check-swift-loc.sh` và `git diff --check` đều pass.
