### PR TITLE
fix(linux): repair Vietnamese typing in Cursor's editor

### DIFF
--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -194,11 +194,17 @@ Cả hai đều tới cùng một process.
   focus-out. Thêm một client kiểu này chỉ là thêm một cái tên vào danh sách đó. **IBus không có
   kênh nào chạy được ở đây** — ForwardKeyEvent đã bị bỏ, surrounding text thì không bao giờ
   tới — nên IBus được để yên.
+- **Editor của Cursor/VS Code bỏ `deleteSurroundingText`.** Nó nhận commit bình thường nhưng bỏ
+  lệnh xoá đi kèm, nên `Phu` `1` sẽ ra `Phuú`. Tệ hơn, nó **trả lời surrounding text rỗng** ở mọi
+  phím — đủ để bật [chế độ không preedit](#chế-độ-không-preedit) nhưng không đủ để kiểm chứng
+  bất cứ lần ghi nào. Đây là phía Chromium/EditContext, Funput không với tới được, nên
+  `BlindWrites` đứng dậy sau hai câu trả lời rỗng — trước lần sửa đầu tiên có lệnh xoá. Khung
+  chat của Cursor là input DOM thường nên không dính.
 - **Phím điều khiển được phân loại theo ký tự C0, không theo keysym.** Cả Fcitx5 lẫn IBus đều
   ánh xạ Return → CR, Tab → HT, Escape → ESC, nên `classify()` phải loại chúng ra *trước* phép
-  thử ranh giới từ — `isBoundary()` cố tình nhận `\t \n \r` vì `adoptWordBeforeBackspace()` dò
-  ranh giới trong tài liệu thật, nơi xuống dòng đúng là ranh giới. Thiếu bước đó thì Enter bị
-  nuốt và CR được nối vào chuỗi commit.
+  thử ranh giới từ — `isBoundary()` cố tình nhận `\t \n \r` vì
+  `adoptWordBeforeBackspace()` dò ranh giới trong tài liệu thật, nơi xuống dòng đúng là ranh
+  giới. Thiếu bước đó thì Enter bị nuốt và CR được nối vào chuỗi commit.
 - **Bỏ dấu sau Backspace chỉ chạy ở chế độ không preedit.** Ở chế độ preedit, Backspace chỉ rút
   ngắn composition, nên `phủ` ␣ ⌫ `s` ra chữ `s` thường.
 - **Một số client làm mất từ đang gõ dở khi đổi focus.** Cả hai shell giao việc flush cho
@@ -285,6 +291,8 @@ common/                 C++ thuần, không framework, dùng chung cho cả hai 
       state.cpp               Settings, VI/EN, và các lối thoát không phải phím
       nonpreedit.h            Chế độ commit-khi-gõ, và cách đánh giá một client
       nonpreedit.cpp          Composer làm gì với đánh giá đó
+      nonpreedit/clients.h    Phán quyết đó thuộc về client nào
+      nonpreedit/verdict.h    Verdict, và client không bao giờ cho xem tài liệu
   settings/               ~/.config/Funput/settings.json
     settings.h              Model mọi shell đều đọc, gồm cả công tắc gõ tắt
     lookup.cpp              File nằm đâu; loại trừ theo app
@@ -478,13 +486,51 @@ Chỉ trường hợp ở giữa là một phán quyết, và sự dè dặt đ�
 thứ tôi mong đợi” là thất bại sẽ tắt chế độ này ở 61% số commit không được trả lời — chữa một
 client hỏng bằng cách làm hỏng tính năng cho tất cả.
 
+Còn lại **một client mà phép so ba chuỗi không bao giờ xử được**: client trả lời tài liệu rỗng ở
+mọi lần đọc. Xoá N ký tự khỏi chuỗi rỗng vẫn là chuỗi rỗng, nên cả ba dòng của bảng trên gộp làm
+một và không lần ghi nào có phán quyết. Đo được ở editor Cursor: nó trả lời surrounding text ở
+**mọi** phím — đủ để bật chế độ — rồi trả lời rỗng ở mọi phím, trong khi bỏ **mọi** lệnh xoá.
+
+Câu trả lời là **`BlindWrites`** (`nonpreedit/verdict.h`): client trả lời rỗng hai lần liên tiếp
+trong khi đang bị ghi vào thì đó là một phán quyết `RefuseMode`. Hai điểm quyết định tính đúng
+của nó:
+
+1. **Đếm câu trả lời, không đếm sự im lặng.** Một lần ghi không được trả lời cũng đọc ra chuỗi
+   rỗng y hệt một câu trả lời rỗng — và 39% số commit không bao giờ được trả lời. Vì vậy shell
+   phải đưa xuống thêm một bit: *client có lên tiếng kể từ phím trước hay không*
+   (`observeDocument(..., answered)`). Bản đầu của quy tắc này đếm ký tự đã ghi bất kể có trả
+   lời hay không, và nó **tắt chế độ ngay trong Chrome** — đúng client mà tính năng sinh ra để
+   phục vụ. Im lặng là “chưa có phán quyết”; trả lời bằng chuỗi rỗng mới là phán quyết.
+2. **Xoá đếm ngay khi đọc được bất cứ thứ gì.** Một ô trống thật cũng trả lời rỗng, nhưng chỉ
+   tới khi commit đầu tiên đáp xuống.
+
+Ngưỡng là **hai**: đủ sớm để đứng dậy trước lần sửa đầu tiên có `deleteChars > 0` — thứ duy nhất
+làm hỏng chữ — và đủ muộn để một lần đua với commit đang bay không buộc tội được ai.
+
+> [!WARNING]
+> Đã thử và đã **revert**: gác ở đầu vào, tức chỉ bật chế độ khi `textBeforeCaret()` khác rỗng.
+> Nghe hợp lý, và nó chặn Cursor sạch sẽ — nhưng nó cũng khiến chế độ **không bao giờ bật trong
+> Chrome**. Một câu trả lời đáng giá bao nhiêu phải được quyết **sau** một lần ghi, không phải
+> trước.
+
 Phán quyết rút lui hẹp đúng bằng phạm vi thất bại. Một sửa chữa bị bỏ **sau khi mở lại một từ**
 chỉ khiến mất khả năng bỏ dấu lại: đó là hình dạng duy nhất từng thấy hỏng. Bất kỳ sửa chữa nào
 khác bị bỏ thì mất cả chế độ, vì không còn tin được thứ gì nó viết ra.
 
 Phán quyết là một **chốt**, không phải một biến. Shell có thể tái khẳng định chế độ — IBus làm
-vậy ở mỗi phím — và không được phép hồi sinh một chế độ mà client đã bị bắt quả tang làm hỏng;
-chỉ `Composer::onFocusChanged()` xoá chốt, vì một client mới là một câu hỏi mới.
+vậy ở mỗi phím — và không được phép hồi sinh một chế độ mà client đã bị bắt quả tang làm hỏng.
+Chốt đó **thuộc về client**, không thuộc về một lần focus: `Composer::onFocusChanged()` nhận tên
+client và chỉ mở lại câu hỏi khi đó thật sự là một client khác.
+
+Sự khác biệt ấy không phải chuyện tinh vi. Fcitx5 gọi `activate()` **cả khi capability đổi**,
+không riêng khi đổi focus — chú thích trong `deactivate()` nói đúng điều đó — nên một client hay
+thay đổi capability sẽ xoá phán quyết chỉ một hai phím sau khi nó được đưa ra. Editor của Cursor
+là client như vậy: chế độ tự bật lại rồi phá tiếp từ sau, lặp vô hạn thay vì hỏng đúng một lần.
+Bộ nhớ nằm ở `compose/composer/nonpreedit/clients.h`, giới hạn tám client gần nhất. Tên client
+là `InputContext::program()`, và khi frontend không phân giải được thì là uuid của chính input
+context — hẹp hơn nhưng đúng phần cần thiết, vì một lần re-activate do capability đổi vẫn là
+cùng context ấy. **Tên rỗng không bao giờ được nhớ**: shell IBus không có tên để đưa, và trên
+GNOME/Wayland mọi client đều trả lời `gnome-shell` — nhớ cái tên đó là tắt chế độ cho tất cả.
 
 Cái giá là việc phát hiện chậm một nhịp, nên từ đầu tiên vẫn bị hỏng trước khi chế độ rút lui.
 Bắt sớm hơn nghĩa là phải ghi chữ dò vào tài liệu của người dùng, và điều đó không nằm trên bàn.

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -194,6 +194,11 @@ Cả hai đều tới cùng một process.
   focus-out. Thêm một client kiểu này chỉ là thêm một cái tên vào danh sách đó. **IBus không có
   kênh nào chạy được ở đây** — ForwardKeyEvent đã bị bỏ, surrounding text thì không bao giờ
   tới — nên IBus được để yên.
+- **Phím điều khiển được phân loại theo ký tự C0, không theo keysym.** Cả Fcitx5 lẫn IBus đều
+  ánh xạ Return → CR, Tab → HT, Escape → ESC, nên `classify()` phải loại chúng ra *trước* phép
+  thử ranh giới từ — `isBoundary()` cố tình nhận `\t \n \r` vì `adoptWordBeforeBackspace()` dò
+  ranh giới trong tài liệu thật, nơi xuống dòng đúng là ranh giới. Thiếu bước đó thì Enter bị
+  nuốt và CR được nối vào chuỗi commit.
 - **Bỏ dấu sau Backspace chỉ chạy ở chế độ không preedit.** Ở chế độ preedit, Backspace chỉ rút
   ngắn composition, nên `phủ` ␣ ⌫ `s` ra chữ `s` thường.
 - **Một số client làm mất từ đang gõ dở khi đổi focus.** Cả hai shell giao việc flush cho

--- a/platforms/linux/common/compose/composer/composer.h
+++ b/platforms/linux/common/compose/composer/composer.h
@@ -18,6 +18,7 @@
 #define FUNPUT_COMPOSE_COMPOSER_H
 
 #include <string>
+#include <string_view>
 
 #include "compose/composer/nonpreedit.h"
 #include "compose/key/classify.h"
@@ -65,16 +66,28 @@ public:
     void setNonPreedit(bool on);
     bool nonPreedit() const { return nonPreedit_.on; }
 
-    // A new input context took focus. Clears what was learned about the last client,
-    // which is the only thing that lets a mode stood down for one client be tried
-    // again in the next. Kept apart from `setNonPreedit()` on purpose: IBus calls that
-    // on every keystroke, so clearing there would erase a verdict immediately.
-    void onFocusChanged();
+    // A client took focus. Clears what was learned about the last one, which is the
+    // only thing that lets a mode stood down for one client be tried again in the next.
+    // Kept apart from `setNonPreedit()` on purpose: IBus calls that on every keystroke,
+    // so clearing there would erase a verdict immediately.
+    //
+    // `client` is how the shell names what it just focused — Fcitx5 passes the program
+    // name, falling back to the input context's own identity. A client already caught
+    // dropping a delete keeps that verdict, because Fcitx5 re-activates on capability
+    // changes too and a client that churns them would otherwise be forgiven every
+    // keystroke. An empty name is always a fresh question; that is the IBus shell,
+    // which has none to give. See nonpreedit/clients.h.
+    void onFocusChanged(std::string_view client = {});
 
     // The document in front of the caret as it stands now, before this keystroke.
     // Checks that the previous repair landed, and stands down as narrowly as the
     // failure allows — see nonpreedit.cpp.
-    void observeDocument(const std::string &textBeforeCaret, bool selectionLive = false);
+    //
+    // `answered` is whether the client sent surrounding text since the last keystroke.
+    // Without it an empty answer and no answer are the same string, and standing the
+    // mode down on silence would take it from the clients it was built for.
+    void observeDocument(const std::string &textBeforeCaret, bool selectionLive = false,
+                         bool answered = true);
 
     // Whether a word is being composed right now. The shells ask before deciding
     // whether a Backspace is shortening a live word or eating a committed one.

--- a/platforms/linux/common/compose/composer/nonpreedit.cpp
+++ b/platforms/linux/common/compose/composer/nonpreedit.cpp
@@ -17,12 +17,14 @@ void Composer::setNonPreedit(bool on) {
     nonPreedit_.on = on && !nonPreedit_.refused;
 }
 
-void Composer::onFocusChanged() {
-    nonPreedit_.reset();
+void Composer::onFocusChanged(std::string_view client) {
+    nonPreedit_.reset(client);
 }
 
-void Composer::observeDocument(const std::string &textBeforeCaret, bool selectionLive) {
+void Composer::observeDocument(const std::string &textBeforeCaret, bool selectionLive,
+                               bool answered) {
     nonPreedit_.selectionLive = selectionLive;
+    nonPreedit_.answered = answered;
     switch (nonPreedit_.observe(textBeforeCaret)) {
     case Verdict::Unknown:
         return;
@@ -33,6 +35,10 @@ void Composer::observeDocument(const std::string &textBeforeCaret, bool selectio
         nonPreedit_.retoneAllowed = false;
         break;
     case Verdict::RefuseMode:
+        // Remember *who* did it, so re-activating this same client — which Fcitx5 does
+        // on every capability change — does not hand it the mode back and cost another
+        // word. See nonpreedit/clients.h.
+        nonPreedit_.clients.remember();
         nonPreedit_.refused = true;
         nonPreedit_.on = false;
         break;

--- a/platforms/linux/common/compose/composer/nonpreedit.h
+++ b/platforms/linux/common/compose/composer/nonpreedit.h
@@ -31,40 +31,28 @@
 // the mode down on most keystrokes, curing one broken client by breaking the feature
 // for everyone. A repair that deletes nothing makes the first two identical, so that
 // case is excluded rather than left to luck.
+//
+// Which leaves one client this can never judge: the one whose document reads empty
+// every time. All three strings collapse into one there, so no repair is ever worth a
+// verdict. `BlindWrites` in nonpreedit/verdict.h is the answer to that one.
+//
+// The verdict belongs to the client it was about, not to the focus it was reached in:
+// a shell may re-activate the same client many times over — Fcitx5 does so on every
+// capability change — and each of those must not reopen a settled question. See
+// nonpreedit/clients.h.
 
 #ifndef FUNPUT_COMPOSE_NONPREEDIT_H
 #define FUNPUT_COMPOSE_NONPREEDIT_H
 
 #include <cstdint>
 #include <string>
-#include <vector>
+#include <string_view>
 
+#include "compose/composer/nonpreedit/clients.h"
+#include "compose/composer/nonpreedit/verdict.h"
 #include "ffi/utf8.h"
 
 namespace funput {
-
-// Drop the last `count` characters. Characters, not bytes — the same unit
-// `deleteChars` is in, and the same reason.
-inline std::string dropLast(const std::string &text, uint32_t count) {
-    std::vector<uint32_t> chars = decodeUtf8(text);
-    const size_t keep = count < chars.size() ? chars.size() - count : 0;
-    std::string out;
-    for (size_t i = 0; i < keep; ++i) appendUtf8(out, chars[i]);
-    return out;
-}
-
-// What the last repair turned out to be worth.
-enum class Verdict : uint8_t {
-    // Either it landed or the client has not said. Both mean carry on.
-    Unknown,
-    // The delete was dropped on a repair that followed a re-opened word. Chrome's
-    // address bar does exactly this: ordinary repairs work, but one issued straight
-    // after the app handled a Backspace itself is discarded. Only re-toning need go.
-    RefuseRetone,
-    // The delete was dropped on an ordinary repair, so nothing written here can be
-    // trusted. The mode goes.
-    RefuseMode,
-};
 
 struct NonPreeditState {
     // The mode as it applies right now. `refused` outranks it: once a client has been
@@ -72,7 +60,16 @@ struct NonPreeditState {
     // re-decides on every keystroke, so without the latch a verdict lasted one key.
     bool on = false;
     bool refused = false;
+    // Which clients that latch has already been spent on — see clients.h. Kept across
+    // `reset()`, since a client is the same client whether it was re-focused or merely
+    // re-activated by a capability change.
+    ClientMemory clients;
+    // How often this client has answered with nothing while being written into.
+    BlindWrites blind;
     bool retoneAllowed = true;
+    // Whether the client answered since the last keystroke. Only the shell can see it,
+    // and `BlindWrites` needs it to tell an empty answer from no answer at all.
+    bool answered = false;
     // Whether the client is holding a selection. Only the shell can see this, and the
     // Backspace path below needs it: taking a Backspace over while text is selected
     // would swallow the key the user pressed to delete that selection.
@@ -93,10 +90,14 @@ struct NonPreeditState {
     // the one a client like the address bar drops.
     bool justAdopted = false;
 
-    // A new input context: whatever the last client did says nothing about this one.
-    // `on` survives — that is the shell's decision, not something learned here.
-    void reset() {
-        refused = false;
+    // A client took focus: whatever the last one did says nothing about this one —
+    // unless it *is* this one, in which case a verdict already reached still stands.
+    // `on` survives either way; that is the shell's decision, not something learned
+    // here.
+    void reset(std::string_view client) {
+        refused = clients.focus(client);
+        blind.reset();
+        answered = false;
         retoneAllowed = true;
         selectionLive = false;
         inSync = false;
@@ -125,6 +126,11 @@ struct NonPreeditState {
             inSync = document == applied;
             if (document == dropped && dropped != applied) {
                 verdict = repairAfterAdopt ? Verdict::RefuseRetone : Verdict::RefuseMode;
+            }
+            // The comparison above is blind to a document that is always empty, which
+            // is a failure of its own rather than an absence of one.
+            if (verdict == Verdict::Unknown && blind.observe(document, answered)) {
+                verdict = Verdict::RefuseMode;
             }
             repairText.clear();
             repairDeleted = 0;

--- a/platforms/linux/common/compose/composer/nonpreedit/clients.h
+++ b/platforms/linux/common/compose/composer/nonpreedit/clients.h
@@ -1,0 +1,61 @@
+// Which client a non-preedit verdict was about.
+//
+// `NonPreeditState` stands the mode down when a client is caught dropping a
+// `deleteSurroundingText`, and latches that so a shell re-asserting the mode cannot
+// revive it. The latch used to be cleared by any `Composer::onFocusChanged()` — one
+// verdict, one focus. That is too little memory for the Fcitx5 shell, because Fcitx5
+// calls `activate()` on a *capability* change too, not only on a real focus change
+// (see funput_engine.cpp's `deactivate()`). Cursor's editor changes capabilities
+// constantly — the suggestion and inline-completion widgets among them — so the
+// verdict was erased a keystroke or two after it was reached, the mode re-armed, and
+// the next word was mangled again. Forever, instead of once.
+//
+// So the latch belongs to the client, not to the focus. The shell names the client it
+// just focused and this decides whether the question is already answered.
+
+#ifndef FUNPUT_COMPOSE_NONPREEDIT_CLIENTS_H
+#define FUNPUT_COMPOSE_NONPREEDIT_CLIENTS_H
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace funput {
+
+class ClientMemory {
+public:
+    // A client took focus. Returns whether it is already known to drop deletes, which
+    // is what keeps a re-activation of the same client from reopening a settled
+    // question. An unnamed client is always a fresh question — the IBus shell has no
+    // name to give — and it is the shell's job never to pass a name that stands for
+    // more than one app (Fcitx5's `clientId()` refuses `gnome-shell` for that reason).
+    bool focus(std::string_view id) {
+        current_.assign(id);
+        return !current_.empty() &&
+               std::find(refused_.begin(), refused_.end(), current_) != refused_.end();
+    }
+
+    // The client in focus was just caught dropping a delete. Most recent first, so a
+    // long session stays bounded without forgetting whoever was last seen.
+    void remember() {
+        if (current_.empty()) return;
+        const auto seen = std::find(refused_.begin(), refused_.end(), current_);
+        if (seen != refused_.end()) refused_.erase(seen);
+        refused_.insert(refused_.begin(), current_);
+        if (refused_.size() > kMax) refused_.resize(kMax);
+    }
+
+private:
+    // Enough for every app one person keeps open; past that the oldest verdict is
+    // dropped and that client is simply judged again, costing it one word.
+    static constexpr size_t kMax = 8;
+
+    std::string current_;
+    std::vector<std::string> refused_;
+};
+
+} // namespace funput
+
+#endif // FUNPUT_COMPOSE_NONPREEDIT_CLIENTS_H

--- a/platforms/linux/common/compose/composer/nonpreedit/verdict.h
+++ b/platforms/linux/common/compose/composer/nonpreedit/verdict.h
@@ -1,0 +1,70 @@
+// What one reading of the document is worth.
+//
+// The comparison `NonPreeditState::observe()` makes is spelled out in nonpreedit.h.
+// This is the enum it produces plus the one failure that comparison cannot see.
+
+#ifndef FUNPUT_COMPOSE_NONPREEDIT_VERDICT_H
+#define FUNPUT_COMPOSE_NONPREEDIT_VERDICT_H
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace funput {
+
+// What the last repair turned out to be worth.
+enum class Verdict : uint8_t {
+    // Either it landed or the client has not said. Both mean carry on.
+    Unknown,
+    // The delete was dropped on a repair that followed a re-opened word. Chrome's
+    // address bar does exactly this: ordinary repairs work, but one issued straight
+    // after the app handled a Backspace itself is discarded. Only re-toning need go.
+    RefuseRetone,
+    // The delete was dropped on an ordinary repair, or the client never shows the
+    // document at all. Nothing written here can be trusted; the mode goes.
+    RefuseMode,
+};
+
+// A document that stays empty while repairs are being written into it.
+//
+// The three-string comparison can only convict when "the delete was dropped" and "the
+// delete landed" are different strings. With nothing in front of the caret they never
+// are — dropping N characters from an empty document leaves it empty — so every
+// reading is a non-verdict and the mode writes on blind forever. That is not a corner
+// case: it is how Cursor's editor answers. It reports surrounding text, which is what
+// arms the mode, and then reports it empty on every keystroke, which is what kept the
+// mode armed there while every single delete was dropped.
+//
+// So a document that will not grow is a verdict of its own — but only when the client
+// is *answering*. This counts answers, never silence, and that distinction is the whole
+// safety of the rule: an unanswered write reads as an empty document too, and 39% of
+// commits go unanswered. A first version of this counted characters written regardless
+// and stood the mode down in Chrome, the client the feature exists for. Silence is
+// "no verdict"; an answer of nothing is a verdict.
+class BlindWrites {
+public:
+    // `answered` is whether the client sent surrounding text since the last keystroke.
+    // Returns true once it has answered with nothing often enough to mean it.
+    bool observe(const std::string &document, bool answered) {
+        if (!document.empty()) {
+            count_ = 0;
+            return false;
+        }
+        if (!answered) return false;
+        return ++count_ >= kLimit;
+    }
+
+    void reset() { count_ = 0; }
+
+private:
+    // Two answers of nothing, which lands before the first repair that deletes
+    // anything — the only kind that can corrupt. One could be a race with a commit
+    // still in flight; two in a row is the client describing itself.
+    static constexpr size_t kLimit = 2;
+
+    size_t count_ = 0;
+};
+
+} // namespace funput
+
+#endif // FUNPUT_COMPOSE_NONPREEDIT_VERDICT_H

--- a/platforms/linux/common/compose/key/classify.cpp
+++ b/platforms/linux/common/compose/key/classify.cpp
@@ -50,7 +50,15 @@ KeyKind classify(const KeyEvent &ev, const Settings &settings) {
     // been claimed as a Shortcut above, and BackSpace's keysym-to-Unicode mapping
     // is not something the typing rules should depend on.
     if (ev.keysym == keysym::BackSpace) return KeyKind::Backspace;
-    if (ev.ch == 0) return KeyKind::NonText;
+    // A control character is a key, not text. Both frameworks hand one over for the
+    // keys that used to have an ASCII meaning — `keySymToUnicode` was measured
+    // answering CR for Return, HT for Tab and ESC for Escape — so testing `ch == 0`
+    // alone let Enter fall through to the boundary test below, which counts CR as a
+    // word boundary. That swallowed the key and appended the CR to the commit: the app
+    // never saw Enter and got a newline inside a commit string instead. Arrows and
+    // F-keys arrive with ch == 0 and are the same kind of key, which is why they share
+    // this line rather than being tested apart.
+    if (ev.ch < 0x20 || ev.ch == 0x7F) return KeyKind::NonText;
     if (isNumpadDigitKeysym(ev.keysym)) return KeyKind::NumpadDigit;
     if (isBoundary(ev.ch, settings.method)) return KeyKind::Boundary;
     return KeyKind::Compose;

--- a/platforms/linux/common/ffi/utf8.h
+++ b/platforms/linux/common/ffi/utf8.h
@@ -76,6 +76,18 @@ inline void appendUtf8(std::string &out, uint32_t cp) {
         out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
     }
 }
+
+// Drop the last `count` characters of a UTF-8 string. Characters, not bytes — the
+// unit `ComposePlan::deleteChars` and `deleteSurroundingText` both count in, and the
+// reason this lives beside the codec rather than being open-coded at either caller.
+inline std::string dropLast(const std::string &text, uint32_t count) {
+    const std::vector<uint32_t> chars = decodeUtf8(text);
+    const size_t keep = count < chars.size() ? chars.size() - count : 0;
+    std::string out;
+    for (size_t i = 0; i < keep; ++i) appendUtf8(out, chars[i]);
+    return out;
+}
+
 } // namespace funput
 
 #endif // FUNPUT_UTF8_H

--- a/platforms/linux/common/tests/CMakeLists.txt
+++ b/platforms/linux/common/tests/CMakeLists.txt
@@ -26,6 +26,8 @@ add_executable(funput_linux_tests
     compose/composer/nonpreedit_tests.cpp
     compose/composer/retone_tests.cpp
     compose/composer/verify_tests.cpp
+    compose/composer/nonpreedit/clients_tests.cpp
+    compose/composer/nonpreedit/blind_tests.cpp
     ffi/utf8_tests.cpp
     settings/lookup_tests.cpp
     settings/io_tests.cpp

--- a/platforms/linux/common/tests/compose/composer/keys_tests.cpp
+++ b/platforms/linux/common/tests/compose/composer/keys_tests.cpp
@@ -87,7 +87,7 @@ TEST_CASE("a non-text key commits but still reaches the app") {
     Composer composer = composerFor(Method::Telex);
     type(composer, "tieengs");
 
-    const ComposePlan plan = composer.onKey(bare(keysym::Return));
+    const ComposePlan plan = composer.onKey(control(keysym::Return, U'\r'));
     CHECK(plan.effect == Effect::Commit);
     CHECK(plan.text == "tiếng");
     CHECK_FALSE(plan.consumed);

--- a/platforms/linux/common/tests/compose/composer/nonpreedit/blind_tests.cpp
+++ b/platforms/linux/common/tests/compose/composer/nonpreedit/blind_tests.cpp
@@ -1,0 +1,112 @@
+// The client whose document never shows anything.
+//
+// Non-preedit judges a repair by comparing three strings — the document with the delete
+// applied, the same document with the delete dropped, and the document untouched. With
+// nothing in front of the caret all three are equal, so no repair can ever be judged
+// and the mode writes on blind. Cursor's editor is exactly that client: it answers
+// surrounding text on every keystroke, which arms the mode, and answers it empty every
+// time, while dropping every delete.
+
+#include <doctest/doctest.h>
+
+#include "compose/composer/nonpreedit/refusal.h"
+#include "support.h"
+
+using namespace funput;
+using namespace funput::test;
+
+// The client sent surrounding text since the last keystroke. Only an answer can
+// accuse — see "silence is never a verdict" below.
+constexpr bool kAnswered = true;
+
+TEST_CASE("a client that never shows its document loses the mode") {
+    Composer composer = composerFor(Method::Telex);
+    composer.setNonPreedit(true);
+
+    const std::string blind;
+    for (char c : std::string("tieengs")) {
+        composer.observeDocument(blind, false, kAnswered);
+        if (!composer.nonPreedit()) break;
+        composer.onKey(ascii(c));
+    }
+    composer.observeDocument(blind, false, kAnswered);
+
+    CHECK_FALSE(composer.nonPreedit());
+    // The composition goes with the mode: the engine believed it owned a word the
+    // document does not have.
+    CHECK_FALSE(composer.isComposing());
+}
+
+TEST_CASE("standing down inside the first word") {
+    Composer composer = composerFor(Method::Telex);
+    composer.setNonPreedit(true);
+
+    // The point of the rule is that it costs one word, not one session. Four characters
+    // is inside `tieengs`, so the verdict lands before a second word is ever typed.
+    const std::string blind;
+    int keys = 0;
+    for (char c : std::string("tieengs")) {
+        composer.observeDocument(blind, false, kAnswered);
+        if (!composer.nonPreedit()) break;
+        composer.onKey(ascii(c));
+        ++keys;
+    }
+    CHECK(keys <= 5);
+}
+
+TEST_CASE("silence is never a verdict") {
+    Composer composer = composerFor(Method::Telex);
+    composer.setNonPreedit(true);
+
+    // 39% of commits go unanswered, and an unanswered write reads as an empty document
+    // exactly like an answer of nothing. Counting those stood the mode down in Chrome —
+    // the client this whole feature exists for — so only an actual answer may accuse.
+    const std::string blind;
+    for (char c : std::string("tieengs ")) {
+        composer.observeDocument(blind, false, !kAnswered);
+        REQUIRE(composer.nonPreedit());
+        composer.onKey(ascii(c));
+    }
+    composer.observeDocument(blind, false, !kAnswered);
+
+    CHECK(composer.nonPreedit());
+}
+
+TEST_CASE("a document that answers is never called blind") {
+    Composer composer = composerFor(Method::Telex);
+    composer.setNonPreedit(true);
+
+    // An empty field answers "" as well — but only until its first commit lands. Any
+    // reading with something in it starts the count over, so a client that is merely
+    // slow, or a caret that returns to the start of a line, cannot accumulate its way
+    // to a verdict.
+    std::string document;
+    for (char c : std::string("tieengs tieengs ")) {
+        composer.observeDocument(document);
+        applyPlan(document, composer.onKey(ascii(c)), c);
+    }
+    composer.observeDocument(document);
+
+    CHECK(composer.nonPreedit());
+    CHECK(document == "tiếng tiếng ");
+}
+
+TEST_CASE("a blind verdict is remembered against the client") {
+    Composer composer = composerFor(Method::Telex);
+    composer.onFocusChanged("cursor");
+    composer.setNonPreedit(true);
+
+    const std::string blind;
+    for (char c : std::string("tieengs")) {
+        composer.observeDocument(blind, false, kAnswered);
+        if (!composer.nonPreedit()) break;
+        composer.onKey(ascii(c));
+    }
+    REQUIRE_FALSE(composer.nonPreedit());
+
+    // Same client re-activating — Fcitx5 does this on every capability change — must
+    // not be handed the mode back and cost another word.
+    composer.onFocusChanged("cursor");
+    composer.setNonPreedit(true);
+    CHECK_FALSE(composer.nonPreedit());
+}

--- a/platforms/linux/common/tests/compose/composer/nonpreedit/clients_tests.cpp
+++ b/platforms/linux/common/tests/compose/composer/nonpreedit/clients_tests.cpp
@@ -1,0 +1,78 @@
+// Who a non-preedit verdict belongs to.
+//
+// The mode stands itself down when a client drops a `deleteSurroundingText`, and that
+// verdict used to last exactly one focus. Fcitx5 calls `activate()` on a capability
+// change as well as on a focus change, so a client that churns capabilities — Cursor's
+// editor, whose suggestion widgets do — was forgiven every keystroke and mangled the
+// next word, over and over. These lock the verdict to the client instead.
+
+#include <doctest/doctest.h>
+
+#include "compose/composer/nonpreedit/refusal.h"
+#include "support.h"
+
+using namespace funput;
+using namespace funput::test;
+
+namespace {
+
+// A composer that has already caught `client` dropping a delete.
+Composer refusedBy(const char *client) {
+    Composer composer = composerFor(Method::Telex);
+    composer.onFocusChanged(client);
+    composer.setNonPreedit(true);
+    typeUntilRefused(composer, "tieengs", applyIgnoringDeletes);
+    REQUIRE_FALSE(composer.nonPreedit());
+    return composer;
+}
+
+// Re-focus `client` and ask for the mode back, as every shell does after an activate.
+bool modeAfterFocusing(Composer &composer, const char *client) {
+    composer.onFocusChanged(client);
+    composer.setNonPreedit(true);
+    return composer.nonPreedit();
+}
+
+} // namespace
+
+TEST_CASE("the same client stays refused across a re-activation") {
+    Composer composer = refusedBy("cursor");
+    // The bug this fixes: Fcitx5 re-activates on a capability change, which is not a
+    // new client and must not reopen a question already answered.
+    CHECK_FALSE(modeAfterFocusing(composer, "cursor"));
+}
+
+TEST_CASE("a different client is a new question") {
+    Composer composer = refusedBy("cursor");
+    CHECK(modeAfterFocusing(composer, "gnome-text-editor"));
+}
+
+TEST_CASE("a refused client is still refused after visiting another") {
+    Composer composer = refusedBy("cursor");
+    REQUIRE(modeAfterFocusing(composer, "gnome-text-editor"));
+    // Alternating between two apps is the ordinary way to work, so remembering only
+    // the client in focus would forgive the broken one on every switch back.
+    CHECK_FALSE(modeAfterFocusing(composer, "cursor"));
+}
+
+TEST_CASE("an unnamed client is always a new question") {
+    Composer composer = refusedBy("");
+    // The IBus shell has no name to give, and on GNOME/Wayland every client answers
+    // `gnome-shell` — one name for all of them. Remembering either would stand the mode
+    // down for everybody at once, so an empty name keeps the old per-focus behaviour.
+    CHECK(modeAfterFocusing(composer, ""));
+}
+
+TEST_CASE("the memory is bounded") {
+    Composer composer = refusedBy("client0");
+    // Eight is the cap. Refusing eight more clients pushes the first one out, and it is
+    // simply judged again — costing it one word, not correctness.
+    for (int i = 1; i <= 8; ++i) {
+        const std::string name = "client" + std::to_string(i);
+        REQUIRE(modeAfterFocusing(composer, name.c_str()));
+        typeUntilRefused(composer, "tieengs", applyIgnoringDeletes);
+        REQUIRE_FALSE(composer.nonPreedit());
+    }
+    CHECK(modeAfterFocusing(composer, "client0"));
+    CHECK_FALSE(modeAfterFocusing(composer, "client8"));
+}

--- a/platforms/linux/common/tests/compose/composer/nonpreedit/refusal.h
+++ b/platforms/linux/common/tests/compose/composer/nonpreedit/refusal.h
@@ -1,0 +1,43 @@
+// The disobedient client both refusal test files drive the composer against.
+//
+// Shared rather than copied: verify_tests.cpp proves the verdict is *reached*, and
+// clients_tests.cpp proves it is *remembered*, and the two must agree on what
+// misbehaviour looks like or they would be testing different clients.
+
+#ifndef FUNPUT_TESTS_NONPREEDIT_REFUSAL_H
+#define FUNPUT_TESTS_NONPREEDIT_REFUSAL_H
+
+#include <string>
+
+#include "support.h"
+
+namespace funput::test {
+
+// A client that takes every commit and drops every delete — Chrome's address bar, and
+// Cursor's editor. `phủ` comes back as `phủú`, which is the whole reason non-preedit
+// checks its work afterwards.
+inline void applyIgnoringDeletes(std::string &document, const ComposePlan &plan, char key) {
+    if (plan.effect != Effect::Replace) {
+        applyPlan(document, plan, key);
+        return;
+    }
+    document += plan.text;
+}
+
+// Type until the mode or re-toning is refused, feeding the client each plan. Returns
+// the document as that client left it.
+inline std::string typeUntilRefused(Composer &composer, const std::string &keys,
+                                    void (*client)(std::string &, const ComposePlan &, char)) {
+    std::string document;
+    for (char c : keys) {
+        composer.observeDocument(document);
+        if (!composer.nonPreedit()) break;
+        client(document, composer.onKey(ascii(c)), c);
+    }
+    composer.observeDocument(document);
+    return document;
+}
+
+} // namespace funput::test
+
+#endif // FUNPUT_TESTS_NONPREEDIT_REFUSAL_H

--- a/platforms/linux/common/tests/compose/composer/nonpreedit_tests.cpp
+++ b/platforms/linux/common/tests/compose/composer/nonpreedit_tests.cpp
@@ -95,7 +95,7 @@ TEST_CASE("Enter ends the composition without re-typing it") {
     composer.setNonPreedit(true);
     type(composer, "tieengs");
 
-    const ComposePlan plan = composer.onKey(bare(keysym::Return));
+    const ComposePlan plan = composer.onKey(control(keysym::Return, U'\r'));
     CHECK(plan.effect == Effect::None);
     CHECK(!plan.consumed); // the app still has to see the Enter
 }

--- a/platforms/linux/common/tests/compose/composer/verify_tests.cpp
+++ b/platforms/linux/common/tests/compose/composer/verify_tests.cpp
@@ -8,37 +8,11 @@
 
 #include <doctest/doctest.h>
 
+#include "compose/composer/nonpreedit/refusal.h"
 #include "support.h"
 
 using namespace funput;
 using namespace funput::test;
-
-namespace {
-
-// A client that drops every delete.
-void applyIgnoringDeletes(std::string &document, const ComposePlan &plan, char key) {
-    if (plan.effect != Effect::Replace) {
-        applyPlan(document, plan, key);
-        return;
-    }
-    document += plan.text;
-}
-
-// Type until the mode or re-toning is refused, feeding the client each plan. Returns
-// the document as that client left it.
-std::string typeUntilRefused(Composer &composer, const std::string &keys,
-                             void (*client)(std::string &, const ComposePlan &, char)) {
-    std::string document;
-    for (char c : keys) {
-        composer.observeDocument(document);
-        if (!composer.nonPreedit()) break;
-        client(document, composer.onKey(ascii(c)), c);
-    }
-    composer.observeDocument(document);
-    return document;
-}
-
-} // namespace
 
 TEST_CASE("a client that obeys keeps the mode") {
     Composer composer = composerFor(Method::Telex);
@@ -79,10 +53,12 @@ TEST_CASE("a silent client keeps the mode") {
     Composer composer = composerFor(Method::Telex);
     composer.setNonPreedit(true);
 
-    // The client answers nothing, so every reading is the document as it was before
-    // any of this. That is the common case — 61% of commits go unanswered — and
-    // reading it as failure would disable the mode for almost everybody.
-    const std::string stale;
+    // The client answers nothing, so every reading is the document as it was before any
+    // of this. That is the common case — 61% of commits go unanswered — and reading it
+    // as failure would disable the mode for almost everybody. Stale, not empty: an
+    // always-empty reading is a verdict of its own now (nonpreedit/verdict.h), and a
+    // client that has never shown a document cannot arm the mode in the first place.
+    const std::string stale = "câu trước đó ";
     for (char c : std::string("tieengs ")) {
         composer.observeDocument(stale);
         composer.onKey(ascii(c));

--- a/platforms/linux/common/tests/compose/key/classify_tests.cpp
+++ b/platforms/linux/common/tests/compose/key/classify_tests.cpp
@@ -89,6 +89,19 @@ TEST_CASE("a key with no character is NonText") {
     CHECK(classify(bare(0xFF51), settings) == KeyKind::NonText); // Left arrow
 }
 
+TEST_CASE("a control character is a key, not text") {
+    Settings settings;
+    // What the shells really send. Reading these as characters put Enter and Tab on
+    // the word-boundary path, where the key was swallowed and its CR appended to the
+    // commit, and put Escape on the composing path, where it was fed to the engine.
+    CHECK(classify(control(keysym::Return, U'\r'), settings) == KeyKind::NonText);
+    CHECK(classify(control(0xFF8D, U'\r'), settings) == KeyKind::NonText);  // KP_Enter
+    CHECK(classify(control(0xFF09, U'\t'), settings) == KeyKind::NonText);  // Tab
+    CHECK(classify(control(0xFF1B, U'\x1B'), settings) == KeyKind::NonText); // Escape
+    // Space is not a control character and must stay a word boundary.
+    CHECK(classify(ascii(' '), settings) == KeyKind::Boundary);
+}
+
 TEST_CASE("numpad digits are told apart from top-row digits") {
     Settings settings;
     settings.method = Method::Vni;

--- a/platforms/linux/common/tests/support.h
+++ b/platforms/linux/common/tests/support.h
@@ -41,6 +41,17 @@ inline KeyEvent bare(uint32_t keysym) {
     return ev;
 }
 
+// A control key as the frameworks actually deliver it: a keysym *and* the C0
+// character it maps to. `bare()` models a key that produces nothing, which Return is
+// not — and a test feeding `bare(Return)` is testing a key neither shell ever sends.
+// That is exactly how Enter came to be classified as a word boundary.
+inline KeyEvent control(uint32_t keysym, char32_t ch) {
+    KeyEvent ev;
+    ev.keysym = keysym;
+    ev.ch = ch;
+    return ev;
+}
+
 // A numeric-keypad digit with NumLock on: it does produce a character, but its
 // keysym is KP_<n> rather than the top-row digit's.
 inline KeyEvent numpadDigit(unsigned digit) {

--- a/platforms/linux/fcitx5/README.md
+++ b/platforms/linux/fcitx5/README.md
@@ -113,9 +113,9 @@ hướng, hoặc lúc bật/tắt VI/EN.
 | File | Dòng | Việc |
 |---|---|---|
 | [`src/funput_engine.h`](src/funput_engine.h) | 105 | Kiểu addon, config, và mọi thứ nửa còn lại cần |
-| [`src/funput_engine.cpp`](src/funput_engine.cpp) | 110 | Vòng đời: watcher, nạp lại settings, bật/tắt chế độ |
+| [`src/funput_engine.cpp`](src/funput_engine.cpp) | 115 | Vòng đời: watcher, nạp lại settings, bật/tắt chế độ |
 | [`src/funput_input.cpp`](src/funput_input.cpp) | 69 | Một phím: chuẩn hoá, hỏi composer |
-| [`src/funput_client.cpp`](src/funput_client.cpp) | 99 | Thi hành plan lên client — preedit, commit, sửa tài liệu |
+| [`src/funput_client.cpp`](src/funput_client.cpp) | 145 | Thi hành plan lên client — preedit, commit, sửa tài liệu; đọc và định danh nó |
 | [`src/hidden_preedit.cpp`](src/hidden_preedit.cpp) | 49 | Allowlist client tự giấu preedit |
 
 ### Một phím đi qua đâu
@@ -185,6 +185,15 @@ shell này:
   `activate()`. Nó kiểm `surroundingText().isValid()` chứ **không** kiểm
   `CapabilityFlag::SurroundingText` — trên GNOME/Wayland cờ đó nói dối cả hai chiều. Text rỗng
   với con trỏ 0 **vẫn** là hợp lệ: đó là một ô GTK trống, và là tín hiệu "client đã lên tiếng".
+  Gác theo *nội dung* ở đây đã thử và đã revert — nó tắt chế độ ngay trong Chrome.
+- **`surroundingFresh_`** là bit thứ hai, và là bit khó thấy: *client có lên tiếng kể từ phím
+  trước hay không*. `BlindWrites` cần nó để phân biệt "trả lời rỗng" với "không trả lời" — hai
+  thứ đọc ra cùng một chuỗi. Mỗi phím tiêu thụ rồi xoá nó.
+- **Phán quyết "client này bỏ lệnh xoá" đi theo client, không theo lần focus.** `activate()`
+  chạy cả khi capability đổi, nên nó truyền `clientId()` xuống `Composer::onFocusChanged()`:
+  `program()` nếu tên đó chỉ đúng một app, không thì uuid của input context. Trên GNOME/Wayland
+  `program()` luôn là `gnome-shell` — đo được, không đoán — nên nó bị loại trừ theo tên và uuid
+  đứng thay. Không có chốt này, một client hay đổi capability được tha thứ mỗi phím.
 - **`applyNonPreeditMode()` không bao giờ lật giữa từ.** Hai chế độ bất đồng về chỗ từ đang gõ
   nằm ở đâu, nên lật khi đang soạn dở sẽ để engine và client mô tả hai thứ khác nhau. Cùng một
   cổng gác với `applyNonPreeditMode()` bên IBus.

--- a/platforms/linux/fcitx5/src/funput_client.cpp
+++ b/platforms/linux/fcitx5/src/funput_client.cpp
@@ -4,6 +4,7 @@
 
 #include "funput_engine.h"
 
+#include <cstdint>
 #include <vector>
 
 #include <fcitx/inputpanel.h>
@@ -22,6 +23,34 @@ std::string textBeforeCaret(fcitx::InputContext *context) {
         funput::appendUtf8(out, chars[i]);
     }
     return out;
+}
+
+// Who this input context is, for the non-preedit verdict to be remembered against.
+//
+// `program()` when it names one app, so a verdict survives clicking away and back. It
+// is documented as possibly empty, and on GNOME/Wayland it is worse than empty: every
+// client answers `gnome-shell`, the proxy they all speak through (see the measurements
+// in README Linux). Remembering that name would stand the mode down for every app at
+// once — curing one broken client by breaking the feature for everyone, which is the
+// mistake this whole mechanism is built to avoid. Excluded by name rather than guessed
+// at, the same way hidden_preedit.cpp names the clients it is about.
+//
+// Either way it falls back to the input context's own uuid. That is narrower — a real
+// focus-out and back may build a new context — but it is the part that matters here:
+// Fcitx5 calls `activate()` on a capability change as well as on a focus change, and
+// that keeps the same context, so a client that churns capabilities (Cursor's editor
+// does, constantly) can no longer wipe a verdict it has already earned.
+std::string clientId(fcitx::InputContext *context) {
+    const std::string &program = context->program();
+    if (!program.empty() && program != "gnome-shell") return program;
+    std::string hex;
+    hex.reserve(context->uuid().size() * 2);
+    for (const uint8_t byte : context->uuid()) {
+        static constexpr char kDigits[] = "0123456789abcdef";
+        hex.push_back(kDigits[byte >> 4]);
+        hex.push_back(kDigits[byte & 0x0F]);
+    }
+    return hex;
 }
 
 // Is the client holding a selection right now? Non-preedit repairs the document by

--- a/platforms/linux/fcitx5/src/funput_engine.cpp
+++ b/platforms/linux/fcitx5/src/funput_engine.cpp
@@ -20,8 +20,12 @@ FunputEngine::FunputEngine(fcitx::Instance *instance) : instance_(instance) {
             if (ic != instance_->lastFocusedInputContext()) return;
             // isValid(), not CapabilityFlag::SurroundingText: on GNOME/Wayland the
             // flag lies both ways. Empty text with cursor 0 is still valid — a blank
-            // GTK field, and the IBus shell's "the client has spoken".
+            // GTK field, and the IBus shell's "the client has spoken". Judging the
+            // *content* here was tried and reverted: it kept the mode off in Chrome,
+            // the client this feature exists for. What an answer is worth is decided
+            // after a write, by BlindWrites, not before one.
             lastSurroundingOk_ = ic->surroundingText().isValid();
+            surroundingFresh_ = true;
         });
 }
 
@@ -74,15 +78,20 @@ void FunputEngine::reset(const fcitx::InputMethodEntry &, fcitx::InputContextEve
     applyPlan(event.inputContext(), composer_.flush());
 }
 
-void FunputEngine::activate(const fcitx::InputMethodEntry &, fcitx::InputContextEvent &) {
+void FunputEngine::activate(const fcitx::InputMethodEntry &, fcitx::InputContextEvent &event) {
     if (composer_.reloadSettingsIfChanged()) composer_.applySettings();
     if (composer_.settings().autoCapitalize) composer_.armCapitalization();
     toggleChord_.reset();
-    // A new client: forget whether the last one could be trusted with a repair.
-    composer_.onFocusChanged();
+    // A new client: forget whether the last one could be trusted with a repair. Named,
+    // because this runs on a capability change too, not only on a focus change — an
+    // unnamed reset would hand the mode back to a client already caught breaking it
+    // every time it toggled a capability, and Cursor's editor toggles them constantly.
+    composer_.onFocusChanged(clientId(event.inputContext()));
     // Like IBus `sawSurroundingText`: a new client has said nothing yet. `isValid()`
-    // here can be leftover from the previous focus, so do not snapshot it.
+    // here can be leftover from the previous focus, so do not snapshot it — and the
+    // last client's answer must not be credited to this one's first keystroke either.
     lastSurroundingOk_ = false;
+    surroundingFresh_ = false;
     applyNonPreeditMode();
 }
 

--- a/platforms/linux/fcitx5/src/funput_engine.h
+++ b/platforms/linux/fcitx5/src/funput_engine.h
@@ -44,10 +44,11 @@ FCITX_CONFIGURATION(
     fcitx::ExternalOption openSettings{
         this, "OpenSettings", "Open Funput Settings", "funput-settings"};);
 
-// Reading the focused client. Document helpers live in funput_client.cpp;
-// the hidden-preedit allowlist lives in hidden_preedit.cpp.
+// Reading the focused client. Document helpers and its identity live in
+// funput_client.cpp; the hidden-preedit allowlist lives in hidden_preedit.cpp.
 std::string textBeforeCaret(fcitx::InputContext *context);
 bool hasSelection(fcitx::InputContext *context);
+std::string clientId(fcitx::InputContext *context);
 bool hidesClientPreedit(fcitx::InputContext *context);
 
 class FunputEngine : public fcitx::InputMethodEngineV2 {
@@ -88,6 +89,10 @@ private:
     // cache can be stale, and surrounding text often arrives only after the client
     // answers. Set by SurroundingTextUpdated; cleared on activate().
     bool lastSurroundingOk_ = false;
+    // Whether the client has answered since the last keystroke. The one bit that tells
+    // an empty answer apart from no answer at all — see BlindWrites, which must never
+    // accuse a client that simply stayed quiet. Cleared as each key consumes it.
+    bool surroundingFresh_ = false;
     // Live settings reload: an inotify fd (settingsWatcher_) wired into Fcitx5's
     // event loop (settingsWatch_).
     funput::SettingsWatcher settingsWatcher_;

--- a/platforms/linux/fcitx5/src/funput_input.cpp
+++ b/platforms/linux/fcitx5/src/funput_input.cpp
@@ -4,6 +4,8 @@
 
 #include "funput_engine.h"
 
+#include <utility>
+
 namespace {
 
 // Fcitx5's key -> the composer's normalized one. Its keysyms are X11 keysyms, the
@@ -48,7 +50,10 @@ void FunputEngine::keyEvent(const fcitx::InputMethodEntry &, fcitx::KeyEvent &ev
     // same text a Backspace needs below.
     const bool nonPreedit = composer_.nonPreedit();
     const std::string before = nonPreedit ? textBeforeCaret(event.inputContext()) : std::string();
-    if (nonPreedit) composer_.observeDocument(before, hasSelection(event.inputContext()));
+    const bool answered = std::exchange(surroundingFresh_, false);
+    if (nonPreedit) {
+        composer_.observeDocument(before, hasSelection(event.inputContext()), answered);
+    }
 
     // A Backspace with nothing composing is about to eat a *committed* character. In
     // non-preedit the word it lands in is right there in the document, so the composer

--- a/platforms/linux/ibus/src/engine/callbacks.cpp
+++ b/platforms/linux/ibus/src/engine/callbacks.cpp
@@ -2,6 +2,8 @@
 
 #include "engine/internal.h"
 
+#include <utility>
+
 namespace funput_ibus {
 
 namespace {
@@ -69,7 +71,8 @@ gboolean processKeyEvent(IBusEngine *engine, guint keyval, guint, guint modifier
     // shell's keyEvent().
     const bool nonPreedit = state->composer.nonPreedit();
     const std::string before = nonPreedit ? textBeforeCaret(engine) : std::string();
-    if (nonPreedit) state->composer.observeDocument(before, hasSelection(engine));
+    const bool answered = std::exchange(state->surroundingFresh, false);
+    if (nonPreedit) state->composer.observeDocument(before, hasSelection(engine), answered);
 
     const bool reopen = state->composer.nonPreedit() && !state->composer.isComposing() &&
                         funput::classify(ev, state->composer.settings()) ==
@@ -89,10 +92,12 @@ void focusIn(IBusEngine *engine) {
     // A different client, which has said nothing yet. Whatever the last one did tells
     // us nothing about this one.
     state->sawSurroundingText = false;
+    state->surroundingFresh = false;
     state->toggleChord.reset();
     // A new client: forget whether the last one could be trusted with a repair. Kept
     // out of applyNonPreeditMode(), which runs every keystroke — clearing there would
-    // wipe a verdict the moment it was reached.
+    // wipe a verdict the moment it was reached. Unnamed, unlike Fcitx5: IBus gives an
+    // engine per input context and calls this only on a real focus change.
     state->composer.onFocusChanged();
     requestSurroundingText(engine);
     if (state->composer.reloadSettingsIfChanged()) state->composer.applySettings();
@@ -118,6 +123,7 @@ void setSurroundingText(IBusEngine *engine, IBusText *text, guint cursorPos, gui
     }
     EngineState *state = stateOf(engine);
     state->sawSurroundingText = true;
+    state->surroundingFresh = true;
     const gchar *raw = text != nullptr ? ibus_text_get_text(text) : nullptr;
     state->surroundingText = raw != nullptr ? raw : "";
     state->surroundingCursor = cursorPos;

--- a/platforms/linux/ibus/src/engine/internal.h
+++ b/platforms/linux/ibus/src/engine/internal.h
@@ -35,6 +35,9 @@ struct EngineState {
     // therefore cannot be true at focus-in the way Fcitx5's `isValid()` can — only
     // once the client has spoken at least once.
     bool sawSurroundingText = false;
+    // Whether the client has answered since the last keystroke — what tells an empty
+    // answer apart from no answer. See BlindWrites.
+    bool surroundingFresh = false;
     // The client's last surrounding text, kept rather than read back on demand.
     // `ibus_engine_get_surrounding_text` hands out null here even right after the
     // client has sent a perfectly good string, so the only reliable copy is the one


### PR DESCRIPTION
## Vấn đề

Người dùng báo: trong **cửa sổ editor của Cursor**, gõ `Phú` (VNI: `Phu1`) ra `Phuú`. Chỉ xảy ra khi bật `"nonPreedit": true`; khung chat của Cursor và mọi app khác bình thường. Lúc đúng lúc sai, không đoán được.

Kèm một lỗi thứ hai lộ ra trong lúc truy: gõ xong một từ rồi **Enter** thì từ đó xuất hiện lại ở dòng mới.

## Nguyên nhân

Hai lỗi độc lập, nên PR có hai commit.

### 1. Chế độ không preedit ghi mù, không bao giờ tự đứng dậy

Editor Cursor nhận `commitString` nhưng bỏ `deleteSurroundingText` đi kèm — đúng chữ ký thất bại mà `nonpreedit.h` đã mô tả sẵn cho thanh địa chỉ Chrome. Chế độ này vốn **được thiết kế để bắt đúng chuyện đó** rồi rút lui, nhưng nó không rút. Hai lý do:

**Phán quyết gắn với một lần focus, không gắn với client.** `Composer::onFocusChanged()` xoá chốt, và shell Fcitx5 gọi hàm đó từ `activate()` — mà Fcitx5 chạy `activate()` **cả khi capability đổi**, không riêng khi đổi focus (chú thích trong `deactivate()` đã nói vậy). Editor Cursor đổi capability liên tục, nên phán quyết bị xoá chỉ một hai phím sau khi đưa ra, chế độ tự bật lại và phá tiếp từ sau — lặp vô hạn thay vì hỏng đúng một lần.

**Nhưng phán quyết chưa từng được đưa ra.** Log từ bản chẩn đoán tại máy, 34 phím liên tiếp:

```
ACTIVATE  program="gnome-shell" caps=18 nonPreedit=1
KEY sym=80  nonPreedit=1 before=""      ← before rỗng ở TẤT CẢ các phím
KEY sym=49  nonPreedit=1 before=""
  APPLY Replace text="ú" del=1 consumed=1
```

Cursor **có** trả lời surrounding text — đủ để bật chế độ — rồi trả lời **rỗng** ở mọi phím. Xoá N ký tự khỏi chuỗi rỗng vẫn là chuỗi rỗng, nên ba dòng của bảng phán quyết (`D` bớt N rồi `T` / `D` rồi `T` / `D`) gộp làm một và không lần ghi nào có thể bị kết tội.

Log cũng giải thích "lúc đúng lúc sai" từng dòng: từ đầu mỗi input context đi đường preedit và **đúng** (`activate()` xoá cờ surrounding), từ thứ hai trở đi chế độ bật lên và **sai**.

### 2. Enter bị phân loại là ranh giới từ

Dò trực tiếp API của Fcitx5:

```
Return   0xFF0D -> 0x0D      Tab      0xFF09 -> 0x09
KP_Enter 0xFF8D -> 0x0D      Escape   0xFF1B -> 0x1B
```

Enter **có** sinh ký tự. `classify()` chỉ hỏi `if (ev.ch == 0) return NonText`, nên Enter trượt xuống phép thử ranh giới — và `isBoundary()` nhận `\r`. Kết quả: Funput **nuốt phím** và commit `"Phú\r"` thay vì commit `"Phú"` rồi cho phím đi qua. Log xác nhận: `consumed=1`, trong khi nhánh Enter đúng phải cho `consumed=0`.

Tab cũng bị nuốt và commit kèm `\t`; Escape rơi vào nhánh Compose, bị nạp vào engine như một ký tự; và `armCapitalization()` sau Enter — code vẫn luôn có — chưa từng chạy.

Phần lớn client giấu lỗi này vì chúng vẽ `\r` thành xuống dòng. Cursor thì không.

**Vì sao lọt test:** cả ba test có sẵn dùng `bare(keysym::Return)`, mà `bare()` đặt `ch = 0` — tức chúng test một phím Enter **không shell nào gửi**.

## Cách sửa

| | |
|---|---|
| `classify()` | Ký tự điều khiển là phím, không phải văn bản (`ch < 0x20 \|\| ch == 0x7F`), đặt **trước** phép thử ranh giới. `isBoundary()` giữ nguyên `\t \n \r` vì `adoptWordBeforeBackspace()` dò ranh giới trong tài liệu thật, nơi xuống dòng đúng là ranh giới |
| `ClientMemory` | Chốt phán quyết gắn theo client shell đặt tên: `program()` khi tên đó chỉ đúng một app, không thì uuid của input context. `gnome-shell` bị loại **theo tên** — trên Wayland mọi client đều trả lời tên đó, nhớ nó là tắt chế độ cho tất cả |
| `BlindWrites` | Trả lời rỗng hai lần liên tiếp trong khi đang bị ghi vào là một phán quyết `RefuseMode`, đủ sớm để đứng dậy **trước** lần sửa đầu tiên có `deleteChars > 0` — thứ duy nhất làm hỏng chữ |
| `observeDocument(…, answered)` | Bit mới, chỉ shell thấy được: *client có lên tiếng kể từ phím trước hay không* |

Bit `answered` là phần quan trọng nhất về tính đúng. Một lần ghi **không được trả lời** đọc ra chuỗi rỗng y hệt một câu **trả lời rỗng**, và 39% số commit không bao giờ được trả lời. Bản đầu của `BlindWrites` đếm ký tự đã ghi bất kể có trả lời hay không, và nó **tắt chế độ ngay trong Chrome** — đúng client mà tính năng này sinh ra để phục vụ. Im lặng là "chưa có phán quyết"; trả lời bằng chuỗi rỗng mới là phán quyết.

> [!NOTE]
> **Đã thử và đã revert**, ghi lại trong README để không ai làm lại: gác ở đầu vào, chỉ bật chế độ khi `textBeforeCaret()` khác rỗng. Nghe hợp lý và chặn Cursor sạch sẽ — nhưng nó cũng khiến chế độ **không bao giờ bật trong Chrome**. Một câu trả lời đáng giá bao nhiêu phải được quyết *sau* một lần ghi, không phải trước.

## Phạm vi ảnh hưởng

- **Mọi app, cả hai shell:** chỉ đúng một thay đổi — phân loại phím điều khiển. Enter/Tab giờ commit từ rồi **cho phím đi qua**; Escape commit thay vì bị nạp vào engine.
- **Chỉ khi `"nonPreedit": true`:** toàn bộ phần còn lại. Tắt setting là mọi thứ thành no-op.
- **Không đụng:** engine Rust (`crates/` không đổi một dòng), luật Telex/VNI, Backspace, space và dấu câu, phím tắt, vẽ preedit, allowlist WPS, gõ tắt, chuyển mã, app Cài đặt. `ffi/utf8.h` chỉ là dời `dropLast()` sang đúng chỗ.

## Kiểm chứng

**Test đơn vị:** 96/96 xanh (thêm 11). Đã xác nhận từng test mới **đỏ khi gỡ bản vá**:

| Gỡ ra | Test đỏ |
|---|---|
| `ch < 0x20` trong `classify()` | `a control character is a key, not text` · `a non-text key commits but still reaches the app` |
| `if (!answered) return false;` | `silence is never a verdict` |

**CI chạy lại tại máy:** `scripts/check-loc.sh` xanh (379 file trong hạn 150 dòng) · `linux-common` configure + build + ctest từ thư mục build sạch, **0 warning** · mỗi commit tự build và test xanh khi checkout riêng (an toàn cho `git bisect`).

**Thủ công**, Ubuntu GNOME/Wayland + Fcitx5 5.1.19, `"nonPreedit": true`:

| Trường hợp | Trước | Sau |
|---|---|---|
| Cursor editor — `Phu1` | `Phuú` | `Phú` |
| Cursor editor — Enter sau một từ | lặp từ ở dòng mới | xuống dòng sạch |
| Cursor editor — Tab | bị nuốt | thụt dòng bình thường |
| Chrome — chế độ không preedit | hoạt động | hoạt động *(kiểm lại sau khi revert cổng gác)* |
| GNOME Text Editor / Terminal | bình thường | bình thường |
| Bôi đen rồi Backspace | xoá đúng vùng chọn | xoá đúng vùng chọn |

Shell IBus được sửa đối xứng nhưng **chưa test trên máy thật** — máy test đang chạy Fcitx5, và README cấm chạy song song hai bộ gõ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
