### PR TITLE
fix(android): keep the buffer when a host reports the caret mid-batch

### DIFF
--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CommittedBufferWriter.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CommittedBufferWriter.kt
@@ -4,8 +4,11 @@ import android.view.KeyEvent
 import android.view.inputmethod.InputConnection
 
 /**
- * True when [CommittedBufferWriter.replace] has to delete before it commits, so the
+ * True when replacing the committed buffer has to delete before it commits, so the
  * document passes through a state that holds neither buffer.
+ *
+ * Mirrors the branch both writers take — [CommittedBufferWriter.replace] and the
+ * KeyEvent plan behind it — so a new branch in either has to be reflected here.
  */
 internal fun deletesBeforeCommit(previous: String, replacement: String): Boolean =
     previous.isNotEmpty() && replacement.isNotEmpty() &&

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CommittedBufferWriter.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CommittedBufferWriter.kt
@@ -4,6 +4,14 @@ import android.view.KeyEvent
 import android.view.inputmethod.InputConnection
 
 /**
+ * True when [CommittedBufferWriter.replace] has to delete before it commits, so the
+ * document passes through a state that holds neither buffer.
+ */
+internal fun deletesBeforeCommit(previous: String, replacement: String): Boolean =
+    previous.isNotEmpty() && replacement.isNotEmpty() &&
+        !replacement.startsWith(previous) && !previous.startsWith(replacement)
+
+/**
  * Writes the engine buffer into editors that cannot host composing spans.
  *
  * Prefer appending/shrinking the committed prefix so broken hosts that ignore

--- a/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CompositionDocumentEditor.kt
+++ b/platforms/android/ime/src/main/java/app/funput/funput/ime/editing/CompositionDocumentEditor.kt
@@ -16,6 +16,7 @@ internal class CompositionDocumentEditor(
     private val committedWriter = CommittedBufferWriter()
     private var committedSelection: Int? = null
     private var expectedCommittedSelection: Int? = null
+    private var midEditCommittedSelection: Int? = null
 
     fun update(
         connection: InputConnection,
@@ -71,6 +72,7 @@ internal class CompositionDocumentEditor(
     } else true.also {
         committedSelection = null
         expectedCommittedSelection = null
+        midEditCommittedSelection = null
     }
 
     fun ownsSelection(
@@ -92,7 +94,7 @@ internal class CompositionDocumentEditor(
         previous: String,
         replacement: String,
     ): Boolean {
-        expectCommittedSelection(previous.length, replacement.length)
+        expectCommittedSelection(previous, replacement)
         return if (mode.writesKeyEvents) {
             keyEventWriter.replace(connection, previous, replacement)
         } else {
@@ -107,6 +109,12 @@ internal class CompositionDocumentEditor(
         selectionEnd: Int,
     ): Boolean {
         if (selectionStart != selectionEnd) return false
+        // Gecko textareas carrying `maxlength` report the caret from inside our batch
+        // edit, after the delete and before the commit. That caret is ours, not a move.
+        if (midEditCommittedSelection == selectionEnd) {
+            midEditCommittedSelection = null
+            return true
+        }
         val beforeCursor = connection?.getTextBeforeCursor(text.length, 0)?.toString()
         val editorConfirmsText = beforeCursor?.endsWith(text) == true
         val editorWithholdsText = beforeCursor.isNullOrEmpty() && selectionEnd >= text.length
@@ -115,13 +123,17 @@ internal class CompositionDocumentEditor(
         if (owned) {
             committedSelection = selectionEnd
             expectedCommittedSelection = null
+            midEditCommittedSelection = null
         }
         return owned
     }
 
-    private fun expectCommittedSelection(previousLength: Int, currentLength: Int) {
+    private fun expectCommittedSelection(previous: String, replacement: String) {
         val base = expectedCommittedSelection ?: committedSelection
-        expectedCommittedSelection = base?.minus(previousLength)?.plus(currentLength)
+        val afterDelete = base?.minus(previous.length)
+        midEditCommittedSelection = afterDelete
+            ?.takeIf { deletesBeforeCommit(previous, replacement) }
+        expectedCommittedSelection = afterDelete?.plus(replacement.length)
     }
 
     private companion object {

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CommittedCompositionSessionTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CommittedCompositionSessionTest.kt
@@ -26,25 +26,6 @@ class CommittedCompositionSessionTest {
     }
 
     @Test
-    fun `selection update from committed replacement keeps engine buffer`() {
-        val editor = CommittedEditor()
-        val session = testSession(ScriptedEngine(ArrayDeque(listOf("chào"))))
-        val handler = ImeKeyActionHandler(
-            composition = session,
-            editor = InputConnectionEditor(),
-            connection = { editor.proxy },
-            enterCommand = { ImeEditCommand.CommitText("\n") },
-        )
-        handler.start(renderMode = CompositionRenderMode.COMMITTED)
-
-        handler.onKeyAction(KeyAction.Input(keyId = "character-a", text = "a"))
-        handler.onSelectionChanged(newStart = 4, newEnd = 4, composingEnd = -1)
-
-        assertTrue(session.isComposing)
-        assertEquals("chào", editor.text)
-    }
-
-    @Test
     fun `boundary replacement rewrites committed word once`() {
         val editor = CommittedEditor()
         val session = testSession(
@@ -113,60 +94,5 @@ class CommittedCompositionSessionTest {
 
         assertEquals("dúng", editor.text)
         assertEquals("dung", engine.adopted)
-    }
-
-    @Test
-    fun `caret reported from inside our batch edit keeps the buffer`() {
-        val editor = CommittedEditor()
-        val session = testSession(ScriptedEngine(ArrayDeque(listOf("u", "uo", "uơ", "ươn"))))
-        val handler = ImeKeyActionHandler(
-            composition = session,
-            editor = InputConnectionEditor(),
-            connection = { editor.proxy },
-            enterCommand = { ImeEditCommand.CommitText("\n") },
-        )
-        handler.start(renderMode = CompositionRenderMode.COMMITTED)
-
-        handler.onKeyAction(KeyAction.Input(keyId = "character-u", text = "u"))
-        handler.onSelectionChanged(newStart = 1, newEnd = 1, composingEnd = -1)
-        handler.onKeyAction(KeyAction.Input(keyId = "character-o", text = "o"))
-        handler.onSelectionChanged(newStart = 2, newEnd = 2, composingEnd = -1)
-        // Replacing "uo" with "uơ" deletes before it commits; a host that ignores the
-        // batch reports the empty document in between before reporting the result.
-        handler.onKeyAction(KeyAction.Input(keyId = "character-w", text = "w"))
-        editor.textBeforeCursor = ""
-        handler.onSelectionChanged(newStart = 0, newEnd = 0, composingEnd = -1)
-        editor.textBeforeCursor = null
-        handler.onSelectionChanged(newStart = 2, newEnd = 2, composingEnd = -1)
-        handler.onKeyAction(KeyAction.Input(keyId = "character-n", text = "n"))
-
-        assertEquals("ươn", editor.text)
-        assertEquals("ươn", session.composingText)
-    }
-
-    @Test
-    fun `caret move after the batch settles releases the buffer`() {
-        val editor = CommittedEditor()
-        val session = testSession(ScriptedEngine(ArrayDeque(listOf("u", "uo", "uơ"))))
-        val handler = ImeKeyActionHandler(
-            composition = session,
-            editor = InputConnectionEditor(),
-            connection = { editor.proxy },
-            enterCommand = { ImeEditCommand.CommitText("\n") },
-        )
-        handler.start(renderMode = CompositionRenderMode.COMMITTED)
-
-        handler.onKeyAction(KeyAction.Input(keyId = "character-u", text = "u"))
-        handler.onSelectionChanged(newStart = 1, newEnd = 1, composingEnd = -1)
-        handler.onKeyAction(KeyAction.Input(keyId = "character-o", text = "o"))
-        handler.onSelectionChanged(newStart = 2, newEnd = 2, composingEnd = -1)
-        // The replacement settles first, which is what retires the caret we expect from
-        // inside the batch. The tap that follows is the user's, and has to be obeyed.
-        handler.onKeyAction(KeyAction.Input(keyId = "character-w", text = "w"))
-        handler.onSelectionChanged(newStart = 2, newEnd = 2, composingEnd = -1)
-        editor.textBeforeCursor = ""
-        handler.onSelectionChanged(newStart = 0, newEnd = 0, composingEnd = -1)
-
-        assertEquals("", session.composingText)
     }
 }

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CommittedCompositionSessionTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CommittedCompositionSessionTest.kt
@@ -134,13 +134,39 @@ class CommittedCompositionSessionTest {
         // Replacing "uo" with "uơ" deletes before it commits; a host that ignores the
         // batch reports the empty document in between before reporting the result.
         handler.onKeyAction(KeyAction.Input(keyId = "character-w", text = "w"))
-        editor.textVisibleToReads = ""
+        editor.textBeforeCursor = ""
         handler.onSelectionChanged(newStart = 0, newEnd = 0, composingEnd = -1)
-        editor.textVisibleToReads = null
+        editor.textBeforeCursor = null
         handler.onSelectionChanged(newStart = 2, newEnd = 2, composingEnd = -1)
         handler.onKeyAction(KeyAction.Input(keyId = "character-n", text = "n"))
 
         assertEquals("ươn", editor.text)
         assertEquals("ươn", session.composingText)
+    }
+
+    @Test
+    fun `caret move after the batch settles releases the buffer`() {
+        val editor = CommittedEditor()
+        val session = testSession(ScriptedEngine(ArrayDeque(listOf("u", "uo", "uơ"))))
+        val handler = ImeKeyActionHandler(
+            composition = session,
+            editor = InputConnectionEditor(),
+            connection = { editor.proxy },
+            enterCommand = { ImeEditCommand.CommitText("\n") },
+        )
+        handler.start(renderMode = CompositionRenderMode.COMMITTED)
+
+        handler.onKeyAction(KeyAction.Input(keyId = "character-u", text = "u"))
+        handler.onSelectionChanged(newStart = 1, newEnd = 1, composingEnd = -1)
+        handler.onKeyAction(KeyAction.Input(keyId = "character-o", text = "o"))
+        handler.onSelectionChanged(newStart = 2, newEnd = 2, composingEnd = -1)
+        // The replacement settles first, which is what retires the caret we expect from
+        // inside the batch. The tap that follows is the user's, and has to be obeyed.
+        handler.onKeyAction(KeyAction.Input(keyId = "character-w", text = "w"))
+        handler.onSelectionChanged(newStart = 2, newEnd = 2, composingEnd = -1)
+        editor.textBeforeCursor = ""
+        handler.onSelectionChanged(newStart = 0, newEnd = 0, composingEnd = -1)
+
+        assertEquals("", session.composingText)
     }
 }

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CommittedCompositionSessionTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CommittedCompositionSessionTest.kt
@@ -114,4 +114,33 @@ class CommittedCompositionSessionTest {
         assertEquals("dúng", editor.text)
         assertEquals("dung", engine.adopted)
     }
+
+    @Test
+    fun `caret reported from inside our batch edit keeps the buffer`() {
+        val editor = CommittedEditor()
+        val session = testSession(ScriptedEngine(ArrayDeque(listOf("u", "uo", "uơ", "ươn"))))
+        val handler = ImeKeyActionHandler(
+            composition = session,
+            editor = InputConnectionEditor(),
+            connection = { editor.proxy },
+            enterCommand = { ImeEditCommand.CommitText("\n") },
+        )
+        handler.start(renderMode = CompositionRenderMode.COMMITTED)
+
+        handler.onKeyAction(KeyAction.Input(keyId = "character-u", text = "u"))
+        handler.onSelectionChanged(newStart = 1, newEnd = 1, composingEnd = -1)
+        handler.onKeyAction(KeyAction.Input(keyId = "character-o", text = "o"))
+        handler.onSelectionChanged(newStart = 2, newEnd = 2, composingEnd = -1)
+        // Replacing "uo" with "uơ" deletes before it commits; a host that ignores the
+        // batch reports the empty document in between before reporting the result.
+        handler.onKeyAction(KeyAction.Input(keyId = "character-w", text = "w"))
+        editor.textVisibleToReads = ""
+        handler.onSelectionChanged(newStart = 0, newEnd = 0, composingEnd = -1)
+        editor.textVisibleToReads = null
+        handler.onSelectionChanged(newStart = 2, newEnd = 2, composingEnd = -1)
+        handler.onKeyAction(KeyAction.Input(keyId = "character-n", text = "n"))
+
+        assertEquals("ươn", editor.text)
+        assertEquals("ươn", session.composingText)
+    }
 }

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CommittedSelectionOwnershipTest.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CommittedSelectionOwnershipTest.kt
@@ -1,0 +1,78 @@
+package app.funput.funput.ime.editing
+
+import app.funput.funput.keyboard.model.KeyAction
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Who owns the caret in committed mode, where there is no composing region to compare
+ * against and the answer has to come from the position and the surrounding text.
+ */
+class CommittedSelectionOwnershipTest {
+    @Test
+    fun `selection update from committed replacement keeps engine buffer`() {
+        val editor = CommittedEditor()
+        val session = testSession(ScriptedEngine(ArrayDeque(listOf("chào"))))
+        val handler = committedHandler(session, editor)
+
+        handler.onKeyAction(KeyAction.Input(keyId = "character-a", text = "a"))
+        handler.onSelectionChanged(newStart = 4, newEnd = 4, composingEnd = -1)
+
+        assertTrue(session.isComposing)
+        assertEquals("chào", editor.text)
+    }
+
+    @Test
+    fun `caret reported from inside our batch edit keeps the buffer`() {
+        val editor = CommittedEditor()
+        val session = testSession(ScriptedEngine(ArrayDeque(listOf("u", "uo", "uơ", "ươn"))))
+        val handler = committedHandler(session, editor)
+
+        handler.onKeyAction(KeyAction.Input(keyId = "character-u", text = "u"))
+        handler.onSelectionChanged(newStart = 1, newEnd = 1, composingEnd = -1)
+        handler.onKeyAction(KeyAction.Input(keyId = "character-o", text = "o"))
+        handler.onSelectionChanged(newStart = 2, newEnd = 2, composingEnd = -1)
+        // Replacing "uo" with "uơ" deletes before it commits; a host that ignores the
+        // batch reports the empty document in between before reporting the result.
+        handler.onKeyAction(KeyAction.Input(keyId = "character-w", text = "w"))
+        editor.textBeforeCursor = ""
+        handler.onSelectionChanged(newStart = 0, newEnd = 0, composingEnd = -1)
+        editor.textBeforeCursor = null
+        handler.onSelectionChanged(newStart = 2, newEnd = 2, composingEnd = -1)
+        handler.onKeyAction(KeyAction.Input(keyId = "character-n", text = "n"))
+
+        assertEquals("ươn", editor.text)
+        assertEquals("ươn", session.composingText)
+    }
+
+    @Test
+    fun `caret move after the batch settles releases the buffer`() {
+        val editor = CommittedEditor()
+        val session = testSession(ScriptedEngine(ArrayDeque(listOf("u", "uo", "uơ"))))
+        val handler = committedHandler(session, editor)
+
+        handler.onKeyAction(KeyAction.Input(keyId = "character-u", text = "u"))
+        handler.onSelectionChanged(newStart = 1, newEnd = 1, composingEnd = -1)
+        handler.onKeyAction(KeyAction.Input(keyId = "character-o", text = "o"))
+        handler.onSelectionChanged(newStart = 2, newEnd = 2, composingEnd = -1)
+        // The replacement settles first, which is what retires the caret we expect from
+        // inside the batch. The tap that follows is the user's, and has to be obeyed.
+        handler.onKeyAction(KeyAction.Input(keyId = "character-w", text = "w"))
+        handler.onSelectionChanged(newStart = 2, newEnd = 2, composingEnd = -1)
+        editor.textBeforeCursor = ""
+        handler.onSelectionChanged(newStart = 0, newEnd = 0, composingEnd = -1)
+
+        assertEquals("", session.composingText)
+    }
+}
+
+private fun committedHandler(
+    session: AndroidCompositionSession,
+    editor: CommittedEditor,
+): ImeKeyActionHandler = ImeKeyActionHandler(
+    composition = session,
+    editor = InputConnectionEditor(),
+    connection = { editor.proxy },
+    enterCommand = { ImeEditCommand.CommitText("\n") },
+).apply { start(renderMode = CompositionRenderMode.COMMITTED) }

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CompositionSessionTestSupport.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CompositionSessionTestSupport.kt
@@ -74,6 +74,11 @@ internal class CommittedEditor(
     private val exposesSurroundingText: Boolean = true,
 ) {
     var setComposingCount = 0
+    /**
+     * What reads see while the host still shows a state our batch edit has moved past —
+     * Gecko answers from the document as it stood between the delete and the commit.
+     */
+    var textVisibleToReads: String? = null
 
     val proxy: InputConnection = Proxy.newProxyInstance(
         InputConnection::class.java.classLoader,
@@ -91,7 +96,7 @@ internal class CommittedEditor(
                 if (!exposesSurroundingText || count >= GraphemeLookback) {
                     null
                 } else {
-                    text.takeLast(count)
+                    (textVisibleToReads ?: text).takeLast(count)
                 }
             }
             "deleteSurroundingTextInCodePoints" -> true.also {

--- a/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CompositionSessionTestSupport.kt
+++ b/platforms/android/ime/src/test/java/app/funput/funput/ime/editing/CompositionSessionTestSupport.kt
@@ -75,10 +75,11 @@ internal class CommittedEditor(
 ) {
     var setComposingCount = 0
     /**
-     * What reads see while the host still shows a state our batch edit has moved past —
-     * Gecko answers from the document as it stood between the delete and the commit.
+     * What `getTextBeforeCursor` answers when the document tail is not what a read sees:
+     * a host still showing the state between our delete and our commit, or a caret this
+     * fake does not otherwise model.
      */
-    var textVisibleToReads: String? = null
+    var textBeforeCursor: String? = null
 
     val proxy: InputConnection = Proxy.newProxyInstance(
         InputConnection::class.java.classLoader,
@@ -96,7 +97,7 @@ internal class CommittedEditor(
                 if (!exposesSurroundingText || count >= GraphemeLookback) {
                     null
                 } else {
-                    (textVisibleToReads ?: text).takeLast(count)
+                    (textBeforeCursor ?: text).takeLast(count)
                 }
             }
             "deleteSurroundingTextInCodePoints" -> true.also {


### PR DESCRIPTION
## Vấn đề

Người dùng báo: trên Firefox Android, ô `Try Now` của ttsfree.com không gõ được `đường` bằng Telex (`Đuơngf`), các từ khác cũng rụng dấu — trong khi mọi trang khác vẫn bình thường.

## Nguyên nhân

Không phải riêng trang đó, mà là **`<textarea maxlength>` trong GeckoView**.

Firefox chạy ở chế độ `COMMITTED`, nên mỗi lần biến đổi dấu là `deleteSurroundingText` + `commitText` trong cùng một batch edit. Khi textarea có `maxlength`, Gecko gửi `onUpdateSelection` **ngay giữa batch** (sau khi xoá, trước khi commit) và `getTextBeforeCursor` lúc đó trả về tài liệu dở dang. `ownsSelection` đọc caret đó như user vừa di chuyển con trỏ → `finish()` → xoá engine; mọi phím sau gõ như một từ mới nên không còn dấu.

Log từ bản debug trên máy thật:

```
replace prev='D' repl='Đ' mode=COMMITTED
onSelectionChanged 0..0                                       ← caret giữa batch
owns? sel=0 text='Đ' before='' confirms=false ... -> false     ← mất quyền, reset engine
onSelectionChanged 1..1 composing=false
```

Trang thử tự dựng cô lập đúng một biến: textarea thường → `Đường`; **cùng trang, chỉ thêm `maxlength`** → `Đuơngf`.

## Cách sửa

Nhớ vị trí caret mà lệnh xoá để lại và coi đúng một thông báo đó là caret của mình. Chỉ những thay thế buộc phải xoá trước khi commit mới đi qua trạng thái dở dang, nên `deletesBeforeCommit` chặn kỳ vọng này lại — caret user di chuyển thật vẫn nhả buffer như cũ.

## Kiểm chứng

Unit test `caret reported from inside our batch edit keeps the buffer` (đã xác nhận đỏ khi gỡ bản vá) và `./gradlew test` xanh.

Trên Galaxy S21 Ultra (Android 16, Firefox):

| Trường hợp | Trước | Sau |
|---|---|---|
| ttsfree.com `Try Now` | `Đuơngf` | `Đường phố nguyễn` |
| textarea + `maxlength` | `Đươngf` | `Đường` |
| textarea thường | `Đường` | `Đường` |
| di chuyển caret rồi gõ tiếp | `SÂ` | `SÂ` |
| xoá lùi rồi bỏ dấu lại | — | `Cháo` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)