### PR TITLE
chore(rust): align crates with edition 2024 and upgrade to 1.98.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ name: CI
 # must never be a required check, because a required check that never reports
 # blocks the merge forever. That is the opposite trade from the one made here.
 #
-# The toolchain comes from rust-toolchain.toml (1.97.1 + rustfmt + clippy), so
+# The toolchain comes from rust-toolchain.toml (1.98.1 + rustfmt + clippy), so
 # bumping the pin moves CI with it. Every shell that links a heavy OS-only
 # dependency is excluded from the cargo workspace and so invisible to the `rust`
 # job — the GTK4 Settings app and the Slint Windows shell each get a job of their

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,12 +416,8 @@ jobs:
   #
   # `cargo fmt --all` in the `rust` job does not reach an excluded package either,
   # which is why formatting is checked here too — the same gap `settings-gtk`
-  # closes for its own package. It was not theoretical: four files had drifted into
-  # style_edition 2024 import ordering while the other twenty-three stayed on the
-  # 2021 ordering this package's edition selects, and nothing on a pull request
-  # looked. Note the check must run from `platforms/windows`, not the root: the
-  # edition in its own manifest is what picks the style, so a root invocation would
-  # reformat it to disagree with itself.
+  # closes for its own package. Run from each package directory so formatting
+  # includes the platform sources and uses its manifest's Rust 2024 edition.
   windows:
     needs: changes
     if: needs.changes.outputs.windows == 'true'

--- a/crates/funput-config/src/unikey/encoding.rs
+++ b/crates/funput-config/src/unikey/encoding.rs
@@ -137,7 +137,9 @@ fn utf16(bytes: &[u8], unit: fn([u8; 2]) -> u16) -> Option<String> {
         return None;
     }
     let units: Vec<u16> = bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| unit([pair[0], pair[1]]))
         .collect();
     String::from_utf16(&units).ok()

--- a/crates/funput-core/src/charset/document.rs
+++ b/crates/funput-core/src/charset/document.rs
@@ -108,7 +108,9 @@ fn utf16(bytes: &[u8], unit: fn([u8; 2]) -> u16) -> Option<String> {
         return None;
     }
     let units: Vec<u16> = bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| unit([pair[0], pair[1]]))
         .collect();
     String::from_utf16(&units).ok()

--- a/platforms/linux/packaging/arch/PKGBUILD.in
+++ b/platforms/linux/packaging/arch/PKGBUILD.in
@@ -54,7 +54,7 @@ prepare() {
 
 build() {
   cd "$_srcdir"
-  # rust-toolchain.toml pins 1.97.1 so contributors and CI share one compiler. On
+  # rust-toolchain.toml pins 1.98.1 so contributors and CI share one compiler. On
   # a rustup host that pin would try to download the toolchain inside the chroot;
   # Arch ships a single rolling stable, so use it.
   export RUSTUP_TOOLCHAIN=stable

--- a/platforms/linux/settings-gtk/Cargo.toml
+++ b/platforms/linux/settings-gtk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "funput-settings"
 version = "1.2026.1"
-edition = "2021"
+edition = "2024"
 description = "Funput Settings & Onboarding (GTK4 + libadwaita) for Linux"
 # Outside the root workspace, so [workspace.package] gives it nothing. See the
 # same note in platforms/windows/Cargo.toml.

--- a/platforms/linux/settings-gtk/src/config_transfer/transfer.rs
+++ b/platforms/linux/settings-gtk/src/config_transfer/transfer.rs
@@ -1,8 +1,8 @@
 use crate::settings::{Method, Settings, Shortcut};
 
 use super::document::{
-    ConfigDocument, ImportSummary, LinuxBlock, Platform, PortableShortcut, Preferences, Source,
-    CURRENT_VERSION, SCHEMA_ID,
+    CURRENT_VERSION, ConfigDocument, ImportSummary, LinuxBlock, Platform, PortableShortcut,
+    Preferences, SCHEMA_ID, Source,
 };
 use super::mapping::{
     flip_from_key, flip_key, hotkey_from_key, hotkey_key, tone_from_key, tone_key,

--- a/platforms/linux/settings-gtk/src/convert/open.rs
+++ b/platforms/linux/settings-gtk/src/convert/open.rs
@@ -3,12 +3,12 @@
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-use adw::prelude::*;
 use adw::Application;
+use adw::prelude::*;
 use funput_convert::Session;
 use gtk::glib;
 
-use super::{io, ui, Convert};
+use super::{Convert, io, ui};
 
 thread_local! {
     /// The open window, or nothing.

--- a/platforms/linux/settings-gtk/src/convert/ui/empty.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/empty.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 use adw::prelude::*;
 
-use crate::convert::{io, Convert};
+use crate::convert::{Convert, io};
 
 pub(in crate::convert) struct Pane {
     pub(in crate::convert) root: adw::StatusPage,

--- a/platforms/linux/settings-gtk/src/convert/ui/files.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/files.rs
@@ -18,7 +18,7 @@ use std::rc::Rc;
 use adw::prelude::*;
 
 use crate::convert::ui::widget;
-use crate::convert::{io, Convert};
+use crate::convert::{Convert, io};
 use funput_convert::View;
 
 /// How many rows to build at once.

--- a/platforms/linux/settings-gtk/src/convert/ui/text.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/text.rs
@@ -18,8 +18,8 @@ use std::rc::Rc;
 
 use adw::prelude::*;
 
-use crate::convert::ui::widget;
 use crate::convert::Convert;
+use crate::convert::ui::widget;
 
 pub(in crate::convert) struct Pane {
     pub(in crate::convert) root: gtk::Box,

--- a/platforms/linux/settings-gtk/src/convert/ui/text/footer.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/text/footer.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use adw::prelude::*;
 
 use crate::convert::ui::widget;
-use crate::convert::{io, Convert};
+use crate::convert::{Convert, io};
 use funput_convert::View;
 
 pub(in crate::convert) struct Footer {

--- a/platforms/linux/settings-gtk/src/convert/ui/text/show.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/text/show.rs
@@ -8,8 +8,8 @@ use std::rc::Rc;
 
 use adw::prelude::*;
 
-use crate::convert::ui::widget;
 use crate::convert::Convert;
+use crate::convert::ui::widget;
 use funput_convert::View;
 
 use super::Pane;

--- a/platforms/linux/settings-gtk/src/main.rs
+++ b/platforms/linux/settings-gtk/src/main.rs
@@ -21,8 +21,8 @@ mod onboarding;
 mod settings;
 mod settings_window;
 
-use adw::prelude::*;
 use adw::Application;
+use adw::prelude::*;
 use gtk::gio;
 use gtk::glib;
 

--- a/platforms/linux/settings-gtk/src/onboarding.rs
+++ b/platforms/linux/settings-gtk/src/onboarding.rs
@@ -5,8 +5,8 @@
 
 use std::rc::Rc;
 
-use adw::prelude::*;
 use adw::Application;
+use adw::prelude::*;
 use gtk::{Align, Justification, Orientation};
 
 use crate::settings::Settings;

--- a/platforms/linux/settings-gtk/src/settings_window/shortcuts.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/shortcuts.rs
@@ -69,11 +69,11 @@ pub(super) fn page() -> gtk::Widget {
                 rows.borrow_mut().push(expander.clone().upcast());
                 last = Some((expander, trigger));
             }
-            if focus_new.replace(false) {
-                if let Some((expander, trigger)) = last {
-                    expander.set_expanded(true);
-                    trigger.grab_focus();
-                }
+            if focus_new.replace(false)
+                && let Some((expander, trigger)) = last
+            {
+                expander.set_expanded(true);
+                trigger.grab_focus();
             }
         })
     };

--- a/platforms/linux/settings-gtk/src/settings_window/shortcuts/empty.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/shortcuts/empty.rs
@@ -1,7 +1,7 @@
 //! Empty-state for the shortcuts page.
 
-use adw::prelude::*;
 use adw::StatusPage;
+use adw::prelude::*;
 use gtk::{Align, Button};
 
 pub(super) fn page(on_add: impl Fn() + 'static) -> StatusPage {

--- a/platforms/linux/settings-gtk/src/settings_window/sidebar/tools.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/sidebar/tools.rs
@@ -1,8 +1,8 @@
 //! Sidebar rows that *do* something rather than go somewhere: the converter, and
 //! import / export.
 
-use adw::prelude::*;
 use adw::ActionRow;
+use adw::prelude::*;
 use gtk::{ListBox, SelectionMode};
 
 use super::transfer;

--- a/platforms/linux/settings-gtk/src/settings_window/typing.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/typing.rs
@@ -4,8 +4,8 @@
 mod method;
 mod smart;
 
-use adw::prelude::*;
 use adw::PreferencesPage;
+use adw::prelude::*;
 
 use crate::settings::Settings;
 

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "funput-windows"
 version = "1.2026.1"
-edition = "2021"
+edition = "2024"
 description = "Funput for Windows — global keyboard hook + tray + native Slint UI."
 # Stated explicitly: this package is outside the root workspace, so it inherits
 # nothing from [workspace.package] — including the MIT licence every other crate

--- a/platforms/windows/README.md
+++ b/platforms/windows/README.md
@@ -230,7 +230,7 @@ platforms/windows/
 
 | | |
 |---|---|
-| Rust | `1.97.1` ([`rust-toolchain.toml`](../../rust-toolchain.toml)) — Slint 1.17 cần ≥ 1.92 |
+| Rust | `1.98.1` ([`rust-toolchain.toml`](../../rust-toolchain.toml)) — Slint 1.17 cần ≥ 1.92 |
 | Slint | `1.17` · winit · renderer **Skia** · style Fluent *(chọn trong [`build.rs`](build.rs))* |
 | Win32 | `windows` 0.62 · `window-vibrancy` 0.8 — Mica (Win11) / Acrylic (Win10 1809+) |
 | Tray | `tray-icon` 0.24 *(không WebView2)* |

--- a/platforms/windows/src/background/hook/foreground.rs
+++ b/platforms/windows/src/background/hook/foreground.rs
@@ -4,20 +4,20 @@
 //! Funput was composing is stale; and the new app may want a different VI/EN state
 //! (see [`crate::shared::shell`]'s per-app auto-switch).
 
-use std::sync::atomic::Ordering;
 use std::sync::OnceLock;
+use std::sync::atomic::Ordering;
 
-use windows::core::PWSTR;
 use windows::Win32::Foundation::{CloseHandle, HWND};
 use windows::Win32::System::Threading::{
-    OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION,
+    OpenProcess, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
 };
 use windows::Win32::UI::Accessibility::HWINEVENTHOOK;
 use windows::Win32::UI::WindowsAndMessaging::{
-    GetClassNameW, GetWindowThreadProcessId, EVENT_SYSTEM_FOREGROUND,
+    EVENT_SYSTEM_FOREGROUND, GetClassNameW, GetWindowThreadProcessId,
 };
+use windows::core::PWSTR;
 
-use super::{toggle, FOREGROUND_IS_FUNPUT};
+use super::{FOREGROUND_IS_FUNPUT, toggle};
 use crate::background::{inject, keymap, tray};
 use crate::shared::shell;
 
@@ -92,36 +92,43 @@ fn own_exe_id() -> &'static String {
 /// [`inject::note_foreground`] recognizes a browser engine without knowing the
 /// browser. Empty when the window is gone or has no class, which reads as "not a
 /// browser" and is the safe answer.
-unsafe fn class_of_window(hwnd: HWND) -> String {
+fn class_of_window(hwnd: HWND) -> String {
     // Class names are capped at 256 characters by `RegisterClass`, so this cannot
     // truncate one that matters.
     let mut buf = [0u16; 257];
-    let len = GetClassNameW(hwnd, &mut buf);
+    // SAFETY: The API receives a writable slice and handles invalid window handles.
+    let len = unsafe { GetClassNameW(hwnd, &mut buf) };
     String::from_utf16_lossy(&buf[..len.max(0) as usize])
 }
 
 /// Resolve a window's owning process to its app id — the lowercased exe file name
 /// (e.g. "code.exe"), which is the key the per-app VI/EN memory uses.
-unsafe fn exe_of_window(hwnd: HWND) -> Option<String> {
+fn exe_of_window(hwnd: HWND) -> Option<String> {
     if hwnd.0.is_null() {
         return None;
     }
     let mut pid = 0u32;
-    GetWindowThreadProcessId(hwnd, Some(&mut pid));
+    // SAFETY: pid is writable; an invalid or expired window returns failure.
+    unsafe { GetWindowThreadProcessId(hwnd, Some(&mut pid)) };
     if pid == 0 {
         return None;
     }
-    let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid).ok()?;
+    // SAFETY: Request query access only; failure is propagated without using a handle.
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }.ok()?;
 
     let mut buf = [0u16; 260];
     let mut len = buf.len() as u32;
-    let res = QueryFullProcessImageNameW(
-        handle,
-        PROCESS_NAME_WIN32,
-        PWSTR(buf.as_mut_ptr()),
-        &mut len,
-    );
-    let _ = CloseHandle(handle);
+    // SAFETY: handle is open and buf has the capacity provided in len.
+    let res = unsafe {
+        QueryFullProcessImageNameW(
+            handle,
+            PROCESS_NAME_WIN32,
+            PWSTR(buf.as_mut_ptr()),
+            &mut len,
+        )
+    };
+    // SAFETY: Release the owned process handle exactly once after its final use.
+    let _ = unsafe { CloseHandle(handle) };
     res.ok()?;
 
     let full = String::from_utf16_lossy(&buf[..len as usize]);

--- a/platforms/windows/src/background/hook/keyboard.rs
+++ b/platforms/windows/src/background/hook/keyboard.rs
@@ -5,14 +5,14 @@
 
 use std::sync::atomic::Ordering;
 
-use funput_desktop::{classify, plan_inject, KeyKind};
+use funput_desktop::{KeyKind, classify, plan_inject};
 use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
 use windows::Win32::UI::Input::KeyboardAndMouse::{VIRTUAL_KEY, VK_RETURN};
 use windows::Win32::UI::WindowsAndMessaging::{
     CallNextHookEx, HC_ACTION, KBDLLHOOKSTRUCT, WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN, WM_SYSKEYUP,
 };
 
-use super::{toggle, FOREGROUND_IS_FUNPUT};
+use super::{FOREGROUND_IS_FUNPUT, toggle};
 use crate::background::hotkey::{self, Hit};
 use crate::background::{inject, keymap};
 use crate::shared::shell;
@@ -23,10 +23,12 @@ pub(super) unsafe extern "system" fn keyboard_proc(
     lparam: LPARAM,
 ) -> LRESULT {
     if code == HC_ACTION as i32 {
-        let kbd = &*(lparam.0 as *const KBDLLHOOKSTRUCT);
+        // SAFETY: HC_ACTION supplies a valid KBDLLHOOKSTRUCT for this callback.
+        let kbd = unsafe { &*(lparam.0 as *const KBDLLHOOKSTRUCT) };
         // Skip the events we ourselves synthesized via SendInput (no re-entrancy).
         if kbd.dwExtraInfo == shell::INJECT_TAG {
-            return CallNextHookEx(None, code, wparam, lparam);
+            // SAFETY: Forward the original callback arguments unchanged.
+            return unsafe { CallNextHookEx(None, code, wparam, lparam) };
         }
         let msg = wparam.0 as u32;
         let down = msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN;
@@ -44,7 +46,8 @@ pub(super) unsafe extern "system" fn keyboard_proc(
             return LRESULT(1); // swallow: do not pass the key to the focused app
         }
     }
-    CallNextHookEx(None, code, wparam, lparam)
+    // SAFETY: Forward the original callback arguments unchanged.
+    unsafe { CallNextHookEx(None, code, wparam, lparam) }
 }
 
 /// Run the hotkey that just matched. Returns false when it was not applicable
@@ -135,8 +138,8 @@ fn handle_keydown(kbd: &KBDLLHOOKSTRUCT) -> bool {
         }
         KeyKind::Flush => {
             shell::clear(); // commit what is shown; nav/Enter/Tab/shortcut passes
-                            // Enter starts a new line → arm auto-capitalize (no-op unless the feature
-                            // is on). The engine never sees the newline itself on this path.
+            // Enter starts a new line → arm auto-capitalize (no-op unless the feature
+            // is on). The engine never sees the newline itself on this path.
             if vk == VK_RETURN {
                 shell::arm_capitalization();
             }

--- a/platforms/windows/src/background/hook/keyboard.rs
+++ b/platforms/windows/src/background/hook/keyboard.rs
@@ -94,10 +94,10 @@ fn handle_keydown(kbd: &KBDLLHOOKSTRUCT) -> bool {
         toggle::defer_notify();
     }
 
-    if let Some(hit) = hotkey::on_keydown(vk, mods) {
-        if fire(hit) {
-            return true;
-        }
+    if let Some(hit) = hotkey::on_keydown(vk, mods)
+        && fire(hit)
+    {
+        return true;
     }
 
     if !shell::enabled() {

--- a/platforms/windows/src/background/hook/mod.rs
+++ b/platforms/windows/src/background/hook/mod.rs
@@ -20,8 +20,8 @@ use windows::Win32::Foundation::HINSTANCE;
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 use windows::Win32::UI::Accessibility::SetWinEventHook;
 use windows::Win32::UI::WindowsAndMessaging::{
-    DispatchMessageW, PeekMessageW, PostQuitMessage, SetWindowsHookExW, TranslateMessage,
-    EVENT_SYSTEM_FOREGROUND, MSG, PM_REMOVE, WH_KEYBOARD_LL, WH_MOUSE_LL, WINEVENT_OUTOFCONTEXT,
+    DispatchMessageW, EVENT_SYSTEM_FOREGROUND, MSG, PM_REMOVE, PeekMessageW, PostQuitMessage,
+    SetWindowsHookExW, TranslateMessage, WH_KEYBOARD_LL, WH_MOUSE_LL, WINEVENT_OUTOFCONTEXT,
     WM_QUIT,
 };
 

--- a/platforms/windows/src/background/hook/mouse.rs
+++ b/platforms/windows/src/background/hook/mouse.rs
@@ -28,7 +28,8 @@ pub(super) unsafe extern "system" fn mouse_proc(
             hotkey::note_other_input();
         }
     }
-    CallNextHookEx(None, code, wparam, lparam)
+    // SAFETY: Forward the original callback arguments unchanged.
+    unsafe { CallNextHookEx(None, code, wparam, lparam) }
 }
 
 /// Mouse messages that reposition the caret and so must flush composition. Move and

--- a/platforms/windows/src/background/hook/toggle.rs
+++ b/platforms/windows/src/background/hook/toggle.rs
@@ -9,8 +9,8 @@
 //! pump in [`super::run`] does the rest one message later, with the user's
 //! keystroke already delivered.
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use windows::Win32::Foundation::{LPARAM, WPARAM};
 use windows::Win32::System::Threading::GetCurrentThreadId;

--- a/platforms/windows/src/background/inject/events.rs
+++ b/platforms/windows/src/background/inject/events.rs
@@ -6,8 +6,8 @@
 //! which is what stops the keyboard hook from composing its own output.
 
 use windows::Win32::UI::Input::KeyboardAndMouse::{
-    SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
-    KEYEVENTF_UNICODE, VIRTUAL_KEY, VK_BACK,
+    INPUT, INPUT_0, INPUT_KEYBOARD, KEYBD_EVENT_FLAGS, KEYBDINPUT, KEYEVENTF_KEYUP,
+    KEYEVENTF_UNICODE, SendInput, VIRTUAL_KEY, VK_BACK,
 };
 
 use crate::shared::shell::INJECT_TAG;

--- a/platforms/windows/src/background/instance.rs
+++ b/platforms/windows/src/background/instance.rs
@@ -6,14 +6,14 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use windows::core::w;
 use windows::Win32::Foundation::{
-    CloseHandle, GetLastError, ERROR_ALREADY_EXISTS, HANDLE, WAIT_OBJECT_0,
+    CloseHandle, ERROR_ALREADY_EXISTS, GetLastError, HANDLE, WAIT_OBJECT_0,
 };
 use windows::Win32::System::Threading::{
-    CreateEventW, CreateMutexW, OpenEventW, ResetEvent, SetEvent, WaitForSingleObject,
-    EVENT_MODIFY_STATE, INFINITE,
+    CreateEventW, CreateMutexW, EVENT_MODIFY_STATE, INFINITE, OpenEventW, ResetEvent, SetEvent,
+    WaitForSingleObject,
 };
+use windows::core::w;
 
 const MUTEX_NAME: windows::core::PCWSTR = w!("Local\\Funput.SingleInstance");
 const EVENT_NAME: windows::core::PCWSTR = w!("Local\\Funput.ActivateSettings");
@@ -59,19 +59,22 @@ pub fn claim() -> bool {
 /// Wake the primary instance so it opens Settings (second-launch path).
 pub fn signal_activate() {
     for _ in 0..2 {
-        if unsafe { try_signal() } {
+        if try_signal() {
             return;
         }
         std::thread::sleep(Duration::from_millis(50));
     }
 }
 
-unsafe fn try_signal() -> bool {
-    let Ok(event) = OpenEventW(EVENT_MODIFY_STATE, false, EVENT_NAME) else {
+fn try_signal() -> bool {
+    // SAFETY: EVENT_NAME is a static, null-terminated string.
+    let Ok(event) = (unsafe { OpenEventW(EVENT_MODIFY_STATE, false, EVENT_NAME) }) else {
         return false;
     };
-    let ok = SetEvent(event).is_ok();
-    let _ = CloseHandle(event);
+    // SAFETY: OpenEventW returned an owned handle that remains open until below.
+    let ok = unsafe { SetEvent(event) }.is_ok();
+    // SAFETY: Close the owned handle exactly once after its final use.
+    let _ = unsafe { CloseHandle(event) };
     ok
 }
 

--- a/platforms/windows/src/shared/commands/config.rs
+++ b/platforms/windows/src/shared/commands/config.rs
@@ -4,7 +4,7 @@
 use std::path::Path;
 
 use funput_config::transfer::{
-    self, ConfigDocument, ConfigError, ImportSummary, Source, SCHEMA_ID,
+    self, ConfigDocument, ConfigError, ImportSummary, SCHEMA_ID, Source,
 };
 use funput_config::unikey::{self, MacroError};
 use funput_core::charset::Charset;

--- a/platforms/windows/src/shared/dark_mode.rs
+++ b/platforms/windows/src/shared/dark_mode.rs
@@ -6,8 +6,8 @@
 //! 135) and `FlushMenuThemes` (ordinal 136), the same trick win32-darkmode uses.
 //! muda themes the menu *bar* but explicitly not popups, so we do this ourselves.
 
-use windows::core::PCSTR;
 use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
+use windows::core::PCSTR;
 
 /// Opt the process into dark menus when Windows is in dark mode (and light when
 /// light). Call once at startup, before the tray menu is first shown. No-op on

--- a/platforms/windows/src/shared/settings_path.rs
+++ b/platforms/windows/src/shared/settings_path.rs
@@ -7,7 +7,7 @@
 
 use std::path::{Path, PathBuf};
 
-use funput_config::settings::path::{dir_is_writable, resolve, FILE};
+use funput_config::settings::path::{FILE, dir_is_writable, resolve};
 
 fn appdata_settings() -> Option<PathBuf> {
     dirs::config_dir().map(|directory| directory.join("Funput").join(FILE))

--- a/platforms/windows/src/shared/update/feed.rs
+++ b/platforms/windows/src/shared/update/feed.rs
@@ -6,7 +6,7 @@
 use std::io::Read;
 use std::time::Duration;
 
-use super::{Error, Manifest, Result, FEED_URL, MAX_DOWNLOAD_BYTES};
+use super::{Error, FEED_URL, MAX_DOWNLOAD_BYTES, Manifest, Result};
 
 /// The feed URL, allowing a debug-build override (`FUNPUT_UPDATE_FEED`) so the
 /// end-to-end flow can be tested against a local manifest before tagging.

--- a/platforms/windows/src/shared/update/install.rs
+++ b/platforms/windows/src/shared/update/install.rs
@@ -3,11 +3,11 @@
 //! The signature is checked against the *same* Ed25519 key Sparkle uses on macOS
 //! before a single byte is written anywhere executable.
 
-use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 
-use super::{Error, Result, PUBLIC_ED_KEY};
+use super::{Error, PUBLIC_ED_KEY, Result};
 
 /// Verify the downloaded bytes against the embedded public key. Sparkle signs the
 /// raw file with Ed25519 (libsodium), which is byte-compatible with `ed25519-dalek`.

--- a/platforms/windows/src/ui/control_center/mod.rs
+++ b/platforms/windows/src/ui/control_center/mod.rs
@@ -74,10 +74,10 @@ fn watch_focus_loss(weak: Weak<ControlCenterWindow>) {
             armed.set(true);
             window.window().on_winit_window_event(move |_, event| {
                 use slint::winit_030::winit::event::WindowEvent;
-                if let WindowEvent::Focused(false) = event {
-                    if armed.get() {
-                        request_exit(EXIT_DISMISS);
-                    }
+                if let WindowEvent::Focused(false) = event
+                    && armed.get()
+                {
+                    request_exit(EXIT_DISMISS);
                 }
                 EventResult::Propagate
             });

--- a/platforms/windows/src/ui/control_center/placement.rs
+++ b/platforms/windows/src/ui/control_center/placement.rs
@@ -13,9 +13,9 @@
 
 use windows::Win32::Foundation::POINT;
 use windows::Win32::Graphics::Gdi::{
-    GetMonitorInfoW, MonitorFromPoint, HMONITOR, MONITORINFO, MONITOR_DEFAULTTONEAREST,
+    GetMonitorInfoW, HMONITOR, MONITOR_DEFAULTTONEAREST, MONITORINFO, MonitorFromPoint,
 };
-use windows::Win32::UI::WindowsAndMessaging::{SystemParametersInfoW, SPI_GETWORKAREA};
+use windows::Win32::UI::WindowsAndMessaging::{SPI_GETWORKAREA, SystemParametersInfoW};
 
 /// Breathing room kept between the flyout and both the icon and the screen edge.
 const GAP: f64 = 8.0;

--- a/platforms/windows/src/ui/control_center/wire.rs
+++ b/platforms/windows/src/ui/control_center/wire.rs
@@ -2,13 +2,13 @@
 
 use slint::ComponentHandle;
 
-use crate::shared::{commands, shell};
 use crate::ControlCenterWindow;
+use crate::shared::{commands, shell};
 use funput_config::ToneStyle;
 
 use super::{
-    cycle_method, method_label, request_exit, status_line, tone_label, EXIT_DISMISS, EXIT_KEYBOARD,
-    EXIT_SETTINGS,
+    EXIT_DISMISS, EXIT_KEYBOARD, EXIT_SETTINGS, cycle_method, method_label, request_exit,
+    status_line, tone_label,
 };
 
 pub(super) fn attach(window: &ControlCenterWindow) {

--- a/platforms/windows/src/ui/convert/mod.rs
+++ b/platforms/windows/src/ui/convert/mod.rs
@@ -24,7 +24,7 @@ use slint::{ComponentHandle, ModelRc, VecModel};
 use crate::ui::{mica, system_accent};
 use crate::{ConvertWindow, Theme};
 
-use view::{ask, current, edit, WINDOW};
+use view::{WINDOW, ask, current, edit};
 
 /// How many rows to build at once.
 ///

--- a/platforms/windows/src/ui/convert/win32/clipboard.rs
+++ b/platforms/windows/src/ui/convert/win32/clipboard.rs
@@ -9,7 +9,7 @@ use windows::Win32::Foundation::{HANDLE, HGLOBAL};
 use windows::Win32::System::DataExchange::{
     CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, SetClipboardData,
 };
-use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GHND};
+use windows::Win32::System::Memory::{GHND, GlobalAlloc, GlobalLock, GlobalUnlock};
 use windows::Win32::System::Ole::CF_UNICODETEXT;
 
 /// Replace the clipboard with `text`. Silently does nothing if Windows refuses —

--- a/platforms/windows/src/ui/convert/win32/drop.rs
+++ b/platforms/windows/src/ui/convert/win32/drop.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::UI::Shell::{
-    DefSubclassProc, DragAcceptFiles, DragFinish, DragQueryFileW, SetWindowSubclass, HDROP,
+    DefSubclassProc, DragAcceptFiles, DragFinish, DragQueryFileW, HDROP, SetWindowSubclass,
 };
 use windows::Win32::UI::WindowsAndMessaging::WM_DROPFILES;
 

--- a/platforms/windows/src/ui/lifecycle/flyout.rs
+++ b/platforms/windows/src/ui/lifecycle/flyout.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tray_icon::Rect;
 
 use super::child::{
-    launch_settings_tab, now_ms, spawn_child, terminate_children, UiKind, UI_PROCESS,
+    UI_PROCESS, UiKind, launch_settings_tab, now_ms, spawn_child, terminate_children,
 };
 use super::control_center;
 use crate::background::tray;

--- a/platforms/windows/src/ui/lifecycle/mod.rs
+++ b/platforms/windows/src/ui/lifecycle/mod.rs
@@ -6,7 +6,7 @@ mod process;
 
 use windows::Win32::Foundation::CloseHandle;
 use windows::Win32::System::Threading::{
-    OpenProcess, TerminateProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE,
+    OpenProcess, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE, TerminateProcess, WaitForSingleObject,
 };
 
 use super::{control_center, convert, onboarding, settings_window};

--- a/platforms/windows/src/ui/lifecycle/process.rs
+++ b/platforms/windows/src/ui/lifecycle/process.rs
@@ -15,13 +15,12 @@ mod buffers;
 
 use std::path::Path;
 
-use windows::core::PWSTR;
 use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_TIMEOUT};
 use windows::Win32::System::Threading::{
-    CreateProcessW, GetExitCodeProcess, TerminateProcess, WaitForSingleObject,
-    CREATE_UNICODE_ENVIRONMENT, INFINITE, PROCESS_INFORMATION, STARTF_FORCEOFFFEEDBACK,
-    STARTUPINFOW,
+    CREATE_UNICODE_ENVIRONMENT, CreateProcessW, GetExitCodeProcess, INFINITE, PROCESS_INFORMATION,
+    STARTF_FORCEOFFFEEDBACK, STARTUPINFOW, TerminateProcess, WaitForSingleObject,
 };
+use windows::core::PWSTR;
 
 use buffers::{command_line, environment};
 

--- a/platforms/windows/src/ui/mica.rs
+++ b/platforms/windows/src/ui/mica.rs
@@ -72,8 +72,8 @@ fn round_flyout(handle: &slint::WindowHandle) {
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use windows::Win32::Foundation::HWND;
     use windows::Win32::Graphics::Dwm::{
-        DwmSetWindowAttribute, DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_ROUNDSMALL,
-        DWM_WINDOW_CORNER_PREFERENCE,
+        DWM_WINDOW_CORNER_PREFERENCE, DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_ROUNDSMALL,
+        DwmSetWindowAttribute,
     };
 
     let Ok(borrowed) = handle.window_handle() else {

--- a/platforms/windows/src/ui/settings_callbacks.rs
+++ b/platforms/windows/src/ui/settings_callbacks.rs
@@ -2,9 +2,9 @@
 
 use slint::ComponentHandle;
 
+use crate::SettingsWindow;
 use crate::shared::commands;
 use crate::ui::recorder;
-use crate::SettingsWindow;
 use funput_config::{FlipHotkey, Hotkey, Method, ToneStyle};
 
 use super::models;

--- a/platforms/windows/src/ui/settings_callbacks/config.rs
+++ b/platforms/windows/src/ui/settings_callbacks/config.rs
@@ -9,8 +9,8 @@ mod message;
 
 use slint::ComponentHandle;
 
-use crate::shared::commands;
 use crate::SettingsWindow;
+use crate::shared::commands;
 use funput_config::transfer;
 
 use message::{import_body, shown_path, unikey_body};

--- a/platforms/windows/src/ui/settings_window.rs
+++ b/platforms/windows/src/ui/settings_window.rs
@@ -30,10 +30,10 @@ pub(super) fn open() {
     let _ = window.show();
     schedule_backdrop(window.as_weak());
     WINDOW.with(|cell| *cell.borrow_mut() = Some(window.as_weak()));
-    if let Ok(tab) = std::env::var("FUNPUT_SETTINGS_ACTIVE") {
-        if !tab.is_empty() {
-            window.set_active(remap_tab(&tab).into());
-        }
+    if let Ok(tab) = std::env::var("FUNPUT_SETTINGS_ACTIVE")
+        && !tab.is_empty()
+    {
+        window.set_active(remap_tab(&tab).into());
     }
 }
 

--- a/platforms/windows/src/ui/system_accent/registry.rs
+++ b/platforms/windows/src/ui/system_accent/registry.rs
@@ -13,11 +13,11 @@ pub(super) const DWM: &str = "Software\\Microsoft\\Windows\\DWM";
 /// Read a value from HKCU into `buf`. Returns the value type and byte count.
 #[cfg(windows)]
 fn query(subkey: &str, value: &str, buf: &mut [u8]) -> Option<(u32, usize)> {
-    use windows::core::PCWSTR;
     use windows::Win32::Foundation::ERROR_SUCCESS;
     use windows::Win32::System::Registry::{
-        RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY_CURRENT_USER, KEY_READ, REG_VALUE_TYPE,
+        HKEY_CURRENT_USER, KEY_READ, REG_VALUE_TYPE, RegCloseKey, RegOpenKeyExW, RegQueryValueExW,
     };
+    use windows::core::PCWSTR;
 
     let subkey: Vec<u16> = subkey.encode_utf16().chain(Some(0)).collect();
     let value: Vec<u16> = value.encode_utf16().chain(Some(0)).collect();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # Pin the toolchain so contributors and CI build with the same compiler.
 # Edition 2024 needs a recent stable; bump deliberately, not per-machine.
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Tóm tắt

Đồng bộ cả 12 crate Funput sang Rust 2024 và nâng toolchain được ghim từ 1.97.1 lên 1.98.1 cho contributors và CI.

- Chuyển hai package độc lập Windows và Linux GTK từ edition 2021 sang 2024; chuẩn hóa định dạng theo edition mới.
- Làm rõ phạm vi `unsafe` và bổ sung chú thích SAFETY cho các thao tác Win32; dùng let chains tại bốn điều kiện lồng nhau để đáp ứng Clippy Rust 2024.
- Cập nhật `rust-toolchain.toml`, README Windows và chú thích CI/Arch packaging sang 1.98.1.
- Chuyển hai bộ giải mã UTF-16 sang `as_chunks::<2>()` theo lint mới của Clippy 1.98.1, giữ nguyên việc từ chối đầu vào có số byte lẻ.

Rust 1.98.1 sửa lỗi sinh vtable của 1.98.0: https://blog.rust-lang.org/2026/09/03/Rust-1.98.1/

## Kiểm tra

- [x] Cargo metadata xác nhận cả 12 crate dùng edition 2024.
- [x] Clippy workspace, tất cả target, với `-D warnings` trên Rust 1.98.1.
- [x] Format workspace và hai package nền tảng trên Rust 1.98.1.
- [x] Sáu test UTF-16 của funput-core và funput-config trên Rust 1.98.1.
- [x] `scripts/check-loc.sh`: 374 file đạt giới hạn; `git diff --check` sạch.
- [x] `cargo test --workspace --locked --offline` trên Rust 1.98.1, gồm doctest.
- [x] CI cho commit nâng toolchain `d3a02231`: https://github.com/Funput/Funput/actions/runs/34020716780

Bản chuyển edition trước đó (`e78f44a6`) đã đạt toàn bộ CI, gồm Clippy và test trên Windows/Linux GTK. Cần chờ CI của commit nâng toolchain trước khi merge.
