### PR TITLE
feat(linux): default the installer to Fcitx5 and harden it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,44 @@ jobs:
       - name: Kotlin, directory layout
         run: bash platforms/android/scripts/check-kotlin-layout.sh
 
+  # The shell scripts a stranger is asked to run. `platforms/linux/install.sh` in
+  # particular is published as a `curl … | bash` one-liner in the docs and on
+  # repo.funput.app, which makes it the most widely *executed* file in the repo and,
+  # until this job, the only one with nothing checking it — a syntax error in a
+  # branch that only Fedora reaches would ship, and be found by a user with a broken
+  # install. `bash -n` parses every path, not just the one this runner would take.
+  #
+  # `--severity=warning` on purpose: the scripts are clean at shellcheck's default
+  # (style/info) level too, but pinning the gate above that keeps a newer shellcheck
+  # in the runner image from failing an unrelated pull request over a new stylistic
+  # check. Both tools are preinstalled on ubuntu-latest, so this job costs a checkout.
+  installer-scripts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Parse
+        run: |
+          for f in platforms/linux/install.sh platforms/linux/build.sh \
+                   platforms/macos/scripts/install.sh platforms/macos/scripts/uninstall.sh \
+                   scripts/check-loc.sh; do
+            bash -n "$f"
+          done
+
+      - name: ShellCheck
+        run: |
+          shellcheck --version
+          shellcheck --severity=warning \
+            platforms/linux/install.sh platforms/linux/build.sh \
+            platforms/macos/scripts/install.sh platforms/macos/scripts/uninstall.sh \
+            scripts/check-loc.sh
+
+      # The installer's own help must not break: it is the first thing anyone runs
+      # when the one-liner misbehaves, and it lives in a heredoc no other test opens.
+      - name: install.sh --help
+        run: bash platforms/linux/install.sh --help
+
   # The GTK4 Settings app, which also hosts the Chuyển mã window. Excluded from the
   # cargo workspace because it links system gtk4/libadwaita, so the `rust` job above —
   # which deliberately installs no system libraries — cannot see it. Before this job it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
             echo "- **iOS** — Tải trên [App Store](https://apps.apple.com/vn/app/id6788829996). Bản thử nghiệm sớm có trên [TestFlight](https://testflight.apple.com/join/E8YRd3sy)."
             echo "- **macOS** — \`Funput-*.pkg\` cài cho toàn máy (cần quyền quản trị), hoặc \`Funput-*.app.zip\` dùng được mà không cần quyền đó."
             echo "- **Windows** — \`Funput-*.exe\` chạy trực tiếp, không cần cài đặt, và tự cập nhật ngay trong ứng dụng."
-            echo "- **Linux** — \`.deb\` cho Debian/Ubuntu, \`.rpm\` cho Fedora/openSUSE. Chọn bản **Fcitx5** (\`funput-*\`) hoặc **IBus** (\`funput-ibus-*\`) theo đúng kiến trúc CPU; \`funput-settings-*\` là ứng dụng Cài đặt dùng chung, được cài kèm tự động và có thể dùng cả hai bản cùng lúc."
+            echo "- **Linux** — \`.deb\` cho Debian/Ubuntu, \`.rpm\` cho Fedora/openSUSE. Khuyến nghị bản **Fcitx5** (\`funput-*\`); bản **IBus** (\`funput-ibus-*\`) dành cho ai đang dùng IBus sẵn và không muốn đổi session. Chọn đúng kiến trúc CPU; \`funput-settings-*\` là ứng dụng Cài đặt dùng chung, cài kèm tự động và hai bản cài chung được (chỉ nên bật một bộ gõ cho mỗi phiên đăng nhập)."
             echo "- **Android** — Đang trong giai đoạn kiểm thử khép kín, chưa mở đăng ký công khai."
           } > notes.md
 

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -101,15 +101,41 @@ Three channels, all fed by the same release:
   `packaging/repo/README.md`.
 - **GitHub Releases** — the `.deb`/`.rpm` themselves, plus the portable `.tar.gz`
   trees behind `install.sh --user`.
-- **`install.sh`** — detect-then-configure front end over the two above.
+- **`install.sh`** — detect-then-configure front end over the two above. It is published
+  as a `curl … | bash` one-liner, which is a lot of trust to ask for, so it prints its plan
+  before it acts, `--dry-run` prints every command and runs none, and each asset it takes
+  from GitHub Releases is checked against the SHA-256 digest the release API publishes for
+  it — the releases carry no `.sha256` files, so a hand-verified checksum was never actually
+  on offer. `ci.yml`'s `installer-scripts` job parses and shellchecks it on every pull
+  request; before that job existed nothing looked at it at all, and a syntax error on a
+  branch only Fedora reaches would have shipped.
+
+`install.sh` installs the **Fcitx5** package on every desktop; `--ibus` picks the IBus one.
+It used to guess from `XDG_CURRENT_DESKTOP` (KDE → Fcitx5, everything else → IBus), which
+handed most users the shell that cannot reach a WPS-shaped client at all. The desktop still
+decides one thing, but only what the script *prints*: outside KDE the session is wired to
+IBus, so Fcitx5 receives nothing until the user sets the variables below and logs out — the
+script says so before it installs, and prints them again after.
 
 Funput does not set `GTK_IM_MODULE` / `QT_IM_MODULE` for the user. Those belong to
-Fcitx5's session, and they differ by desktop — see
-[Using Fcitx 5 on Wayland](https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland).
-`install.sh` and the repo landing page print the same split: **GNOME** wants
-`XMODIFIERS=@im=fcitx` and `QT_IM_MODULE=fcitx` (leave `GTK_IM_MODULE` unset);
-**KDE** wants only `XMODIFIERS=@im=fcitx` and must not set the IM_MODULE trio
-globally. Put them in `~/.config/environment.d/fcitx5.conf` and log out.
+the session, not to us, and what is correct depends on the **session type first**:
+the classic `XMODIFIERS` + `GTK_IM_MODULE` + `QT_IM_MODULE` trio is right under X11
+and wrong under Wayland, where GTK 3/4 reach the compositor through text-input-v3
+themselves and the trio set globally makes KWin blink the candidate window. Under
+Wayland the desktop then decides: **GNOME** (and sway) wants `XMODIFIERS=@im=fcitx`
+plus `QT_IM_MODULE=fcitx` — or `QT_IM_MODULES=wayland;fcitx` on Qt 6.8.2+ — with
+`GTK_IM_MODULE` left unset; **KDE** wants `XMODIFIERS=@im=fcitx` alone. `install.sh`
+reads `$XDG_SESSION_TYPE` and prints only the block that applies, the docs carry the
+full matrix, and both name the distro tools that own this on Debian/Ubuntu
+(`im-config`, which does nothing in a Wayland session — its hook ships disabled) and
+Fedora (`fcitx5-autostart`). Sources:
+[Using Fcitx 5 on Wayland](https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland),
+[Setup Fcitx 5](https://fcitx-im.org/wiki/Setup_Fcitx_5).
+
+One thing that follows for the shells rather than the docs: on KDE, Fcitx5 is started
+by KWin's Virtual Keyboard KCM and handed a socket a replacement process cannot
+inherit, so `fcitx5 -r` breaks input for Wayland clients until the next login. Every
+place that suggested restarting the daemon now says so.
 
 Arch is inside the first of those rather than a channel of its own. It has no release
 asset — a rolling source distro has no use for a `.deb` or `.rpm` — so the `pacman` job

--- a/platforms/linux/install.sh
+++ b/platforms/linux/install.sh
@@ -2,75 +2,219 @@
 # Funput Linux installer: detect the distro + arch and install with the native
 # package manager.
 #
+# Part of Funput — https://github.com/Funput/Funput — MIT licensed.
+#
 # By default it adds the signed Funput repository (repo.funput.app) and installs
 # from it, so `apt/dnf/zypper upgrade` picks up later releases like any other
 # system package. Apt and rpm are different repo formats, so a single repo can
 # never serve every distro — only this kind of detect-then-configure script gives
 # the unified experience.
 #
-# Usage:
-#   curl -fsSL https://raw.githubusercontent.com/Funput/Funput/main/platforms/linux/install.sh | bash
-#   ./install.sh [--ibus | --fcitx5] [--no-repo] [--version vX.Y.Z]
+# Framework: Fcitx5 on every desktop, --ibus for the IBus engine instead. Fcitx5
+# is the fuller shell — it can draw a panel preedit for clients that hide the
+# client one (WPS Office), which the IBus side has no channel for. Outside a KDE
+# session it does cost one-time session wiring (environment.d + a re-login),
+# which this script prints rather than writes: those variables belong to the
+# session, not to Funput.
 #
-# --no-repo: skip the repository and install a versioned asset straight from
-# GitHub Releases instead. No automatic upgrades — re-run to update. Implied by
-# --version, because the repository only ever carries the newest release. Not
-# available on Arch, which has no release asset — use the repository or --user.
+# This file is what a `curl … | bash` reader is being asked to trust, so:
+#   - it prints the plan (distro, framework, package, channel) before it acts,
+#     and `--dry-run` prints without acting at all;
+#   - every asset it fetches from GitHub Releases is checked against the SHA-256
+#     digest the release API publishes for that asset;
+#   - nothing fails silently: an unexpected error names the line and the issue
+#     tracker rather than leaving a half-install behind without a word.
 #
-# No-sudo (user-local): install the engine into ~/.local — no root, no package
-# manager. Needs an already-installed IBus or Fcitx5 daemon. IBus works right
-# away; Fcitx5 also writes ~/.config/environment.d and needs a re-login.
-#   curl -fsSL https://raw.githubusercontent.com/Funput/Funput/main/platforms/linux/install.sh | bash -s -- --user
-#   ./install.sh --user [--ibus | --fcitx5] [--version vX.Y.Z]
-#
-# Framework: defaults to IBus, except KDE Plasma sessions default to Fcitx5.
-# Override with --ibus / --fcitx5.
-set -euo pipefail
+# usage() below is the single source of `--help`.
+
+# -E keeps the ERR trap alive inside functions; -u turns a typo into a failure
+# instead of an empty string; pipefail stops `curl … | tee` reporting success on
+# an HTTP error.
+set -Eeuo pipefail
 
 REPO="Funput/Funput"
-REPO_URL="https://repo.funput.app"   # the signed apt/dnf/zypper repository
-FRAMEWORK=""        # "ibus" | "fcitx5"; empty = auto-detect
-VERSION="latest"    # "latest" or a tag like v1.2026.1
-USER_INSTALL=0      # 1 = no-sudo, user-local install into ~/.local (IBus only)
-USE_REPO=1          # 0 = --no-repo: fetch a release asset instead
+API="https://api.github.com/repos/${REPO}"
+REPO_URL="https://repo.funput.app"   # the signed apt/dnf/zypper/pacman repository
+ISSUES_URL="https://github.com/${REPO}/issues"
 
-die() { echo "Error: $*" >&2; exit 1; }
+FRAMEWORK=""        # "fcitx5" | "ibus"; empty = the default, fcitx5
+VERSION="latest"    # "latest" or a tag like v1.2026.1
+USER_INSTALL=0      # 1 = no-sudo, user-local install into ~/.local (either framework)
+USE_REPO=1          # 0 = --no-repo: fetch a release asset instead
+DRY_RUN=0           # 1 = print what would happen, change nothing
+
+# --- Output ----------------------------------------------------------------
+# Colour only when stdout is a terminal and the user has not opted out. Under
+# `curl … | bash` the script arrives on stdin, so stdout is still the terminal
+# and this stays colourful — which is the common case worth getting right.
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  C_OFF=$'\033[0m'; C_DIM=$'\033[2m'; C_BLUE=$'\033[34m'
+  C_YELLOW=$'\033[33m'; C_RED=$'\033[31m'
+else
+  C_OFF=""; C_DIM=""; C_BLUE=""; C_YELLOW=""; C_RED=""
+fi
+
+info() { printf '%s==>%s %s\n' "$C_BLUE" "$C_OFF" "$*"; }
+note() { printf '    %s%s%s\n' "$C_DIM" "$*" "$C_OFF"; }
+warn() { printf '%swarning:%s %s\n' "$C_YELLOW" "$C_OFF" "$*" >&2; }
+die()  { printf '%serror:%s %s\n' "$C_RED" "$C_OFF" "$*" >&2; exit 1; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
-# Resolve a release asset's download URL by filename pattern (an extended regex,
-# anchored to the asset basename). Prints the URL, or nothing if unmatched. Avoids
-# a jq dependency by grepping browser_download_url out of the release API JSON.
-resolve_url() {
-  local pattern="$1" api
-  if [ "$VERSION" = "latest" ]; then
-    api="https://api.github.com/repos/${REPO}/releases/latest"
-  else
-    api="https://api.github.com/repos/${REPO}/releases/tags/${VERSION}"
+# An unexpected failure (a command nobody guarded) should not read like a crash.
+# `die` exits rather than returning non-zero, so intentional errors never reach
+# here and this only ever fires on a genuine bug or a broken environment.
+on_error() {
+  local code=$? line="${1:-?}"
+  printf '%serror:%s install.sh stopped unexpectedly at line %s (exit %s).\n' \
+    "$C_RED" "$C_OFF" "$line" "$code" >&2
+  printf '       Nothing further was installed. Please report the output above: %s\n' \
+    "$ISSUES_URL" >&2
+}
+trap 'on_error $LINENO' ERR
+
+# Run a command that changes the system. Under --dry-run it is printed, not run,
+# which is the whole promise of that flag: every mutation goes through here or
+# through write_file/write_root below.
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    %s$ %s%s\n' "$C_DIM" "$*" "$C_OFF"; return 0; fi
+  "$@"
+}
+
+# The one shape `run` cannot express: writing a stream to a file. write_root goes
+# through sudo tee for paths we do not own.
+write_file() {
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    %s$ write %s%s\n' "$C_DIM" "$1" "$C_OFF"; cat >/dev/null; return 0; fi
+  cat > "$1"
+}
+write_root() {
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    %s$ write %s (sudo)%s\n' "$C_DIM" "$1" "$C_OFF"; cat >/dev/null; return 0; fi
+  $SUDO tee "$1" >/dev/null
+}
+# Fetch a URL straight into a root-owned path. Its own helper so --dry-run can
+# print the whole pipeline and make no network call at all.
+fetch_to_root() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '    %s$ curl -fsSL %s | sudo tee %s%s\n' "$C_DIM" "$1" "$2" "$C_OFF"; return 0
   fi
-  curl -fsSL "$api" \
-    | grep -Eo '"browser_download_url": *"[^"]*"' \
-    | sed -E 's/.*"(https[^"]*)".*/\1/' \
-    | grep -E "/${pattern}$" \
-    | head -n1 || true
+  curl -fsSL "$1" | $SUDO tee "$2" >/dev/null
+}
+append_root() {
+  if [ "$DRY_RUN" -eq 1 ]; then printf '    %s$ append to %s (sudo)%s\n' "$C_DIM" "$1" "$C_OFF"; cat >/dev/null; return 0; fi
+  $SUDO tee -a "$1" >/dev/null
 }
 
-# Download $1 to $2. `curl -f` fails on HTTP errors and HTTPS covers transport
-# integrity; GitHub exposes a per-asset SHA-256 digest for manual verification.
+usage() {
+  cat <<'EOF'
+Funput — Vietnamese input method for Linux
+Installs the Fcitx5 (default) or IBus engine with your native package manager.
+
+USAGE
+  curl -fsSL https://raw.githubusercontent.com/Funput/Funput/main/platforms/linux/install.sh | bash
+  ./install.sh [OPTIONS]
+
+OPTIONS
+  --fcitx5        Install the Fcitx5 engine (package "funput"). The default.
+  --ibus          Install the IBus engine (package "funput-ibus") instead.
+  --user          Install into ~/.local — no root, no package manager. Needs an
+                  already-installed Fcitx5 or IBus daemon. With Fcitx5 this also
+                  writes ~/.config/environment.d and needs a re-login; IBus works
+                  right away.
+  --no-repo       Skip the repository; install one versioned package straight
+                  from GitHub Releases. No automatic upgrades — re-run to update.
+                  Not available on Arch, which has no release asset.
+  --version TAG   Install a specific release, e.g. --version v1.2026.28. Implies
+                  --no-repo, because the repository only carries the newest one.
+  --dry-run       Print every command that would run, and run none of them.
+  -h, --help      Show this help.
+
+ENVIRONMENT
+  NO_COLOR        Set to any value to disable coloured output.
+
+By default the signed repository at https://repo.funput.app is added, so later
+releases arrive through apt/dnf/zypper/pacman like any other system package.
+
+Docs   https://docs.funput.app/docs/install/linux
+Issues https://github.com/Funput/Funput/issues
+EOF
+}
+
+# --- Release assets --------------------------------------------------------
+
+# Resolve a release asset by name pattern (an extended regex, anchored to the
+# whole asset name). Prints "<url><TAB><sha256>", or nothing when unmatched.
+#
+# No jq dependency: the release API pretty-prints one field per line, and within
+# an asset object "name" precedes "digest", which precedes "browser_download_url"
+# — so a single awk pass keeps the three together. Nothing is emitted until a
+# browser_download_url closes an asset, so the release's own "name" and the
+# uploader object cannot be mistaken for one.
+resolve_asset() {
+  local pattern="$1" api json
+  if [ "$VERSION" = "latest" ]; then
+    api="${API}/releases/latest"
+  else
+    api="${API}/releases/tags/${VERSION}"
+  fi
+  # Fetched into a variable rather than piped, so an unreachable API or a wrong
+  # --version tag says so, instead of arriving at awk as an empty stream and
+  # being reported as "no matching asset".
+  json="$(curl -fsSL "$api")" \
+    || die "cannot read the ${VERSION} release from GitHub.
+       Tried ${api} — check your network, and the tag if you passed --version."
+  printf '%s\n' "$json" | awk -v pat="^${pattern}$" '
+    function val(line,   v) {
+      v = line; sub(/^[^:]*:[[:space:]]*"?/, "", v); sub(/"?,?$/, "", v); return v
+    }
+    /^[[:space:]]*"name":[[:space:]]/                 { name = val($0); next }
+    /^[[:space:]]*"digest":[[:space:]]/               { dg   = val($0); next }
+    /^[[:space:]]*"browser_download_url":[[:space:]]/ {
+      if (name ~ pat) { sub(/^sha256:/, "", dg); print val($0) "\t" dg; exit }
+      name = ""; dg = ""
+    }'
+}
+
+# Check a downloaded file against the digest the release API published for it.
+# HTTPS already covers the transport; this covers the rest of the path — a
+# truncated download, a mirror, a tampered artifact — and is the reason the docs
+# no longer ask anyone to verify a checksum by hand.
+verify_sha256() {
+  local file="$1" want="$2" got
+  case "$want" in
+    ""|null|-) warn "the release metadata carries no checksum for $(basename "$file"); skipping verification"; return 0 ;;
+  esac
+  if   have sha256sum; then got="$(sha256sum "$file" | cut -d' ' -f1)"
+  elif have shasum;    then got="$(shasum -a 256 "$file" | cut -d' ' -f1)"
+  else warn "neither sha256sum nor shasum found; skipping checksum verification"; return 0
+  fi
+  [ "$got" = "$want" ] || die "checksum mismatch for $(basename "$file")
+       expected $want
+       got      $got
+       The download is corrupt or has been tampered with. Nothing was installed."
+  note "sha256 verified"
+}
+
 download() {
-  local url="$1" file="$2"
-  echo "Downloading $(basename "$url")…"
+  local url="$1" file="$2" digest="${3:-}"
+  info "Downloading $(basename "$url")"
   curl -fsSL "$url" -o "$file"
+  verify_sha256 "$file" "$digest"
 }
 
-# Pick the framework from the running desktop when the user didn't force one:
-# KDE Plasma → Fcitx5, everything else → IBus.
+# --- Framework and arch ----------------------------------------------------
+
+# Fcitx5 unless the user asked for IBus. Not a per-desktop guess any more: the
+# choice is about which shell Funput is better on, and the desktop only changes
+# how much session wiring the user still owes — which is what the note below is
+# for. KDE already talks to Fcitx5, so it gets no note.
 detect_framework() {
   [ -n "$FRAMEWORK" ] && return 0
+  FRAMEWORK="fcitx5"
   case " ${XDG_CURRENT_DESKTOP:-} " in
-    *KDE*|*plasma*|*Plasma*) FRAMEWORK="fcitx5" ;;
-    *)                       FRAMEWORK="ibus" ;;
+    *KDE*|*plasma*|*Plasma*) ;;
+    *) warn "this session (${XDG_CURRENT_DESKTOP:-unknown}) most likely runs IBus, so Fcitx5 will not
+         receive keys until you set the session variables printed at the end and log out.
+         Prefer to stay on IBus? Re-run with --ibus." ;;
   esac
-  echo "Auto-selected framework: $FRAMEWORK (override with --ibus / --fcitx5)"
 }
 
 # The arch label used in the tarball / .deb names (amd64 / arm64).
@@ -78,9 +222,11 @@ user_pkg_arch() {
   case "$(uname -m)" in
     x86_64)        echo amd64 ;;
     aarch64|arm64) echo arm64 ;;
-    *) die "unsupported CPU arch: $(uname -m)" ;;
+    *) die "unsupported CPU architecture: $(uname -m)" ;;
   esac
 }
+
+# --- User-local (--user) ---------------------------------------------------
 
 # Shared across the --user flows: drop the Settings binary, icons and desktop entry
 # into ~/.local, then refresh the icon/desktop caches (best-effort, never fatal).
@@ -97,8 +243,28 @@ place_common_assets() {
 path_note() {
   case ":$PATH:" in
     *":$1:"*) : ;;
-    *) echo "Note: $1 is not on PATH — add it so \"funput-settings\" launches from the app menu." ;;
+    *) warn "$1 is not on PATH — add it so \"funput-settings\" launches from the app menu." ;;
   esac
+}
+
+# Front half of both --user flows: resolve the framework's portable tarball,
+# download it, verify it, unpack it. Sets TREE_DIR to the unpacked tree; the
+# caller owns $tmp and its cleanup.
+TREE_DIR=""
+fetch_user_tree() {
+  local fw="$1" tmp="$2" pkg_arch pattern url digest file
+  pkg_arch="$(user_pkg_arch)"
+  pattern="funput-${fw}-.*-${pkg_arch}-linux\\.tar\\.gz"
+  info "Looking up the ${fw} tarball (${pkg_arch}) in ${REPO} ${VERSION}"
+  local found; found="$(resolve_asset "$pattern")" || exit 1
+  [ -n "$found" ] || die "no funput-${fw}-*-${pkg_arch}-linux.tar.gz in the ${VERSION} release"
+  url="${found%%$'\t'*}"; digest="${found#*$'\t'}"
+  file="$tmp/$(basename "$url")"
+  download "$url" "$file" "$digest"
+  info "Extracting"
+  tar -xzf "$file" -C "$tmp"
+  TREE_DIR="$(find "$tmp" -maxdepth 1 -type d -name "funput-${fw}-*-linux" | head -n1)"
+  [ -n "$TREE_DIR" ] || die "unexpected tarball layout (no funput-${fw}-*-linux/ directory)"
 }
 
 # No-sudo, user-local IBus install. The engine binary is relocatable (its RPATH is
@@ -107,42 +273,35 @@ path_note() {
 # generating a component manifest that points <exec> at the real $HOME path is all
 # it takes. No root, no package manager, no session env var.
 user_install_ibus() {
-  have curl || die "curl is required"
-  have tar  || die "tar is required"
-  have ibus || echo "Warning: 'ibus' is not on PATH — install the IBus daemon (needs your package manager / sudo) before the engine can run." >&2
-
-  local pkg_arch; pkg_arch="$(user_pkg_arch)"
-  local pattern="funput-ibus-[^/]*-${pkg_arch}-linux\.tar\.gz"
-  echo "Looking up IBus tarball (${pkg_arch}) in ${REPO} ${VERSION} release…"
-  local url; url="$(resolve_url "$pattern")"
-  [ -n "$url" ] || die "no matching asset (${pattern}) in the ${VERSION} release"
-
-  local tmp; tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' RETURN
-  local file="$tmp/$(basename "$url")"
-  download "$url" "$file"
-  echo "Extracting…"; tar -xzf "$file" -C "$tmp"
-  local src; src="$(find "$tmp" -maxdepth 1 -type d -name 'funput-ibus-*-linux' | head -n1)"
-  [ -n "$src" ] || die "unexpected tarball layout (no funput-ibus-*-linux/ directory)"
-
   # lib/ and bin/ can live anywhere (the component <exec> is an absolute path); the
   # component XML MUST land under the ibus-scanned $XDG_DATA_HOME/ibus/component.
   local data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
   local lib_dir="$HOME/.local/lib/funput"
   local bin_dir="$HOME/.local/bin"
 
-  echo "Installing into $HOME/.local …"
+  have ibus || warn "'ibus' is not on PATH — install the IBus daemon (needs your package manager / sudo) before the engine can run."
+  if [ "$DRY_RUN" -eq 1 ]; then
+    note "would install into $lib_dir, $bin_dir and $data_home/ibus/component"
+    return 0
+  fi
+
+  local tmp; tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' RETURN
+  fetch_user_tree ibus "$tmp"
+  local src="$TREE_DIR"
+
+  info "Installing into $HOME/.local"
   mkdir -p "$lib_dir" "$bin_dir" "$data_home/ibus/component"
   install -m 0755 "$src/lib/funput/ibus-engine-funput" "$lib_dir/"
   install -m 0644 "$src/lib/funput/libfunput_ffi.so"   "$lib_dir/"
   # ibus-daemon launches <exec> by absolute path, so point it at our real location.
   sed "s|@IBUS_ENGINE_PATH@|$lib_dir/ibus-engine-funput|g" \
     "$src/share/ibus/component/funput.xml.in" \
-    > "$data_home/ibus/component/funput.xml"
+    | write_file "$data_home/ibus/component/funput.xml"
   place_common_assets "$src" "$data_home" "$bin_dir"
   ibus restart >/dev/null 2>&1 || true
 
   echo
-  echo "Installed (no sudo) into $HOME/.local."
+  info "Installed (no sudo) into $HOME/.local"
   path_note "$bin_dir"
   echo "Next steps:"
   echo "  1. ibus restart            # if the engine is not listed yet"
@@ -151,7 +310,7 @@ user_install_ibus() {
   echo
   # No auto-updater on Linux yet — re-running fetches the latest release and
   # overwrites in place (then ibus restart loads the new engine).
-  echo "To update later: re-run this installer (grabs the latest release)."
+  note "To update later: re-run this installer (it takes the latest release)."
 }
 
 # Best-effort locate the system Fcitx5 addon dir (its layout varies by distro:
@@ -168,7 +327,7 @@ fcitx5_system_addon_dir() {
   done
   # Nothing found (Fcitx5 maybe not installed yet). Guess the Debian path for this
   # arch and warn — the user can fix the env file if it's wrong.
-  echo "Warning: could not find the system Fcitx5 addon dir; guessing /usr/lib/${triplet}/fcitx5." >&2
+  warn "could not find the system Fcitx5 addon dir; guessing /usr/lib/${triplet}/fcitx5."
   echo "/usr/lib/${triplet}/fcitx5"
 }
 
@@ -178,28 +337,24 @@ fcitx5_system_addon_dir() {
 # OVERRIDES the default, so we re-list the system addon dir too, and it only takes
 # effect after a re-login.
 user_install_fcitx5() {
-  have curl   || die "curl is required"
-  have tar    || die "tar is required"
-  have fcitx5 || echo "Warning: 'fcitx5' is not on PATH — install the Fcitx5 daemon (needs your package manager / sudo) before the engine can run." >&2
-
-  local pkg_arch; pkg_arch="$(user_pkg_arch)"
-  local pattern="funput-fcitx5-[^/]*-${pkg_arch}-linux\.tar\.gz"
-  echo "Looking up Fcitx5 tarball (${pkg_arch}) in ${REPO} ${VERSION} release…"
-  local url; url="$(resolve_url "$pattern")"
-  [ -n "$url" ] || die "no matching asset (${pattern}) in the ${VERSION} release"
-
-  local tmp; tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' RETURN
-  local file="$tmp/$(basename "$url")"
-  download "$url" "$file"
-  echo "Extracting…"; tar -xzf "$file" -C "$tmp"
-  local src; src="$(find "$tmp" -maxdepth 1 -type d -name 'funput-fcitx5-*-linux' | head -n1)"
-  [ -n "$src" ] || die "unexpected tarball layout (no funput-fcitx5-*-linux/ directory)"
-
   local data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
   local lib_dir="$HOME/.local/lib/fcitx5"
   local bin_dir="$HOME/.local/bin"
+  local envd="${XDG_CONFIG_HOME:-$HOME/.config}/environment.d"
 
-  echo "Installing into $HOME/.local …"
+  have fcitx5 || warn "'fcitx5' is not on PATH — install the Fcitx5 daemon (needs your package manager / sudo) before the engine can run."
+  if [ "$DRY_RUN" -eq 1 ]; then
+    note "would install into $lib_dir, $bin_dir and $data_home/fcitx5"
+    note "would write $envd/funput.conf (FCITX_ADDON_DIRS)"
+    return 0
+  fi
+
+  local tmp; tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' RETURN
+  fetch_user_tree fcitx5 "$tmp"
+  local src="$TREE_DIR"
+  local pkg_arch; pkg_arch="$(user_pkg_arch)"
+
+  info "Installing into $HOME/.local"
   mkdir -p "$lib_dir" "$bin_dir" "$data_home/fcitx5/addon" "$data_home/fcitx5/inputmethod"
   # Addon shared library + Rust core side by side (libfunput.so finds
   # libfunput_ffi.so via $ORIGIN). Config is loaded by name, so no path rewrite.
@@ -212,35 +367,72 @@ user_install_fcitx5() {
   # Tell Fcitx5 where our addon .so lives. Keep the system dir first so the built-in
   # engines (keyboard, spell, …) still load.
   local sys_addon; sys_addon="$(fcitx5_system_addon_dir "$pkg_arch")"
-  local envd="${XDG_CONFIG_HOME:-$HOME/.config}/environment.d"
   mkdir -p "$envd"
-  printf 'FCITX_ADDON_DIRS=%s:%s\n' "$sys_addon" "$lib_dir" > "$envd/funput.conf"
+  printf 'FCITX_ADDON_DIRS=%s:%s\n' "$sys_addon" "$lib_dir" | write_file "$envd/funput.conf"
 
   echo
-  echo "Installed (no sudo) into $HOME/.local."
+  info "Installed (no sudo) into $HOME/.local"
   path_note "$bin_dir"
   echo "IMPORTANT — Fcitx5 loads the addon .so only after the session env updates:"
   echo "  Wrote $envd/funput.conf → FCITX_ADDON_DIRS=$sys_addon:$lib_dir"
   echo "  1. Log out and back in (applies environment.d), OR for a quick test now:"
   echo "       FCITX_ADDON_DIRS=$sys_addon:$lib_dir fcitx5 -r -d"
+  case " ${XDG_CURRENT_DESKTOP:-} " in
+    # On KDE that quick test is not available: KWin starts Fcitx5 itself and hands
+    # it a socket a replacement process cannot inherit, so -r leaves Wayland
+    # clients with no input method until the next login.
+    *KDE*|*plasma*|*Plasma*)
+      echo "       ^ not on KDE: KWin owns the Fcitx5 socket, so log out instead." ;;
+  esac
   echo "  2. fcitx5-configtool → + → add Funput (Vietnamese group)"
   echo "  Open \"Funput\" from the app menu to switch Telex/VNI."
-  fcitx5_wayland_hint
+  fcitx5_session_hint
   echo
-  echo "To update later: re-run this installer (grabs the latest release)."
+  note "To update later: re-run this installer (it takes the latest release)."
 }
 
 # Funput is an Fcitx5 engine; apps only reach it if the *session* talks to Fcitx5.
-# That wiring is desktop-specific (GNOME vs KDE) and Funput must not write a
-# global GTK_IM_MODULE=fcitx block — KWin blinks the candidate window if you do.
-# Official: https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland
-fcitx5_wayland_hint() {
-  echo "  Wayland session env (by desktop, then log out):"
-  echo "    GNOME  ~/.config/environment.d/fcitx5.conf :"
-  echo "           XMODIFIERS=@im=fcitx"
-  echo "           QT_IM_MODULE=fcitx"
-  echo "           (leave GTK_IM_MODULE unset — GNOME uses Fcitx5's ibus frontend)"
-  echo "    KDE    XMODIFIERS=@im=fcitx only; do not set GTK/QT/SDL_IM_MODULE"
+# Funput must not write any of this — these variables belong to the session.
+#
+# What to set depends on the session type first and the desktop second, which is
+# why this reads $XDG_SESSION_TYPE rather than printing one block for everyone:
+# the classic GTK+QT+XMODIFIERS trio is right on X11 and wrong on Wayland, where
+# GTK 3/4 reach the compositor through text-input-v3 on their own and setting the
+# trio globally under KWin makes the candidate window blink.
+#   https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland
+#   https://fcitx-im.org/wiki/Setup_Fcitx_5
+fcitx5_session_hint() {
+  echo "  Session variables — set them, then log out and back in:"
+  if [ "${XDG_SESSION_TYPE:-}" = "x11" ]; then
+    echo "    X11 session — the classic three:"
+    echo "           XMODIFIERS=@im=fcitx"
+    echo "           GTK_IM_MODULE=fcitx"
+    echo "           QT_IM_MODULE=fcitx"
+    if [ "${FAMILY:-}" = "debian" ]; then
+      echo "      On Debian/Ubuntu, \"im-config -n fcitx5\" writes exactly this and"
+      echo "      starts the daemon for you — prefer it over editing files by hand."
+    fi
+  else
+    case " ${XDG_CURRENT_DESKTOP:-} " in
+      *KDE*|*plasma*|*Plasma*)
+        echo "    KDE Plasma (Wayland) — one variable only:"
+        echo "           XMODIFIERS=@im=fcitx"
+        echo "      Do NOT set GTK_IM_MODULE / QT_IM_MODULE / SDL_IM_MODULE globally:"
+        echo "      KWin blinks the candidate window when you do."
+        echo "      Once Fcitx5 is started from System Settings → Virtual keyboard, do"
+        echo "      not restart it (tray menu or fcitx5 -r): KWin hands it a socket that"
+        echo "      a restarted process cannot reuse. Log out instead." ;;
+      *)
+        echo "    GNOME / sway / other Wayland compositors:"
+        echo "           XMODIFIERS=@im=fcitx"
+        echo "           QT_IM_MODULE=fcitx              # Qt 5, and Qt older than 6.8.2"
+        echo "           QT_IM_MODULES=wayland;fcitx     # Qt 6.8.2+, replaces the line above"
+        echo "      Leave GTK_IM_MODULE unset — GTK 3/4 use Wayland text-input-v3 directly." ;;
+    esac
+  fi
+  echo "    Put them in ~/.config/environment.d/fcitx5.conf (read by GDM and by"
+  echo "    Plasma 5.22+), or in ~/.bash_profile, which every display manager and a"
+  echo "    TTY login read. Upstream notes environment.d may need a reboot to apply."
   echo "  https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland"
 }
 
@@ -248,20 +440,33 @@ fcitx5_wayland_hint() {
 # --no-repo one, which install the same package by different routes.
 post_install_hint() {
   echo
-  echo "Installed. Next steps:"
-  if [ "$FRAMEWORK" = "ibus" ]; then
+  info "Installed. Next steps:"
+  if [ "$FRAMEWORK" = "fcitx5" ]; then
+    echo "  1. Make sure Fcitx5 runs in your session, and starts with it:"
+    # Only report the daemon state when we can actually check it; a missing pgrep
+    # must not be read as "not running".
+    if have pgrep; then
+      if pgrep -x fcitx5 >/dev/null 2>&1; then
+        echo "       fcitx5 is running now."
+      else
+        echo "       fcitx5 is NOT running — start it with \"fcitx5 -d\" to test."
+      fi
+    fi
+    echo "       KDE: System Settings → Virtual keyboard → Fcitx 5."
+    echo "       Others: enable the Fcitx 5 autostart entry (or copy its .desktop"
+    echo "       into ~/.config/autostart)."
+    echo "  2. fcitx5-configtool       # + → add Funput (Vietnamese group)"
+    echo "  3. Set the session variables below, then log out and back in."
+    fcitx5_session_hint
+  else
     echo "  1. ibus restart            # load the newly registered engine"
     echo "  2. Settings → Keyboard → Input Sources → + → Vietnamese → Funput"
-  else
-    echo "  1. fcitx5-configtool       # + → add Funput (Vietnamese group)"
-    echo "  2. log out/in if Fcitx5 was not already running"
-    fcitx5_wayland_hint
   fi
   echo "  Open \"Funput\" from the app menu to switch Telex/VNI."
   if [ "$USE_REPO" -eq 0 ]; then
     echo
-    echo "Installed from a release asset, so this will not upgrade itself."
-    echo "For automatic updates, re-run without --version/--no-repo to add ${REPO_URL}."
+    note "Installed from a release asset, so this will not upgrade itself."
+    note "For automatic updates, re-run without --version/--no-repo to add ${REPO_URL}."
   fi
 }
 
@@ -276,12 +481,12 @@ post_install_hint() {
 # repository is spelled `Suites: ./` with no Components.
 repo_add_debian() {
   local keyring="/usr/share/keyrings/funput.asc"
-  echo "Adding ${REPO_URL} (apt)…"
-  $SUDO install -d /usr/share/keyrings
-  curl -fsSL "${REPO_URL}/funput.asc" | $SUDO tee "$keyring" >/dev/null
+  info "Adding ${REPO_URL} (apt)"
+  run $SUDO install -d /usr/share/keyrings
+  fetch_to_root "${REPO_URL}/funput.asc" "$keyring"
   printf 'Types: deb\nURIs: %s/deb\nSuites: ./\nSigned-By: %s\n' \
-    "$REPO_URL" "$keyring" | $SUDO tee /etc/apt/sources.list.d/funput.sources >/dev/null
-  $SUDO apt-get update
+    "$REPO_URL" "$keyring" | write_root /etc/apt/sources.list.d/funput.sources
+  run $SUDO apt-get update
 }
 
 # Fedora/RHEL. Written straight into /etc/yum.repos.d rather than through
@@ -289,16 +494,16 @@ repo_add_debian() {
 # drop works on both dnf4 and dnf5. The key is not imported here — funput.repo
 # carries `gpgkey=` and dnf fetches it on first install.
 repo_add_fedora() {
-  echo "Adding ${REPO_URL} (dnf)…"
-  curl -fsSL "${REPO_URL}/funput.repo" | $SUDO tee /etc/yum.repos.d/funput.repo >/dev/null
+  info "Adding ${REPO_URL} (dnf)"
+  fetch_to_root "${REPO_URL}/funput.repo" /etc/yum.repos.d/funput.repo
 }
 
 # openSUSE. zypper wants the key in the rpm database up front, unlike dnf.
 repo_add_suse() {
-  echo "Adding ${REPO_URL} (zypper)…"
-  $SUDO rpm --import "${REPO_URL}/funput.asc"
-  $SUDO zypper --non-interactive addrepo -gf "${REPO_URL}/rpm/" funput
-  $SUDO zypper --non-interactive refresh
+  info "Adding ${REPO_URL} (zypper)"
+  run $SUDO rpm --import "${REPO_URL}/funput.asc"
+  run $SUDO zypper --non-interactive addrepo -gf "${REPO_URL}/rpm/" funput
+  run $SUDO zypper --non-interactive refresh
 }
 
 # Arch. Two steps no other package manager needs: pacman keeps its own keyring,
@@ -307,62 +512,92 @@ repo_add_suse() {
 # x86_64 only, which is all Arch officially supports.
 repo_add_arch() {
   [ "$(uname -m)" = "x86_64" ] || die "the Funput pacman repo is x86_64 only (Arch Linux ARM is a separate distribution). Try --user."
-  echo "Adding ${REPO_URL} (pacman)…"
+  info "Adding ${REPO_URL} (pacman)"
   local tmp; tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' RETURN
-  curl -fsSL "${REPO_URL}/funput.asc" -o "$tmp/funput.asc"
-  $SUDO pacman-key --add "$tmp/funput.asc"
+  run curl -fsSL "${REPO_URL}/funput.asc" -o "$tmp/funput.asc"
+  run $SUDO pacman-key --add "$tmp/funput.asc"
   # Local signing is what promotes the key from "known" to "trusted"; without it
   # pacman reports every package as signed by an unknown key.
-  $SUDO pacman-key --lsign-key hello@funput.app
+  run $SUDO pacman-key --lsign-key hello@funput.app
 
   # Appended, not written: pacman.conf is one file holding every repo, and the
   # order of sections is the priority order. Skip if it is already there so
   # re-running does not stack duplicate sections.
   if ! grep -q '^\[funput\]' /etc/pacman.conf; then
-    printf '\n[funput]\nServer = %s/arch/$arch\n' "$REPO_URL" \
-      | $SUDO tee -a /etc/pacman.conf >/dev/null
+    # shellcheck disable=SC2016  # $arch is pacman's own placeholder, not a shell variable
+    printf '\n[funput]\nServer = %s/arch/$arch\n' "$REPO_URL" | append_root /etc/pacman.conf
   fi
-  $SUDO pacman -Sy
+  run $SUDO pacman -Sy
 }
 
 # Install (or upgrade to) the package for the chosen framework from the repo.
 repo_install() {
-  local pkg="funput"
-  [ "$FRAMEWORK" = "ibus" ] && pkg="funput-ibus"
-  echo "Installing ${pkg} from ${REPO_URL}…"
+  info "Installing ${PACKAGE} from ${REPO_URL}"
   case "$FAMILY" in
-    debian) $SUDO apt-get install -y "$pkg" ;;
-    fedora) $SUDO dnf install -y "$pkg" ;;
-    suse)   $SUDO zypper --non-interactive install "$pkg" ;;
-    arch)   $SUDO pacman -S --noconfirm "$pkg" ;;
+    debian) run $SUDO apt-get install -y "$PACKAGE" ;;
+    fedora) run $SUDO dnf install -y "$PACKAGE" ;;
+    suse)   run $SUDO zypper --non-interactive install "$PACKAGE" ;;
+    arch)   run $SUDO pacman -S --noconfirm "$PACKAGE" ;;
   esac
 }
 
+# --- Plan ------------------------------------------------------------------
+# Printed before anything is touched. A `curl … | bash` user cannot review the
+# script they just piped into a shell; they can review four lines of plan.
+print_plan() {
+  info "Funput installer"
+  if [ "$USER_INSTALL" -eq 1 ]; then
+    note "framework  ${FRAMEWORK}  (portable tarball)"
+    note "target     $HOME/.local  (no sudo, no package manager)"
+    note "source     GitHub Releases, ${VERSION}  (re-run this script to update)"
+  else
+    note "framework  ${FRAMEWORK}  (package: ${PACKAGE})"
+    note "system     ${DISTRO_NAME:-${DISTRO_ID:-unknown}}  (${FAMILY}, $(uname -m))"
+    if [ "$USE_REPO" -eq 1 ]; then
+      note "source     ${REPO_URL}  (signed; automatic updates afterwards)"
+    else
+      note "source     GitHub Releases, ${VERSION}  (no automatic updates)"
+    fi
+    note "privileges ${SUDO:-none (already root)}"
+  fi
+  [ "$DRY_RUN" -eq 1 ] && info "Dry run — the commands below are printed, not executed"
+  echo
+}
+
+# --- Arguments -------------------------------------------------------------
 while [ $# -gt 0 ]; do
   case "$1" in
-    --ibus)    FRAMEWORK="ibus" ;;
     --fcitx5)  FRAMEWORK="fcitx5" ;;
+    --ibus)    FRAMEWORK="ibus" ;;
     --user)    USER_INSTALL=1 ;;
     --no-repo) USE_REPO=0 ;;
+    --dry-run) DRY_RUN=1 ;;
     # Pinning a version means leaving the repository behind: it is rebuilt from
     # the current release each time and serves nothing else.
-    --version) shift; VERSION="${1:?--version needs a tag}"; USE_REPO=0 ;;
-    -h|--help)
-      # Print the usage header (everything between line 2 and `set -euo …`).
-      sed -n '2,/^set -euo/p' "$0" | sed -e '/^set -euo/d' -e 's/^# \{0,1\}//'
-      exit 0 ;;
+    --version)
+      shift
+      [ $# -gt 0 ] || die "--version needs a release tag, e.g. --version v1.2026.28"
+      VERSION="$1"; USE_REPO=0 ;;
+    -h|--help) usage; exit 0 ;;
     *) die "unknown argument: $1 (try --help)" ;;
   esac
   shift
 done
 
-# No-sudo path: user-local install into ~/.local, then done — it needs none of the
-# distro-family / package-manager logic below.
+have curl || die "curl is required but was not found. Install it and re-run."
+
+# --- No-sudo path ----------------------------------------------------------
+# User-local install into ~/.local, then done — it needs none of the distro-family
+# or package-manager logic below.
 if [ "$USER_INSTALL" -eq 1 ]; then
+  have tar || die "tar is required but was not found. Install it and re-run."
+  [ "$(id -u)" -ne 0 ] || warn "running --user as root installs into /root/.local, which no desktop session reads."
   detect_framework
+  FAMILY=""; SUDO=""
+  print_plan
   case "$FRAMEWORK" in
-    ibus)   user_install_ibus ;;
     fcitx5) user_install_fcitx5 ;;
+    ibus)   user_install_ibus ;;
     *)      die "unknown framework: $FRAMEWORK" ;;
   esac
   exit 0
@@ -370,34 +605,49 @@ fi
 
 # --- Distro family ---------------------------------------------------------
 [ -r /etc/os-release ] || die "cannot read /etc/os-release; unsupported system"
-# shellcheck disable=SC1091
-. /etc/os-release
+
+# Read one field of /etc/os-release. In a subshell on purpose: sourcing that file
+# into this one overwrites any variable sharing a name with one of its fields, and
+# VERSION is exactly that — the distro's version silently replaced this script's
+# release tag, so --version and --no-repo resolved a nonexistent release.
+os_release() {
+  # shellcheck disable=SC1091  # a system file, not part of this repository
+  ( set +u; . /etc/os-release; printf '%s' "${!1:-}" )
+}
+DISTRO_ID="$(os_release ID)"
+DISTRO_LIKE="$(os_release ID_LIKE)"
+DISTRO_NAME="$(os_release PRETTY_NAME)"
+
 # Match on ID first, then ID_LIKE so derivatives (Linux Mint, Pop!_OS, Nobara,
 # openSUSE variants, Manjaro/EndeavourOS) resolve to the right family.
-case " ${ID:-} ${ID_LIKE:-} " in
+case " ${DISTRO_ID} ${DISTRO_LIKE} " in
   *" debian "*|*" ubuntu "*) FAMILY="debian" ;;
   *" fedora "*|*" rhel "*)   FAMILY="fedora" ;;
   *" suse "*|*" opensuse "*) FAMILY="suse" ;;
   *" arch "*)                FAMILY="arch" ;;
-  *) die "unsupported distro (ID=${ID:-?}, ID_LIKE=${ID_LIKE:-?}). Build from source: platforms/linux/build.sh" ;;
+  *) die "unsupported distro (ID=${DISTRO_ID:-?}, ID_LIKE=${DISTRO_LIKE:-?}). Build from source: platforms/linux/build.sh" ;;
 esac
 
 SUDO=""
-[ "$(id -u)" -eq 0 ] || SUDO="sudo"
+if [ "$(id -u)" -ne 0 ]; then
+  have sudo || die "this install needs root and sudo was not found. Re-run as root, or use --user."
+  SUDO="sudo"
+fi
 
 # Arch has no release asset: it is a rolling source distro, so the .deb/.rpm
 # builds have nothing to offer it. What repo.funput.app serves instead is a
 # pacman repository of the same three packages, under the same key. Handled
 # entirely by repo_add_arch below, so it falls through with the others.
 
-# --- Framework -------------------------------------------------------------
 detect_framework
+PACKAGE="funput"
+[ "$FRAMEWORK" = "ibus" ] && PACKAGE="funput-ibus"
+print_plan
 
 # --- Repository path (the default) -----------------------------------------
 # Everything below this block is the --no-repo fallback: one versioned asset,
 # updated only by re-running the script.
 if [ "$USE_REPO" -eq 1 ]; then
-  have curl || die "curl is required"
   case "$FAMILY" in
     debian) repo_add_debian ;;
     fedora) repo_add_fedora ;;
@@ -425,45 +675,50 @@ if [ "$FAMILY" = "debian" ]; then
   case "$MACHINE" in
     x86_64) PKG_ARCH="amd64" ;;
     aarch64|arm64) PKG_ARCH="arm64" ;;
-    *) die "unsupported CPU arch: $MACHINE" ;;
+    *) die "unsupported CPU architecture: $MACHINE" ;;
   esac
-  if [ "$FRAMEWORK" = "ibus" ]; then
-    PATTERN="funput-ibus_[^/]*_${PKG_ARCH}\.deb"
-  else
-    PATTERN="funput_[^/]*_${PKG_ARCH}\.deb"
-  fi
+  PATTERN="${PACKAGE}_.*_${PKG_ARCH}\.deb"
 else
   # fedora + suse → .rpm
   FORMAT="rpm"
   case "$MACHINE" in
     x86_64) PKG_ARCH="x86_64" ;;
     aarch64|arm64) PKG_ARCH="aarch64" ;;
-    *) die "unsupported CPU arch: $MACHINE" ;;
+    *) die "unsupported CPU architecture: $MACHINE" ;;
   esac
   if [ "$FRAMEWORK" = "ibus" ]; then
-    PATTERN="funput-ibus-[^/]*\.${PKG_ARCH}\.rpm"
+    PATTERN="funput-ibus-.*\.${PKG_ARCH}\.rpm"
   else
     # funput- followed by a digit = version, to not match funput-ibus-*.
-    PATTERN="funput-[0-9][^/]*\.${PKG_ARCH}\.rpm"
+    PATTERN="funput-[0-9].*\.${PKG_ARCH}\.rpm"
   fi
 fi
 
 # --- Resolve + download the release asset ----------------------------------
-have curl || die "curl is required"
-echo "Looking up ${FRAMEWORK} ${FORMAT} (${PKG_ARCH}) in ${REPO} ${VERSION} release…"
-URL="$(resolve_url "$PATTERN")"
-[ -n "$URL" ] || die "no matching asset (${PATTERN}) in the ${VERSION} release"
+info "Looking up the ${FRAMEWORK} ${FORMAT} (${PKG_ARCH}) in ${REPO} ${VERSION}"
+FOUND="$(resolve_asset "$PATTERN")" || exit 1
+[ -n "$FOUND" ] || die "no matching asset (${PATTERN}) in the ${VERSION} release"
+URL="${FOUND%%$'\t'*}"; DIGEST="${FOUND#*$'\t'}"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  note "would download $(basename "$URL") and verify its sha256"
+  note "would install it with ${FAMILY}'s package manager"
+  post_install_hint
+  exit 0
+fi
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 FILE="$TMP/$(basename "$URL")"
-download "$URL" "$FILE"
+download "$URL" "$FILE" "$DIGEST"
 
 # --- Install ---------------------------------------------------------------
-echo "Installing $(basename "$FILE")…"
+info "Installing $(basename "$FILE")"
 case "$FAMILY" in
   debian) $SUDO apt-get install -y "$FILE" ;;
   fedora) $SUDO dnf install -y "$FILE" ;;
+  # Release assets are unsigned (only the repository signs); zypper stops on that
+  # unless told, while apt and dnf take a local file as it is.
   suse)   $SUDO zypper --non-interactive install --allow-unsigned-rpm "$FILE" ;;
 esac
 

--- a/platforms/linux/packaging/repo/index.html.in
+++ b/platforms/linux/packaging/repo/index.html.in
@@ -107,14 +107,15 @@
 
   <div class="pick">
     <div class="opt">
-      <span class="badge ibus">IBus</span>
-      <b style="margin-top:.4rem">GNOME / Ubuntu mặc định</b>
-      <small>Cài sẵn trên hầu hết desktop. Gói <code class="inline">funput-ibus</code>.</small>
+      <span class="badge fcitx">Fcitx5</span>
+      <b style="margin-top:.4rem">Khuyến nghị cho mọi desktop</b>
+      <small>Bản đầy đủ hơn. Gói <code class="inline">funput</code>. Ngoài KDE thì cần
+      <a href="#session">nối session</a> rồi đăng xuất.</small>
     </div>
     <div class="opt">
-      <span class="badge fcitx">Fcitx5</span>
-      <b style="margin-top:.4rem">KDE, hoặc muốn đầy đủ tính năng</b>
-      <small>Gói <code class="inline">funput</code>.</small>
+      <span class="badge ibus">IBus</span>
+      <b style="margin-top:.4rem">Đang dùng IBus sẵn (GNOME / Ubuntu)</b>
+      <small>Không phải đổi session. Gói <code class="inline">funput-ibus</code>.</small>
     </div>
   </div>
 
@@ -136,12 +137,12 @@ sudo apt update</code></pre></div>
     <div class="step">2 · Cài đặt</div>
     <div class="grid">
       <div>
-        <div class="lbl"><span class="badge ibus">IBus</span></div>
-        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo apt install funput-ibus</code></pre></div>
+        <div class="lbl"><span class="badge fcitx">Fcitx5</span> <small style="color:var(--muted)">khuyến nghị</small></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo apt install funput</code></pre></div>
       </div>
       <div>
-        <div class="lbl"><span class="badge fcitx">Fcitx5</span></div>
-        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo apt install funput</code></pre></div>
+        <div class="lbl"><span class="badge ibus">IBus</span></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo apt install funput-ibus</code></pre></div>
       </div>
     </div>
   </div>
@@ -156,12 +157,12 @@ sudo apt update</code></pre></div>
     <div class="step">2 · Cài đặt</div>
     <div class="grid">
       <div>
-        <div class="lbl"><span class="badge ibus">IBus</span></div>
-        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo dnf install funput-ibus</code></pre></div>
+        <div class="lbl"><span class="badge fcitx">Fcitx5</span> <small style="color:var(--muted)">khuyến nghị</small></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo dnf install funput</code></pre></div>
       </div>
       <div>
-        <div class="lbl"><span class="badge fcitx">Fcitx5</span></div>
-        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo dnf install funput</code></pre></div>
+        <div class="lbl"><span class="badge ibus">IBus</span></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo dnf install funput-ibus</code></pre></div>
       </div>
     </div>
   </div>
@@ -178,12 +179,12 @@ sudo zypper refresh</code></pre></div>
     <div class="step">2 · Cài đặt</div>
     <div class="grid">
       <div>
-        <div class="lbl"><span class="badge ibus">IBus</span></div>
-        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo zypper install funput-ibus</code></pre></div>
+        <div class="lbl"><span class="badge fcitx">Fcitx5</span> <small style="color:var(--muted)">khuyến nghị</small></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo zypper install funput</code></pre></div>
       </div>
       <div>
-        <div class="lbl"><span class="badge fcitx">Fcitx5</span></div>
-        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo zypper install funput</code></pre></div>
+        <div class="lbl"><span class="badge ibus">IBus</span></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo zypper install funput-ibus</code></pre></div>
       </div>
     </div>
   </div>
@@ -207,12 +208,12 @@ sudo pacman -Sy</code></pre></div>
     <div class="step">3 · Cài đặt</div>
     <div class="grid">
       <div>
-        <div class="lbl"><span class="badge ibus">IBus</span></div>
-        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo pacman -S funput-ibus</code></pre></div>
+        <div class="lbl"><span class="badge fcitx">Fcitx5</span> <small style="color:var(--muted)">khuyến nghị</small></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo pacman -S funput</code></pre></div>
       </div>
       <div>
-        <div class="lbl"><span class="badge fcitx">Fcitx5</span></div>
-        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo pacman -S funput</code></pre></div>
+        <div class="lbl"><span class="badge ibus">IBus</span></div>
+        <div class="cmd"><button class="copy">Copy</button><pre><code>sudo pacman -S funput-ibus</code></pre></div>
       </div>
     </div>
 
@@ -223,33 +224,52 @@ sudo pacman -Sy</code></pre></div>
   </div>
 
   <div class="note">
-    <b>Sau khi cài:</b> <span class="badge ibus">IBus</span> chạy <code class="inline">ibus restart</code>
+    <b>Sau khi cài:</b> <span class="badge fcitx">Fcitx5</span> đặt biến môi trường bên dưới,
+    đăng xuất, rồi mở <code class="inline">fcitx5-configtool</code> → thêm <b>Funput</b> (nhóm Vietnamese).
+    <span class="badge ibus">IBus</span> chạy <code class="inline">ibus restart</code>
     rồi <b>Settings → Keyboard → Input Sources → + → Vietnamese → Funput</b>.
-    <span class="badge fcitx">Fcitx5</span> mở <code class="inline">fcitx5-configtool</code> → thêm
-    <b>Funput</b> (nhóm Vietnamese). Mở <b>Funput</b> trong menu ứng dụng để chỉnh Telex/VNI.
+    Mở <b>Funput</b> trong menu ứng dụng để chỉnh Telex/VNI.
   </div>
 
   <div class="card">
-    <h2><span class="badge fcitx">Fcitx5</span> Biến môi trường (Wayland)</h2>
+    <h2 id="session"><span class="badge fcitx">Fcitx5</span> Biến môi trường session</h2>
     <p style="color:var(--muted);margin:0 0 1rem;font-size:.95rem">
       Funput là engine trong Fcitx5 — app chỉ gõ được nếu session đã nối đúng Fcitx5.
-      Cấu hình theo <b>desktop</b>, không copy một khối <code class="inline">GTK_IM_MODULE</code> cho mọi máy.
-      Nguồn: <a href="https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland">Fcitx 5 on Wayland</a>.
+      Đặt biến nào phụ thuộc <b>loại session trước, desktop sau</b> — kiểm tra bằng
+      <code class="inline">echo $XDG_SESSION_TYPE</code>. Đừng copy chung một khối
+      <code class="inline">GTK_IM_MODULE</code> cho mọi máy. Nguồn:
+      <a href="https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland">Fcitx 5 on Wayland</a>,
+      <a href="https://fcitx-im.org/wiki/Setup_Fcitx_5">Setup Fcitx 5</a>.
       Ghi vào <code class="inline">~/.config/environment.d/fcitx5.conf</code> rồi đăng xuất.
     </p>
 
-    <div class="step">GNOME</div>
+    <div class="step">X11 (mọi desktop)</div>
+    <div class="cmd"><button class="copy">Copy</button><pre><code>mkdir -p ~/.config/environment.d
+cat &gt; ~/.config/environment.d/fcitx5.conf &lt;&lt;'EOF'
+XMODIFIERS=@im=fcitx
+GTK_IM_MODULE=fcitx
+QT_IM_MODULE=fcitx
+EOF</code></pre></div>
+    <p style="color:var(--muted);font-size:.9rem;margin:.35rem 0 0">
+      Trên Debian/Ubuntu dùng <code class="inline">im-config -n fcitx5</code> thay cho khối này —
+      nó ghi đúng bộ trên và khởi động daemon. Fedora có gói
+      <code class="inline">fcitx5-autostart</code>.
+    </p>
+
+    <div class="step">GNOME (Wayland) — và sway, wlroots</div>
     <div class="cmd"><button class="copy">Copy</button><pre><code>mkdir -p ~/.config/environment.d
 cat &gt; ~/.config/environment.d/fcitx5.conf &lt;&lt;'EOF'
 XMODIFIERS=@im=fcitx
 QT_IM_MODULE=fcitx
 EOF</code></pre></div>
     <p style="color:var(--muted);font-size:.9rem;margin:.35rem 0 0">
-      Để trống <code class="inline">GTK_IM_MODULE</code> — GNOME đi frontend IBus của Fcitx5.
-      App Qt/XWayland (WPS, …) cần <code class="inline">QT_IM_MODULE=fcitx</code>.
+      Để trống <code class="inline">GTK_IM_MODULE</code> — GTK 3/4 đã đi thẳng
+      <code class="inline">text-input-v3</code>. Dòng <code class="inline">QT_IM_MODULE</code> là cho
+      Qt 5 và Qt cũ hơn 6.8.2 (chạy qua XWayland); từ <b>Qt 6.8.2</b> trở lên dùng
+      <code class="inline">QT_IM_MODULES=wayland;fcitx</code> thay cho nó.
     </p>
 
-    <div class="step">KDE Plasma</div>
+    <div class="step">KDE Plasma (Wayland, 5.27+)</div>
     <div class="cmd"><button class="copy">Copy</button><pre><code>mkdir -p ~/.config/environment.d
 cat &gt; ~/.config/environment.d/fcitx5.conf &lt;&lt;'EOF'
 XMODIFIERS=@im=fcitx
@@ -258,7 +278,10 @@ EOF</code></pre></div>
       <b>Không</b> set global <code class="inline">GTK_IM_MODULE</code> /
       <code class="inline">QT_IM_MODULE</code> /
       <code class="inline">SDL_IM_MODULE</code> — candidate window sẽ nhấp nháy trên KWin.
-      Bật Fcitx5 ở System Settings → Virtual keyboard.
+      Ứng dụng riêng lẻ cần thì đặt riêng: <code class="inline">env QT_IM_MODULE=fcitx wps</code>.
+      Bật Fcitx5 ở System Settings → Virtual keyboard, và <b>đừng restart</b> nó
+      (<code class="inline">fcitx5 -r</code> hay menu tray) — KWin trao socket mà tiến trình
+      mới không kế thừa được; hãy đăng xuất.
     </p>
   </div>
 


### PR DESCRIPTION
## Tóm tắt

- `install.sh` trước đây đoán framework theo `XDG_CURRENT_DESKTOP` (KDE → Fcitx5, còn lại → IBus), tức là phần lớn người dùng nhận bản IBus — bản không có kênh nào chạy được với client kiểu WPS. Giờ **Fcitx5 là mặc định trên mọi desktop**, `--ibus` để chọn ngược lại. Tên gói vốn đã hợp: `funput` = Fcitx5.
- Ngoài KDE, chọn Fcitx5 kéo theo một lần cấu hình session. Script **cảnh báo trước khi cài** và in biến môi trường sau khi cài, nhưng **vẫn không tự ghi** — biến đó thuộc về session, không thuộc về Funput (nguyên tắc đã ghi trong `platforms/linux/README.md`).

**Sửa một bug có sẵn:** `. /etc/os-release` ghi đè biến `VERSION` của script bằng version của distro, nên `--version` và `--no-repo` đi hỏi một release không tồn tại trên mọi distro có khai field đó (Debian, Ubuntu, Fedora…). Giờ đọc từng field trong subshell.

**Hướng dẫn biến môi trường được làm lại theo tài liệu upstream** ([Using Fcitx 5 on Wayland](https://fcitx-im.org/index.php?title=Using_Fcitx_5_on_Wayland&oldid=46245), [Setup Fcitx 5](https://fcitx-im.org/index.php?title=Setup_Fcitx_5&oldid=45899)). Khối in ra trước đây chỉ có dạng Wayland cho tất cả mọi người, quá thô:

| | Đặt gì |
|---|---|
| Session `x11` (mọi desktop) | `XMODIFIERS` + `GTK_IM_MODULE` + `QT_IM_MODULE` |
| Wayland, GNOME/sway | `XMODIFIERS` + `QT_IM_MODULE`; **để trống** `GTK_IM_MODULE` (GTK 3/4 tự đi `text-input-v3`). Qt 6.8.2+ dùng `QT_IM_MODULES=wayland;fcitx` |
| Wayland, KDE Plasma | **chỉ** `XMODIFIERS` — đặt cả bộ làm nhấp nháy candidate window trên KWin |

Script đọc `$XDG_SESSION_TYPE` và **chỉ in khối áp dụng cho máy đó**, kèm công cụ của distro khi có (`im-config` trên Debian/Ubuntu). Thêm cảnh báo KDE: đừng `fcitx5 -r` khi KWin đã khởi động daemon — nó trao một socket mà tiến trình mới không kế thừa được.

**Phần còn lại là những gì một one-liner `curl … | bash` nợ người chạy nó:**

- In **kế hoạch** (distro, framework, gói, nguồn, có sudo hay không) trước khi động vào máy; `--dry-run` in **đúng từng lệnh** và không chạy lệnh nào — mọi thao tác thay đổi hệ thống đều đi qua `run` / `write_root` / `fetch_to_root` nên lời hứa đó là thật.
- Gói tải từ GitHub Releases được **đối chiếu SHA-256** với digest mà release API công bố cho chính asset đó. Đây đúng là thứ tài liệu từng bảo người dùng tự verify bằng file `.sha256` — mà **release Linux chưa bao giờ có file đó**.
- `set -Eeuo pipefail` + `trap ERR`: lỗi bất ngờ nêu rõ dòng và link issue; lỗi có chủ đích đi qua `die` nên hai loại không lẫn nhau. Lỗi mạng giờ nói "không đọc được release" thay vì "no matching asset".
- Output có màu theo cấp, tôn trọng `NO_COLOR`, tự tắt khi không phải terminal. `usage()` thật thay cho mẹo `sed` cắt comment header.
- Job CI mới **`installer-scripts`**: `bash -n` + `shellcheck --severity=warning` + `--help` trên các script người ngoài thật sự chạy. Trước đó **không có gì** kiểm tra `install.sh` — một lỗi cú pháp ở nhánh chỉ Fedora đi qua sẽ ship thẳng tới người dùng.

Tài liệu đi kèm ở **Funput/Docs#7** — nên merge PR này trước.

## Cách kiểm tra

Đã chạy trên Ubuntu 26.04 (GNOME/Wayland, fcitx5 5.1.19), dùng shellcheck 0.10.0:

- [x] `shellcheck` sạch ở **severity mặc định** (baseline trên `main` là 3 findings); `bash -n` sạch.
- [x] `resolve_asset` chạy trên JSON release thật với 6 pattern, gồm ca khó `funput-[0-9].*\.x86_64\.rpm` (không được khớp `funput-ibus-*`) — đúng cả 6, digest ghép đúng asset.
- [x] Tải thật `funput_1.2026.75_amd64.deb` → digest khớp. Thêm một byte vào file → script dừng với thông báo mismatch, không cài.
- [x] `--dry-run` cho: mặc định qua kho, `--ibus --no-repo`, `--version v1.2026.75`, `--user`, `--user --ibus`.
- [x] Đường lỗi: tag không tồn tại, tham số lạ, `--version` thiếu giá trị — đều exit 1 với thông báo rõ.
- [x] `fcitx5_session_hint` với 5 tổ hợp session/desktop/distro — mỗi tổ hợp ra đúng khối, dòng `im-config` chỉ hiện khi X11 + họ Debian.
- [x] Chạy đúng lệnh của job CI mới tại máy → pass. `scripts/check-loc.sh` xanh.

Chưa kiểm được, cần người review có máy tương ứng:

- [x] Cài thật (không `--dry-run`) trên Fedora, openSUSE, Arch.
- [x] Phiên **X11** thật và phiên **KDE Plasma** thật — hai nhánh hint mới chỉ được test bằng cách set biến, chưa test trên session thật.
- [x] Nhánh `--user` chạy thật (test mới dừng ở `--dry-run` và ở bước tải + verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
