### PR TITLE
feat(linux): type straight into the app by default

### DIFF
--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -35,7 +35,7 @@
 | ✂️ **Gõ tắt** | Bảng viết tắt tự bung, tuỳ chọn khớp cả hoa lẫn thường |
 | 🔄 **Chuyển mã** | Đổi qua lại giữa Unicode dựng sẵn, Unicode tổ hợp, TCVN3 (ABC) và VNI-Windows |
 | ⚙️ **App Cài đặt GTK4** | Dùng chung cho cả hai shell, giao diện libadwaita |
-| 📝 **Chế độ không preedit** | Gõ thẳng vào tài liệu thay vì hiện preedit — cứu được Chrome. [Chi tiết](#chế-độ-không-preedit) |
+| 📝 **Gõ thẳng vào ứng dụng** | Chữ vào thẳng tài liệu thay vì nằm ở preedit — cứu được Chrome. **Mặc định bật.** [Chi tiết](#chế-độ-không-preedit) |
 | 🔁 **Nạp lại cấu hình tức thì** | `inotify` theo dõi `settings.json`, không cần khởi động lại |
 
 ## Yêu cầu
@@ -424,9 +424,13 @@ nhập qua `notify::selected` và panic vì `borrow_mut` lồng nhau.
 
 ### Chế độ không preedit
 
-Mặc định tắt; công tắc nằm trong Cài đặt mục **Kiểu gõ**, hoặc đặt thẳng `"nonPreedit": true`
-trong `~/.config/Funput/settings.json`. Kiểu nào thì watcher cũng nhận ra ngay, không cần khởi
-động lại. **Cả hai shell đều thi hành nó.**
+**Mặc định bật**; công tắc “Bật gõ thẳng” nằm ở trang **Tổng quan** của app Cài đặt, hoặc đặt
+thẳng `"nonPreedit": false` trong `~/.config/Funput/settings.json`. Kiểu nào thì watcher cũng
+nhận ra ngay, không cần khởi động lại. **Cả hai shell đều thi hành nó.**
+
+Chỉ **bản cài mới** thừa hưởng mặc định đó. App Cài đặt ghi đè nguyên `settings.json` từ struct
+của nó, nên máy nào đã từng mở Cài đặt thì khoá `nonPreedit` đã nằm sẵn trong file và lựa chọn
+cũ được giữ nguyên — mặc định chỉ áp khi khoá vắng mặt.
 
 Thay vì đỗ từ đang gõ trong một preedit, mỗi phím commit thẳng vào tài liệu rồi sửa lại thứ phím
 trước đã viết — `Effect::Replace` mang theo “xoá N ký tự, rồi commit cái này”. Đó đúng là chỉ thị

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -35,7 +35,7 @@
 | ✂️ **Gõ tắt** | Bảng viết tắt tự bung, tuỳ chọn khớp cả hoa lẫn thường |
 | 🔄 **Chuyển mã** | Đổi qua lại giữa Unicode dựng sẵn, Unicode tổ hợp, TCVN3 (ABC) và VNI-Windows |
 | ⚙️ **App Cài đặt GTK4** | Dùng chung cho cả hai shell, giao diện libadwaita |
-| 📝 **Gõ thẳng vào ứng dụng** | Chữ vào thẳng tài liệu thay vì nằm ở preedit — cứu được Chrome. **Mặc định bật.** [Chi tiết](#chế-độ-không-preedit) |
+| 📝 **Gõ thẳng, không gạch chân** | Chữ vào thẳng ô nhập thay vì đợi ở dòng gạch chân — cứu được Chrome. **Mặc định bật.** [Chi tiết](#chế-độ-không-preedit) |
 | 🔁 **Nạp lại cấu hình tức thì** | `inotify` theo dõi `settings.json`, không cần khởi động lại |
 
 ## Yêu cầu
@@ -424,7 +424,8 @@ nhập qua `notify::selected` và panic vì `borrow_mut` lồng nhau.
 
 ### Chế độ không preedit
 
-**Mặc định bật**; công tắc “Bật gõ thẳng” nằm ở trang **Tổng quan** của app Cài đặt, hoặc đặt
+**Mặc định bật**; công tắc “Gõ thẳng, không gạch chân” nằm ở trang **Tổng quan** của app Cài
+đặt, hoặc đặt
 thẳng `"nonPreedit": false` trong `~/.config/Funput/settings.json`. Kiểu nào thì watcher cũng
 nhận ra ngay, không cần khởi động lại. **Cả hai shell đều thi hành nó.**
 

--- a/platforms/linux/common/settings/settings.h
+++ b/platforms/linux/common/settings/settings.h
@@ -34,11 +34,13 @@ struct Settings {
     // Auto-capitalize ("Tự động viết hoa"): uppercase the first letter at the start of
     // a sentence. Off by default.
     bool autoCapitalize = false;
-    // Non-preedit: build the word in the document and repair it with a delete,
-    // instead of showing a preedit. Off by default. No shell performs it yet, so
-    // turning this on changes nothing today — see
-    // common/compose/composer/nonpreedit.cpp for what it will ask of one.
-    bool nonPreedit = false;
+    // Non-preedit ("Gõ thẳng vào ứng dụng"): build the word in the document and
+    // repair it with a delete, instead of showing a preedit. On by default — both
+    // shells perform it, and a client that cannot take a repair is detected and put
+    // back on the preedit by itself (common/compose/composer/nonpreedit.cpp). Only a
+    // file that predates the key inherits this; the Settings app writes every field,
+    // so an existing install keeps whatever it already chose.
+    bool nonPreedit = true;
     Hotkey toggleHotkey = Hotkey::CtrlBacktick;
     FlipHotkey flipHotkey = FlipHotkey::Off;
     // Text-expansion shortcuts (gõ tắt): (trigger, expansion) pairs. Owned by the

--- a/platforms/linux/common/tests/compose/composer/keys_tests.cpp
+++ b/platforms/linux/common/tests/compose/composer/keys_tests.cpp
@@ -108,6 +108,7 @@ TEST_CASE("the flip hotkey swaps the word for its raw keys") {
     Settings settings;
     settings.method = Method::Telex;
     settings.flipHotkey = FlipHotkey::CtrlShiftZ;
+    settings.nonPreedit = false; // this case is about the preedit the flip rewrites
     Composer composer(settings);
 
     type(composer, "tieengs");

--- a/platforms/linux/common/tests/compose/composer/nonpreedit_tests.cpp
+++ b/platforms/linux/common/tests/compose/composer/nonpreedit_tests.cpp
@@ -100,7 +100,14 @@ TEST_CASE("Enter ends the composition without re-typing it") {
     CHECK(!plan.consumed); // the app still has to see the Enter
 }
 
-TEST_CASE("the mode is off unless it is asked for") {
+TEST_CASE("the shipped default is direct typing") {
+    Settings settings;
+    settings.method = Method::Telex;
+    Composer composer(settings);
+    CHECK(composer.nonPreedit());
+}
+
+TEST_CASE("turning the setting off puts the word back in a preedit") {
     Composer composer = composerFor(Method::Telex);
     CHECK(!composer.nonPreedit());
     // Byte-for-byte the behaviour of every other test in this directory.

--- a/platforms/linux/common/tests/compose/composer/state_tests.cpp
+++ b/platforms/linux/common/tests/compose/composer/state_tests.cpp
@@ -103,6 +103,7 @@ TEST_CASE("gõ tắt expansions survive a settings push") {
     Settings settings;
     settings.method = Method::Telex;
     settings.shortcuts = {{"vn", "Việt Nam"}};
+    settings.nonPreedit = false; // the expansion is asserted as one preedit commit
     Composer composer(settings);
 
     // The trigger expands when the word ends.

--- a/platforms/linux/common/tests/settings/io_tests.cpp
+++ b/platforms/linux/common/tests/settings/io_tests.cpp
@@ -60,6 +60,24 @@ TEST_CASE("the gõ tắt switches default to on when the file predates them") {
     CHECK(settings.shortcutSmartCase);
 }
 
+TEST_CASE("direct typing defaults to on when the file predates the key") {
+    // The only users the flip reaches. The Settings app writes every field, so an
+    // install that has ever opened it keeps whatever it already chose.
+    writeSettingsFile(R"({"method": "telex"})");
+
+    Settings settings;
+    REQUIRE(settings.reload());
+    CHECK(settings.nonPreedit);
+}
+
+TEST_CASE("an explicit choice still wins over the default") {
+    writeSettingsFile(R"({"method": "telex", "nonPreedit": false})");
+
+    Settings settings;
+    REQUIRE(settings.reload());
+    CHECK_FALSE(settings.nonPreedit);
+}
+
 TEST_CASE("tone placement is modern only without an existing settings file") {
     Settings fresh;
     CHECK(fresh.toneStyle == ToneStyle::Modern);

--- a/platforms/linux/common/tests/support.h
+++ b/platforms/linux/common/tests/support.h
@@ -111,10 +111,14 @@ inline std::string typeDocument(Composer &composer, const std::string &keys) {
     return document;
 }
 
-// A composer configured for one input method, with everything else default.
+// A composer on the preedit path, which is what most of this suite is about. Pinned
+// rather than inherited: `Settings::nonPreedit` ships **on**, so leaving it at the
+// default would silently move every case here onto the other path. Cases that mean to
+// test the shipped default say so — see "the shipped default is direct typing".
 inline Composer composerFor(Method method) {
     Settings settings;
     settings.method = method;
+    settings.nonPreedit = false;
     return Composer(settings);
 }
 

--- a/platforms/linux/settings-gtk/src/settings/model.rs
+++ b/platforms/linux/settings-gtk/src/settings/model.rs
@@ -94,9 +94,9 @@ pub struct Settings {
     pub spell_check: bool,
     #[serde(default)]
     pub auto_capitalize: bool,
-    /// Read and written but not shown: no shell performs non-preedit yet. Carried
-    /// so `save()` does not drop it — see the note there.
-    #[serde(default)]
+    /// "Gõ thẳng vào ứng dụng", shown on Tổng quan. `default = "on"`, not a bare
+    /// `#[serde(default)]`: that reads a keyless document as false and saves it back.
+    #[serde(default = "on")]
     pub non_preedit: bool,
     pub toggle_hotkey: Hotkey,
     #[serde(default)]
@@ -137,7 +137,7 @@ impl Default for Settings {
             eager_restore: true,
             spell_check: false,
             auto_capitalize: false,
-            non_preedit: false,
+            non_preedit: true,
             toggle_hotkey: Hotkey::CtrlBacktick,
             flip_hotkey: FlipHotkey::Off,
             launch_at_login: false,

--- a/platforms/linux/settings-gtk/src/settings/model.rs
+++ b/platforms/linux/settings-gtk/src/settings/model.rs
@@ -94,7 +94,7 @@ pub struct Settings {
     pub spell_check: bool,
     #[serde(default)]
     pub auto_capitalize: bool,
-    /// "Gõ thẳng vào ứng dụng", shown on Tổng quan. `default = "on"`, not a bare
+    /// "Gõ thẳng, không gạch chân", shown on Tổng quan. `default = "on"`, not a bare
     /// `#[serde(default)]`: that reads a keyless document as false and saves it back.
     #[serde(default = "on")]
     pub non_preedit: bool,

--- a/platforms/linux/settings-gtk/src/settings/tests.rs
+++ b/platforms/linux/settings-gtk/src/settings/tests.rs
@@ -16,6 +16,26 @@ fn a_new_install_uses_modern_tone_placement() {
 }
 
 #[test]
+fn a_new_install_types_straight_into_the_app() {
+    assert!(Settings::default().non_preedit);
+}
+
+#[test]
+fn a_legacy_document_without_non_preedit_still_gets_it() {
+    // `#[serde(default)]` would hand this `false` and the next save() would write that
+    // back, turning the mode off behind the user while the shells default it on.
+    let settings: Settings = serde_json::from_str(LEGACY).unwrap();
+    assert!(settings.non_preedit);
+}
+
+#[test]
+fn an_explicit_non_preedit_choice_is_kept() {
+    let json = LEGACY.replace('{', "{\n    \"nonPreedit\":false,");
+    let settings: Settings = serde_json::from_str(&json).unwrap();
+    assert!(!settings.non_preedit);
+}
+
+#[test]
 fn a_legacy_document_without_tone_style_stays_traditional() {
     let settings: Settings = serde_json::from_str(LEGACY).unwrap();
     assert_eq!(settings.tone_style, ToneStyle::Traditional);

--- a/platforms/linux/settings-gtk/src/settings_window/overview/delivery.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/overview/delivery.rs
@@ -16,12 +16,16 @@ pub(super) fn group(settings: &Settings) -> PreferencesGroup {
         )
         .build();
     // Named for what the user sees, not for the mechanism: "preedit" is a word this
-    // audience has no reason to know, while the underline is on their screen. Someone
-    // arriving from UniKey on Windows has only ever seen the direct kind, so the
-    // subtitle says so rather than explaining a concept they never had.
+    // audience has no reason to know, while the underline is on their screen. The
+    // subtitle spends itself on the one thing the switch cannot promise — the mode
+    // stands itself down for a client that cannot take a document repair — and names
+    // the fallback by the same underline the title does, so "the old way" is not left
+    // to the reader. No other product is named here: Funput's own Windows shell types
+    // straight into the document too, so borrowing someone else's name for our own
+    // behaviour would be both unnecessary and wrong.
     let row = SwitchRow::builder()
         .title("Gõ thẳng, không gạch chân")
-        .subtitle("Giống UniKey trên Windows. App nào không nhận được thì Funput tự về cách cũ.")
+        .subtitle("App nào không nhận được thì Funput tự chuyển về kiểu gạch chân.")
         .active(settings.non_preedit)
         .build();
     row.add_prefix(&gtk::Image::from_icon_name("document-edit-symbolic"));

--- a/platforms/linux/settings-gtk/src/settings_window/overview/delivery.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/overview/delivery.rs
@@ -17,7 +17,7 @@ pub(super) fn group(settings: &Settings) -> PreferencesGroup {
         .build();
     let row = SwitchRow::builder()
         .title("Bật gõ thẳng")
-        .subtitle("Đang thử nghiệm. App nào chưa hỗ trợ thì Funput tự về cách cũ.")
+        .subtitle("App nào không nhận được thì Funput tự về cách cũ.")
         .active(settings.non_preedit)
         .build();
     row.add_prefix(&gtk::Image::from_icon_name("document-edit-symbolic"));

--- a/platforms/linux/settings-gtk/src/settings_window/overview/delivery.rs
+++ b/platforms/linux/settings-gtk/src/settings_window/overview/delivery.rs
@@ -10,14 +10,18 @@ use crate::settings::Settings;
 
 pub(super) fn group(settings: &Settings) -> PreferencesGroup {
     let group = PreferencesGroup::builder()
-        .title("Gõ thẳng vào ứng dụng")
+        .title("Cách chữ hiện ra khi gõ")
         .description(
-            "Chữ hiện ngay trong ô gõ, không nằm ở dòng gạch chân. Đổi cửa sổ giữa chừng cũng không mất chữ.",
+            "Có hai kiểu: chữ vào thẳng ô nhập, hoặc đợi ở một dòng gạch chân rồi mới đáp xuống — đổi cửa sổ giữa chừng thì kiểu sau làm mất từ đang gõ.",
         )
         .build();
+    // Named for what the user sees, not for the mechanism: "preedit" is a word this
+    // audience has no reason to know, while the underline is on their screen. Someone
+    // arriving from UniKey on Windows has only ever seen the direct kind, so the
+    // subtitle says so rather than explaining a concept they never had.
     let row = SwitchRow::builder()
-        .title("Bật gõ thẳng")
-        .subtitle("App nào không nhận được thì Funput tự về cách cũ.")
+        .title("Gõ thẳng, không gạch chân")
+        .subtitle("Giống UniKey trên Windows. App nào không nhận được thì Funput tự về cách cũ.")
         .active(settings.non_preedit)
         .build();
     row.add_prefix(&gtk::Image::from_icon_name("document-edit-symbolic"));


### PR DESCRIPTION
## Vì sao

Chế độ **"Gõ thẳng vào ứng dụng"** (`nonPreedit`) ra đời để cứu những client làm mất từ đang gõ dở khi đổi focus — Chrome là ca điển hình. Nhưng nó vẫn mặc định **tắt** từ lúc hoàn thành, nên phần lớn người dùng chưa bao giờ chạm tới.

Sau [#353](https://github.com/Funput/Funput/pull/353), hai đường mà chế độ có thể **giữ nguyên trạng thái bật với một client nó đã làm hỏng** đã bị bịt: phán quyết giờ gắn theo client thay vì theo một lần focus, và một client trả lời tài liệu rỗng đã trở thành phán quyết thay vì một khoảng mù. Chế độ tự lùi về preedit khi client không nhận được lệnh sửa tài liệu.

PR này lật mặc định.

## Phạm vi thật sự

**Chỉ với tới bản cài mới.** `io.cpp` chỉ dùng giá trị mặc định khi khoá `nonPreedit` **vắng mặt** trong `settings.json`, mà app Cài đặt ghi đè nguyên file từ struct của nó — nên máy nào đã từng mở Cài đặt đều đã có sẵn khoá đó và giữ nguyên lựa chọn cũ.

Người dùng vẫn tắt được: công tắc **"Bật gõ thẳng"** ở trang Tổng quan của app Cài đặt, hoặc `"nonPreedit": false` trong `settings.json` — watcher nhận ra ngay.

## Một cái bẫy trên đường

Lật `Default` bên Rust là **chưa đủ**. `non_preedit` mang `#[serde(default)]` trần, tức một document không có khoá sẽ đọc ra `bool::default()` — **false** — trong khi model C++ của hai shell đọc chính file đó ra **true**. Lần `save()` kế tiếp sẽ ghi cái `false` đó đè lên và **tắt chế độ sau lưng người dùng**.

Sửa thành `#[serde(default = "on")]`, đúng khuôn mà hai công tắc gõ tắt đã dùng cho cùng lý do này. Test `a_legacy_document_without_non_preedit_still_gets_it` khoá lại — đã xác nhận **đỏ** khi trả về `#[serde(default)]`.

## Test

Lật mặc định làm lộ ra mọi chỗ đang ngầm dựa vào nó, và đó là phần có giá trị: `composerFor()` cùng hai case dựng `Settings` trực tiếp giờ **nói rõ** `nonPreedit = false` ở nơi chúng muốn thử đường preedit, thay vì thừa hưởng một mặc định không còn đồng ý với chúng.

Bốn test mới, đều đã xác nhận đỏ khi gỡ bản vá:

| Test | Khoá điều gì |
|---|---|
| `the shipped default is direct typing` (C++) | `Settings` mặc định bật chế độ |
| `direct typing defaults to on when the file predates the key` (C++) | File cũ không có khoá → bật |
| `an explicit choice still wins over the default` (C++) | `"nonPreedit": false` vẫn thắng |
| `a_legacy_document_without_non_preedit_still_gets_it` (Rust) | Chính cái bẫy serde ở trên |

**Cổng CI chạy lại tại máy:** `check-loc.sh` xanh (379 file) · `linux-common` **99/99** · `settings-gtk` fmt + clippy `-D warnings` + `cargo test` **11/11**.

## Dọn kèm

Ba chỗ sai sự thật gặp trên đường, đều nằm đúng dòng đang sửa:

- `settings.h` và `model.rs` vẫn ghi *"no shell performs non-preedit yet"* — cả hai shell thi hành nó từ lâu
- README Linux chỉ công tắc nằm ở mục **Kiểu gõ**; thật ra nó ở **Tổng quan**
- Phụ đề công tắc tự nhận *"Đang thử nghiệm"* — mâu thuẫn với việc bật mặc định

## Điều người review cần cân nhắc

Bằng chứng ổn định đến từ **một máy**: Ubuntu GNOME/Wayland, Fcitx5 5.1.19 qua frontend ibus, kiểm chủ yếu Chrome, Cursor, GNOME Text Editor. **Shell IBus chưa từng chạy thật** với các thay đổi của #353 — hai shell dùng chung composer và phần riêng của IBus là mã đối xứng, nhưng đó là suy luận, không phải đo đạc.

Cơ chế an toàn của chế độ là phát hiện **sau khi đã ghi**, nên với client nào bỏ `deleteSurroundingText` mà vẫn trả lời tài liệu, người dùng vẫn mất một từ trước khi nó rút lui. Bật mặc định nghĩa là chấp nhận cái giá đó một lần trên mỗi client hỏng, đổi lấy việc không còn mất từ khi đổi focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
