### PR TITLE
feat(windows): open Settings on a tray icon double-click

### DIFF
--- a/platforms/windows/src/background/tray/events.rs
+++ b/platforms/windows/src/background/tray/events.rs
@@ -1,11 +1,54 @@
 //! Tray click and context-menu event handling.
+//!
+//! Windows delivers one double-click on a notification icon as *four* events —
+//! `Click{Down}`, `Click{Up}`, `DoubleClick`, `Click{Up}` — so the single-click
+//! action has already run by the time the double-click arrives, and there is no
+//! way to see it coming. Deferring every single click by `GetDoubleClickTime()`
+//! would put half a second between the tray and the Control Center, which is the
+//! gesture people use most, so the single click stays instant and the *trailing*
+//! `Click{Up}` is dropped instead.
+//!
+//! Dropping it is not optional. Left in, it re-enters `toggle_control_center`,
+//! where `is_cc` is now false (the slot holds Settings) and the
+//! `LAST_CC_DISMISS_MS` debounce is unarmed — that timestamp is only written when
+//! the flyout exits with `EXIT_DISMISS`, and here it was killed. So it would fall
+//! straight through to killing Settings and reopening the flyout: the exact
+//! opposite of what the double-click asked for.
+
+use std::cell::Cell;
+use std::time::{Duration, Instant};
 
 use tray_icon::menu::MenuEvent;
-use tray_icon::{MouseButton, MouseButtonState, TrayIconEvent};
+use tray_icon::{MouseButton, MouseButtonState, Rect, TrayIconEvent};
+use windows::Win32::UI::Input::KeyboardAndMouse::GetDoubleClickTime;
 
 use super::menu::{CONVERT_ID, QUIT_ID, SETTINGS_ID, UPDATE_ID};
 use crate::background::hook;
 use crate::ui;
+
+thread_local! {
+    /// When the last tray double-click landed. `thread_local` for the same reason
+    /// the tray itself is: only the hook thread ever drains these events.
+    ///
+    /// A timestamp rather than a "skip the next Up" flag on purpose — a flag that
+    /// never gets consumed stays armed and silently eats the next *legitimate*
+    /// click, breaking the primary gesture. This expires on its own.
+    static LAST_DBLCLK: Cell<Option<Instant>> = const { Cell::new(None) };
+}
+
+/// The two left-button tray events worth acting on.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum LeftEvent {
+    Up,
+    Double,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Action {
+    ControlCenter,
+    Settings,
+    Ignore,
+}
 
 /// Drain pending tray + menu events. Call after each `DispatchMessageW`.
 ///
@@ -14,14 +57,22 @@ use crate::ui;
 /// `try_wait` syscall to every mouse move the low-level hook delivers.
 pub(super) fn drain() {
     while let Ok(ev) = TrayIconEvent::receiver().try_recv() {
-        if let TrayIconEvent::Click {
-            button: MouseButton::Left,
-            button_state: MouseButtonState::Up,
-            rect,
-            ..
-        } = ev
-        {
-            on_left_click(rect);
+        let Some((left, rect)) = as_left_event(&ev) else {
+            continue;
+        };
+        let window = Duration::from_millis(u64::from(unsafe { GetDoubleClickTime() }));
+        let now = Instant::now();
+        match decide(left, LAST_DBLCLK.get(), now, window) {
+            // Toggle VI lives on the flyout (the hotkey still refreshes the tray
+            // glyph via `ON_TOGGLE`).
+            Action::ControlCenter => ui::toggle_control_center(rect),
+            Action::Settings => {
+                LAST_DBLCLK.set(Some(now));
+                // Kills the flyout the opening click just spawned, then opens the
+                // Settings window on its overview tab.
+                ui::launch_settings(false);
+            }
+            Action::Ignore => {}
         }
     }
 
@@ -30,10 +81,40 @@ pub(super) fn drain() {
     }
 }
 
-/// Phase B: open/close the Acrylic Control Center. Toggle VI lives on the flyout
-/// (hotkey still refreshes the tray glyph via `ON_TOGGLE`).
-fn on_left_click(rect: tray_icon::Rect) {
-    ui::toggle_control_center(rect);
+fn as_left_event(ev: &TrayIconEvent) -> Option<(LeftEvent, Rect)> {
+    match *ev {
+        TrayIconEvent::Click {
+            button: MouseButton::Left,
+            button_state: MouseButtonState::Up,
+            rect,
+            ..
+        } => Some((LeftEvent::Up, rect)),
+        // Note this variant carries no `button_state` — it is emitted once, for
+        // the `WM_LBUTTONDBLCLK` in the middle of the four-event sequence.
+        TrayIconEvent::DoubleClick {
+            button: MouseButton::Left,
+            rect,
+            ..
+        } => Some((LeftEvent::Double, rect)),
+        _ => None,
+    }
+}
+
+/// What a left-button tray event should do, given when the last double-click
+/// landed.
+///
+/// Pure so the four-event sequence Windows sends for one double-click can be
+/// replayed in a test without a mouse or a clock. The `window` guard swallows the
+/// trailing `Up`, and a second `Double` with it, so a triple-click does not kill
+/// and respawn the Settings window.
+fn decide(ev: LeftEvent, last: Option<Instant>, now: Instant, window: Duration) -> Action {
+    if last.is_some_and(|t| now.saturating_duration_since(t) <= window) {
+        return Action::Ignore;
+    }
+    match ev {
+        LeftEvent::Up => Action::ControlCenter,
+        LeftEvent::Double => Action::Settings,
+    }
 }
 
 fn handle_menu(id: &str) {
@@ -46,5 +127,85 @@ fn handle_menu(id: &str) {
             hook::quit();
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A typical `GetDoubleClickTime()`.
+    fn window() -> Duration {
+        Duration::from_millis(500)
+    }
+
+    #[test]
+    fn it_opens_the_control_center_on_a_lone_click() {
+        let action = decide(LeftEvent::Up, None, Instant::now(), window());
+        assert_eq!(action, Action::ControlCenter);
+    }
+
+    #[test]
+    fn it_opens_settings_on_a_double_click() {
+        let action = decide(LeftEvent::Double, None, Instant::now(), window());
+        assert_eq!(action, Action::Settings);
+    }
+
+    #[test]
+    fn the_trailing_up_of_a_double_click_does_nothing() {
+        // The reported bug, replayed as Windows actually delivers it. Without the
+        // last assertion that trailing Up re-enters toggle_control_center, kills
+        // the Settings window that just opened, and reopens the flyout instead.
+        let t0 = Instant::now();
+        assert_eq!(
+            decide(LeftEvent::Up, None, t0, window()),
+            Action::ControlCenter
+        );
+
+        let t1 = t0 + Duration::from_millis(120);
+        assert_eq!(
+            decide(LeftEvent::Double, None, t1, window()),
+            Action::Settings
+        );
+
+        let t2 = t1 + Duration::from_millis(2);
+        assert_eq!(
+            decide(LeftEvent::Up, Some(t1), t2, window()),
+            Action::Ignore
+        );
+    }
+
+    #[test]
+    fn a_triple_click_does_not_relaunch_settings() {
+        let t = Instant::now();
+        let third = decide(
+            LeftEvent::Double,
+            Some(t),
+            t + Duration::from_millis(150),
+            window(),
+        );
+        assert_eq!(third, Action::Ignore);
+    }
+
+    #[test]
+    fn a_click_after_the_window_works_again() {
+        // The suppression expires on its own, so a stuck state cannot swallow the
+        // gesture the tray is used for most.
+        let t = Instant::now();
+        let later = t + window() + Duration::from_millis(1);
+        assert_eq!(
+            decide(LeftEvent::Up, Some(t), later, window()),
+            Action::ControlCenter
+        );
+    }
+
+    #[test]
+    fn the_window_boundary_still_suppresses() {
+        let t = Instant::now();
+        let edge = t + window();
+        assert_eq!(
+            decide(LeftEvent::Up, Some(t), edge, window()),
+            Action::Ignore
+        );
     }
 }

--- a/platforms/windows/src/background/tray/mod.rs
+++ b/platforms/windows/src/background/tray/mod.rs
@@ -1,6 +1,7 @@
 //! Native tray icon + context menu on the keyboard-hook Win32 message loop.
 //!
-//! Left-click toggles the Acrylic Control Center; right-click opens a thin menu.
+//! Left-click toggles the Acrylic Control Center, double-click opens Settings,
+//! right-click opens a thin menu.
 
 use std::cell::RefCell;
 


### PR DESCRIPTION
## Tóm tắt

- Double-click trái vào tray icon mở **cửa sổ Cài đặt** ở tab Tổng quan. Trước đây `tray-icon` vẫn phát `TrayIconEvent::DoubleClick` trên Windows nhưng `events.rs` chỉ match `Click{Left, Up}`, nên event rơi vào nhánh không khớp và bị drop im lặng.
- Click đơn **không đổi**: vẫn mở/đóng Control Center tức thì. Menu chuột phải không đổi.

**Vì sao không chỉ là thêm một nhánh `match`.** Windows gửi một cú double-click trên notification icon thành **bốn** event — `Click{Down}`, `Click{Up}`, `DoubleClick`, `Click{Up}` — nên hành động của click đơn đã chạy xong trước khi double-click tới, và không có cách nào biết trước. Cú `Click{Up}` **đuôi** mới là vấn đề: để nguyên, nó quay lại `toggle_control_center`, lúc đó `is_cc` là `false` (slot `UI_PROCESS` đang giữ `UiKind::Settings`) và debounce `LAST_CC_DISMISS_MS` **không được arm** — timestamp đó chỉ được ghi khi flyout thoát bằng `EXIT_DISMISS`, còn ở đây nó bị `kill()`. Nên nó rơi thẳng xuống `terminate_children()` + spawn flyout, tức **giết Settings và mở lại flyout** — ngược hẳn ý định.

**Đánh đổi đã cân nhắc.** Hướng còn lại là hoãn mọi click đơn bằng `SetTimer(GetDoubleClickTime())` để không bao giờ đoán sai. Đã loại: nó đặt nửa giây giữa tray và Control Center — *thao tác chính, dùng nhiều nhất* — để đổi lấy một shortcut phụ. Giữ click đơn tức thì, chặn cú `Up` đuôi thay vào đó. Hệ quả: khi flyout **đang đóng**, tiến trình flyout vẫn kịp spawn rồi bị giết nên có thể loé rất ngắn trước khi Settings mở; khi flyout **đang mở** thì không loé (cú click đầu chỉ đóng nó).

Phần chặn dùng **timestamp** (`Instant`, monotonic) chứ không phải cờ `bool` "bỏ qua cú Up kế tiếp": cờ không được tiêu thụ sẽ kẹt lại và âm thầm nuốt mất *click đơn hợp lệ tiếp theo*, tức hỏng đúng thao tác chính. Timestamp tự hết hạn sau `GetDoubleClickTime()` nên tôn trọng cả cài đặt chuột của người dùng. Nó đồng thời xử lý triple-click, vốn sẽ khiến cú `DoubleClick` thứ hai giết rồi spawn lại cửa sổ Settings.

Phần quyết định tách thành hàm thuần `decide()` theo khuôn `ui/control_center/placement.rs`, để replay được chuỗi bốn event trong test mà không cần chuột hay clock thật.

Không thêm dependency — `Win32_UI_Input_KeyboardAndMouse` (chứa `GetDoubleClickTime`) đã bật sẵn.

## Cách kiểm tra

Đã chạy trên Windows 11 Education 26200, Rust 1.97.1:

- [x] `cargo test` — **64 pass** (58 → 64). Test chống hồi quy chính là `the_trailing_up_of_a_double_click_does_nothing`: replay đúng chuỗi bốn event; thiếu nó thì double-click giết Settings và mở lại flyout.
- [x] `cargo clippy --all-targets -- -D warnings` sạch; `cargo fmt -- --check` sạch; `cargo build` link được.
- [x] `scripts/check-loc.sh` xanh — `events.rs` 50 → **132 dòng**, dưới ngưỡng 150. Nếu file phải lớn thêm, `LeftEvent`/`Action`/`decide`/`as_left_event` tách sạch sang `background/tray/click.rs`.
- [x] Click đơn mở Control Center tức thì, không trễ; click đơn lần nữa đóng. Đây là hồi quy nguy hiểm nhất.
- [x] Double-click khi flyout đang đóng → Cài đặt mở ở tab Tổng quan.
- [x] Double-click khi flyout đang mở → Cài đặt mở, không loé.
- [x] Chuột phải → menu vẫn đủ bốn mục, "Cài đặt…" vẫn chạy.
- [x] Triple-click → Cài đặt mở đúng một lần.

Ghi chú cho người review: `DoubleClick` là **Windows-only** trong `tray-icon` (trên Linux event này không bao giờ phát), nên thay đổi nằm trọn trong shell Windows và không ảnh hưởng các platform khác.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
