### PR TITLE
ci(windows): check formatting, and fix the drift it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,6 +413,15 @@ jobs:
   # this job is still too slow once the cache is warm, the answer is to move the
   # test step to an unfiltered nightly run — not to delete the only thing that
   # checks whether the shell works.
+  #
+  # `cargo fmt --all` in the `rust` job does not reach an excluded package either,
+  # which is why formatting is checked here too — the same gap `settings-gtk`
+  # closes for its own package. It was not theoretical: four files had drifted into
+  # style_edition 2024 import ordering while the other twenty-three stayed on the
+  # 2021 ordering this package's edition selects, and nothing on a pull request
+  # looked. Note the check must run from `platforms/windows`, not the root: the
+  # edition in its own manifest is what picks the style, so a root invocation would
+  # reformat it to disagree with itself.
   windows:
     needs: changes
     if: needs.changes.outputs.windows == 'true'
@@ -436,6 +445,10 @@ jobs:
         with:
           workspaces: platforms/windows -> target
           key: ci-dev
+
+      - name: Format
+        working-directory: platforms/windows
+        run: cargo fmt -- --check
 
       - name: Clippy
         working-directory: platforms/windows

--- a/platforms/windows/src/background/tray/menu.rs
+++ b/platforms/windows/src/background/tray/menu.rs
@@ -21,6 +21,6 @@ pub(super) fn build() -> Menu {
         &PredefinedMenuItem::separator(),
         &quit,
     ])
-        .expect("build tray menu");
+    .expect("build tray menu");
     menu
 }

--- a/platforms/windows/src/ui/convert/win32/clipboard.rs
+++ b/platforms/windows/src/ui/convert/win32/clipboard.rs
@@ -9,7 +9,7 @@ use windows::Win32::Foundation::{HANDLE, HGLOBAL};
 use windows::Win32::System::DataExchange::{
     CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, SetClipboardData,
 };
-use windows::Win32::System::Memory::{GHND, GlobalAlloc, GlobalLock, GlobalUnlock};
+use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GHND};
 use windows::Win32::System::Ole::CF_UNICODETEXT;
 
 /// Replace the clipboard with `text`. Silently does nothing if Windows refuses —
@@ -90,7 +90,9 @@ unsafe fn read_open() -> Option<String> {
     // SAFETY: `CF_UNICODETEXT` is NUL-terminated UTF-16 by definition of the format.
     let text = unsafe { wide_string(source.cast::<u16>()) };
     // SAFETY: paired with the lock above.
-    unsafe { let _ = GlobalUnlock(block); }
+    unsafe {
+        let _ = GlobalUnlock(block);
+    }
     Some(text)
 }
 

--- a/platforms/windows/src/ui/convert/win32/drop.rs
+++ b/platforms/windows/src/ui/convert/win32/drop.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::UI::Shell::{
-    DefSubclassProc, DragAcceptFiles, DragFinish, DragQueryFileW, HDROP, SetWindowSubclass,
+    DefSubclassProc, DragAcceptFiles, DragFinish, DragQueryFileW, SetWindowSubclass, HDROP,
 };
 use windows::Win32::UI::WindowsAndMessaging::WM_DROPFILES;
 

--- a/platforms/windows/src/ui/lifecycle/mod.rs
+++ b/platforms/windows/src/ui/lifecycle/mod.rs
@@ -12,8 +12,7 @@ use windows::Win32::System::Threading::{
 use super::{control_center, convert, onboarding, settings_window};
 
 pub(crate) use child::{
-    current_child_handle, launch_convert, launch_onboarding, launch_settings,
-    terminate_children,
+    current_child_handle, launch_convert, launch_onboarding, launch_settings, terminate_children,
 };
 pub(crate) use flyout::{reap_ui_child, toggle_control_center};
 


### PR DESCRIPTION
> Stack: base là `feat/windows-tray-double-click-settings` (#342), không phải `main`. Merge #342 trước, GitHub sẽ tự đổi base của PR này về `main`.

## Tóm tắt

- Thêm bước **`Format`** (`cargo fmt -- --check`) vào job `windows`, đặt trước `Clippy` — đúng thứ tự và đúng khuôn job `settings-gtk` đã có.
- Dọn **4 file** rustfmt phát hiện. Thuần formatting, **không đổi hành vi**.

**Vì sao có lỗ hổng này.** `cargo fmt --all` trong job `rust` không với tới package bị loại khỏi cargo workspace. `platforms/linux/settings-gtk` đã đóng lỗ đó cho chính nó bằng một bước `Format` (comment ở `ci.yml` ghi rõ lý do), nhưng `platforms/windows` — cũng bị loại khỏi workspace, cũng vì link thư viện OS-only — thì chưa. Nên format của shell Windows trôi dần mà không có gì trên pull request nhìn tới.

**Thêm *bước* vào job có sẵn, không tạo job mới — có chủ đích.** `windows` vốn đã nằm trong danh sách required status check, nên phạm vi gate mở rộng mà **không phải đụng tới ruleset trên `main`**. Comment đầu `ci.yml` cảnh báo rất rõ: đổi tên/thêm job mà quên cập nhật ruleset thì rule "âm thầm không khớp gì nữa và cổng lặng lẽ mở ra". Một job mới chưa được thêm vào ruleset cũng sẽ không gate được gì cả.

Bộ lọc `changes` cho job này là `^platforms/windows/`, nên **mọi** thay đổi trong shell Windows — kể cả thay đổi thuần format — đều kích hoạt job. Bước mới vì thế thật sự chặn được drift về sau, chứ không chỉ dọn một lần.

## Về 4 file drift

Cả bốn có import bị sắp lại theo **style_edition 2024**, trong khi 23 file còn lại giữ thứ tự **2021** mà edition của package này chọn (`platforms/windows` là `edition = "2021"`, và repo không có `rustfmt.toml` nào).

Đã thử hướng ngược lại — thêm `rustfmt.toml` với `style_edition = "2024"` cho khớp phần còn lại của repo — rồi **bỏ**: nó làm **23 file** đổi thay vì 4, tức là chính 4 file kia mới là ngoại lệ. `settings-gtk` cũng `edition = "2021"`, cũng không có `rustfmt.toml`, và bước `Format` của nó vẫn xanh — nên quy ước của project là **để edition quyết định style**, và để check này giữ nó đứng yên.

Bước chạy từ `platforms/windows` chứ không từ root, cùng lý do với `settings-gtk`: edition trong manifest riêng của package là thứ chọn style, gọi rustfmt từ root sẽ format package thành tự mâu thuẫn với chính nó.

<details>
<summary>Toàn bộ thay đổi format (13 dòng)</summary>

| File | Thay đổi |
|---|---|
| `background/tray/menu.rs` | thụt lề `.expect()` sau `])` |
| `ui/convert/win32/clipboard.rs` | thứ tự import `GHND`; tách `unsafe { }` một dòng thành khối |
| `ui/convert/win32/drop.rs` | thứ tự import `HDROP` |
| `ui/lifecycle/mod.rs` | gộp danh sách `pub(crate) use` vừa một dòng |

</details>

## Cách kiểm tra

Chạy đúng ba bước của job `windows` tại máy (Windows 11, Rust 1.97.1):

- [x] `cargo fmt -- --check` trong `platforms/windows` → **pass** (trước khi dọn thì fail đúng 4 file này, tức bước mới thật sự bắt được lỗi chứ không phải no-op).
- [x] `cargo clippy --all-targets -- -D warnings` → sạch.
- [x] `cargo test` → **64 pass**, không đổi so với base.
- [x] `scripts/check-loc.sh` → xanh.
- [x] `ci.yml`: không có tab, thụt lề của bước mới khớp từng ký tự với `Clippy`/`Test` liền kề; thứ tự bước Format → Clippy → Test giống hệt `settings-gtk`.

Kiểm chứng thật sự cho PR này là **chính CI của nó**: `ci.yml` nằm trong nhóm trigger `shared`, nên job `windows` chắc chắn chạy trên PR này và sẽ thực thi bước `Format` vừa thêm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
