### PR TITLE
feat(linux): show Fcitx5 panel preedit for clients that hide it

### DIFF
--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -32,6 +32,7 @@ common/                 Framework-free C++ shared by both shells
 fcitx5/src/             Fcitx5 addon -> libfunput.so
   funput_input.cpp        One keystroke: normalize, ask the composer
   funput_client.cpp       Talking to the client, both directions
+  hidden_preedit.cpp      Clients that hide the client preedit (allowlist)
 ibus/src/               IBus engine -> ibus-engine-funput
   engine.h                The public GObject type
   engine/                 internal.h, object.cpp, callbacks.cpp, client.cpp
@@ -101,6 +102,15 @@ Three channels, all fed by the same release:
 - **GitHub Releases** — the `.deb`/`.rpm` themselves, plus the portable `.tar.gz`
   trees behind `install.sh --user`.
 - **`install.sh`** — detect-then-configure front end over the two above.
+
+Funput does not set `GTK_IM_MODULE` / `QT_IM_MODULE` for the user. Those belong to
+Fcitx5's session, and they differ by desktop — see
+[Using Fcitx 5 on Wayland](https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland).
+`install.sh` and the repo landing page print the same split: **GNOME** wants
+`XMODIFIERS=@im=fcitx` and `QT_IM_MODULE=fcitx` (leave `GTK_IM_MODULE` unset);
+**KDE** wants only `XMODIFIERS=@im=fcitx` and must not set the IM_MODULE trio
+globally. Put them in `~/.config/environment.d/fcitx5.conf` and log out.
+
 Arch is inside the first of those rather than a channel of its own. It has no release
 asset — a rolling source distro has no use for a `.deb` or `.rpm` — so the `pacman` job
 in `publish-repo.yml` *builds* it, from `packaging/arch/PKGBUILD.in`, and serves the
@@ -292,7 +302,7 @@ reasoned rather than measured.
 
 ### On the IBus side
 
-Three API facts, each of which cost several rounds to find, and none of which the
+Four API facts, each of which cost several rounds to find, and none of which the
 headers tell you:
 
 - **Registering for surrounding text is per input context, not per engine.** IBus
@@ -301,6 +311,24 @@ headers tell you:
   engine that only asks there receives nothing for the rest of the session. It has to
   be asked again on every focus-in. Until that was found, non-preedit had never once
   engaged on IBus, while looking as though it had.
+- **But asking is not what makes it arrive — the daemon deduplicates.**
+  `bus_engine_proxy_set_surrounding_text()` calls down to the engine only when the
+  text, the cursor or the anchor differs from what it last forwarded. That cache sits
+  on the engine *proxy*, is seeded with `("", 0, 0)`, and is never cleared on focus
+  change — only when the proxy is destroyed. So a client that answers with an empty
+  string is invisible to the engine no matter how often it is asked. WPS Office is
+  exactly that client: its editor does not implement `Qt::ImSurroundingText`, so Qt
+  answers every request with `("", 0, 0)`, which is precisely the seed value, and
+  `set_surrounding_text` never fires once — while `SetSurroundingText` lands on the
+  daemon sixteen times in a minute. Reading the count on the client side and calling
+  it support is the trap; the payload is the fact.
+
+  The same cache makes `focusIn()` clearing `sawSurroundingText` a latent bug: the
+  daemon will not repeat itself for a new focus, so once cleared the flag can only
+  return if the document *changes*. The repair belongs on the clearing side, not the
+  asking side — re-asking was tried and moved nothing. Left undone: no client here
+  shows the symptom, and guessing at a fix for one is how the capability flags got
+  trusted the first time.
 - **Reading it back does not work.** `ibus_engine_get_surrounding_text()` returns a
   null text immediately after the client has sent a perfectly good string. The only
   reliable copy is the one arriving in the `set_surrounding_text` vfunc, so the engine
@@ -327,6 +355,16 @@ client reported cursor 4 for `phủ ` (five bytes) and 3 for `phủ` (four).
   through `zwp_text_input_v3`; the same session shows preedit working normally in other
   apps, so this is Chrome's end and nothing in Funput can reach it. **Non-preedit is
   the answer for Chrome**, which is the shape the mode was built for.
+- **WPS Office paints no client preedit.** It advertises the Preedit capability, so
+  the Fcitx5 panel preedit was also skipped, and the composing word stayed invisible
+  until Space (or another commit). Non-preedit cannot run: WPS does not implement
+  `Qt::ImSurroundingText`, and forcing a delete-then-commit repair mangles the text
+  (`nguyen64` coming back `nguyenênễn`). The Fcitx5 shell therefore draws the panel
+  preedit for any basename on the allowlist in `hidden_preedit.cpp` (`wps`, `wpp`,
+  `et`, `wpspdf` today) and still sends the client preedit so a focus-out flush is
+  not lost. Adding another client of this kind is a name on that list. IBus has no
+  channel that works here — ForwardKeyEvent is gone, surrounding text never arrives —
+  and is left alone.
 - **Re-toning after Backspace is non-preedit only.** In preedit mode Backspace just
   shortens the composition, so `phủ` ␣ ⌫ `s` types a literal `s` — while macOS, Windows
   and Android all re-open the word. macOS manages it with one atomic

--- a/platforms/linux/fcitx5/CMakeLists.txt
+++ b/platforms/linux/fcitx5/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(funput MODULE
     src/funput_engine.cpp
     src/funput_input.cpp
     src/funput_client.cpp
+    src/hidden_preedit.cpp
 )
 add_dependencies(funput funput_ffi)
 

--- a/platforms/linux/fcitx5/src/funput_client.cpp
+++ b/platforms/linux/fcitx5/src/funput_client.cpp
@@ -46,7 +46,8 @@ void FunputEngine::updatePreedit(fcitx::InputContext *context, const std::string
     // unaffected — InputContext::updatePreedit() returns early without the Preedit
     // capability, so those clients still get the Fcitx5-drawn panel preedit below.
     panel.setClientPreedit(preedit);
-    if (!context->capabilityFlags().test(fcitx::CapabilityFlag::Preedit)) {
+    if (!context->capabilityFlags().test(fcitx::CapabilityFlag::Preedit) ||
+        hidesClientPreedit(context)) {
         panel.setPreedit(preedit);
     }
     context->updatePreedit();

--- a/platforms/linux/fcitx5/src/funput_engine.h
+++ b/platforms/linux/fcitx5/src/funput_engine.h
@@ -44,10 +44,11 @@ FCITX_CONFIGURATION(
     fcitx::ExternalOption openSettings{
         this, "OpenSettings", "Open Funput Settings", "funput-settings"};);
 
-// Reading the focused client. Defined in funput_client.cpp beside the writing half —
-// talking to the client is one concern, whichever direction it goes.
+// Reading the focused client. Document helpers live in funput_client.cpp;
+// the hidden-preedit allowlist lives in hidden_preedit.cpp.
 std::string textBeforeCaret(fcitx::InputContext *context);
 bool hasSelection(fcitx::InputContext *context);
+bool hidesClientPreedit(fcitx::InputContext *context);
 
 class FunputEngine : public fcitx::InputMethodEngineV2 {
 public:

--- a/platforms/linux/fcitx5/src/hidden_preedit.cpp
+++ b/platforms/linux/fcitx5/src/hidden_preedit.cpp
@@ -1,0 +1,49 @@
+// Clients that advertise Preedit but paint nothing. The composing word is
+// invisible until a commit. Non-preedit cannot fill that gap when surrounding
+// text is missing or deleteSurroundingText is not honoured, so the remaining
+// channel is the Fcitx5-drawn panel preedit. IBus has no equivalent that works;
+// this file is Fcitx5-only.
+//
+// Adding an app: put its process basename in kHiddenPreedit below.
+// updatePreedit() already draws the panel for anyone on the list. Do not match
+// on capability flags or missing surrounding text — those lie both ways, and
+// would pull in clients that already work.
+
+#include "funput_engine.h"
+
+#include <cctype>
+#include <string_view>
+
+namespace {
+
+constexpr std::string_view kHiddenPreedit[] = {
+    "wps",    // WPS Writer
+    "wpp",    // WPS Presentation
+    "et",     // WPS Spreadsheets
+    "wpspdf", // WPS PDF
+};
+
+std::string_view basenameOf(std::string_view path) {
+    const auto slash = path.find_last_of('/');
+    return slash == std::string_view::npos ? path : path.substr(slash + 1);
+}
+
+bool equalsIgnoreCase(std::string_view left, std::string_view right) {
+    if (left.size() != right.size()) return false;
+    for (size_t i = 0; i < left.size(); ++i) {
+        const auto a = static_cast<unsigned char>(left[i]);
+        const auto b = static_cast<unsigned char>(right[i]);
+        if (std::tolower(a) != std::tolower(b)) return false;
+    }
+    return true;
+}
+
+} // namespace
+
+bool hidesClientPreedit(fcitx::InputContext *context) {
+    const std::string_view name = basenameOf(context->program());
+    for (const auto binary : kHiddenPreedit) {
+        if (equalsIgnoreCase(name, binary)) return true;
+    }
+    return false;
+}

--- a/platforms/linux/install.sh
+++ b/platforms/linux/install.sh
@@ -225,8 +225,23 @@ user_install_fcitx5() {
   echo "       FCITX_ADDON_DIRS=$sys_addon:$lib_dir fcitx5 -r -d"
   echo "  2. fcitx5-configtool → + → add Funput (Vietnamese group)"
   echo "  Open \"Funput\" from the app menu to switch Telex/VNI."
+  fcitx5_wayland_hint
   echo
   echo "To update later: re-run this installer (grabs the latest release)."
+}
+
+# Funput is an Fcitx5 engine; apps only reach it if the *session* talks to Fcitx5.
+# That wiring is desktop-specific (GNOME vs KDE) and Funput must not write a
+# global GTK_IM_MODULE=fcitx block — KWin blinks the candidate window if you do.
+# Official: https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland
+fcitx5_wayland_hint() {
+  echo "  Wayland session env (by desktop, then log out):"
+  echo "    GNOME  ~/.config/environment.d/fcitx5.conf :"
+  echo "           XMODIFIERS=@im=fcitx"
+  echo "           QT_IM_MODULE=fcitx"
+  echo "           (leave GTK_IM_MODULE unset — GNOME uses Fcitx5's ibus frontend)"
+  echo "    KDE    XMODIFIERS=@im=fcitx only; do not set GTK/QT/SDL_IM_MODULE"
+  echo "  https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland"
 }
 
 # What to do once the package is on disk. Shared by the repository path and the
@@ -240,6 +255,7 @@ post_install_hint() {
   else
     echo "  1. fcitx5-configtool       # + → add Funput (Vietnamese group)"
     echo "  2. log out/in if Fcitx5 was not already running"
+    fcitx5_wayland_hint
   fi
   echo "  Open \"Funput\" from the app menu to switch Telex/VNI."
   if [ "$USE_REPO" -eq 0 ]; then

--- a/platforms/linux/packaging/repo/index.html.in
+++ b/platforms/linux/packaging/repo/index.html.in
@@ -229,6 +229,39 @@ sudo pacman -Sy</code></pre></div>
     <b>Funput</b> (nhóm Vietnamese). Mở <b>Funput</b> trong menu ứng dụng để chỉnh Telex/VNI.
   </div>
 
+  <div class="card">
+    <h2><span class="badge fcitx">Fcitx5</span> Biến môi trường (Wayland)</h2>
+    <p style="color:var(--muted);margin:0 0 1rem;font-size:.95rem">
+      Funput là engine trong Fcitx5 — app chỉ gõ được nếu session đã nối đúng Fcitx5.
+      Cấu hình theo <b>desktop</b>, không copy một khối <code class="inline">GTK_IM_MODULE</code> cho mọi máy.
+      Nguồn: <a href="https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland">Fcitx 5 on Wayland</a>.
+      Ghi vào <code class="inline">~/.config/environment.d/fcitx5.conf</code> rồi đăng xuất.
+    </p>
+
+    <div class="step">GNOME</div>
+    <div class="cmd"><button class="copy">Copy</button><pre><code>mkdir -p ~/.config/environment.d
+cat &gt; ~/.config/environment.d/fcitx5.conf &lt;&lt;'EOF'
+XMODIFIERS=@im=fcitx
+QT_IM_MODULE=fcitx
+EOF</code></pre></div>
+    <p style="color:var(--muted);font-size:.9rem;margin:.35rem 0 0">
+      Để trống <code class="inline">GTK_IM_MODULE</code> — GNOME đi frontend IBus của Fcitx5.
+      App Qt/XWayland (WPS, …) cần <code class="inline">QT_IM_MODULE=fcitx</code>.
+    </p>
+
+    <div class="step">KDE Plasma</div>
+    <div class="cmd"><button class="copy">Copy</button><pre><code>mkdir -p ~/.config/environment.d
+cat &gt; ~/.config/environment.d/fcitx5.conf &lt;&lt;'EOF'
+XMODIFIERS=@im=fcitx
+EOF</code></pre></div>
+    <p style="color:var(--muted);font-size:.9rem;margin:.35rem 0 0">
+      <b>Không</b> set global <code class="inline">GTK_IM_MODULE</code> /
+      <code class="inline">QT_IM_MODULE</code> /
+      <code class="inline">SDL_IM_MODULE</code> — candidate window sẽ nhấp nháy trên KWin.
+      Bật Fcitx5 ở System Settings → Virtual keyboard.
+    </p>
+  </div>
+
   <footer>
     Khóa ký công khai: <a href="@REPO_URL@funput.asc">funput.asc</a> ·
     Mã nguồn: <a href="https://github.com/Funput/Funput">github.com/Funput/Funput</a>


### PR DESCRIPTION
## Tóm tắt
- WPS khai báo Preedit nhưng không vẽ, nên từ đang soạn chỉ hiện khi nhấn Space. Fcitx5 giờ vẽ thêm panel preedit cho allowlist tên process (`hidden_preedit.cpp`: `wps`, `wpp`, `et`, `wpspdf`); app khác giữ luồng cũ.
- Composer, non-preedit và IBus không đổi. IBus không có kênh nào chạy được ở đây (surrounding text rỗng bị cache nuốt; ForwardKeyEvent đã mất).
- Installer và trang kho hướng dẫn biến môi trường Wayland theo desktop (GNOME vs KDE) từ tài liệu Fcitx5, không copy một khối `GTK_IM_MODULE` cho mọi máy.

## Cách kiểm tra
- [x] App GTK trên GNOME (gedit / Files): từ đang soạn vẫn gạch chân trong ô gõ; không thêm popup Fcitx5.
- [x] WPS Writer/Presentation/Spreadsheets với `QT_IM_MODULE=fcitx`: panel hiện `tiếng` khi gõ `tieesng`; Space commit vào document.
- [x] App không nằm trong allowlist (hoặc Qt app khác WPS): hành vi như `main`.
- [x] Non-preedit chỉ bật khi đã có surrounding text; WPS không bị ép repair document.
- [x] Bản IBus không đổi; WPS trên IBus vẫn chỉ hiện chữ khi commit.