### PR TITLE
test(ios): align tone placement expectations with the modern default

### DIFF
--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Coordinator/KeyboardInputConfigurationTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardInputTests/Coordinator/KeyboardInputConfigurationTests.swift
@@ -1,4 +1,5 @@
 #if os(iOS) && canImport(FunputCore)
+import Foundation
 import Testing
 import FunputShared
 import KeyboardInput
@@ -42,14 +43,35 @@ struct KeyboardInputConfigurationTests {
         #expect(document.text == "as")
     }
 
-    @Test("Default configuration keeps traditional tone placement")
-    func defaultUsesTraditionalTone() {
+    @Test("Default configuration uses modern tone placement")
+    func defaultUsesModernTone() {
         let coordinator = KeyboardInputCoordinator()
         coordinator.apply(.default)
         let document = TestKeyboardWriter()
         type("hoa", with: coordinator, into: document)
         type("2", role: .vniModifier, with: coordinator, into: document)
-        #expect(document.text == "hòa") // traditional; the modern style would yield "hoà"
+        #expect(document.text == "hoà")
+    }
+
+    @Test("Explicit tone style controls placement", arguments: [ToneStyleOption.traditional, .modern])
+    func explicitToneStyle(style: ToneStyleOption) {
+        let coordinator = KeyboardInputCoordinator()
+        coordinator.apply(FunputConfiguration(inputMethod: .vni, toneStyle: style))
+        let document = TestKeyboardWriter()
+        type("hoa", with: coordinator, into: document)
+        type("2", role: .vniModifier, with: coordinator, into: document)
+        #expect(document.text == (style == .traditional ? "hòa" : "hoà"))
+    }
+
+    @Test("Legacy configuration without tone style keeps traditional placement")
+    func legacyUsesTraditionalTone() throws {
+        let configuration = try JSONDecoder().decode(FunputConfiguration.self, from: Data("{}".utf8))
+        let coordinator = KeyboardInputCoordinator()
+        coordinator.apply(configuration)
+        let document = TestKeyboardWriter()
+        type("hoa", with: coordinator, into: document)
+        type("2", role: .vniModifier, with: coordinator, into: document)
+        #expect(document.text == "hòa")
     }
 }
 #endif


### PR DESCRIPTION
Deploy iOS dừng ở `KeyboardInputConfigurationTests.defaultUsesTraditionalTone()`: engine trả `hoà`, còn test mong `hòa`.

Commit `ad1aebb3` đã đổi mặc định cài mới sang kiểu dấu hiện đại, nhưng test tích hợp coordinator vẫn giữ kỳ vọng cũ. Cập nhật test mặc định thành `hoà`, bổ sung kiểm tra cấu hình chọn rõ từng kiểu dấu và cấu hình cũ thiếu `toneStyle` vẫn gõ `hòa`.

Chỉ thay đổi test; giữ nguyên hành vi sản phẩm và cơ chế tương thích cấu hình cũ.

## Kiểm chứng

- Toàn bộ **573 test FunputKit pass**, 0 fail, 0 skipped trên iOS Simulator, gồm các test tích hợp Rust engine.
- `check-swift-loc.sh` pass: file thay đổi 77 dòng, dưới giới hạn 150.
- `git diff --check` pass.

Run deploy gặp lỗi: https://github.com/Funput/Funput/actions/runs/34008654326
