### PR TITLE
docs(platforms): rewrite the platform READMEs in Vietnamese

### DIFF
--- a/platforms/android/README.md
+++ b/platforms/android/README.md
@@ -1,70 +1,229 @@
-# Funput for Android
+<p align="center">
+  <img
+    src="../../assets/horizontal-lockup/gradient.png"
+    width="420"
+    alt="Funput"
+  >
+</p>
 
-Native Android shell and keyboard UI for Funput. The Android app is written in
-Kotlin; Vietnamese composition comes from the shared Rust engine through JNI.
+<p align="center">
+  <strong>Funput cho Android</strong> — bàn phím tiếng Việt cho điện thoại và máy tính bảng.<br>
+  Kotlin + Jetpack Compose · vẽ phím bằng Canvas · engine Rust qua
+  <code>funput-jni</code>
+</p>
 
-## Modules
+<p align="center">
+  <a href="mailto:hello@funput.app">
+    <img src="https://img.shields.io/badge/Kiểm_thử_khép_kín-Gửi_email_tham_gia-22C55E?style=for-the-badge&logo=gmail&logoColor=white" alt="Tham gia kiểm thử">
+  </a>
+  <a href="https://docs.funput.app/docs/install/android">
+    <img src="https://img.shields.io/badge/Tài_liệu-Hướng_dẫn_cài_đặt-2563EB?style=for-the-badge&logo=readthedocs&logoColor=white" alt="Hướng dẫn cài đặt">
+  </a>
+  <a href="https://github.com/Funput/Funput/issues">
+    <img src="https://img.shields.io/badge/Hỗ_trợ-Báo_lỗi-E11D48?style=for-the-badge&logo=github&logoColor=white" alt="Báo lỗi">
+  </a>
+</p>
 
-| Module | Responsibility |
+---
+
+<p align="center">
+  <img
+    src="../../assets/screenshot/android.png"
+    height="420"
+    alt="Bàn phím Funput trên Android"
+  >
+  <br>
+  <sub>Bàn phím Funput trên Android.</sub>
+</p>
+
+## Tính năng
+
+| | |
 |---|---|
-| `app` | Compose host for onboarding, settings, and keyboard previews |
-| `ime` | Android input-method lifecycle and focused-editor bridge |
-| `keyboard-ui` | Panel navigation and the lazy-loaded AndroidX emoji picker |
-| `keyboard-renderer` | Responsive keyboard layout, touch, accessibility, and Canvas rendering |
-| `theme-runtime` | Versioned theme contract, validation, token resolution, and safe asset access |
+| ⌨️ **Ba kiểu gõ** | Telex · **Telex nâng cao** (thêm `w` đầu từ và phím tắt `[` `]`) · VNI |
+| 🧠 **Gõ thông minh** | Tự khôi phục tiếng Anh · khôi phục tức thì · kiểm tra chính tả · tự động viết hoa |
+| 💬 **Gợi ý từ cá nhân** | Chỉ học chữ bạn gõ qua Funput, **lưu trên máy** |
+| 👆 **Cử chỉ thông minh** | Gõ đúp phím cách để chấm câu · giữ phím cách rồi kéo để di chuyển con trỏ mọi hướng · vuốt trái phím xoá để xoá cả từ |
+| 🎨 **7 theme dựng sẵn** | Slate · Ink · Paper · Glass Dark · Glass Light · Blossom · Orchid |
+| 🖌️ **Theme tự tạo** | Tự chỉnh màu và ảnh nền, lưu thành theme riêng |
+| 🔢 **Tuỳ chỉnh bố cục** | Bật hàng phím số · chỉnh kích thước phím |
+| 😀 **Bảng emoji** | Emoji picker của AndroidX, nạp trễ để bàn phím mở nhanh |
+| 📳 **Âm thanh và rung** | Chỉnh riêng cho từng loại phản hồi |
 
-Dependency direction is intentionally one-way:
+## Yêu cầu
+
+| | |
+|---|---|
+| **Hệ điều hành tối thiểu** | **Android 8.0 (Oreo, API 26)** trở lên |
+| **Thiết bị** | Điện thoại và máy tính bảng · `arm64-v8a` và `x86_64` |
+| **Cài đặt** | Đang ở vòng **kiểm thử khép kín**, chưa lên Play Store công khai |
+
+> [!IMPORTANT]
+> **Android 8.0 là sàn cứng.** `minSdk = 26` được đặt ở **toàn bộ sáu module** của dự án, nên
+> Google Play sẽ không cho cài trên máy chạy Android thấp hơn.
+>
+> Kiểm tra máy bạn: **Cài đặt → Giới thiệu điện thoại → Phiên bản Android**.
+
+## Cài đặt
+
+> [!NOTE]
+> **Funput chưa có trên Play Store công khai.** Google Play bắt buộc một vòng kiểm thử khép kín
+> đủ **14 ngày** với số tester tối thiểu trước khi cho xuất bản, và Funput đang chạy lại vòng đó.
+>
+> Muốn dùng thử và giúp Funput lên Play Store, gửi email tới
+> [hello@funput.app](mailto:hello@funput.app) — nên dùng Gmail gắn với tài khoản Google Play của
+> bạn. Chúng tôi sẽ mời bạn vào nhóm kiểm thử khép kín.
+
+Cài xong app **chưa gõ được ngay** — Android bắt buộc bật bàn phím thủ công. App tự dò xem bạn
+đang ở bước nào và hiện thẻ **Thiết lập Funput** với đúng nút cần bấm:
+
+1. **Bật Funput** trong cài đặt bàn phím của Android.
+2. **Chọn Funput** khi đang gõ — chạm biểu tượng bàn phím ở thanh điều hướng, hoặc giữ phím
+   🌐 / phím cách tuỳ máy.
+
+Xong bước hai, thẻ đổi thành **Funput đã sẵn sàng**.
+
+## Dùng hằng ngày
+
+### Thử nhanh
+
+| Kiểu gõ | Gõ | Ra |
+|---|---|---|
+| Telex | `tieesng vieejt` | tiếng việt |
+| VNI | `xin chao2` | xin chào |
+
+Mặc định lần đầu chạy là **VNI**. Đổi trong **Cài đặt → Bàn phím → Kiểu gõ**.
+
+> [!TIP]
+> **VNI luôn cần hàng phím số** để nhập dấu, nên Funput tự bật hàng số khi bạn chọn VNI. Với các
+> kiểu Telex thì hàng số là tuỳ chọn — bật hay tắt trong **Cài đặt → Bàn phím → Hàng phím số**.
+
+### Cử chỉ
+
+| Cử chỉ | Việc |
+|---|---|
+| **Gõ đúp phím cách** | Chèn dấu chấm và một khoảng trắng |
+| **Giữ phím cách rồi kéo** | Rê con trỏ **theo mọi hướng**, không chỉ trái phải |
+| **Vuốt trái trên phím xoá** | Xoá cả từ thay vì từng ký tự |
+
+Cả ba nằm chung một công tắc **Cử chỉ thông minh**.
+
+### Cài đặt có gì
+
+| Mục | Chỉnh được gì |
+|---|---|
+| **Bàn phím** | Kiểu gõ · hàng phím số · kích thước phím |
+| **Gõ thông minh** | Khôi phục tiếng Anh · khôi phục sớm · kiểm tra chính tả · tự viết hoa · gợi ý từ cá nhân |
+| **Giao diện** | Chọn theme dựng sẵn hoặc tự tạo theme riêng |
+| **Âm thanh & rung** | Phản hồi khi gõ |
+| **Cử chỉ** | Công tắc cử chỉ thông minh |
+
+Cấu hình lưu bằng **Preferences DataStore**; gỡ app là mất sạch, gồm cả theme tự tạo và gợi ý
+từ cá nhân.
+
+## Giới hạn đã biết
+
+- **Chưa lên Play Store công khai** — xem mục [Cài đặt](#cài-đặt).
+- **Chưa có công cụ Chuyển mã.** Đổi bảng mã hiện chỉ có trên bản desktop.
+- **Chỉ `arm64-v8a` và `x86_64`.** Máy 32-bit không nằm trong phạm vi hỗ trợ.
+
+## Gỡ cài đặt
+
+Gỡ app Funput như mọi app khác. Android tự bỏ bàn phím khỏi danh sách, cùng toàn bộ dữ liệu
+trong DataStore.
+
+Muốn giữ app nhưng tạm ngưng bàn phím thì tắt Funput trong cài đặt bàn phím của Android.
+
+---
+
+## Dành cho developer
+
+### Kiến trúc
+
+Shell và giao diện bàn phím viết bằng **Kotlin**; toàn bộ luật gõ tiếng Việt vẫn tới từ engine
+Rust dùng chung, qua **JNI** ([`funput-jni`](../../crates/funput-jni)).
+
+IME sở hữu composing span của Android, còn
+[`funput-engine`](../../crates/funput-engine) vẫn là **nguồn chân lý duy nhất** cho luật Telex,
+Telex nâng cao và VNI.
+
+| Module | Trách nhiệm |
+|---|---|
+| `app` | Host Compose cho onboarding, cài đặt, trình tạo theme và bản xem trước bàn phím |
+| `ime` | Vòng đời input-method của Android và cầu nối tới ô nhập đang focus |
+| `keyboard-ui` | Điều hướng giữa các panel và emoji picker AndroidX nạp trễ |
+| `keyboard-renderer` | Bố cục co giãn, chạm, trợ năng và vẽ bằng Canvas |
+| `theme-runtime` | Hợp đồng theme có version, kiểm tra hợp lệ, phân giải token, truy cập asset an toàn |
+| `theme-store` | Lưu theme tự tạo: JSON, bản nháp và kho asset |
+
+Chiều phụ thuộc là **một chiều, cố ý**:
 
 ```text
-app -> ime -> keyboard-ui -> keyboard-renderer -> theme-runtime
-app --------> keyboard-ui ----------------------> theme-runtime
+app ──▶ ime ──▶ keyboard-ui ──▶ keyboard-renderer ──▶ theme-runtime
+ │       │           │                                     ▲
+ │       └──▶ theme-store ────────────────────────────────┤
+ │                                                         │
+ ├──▶ keyboard-renderer ──────────────────────────────────┤
+ └──▶ theme-runtime ──────────────────────────────────────┘
 ```
 
-The app persists the Vietnamese input method with Preferences DataStore. VNI is
-the first-run default; selecting Telex, Advanced Telex, or VNI in the app updates
-the active IME through the same observable setting.
+`theme-runtime` là lá — nó không phụ thuộc module nào khác trong dự án.
 
-The IME owns Android composing spans while `funput-engine` remains the only
-source of truth for Telex, Advanced Telex, and VNI rules.
+### Build
 
-## Build
-
-Open this directory in the latest stable Android Studio, or run:
+Mở thư mục này bằng Android Studio bản stable mới nhất, hoặc chạy:
 
 ```bash
 ./gradlew :app:assembleDebug
 ```
 
-The Gradle build cross-compiles `funput-jni` for `arm64-v8a` and `x86_64`.
-Install the matching Rust standard libraries once:
+Gradle sẽ cross-compile `funput-jni` cho `arm64-v8a` và `x86_64`. Cài thư viện chuẩn Rust tương
+ứng một lần:
 
 ```bash
 rustup target add aarch64-linux-android x86_64-linux-android
 ```
 
-The project requires Android SDK 37, NDK 29, and supports Android 8.0 (API 26)
-or newer. The NDK version is pinned for reproducible native builds.
+| | |
+|---|---|
+| Kotlin | Jetpack Compose *(app)* + Canvas *(bàn phím)* |
+| `compileSdk` · `targetSdk` | **37** |
+| `minSdk` | **26** — đặt ở cả sáu module |
+| NDK | `29.0.14206865` — ghim để build native tái lập được |
+| Application ID | `app.funput.funput` |
 
-## Release
+### Phát hành
 
-`Deploy Android` (`.github/workflows/deploy-android.yml`) is manual, like its iOS
-counterpart: run it from Actions on whichever branch you want to ship, type the
-marketing version, and pick a track. It builds the signed `.aab`, uploads it to
-Google Play, and attaches the ProGuard mapping so crash reports stay readable.
+`Deploy Android` ([`deploy-android.yml`](../../.github/workflows/deploy-android.yml)) chạy **thủ
+công**, giống bản iOS: mở Actions, chọn nhánh muốn ship, gõ marketing version và chọn track. Nó
+build `.aab` đã ký, tải lên Google Play, và đính kèm ProGuard mapping để crash report còn đọc
+được.
 
-The **version code is not committed** — it is derived from the workflow's run
-number, so shipping needs no version bump in the tree and two deploys can never
-claim the same code. `versionCode`/`versionName` in `app/build.gradle.kts` are only
-what a local build gets; CI passes `-Pfunput.versionCode` and `-Pfunput.versionName`
-over the top.
+> [!IMPORTANT]
+> **Version code không được commit.** Nó suy ra từ số thứ tự lần chạy workflow, nên phát hành
+> không cần bump version trong cây mã, và hai lần deploy không bao giờ giành cùng một mã.
+> `versionCode` / `versionName` trong `app/build.gradle.kts` chỉ là thứ một bản build tại máy
+> nhận được; CI truyền `-Pfunput.versionCode` và `-Pfunput.versionName` đè lên.
 
-`dry_run` builds and signs without uploading. The `.aab`, its SHA-256 and the
-mapping are attached to every run either way.
+`dry_run` build và ký nhưng không tải lên. Dù chọn kiểu nào, `.aab`, SHA-256 của nó và file
+mapping đều được đính vào mỗi lần chạy.
 
-Secrets the workflow needs are listed in its header. Uploading is not releasing:
-the build reaches the track you picked, and promoting it to production stays a
-deliberate act in the Play Console.
+Các secret mà workflow cần được liệt kê ngay ở đầu file đó. **Tải lên không phải là phát hành:**
+bản build tới đúng track bạn chọn, còn đẩy nó lên production vẫn là một hành động có chủ ý trong
+Play Console.
 
-See [`docs/ARCHITECTURE_PROPOSAL.md`](docs/ARCHITECTURE_PROPOSAL.md) for the
-long-term architecture. The repository is licensed under the
-[`MIT License`](../../LICENSE).
+Kiến trúc dài hạn: [`docs/ARCHITECTURE_PROPOSAL.md`](docs/ARCHITECTURE_PROPOSAL.md).
+
+## Giấy phép
+
+MIT — [`LICENSE`](../../LICENSE).
+
+<p align="center">
+  <sub>
+    <a href="https://funput.app">funput.app</a>
+    ·
+    <a href="../../README.md">README gốc</a>
+    ·
+    Made with ♥ by Funput
+  </sub>
+</p>

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -1,0 +1,268 @@
+<p align="center">
+  <img
+    src="../../assets/horizontal-lockup/gradient.png"
+    width="420"
+    alt="Funput"
+  >
+</p>
+
+<p align="center">
+  <strong>Funput cho iOS</strong> — bàn phím tiếng Việt cho iPhone và iPad.<br>
+  Tiện ích bàn phím UIKit · app cấu hình SwiftUI · engine Rust qua
+  <code>funput-ffi</code>
+</p>
+
+<p align="center">
+  <a href="https://apps.apple.com/vn/app/id6788829996">
+    <img src="https://img.shields.io/badge/Tải_về-App_Store-0D96F6?style=for-the-badge&logo=appstore&logoColor=white" alt="Funput trên App Store">
+  </a>
+  <a href="https://docs.funput.app/docs/install/ios">
+    <img src="https://img.shields.io/badge/Tài_liệu-Hướng_dẫn_cài_đặt-2563EB?style=for-the-badge&logo=readthedocs&logoColor=white" alt="Hướng dẫn cài đặt">
+  </a>
+  <a href="https://github.com/Funput/Funput/issues">
+    <img src="https://img.shields.io/badge/Hỗ_trợ-Báo_lỗi-E11D48?style=for-the-badge&logo=github&logoColor=white" alt="Báo lỗi">
+  </a>
+</p>
+
+---
+
+<p align="center">
+  <img
+    src="../../assets/screenshot/ios.png"
+    height="420"
+    alt="Bàn phím Funput trên iOS"
+  >
+  <br>
+  <sub>Bàn phím Funput trên iPhone.</sub>
+</p>
+
+## Tính năng
+
+| | |
+|---|---|
+| ⌨️ **Ba kiểu gõ** | Telex · **Telex nâng cao** (thêm `w` đầu từ và phím tắt `[` `]`) · VNI |
+| 🧠 **Nhập liệu thông minh** | Khôi phục từ thông minh · khôi phục sớm · kiểm tra chính tả · tự viết hoa |
+| 💬 **Gợi ý từ cá nhân** | Chỉ học chữ bạn gõ qua Funput, **lưu trên thiết bị** |
+| 👆 **Cử chỉ thông minh** | Gõ đúp phím cách để chấm câu · giữ phím cách rồi kéo để di chuyển con trỏ · vuốt trái phím xoá để xoá cả từ |
+| 🎨 **Theme** | 5 theme dựng sẵn, gồm cả Liquid Glass trên iOS 26 |
+| 🔢 **Bố cục** | Bật hàng phím số · chọn kiểu Funput hoặc “Giống hệ thống” |
+| 📋 **Lịch sử clipboard** | Chỉ lưu thứ bạn đã dán qua Funput, trên thiết bị |
+| 📳 **Phản hồi khi gõ** | Rung · âm thanh click · xem trước phím |
+| 😀 **Emoji và kaomoji** | Hai bảng riêng, tối ưu cho từng loại |
+
+## Yêu cầu
+
+| | |
+|---|---|
+| **Hệ điều hành tối thiểu** | **iOS / iPadOS 18.6** trở lên |
+| **Thiết bị** | iPhone và iPad |
+| **Cài đặt** | Miễn phí trên [App Store](https://apps.apple.com/vn/app/id6788829996) |
+| **Quyền** | Cần bật **Cho phép truy cập đầy đủ** — [xem vì sao](#vì-sao-cần-cho-phép-truy-cập-đầy-đủ) |
+
+> [!IMPORTANT]
+> **iOS 18.6 là sàn cứng.** Cả app lẫn tiện ích bàn phím đều khai `MinimumOSVersion` là `18.6`
+> *(kiểm chứng được trong chính bản đã đóng gói)*, nên App Store sẽ không cho cài trên máy chạy
+> iOS thấp hơn.
+>
+> Kiểm tra máy bạn: **Cài đặt → Cài đặt chung → Giới thiệu → Phiên bản phần mềm**.
+>
+> Giao diện **Liquid Glass cần iOS 26**. Trên iOS 18–25 bàn phím vẫn chạy đầy đủ, chỉ là các
+> theme kính đổi sang nền đặc tương đương.
+
+## Cài đặt
+
+Cài xong app **chưa gõ được ngay** — iOS bắt buộc bạn thêm bàn phím thủ công. Ba bước:
+
+1. **Cài Funput** từ [App Store](https://apps.apple.com/vn/app/id6788829996), rồi mở app một lần.
+2. **Thêm bàn phím:** Cài đặt → Cài đặt chung → Bàn phím → Các bàn phím → **Thêm bàn phím mới…** → **Funput**.
+3. **Bật quyền:** trong danh sách Các bàn phím, chọn **Funput** → bật **Cho phép truy cập đầy đủ**.
+
+Sau đó, ở bất kỳ ô nhập nào, chạm giữ phím 🌐 và chọn **Funput**.
+
+Thẻ **Hoàn tất thiết lập Funput** trong app tự dò xem bạn đã làm tới bước nào và mở thẳng đúng
+trang Cài đặt tương ứng.
+
+### Vì sao cần “Cho phép truy cập đầy đủ”
+
+iOS chạy tiện ích bàn phím trong sandbox riêng. Nếu không có quyền này, tiện ích **không đọc được
+App Group** — nơi app lưu mọi thiết lập của bạn. Hệ quả rất cụ thể: bàn phím sẽ không biết bạn
+chọn Telex hay VNI, không lấy được theme, không thấy gợi ý từ cá nhân, và không rung hay phát
+tiếng khi gõ.
+
+> [!NOTE]
+> **Funput không gửi thứ bạn gõ đi đâu cả.** Tiện ích bàn phím **không chứa một dòng code mạng
+> nào** — không `URLSession`, không kết nối ra ngoài. Privacy manifest khai
+> `NSPrivacyTracking = false` và **không thu thập dữ liệu người dùng**
+> *(`NSPrivacyCollectedDataTypes` rỗng)*. Gợi ý từ cá nhân và lịch sử clipboard nằm trên máy bạn.
+>
+> Kiểm chứng được: [`Keyboard/PrivacyInfo.xcprivacy`](Keyboard/PrivacyInfo.xcprivacy) và
+> toàn bộ [`Keyboard/`](Keyboard).
+
+## Dùng hằng ngày
+
+### Chuyển bàn phím
+
+Chạm giữ phím 🌐 rồi chọn **Funput**. Muốn bỏ bớt bàn phím thừa trong vòng lặp thì vào
+Cài đặt → Cài đặt chung → Bàn phím → Các bàn phím → **Sửa**.
+
+### Thử nhanh
+
+| Kiểu gõ | Gõ | Ra |
+|---|---|---|
+| Telex | `tieesng vieejt` | tiếng việt |
+| VNI | `xin chao2` | xin chào |
+
+### Cử chỉ
+
+| Cử chỉ | Việc |
+|---|---|
+| **Gõ đúp phím cách** | Chèn dấu chấm và một khoảng trắng |
+| **Giữ phím cách rồi kéo** | Biến bàn phím thành trackpad để rê con trỏ |
+| **Vuốt trái trên phím xoá** | Xoá cả từ thay vì từng ký tự |
+
+Cả ba nằm chung một công tắc **Cử chỉ thông minh** trong Cài đặt.
+
+### Cấu hình lưu ở đâu
+
+Trong App Group `group.app.funput.funput`, dùng chung giữa app và tiện ích bàn phím. Không có file
+cấu hình để chép tay; gỡ app là mất sạch.
+
+## Giới hạn đã biết
+
+- **Không có “Cho phép truy cập đầy đủ” thì gần như không dùng được.** Đây là ràng buộc của iOS
+  với mọi bàn phím bên thứ ba, không riêng Funput.
+- **Liquid Glass chỉ có trên iOS 26.** Máy cũ hơn nhận nền đặc tương đương.
+- **Chưa có công cụ Chuyển mã.** Đổi bảng mã hiện chỉ có trên bản desktop.
+
+## Cập nhật
+
+Qua App Store như mọi app khác. Bật **Cập nhật ứng dụng tự động** trong
+Cài đặt → App Store nếu muốn không phải nghĩ tới nó nữa.
+
+## Gỡ cài đặt
+
+Xoá app Funput là iOS tự gỡ luôn tiện ích bàn phím khỏi danh sách Các bàn phím, cùng toàn bộ dữ
+liệu trong App Group — gồm cả gợi ý từ cá nhân và lịch sử clipboard.
+
+Muốn giữ app nhưng tạm ngưng bàn phím thì vào Cài đặt → Cài đặt chung → Bàn phím → Các bàn phím →
+**Sửa** → xoá Funput khỏi danh sách.
+
+---
+
+## Dành cho developer
+
+### Kiến trúc
+
+Hai bundle rời nhau, nối bằng một App Group. App cấu hình viết bằng **SwiftUI**; bàn phím viết
+bằng **UIKit** vì nó cần kiểm soát chạm và vòng đời ở mức thấp hơn nhiều so với những gì SwiftUI
+cho phép. Logic dùng chung nằm trong **FunputKit**, một SPM package cục bộ.
+
+Khác macOS *(preedit qua `setMarkedText`)*, iOS **commit thẳng** vào document —
+đây là lựa chọn thiết kế, không phải giới hạn của nền tảng.
+
+```text
+Funput.app      containing app — app.funput.funput
+│
+├── Onboarding .............. hướng dẫn 3 bước bật bàn phím
+├── Cài đặt ................. SwiftUI · theme · gợi ý · cử chỉ
+└── App Group ............... group.app.funput.funput
+             │
+             │   UserDefaults(suiteName:) — đây là lý do cần
+             │   “Cho phép truy cập đầy đủ”
+             ▼
+Keyboard.appex  tiện ích bàn phím — app.funput.funput.Keyboard
+│
+├── UIInputViewController ... vòng đời · chiều cao · traits
+├── KeyboardTouch* .......... chạm · rollover · key repeat
+├── KeyboardRenderer ........ vẽ phím bằng Core Animation
+└── KeyboardInput ........... phím → engine
+             │
+             └──▶ FunputCore.xcframework ──▶ funput-engine
+                  (funput-ffi, C ABI, link tĩnh)
+```
+
+Tài liệu kiến trúc chi tiết: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md),
+[`docs/INPUT_PIPELINE_2_ARCHITECTURE.md`](docs/INPUT_PIPELINE_2_ARCHITECTURE.md),
+[`docs/INPUT_PIPELINE_3_ARCHITECTURE.md`](docs/INPUT_PIPELINE_3_ARCHITECTURE.md).
+
+### Cây thư mục
+
+```text
+platforms/ios/
+  Funput.xcodeproj
+  Funput/                  Containing app (SwiftUI)
+    App/ Settings/ About/ Appearance/ Components/
+  Keyboard/                Tiện ích bàn phím (UIKit)
+    Controller/              UIInputViewController + gestures, height, traits, input
+    Document/ Suggestions/ Clipboard/ Presentation/ Diagnostics/
+    Info.plist · Keyboard.entitlements · PrivacyInfo.xcprivacy
+  Packages/FunputKit/      SPM cục bộ, 11 module dùng chung
+  Frameworks/              FunputCore.xcframework — sinh ra, không commit
+  FunputTests/ FunputUITests/
+  Scripts/  docs/
+```
+
+### Stack
+
+| | |
+|---|---|
+| Swift | `6.3`, Swift language mode 6 · SwiftUI *(app)* + UIKit *(bàn phím)* |
+| Deployment target | **`18.6`** cho cả app, bàn phím và test target |
+| Engine | [`funput-ffi`](../../crates/funput-ffi) đóng thành `FunputCore.xcframework`, link tĩnh |
+| Cấu hình chia sẻ | App Group `group.app.funput.funput` + `UserDefaults(suiteName:)` |
+| Phát hành | App Store Connect → TestFlight → App Store |
+
+> [!WARNING]
+> **Cài đặt cấp project là `IPHONEOS_DEPLOYMENT_TARGET = 26.5`, không phải 18.6.** Mọi target hiện
+> có đều ghi đè xuống 18.6 nên giá trị đó vô hại — nhưng một target **mới** thêm vào mà quên đặt
+> giá trị riêng sẽ âm thầm thừa kế 26.5, tức là loại bỏ gần hết thiết bị người dùng. Đặt
+> `IPHONEOS_DEPLOYMENT_TARGET` một cách tường minh cho mọi target mới.
+
+### Build
+
+Cần **macOS** + Xcode, cộng Rust toolchain để dựng `FunputCore.xcframework`.
+
+```bash
+# Lần đầu: dựng xcframework từ funput-ffi (device + simulator)
+./Scripts/bootstrap-ios.sh
+```
+
+```bash
+# Test logic dùng chung, không cần Xcode project
+./Scripts/test-funput-kit.sh
+```
+
+```bash
+# Build + test đầy đủ
+xcodebuild -project Funput.xcodeproj -scheme Funput \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test
+```
+
+Giới hạn kích thước file Swift: **150 dòng/file**, tối đa **5 file/thư mục tính năng** —
+[`Scripts/check-swift-loc.sh`](Scripts/check-swift-loc.sh), và CI có gác cổng này.
+
+### CI
+
+| Workflow | Việc |
+|---|---|
+| [`ci.yml`](../../.github/workflows/ci.yml) | Job `shell-line-budget` chạy `check-swift-loc.sh`. **Không** compile hay test Swift |
+| [`deploy-ios.yml`](../../.github/workflows/deploy-ios.yml) | `workflow_dispatch` thủ công: test FunputKit · build `.ipa` · ký Apple Distribution · tải lên App Store Connect → TestFlight |
+
+> [!WARNING]
+> **Test iOS không chạy trên pull request.** Chúng chỉ nằm trong `deploy-ios.yml`, mà workflow đó
+> chạy thủ công và **cố ý không** nối vào `release.yml` — mỗi lần tải lên là đốt một build number.
+> Hãy chạy `./Scripts/test-funput-kit.sh` tại máy trước khi mở PR.
+
+## Giấy phép
+
+MIT — [`LICENSE`](../../LICENSE).
+
+<p align="center">
+  <sub>
+    <a href="https://funput.app">funput.app</a>
+    ·
+    <a href="../../README.md">README gốc</a>
+    ·
+    Made with ♥ by Funput
+  </sub>
+</p>

--- a/platforms/ios/docs/ARCHITECTURE.md
+++ b/platforms/ios/docs/ARCHITECTURE.md
@@ -31,7 +31,7 @@ Funput iOS sử dụng kiến trúc **hybrid native**: giao diện và tích h�
 - **Swift:** 6.3, Swift language mode 6
 - **iOS SDK:** 26.4
 - **Rust:** 1.97 stable, edition 2024
-- **Minimum deployment:** iOS 18.0
+- **Minimum deployment:** iOS 18.6 — giá trị `IPHONEOS_DEPLOYMENT_TARGET` của mọi target trong `Funput.xcodeproj`, và là `MinimumOSVersion` của cả `.app` lẫn `.appex` khi đóng gói. Lưu ý cài đặt **cấp project** là 26.5: mọi target hiện có đều ghi đè xuống 18.6, nhưng một target mới quên đặt giá trị riêng sẽ âm thầm thừa kế 26.5
 - **Giao diện mục tiêu chính:** iOS/iPadOS 26.4
 
 Không đóng băng toolchain vĩnh viễn. Khi bắt đầu một milestone mới, cập nhật lên bản stable mới nhất sau khi CI và test thiết bị đã xanh.

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -1,411 +1,530 @@
-# Funput on Linux
+<p align="center">
+  <img
+    src="../../assets/horizontal-lockup/gradient.png"
+    width="420"
+    alt="Funput"
+  >
+</p>
 
-Two input-method shells — **Fcitx5** and **IBus** — over one shared composer, which
-in turn drives the Rust engine (`crates/funput-engine`) through the `funput-ffi`
-C ABI.
+<p align="center">
+  <strong>Funput cho Linux</strong> — bộ gõ tiếng Việt cho <b>Fcitx5</b> và <b>IBus</b>.<br>
+  Hai shell · một composer dùng chung · engine Rust qua <code>funput-ffi</code>
+</p>
 
-## Layout
+<p align="center">
+  <a href="https://repo.funput.app">
+    <img src="https://img.shields.io/badge/Kho_phần_mềm-repo.funput.app-22C55E?style=for-the-badge&logo=linux&logoColor=white" alt="Kho Funput">
+  </a>
+  <a href="https://docs.funput.app/docs/install/linux">
+    <img src="https://img.shields.io/badge/Tài_liệu-Hướng_dẫn_cài_đặt-2563EB?style=for-the-badge&logo=readthedocs&logoColor=white" alt="Hướng dẫn cài đặt">
+  </a>
+  <a href="https://github.com/Funput/Funput/issues">
+    <img src="https://img.shields.io/badge/Hỗ_trợ-Báo_lỗi-E11D48?style=for-the-badge&logo=github&logoColor=white" alt="Báo lỗi">
+  </a>
+</p>
+
+---
+
+## Tính năng
+
+| | |
+|---|---|
+| ⌨️ **Ba kiểu gõ** | Telex · **Telex nâng cao** (thêm `w` đầu từ và phím tắt `[` `]`) · VNI |
+| 🔤 **Kiểu đặt dấu** | Truyền thống (`hòa`, `khỏe`) hoặc hiện đại (`hoà`, `khoẻ`) |
+| 🧠 **Gõ thông minh** | Tự khôi phục tiếng Anh · khôi phục tức thì · kiểm tra chính tả · tự động viết hoa |
+| ✂️ **Gõ tắt** | Bảng viết tắt tự bung, tuỳ chọn khớp cả hoa lẫn thường |
+| 🔄 **Chuyển mã** | Đổi qua lại giữa Unicode dựng sẵn, Unicode tổ hợp, TCVN3 (ABC) và VNI-Windows |
+| ⚙️ **App Cài đặt GTK4** | Dùng chung cho cả hai shell, giao diện libadwaita |
+| 📝 **Chế độ không preedit** | Gõ thẳng vào tài liệu thay vì hiện preedit — cứu được Chrome. [Chi tiết](#chế-độ-không-preedit) |
+| 🔁 **Nạp lại cấu hình tức thì** | `inotify` theo dõi `settings.json`, không cần khởi động lại |
+
+## Yêu cầu
+
+| | |
+|---|---|
+| **Framework** | **Fcitx5** hoặc **IBus** — chọn đúng cái mà phiên desktop đang chạy |
+| **Distro** | Debian/Ubuntu (`.deb`) · Fedora/openSUSE (`.rpm`) · Arch (`pacman`) |
+| **Kiến trúc** | x86-64 |
+| **Quyền root** | Cần, trừ khi dùng `install.sh --user` |
+
+| Framework | Gói | Dùng khi |
+|---|---|---|
+| **Fcitx5** | `funput` | **Khuyến nghị.** Chạy được với cả những client mà IBus không với tới, ví dụ WPS Office |
+| IBus | `funput-ibus` | Bạn muốn dùng đúng thứ GNOME/Ubuntu đã nối sẵn và không cần đụng biến môi trường |
+
+Fcitx5 là mặc định của `install.sh` trên **mọi** desktop. Đổi lại, ngoài KDE bạn phải đặt biến
+môi trường cho session rồi đăng nhập lại — xem [mục Cài đặt](#cài-đặt).
+
+> [!CAUTION]
+> **Đừng cài cả hai gói cho cùng một phiên desktop.** Chạy hai bộ gõ song song sẽ tranh nhau
+> phím và cho ra hành vi khó lần ra. Chọn đúng một framework mà session đang dùng.
+
+## Cài đặt
+
+Cách khuyến nghị là **kho `repo.funput.app`** — kho apt/dnf/zypper/pacman có ký GPG, nên
+`apt upgrade` hay `dnf upgrade` sẽ nâng cấp Funput như mọi gói hệ thống khác. Thêm kho một lần,
+sau đó quên nó đi.
+
+Nhanh nhất là để script tự dò distro rồi cấu hình kho:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Funput/Funput/main/platforms/linux/install.sh | bash
+```
+
+Script cài gói **Fcitx5** trên **mọi** desktop; `--ibus` mới chọn bản IBus. Trước đây nó đoán
+theo `XDG_CURRENT_DESKTOP` (KDE → Fcitx5, còn lại → IBus), và điều đó trao cho phần lớn người
+dùng đúng cái shell **không với tới nổi** một client kiểu WPS.
+
+| Cờ | Việc |
+|---|---|
+| `--ibus` · `--fcitx5` | Chọn framework |
+| `--dry-run` | In ra mọi lệnh sẽ chạy, **không chạy gì cả** |
+| `--no-repo` | Bỏ qua kho, tải thẳng asset từ GitHub Releases — **không tự cập nhật** |
+| `--version vX.Y.Z` | Cài đúng một phiên bản (ngầm định `--no-repo`) |
+| `--user` | Cài vào `~/.local`, **không cần root** |
+
+> [!IMPORTANT]
+> **Ngoài KDE, cài xong Fcitx5 vẫn chưa gõ được ngay.** Phiên desktop của bạn đang nối vào
+> **IBus**, nên Fcitx5 không nhận được gì cho tới khi bạn đặt biến môi trường cho session rồi
+> **đăng xuất đăng nhập lại**. Script nói điều này trước khi cài, và in lại các biến đó sau khi
+> cài xong.
+>
+> Funput **không** tự đặt `GTK_IM_MODULE` / `QT_IM_MODULE` giúp bạn — chúng thuộc về session,
+> không thuộc về chúng tôi, và đặt sai còn hại hơn không đặt. Giá trị đúng phụ thuộc
+> **loại session trước tiên**:
+>
+> | Session | Cần đặt |
+> |---|---|
+> | **X11** | Bộ ba kinh điển `XMODIFIERS` + `GTK_IM_MODULE` + `QT_IM_MODULE` |
+> | **Wayland · GNOME** *(và sway)* | `XMODIFIERS=@im=fcitx` và `QT_IM_MODULE=fcitx` — hoặc `QT_IM_MODULES=wayland;fcitx` trên Qt 6.8.2+ — **để trống** `GTK_IM_MODULE` |
+> | **Wayland · KDE** | Chỉ `XMODIFIERS=@im=fcitx` |
+>
+> Dưới Wayland, GTK 3/4 tự nói chuyện với compositor qua `text-input-v3`, nên đặt cả bộ ba
+> khiến KWin nhấp nháy cửa sổ gợi ý. `install.sh` đọc `$XDG_SESSION_TYPE` và chỉ in đúng khối
+> áp dụng cho bạn. Trên Debian/Ubuntu việc này thuộc về `im-config` *(vốn không làm gì trong
+> phiên Wayland — hook của nó ship ở trạng thái tắt)*, trên Fedora là `fcitx5-autostart`.
+> Nguồn: [Using Fcitx 5 on Wayland](https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland) ·
+> [Setup Fcitx 5](https://fcitx-im.org/wiki/Setup_Fcitx_5).
+
+> [!NOTE]
+> `install.sh` được phát hành dưới dạng một dòng `curl … | bash`, tức là đòi hỏi rất nhiều
+> lòng tin. Nên nó **in kế hoạch ra trước khi làm**, có `--dry-run`, và mọi asset lấy từ GitHub
+> Releases đều được đối chiếu với **SHA-256 do API của release công bố** — các bản phát hành
+> không kèm file `.sha256`, nên thật ra chưa bao giờ có chuyện tự kiểm checksum bằng tay.
+
+Các bước thêm kho thủ công cho từng distro nằm ở
+[docs.funput.app — Linux](https://docs.funput.app/docs/install/linux) và
+[repo.funput.app](https://repo.funput.app) (có sẵn nút copy lệnh).
+
+> [!NOTE]
+> **Không có quyền root?** Dùng `install.sh --user`: nó đặt engine vào `~/.local`, không đụng
+> tới trình quản lý gói. Cần sẵn daemon IBus hoặc Fcitx5 trên máy. IBus dùng được ngay; Fcitx5
+> còn ghi thêm `~/.config/environment.d` nên phải đăng xuất rồi đăng nhập lại.
+
+### Bật bộ gõ
+
+**IBus (GNOME / Ubuntu):** Settings → Keyboard → Input Sources → **+** → Vietnamese → **Funput**.
+
+**Fcitx5:** Fcitx5 Configuration → **+** → bỏ chọn "Only Show Current Language" → **Funput**.
+
+Nếu chưa thấy Funput trong danh sách:
+
+- **IBus:** chạy `ibus restart`, hoặc đăng xuất rồi đăng nhập lại.
+- **Fcitx5:** đăng xuất rồi đăng nhập lại.
+
+> [!CAUTION]
+> **Trên KDE, đừng chạy `fcitx5 -r`.** KWin khởi động Fcitx5 từ Virtual Keyboard KCM và trao
+> cho nó một socket mà tiến trình thay thế **không kế thừa được**, nên khởi động lại daemon sẽ
+> làm hỏng việc nhập liệu của mọi client Wayland cho tới lần đăng nhập kế tiếp. Đăng xuất rồi
+> đăng nhập lại mới là cách đúng.
+
+## Dùng hằng ngày
+
+### Phím tắt
+
+| Phím | Việc |
+|---|---|
+| **`Ctrl` + `` ` ``** | Bật / tắt tiếng Việt *(mặc định)* |
+| **`Ctrl` `Shift` `Z`** | Lật lại từ vừa gõ *(mặc định tắt)* |
+
+Đổi được trong app **Cài đặt**. Phím chuyển có 5 lựa chọn: `Ctrl` + `` ` ``, `Ctrl Space`,
+`Alt Shift`, `Super Space`, `Ctrl Shift Space`.
+
+### Thử nhanh
+
+| Kiểu gõ | Gõ | Ra |
+|---|---|---|
+| Telex | `tieesng vieejt` | tiếng việt |
+| VNI | `xin chao2` | xin chào |
+
+### Cấu hình lưu ở đâu
 
 ```
-common/                 Framework-free C++ shared by both shells
-  compose/                The typing rules: one copy, no Fcitx5/IBus symbols
-    plan.h                  ComposePlan — what the shell is asked to do
+~/.config/Funput/settings.json
+```
+
+Sửa bằng app **Cài đặt**, hoặc sửa tay file JSON cũng được — một watcher `inotify` sẽ nạp lại
+ngay, không cần khởi động lại bộ gõ.
+
+### Chuyển mã
+
+Có hai lối vào, vì Linux **không có khay hệ thống** như chỗ Windows đặt nó:
+
+- **Cài đặt → Chung → “Công cụ chuyển mã”**
+- Mục **Funput Chuyển mã** trong menu ứng dụng *(chạy `funput-settings --convert`)*
+
+Cả hai đều tới cùng một process.
+
+## Giới hạn đã biết
+
+> [!IMPORTANT]
+> **Không có tính năng nhớ VI/EN theo từng ứng dụng trên Linux.** Trên GNOME/Wayland, mọi
+> ứng dụng đều báo tên tiến trình là `gnome-shell`, không phải app thật — nên một chính sách
+> dựa trên giá trị đó sẽ áp cho tất cả cùng lúc. macOS và Windows có tính năng này; Linux thì
+> không, và đó là giới hạn của nền tảng chứ không phải thiếu sót chưa làm.
+
+- **Chrome không hiện preedit.** Commit vào bình thường, nhưng mọi thứ cần client tự vẽ và quản
+  lý composition thì không. Đây là phía Chrome, Funput không với tới được —
+  [chế độ không preedit](#chế-độ-không-preedit) chính là câu trả lời cho Chrome.
+- **WPS Office không vẽ preedit của client.** Nó lại khai là *có* năng lực Preedit, nên panel
+  preedit của Fcitx5 cũng bị bỏ qua, khiến từ đang gõ vô hình cho tới khi nhấn Space. Chế độ
+  không preedit cũng không chạy được: WPS không hiện thực `Qt::ImSurroundingText`, và ép
+  xoá-rồi-commit sẽ làm nát chữ (`nguyen64` trả về `nguyenênễn`). Vì vậy **shell Fcitx5 tự vẽ
+  panel preedit** cho mọi tên tiến trình nằm trong allowlist ở `hidden_preedit.cpp` (hiện là
+  `wps`, `wpp`, `et`, `wpspdf`), đồng thời vẫn gửi client preedit để không mất lần flush khi
+  focus-out. Thêm một client kiểu này chỉ là thêm một cái tên vào danh sách đó. **IBus không có
+  kênh nào chạy được ở đây** — ForwardKeyEvent đã bị bỏ, surrounding text thì không bao giờ
+  tới — nên IBus được để yên.
+- **Bỏ dấu sau Backspace chỉ chạy ở chế độ không preedit.** Ở chế độ preedit, Backspace chỉ rút
+  ngắn composition, nên `phủ` ␣ ⌫ `s` ra chữ `s` thường.
+- **Một số client làm mất từ đang gõ dở khi đổi focus.** Cả hai shell giao việc flush cho
+  framework; client nào bỏ preedit thay vì commit thì mất từ đó.
+- **App Cài đặt ghi đè nguyên `settings.json`.** Nó serialize struct của chính nó lên file, nên
+  một khoá nó không biết sẽ bị xoá ở lần bạn đổi thiết lập kế tiếp.
+- **Chưa có AppStream metainfo**, nên `funput-settings` không xuất hiện trong GNOME Software
+  hay KDE Discover.
+
+## Gỡ cài đặt
+
+```bash
+sudo apt remove funput funput-ibus funput-settings     # Debian / Ubuntu
+sudo dnf remove funput funput-ibus funput-settings     # Fedora / openSUSE
+sudo pacman -R funput funput-settings                  # Arch
+```
+
+Xoá luôn cấu hình nếu muốn sạch hẳn:
+
+```bash
+rm -rf ~/.config/Funput
+```
+
+Cách gỡ kho `repo.funput.app` nằm ở [docs.funput.app — Linux](https://docs.funput.app/docs/install/linux#gỡ-kho-funput-nếu-cần).
+
+---
+
+## Dành cho developer
+
+### Kiến trúc
+
+Hai shell input-method — **Fcitx5** và **IBus** — chồng lên **một composer dùng chung**, và
+composer đó điều khiển engine Rust ([`crates/funput-engine`](../../crates/funput-engine)) qua
+C ABI của [`funput-ffi`](../../crates/funput-ffi).
+
+Điểm mấu chốt: **shell không quyết định gì cả.** Nó dịch sự kiện phím của framework thành
+`funput::KeyEvent`, đưa cho `funput::Composer`, rồi thi hành `funput::ComposePlan` nhận về. Mọi
+chuyện *nên làm gì* nằm hết trong `common/compose/`. Trước khi có tách bạch này, cây quyết định
+tồn tại hai bản — mỗi shell một — và chúng đã trôi khỏi nhau.
+
+```text
+        Ứng dụng đang gõ
+               │  sự kiện phím
+               ▼
+   Fcitx5 addon          IBus engine
+   libfunput.so          ibus-engine-funput
+               │  chỉ dịch sự kiện, không quyết định
+               ▼
+   common/compose/   Composer — toàn bộ luật gõ, MỘT bản duy nhất
+               │     không tham chiếu ký hiệu nào của Fcitx5/IBus
+               ▼
+   funput-ffi ──▶ funput-engine ──▶ funput-core
+               │
+               ▼
+   ComposePlan ──▶ shell thi hành: preedit · commit · deleteChars
+```
+
+Thứ thật sự khác nhau giữa hai shell chỉ là preedit tới client bằng đường nào, và **ai commit
+nó khi mất focus** — Fcitx5 dùng `setClientPreedit` cộng watcher focus-out, IBus dùng
+`IBUS_ENGINE_PREEDIT_COMMIT`. Cả hai đều có chú thích tại chỗ.
+
+Mô hình này giống hệt các nền tảng desktop khác: `crates/funput-desktop/src/key.rs` là đúng cái
+classifier ấy cho shell hook trên Windows, và `inject.rs` của nó là đúng cái tách bạch “core trả
+về kế hoạch, shell thi hành”.
+
+### Cây thư mục
+
+```text
+common/                 C++ thuần, không framework, dùng chung cho cả hai shell
+  compose/                Luật gõ: một bản, không ký hiệu Fcitx5/IBus
+    plan.h                  ComposePlan — shell được yêu cầu làm gì
     key/
-      event.h                 Mods / KeyEvent / keysym constants (no dependencies)
-      classify.h/.cpp         KeyKind + what a key means
-      boundary.h              Word-boundary test
+      event.h                 Mods / KeyEvent / hằng keysym (không phụ thuộc gì)
+      classify.h/.cpp         KeyKind + ý nghĩa của một phím
+      boundary.h              Kiểm tra ranh giới từ
     composer/
-      composer.h              The state machine (engine + settings + VI/EN)
-      keys.cpp                onKey(): the keystroke decision tree
-      state.cpp               Settings, VI/EN, and the non-key exits
-      nonpreedit.h            Commit-as-you-type: the mode, and judging a client
-      nonpreedit.cpp          What the composer does with that judgement
+      composer.h              Máy trạng thái (engine + settings + VI/EN)
+      keys.cpp                onKey(): cây quyết định cho mỗi phím
+      state.cpp               Settings, VI/EN, và các lối thoát không phải phím
+      nonpreedit.h            Chế độ commit-khi-gõ, và cách đánh giá một client
+      nonpreedit.cpp          Composer làm gì với đánh giá đó
   settings/               ~/.config/Funput/settings.json
-    settings.h              The model every shell reads, gõ tắt switches included
-    lookup.cpp              Where the file lives; app exclusion
-    io.cpp                  Parse and save (JSON)
-    watch.h/.cpp            inotify watcher for live reload
-  ffi/                    The funput-ffi C ABI
-    handle.h                RAII wrapper around the engine handle
-    utf8.h                  UTF-8 <-> UTF-32 marshalling
-  tests/                  doctest, in a tree mirroring the above
-fcitx5/src/             Fcitx5 addon -> libfunput.so
-  funput_input.cpp        One keystroke: normalize, ask the composer
-  funput_client.cpp       Talking to the client, both directions
-  hidden_preedit.cpp      Clients that hide the client preedit (allowlist)
+    settings.h              Model mọi shell đều đọc, gồm cả công tắc gõ tắt
+    lookup.cpp              File nằm đâu; loại trừ theo app
+    io.cpp                  Parse và lưu (JSON)
+    watch.h/.cpp            Watcher inotify để nạp lại tức thì
+  ffi/                    C ABI của funput-ffi
+    handle.h                Bọc RAII quanh handle của engine
+    utf8.h                  Chuyển đổi UTF-8 <-> UTF-32
+  tests/                  doctest, cây thư mục soi gương phần trên
+fcitx5/src/             Addon Fcitx5 -> libfunput.so
+  funput_input.cpp        Một phím: chuẩn hoá, hỏi composer
+  funput_client.cpp       Nói chuyện với client, cả hai chiều
+  hidden_preedit.cpp      Danh sách client tự giấu preedit (allowlist)
 ibus/src/               IBus engine -> ibus-engine-funput
-  engine.h                The public GObject type
+  engine.h                Kiểu GObject công khai
   engine/                 internal.h, object.cpp, callbacks.cpp, client.cpp
-settings-gtk/           GTK4 + libadwaita Settings app (its own cargo crate,
-                        and its own package — see Build)
-  src/settings_window/    one submodule per preferences page
-    shortcuts/              the gõ tắt switches, the rows, the empty state
-  src/convert/            the Chuyển mã window — see below
-packaging/              two .desktop files, apt/dnf repo metadata
+settings-gtk/           App Cài đặt GTK4 + libadwaita (crate cargo riêng,
+                        và là gói riêng — xem mục Build)
+  src/settings_window/    mỗi trang preferences một submodule
+    shortcuts/              công tắc gõ tắt, các hàng, trạng thái rỗng
+  src/convert/            cửa sổ Chuyển mã — xem bên dưới
+packaging/              hai file .desktop, metadata kho apt/dnf/pacman
 ```
 
-Directories are kept to five files or fewer; when one grows past that, it splits by
-concern rather than by size.
+Mỗi thư mục giữ tối đa năm file; vượt quá thì tách theo mối quan tâm chứ không theo kích thước.
+Mọi file ở đây bị giới hạn **150 dòng** bởi `scripts/check-loc.sh`, kể cả file test.
 
-The split is deliberate: **the shells decide nothing.** They translate their
-framework's key event into a `funput::KeyEvent`, hand it to `funput::Composer`, and
-perform the returned `funput::ComposePlan`. Everything about *what* should happen
-lives in `common/compose/`. Before it did, the same decision tree existed twice —
-once per shell — and drifted.
+### Build
 
-What genuinely stays per-shell is how a preedit reaches the client and who commits
-it when focus is lost (Fcitx5's `setClientPreedit` + its focus-out watcher, IBus's
-`IBUS_ENGINE_PREEDIT_COMMIT`). Both are commented where they live.
-
-The model mirrors the other desktop platforms: `crates/funput-desktop/src/key.rs`
-is the same classifier for the Windows hook shell, and its `inject.rs` is the same
-"the core returns a plan, the shell performs it" split.
-
-## Build
-
-Needs the build deps for whichever shell you are packaging:
+Cài dependency cho shell bạn định đóng gói:
 
 ```bash
 sudo apt-get install cmake nlohmann-json3-dev fcitx5 libfcitx5core-dev libfcitx5utils-dev libfcitx5config-dev ibus libibus-1.0-dev libglib2.0-dev libgtk-4-dev libadwaita-1-dev librsvg2-dev
 ```
 
-Then, from the repo's `app/` directory:
+Rồi chạy từ thư mục `app/` của repo:
 
 ```bash
 FUNPUT_FRAMEWORK=all platforms/linux/build.sh
 ```
 
-`FUNPUT_FRAMEWORK` takes `fcitx5`, `ibus` or `all`; `FUNPUT_PKG` takes `deb` or
-`rpm` (default: whichever the host supports). Each shell is its own top-level CMake
-project, so they package independently.
+`FUNPUT_FRAMEWORK` nhận `fcitx5`, `ibus` hoặc `all`; `FUNPUT_PKG` nhận `deb` hoặc `rpm` (mặc
+định theo host). Mỗi shell là một project CMake cấp cao riêng, nên đóng gói độc lập được.
 
-Three packages come out, not two. `funput` (Fcitx5) and `funput-ibus` each hold their
-own addon, and **`funput-settings`** holds the GUI, its launcher and its icons. Those
-four files used to be shipped by both shells, which meant dpkg refused to unpack the
-second one — identical contents are still a file conflict, so installing both was
-simply impossible on Debian/Ubuntu. `funput-settings` is built whichever framework you
-asked for, since both depend on it.
+**Ra ba gói, không phải hai:**
 
-That dependency is pinned to the exact version (`funput-settings (= <version>)`), and
-that is the part worth keeping: the Settings app rewrites `settings.json` from its own
-struct, so a copy older than the addon deletes settings the addon has since learned.
-The package manager now refuses the mismatch that used to cause it.
+| Gói | Chứa |
+|---|---|
+| `funput` | Addon Fcitx5 |
+| `funput-ibus` | Engine IBus |
+| `funput-settings` | App GUI, launcher và icon |
 
-## Distribution
+Bốn file của GUI trước kia được **cả hai** shell ship, khiến dpkg từ chối giải nén gói thứ hai —
+nội dung giống hệt nhau vẫn tính là xung đột file, nên cài cả hai là bất khả thi trên
+Debian/Ubuntu. Giờ `funput-settings` được build bất kể bạn yêu cầu framework nào, vì cả hai đều
+phụ thuộc vào nó.
 
-Three channels, all fed by the same release:
+Phụ thuộc đó ghim **đúng phiên bản** (`funput-settings (= <version>)`), và đây mới là phần đáng
+giữ: app Cài đặt ghi lại `settings.json` từ struct của chính nó, nên một bản cũ hơn addon sẽ xoá
+mất những thiết lập mà addon đã học được từ lúc ấy. Trình quản lý gói bây giờ từ chối đúng cái
+lệch phiên bản từng gây ra chuyện đó.
 
-- **`repo.funput.app`** — signed apt, dnf/zypper and pacman repositories on GitHub
-  Pages, built by `.github/workflows/publish-repo.yml`. The only channel with
-  automatic upgrades, and what `install.sh` configures by default. See
-  `packaging/repo/README.md`.
-- **GitHub Releases** — the `.deb`/`.rpm` themselves, plus the portable `.tar.gz`
-  trees behind `install.sh --user`.
-- **`install.sh`** — detect-then-configure front end over the two above. It is published
-  as a `curl … | bash` one-liner, which is a lot of trust to ask for, so it prints its plan
-  before it acts, `--dry-run` prints every command and runs none, and each asset it takes
-  from GitHub Releases is checked against the SHA-256 digest the release API publishes for
-  it — the releases carry no `.sha256` files, so a hand-verified checksum was never actually
-  on offer. `ci.yml`'s `installer-scripts` job parses and shellchecks it on every pull
-  request; before that job existed nothing looked at it at all, and a syntax error on a
-  branch only Fedora reaches would have shipped.
+### Test
 
-`install.sh` installs the **Fcitx5** package on every desktop; `--ibus` picks the IBus one.
-It used to guess from `XDG_CURRENT_DESKTOP` (KDE → Fcitx5, everything else → IBus), which
-handed most users the shell that cannot reach a WPS-shaped client at all. The desktop still
-decides one thing, but only what the script *prints*: outside KDE the session is wired to
-IBus, so Fcitx5 receives nothing until the user sets the variables below and logs out — the
-script says so before it installs, and prints them again after.
-
-Funput does not set `GTK_IM_MODULE` / `QT_IM_MODULE` for the user. Those belong to
-the session, not to us, and what is correct depends on the **session type first**:
-the classic `XMODIFIERS` + `GTK_IM_MODULE` + `QT_IM_MODULE` trio is right under X11
-and wrong under Wayland, where GTK 3/4 reach the compositor through text-input-v3
-themselves and the trio set globally makes KWin blink the candidate window. Under
-Wayland the desktop then decides: **GNOME** (and sway) wants `XMODIFIERS=@im=fcitx`
-plus `QT_IM_MODULE=fcitx` — or `QT_IM_MODULES=wayland;fcitx` on Qt 6.8.2+ — with
-`GTK_IM_MODULE` left unset; **KDE** wants `XMODIFIERS=@im=fcitx` alone. `install.sh`
-reads `$XDG_SESSION_TYPE` and prints only the block that applies, the docs carry the
-full matrix, and both name the distro tools that own this on Debian/Ubuntu
-(`im-config`, which does nothing in a Wayland session — its hook ships disabled) and
-Fedora (`fcitx5-autostart`). Sources:
-[Using Fcitx 5 on Wayland](https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland),
-[Setup Fcitx 5](https://fcitx-im.org/wiki/Setup_Fcitx_5).
-
-One thing that follows for the shells rather than the docs: on KDE, Fcitx5 is started
-by KWin's Virtual Keyboard KCM and handed a socket a replacement process cannot
-inherit, so `fcitx5 -r` breaks input for Wayland clients until the next login. Every
-place that suggested restarting the daemon now says so.
-
-Arch is inside the first of those rather than a channel of its own. It has no release
-asset — a rolling source distro has no use for a `.deb` or `.rpm` — so the `pacman` job
-in `publish-repo.yml` *builds* it, from `packaging/arch/PKGBUILD.in`, and serves the
-result under `arch/x86_64/`. The AUR would be the conventional home for that recipe and
-it is written to AUR conventions, but nothing uploads it: Arch has new-account
-registration paused. `arch-recipe.yml` runs a real `makepkg` on pull requests that
-touch the recipe, so a break is caught before it fails a publish.
-
-What binaries cost on a rolling distro is that they link the libraries of the build day,
-so a soname bump in fcitx5, ibus or gtk4 breaks them. A dependency cannot express that
-constraint: Arch's `fcitx5` and `ibus` packages declare no soname `provides` at all
-(only gtk4, libadwaita and glib2 do), so pacman has nothing to check and cannot warn.
-The repair is therefore a schedule, not a dependency — `publish-repo.yml` also runs on
-the 1st and 15th, rebuilding the current release against current Arch, with `pkgrel`
-rendered as the build date so pacman sees an upgrade even though `pkgver` has not
-moved. That is
-what `@PKGREL@` in the template is for; the AUR renders it as `1`.
-
-## Tests
-
-`common/` is buildable and testable on its own, with **neither Fcitx5 nor IBus
-installed** — that is what `compose/` linking no framework symbol buys. Needs only
-`cmake`, `nlohmann-json3-dev` and cargo:
+`common/` build và test được độc lập, **không cần cài Fcitx5 lẫn IBus** — đó chính là thứ mà
+việc `compose/` không link ký hiệu framework nào mua về. Chỉ cần `cmake`,
+`nlohmann-json3-dev` và cargo:
 
 ```bash
 cmake -S platforms/linux -B platforms/linux/build/tests -DFUNPUT_BUILD_TESTS=ON
+cmake --build platforms/linux/build/tests --parallel
+ctest --test-dir platforms/linux/build/tests --output-on-failure
 ```
 
-```bash
-cmake --build platforms/linux/build/tests --parallel && ctest --test-dir platforms/linux/build/tests --output-on-failure
-```
+Test link `libfunput_ffi.so` thật, nên nó chạy qua engine Rust bằng C ABI chứ không phải mock.
+`platforms/linux/CMakeLists.txt` tồn tại chỉ vì việc này — đóng gói không bao giờ đi qua nó, và
+`FUNPUT_BUILD_TESTS` mặc định `OFF` nên người đóng gói distro không bao giờ kích hoạt bước tải
+framework.
 
-The tests link the real `libfunput_ffi.so`, so they exercise the Rust engine across
-the C ABI rather than a mock. `platforms/linux/CMakeLists.txt` exists only for this
-— packaging never goes through it, and `FUNPUT_BUILD_TESTS` is `OFF` by default so
-distro packagers never trigger the framework fetch.
+> [!WARNING]
+> CI chạy phần này ở mọi pull request (`ci.yml`, job `linux-common`). Nhưng **hai shell chỉ được
+> biên dịch bởi workflow phát hành**, nên thay đổi trong `fcitx5/` hay `ibus/` vẫn cần build tại
+> máy trước khi merge.
 
-CI runs this on every pull request (`.github/workflows/ci.yml`, job `linux-common`).
-Note that the two **shells** are only compiled by the release workflow, so a change
-under `fcitx5/` or `ibus/` still wants a local build before merging.
+### Phát hành
 
-Every file here is held to 150 lines by `scripts/check-loc.sh`, test files included.
+Ba kênh, cùng ăn từ một bản phát hành:
 
-## Chuyển mã
+- **`repo.funput.app`** — kho apt, dnf/zypper và pacman có ký, host trên GitHub Pages, dựng bởi
+  `.github/workflows/publish-repo.yml`. Đây là kênh **duy nhất** có nâng cấp tự động, và là thứ
+  `install.sh` cấu hình mặc định. Xem `packaging/repo/README.md`.
+- **GitHub Releases** — chính các file `.deb`/`.rpm`, cộng cây `.tar.gz` portable đứng sau
+  `install.sh --user`.
+- **`install.sh`** — lớp mặt tiền dò-rồi-cấu-hình cho hai kênh trên.
 
-The charset converter (`settings-gtk/src/convert/`) is **shared by both shells** in the
-strongest sense: it never asks which one is running, never reads `settings.json`, and
-never touches the engine. Fcitx5 and IBus both depend on the `funput-settings` package
-at the exact version, so both get it without a line of C++ changing.
+**Arch nằm trong kênh thứ nhất**, không phải một kênh riêng. Nó không có release asset — một
+distro rolling chẳng dùng gì `.deb` hay `.rpm` — nên job `pacman` trong `publish-repo.yml` *tự
+build* từ `packaging/arch/PKGBUILD.in` rồi phục vụ kết quả dưới `arch/x86_64/`. AUR mới là chỗ
+thông thường cho công thức này và nó được viết theo đúng quy ước AUR, nhưng không có gì tải nó
+lên: Arch đang tạm ngưng đăng ký tài khoản mới. `arch-recipe.yml` chạy `makepkg` thật trên các
+pull request đụng vào công thức, để lỗi bị bắt trước khi làm hỏng một lần publish.
 
-Everything about *what* a conversion is and costs lives in `crates/funput-convert`,
-shared with the Slint window on Windows — the loss warning, the batch rules, the
-`Đã chuyển mã` folder name and its collision-avoiding `vanban (2).txt`. Writing those
-twice is how the two platforms would start disagreeing about the same document. What
-stays here is drag-and-drop, the clipboard, the dialogs, and getting file I/O off the
-UI thread.
+Cái giá của binary trên distro rolling là chúng link thư viện của **ngày build**, nên một cú
+soname bump ở fcitx5, ibus hay gtk4 sẽ làm chúng gãy. Dependency không diễn đạt được ràng buộc
+đó: gói `fcitx5` và `ibus` của Arch không khai `provides` theo soname (chỉ gtk4, libadwaita và
+glib2 có), nên pacman chẳng có gì để kiểm và không thể cảnh báo. Vì vậy cách chữa là **một lịch
+chạy, không phải một dependency** — `publish-repo.yml` còn chạy vào ngày 1 và 15, build lại bản
+phát hành hiện tại trên nền Arch hiện tại, với `pkgrel` render thành ngày build để pacman thấy
+có nâng cấp dù `pkgver` không đổi. Đó là công dụng của `@PKGREL@` trong template; AUR render nó
+thành `1`.
 
-Two ways in, because **there is no tray** for the item Windows puts there:
+### Chuyển mã
 
-- Settings → **Chung** → "Công cụ chuyển mã", mirroring Windows' Settings → Dữ liệu.
-- `funput-convert.desktop`, which runs `funput-settings --convert`.
+Bộ chuyển bảng mã (`settings-gtk/src/convert/`) **dùng chung cho cả hai shell** theo nghĩa mạnh
+nhất: nó không bao giờ hỏi shell nào đang chạy, không đọc `settings.json`, và không đụng tới
+engine. Fcitx5 và IBus đều phụ thuộc gói `funput-settings` ở đúng phiên bản, nên cả hai đều có
+nó mà không phải đổi một dòng C++ nào.
 
-Both reach the same process. That needs `ApplicationFlags::HANDLES_COMMAND_LINE` —
-GApplication's default flags do not forward argv to the running instance, so `--convert`
-would vanish without a trace — and it is why `route()` in `main.rs` looks for a window
-*of the right type* rather than calling `active_window()`, which would raise the
-converter when someone asked for Settings.
+Mọi thứ về việc *một lần chuyển mã là gì và tốn gì* nằm trong
+[`crates/funput-convert`](../../crates/funput-convert/README.md), dùng chung với cửa sổ Slint
+trên Windows — cảnh báo mất chữ, luật xử lý hàng loạt, tên thư mục `Đã chuyển mã` và cách tránh
+trùng tên bằng `vanban (2).txt`. Viết hai lần là cách để hai nền tảng bắt đầu bất đồng về cùng
+một tài liệu. Phần ở lại đây là kéo-thả, clipboard, hộp thoại, và đẩy I/O file ra khỏi luồng UI.
 
-`src/convert/state.rs` is the only file under `convert/` that decides anything, and the
-only one with tests. The `ui/*` files read the state and set properties; they decide
-nothing. One `refreshing` latch guards every signal a refresh fires — without it, a
-refresh setting a dropdown re-enters through `notify::selected` and panics on a nested
-`borrow_mut`.
+`src/convert/state.rs` là file duy nhất dưới `convert/` có quyết định gì, và cũng là file duy
+nhất có test. Các file `ui/*` đọc state rồi set property, không quyết định gì. Một chốt
+`refreshing` canh mọi tín hiệu mà một lần refresh bắn ra — thiếu nó, refresh set dropdown sẽ tái
+nhập qua `notify::selected` và panic vì `borrow_mut` lồng nhau.
 
-## Non-preedit mode
+### Chế độ không preedit
 
-Off by default; the switch is in Settings under **Kiểu gõ**, or set
-`"nonPreedit": true` in `~/.config/Funput/settings.json` directly. Either way the
-settings watcher picks it up live, with no restart. Both shells perform it.
+Mặc định tắt; công tắc nằm trong Cài đặt mục **Kiểu gõ**, hoặc đặt thẳng `"nonPreedit": true`
+trong `~/.config/Funput/settings.json`. Kiểu nào thì watcher cũng nhận ra ngay, không cần khởi
+động lại. **Cả hai shell đều thi hành nó.**
 
-Instead of parking the composing word in a preedit, each keystroke commits into the
-document and repairs what the previous one wrote — `Effect::Replace` carries "delete
-N characters, then commit this". That is the instruction the Windows hook shell
-already performs (`crates/funput-desktop/src/inject.rs`), and N comes straight from
-the engine as `FunputResult::backspace`, so the platforms stay one behaviour rather
-than three. Backspacing onto a finished word re-opens it, so `phủ` Space Backspace
-`s` gives `phú`; Windows keeps a shadow copy of what it typed to manage that
-(`retone.rs`), while here the document can simply be read.
+Thay vì đỗ từ đang gõ trong một preedit, mỗi phím commit thẳng vào tài liệu rồi sửa lại thứ phím
+trước đã viết — `Effect::Replace` mang theo “xoá N ký tự, rồi commit cái này”. Đó đúng là chỉ thị
+mà shell hook trên Windows đã thi hành (`crates/funput-desktop/src/inject.rs`), và N tới thẳng từ
+engine dưới dạng `FunputResult::backspace`, nên các nền tảng giữ **một** hành vi chứ không phải
+ba. Backspace lùi vào một từ đã xong sẽ mở lại từ đó, nên `phủ` ␣ ⌫ `s` cho ra `phú`; Windows giữ
+một bản bóng của thứ nó đã gõ để làm việc này (`retone.rs`), còn ở đây thì đọc thẳng tài liệu là
+được.
 
-A Backspace with nothing composing is performed by *us*, not passed to the app, so the
-deletion travels the same channel as every other repair. Letting the app do it is what
-broke re-toning in Chrome's address bar: the app edited behind our back and then
-discarded the repair issued on the next keystroke. It is only taken over on positive
-evidence that the document being read is current — a change we predicted and then saw
-land, whether that was a repair or a plain character the app typed itself. Without that
-evidence the key goes through, which is what keeps a mouse selection deletable: the
-selection flag comes from the same cache and had not caught up, so on the strength of
-that alone the key was swallowed and Backspace appeared dead until pressed twice.
+Một Backspace khi không có gì đang soạn sẽ do **chính chúng ta** thi hành, không chuyển cho app,
+để việc xoá đi cùng một kênh với mọi sửa chữa khác. Để app tự làm chính là thứ đã làm hỏng việc
+bỏ dấu lại trong thanh địa chỉ Chrome: app sửa sau lưng ta rồi vứt bỏ sửa chữa được phát ở phím
+kế tiếp. Việc tiếp quản chỉ xảy ra khi **có bằng chứng dương** rằng tài liệu đang đọc là mới —
+một thay đổi ta dự đoán rồi thấy nó xảy ra thật. Không có bằng chứng đó thì phím đi thẳng qua, và
+chính điều này giữ cho một vùng bôi đen bằng chuột vẫn xoá được.
 
-That repair cannot be checked afterwards. It carries no text, so "applied" and
-"dropped" read as the same document — the silent-client signature below — and a client
-that refuses it will simply appear to ignore Backspace. A Backspace *inside* a word is
-still left to the app; the same hazard applies in principle, but nothing has been seen
-to fail there.
+#### Đo được gì, và suy ra gì
 
-Whether it engages is decided per input context. Both shells wait until the client
-has actually sent surrounding text this focus — Fcitx5 via `SurroundingTextUpdated`,
-IBus via `set_surrounding_text` — then re-ask between words, on any keystroke with
-nothing composing. Neither snapshots capability flags or a cache at focus-in: the
-text often arrives only after the client answers (Calc, an empty GTK field), and a
-stale `isValid()` from the previous focus would turn the mode on in a terminal that
-never sends updates. Never mid-word: the modes disagree about where the composing
-word lives, and switching under one leaves the engine and the client describing
-different things.
+Trên GNOME/Wayland, nơi Fcitx5 được với tới qua frontend **ibus** và GNOME Shell là client của
+mọi ứng dụng:
 
-### What was measured, and what follows from it
+- **Cờ capability nói dối theo cả hai chiều.** Có context báo không có `SurroundingText` trong
+  khi nó chạy hoàn hảo, có context báo `caps: []` — không có cả `Preedit` — trong khi preedit rõ
+  ràng vẫn chạy. Không shell nào gác theo cờ; thứ client **thực sự làm** mới quyết định.
+- **`program()` luôn là `gnome-shell`**, không bao giờ là app thật. Đó là lý do Linux không có
+  danh sách VI/EN theo từng app.
+- **`deleteSurroundingText` đếm ký tự, không đếm byte** — kiểm bằng `ế`, một ký tự và ba byte.
+  Vì vậy `ComposePlan::deleteChars` là số ký tự từ đầu đến cuối; một test chỉ dùng ASCII sẽ
+  không bắt được khác biệt này.
+- **Client chỉ trả lời 61% số commit**, và kênh này chết rồi sống lại ngay trong một phiên, nên
+  không được phép chờ nó.
+- **Một chuỗi commit/delete/commit phát ra không nghỉ sẽ phá nát chữ của người dùng**: `;;;` trả
+  về `;;y` trong cả chín lần thử.
+- **Nhưng gõ tay không thể tạo ra chuỗi đó.** Một `Replace` cần cú phím khiến engine viết lại
+  phần đuôi. Hai lần liên tiếp chưa bao giờ gần nhau hơn 49 ms, và giữ phím cũng không giúp gì —
+  sau lần nhấn thứ hai engine ngừng viết lại, các lần lặp đi thẳng qua, để lại 500 ms giữa hai
+  `Replace` khi auto-repeat, chậm gấp mười lần gõ tay.
 
-On GNOME/Wayland, where Fcitx5 is reached through its **ibus** frontend and GNOME
-Shell is the client for every application:
+Ba điều cuối cộng lại là lý do **các lần ghi cố tình không được tuần tự hoá**. Chờ client xác
+nhận lần ghi này trước khi phát lần sau sẽ tốn ~25 ms mỗi phím và treo hẳn ở những commit nó
+không bao giờ trả lời — một cái giá chắc chắn để đổi lấy một thất bại mà gõ tay không với tới
+được.
 
-- **Capability flags lie in both directions.** Contexts report `SurroundingText`
-  absent while it works perfectly, and some report `caps: []` — not even `Preedit` —
-  while preedit plainly works. Neither shell gates on them; what the client actually
-  does decides instead.
-- **`program()` is always `gnome-shell`**, never the real app. Funput therefore
-  has no per-app VI/EN list on Linux — a policy keyed on that value would apply to
-  every client at once.
-- **`deleteSurroundingText` counts characters, not bytes** — verified with `ế`, one
-  character and three bytes. `ComposePlan::deleteChars` is a character count end to
-  end for that reason, and an ASCII-only test would not have caught the difference.
-- **The client answers only 61% of commits**, and the channel dies and revives within
-  one session, so nothing may wait on it.
-- **A commit/delete/commit burst issued with no gap destroys the user's text**: `;;;`
-  came back as `;;y` in all nine attempts.
-- **But typing cannot produce that burst.** A `Replace` needs a keystroke that makes
-  the engine rewrite its tail. Consecutive ones were never closer than 49ms, and
-  holding a key down does not help — after the second press the engine stops
-  rewriting and the repeats pass straight through, leaving 500ms between `Replace`es
-  under auto-repeat, ten times slower than typing by hand.
+Không chờ trước khi ghi **không** đồng nghĩa với không bao giờ kiểm tra sau khi ghi. Việc lẫn lộn
+hai điều đó từng để thanh địa chỉ Chrome làm hỏng chữ: nó nhận commit nhưng bỏ
+`deleteSurroundingText` đi kèm, nên `phủ` ra thành `phủú`. Phép kiểm chẳng tốn gì — hai shell vốn
+đã đọc tài liệu ở mỗi phím. Sau một `Replace{N, T}` phát ra trên tài liệu `D`, lần đọc kế tiếp
+chỉ có thể là một trong ba chuỗi, và chúng khác nhau:
 
-The last three together are why **writes are deliberately not serialized**. Waiting
-for the client to confirm one write before issuing the next would cost ~25ms per
-keystroke and stall outright on the commits it never answers — a certain cost against
-a failure real typing cannot reach. Reconsider only if something starts issuing
-several `Replace`es for one keystroke.
-
-Not waiting before a write is not the same as never checking after one, though, and
-conflating the two let Chrome's address bar corrupt text for a while: it took the
-commit and dropped the `deleteSurroundingText` beside it, so `phủ` came out `phủú`.
-That particular case is gone — the Backspace is no longer the app's to handle — but the
-check earned its place and stays, because the next client of this kind will not
-announce itself. It costs nothing: the shells already read the document each keystroke. After
-a `Replace{N, T}` issued against document `D`, the next reading can only be one of
-three strings, and they differ:
-
-| Reading | Meaning |
+| Đọc được | Nghĩa là |
 |---|---|
-| `D` less N characters, then `T` | it worked |
-| `D` then `T` | the client dropped the delete — turn the mode off for this client |
-| `D` | the client has not answered yet — no verdict |
+| `D` bớt N ký tự, rồi `T` | Thành công |
+| `D` rồi `T` | Client đã bỏ lệnh xoá — **tắt chế độ này cho client đó** |
+| `D` | Client chưa trả lời — chưa có phán quyết |
 
-Only the middle one is a verdict, and that restraint is the point: treating "not what
-I expected" as failure would disable the mode on the 61% of commits that go
-unanswered, curing one broken client by breaking the feature for everyone. Anything
-matching none of the three is no verdict either. `NonPreeditState` in
-`common/compose/composer/nonpreedit.h` holds this; the shells only hand it the text.
+Chỉ trường hợp ở giữa là một phán quyết, và sự dè dặt đó mới là điểm mấu chốt: coi “không giống
+thứ tôi mong đợi” là thất bại sẽ tắt chế độ này ở 61% số commit không được trả lời — chữa một
+client hỏng bằng cách làm hỏng tính năng cho tất cả.
 
-A verdict stands down as narrowly as the failure allows. A dropped repair that followed
-a **re-opened word** costs only re-toning: that was the one shape ever observed to fail,
-in an address bar that took ordinary repairs perfectly well. Any other dropped repair
-costs the whole mode, since nothing it writes can then be trusted.
+Phán quyết rút lui hẹp đúng bằng phạm vi thất bại. Một sửa chữa bị bỏ **sau khi mở lại một từ**
+chỉ khiến mất khả năng bỏ dấu lại: đó là hình dạng duy nhất từng thấy hỏng. Bất kỳ sửa chữa nào
+khác bị bỏ thì mất cả chế độ, vì không còn tin được thứ gì nó viết ra.
 
-The verdict is a latch, not a variable. A shell may re-assert the mode — IBus does, on
-every keystroke — and must not be able to revive one a client has already been caught
-breaking; only `Composer::onFocusChanged()` clears it, because a new client is a new
-question.
+Phán quyết là một **chốt**, không phải một biến. Shell có thể tái khẳng định chế độ — IBus làm
+vậy ở mỗi phím — và không được phép hồi sinh một chế độ mà client đã bị bắt quả tang làm hỏng;
+chỉ `Composer::onFocusChanged()` xoá chốt, vì một client mới là một câu hỏi mới.
 
-The cost is that detection is one beat late, so the first word is still mangled before
-the mode stands down. Catching it sooner would mean writing probe text into the user's
-document, which is not on the table.
+Cái giá là việc phát hiện chậm một nhịp, nên từ đầu tiên vẫn bị hỏng trước khi chế độ rút lui.
+Bắt sớm hơn nghĩa là phải ghi chữ dò vào tài liệu của người dùng, và điều đó không nằm trên bàn.
 
-A selection live at delete time would take the highlighted text instead of ours, so
-both shells abandon the repair *and* the composition when they see one (`applyPlan`
-in `fcitx5/src/funput_client.cpp` and `ibus/src/engine/client.cpp`). Abandoning only
-the delete would double the word; abandoning it silently would leave the engine owning
-a word it could not correct, aiming the next keystroke's delete at text Funput never
-wrote. Measuring never caught a live selection in 93 commits, so that guard is
-reasoned rather than measured.
+#### Về phía IBus
 
-### On the IBus side
+Bốn sự thật về API, mỗi cái tốn vài vòng mới tìm ra, và không cái nào được header nói cho biết:
 
-Four API facts, each of which cost several rounds to find, and none of which the
-headers tell you:
+- **Đăng ký nhận surrounding text là theo từng input context, không phải theo engine.** IBus ghi
+  tài liệu cho `ibus_engine_get_surrounding_text()` với out-param null như cách đăng ký và bảo
+  gọi nó “trong enable handler” — nhưng enable chỉ chạy một lần, và engine nào chỉ hỏi ở đó sẽ
+  không nhận được gì trong suốt phần còn lại của phiên. **Phải hỏi lại ở mỗi lần focus-in.** Cho
+  tới khi tìm ra điều này, chế độ không preedit chưa từng một lần hoạt động trên IBus, trong khi
+  trông như thể có.
+- **Nhưng hỏi không phải là thứ làm nó tới — daemon khử trùng lặp.**
+  `bus_engine_proxy_set_surrounding_text()` chỉ gọi xuống engine khi text, con trỏ hoặc anchor
+  **khác** với thứ nó chuyển tiếp lần trước. Cache đó nằm trên **engine proxy**, được gieo sẵn
+  bằng `("", 0, 0)`, và **không bao giờ bị xoá khi đổi focus** — chỉ khi proxy bị huỷ. Nên một
+  client trả lời bằng chuỗi rỗng là **vô hình** với engine, dù có hỏi bao nhiêu lần đi nữa.
+  WPS Office đúng là client đó: trình soạn thảo của nó không hiện thực
+  `Qt::ImSurroundingText`, nên Qt trả lời mọi yêu cầu bằng `("", 0, 0)` — đúng bằng giá trị
+  gieo — và `set_surrounding_text` không nổ lấy một lần, trong khi `SetSurroundingText` đáp
+  xuống daemon **mười sáu lần một phút**. Đếm ở phía client rồi gọi đó là “có hỗ trợ” chính là
+  cái bẫy; **payload mới là sự thật**.
 
-- **Registering for surrounding text is per input context, not per engine.** IBus
-  documents `ibus_engine_get_surrounding_text()` with null out-params as the way to
-  register and says to call it "in the enable handler" — but enable fires once, and an
-  engine that only asks there receives nothing for the rest of the session. It has to
-  be asked again on every focus-in. Until that was found, non-preedit had never once
-  engaged on IBus, while looking as though it had.
-- **But asking is not what makes it arrive — the daemon deduplicates.**
-  `bus_engine_proxy_set_surrounding_text()` calls down to the engine only when the
-  text, the cursor or the anchor differs from what it last forwarded. That cache sits
-  on the engine *proxy*, is seeded with `("", 0, 0)`, and is never cleared on focus
-  change — only when the proxy is destroyed. So a client that answers with an empty
-  string is invisible to the engine no matter how often it is asked. WPS Office is
-  exactly that client: its editor does not implement `Qt::ImSurroundingText`, so Qt
-  answers every request with `("", 0, 0)`, which is precisely the seed value, and
-  `set_surrounding_text` never fires once — while `SetSurroundingText` lands on the
-  daemon sixteen times in a minute. Reading the count on the client side and calling
-  it support is the trap; the payload is the fact.
+  Cũng chính cache đó khiến việc `focusIn()` xoá `sawSurroundingText` trở thành một lỗi tiềm
+  ẩn: daemon sẽ không lặp lại chính nó cho một focus mới, nên sau khi bị xoá, cờ đó chỉ có thể
+  trở lại nếu tài liệu **thay đổi**. Chỗ phải sửa là phía xoá cờ, không phải phía hỏi — thử
+  hỏi lại rồi, không xê dịch gì. Chưa làm: chưa client nào ở đây lộ triệu chứng, và đoán một
+  bản vá cho một client chính là cách mà đám cờ capability được tin tưởng lần đầu.
+- **Đọc ngược lại không được.** `ibus_engine_get_surrounding_text()` trả về text null ngay sau
+  khi client vừa gửi một chuỗi hoàn toàn tốt. Bản sao đáng tin duy nhất là bản đến trong vfunc
+  `set_surrounding_text`, nên engine giữ nó trong `EngineState`.
+- **`g_debug` không tới tay ai.** ibus-daemon trỏ stdio của engine nó sinh ra vào `/dev/null` bất
+  kể daemon được khởi động kiểu gì, nên chẩn đoán ở đây phải ghi ra file.
 
-  The same cache makes `focusIn()` clearing `sawSurroundingText` a latent bug: the
-  daemon will not repeat itself for a new focus, so once cleared the flag can only
-  return if the document *changes*. The repair belongs on the clearing side, not the
-  asking side — re-asking was tried and moved nothing. Left undone: no client here
-  shows the symptom, and guessing at a fix for one is how the capability flags got
-  trusted the first time.
-- **Reading it back does not work.** `ibus_engine_get_surrounding_text()` returns a
-  null text immediately after the client has sent a perfectly good string. The only
-  reliable copy is the one arriving in the `set_surrounding_text` vfunc, so the engine
-  keeps it in `EngineState` — which also means no question of how stale a framework
-  cache is.
-- **`g_debug` reaches nobody.** ibus-daemon points a spawned engine's stdio at
-  `/dev/null` no matter how the daemon itself was started, so diagnostics here have to
-  be written to a file, the way the Fcitx5 probe once did.
+Việc đếm theo ký tự được xác nhận lần thứ hai từ phía này, không cần suy luận: client báo con trỏ
+ở 4 cho `phủ ` (năm byte) và 3 cho `phủ` (bốn byte).
 
-The character count was confirmed a second time from this side, without inference: the
-client reported cursor 4 for `phủ ` (five bytes) and 3 for `phủ` (four).
+## Giấy phép
 
-## Known gaps
+MIT — [`LICENSE`](../../LICENSE).
 
-- **Preedit loses a half-typed word in some clients on focus change.** Both shells
-  hand the flush to their framework (see the comments in `deactivate()` and
-  `updatePreedit()`); clients that drop the preedit instead of committing it lose
-  the word anyway. Non-preedit above is the fix on both shells, so this now only bites
-  where that mode cannot run: a client that reports no surrounding text, one that
-  ignores `deleteSurroundingText`, and anyone who leaves the mode off.
-- **Chrome shows no preedit at all.** Commits reach it fine — non-preedit works
-  throughout, address bar included — but nothing that needs the client to draw and
-  manage a composition does. Chrome is a native Wayland client here, so that path runs
-  through `zwp_text_input_v3`; the same session shows preedit working normally in other
-  apps, so this is Chrome's end and nothing in Funput can reach it. **Non-preedit is
-  the answer for Chrome**, which is the shape the mode was built for.
-- **WPS Office paints no client preedit.** It advertises the Preedit capability, so
-  the Fcitx5 panel preedit was also skipped, and the composing word stayed invisible
-  until Space (or another commit). Non-preedit cannot run: WPS does not implement
-  `Qt::ImSurroundingText`, and forcing a delete-then-commit repair mangles the text
-  (`nguyen64` coming back `nguyenênễn`). The Fcitx5 shell therefore draws the panel
-  preedit for any basename on the allowlist in `hidden_preedit.cpp` (`wps`, `wpp`,
-  `et`, `wpspdf` today) and still sends the client preedit so a focus-out flush is
-  not lost. Adding another client of this kind is a name on that list. IBus has no
-  channel that works here — ForwardKeyEvent is gone, surrounding text never arrives —
-  and is left alone.
-- **Re-toning after Backspace is non-preedit only.** In preedit mode Backspace just
-  shortens the composition, so `phủ` ␣ ⌫ `s` types a literal `s` — while macOS, Windows
-  and Android all re-open the word. macOS manages it with one atomic
-  `setMarkedText(replacementRange:)`, replacing the word and the deleted character in a
-  single edit; neither Fcitx5 nor IBus has that, so a port would be delete-then-preedit,
-  with the gap between them that this file spends so long on. Worth doing, and worth
-  copying macOS's two guards when it is done: a setting of its own, and skipping key
-  auto-repeat so holding Backspace does not re-open a word per repeat.
-- **The Settings app rewrites `settings.json` wholesale.** Unlike the addon's merging
-  writer, it serializes its own struct over the file, so a key it does not know is
-  deleted the next time the user changes anything there. Every setting the addon owns
-  still needs a field in `settings-gtk`'s `Settings` too. The *release* half of this is
-  no longer a matter of remembering — the shells depend on `funput-settings` at their
-  exact version — but a field left out of the struct is still silent data loss, and
-  nothing checks for that.
-- **No AppStream metainfo.** `funput-settings` ships a `.desktop` entry but no
-  `metainfo.xml`, so it has no entry in GNOME Software or KDE Discover and distro
-  reviewers will ask for one before packaging it downstream.
+<p align="center">
+  <sub>
+    <a href="https://funput.app">funput.app</a>
+    ·
+    <a href="../../README.md">README gốc</a>
+    ·
+    Made with ♥ by Funput
+  </sub>
+</p>

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -256,6 +256,10 @@ Thứ thật sự khác nhau giữa hai shell chỉ là preedit tới client b�
 nó khi mất focus** — Fcitx5 dùng `setClientPreedit` cộng watcher focus-out, IBus dùng
 `IBUS_ENGINE_PREEDIT_COMMIT`. Cả hai đều có chú thích tại chỗ.
 
+> [!TIP]
+> Shell Fcitx5 có README riêng: [`fcitx5/README.md`](fcitx5/README.md) — panel preedit, allowlist
+> client tự giấu preedit, biến môi trường theo session, và các đường dẫn cài đặt của addon.
+
 Mô hình này giống hệt các nền tảng desktop khác: `crates/funput-desktop/src/key.rs` là đúng cái
 classifier ấy cho shell hook trên Windows, và `inject.rs` của nó là đúng cái tách bạch “core trả
 về kế hoạch, shell thi hành”.

--- a/platforms/linux/fcitx5/README.md
+++ b/platforms/linux/fcitx5/README.md
@@ -1,0 +1,260 @@
+<p align="center">
+  <img
+    src="../../../assets/horizontal-lockup/gradient.png"
+    width="360"
+    alt="Funput"
+  >
+</p>
+
+<p align="center">
+  <strong>Funput cho Fcitx5</strong> — addon input method, build ra <code>libfunput.so</code>.<br>
+  Một trong hai shell trên Linux · adapter mỏng trên <code>funput::Composer</code>
+</p>
+
+<p align="center">
+  <a href="../README.md">
+    <img src="https://img.shields.io/badge/←_Quay_lại-README_Linux-2563EB?style=for-the-badge&logo=linux&logoColor=white" alt="README Linux">
+  </a>
+  <a href="../ibus/">
+    <img src="https://img.shields.io/badge/Shell_còn_lại-IBus-6B7280?style=for-the-badge" alt="Shell IBus">
+  </a>
+</p>
+
+---
+
+## Vì sao Fcitx5 là mặc định
+
+`install.sh` cài gói **Fcitx5 trên mọi desktop**, kể cả GNOME. Trước đây nó đoán theo
+`XDG_CURRENT_DESKTOP` — KDE thì Fcitx5, còn lại IBus — và điều đó trao cho phần lớn người dùng
+đúng cái shell **không với tới nổi** một client kiểu WPS Office.
+
+Lý do nằm ở một năng lực mà IBus không có: khi client tự giấu preedit, Fcitx5 còn **panel
+preedit của riêng nó** để vẽ thay. IBus thì hết đường — ForwardKeyEvent đã bị bỏ, surrounding
+text không bao giờ tới. Xem [Client tự giấu preedit](#client-tự-giấu-preedit).
+
+| | Fcitx5 | IBus |
+|---|---|---|
+| Panel preedit riêng | **Có** | Không |
+| Chạy với WPS Office | **Có** | Không |
+| Được session nối sẵn | Chỉ KDE | GNOME · Ubuntu |
+| Gói | `funput` | `funput-ibus` |
+
+## Cài đặt
+
+Xem [README Linux](../README.md#cài-đặt). Ngắn gọn:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Funput/Funput/main/platforms/linux/install.sh | bash
+```
+
+Rồi bật trong **Fcitx5 Configuration → `+` → bỏ chọn "Only Show Current Language" → Funput**.
+
+> [!IMPORTANT]
+> **Ngoài KDE, cài xong vẫn chưa gõ được ngay.** Phiên desktop của bạn đang nối vào IBus, nên
+> Fcitx5 không nhận được gì cho tới khi bạn đặt biến môi trường cho session rồi **đăng xuất
+> đăng nhập lại**.
+>
+> | Session | Cần đặt |
+> |---|---|
+> | **X11** | Bộ ba `XMODIFIERS` + `GTK_IM_MODULE` + `QT_IM_MODULE` |
+> | **Wayland · GNOME** *(và sway)* | `XMODIFIERS=@im=fcitx` và `QT_IM_MODULE=fcitx` — hoặc `QT_IM_MODULES=wayland;fcitx` trên Qt 6.8.2+ — **để trống** `GTK_IM_MODULE` |
+> | **Wayland · KDE** | Chỉ `XMODIFIERS=@im=fcitx` |
+>
+> Dưới Wayland, GTK 3/4 tự nói chuyện với compositor qua `text-input-v3`, nên đặt cả bộ ba
+> khiến KWin nhấp nháy cửa sổ gợi ý. `install.sh` đọc `$XDG_SESSION_TYPE` và chỉ in đúng khối
+> áp dụng cho bạn.
+
+> [!CAUTION]
+> **Trên KDE, đừng chạy `fcitx5 -r`.** KWin khởi động Fcitx5 từ Virtual Keyboard KCM và trao cho
+> nó một socket mà tiến trình thay thế **không kế thừa được**. Khởi động lại daemon sẽ làm hỏng
+> việc nhập liệu của mọi client Wayland cho tới lần đăng nhập kế tiếp. Đăng xuất rồi đăng nhập
+> lại mới là cách đúng.
+
+## Client tự giấu preedit
+
+Một số client **khai là có** năng lực Preedit rồi **không vẽ gì cả**. Từ đang gõ trở nên vô
+hình cho tới khi bạn nhấn Space. WPS Office là trường hợp điển hình.
+
+Chế độ không preedit cũng không cứu được: WPS không hiện thực `Qt::ImSurroundingText`, và ép
+xoá-rồi-commit thì làm nát chữ — `nguyen64` trả về `nguyenênễn`.
+
+Nên shell Fcitx5 **tự vẽ panel preedit** cho mọi tên tiến trình nằm trong allowlist ở
+[`src/hidden_preedit.cpp`](src/hidden_preedit.cpp):
+
+```cpp
+constexpr std::string_view kHiddenPreedit[] = {
+    "wps",    // WPS Writer
+    "wpp",    // WPS Presentation
+    "et",     // WPS Spreadsheets
+    "wpspdf", // WPS PDF
+};
+```
+
+Khớp theo **basename của tiến trình**, không phân biệt hoa thường. Thêm một client kiểu này chỉ
+là thêm một cái tên vào danh sách — `updatePreedit()` đã vẽ panel cho bất kỳ ai trong đó.
+
+> [!WARNING]
+> **Đừng khớp theo cờ capability hay theo việc thiếu surrounding text.** Chúng nói dối theo cả
+> hai chiều, và sẽ kéo vào cả những client vốn đang chạy tốt. Một cái tên trong danh sách là
+> có chủ ý; một điều kiện suy đoán thì không.
+
+## Dành cho developer
+
+### Vai trò
+
+Addon này là **adapter mỏng** trên [`funput::Composer`](../common/compose/) — nơi giữ luật gõ và
+dùng chung với shell IBus. File ở đây **chỉ dịch**: `fcitx::KeyEvent` vào,
+`funput::ComposePlan` ra, rồi thi hành plan đó lên input context.
+
+Hình dạng composition giống **shell IMKit trên macOS**, không phải đường tiêm backspace của
+Windows: từ đang gõ hiện dưới dạng preedit gạch chân, và commit khi gặp ranh giới từ, phím điều
+hướng, hoặc lúc bật/tắt VI/EN.
+
+| File | Dòng | Việc |
+|---|---|---|
+| [`src/funput_engine.h`](src/funput_engine.h) | 105 | Kiểu addon, config, và mọi thứ nửa còn lại cần |
+| [`src/funput_engine.cpp`](src/funput_engine.cpp) | 110 | Vòng đời: watcher, nạp lại settings, bật/tắt chế độ |
+| [`src/funput_input.cpp`](src/funput_input.cpp) | 69 | Một phím: chuẩn hoá, hỏi composer |
+| [`src/funput_client.cpp`](src/funput_client.cpp) | 99 | Thi hành plan lên client — preedit, commit, sửa tài liệu |
+| [`src/hidden_preedit.cpp`](src/hidden_preedit.cpp) | 49 | Allowlist client tự giấu preedit |
+
+### Một phím đi qua đâu
+
+```text
+fcitx::KeyEvent
+      │
+      ▼
+toKeyEvent() ............. keysym X11 đi thẳng qua (IBus dùng cùng giá trị);
+      │                    chỉ mods và keysym→Unicode là của riêng Fcitx5
+      ▼
+toggleChord_.feed() ...... phím bật/tắt VI/EN — nuốt phím, xong
+      │
+      ▼   (bỏ qua mọi key release: luật gõ không phụ thuộc chúng,
+      │    và mỗi framework báo release một kiểu khác nhau)
+      │
+applyNonPreeditMode() .... hỏi lại GIỮA CÁC TỪ xem client này có nhận
+      │                    được sửa tài liệu không
+      ▼
+textBeforeCaret() ........ MỘT lần đọc tài liệu, dùng cho HAI việc
+      │
+      ▼
+Composer::onKey() ──▶ ComposePlan ──▶ applyPlan()
+      │
+      ▼
+adoptWordBeforeBackspace()  chỉ khi Backspace mở lại một từ đã commit
+```
+
+Vài chi tiết đắt giá:
+
+- **Đọc tài liệu một lần, dùng hai việc.** Nó vừa để composer kiểm xem lần sửa trước có thật sự
+  đáp xuống không, vừa là đúng đoạn text mà một Backspace cần.
+- **`reopen` hỏi `classify()` chứ không so keysym.** Nhờ vậy `Ctrl+Backspace` (xoá cả từ) không
+  lọt vào — đó là phím tắt, không phải Backspace.
+- **`adoptWordBeforeBackspace()` chạy *sau* plan và không tự viết gì.** Phím đi qua, app tự xoá
+  ký tự của nó, engine chỉ nhận quyền sở hữu phần còn lại để phím kế tiếp sửa được.
+
+### Preedit, và ai commit khi mất focus
+
+`updatePreedit()` **luôn** publish client preedit, kể cả cho client không vẽ được nó. Đây không
+phải thừa: Fcitx5 tự commit `clientPreedit()` khi input context mất focus (watcher focus-out
+`ReservedFirst` của `Instance`), và **đó chính là thứ giữ cho một từ gõ dở không biến mất** khi
+bạn bấm sang ô khác.
+
+Hiển thị thì không bị ảnh hưởng — `InputContext::updatePreedit()` trả về sớm nếu thiếu năng lực
+Preedit, nên những client đó vẫn nhận panel preedit do Fcitx5 vẽ.
+
+```cpp
+panel.setClientPreedit(preedit);              // luôn luôn — để focus-out flush được
+if (!context->capabilityFlags().test(fcitx::CapabilityFlag::Preedit) ||
+    hidesClientPreedit(context)) {
+    panel.setPreedit(preedit);                // panel do Fcitx5 vẽ
+}
+```
+
+> [!NOTE]
+> `deactivate()` **không được commit lần nữa** — Fcitx5 đã commit client preedit trước khi gọi
+> nó. Commit lại là nhân đôi từ.
+
+### Chế độ không preedit phía Fcitx5
+
+Toàn bộ lý lẽ và số liệu đo nằm ở
+[README Linux — Chế độ không preedit](../README.md#chế-độ-không-preedit). Phần thuộc riêng
+shell này:
+
+- **`lastSurroundingOk_`** bật bởi sự kiện `InputContextSurroundingTextUpdated`, xoá ở
+  `activate()`. Nó kiểm `surroundingText().isValid()` chứ **không** kiểm
+  `CapabilityFlag::SurroundingText` — trên GNOME/Wayland cờ đó nói dối cả hai chiều. Text rỗng
+  với con trỏ 0 **vẫn** là hợp lệ: đó là một ô GTK trống, và là tín hiệu "client đã lên tiếng".
+- **`applyNonPreeditMode()` không bao giờ lật giữa từ.** Hai chế độ bất đồng về chỗ từ đang gõ
+  nằm ở đâu, nên lật khi đang soạn dở sẽ để engine và client mô tả hai thứ khác nhau. Cùng một
+  cổng gác với `applyNonPreeditMode()` bên IBus.
+- **Có selection thì bỏ luôn cả sửa chữa lẫn composition.** Xoá lúc đó sẽ nuốt đoạn người dùng
+  đang bôi đen. Bỏ mỗi lệnh xoá sẽ nhân đôi từ; bỏ im lặng sẽ để engine tin rằng nó sở hữu một
+  từ mà nó không sửa được, khiến lệnh xoá của phím kế tiếp nhắm vào chữ Funput chưa từng viết.
+- **`deleteSurroundingText` tính theo ký tự.** Engine phát ra ký tự, API nhận ký tự — không có
+  chỗ nào chuyển đổi dọc đường. Riêng `textBeforeCaret()` thì phải hoà giải: Fcitx5 báo con trỏ
+  theo **ký tự** trong khi text là **UTF-8**, nên cắt theo con trỏ như thể nó là byte offset sẽ
+  chặt đôi chữ tiếng Việt.
+
+### Cấu hình
+
+Fcitx5 chỉ thấy **đúng một** tuỳ chọn: một nút mở app Cài đặt GTK.
+
+```cpp
+FCITX_CONFIGURATION(
+    FunputEngineConfig,
+    fcitx::ExternalOption openSettings{
+        this, "OpenSettings", "Open Funput Settings", "funput-settings"};);
+```
+
+Cố ý như vậy. Thiết lập thật nằm ở `~/.config/Funput/settings.json`, và `settings-gtk` **ghi đè
+nguyên file** từ struct của chính nó — nên nhân bản chúng thành `Option` của Fcitx5 là tự tạo ra
+hai nguồn sự thật, với một bên xoá bên kia.
+
+`getConfigForInputMethod()` mặc định trả về `getConfig()`, nên nút Configure của input method
+trong `fcitx5-configtool` cũng dùng chính cái này. Từ configtool 5.1.6+, khi `ExternalOption` là
+trường duy nhất thì nó chạy thẳng lệnh luôn.
+
+Nạp lại settings là **tức thì**: một fd `inotify` (`SettingsWatcher`) được nối vào chính event
+loop của Fcitx5 qua `addIOEvent`.
+
+### Build và cài
+
+```bash
+FUNPUT_FRAMEWORK=fcitx5 ../build.sh    # từ platforms/linux/fcitx5
+```
+
+| | |
+|---|---|
+| Chuẩn C++ | **20** — header công khai của Fcitx5 5.1+ dùng `std::span` và `string_view::starts_with`, nên 17 không compile nổi trên Fedora |
+| Install prefix | Ép về **`/usr`**, không phải `/usr/local` mặc định |
+| Sản phẩm | `libfunput.so` + `libfunput_ffi.so` đặt cạnh nhau trong addon dir |
+| Gói | `funput` |
+
+> [!IMPORTANT]
+> Prefix `/usr` là **bắt buộc**, không phải sở thích: Fcitx5 chỉ quét addon dir hệ thống
+> (`/usr/lib/<triplet>/fcitx5`, `/usr/share/fcitx5`) và **bỏ qua `/usr/local`**. Prefix này cũng
+> khiến `GNUInstallDirs` dùng đúng libdir multiarch của Debian, nhờ đó
+> `FCITX_INSTALL_ADDONDIR` phân giải chính xác. Nó phải được đặt **trước**
+> `find_package(Fcitx5Utils)`, vì đó là chỗ các đường dẫn cài được tính ra.
+
+`libfunput_ffi.so` được cài **cạnh** `libfunput.so` và phân giải qua `INSTALL_RPATH "$ORIGIN"`,
+nên không cần thêm mục nào vào `ldconfig` toàn hệ thống.
+
+Metadata addon nằm ở [`data/`](data): `funput-addon.conf.in` đăng ký addon
+(`Library=libfunput`, `Category=InputMethod`), còn `funput.conf.in` đăng ký input method
+(`Label=FU`, `LangCode=vi`).
+
+## Giấy phép
+
+MIT — [`LICENSE`](../../../LICENSE).
+
+<p align="center">
+  <sub>
+    <a href="https://funput.app">funput.app</a>
+    ·
+    <a href="../README.md">README Linux</a>
+    ·
+    Made with ♥ by Funput
+  </sub>
+</p>

--- a/platforms/macos/Launcher/Info.plist
+++ b/platforms/macos/Launcher/Info.plist
@@ -4,8 +4,15 @@
 <dict>
     <!-- The launcher carries a distinct bundle id from the input method
          (app.funput.inputmethod.Funput) so the two bundles never collide in
-         LaunchServices. Version values are stamped at build time by
-         scripts/build-launcher.sh. -->
+         LaunchServices. CFBundleShortVersionString, CFBundleVersion and
+         LSMinimumSystemVersion are all stamped at build time by
+         scripts/build-launcher.sh; the values below are only what an unstamped
+         copy of this file would say. Keep LSMinimumSystemVersion in step with
+         MACOSX_DEPLOYMENT_TARGET in Funput.xcodeproj: it was hand-set to 26.5
+         while the input method shipped at 26.0, which made LaunchServices refuse
+         to open the launcher on macOS 26.0-26.4 even though the input method
+         itself ran — exactly the Spotlight entry point this bundle exists to
+         provide. -->
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleDisplayName</key>
@@ -29,7 +36,7 @@
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.productivity</string>
     <key>LSMinimumSystemVersion</key>
-    <string>26.5</string>
+    <string>26.0</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
 </dict>

--- a/platforms/macos/README.md
+++ b/platforms/macos/README.md
@@ -1,0 +1,325 @@
+<p align="center">
+  <img
+    src="../../assets/horizontal-lockup/gradient.png"
+    width="420"
+    alt="Funput"
+  >
+</p>
+
+<p align="center">
+  <strong>Funput cho macOS</strong> — Input Method native, tích hợp thẳng vào hệ thống.<br>
+  SwiftUI + InputMethodKit · gõ bằng preedit · engine Rust qua
+  <code>funput-ffi</code>
+</p>
+
+<p align="center">
+  <a href="https://github.com/Funput/Funput/releases/latest">
+    <img src="https://img.shields.io/badge/Tải_xuống-Bản_mới_nhất-22C55E?style=for-the-badge&logo=github&logoColor=white" alt="Tải Funput macOS">
+  </a>
+  <a href="https://docs.funput.app/docs/install/macos">
+    <img src="https://img.shields.io/badge/Tài_liệu-Hướng_dẫn_cài_đặt-2563EB?style=for-the-badge&logo=readthedocs&logoColor=white" alt="Hướng dẫn cài đặt">
+  </a>
+  <a href="https://github.com/Funput/Funput/issues">
+    <img src="https://img.shields.io/badge/Hỗ_trợ-Báo_lỗi-E11D48?style=for-the-badge&logo=github&logoColor=white" alt="Báo lỗi">
+  </a>
+</p>
+
+---
+
+<p align="center">
+  <img
+    src="../../assets/screenshot/macOS.png"
+    width="640"
+    alt="Giao diện Cài đặt Funput trên macOS"
+  >
+  <br>
+  <sub>Cửa sổ Cài đặt — Tổng quan, Cách gõ, Phím tắt, Gõ tắt.</sub>
+</p>
+
+## Tính năng
+
+| | |
+|---|---|
+| ⌨️ **Ba kiểu gõ** | Telex · **Telex nâng cao** (thêm `w` đầu từ và phím tắt `[` `]`) · VNI |
+| 🔤 **Kiểu đặt dấu** | Truyền thống (`hòa`, `khỏe`) hoặc hiện đại (`hoà`, `khoẻ`) |
+| 🧠 **Gõ thông minh** | Tự khôi phục từ tiếng Anh · khôi phục tức thì · kiểm tra chính tả · tự động viết hoa |
+| ↩️ **Bỏ dấu sau Backspace** | Xoá lùi rồi gõ dấu khác, Funput đặt lại dấu cho đúng từ |
+| 🗂️ **Nhớ theo ứng dụng** | Bật tiếng Việt ở Pages, tắt ở Terminal — Funput tự chuyển khi bạn đổi app |
+| ✂️ **Gõ tắt** | Bảng viết tắt tự bung, tuỳ chọn khớp cả hoa lẫn thường |
+| 🔄 **Chuyển mã** | Đổi qua lại giữa Unicode dựng sẵn, Unicode tổ hợp, TCVN3 (ABC) và VNI-Windows |
+| 💾 **Xuất / nhập cấu hình** | Mang toàn bộ tuỳ chọn và gõ tắt sang máy khác bằng một tệp |
+| 🍎 **Hợp chuẩn macOS 26** | Liquid Glass, thanh menu, khởi động cùng máy |
+
+## Yêu cầu
+
+| | |
+|---|---|
+| **Hệ điều hành tối thiểu** | **macOS 26 (Tahoe)**. macOS 27 được hỗ trợ đầy đủ |
+| **Chip** | **Apple Silicon và Intel** — bản phát hành là universal binary (`arm64` + `x86_64`) |
+| **Cài đặt** | `.pkg` *(cần quyền admin)* hoặc `.app.zip` *(không cần admin)* |
+| **Chữ ký** | Ký **Developer ID** và **notarized** — Gatekeeper không chặn |
+
+> [!IMPORTANT]
+> **macOS 26 là sàn cứng, không phải khuyến nghị.** `MACOSX_DEPLOYMENT_TARGET` của dự án là
+> `26.0`, và `LSMinimumSystemVersion` trong `Info.plist` lấy thẳng giá trị đó. Trên macOS 15
+> (Sequoia) trở xuống, hệ thống **từ chối nạp bundle** — không có chế độ chạy giới hạn nào cả.
+>
+> Sàn này đến từ việc giao diện dựng trên các API SwiftUI của macOS 26 (Liquid Glass —
+> xem [`docs/LIQUID_GLASS.md`](docs/LIQUID_GLASS.md)), không phải từ engine gõ.
+
+## Cài đặt
+
+Tải bản mới nhất từ [GitHub Releases](https://github.com/Funput/Funput/releases/latest). Mỗi bản
+macOS có hai lựa chọn:
+
+| File | Cài vào | Khi nào chọn |
+|---|---|---|
+| `Funput-*.pkg` | `/Library/Input Methods/` | Bạn có quyền admin — một bước, dùng chung cho mọi tài khoản |
+| `Funput-*.app.zip` | `~/Library/Input Methods/` | Máy công ty, tài khoản Standard — **không cần admin** |
+
+Kiểm tra toàn vẹn trước khi cài, so với asset `.sha256` cùng bản phát hành:
+
+```bash
+shasum -a 256 Funput-*.pkg
+```
+
+### Bật bộ gõ
+
+Cài xong **chưa gõ được ngay** — macOS cần bạn thêm Funput vào nguồn nhập:
+
+1. Mở **System Settings** → **Keyboard** → **Input Sources**
+2. Nhấn **+** → chọn **Vietnamese** → **Funput** → **Add**
+3. Chuyển sang Funput bằng phím tắt đổi bộ gõ của macOS (thường là `⌃Space` hoặc phím 🌐)
+
+> [!TIP]
+> Không thấy Funput trong danh sách? **Đăng xuất rồi đăng nhập lại** một lần — macOS chỉ quét lại
+> cơ sở dữ liệu Input Method khi phiên đăng nhập bắt đầu.
+
+### Tìm Funput ở đâu sau khi cài
+
+Bundle Input Method nằm trong `Library/Input Methods` nên **Spotlight không thấy nó**. Vì vậy
+Funput tự đặt thêm một app stub tí hon:
+
+| Cách cài | Stub nằm ở |
+|---|---|
+| `.pkg` | `/Applications/Funput.app` |
+| `.app.zip` hoặc `install.sh` | `~/Applications/Funput.app` *(app tự tạo ở lần chạy đầu)* |
+
+Stub này không phải bộ gõ — nó chỉ mở `funput://settings`, để bạn gõ “Funput” trong Spotlight là
+ra cửa sổ Cài đặt.
+
+## Dùng hằng ngày
+
+### Thanh menu
+
+Icon **VI** trên thanh menu là bảng điều khiển nhanh: bật / tắt tiếng Việt, đổi kiểu gõ, mở Cài
+đặt. Tắt được icon này trong **Cài đặt → Tổng quan → Hiện biểu tượng thanh menu**.
+
+### Phím tắt
+
+| Phím | Việc |
+|---|---|
+| **`⌃` `\`** | Bật / tắt tiếng Việt *(mặc định — ghi đè được trong **Cài đặt → Phím tắt**)* |
+| *(chưa đặt)* | Lật lại từ vừa gõ, `card` ⇄ `cải` — tự chọn tổ hợp trong **Cài đặt → Phím tắt** |
+
+Tổ hợp tự đặt bắt buộc phải kèm `⌃`, `⌥` hoặc `⌘`; phím trần sẽ bắn nhầm khi đang gõ nên bị từ chối.
+
+### Thử nhanh
+
+| Kiểu gõ | Gõ | Ra |
+|---|---|---|
+| Telex | `tieesng vieejt` | tiếng việt |
+| VNI | `xin chao2` | xin chào |
+
+### Cấu hình lưu ở đâu
+
+macOS không dùng file cấu hình riêng — Funput ghi vào `UserDefaults`:
+
+| Domain | Của |
+|---|---|
+| `app.funput.inputmethod.Funput` | Bộ gõ và mọi tuỳ chọn |
+| `app.funput.Funput` | App stub trong Applications |
+
+Xem hoặc chỉnh tay bằng `defaults`, ví dụ tắt tính năng bỏ dấu sau Backspace:
+
+```bash
+defaults write app.funput.inputmethod.Funput retoneAfterBackspace -bool false
+```
+
+Muốn mang cấu hình sang máy khác thì dùng **Cài đặt → Dữ liệu → Xuất cấu hình**.
+
+## Giới hạn đã biết
+
+> [!CAUTION]
+> **Gõ vào app Chromium/Electron trên macOS 26/27 beta có thể đứng im.** Sau khi chuyển nguồn nhập
+> trong lúc một ô nhập của Chrome, Cursor, VS Code, Slack, Discord, Notion… đang có focus, phím chữ
+> ngừng ra chữ. **Không phải lỗi của Funput** — Apple đổi nội bộ `TextInputUIMacHelper` và cầu
+> `NSTextInputContext` của Chromium chưa theo kịp; mọi bộ gõ bên thứ ba đều dính.
+> Chi tiết và cách né: [`docs/KNOWN_ISSUES.md`](docs/KNOWN_ISSUES.md).
+
+- **Bỏ dấu sau Backspace không chạy trong Cursor.** Cursor báo vị trí con trỏ mâu thuẫn qua
+  `IMKTextInput`, nên Funput từ chối thay vì đoán bừa. VS Code thì bình thường.
+- **Không tự kiểm tra cập nhật nền.** `SUEnableAutomaticChecks` được đặt `false` — chỉ chạy khi
+  bạn bấm **Kiểm tra cập nhật**.
+- **Không có bản Mac App Store.** Input Method không thể chạy sandbox, nên chỉ phát hành trực tiếp.
+
+## Cập nhật
+
+**Cài đặt → Kiểm tra cập nhật** (Sparkle). Funput đọc `appcast.xml` đã ký từ GitHub Releases, xác
+minh chữ ký **Ed25519** rồi cài bản mới. Cùng khoá ký với bản Windows.
+
+Cập nhật thủ công thì tải bản mới rồi cài đè đúng cách bạn đã dùng lần trước (`.pkg` hoặc
+`.app.zip`).
+
+## Gỡ cài đặt
+
+Làm đúng thứ tự này, vì macOS nhớ nguồn nhập độc lập với file trên đĩa:
+
+1. **System Settings → Keyboard → Input Sources**, chọn **Funput**, nhấn **−**.
+2. Chạy script gỡ — nó dọn cả bản system-wide lẫn bản per-user, app stub, receipt của `.pkg`,
+   preferences và cache:
+
+   ```bash
+   ./scripts/uninstall.sh              # gỡ sạch
+   ./scripts/uninstall.sh --keep-prefs # gỡ app, giữ lại cài đặt
+   ```
+
+3. **Đăng xuất rồi đăng nhập lại** (hoặc khởi động lại máy) để macOS quên hẳn nguồn nhập.
+
+> [!WARNING]
+> Chạy script bằng tài khoản thường, **đừng `sudo ./uninstall.sh`**. Script tự gọi `sudo` cho những
+> chỗ cần quyền; chạy cả script dưới root sẽ xoá preferences của root thay vì của bạn.
+
+Hướng dẫn đầy đủ hơn: [docs.funput.app — macOS](https://docs.funput.app/docs/install/macos).
+
+---
+
+## Dành cho developer
+
+### Kiến trúc
+
+Funput trên macOS là **bundle Input Method**, không phải app thường: macOS nạp nó, nó dựng
+`IMKServer`, và từ đó chạy như một background agent (`LSUIElement`). Cùng process đó cũng host các
+scene SwiftUI — thanh menu, Cài đặt, Onboarding, Chuyển mã — nên không có process con nào cả (khác
+hẳn shell Windows).
+
+Composition đi theo đường **preedit**: chữ đang gõ hiện ra qua `setMarkedText` và chỉ `insertText`
+khi từ đã chốt. Engine là Rust, vào qua [`funput-ffi`](../../crates/funput-ffi) dưới dạng static
+library `Vendor/libfunput_ffi.a`.
+
+```text
+Funput.app   trong /Library/Input Methods — MỘT process, hai vai trò
+│
+├── IMKServer ................ cầu nối với app đang gõ (XPC/Mach)
+│        │
+│        └──▶ FunputInputController ──▶ FunputComposer
+│                     │                       │
+│                     │                       └──▶ funput-ffi ──▶ funput-engine
+│                     │
+│                     ├── setMarkedText   preedit — chữ đang gõ, gạch chân
+│                     └── insertText      commit — chốt từ đã xong
+│
+├── Thanh menu ............... SwiftUI · bật/tắt VI · đổi kiểu gõ
+├── Cài đặt · Onboarding ..... SwiftUI Scene, cùng process
+└── Sparkle .................. cập nhật — chỉ chạy khi bạn bấm
+
+Funput.app   trong /Applications — bundle stub riêng, id app.funput.Funput
+│
+└── mở funput://settings ..... để Spotlight tìm được “Funput”
+```
+
+Hai bundle mang **bundle id khác nhau** (`app.funput.inputmethod.Funput` và `app.funput.Funput`)
+để LaunchServices không bao giờ nhầm hai bản với nhau.
+
+### Cây thư mục
+
+```text
+platforms/macos/
+  Funput.xcodeproj · Info.plist · Bridging-Funput.h · ExportOptions.plist
+  Funput/
+    FunputApp.swift        IMKServer · xử lý URL funput:// · cài stub launcher
+    IME/                   Controller · Composer · retone · chính sách phím
+    Model/                 AppSettings (UserDefaults) · KeyCombo · nhớ theo app
+    Settings/ MenuBar/ Onboarding/ Convert/     SwiftUI
+    DesignSystem/          Theme + lớp Liquid Glass
+  Launcher/                Stub Spotlight (một file main.swift)
+  FunputTests/             XCTest
+  Vendor/libfunput_ffi.a   Sinh ra bởi scripts/build-ffi.sh, không commit
+  scripts/
+  docs/                    LIQUID_GLASS.md · KNOWN_ISSUES.md
+```
+
+### Stack
+
+| | |
+|---|---|
+| Swift | `5.0` language mode · SwiftUI · InputMethodKit |
+| Deployment target | `26.0` — cả app, launcher lẫn test target |
+| Kiến trúc | Debug: chỉ arch đang chạy. Release: universal, ghép bằng `lipo` |
+| Engine | [`funput-ffi`](../../crates/funput-ffi) `--features convert`, link tĩnh |
+| Cập nhật | Sparkle · appcast ký Ed25519 |
+| Phát hành | Developer ID + notarize + `.pkg` *(Team `RSARFZ5CD3`)* |
+
+Crate dùng chung: [`funput-engine`](../../crates/funput-engine) ·
+[`funput-convert`](../../crates/funput-convert/README.md) ·
+[`funput-core`](../../crates/funput-core).
+Định dạng cấu hình: [`../CONFIG_FORMAT.md`](../CONFIG_FORMAT.md).
+
+### Build
+
+Cần **macOS** + Xcode, cộng Rust toolchain cho `funput-ffi`. Build phase “Run Script” của Xcode tự
+gọi [`scripts/build-ffi.sh`](scripts/build-ffi.sh) trước khi compile Swift, nên không phải build
+thư viện bằng tay.
+
+```bash
+# Build rồi cài thẳng làm input method của người dùng hiện tại
+./scripts/install.sh
+CONFIGURATION=Debug ./scripts/install.sh
+```
+
+```bash
+# Test
+xcodebuild -project Funput.xcodeproj -scheme Funput -destination 'platform=macOS' test
+```
+
+```bash
+# Bản phát hành đầy đủ: universal + Developer ID + notarize + .pkg
+./scripts/release.sh
+DRY_RUN=1 ./scripts/release.sh   # ký ad-hoc, bỏ qua notarize — thử pipeline
+```
+
+> [!TIP]
+> `install.sh` mặc định build **Release**, cố ý: bản Debug tách ra một `.debug.dylib` mà trình quét
+> input method của macOS có thể từ chối. Script cũng tự `lsregister` + `TISRegisterInputSource` để
+> nguồn nhập hiện ra ngay, không cần đăng xuất.
+
+Giới hạn kích thước file Swift: **150 dòng/file**, tối đa **5 file/thư mục tính năng** —
+[`scripts/check-swift-loc.sh`](scripts/check-swift-loc.sh), và CI có gác cổng này.
+
+### CI
+
+| Workflow | Việc |
+|---|---|
+| [`ci.yml`](../../.github/workflows/ci.yml) | Job `shell-line-budget` chạy `check-swift-loc.sh`. **Không** compile hay test Swift |
+| [`build-macos.yml`](../../.github/workflows/build-macos.yml) | `workflow_call`: test macOS · build universal · Developer ID · notarize · `.pkg` + `.app.zip` · sinh và ký `appcast.xml` |
+| [`release.yml`](../../.github/workflows/release.yml) | Gọi workflow trên và đẩy artifact lên GitHub Releases |
+
+> [!WARNING]
+> **Test macOS không chạy trên pull request.** Chúng chỉ nằm trong `build-macos.yml`, mà workflow
+> này là `workflow_call` — chỉ `release.yml` gọi tới. Nghĩa là một thay đổi Swift làm hỏng test có
+> thể vào `main` mà không ai biết, cho đến lúc phát hành. Hãy chạy `xcodebuild … test` tại máy
+> trước khi mở PR.
+
+## Giấy phép
+
+MIT — [`LICENSE`](../../LICENSE).
+
+<p align="center">
+  <sub>
+    <a href="https://funput.app">funput.app</a>
+    ·
+    <a href="../../README.md">README gốc</a>
+    ·
+    Made with ♥ by Funput
+  </sub>
+</p>

--- a/platforms/macos/scripts/build-launcher.sh
+++ b/platforms/macos/scripts/build-launcher.sh
@@ -46,6 +46,12 @@ rm -rf "$TMP"
 cp "$SRC/Info.plist" "$APP/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$APP/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION" "$APP/Contents/Info.plist"
+# Stamp the OS floor from the same variable the binary is compiled against, rather
+# than trusting the checked-in value. Those two drifted once already: the plist said
+# 26.5 while the input method (and this binary) shipped at 26.0, so LaunchServices
+# refused to open the launcher on macOS 26.0-26.4 — leaving a "Funput" in Spotlight
+# that did nothing, which is the one job this bundle has.
+/usr/libexec/PlistBuddy -c "Set :LSMinimumSystemVersion $DEPLOY_TARGET" "$APP/Contents/Info.plist"
 
 # App icon (best-effort): build AppIcon.icns from the 1024px master so Spotlight
 # and Finder show the Funput logo. Skipped quietly if the tools/source are missing.

--- a/platforms/windows/README.md
+++ b/platforms/windows/README.md
@@ -1,0 +1,298 @@
+<p align="center">
+  <img
+    src="../../assets/horizontal-lockup/gradient.png"
+    width="420"
+    alt="Funput"
+  >
+</p>
+
+<p align="center">
+  <strong>Funput cho Windows</strong> — bộ gõ tiếng Việt portable, chạy nền ở khay hệ thống.<br>
+  Một file <code>.exe</code> · không cài đặt · UI native <a href="https://slint.dev">Slint</a> · link trực tiếp
+  <code>funput-engine</code>
+</p>
+
+<p align="center">
+  <a href="https://github.com/Funput/Funput/releases/latest">
+    <img src="https://img.shields.io/badge/Tải_xuống-Bản_mới_nhất-22C55E?style=for-the-badge&logo=github&logoColor=white" alt="Tải Funput Windows">
+  </a>
+  <a href="https://docs.funput.app/docs/install/windows">
+    <img src="https://img.shields.io/badge/Tài_liệu-Hướng_dẫn_cài_đặt-2563EB?style=for-the-badge&logo=readthedocs&logoColor=white" alt="Hướng dẫn cài đặt">
+  </a>
+  <a href="https://github.com/Funput/Funput/issues">
+    <img src="https://img.shields.io/badge/Hỗ_trợ-Báo_lỗi-E11D48?style=for-the-badge&logo=github&logoColor=white" alt="Báo lỗi">
+  </a>
+</p>
+
+---
+
+<p align="center">
+  <img
+    src="../../assets/screenshot/windows.png"
+    width="640"
+    alt="Giao diện Cài đặt Funput trên Windows"
+  >
+  <br>
+  <sub>Cửa sổ Cài đặt — Tổng quan, Telex / Telex+ / VNI, khởi động cùng Windows.</sub>
+</p>
+
+## Tính năng
+
+| | |
+|---|---|
+| ⌨️ **Ba kiểu gõ** | Telex · **Telex+** (thêm `w` đầu từ và phím tắt `[` `]`) · VNI |
+| 🔤 **Kiểu đặt dấu** | Truyền thống (`hòa`, `khỏe`) hoặc hiện đại (`hoà`, `khoẻ`) |
+| 🧠 **Gõ thông minh** | Tự khôi phục tiếng Anh · khôi phục tức thì · kiểm tra chính tả · tự động viết hoa |
+| 🗂️ **Nhớ theo ứng dụng** | Bật tiếng Việt ở Word, tắt ở Terminal — Funput tự chuyển khi bạn đổi cửa sổ |
+| 🌏 **Tự tắt khi đổi bàn phím** | Chuyển sang EN khi bạn dùng bàn phím tiếng Nhật, Hàn, Trung… |
+| ✂️ **Gõ tắt** | Bảng viết tắt tự bung, khớp cả hoa lẫn thường; nhập được bảng gõ tắt UniKey |
+| 🔄 **Chuyển mã** | Đổi qua lại giữa Unicode dựng sẵn, Unicode tổ hợp, TCVN3 (ABC) và VNI-Windows — dán văn bản hoặc chuyển cả tệp |
+| 💾 **Xuất / nhập cấu hình** | Mang toàn bộ tuỳ chọn và gõ tắt sang máy khác bằng một tệp |
+| 🚀 **Khởi động cùng Windows** | Tuỳ chọn, ghi vào registry `HKCU\…\Run` |
+
+Không cần thêm Input Source như macOS hay Linux — Funput hoạt động ngay qua keyboard hook toàn cục.
+
+## Yêu cầu
+
+| | |
+|---|---|
+| **Hệ điều hành** | **Windows 10 phiên bản 1809 (build 17763)** trở lên · Windows 11 |
+| **Kiến trúc** | **x86-64**. Windows on ARM chạy được qua emulation, nhưng không có bản build riêng |
+| **Cài đặt** | Một file `.exe` portable — chưa có MSI/installer |
+| **Runtime ngoài** | Không cần. Không WebView2, không .NET |
+
+> [!NOTE]
+> **Vì sao là build 17763?** Đó là mốc `window-vibrancy` cần để dựng nền Acrylic cho Control Center.
+> Bản Windows cũ hơn không bị chặn chạy, nhưng không được thử nghiệm và flyout sẽ mất hiệu ứng nền.
+>
+> **Mica là Win11.** Trên Windows 10, cửa sổ Cài đặt dùng nền đục — cố ý như vậy, không phải lỗi:
+> đường Acrylic thay thế khiến cửa sổ kéo/resize bị giật (xem [`src/ui/mica.rs`](src/ui/mica.rs)).
+
+## Cài đặt
+
+1. Tải `Funput-<version>.exe` từ [GitHub Releases](https://github.com/Funput/Funput/releases/latest).
+2. Đặt file ở vị trí cố định, ví dụ `%LOCALAPPDATA%\Programs\Funput\` — **đừng để trong Downloads**.
+3. Double-click. Icon **f** của Funput xuất hiện ở khay hệ thống.
+4. Lần đầu chạy sẽ mở **Onboarding**; xong là gõ được ngay trên mọi ứng dụng.
+
+Kiểm tra toàn vẹn file trước khi chạy — so kết quả với asset `.sha256` cùng bản phát hành:
+
+```powershell
+Get-FileHash .\Funput-*.exe -Algorithm SHA256
+```
+
+> [!IMPORTANT]
+> **File bạn vừa tải sẽ tự đổi tên.** Lần chạy đầu tiên, `Funput-<version>.exe` tự nhân bản thành
+> `Funput.exe` cạnh nó, khởi động lại từ file mới rồi **xoá file có số phiên bản**. Đây là hành vi
+> cố ý: autostart và cập nhật cần một đường dẫn cố định. Từ đó trở đi bạn chỉ chạy `Funput.exe`.
+
+> [!WARNING]
+> **SmartScreen** có thể cảnh báo lần đầu (exe chưa ký Authenticode). Chỉ tải từ
+> [GitHub Releases](https://github.com/Funput/Funput/releases) chính thức, rồi chọn
+> **More info** → **Run anyway**.
+
+## Dùng hằng ngày
+
+### Khay hệ thống
+
+| Thao tác | Chức năng |
+|---|---|
+| **Click trái** | Mở / đóng **Control Center** — bật tắt tiếng Việt, đổi kiểu gõ, bật nhanh chính tả / khôi phục tiếng Anh / viết hoa |
+| **Click phải** | Cài đặt… · Chuyển mã… · Kiểm tra cập nhật… · Thoát |
+
+Icon tray đổi **màu ↔ mono** theo trạng thái tiếng Việt, nên liếc một cái là biết đang gõ kiểu gì.
+
+### Phím tắt
+
+| Phím | Việc |
+|---|---|
+| **`Ctrl` + `` ` ``** | Bật / tắt tiếng Việt *(mặc định — đổi được sang `Ctrl Space` hoặc `Alt Shift`)* |
+| **`Ctrl` `Shift` `Z`** | Lật lại từ vừa gõ *(mặc định tắt; bật trong **Cài đặt → Phím tắt**)* |
+
+### Thử nhanh
+
+| Kiểu gõ | Gõ | Ra |
+|---|---|---|
+| Telex | `tieesng vieejt` | tiếng việt |
+| VNI | `xin chao2` | xin chào |
+
+### Cấu hình lưu ở đâu
+
+Funput ưu tiên **portable**: cấu hình nằm cạnh chính file exe để cả app đi theo USB được.
+
+| Thứ tự | Vị trí | Khi nào dùng |
+|---|---|---|
+| 1 | `%FUNPUT_CONFIG%` | Khi biến môi trường này được đặt |
+| 2 | `<thư mục chứa Funput.exe>\settings.json` | **Mặc định** — khi thư mục đó ghi được |
+| 3 | `%APPDATA%\Funput\settings.json` | Dự phòng, khi thư mục exe chỉ đọc (ví dụ đặt trong `C:\Program Files\`) |
+
+## Giới hạn đã biết
+
+> [!CAUTION]
+> **Không gõ được vào ứng dụng chạy quyền Administrator** (Task Manager, regedit, một số trình cài đặt).
+> Funput chạy ở quyền thường (`asInvoker`) nên Windows chặn nó đưa phím vào cửa sổ elevated.
+> Cách duy nhất: chạy Funput bằng **Run as administrator**.
+
+- **Không tự kiểm tra cập nhật nền.** Chỉ chạy khi bạn bấm **Kiểm tra cập nhật…**.
+- **Chưa có installer.** Bản phát hành là một file `.exe` portable, chưa có MSI.
+- **Chưa ký Authenticode**, nên SmartScreen sẽ cảnh báo ở lần chạy đầu.
+
+## Cập nhật
+
+Tray → **Kiểm tra cập nhật…**. Funput đọc manifest `funput-windows.json` từ GitHub Releases, tải
+`.exe` mới, **xác minh chữ ký Ed25519** (cùng public key với Sparkle trên macOS), thay file đang
+chạy tại chỗ rồi tự khởi động lại — không cần đăng xuất.
+
+## Gỡ cài đặt
+
+Portable nên không có trình gỡ; dọn ba thứ:
+
+```powershell
+# 1. Thoát Funput từ menu tray, rồi xoá thư mục chứa app
+Remove-Item -Recurse "$env:LOCALAPPDATA\Programs\Funput"
+
+# 2. Xoá mục khởi động cùng Windows (nếu đã bật)
+Remove-ItemProperty "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run" -Name Funput -EA SilentlyContinue
+
+# 3. Xoá cấu hình dự phòng, nếu có
+Remove-Item -Recurse "$env:APPDATA\Funput" -EA SilentlyContinue
+```
+
+Hướng dẫn đầy đủ hơn: [docs.funput.app — Windows](https://docs.funput.app/docs/install/windows).
+
+---
+
+## Dành cho developer
+
+### Kiến trúc
+
+Package độc lập `funput-windows`, **nằm ngoài Cargo workspace** của repo: nó kéo Slint và crate
+`windows`, vốn chỉ build trên target Windows. Hệ quả cần nhớ — package này **không** thừa kế
+`[profile.release]` lẫn `[lints]` của workspace, nên giữ bản sao tương đương trong `Cargo.toml`
+của chính nó.
+
+Khác mọi nền tảng khác (macOS/Linux qua [`funput-ffi`](../../crates/funput-ffi), Android qua
+[`funput-jni`](../../crates/funput-jni)), shell này **link thẳng** Rust vào
+[`funput-engine`](../../crates/funput-engine) / [`funput-desktop`](../../crates/funput-desktop).
+
+Một file `.exe`, hai chương trình:
+
+```text
+Process nền   luôn chạy · giữ hook + tray · không nhúng runtime UI
+│
+├── WH_KEYBOARD_LL ............ phím người dùng gõ
+├── WH_MOUSE_LL ............... click chuột dời caret
+├── WinEvent FOREGROUND ....... đổi app → nhớ VI/EN theo từng app
+│        │
+│        └──▶ funput-desktop ──▶ funput-engine ──▶ SendInput
+│                                  (Backspace + ký tự Unicode)
+│
+└── tray-icon ................. icon trạng thái + menu ngữ cảnh
+
+Process UI    sinh theo yêu cầu · sống ngắn · chọn bằng cờ dòng lệnh
+│
+└── Slint (style Fluent · renderer Skia) · window-vibrancy
+```
+
+Cả **ba** hook chạy trên main thread của process nền — `WH_KEYBOARD_LL` bắt buộc phải có message
+loop, và tray dùng chung vòng lặp đó. Mọi sự kiện synthesize ra bằng `SendInput` đều mang
+`INJECT_TAG` trong `dwExtraInfo` để chính hook bỏ qua, tránh đệ quy.
+
+Cửa sổ Slint là **process con**, chọn bằng cờ dòng lệnh; đóng cửa sổ là Windows thu hồi trọn vẹn
+Skia, font cache và cấp phát của driver đồ hoạ:
+
+| Cờ | Cửa sổ |
+|---|---|
+| `--settings` | Cài đặt |
+| `--settings-check-update` | Cài đặt, mở thẳng **Giới thiệu** và kiểm tra cập nhật |
+| `--onboarding` | Onboarding lần chạy đầu |
+| `--control-center` | Flyout Control Center |
+| `--convert` | Công cụ Chuyển mã |
+
+Không cờ nào ⇒ chạy process nền, sau khi đã chuẩn hoá tên exe và **giành singleton**. Lần chạy
+thứ hai không tự dựng tray: nó báo bản gốc mở Cài đặt rồi thoát.
+
+### Cây thư mục
+
+```text
+platforms/windows/
+  Cargo.toml · build.rs · ui/ · icons/
+  src/
+    main.rs        Định tuyến cờ · chuẩn hoá exe · singleton
+    background/    hook/ (keyboard · mouse · foreground) · hotkey/ · inject/ · keymap · tray/
+    shared/        shell/ (state toàn cục) · commands/ · update/ · settings_path · canonical_exe
+    ui/            Cửa sổ Slint · control_center/ · mica.rs
+  scripts/
+    build-release.ps1 · build-release.sh
+```
+
+### Stack
+
+| | |
+|---|---|
+| Rust | `1.97.1` ([`rust-toolchain.toml`](../../rust-toolchain.toml)) — Slint 1.17 cần ≥ 1.92 |
+| Slint | `1.17` · winit · renderer **Skia** · style Fluent *(chọn trong [`build.rs`](build.rs))* |
+| Win32 | `windows` 0.62 · `window-vibrancy` 0.8 — Mica (Win11) / Acrylic (Win10 1809+) |
+| Tray | `tray-icon` 0.24 *(không WebView2)* |
+| Cập nhật | `ureq` · `ed25519-dalek` · `self-replace` |
+
+Crate dùng chung: [`funput-engine`](../../crates/funput-engine) ·
+[`funput-desktop`](../../crates/funput-desktop/README.md) ·
+[`funput-config`](../../crates/funput-config) ·
+[`funput-convert`](../../crates/funput-convert/README.md) ·
+[`funput-core`](../../crates/funput-core).
+Định dạng cấu hình: [`../CONFIG_FORMAT.md`](../CONFIG_FORMAT.md).
+
+### Build
+
+Cần **Windows** + MSVC (workload “Desktop development with C++”). Skia chỉ có binary dựng sẵn cho
+`*-windows-msvc` — cross-compile `windows-gnu` từ macOS/Linux sẽ thất bại.
+
+```powershell
+# Vòng lặp phát triển — profile dev, giống hệt job `windows` của CI
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+```powershell
+# Bản phát hành, từ thư mục này
+.\scripts\build-release.ps1
+```
+
+> [!TIP]
+> Đừng lint/test bằng `--release`. Profile release ở đây bật `lto = "fat"` +
+> `codegen-units = 1` trên cây phụ thuộc Slint + Skia: CI đo được **220 s clippy và 248 s test**
+> khi cache nguội. CI cố tình chạy profile dev, và bạn cũng nên vậy.
+
+Artifact trong `build/release/`:
+
+| File | |
+|---|---|
+| `Funput-<version>.exe` | Asset để phát hành |
+| `Funput.exe` | Tên ổn định, dùng cho autostart và chạy thử tại chỗ |
+| `Funput-<version>.exe.sha256` | Checksum |
+
+Test cần trỏ cấu hình đi chỗ khác thì đặt `FUNPUT_CONFIG` — nó thắng mọi lựa chọn vị trí khác.
+
+### CI
+
+| Workflow | Việc |
+|---|---|
+| [`ci.yml`](../../.github/workflows/ci.yml) | Job `windows`: clippy + test *(profile dev)*. Job `cargo-deny` có bước riêng cho shell này |
+| [`build-windows.yml`](../../.github/workflows/build-windows.yml) | Build `Funput.exe` và `funput` CLI; job `windows-feed` chạy trên **macOS runner** để ký Ed25519 và phát `funput-windows.json` |
+| [`release.yml`](../../.github/workflows/release.yml) | Gom artifact lên GitHub Releases |
+| [`audit.yml`](../../.github/workflows/audit.yml) | Rà advisory của dependency |
+
+## Giấy phép
+
+MIT — [`LICENSE`](../../LICENSE).
+
+<p align="center">
+  <sub>
+    <a href="https://funput.app">funput.app</a>
+    ·
+    <a href="../../README.md">README gốc</a>
+    ·
+    Made with ♥ by Funput
+  </sub>
+</p>


### PR DESCRIPTION
## Tóm tắt

- **Sáu README** theo cùng một cấu trúc, bằng tiếng Việt: năm nền tảng (Windows, macOS, iOS, Android, Linux) cộng shell Fcitx5. Windows, macOS và iOS trước đây **không có** README; Linux và Android có, nhưng bằng tiếng Anh và thiếu hẳn phần cho người dùng cuối.
- **Mỗi README mở đầu bằng hệ điều hành tối thiểu.** Đây là yêu cầu dẫn dắt cả PR — người dùng phải trả lời được "máy tôi có chạy được không?" trước khi đọc bất cứ thứ gì khác.
- Ngoài README, PR sửa **hai lỗi thật** tìm thấy trong lúc đối chiếu tài liệu với code (xem bên dưới).

Mỗi file chia hai nửa: nửa trên cho người dùng cuối (Tính năng · Yêu cầu · Cài đặt · Dùng hằng ngày · Giới hạn đã biết · Gỡ cài đặt), nửa dưới sau đường kẻ ngang là **Dành cho developer** (kiến trúc, cây thư mục, stack, build, CI).

## Hệ điều hành tối thiểu

Không con số nào lấy từ tài liệu cũ — tất cả đọc từ build config, và đối chiếu lại với sản phẩm đã đóng gói khi có.

| Nền tảng | Sàn | Đọc từ đâu |
|---|---|---|
| **Android** | 8.0 (Oreo, API 26) | `minSdk = 26` ở cả **sáu** module |
| **iOS** | 18.6 | `MinimumOSVersion` trong `Funput.xcarchive` — cả `.app` lẫn `.appex` |
| **macOS** | 26 (Tahoe) | `MACOSX_DEPLOYMENT_TARGET = 26.0` |
| **Windows** | 10 build 17763 | mốc Acrylic của `window-vibrancy` 0.8 |
| **Linux** | *không có số* | phụ thuộc Fcitx5/IBus của distro, không phải phiên bản kernel |

Linux là ngoại lệ có lý do, nên mục **Yêu cầu** của nó nêu thứ thật sự quyết định: framework nào, distro nào, kiến trúc gì, có cần root không.

## Hai lỗi được sửa

**`LSMinimumSystemVersion` của launcher macOS lệch với binary.** `Launcher/Info.plist` khai `26.5` trong khi binary compile ở `26.0` và bộ gõ khai `26.0`. Giá trị này **không** được stamp lúc build — `build-launcher.sh` chỉ ghi đè `CFBundleShortVersionString` và `CFBundleVersion`. Hệ quả trên macOS 26.0–26.4: bộ gõ chạy bình thường nhưng LaunchServices **từ chối mở app stub**, tức người dùng tìm thấy "Funput" trong Spotlight mà bấm vào không lên gì — đúng cái việc duy nhất bundle đó sinh ra để làm.

Sửa ở hai chỗ, vì một chỗ chỉ vá triệu chứng: plist về `26.0`, **và** `build-launcher.sh` stamp `LSMinimumSystemVersion` từ chính biến `DEPLOY_TARGET` mà binary được compile với. Nguyên nhân gốc là giá trị đó được sửa tay trong khi deployment target thật nằm trong script — không có gì buộc hai chỗ khớp nhau, nên chúng đã lệch một lần rồi.

**`platforms/ios/docs/ARCHITECTURE.md` ghi sai sàn iOS:** `18.0`, thực tế `18.6`. Sửa kèm nguồn xác minh, và kèm cảnh báo cái bẫy đứng sau nó — cài đặt **cấp project** là `IPHONEOS_DEPLOYMENT_TARGET = 26.5`; mọi target hiện có đều ghi đè xuống 18.6 nên nó vô hại *lúc này*, nhưng một target mới quên đặt giá trị riêng sẽ âm thầm thừa kế 26.5 và loại gần hết thiết bị người dùng.

## Những chỗ tài liệu cũ nói sai

Phần lớn công sức của PR nằm ở đây chứ không ở việc dịch.

| Chỗ | Trước | Thực tế |
|---|---|---|
| Ví dụ VNI *(README + trang docs)* | `xin chaof` | `chaof` là **Telex**. VNI dùng chữ số: `xin chao2` |
| Nơi lưu cấu hình Windows | `%APPDATA%\Funput\settings.json` | **Portable-first**: `$FUNPUT_CONFIG` → cạnh exe *(mặc định)* → `%APPDATA%` *(dự phòng)* |
| Icon tray Windows | "icon **FU**" | logomark chữ **f** |
| Sàn Windows 17763 | "sàn kỹ thuật" | Code degrade an toàn (`is_ok()`); đây là mốc Acrylic cho Control Center, không phải rào chặn chạy |
| Cập nhật macOS | "app sẽ thông báo khi có bản mới" | `SUEnableAutomaticChecks = false` — **không bao giờ** tự kiểm hay thông báo |
| Module Android | 5 module | **6** — thiếu `theme-store` |

Ngoài ra, mỗi README bổ sung những thứ người dùng chắc chắn vấp phải mà không nơi nào nói:

- **Windows:** file `Funput-<version>.exe` vừa tải **tự đổi tên** thành `Funput.exe` rồi tự xoá bản có số phiên bản; và **không gõ được vào ứng dụng chạy quyền Administrator** (`asInvoker`).
- **macOS:** cài xong **chưa gõ được** cho tới khi thêm Input Source; Spotlight không thấy bộ gõ nên có app stub trong `Applications`; hai lỗi đã biết từ `KNOWN_ISSUES.md` (Chromium/Electron trên macOS 26/27 beta, bỏ dấu sau Backspace trong Cursor).
- **iOS:** vì sao cần **Cho phép truy cập đầy đủ** — không có nó thì tiện ích không đọc được App Group, tức không biết Telex hay VNI, không có theme, không rung.
- **Android:** **chưa lên Play Store công khai**, đang ở vòng kiểm thử khép kín 14 ngày.
- **Linux:** **không có nhớ VI/EN theo app** — trên GNOME/Wayland mọi app đều báo tên là `gnome-shell`.

## README cho shell Fcitx5

`platforms/linux/fcitx5/README.md` là file mới, tách riêng vì nội dung #341 và #339 vừa thêm **chỉ đúng với Fcitx5**, và chính nó làm Fcitx5 thành mặc định của `install.sh` trên mọi desktop. Nhồi vào README Linux thì phần "cả hai shell" và phần "chỉ Fcitx5" lẫn vào nhau.

Nó chứa: vì sao Fcitx5 là mặc định · allowlist client tự giấu preedit *(trích thẳng `kHiddenPreedit[]`, giữ nguyên cảnh báo trong source là đừng khớp theo cờ capability)* · ma trận biến môi trường theo session · cảnh báo `fcitx5 -r` trên KDE · và những chi tiết chỉ đọc code mới thấy — vì sao `setClientPreedit()` luôn được publish kể cả cho client không vẽ được, vì sao `reopen` hỏi `classify()` chứ không so keysym, vì sao prefix `/usr` là bắt buộc.

Lý lẽ và số liệu đo của chế độ không preedit **không chép lại**, chỉ link về README Linux.

## Ghi chú cho người review

**Nhánh đã rebase lên `main`** (gồm #341 và #339), không merge — để `git diff main...HEAD` chỉ hiện đúng thứ PR này viết, thay vì 75 file của main. Xung đột duy nhất là `platforms/linux/README.md`; nó được giải quyết bằng cách **mang toàn bộ nội dung mới của main vào bản tiếng Việt**, không phải chọn một bên. Hai câu trong bản viết trước đó đã thành sai và được sửa theo #341: mặc định installer *(IBus → **Fcitx5 trên mọi desktop**)*, và `fcitx5 -r` *(từ "cách xử lý sự cố" → cảnh báo, vì trên KDE nó phá input tới lần đăng nhập sau)*.

**Ba file không phải README** là hai bản vá ở trên: `Launcher/Info.plist`, `scripts/build-launcher.sh`, `docs/ARCHITECTURE.md`.

**Về ngôn ngữ:** Linux và Android trước đây là tiếng Anh, giờ thành tiếng Việt cho đồng bộ với ba bản mới và với `README.md` gốc *(vốn đã có cặp `README.md` tiếng Việt + `README.en.md`)*. Hệ quả cần biết: những đoạn kỹ thuật sâu trong README Linux giờ **chỉ còn một bản tiếng Việt**, nên PR sau đụng vào `install.sh` hay shell Fcitx5 sẽ phải cập nhật tài liệu bằng tiếng Việt. Nếu muốn tránh, hướng đi là tách tài liệu kỹ thuật sâu ra `platforms/linux/docs/` giữ tiếng Anh — chưa làm trong PR này.

**Chưa có README cho shell IBus.** Nội dung đã sẵn (bốn sự thật API, cache khử trùng lặp của daemon) nhưng để riêng một PR sau cho cân xứng.

## Cách kiểm tra

- [x] **Sàn iOS 18.6** đối chiếu ba nguồn độc lập: `IPHONEOS_DEPLOYMENT_TARGET` từng target trong `project.pbxproj`, và `MinimumOSVersion` trong `build/release/Funput.xcarchive` cho **cả** `.app` lẫn `.appex`.
- [x] **Bản vá launcher macOS chạy thật.** Gọi `build-launcher.sh` end-to-end (swiftc có sẵn trên máy), rồi soi bundle sinh ra: `LSMinimumSystemVersion = 26.0` *(trước là 26.5)*. `vtool -show-build-version` xác nhận `minos 26.0` trên **cả** `arm64` và `x86_64` — plist và binary giờ khớp nhau, trước thì không. `plutil -lint` sạch, `sh -n` sạch.
- [x] **Android `minSdk = 26`** kiểm ở cả sáu module; sơ đồ phụ thuộc dựng lại từ `build.gradle.kts` của từng module *(đó là cách phát hiện thiếu `theme-store`)*.
- [x] **Mọi khẳng định về tính năng đọc từ source**, không từ tài liệu cũ: phím tắt mặc định *(`Hotkey::CtrlBacktick` trên Windows/Linux, `⌃\` trên macOS)*, bảng chữ số VNI trong `funput-core`, 7 theme Android, 5 theme iOS, chuỗi kiểu gõ trên từng nền tảng.
- [x] **Sửa một khẳng định của chính mình giữa chừng:** ban đầu viết iOS "chỉ Telex và VNI" — sai, `KeyboardInputMethod` có `telexAdvanced` và nó hiện trong Settings.
- [x] **Toàn bộ link tương đối, ảnh và neo chéo file trong 6 README đều resolve** (kiểm bằng script, không đọc mắt).
- [x] **Sau rebase, README Linux không còn conflict marker** và 9/9 mốc nội dung của main còn nguyên: `hidden_preedit` · `--dry-run` · SHA-256 · `GTK_IM_MODULE` · `fcitx5 -r` · WPS Office · "Bốn sự thật" · "mười sáu lần" · "Fcitx5 trên mọi desktop".
- [x] Gỡ `platforms/android/.idea/kotlinc.xml` khỏi lịch sử — rác Android Studio tự ghi, bị cuốn vào commit Android.

Chưa kiểm được, cần người review:

- [x] **Cách 6 file render trên GitHub** — GitHub alert (`[!NOTE]`, `[!CAUTION]`…), bảng, emoji và các sơ đồ ASCII căn cột. Sơ đồ được sinh bằng script để căn cột, nhưng chỉ nhìn mắt trên GitHub mới chắc.
- [x] **Không có gì được biên dịch trong PR này.** Thay đổi `build-launcher.sh` chạy đúng khi gọi riêng, nhưng đường `release.sh` đầy đủ *(Developer ID + notarize + `.pkg`)* thì chưa.

**Tài liệu đi kèm:** trang cài đặt Windows và macOS trên `Funput/Docs` (VI + EN) cũng đã được viết lại theo cùng các phát hiện ở trên — đặc biệt là ví dụ VNI và mục "app sẽ thông báo khi có bản mới". Chưa mở PR, sẽ đưa lên riêng.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
