### PR TITLE
docs(linux): make the repo landing page point at the docs site

### DIFF
--- a/.github/workflows/publish-repo.yml
+++ b/.github/workflows/publish-repo.yml
@@ -307,6 +307,8 @@ jobs:
           mv public/deb/funput.asc public/funput.asc
           T=platforms/linux/packaging/repo
           sed "s#@REPO_URL@#${REPO_URL}#g" "$T/index.html.in"  > public/index.html
+          # Pages serves no directory listings, so /deb/ and typos land on 404.
+          sed "s#@REPO_URL@#${REPO_URL}#g" "$T/404.html.in"    > public/404.html
           sed "s#@REPO_URL@#${REPO_URL}#g" "$T/funput.repo.in" > public/funput.repo
           # Custom domain: derive the host from REPO_URL so it tracks the override.
           echo "${REPO_URL}" | sed -E 's#^https?://([^/]+)/?.*#\1#' > public/CNAME

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -113,8 +113,7 @@ dùng đúng cái shell **không với tới nổi** một client kiểu WPS.
 > không kèm file `.sha256`, nên thật ra chưa bao giờ có chuyện tự kiểm checksum bằng tay.
 
 Các bước thêm kho thủ công cho từng distro nằm ở
-[docs.funput.app — Linux](https://docs.funput.app/docs/install/linux) và
-[repo.funput.app](https://repo.funput.app) (có sẵn nút copy lệnh).
+[docs.funput.app — Linux](https://docs.funput.app/docs/install/linux).
 
 > [!NOTE]
 > **Không có quyền root?** Dùng `install.sh --user`: nó đặt engine vào `~/.local`, không đụng
@@ -218,7 +217,8 @@ Xoá luôn cấu hình nếu muốn sạch hẳn:
 rm -rf ~/.config/Funput
 ```
 
-Cách gỡ kho `repo.funput.app` nằm ở [docs.funput.app — Linux](https://docs.funput.app/docs/install/linux#gỡ-kho-funput-nếu-cần).
+Cách gỡ kho `repo.funput.app` nằm ở
+[docs.funput.app — Xử lý sự cố](https://docs.funput.app/docs/install/linux/troubleshooting#remove-repo).
 
 ---
 

--- a/platforms/linux/packaging/repo/404.html.in
+++ b/platforms/linux/packaging/repo/404.html.in
@@ -1,17 +1,16 @@
 <!DOCTYPE html>
-<!-- Landing page for the Funput Linux package repository.
+<!-- 404 page for the Funput Linux package repository.
      @REPO_URL@ is substituted by the publish-repo workflow with the Pages base URL.
 
-     This host serves the apt/dnf/zypper/pacman trees; the install instructions
-     live at docs.funput.app so there is only one copy of them to maintain. The
-     page is a signpost, nothing more. Everything is inline because the workflow
-     copies no assets into the Pages artifact — see .github/workflows/publish-repo.yml. -->
+     GitHub Pages serves no directory listings, so a path like /deb/ or a typo in
+     a package name lands here. Same design as index.html.in — keep the two in
+     sync when either changes. -->
 <html lang="vi">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Funput — kho phần mềm Linux</title>
-<meta name="description" content="Kho apt/dnf/zypper/pacman của Funput. Hướng dẫn cài đặt nằm ở docs.funput.app.">
+<title>Không tìm thấy — kho phần mềm Funput</title>
+<meta name="robots" content="noindex">
 <style>
   :root {
     color-scheme: light dark;
@@ -36,8 +35,6 @@
     overflow-x: hidden;
   }
 
-  /* Two soft colour fields drifting behind the logo, drawn from the gradients
-     inside the mark itself. Fixed and non-interactive so they never affect layout. */
   .glow { position: fixed; inset: 0; overflow: hidden; pointer-events: none; z-index: 0; }
   .glow i {
     position: absolute; display: block; border-radius: 50%;
@@ -67,11 +64,7 @@
     max-width: 34rem; text-align: center;
   }
 
-  .mark { width: 118px; height: 118px; display: block; margin: 0 auto 1.6rem; }
-
-  /* The mark is a spine with three ribbon leaves hinged on it. Bringing the
-     spine in first and then swinging the leaves out reads as the logo drawing
-     itself; each leaf's box starts at the spine, so `0% 50%` is that hinge. */
+  .mark { width: 92px; height: 92px; display: block; margin: 0 auto 1.5rem; }
   .mark path { transform-box: fill-box; }
   .spine {
     opacity: 0; transform-origin: 50% 0%;
@@ -103,7 +96,11 @@
     to   { opacity: 1; transform: none; }
   }
 
-  h1 { font-size: 1.9rem; margin: 0 0 .6rem; letter-spacing: -.022em; }
+  .code {
+    display: block; font-size: .8rem; font-weight: 700; letter-spacing: .14em;
+    text-transform: uppercase; color: var(--muted); margin-bottom: .5rem;
+  }
+  h1 { font-size: 1.7rem; margin: 0 0 .6rem; letter-spacing: -.022em; }
   p  { margin: 0 auto; color: var(--muted); max-width: 30rem; }
 
   .btn {
@@ -130,8 +127,8 @@
   footer a { color: inherit; }
 
   @media (max-width: 400px) {
-    h1 { font-size: 1.55rem; }
-    .mark { width: 88px; height: 88px; }
+    h1 { font-size: 1.45rem; }
+    .mark { width: 76px; height: 76px; }
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -180,17 +177,18 @@
       d="M261 887V743C261 642 346 572 458 572H541C545 572 548 575 547 579C539 670 502 747 436 794C401 819 360 828 323 839C295 847 278 867 266 895C264 900 261 897 261 887Z"/>
   </svg>
 
-  <h1 class="fade d1">Kho phần mềm Funput</h1>
+  <span class="code fade d1">404</span>
+  <h1 class="fade d1">Không có gì ở đường dẫn này</h1>
 
   <p class="fade d2">
-    Địa chỉ này phục vụ kho <b>apt</b>, <b>dnf</b>, <b>zypper</b> và <b>pacman</b> của Funput —
-    bộ gõ tiếng Việt cho Fcitx5 và IBus. Hướng dẫn cài đặt nằm ở trang tài liệu.
+    Địa chỉ này phục vụ kho <b>apt</b>, <b>dnf</b>, <b>zypper</b> và <b>pacman</b> của Funput.
+    Các thư mục của kho không duyệt bằng trình duyệt được — package manager mới đọc chúng.
   </p>
 
-  <a class="btn fade d3" href="https://docs.funput.app/docs/install/linux">Xem hướng dẫn cài đặt</a>
+  <a class="btn fade d3" href="@REPO_URL@">Về trang chủ kho</a>
 
   <span class="alt fade d4">
-    <a href="https://docs.funput.app/en/docs/install/linux">Read this in English</a>
+    <a href="https://docs.funput.app/docs/install/linux">Hướng dẫn cài đặt</a>
   </span>
 
   <footer class="fade d4">

--- a/platforms/linux/packaging/repo/README.md
+++ b/platforms/linux/packaging/repo/README.md
@@ -1,9 +1,9 @@
 # Kho phần mềm Funput — vận hành (maintainer)
 
 > **Đối tượng: maintainer/người vận hành kho**, không phải người dùng cuối.
-> Người dùng cài đặt tại **https://repo.funput.app** (trang `index.html`) hoặc theo
-> mục cài đặt trong [`platforms/linux/README.md`](../../README.md). File này ghi cách
-> *dựng* và *bảo trì* kho (khóa GPG, secrets, Pages, DNS).
+> Người dùng cài đặt theo [docs.funput.app — Linux](https://docs.funput.app/docs/install/linux).
+> `index.html` chỉ là trang dẫn đường sang đó, **không** chứa hướng dẫn — docs là nguồn duy
+> nhất. File này ghi cách *dựng* và *bảo trì* kho (khóa GPG, secrets, Pages, DNS).
 
 Phân phối Phase 2: biến `.deb`/`.rpm` của bản release mới nhất — cộng gói Arch dựng tại
 chỗ — thành **kho apt + dnf + pacman có ký GPG**, host trên **GitHub Pages**, để người dùng `apt/dnf/zypper upgrade` thay vì
@@ -70,7 +70,7 @@ Actions → **Publish package repo** → Run workflow (khi đó workflow tự l�
 > phép deploy từ `main`, nên run ở ref tag sẽ dựng xong cả ba kho rồi bị chặn ở job `deploy`.
 > Đó là lý do workflow **không** dùng trigger `release: [released]`: sự kiện release luôn nằm
 > ở `refs/tags/v*`. Publish release bằng tay trong web UI thì phải bấm Run workflow ở đây.
-Xong, trang cài đặt nằm ở URL Pages (xem mục cuối `index.html.in` để biết các lệnh người dùng).
+Xong. URL Pages phục vụ kho; hướng dẫn cho người dùng nằm ở docs.funput.app.
 
 ## Hoạt động thế nào (tóm tắt)
 - **apt** (job `apt`): tải `.deb` của release → `apt-ftparchive` tạo `Packages`/`Release` →
@@ -81,7 +81,9 @@ Xong, trang cài đặt nằm ở URL Pages (xem mục cuối `index.html.in` đ
   rolling, build từ nguồn), nên job này *dựng* gói từ `packaging/arch/PKGBUILD.in` rồi ký từng
   gói, `repo-add`, ký luôn `funput.db`. Chỉ **x86_64** (Arch chỉ hỗ trợ chính thức kiến
   trúc này). Đây là job duy nhất phải biên dịch, nên cũng là job lâu nhất.
-- **deploy**: gộp `public/{deb,rpm,arch}` + `funput.asc` + `index.html` + `funput.repo`, đẩy lên Pages.
+- **deploy**: gộp `public/{deb,rpm,arch}` + `funput.asc` + `index.html` + `404.html` +
+  `funput.repo`, đẩy lên Pages. Hai trang HTML dựng từ `*.html.in` bằng một phép thay
+  `@REPO_URL@`; sửa trang thì sửa cả hai để chúng không lệch nhau.
 
 Mỗi lần chạy **dựng lại toàn bộ** từ release hiện tại (stateless) — package manager chỉ cần
 phiên bản mới nhất để chào upgrade, nên không cần giữ lịch sử gh-pages.


### PR DESCRIPTION
## Vì sao

`index.html.in` (309 dòng) chép lại **toàn bộ hướng dẫn cài đặt** cho 4 distro cộng phần biến môi trường session — bản sao thứ hai của những gì đã có ở `docs.funput.app`, và hai bên đã bắt đầu lệch nhau.

Chủ trương: **docs là nguồn duy nhất**. Trang chủ kho rút về một tấm biển chỉ đường.

> [!IMPORTANT]
> **Không đụng gì tới kho phần mềm.** `publish-repo.yml` chỉ sinh `index.html` từ template này; `deb/`, `rpm/`, `arch/`, `funput.asc`, `funput.repo` và `CNAME` đến từ artifact riêng. apt/dnf/zypper/pacman chạy y nguyên.
>
> Đã kiểm: không có link sâu nào (`repo.funput.app/#...`) trong toàn bộ mã nguồn, nên thay trọn trang là an toàn.

## Trang mới

Một màn hình canh giữa: logo → tiêu đề → một câu → nút sang `docs.funput.app/docs/install/linux` → link phụ tiếng Anh → footer. **309 → 152 dòng**, bỏ hết khối lệnh 4 distro, phần session, và script copy 16 nút.

**Hiệu ứng logo bám theo chính cấu trúc file SVG.** Logo là một "spine" với ba chiếc lá gắn vào. Spine hiện trước, rồi ba lá lần lượt bung ra quanh bản lề chính là spine — `transform-box: fill-box` cộng `transform-origin: 0% 50%`, lệch nhau 110ms. Đọc như logo tự vẽ ra, không phải một khối fade-in chung.

Nền là hai vùng màu mờ lấy đúng màu trong gradient của logo (cam/hồng, lam/tím), trôi chậm 28-34s.

SVG **inline thẳng vào file** vì workflow không copy asset nào vào Pages artifact. Trang nặng 8,3 KB, không request ngoài.

**Footer giữ link tới `funput.asc`** — host này là nơi duy nhất phục vụ khoá công khai, người muốn kiểm chữ ký không còn chỗ nào khác để đi.

## Thêm trang 404

Cùng thiết kế, `noindex`. GitHub Pages không liệt kê thư mục nên gõ `/deb/` hay sai tên gói hiện rơi vào trang 404 mặc định của GitHub. Workflow thêm đúng một dòng `sed`.

## Sửa link cũ (`0fe2b101`)

Hai chỗ trong `platforms/linux/README.md` đã lỗi thời:

- Anchor `#gỡ-kho-funput-nếu-cần` chết sau đợt đổi anchor sang tiếng Anh — mục này giờ nằm ở trang `troubleshooting` riêng với anchor `#remove-repo`.
- Câu mô tả `repo.funput.app` "có sẵn nút copy lệnh" — không còn đúng sau PR này.

## Thứ tự merge

Link `troubleshooting#remove-repo` **chỉ phân giải sau khi [Funput/Docs#10](https://github.com/Funput/Docs/pull/10) được merge**. Trước đó nó rơi về đầu trang, không phải 404. Nút chính (`/docs/install/linux`) thì đúng ở cả hai trạng thái vì URL trang không đổi.

Nên merge Docs#10 trước, hoặc chấp nhận một khoảng ngắn link rơi về đầu trang.

## Đã kiểm

Dựng bằng đúng phép thay của workflow rồi soát trên trình duyệt:

- Không còn `@REPO_URL@` sót; 4 link đều đúng đích.
- Sáng và tối đều đọc được. Bản đầu quầng sáng ở chế độ sáng quá gắt làm chữ chìm — đã hạ opacity từ `.55` xuống `.28`.
- 375px không tràn ngang, logo tự thu còn 88px.
- `prefers-reduced-motion` phủ **đủ 11 phần tử** có animation (2 vùng sáng, 4 path, 5 khối chữ). Pane không giả lập được media query này nên tôi đọc thẳng rule trong stylesheet để xác nhận.
- YAML workflow parse được, bước assemble đúng thứ tự.
- Quét cả repo: không còn link docs nào kèm anchor chết, không còn chỗ nào hứa hướng dẫn nằm trên trang kho.

Chưa chạy workflow thật — cần một release hoặc bấm tay Run workflow. Dòng `find public -maxdepth 2 -type f` sẵn có ở cuối bước assemble sẽ liệt kê `404.html` khi chạy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
