### PR TITLE
feat(ios): support iOS 16 as the minimum

### DIFF
--- a/platforms/ios/Funput.xcodeproj/project.pbxproj
+++ b/platforms/ios/Funput.xcodeproj/project.pbxproj
@@ -488,7 +488,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -548,7 +548,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -578,7 +578,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -616,7 +616,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -642,7 +642,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = RSARFZ5CD3;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.funput.FunputTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -664,7 +664,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = RSARFZ5CD3;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.funput.FunputTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -685,7 +685,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = RSARFZ5CD3;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.funput.FunputUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -706,7 +706,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = RSARFZ5CD3;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = app.funput.FunputUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -733,7 +733,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Funput;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -765,7 +765,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Funput;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/platforms/ios/Funput/About/AboutLinkSection.swift
+++ b/platforms/ios/Funput/About/AboutLinkSection.swift
@@ -31,7 +31,10 @@ private struct AboutLinkRow: View {
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundStyle(destination.tint)
                     .frame(width: 36, height: 36)
-                    .background(destination.tint.opacity(0.12), in: .rect(cornerRadius: 10))
+                    .background(
+                        destination.tint.opacity(0.12),
+                        in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    )
                 VStack(alignment: .leading, spacing: 2) {
                     Text(destination.title)
                         .font(.subheadline.weight(.semibold))
@@ -45,7 +48,7 @@ private struct AboutLinkRow: View {
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.tertiary)
             }
-            .contentShape(.rect)
+            .contentShape(Rectangle())
             .padding(.vertical, 9)
         }
         .buttonStyle(.plain)

--- a/platforms/ios/Funput/App/Shell/AppShellView.swift
+++ b/platforms/ios/Funput/App/Shell/AppShellView.swift
@@ -4,32 +4,51 @@ struct AppShellView: View {
     @State private var selectedTab = AppTab.defaultTab
 
     var body: some View {
-        TabView(selection: $selectedTab) {
-            Tab(
-                AppTab.settings.title,
-                systemImage: AppTab.settings.systemImage,
-                value: AppTab.settings
-            ) {
+        if #available(iOS 18, *) {
+            TabView(selection: $selectedTab) {
+                Tab(
+                    AppTab.settings.title,
+                    systemImage: AppTab.settings.systemImage,
+                    value: AppTab.settings
+                ) {
+                    NavigationStack { SettingsScreen() }
+                }
+                Tab(
+                    AppTab.appearance.title,
+                    systemImage: AppTab.appearance.systemImage,
+                    value: AppTab.appearance
+                ) {
+                    NavigationStack { AppearanceScreen() }
+                }
+                Tab(
+                    AppTab.about.title,
+                    systemImage: AppTab.about.systemImage,
+                    value: AppTab.about
+                ) {
+                    NavigationStack { AboutScreen() }
+                }
+            }
+            .tint(.accentColor)
+        } else {
+            TabView(selection: $selectedTab) {
                 NavigationStack { SettingsScreen() }
-            }
-
-            Tab(
-                AppTab.appearance.title,
-                systemImage: AppTab.appearance.systemImage,
-                value: AppTab.appearance
-            ) {
+                    .tabItem {
+                        Label(AppTab.settings.title, systemImage: AppTab.settings.systemImage)
+                    }
+                    .tag(AppTab.settings)
                 NavigationStack { AppearanceScreen() }
-            }
-
-            Tab(
-                AppTab.about.title,
-                systemImage: AppTab.about.systemImage,
-                value: AppTab.about
-            ) {
+                    .tabItem {
+                        Label(AppTab.appearance.title, systemImage: AppTab.appearance.systemImage)
+                    }
+                    .tag(AppTab.appearance)
                 NavigationStack { AboutScreen() }
+                    .tabItem {
+                        Label(AppTab.about.title, systemImage: AppTab.about.systemImage)
+                    }
+                    .tag(AppTab.about)
             }
+            .tint(.accentColor)
         }
-        .tint(.accentColor)
     }
 }
 

--- a/platforms/ios/Funput/App/TypingHarness/KeyboardTouchAcceptanceView.swift
+++ b/platforms/ios/Funput/App/TypingHarness/KeyboardTouchAcceptanceView.swift
@@ -21,8 +21,10 @@ struct KeyboardTouchAcceptanceView: View {
             .navigationTitle("Touch Acceptance")
             .onAppear { model.appear() }
             .onDisappear { model.disappear() }
-            .onChange(of: scenePhase) { _, phase in
-                if phase == .active { model.appear() }
+            .background {
+                if #available(iOS 17, *) {
+                    Color.clear.onChange(of: scenePhase) { _, p in if p == .active { model.appear() } }
+                } else { Color.clear.onChange(of: scenePhase) { p in if p == .active { model.appear() } } }
             }
         }
     }
@@ -34,11 +36,7 @@ struct KeyboardTouchAcceptanceView: View {
                     Text(fixture.title).tag(fixture.inputMethod)
                 }
             }
-            .disabled(
-                model.stage == .guided || model.stage == .settling
-                    || model.stage == .gestures
-                    || model.stage == .free
-            )
+            .disabled([.guided, .settling, .gestures, .free].contains(model.stage))
             if !model.hasFullAccess {
                 Label("Cần bật Full Access để nhận live report.",
                       systemImage: "exclamationmark.triangle")

--- a/platforms/ios/Funput/Appearance/AppearanceModel.swift
+++ b/platforms/ios/Funput/Appearance/AppearanceModel.swift
@@ -1,18 +1,18 @@
+import Combine
 import FunputShared
 import KeyboardRenderer
-import Observation
 import SwiftUI
 import ThemeRuntime
 import ThemeSchema
 import UIKit
-@MainActor @Observable
-final class AppearanceModel {
-    private(set) var configuration: FunputConfiguration
-    private(set) var appliedThemeID: String
-    private(set) var customThemes: [CustomKeyboardTheme]
-    var previewThemeID: String
-    var previewMode = AppearancePreviewMode.light
-    var showsSaveError = false
+@MainActor
+final class AppearanceModel: ObservableObject {
+    @Published private(set) var configuration: FunputConfiguration
+    @Published private(set) var appliedThemeID: String
+    @Published private(set) var customThemes: [CustomKeyboardTheme]
+    @Published var previewThemeID: String
+    @Published var previewMode = AppearancePreviewMode.light
+    @Published var showsSaveError = false
 
     let store: any FunputConfigurationStoring
     let bootstrap: any KeyboardBootstrapSynchronizing

--- a/platforms/ios/Funput/Appearance/AppearanceScreen.swift
+++ b/platforms/ios/Funput/Appearance/AppearanceScreen.swift
@@ -1,3 +1,4 @@
+import Combine
 import FunputShared
 import KeyboardRenderer
 import SwiftUI
@@ -7,7 +8,7 @@ import ThemeSchema
 struct AppearanceScreen: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.scenePhase) private var scenePhase
-    @State private var model: AppearanceModel
+    @StateObject private var model: AppearanceModel
     @State private var confirmsReset = false
     @State private var confirmsDelete = false
     @State private var editorRequest: ThemeEditorRequest?
@@ -18,7 +19,7 @@ struct AppearanceScreen: View {
         assetStore: any ThemeAssetStoring = ThemeAssetStore(),
         bootstrap: any KeyboardBootstrapSynchronizing = KeyboardBootstrapSynchronizer()
     ) {
-        _model = State(initialValue: AppearanceModel(
+        _model = StateObject(wrappedValue: AppearanceModel(
             store: store,
             customStore: customStore,
             assetStore: assetStore,
@@ -39,7 +40,7 @@ struct AppearanceScreen: View {
             // it, so UIKit never interpolates the glass colors out of range.
             .id(model.previewMode)
             .frame(height: previewHeight)
-            .clipShape(.rect(cornerRadius: 22))
+            .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
             .shadow(color: .black.opacity(0.14), radius: 16, y: 8)
             .accessibilityLabel("Bản xem trước bàn phím \(model.previewTheme.metadata.name)")
 
@@ -83,8 +84,12 @@ struct AppearanceScreen: View {
             Text("Nếu theme đang được dùng, Funput sẽ chuyển về theme hệ thống gốc.")
         }
         .onAppear { model.setInitialMode(for: colorScheme) }
-        .onChange(of: scenePhase) { _, phase in
-            if phase == .active { model.reload() }
+        .background {
+            if #available(iOS 17, *) {
+                Color.clear.onChange(of: scenePhase) { _, p in if p == .active { model.reload() } }
+            } else {
+                Color.clear.onChange(of: scenePhase) { p in if p == .active { model.reload() } }
+            }
         }
     }
 

--- a/platforms/ios/Funput/Appearance/ThemeCard.swift
+++ b/platforms/ios/Funput/Appearance/ThemeCard.swift
@@ -43,8 +43,8 @@ struct ThemeCard: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
             Button(action: action) {
-                Color.clear
-                    .contentShape(.rect)
+                    Color.clear
+                    .contentShape(Rectangle())
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
             .buttonStyle(.plain)
@@ -79,8 +79,12 @@ struct ThemeCard: View {
 
     private var actionsMenu: some View {
         Menu {
-            Button("Chỉnh sửa", systemImage: "slider.horizontal.3", action: editAction)
-            Button("Xóa", systemImage: "trash", role: .destructive, action: deleteAction)
+            Button(action: editAction) {
+                Label("Chỉnh sửa", systemImage: "slider.horizontal.3")
+            }
+            Button(role: .destructive, action: deleteAction) {
+                Label("Xóa", systemImage: "trash")
+            }
                 .accessibilityIdentifier("themeEditor.delete")
         } label: {
             Image(systemName: "ellipsis.circle.fill")
@@ -88,7 +92,7 @@ struct ThemeCard: View {
                 .symbolRenderingMode(.palette)
                 .foregroundStyle(.primary, .ultraThinMaterial)
                 .padding(8)
-                .contentShape(.circle)
+                .contentShape(Circle())
         }
         .accessibilityLabel("Tùy chọn theme \(theme.metadata.name)")
         .accessibilityIdentifier("appearance.theme.\(theme.id).menu")

--- a/platforms/ios/Funput/Appearance/ThemeCardThumbnail.swift
+++ b/platforms/ios/Funput/Appearance/ThemeCardThumbnail.swift
@@ -23,7 +23,7 @@ struct ThemeCardThumbnail: View {
             }
             .padding(12)
         }
-        .clipShape(.rect(cornerRadius: 16))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .stroke(

--- a/platforms/ios/Funput/Appearance/ThemeEditor.swift
+++ b/platforms/ios/Funput/Appearance/ThemeEditor.swift
@@ -1,10 +1,11 @@
+import Combine
 import KeyboardRenderer
 import SwiftUI
 import ThemeSchema
 
 struct ThemeEditor: View {
     @Environment(\.dismiss) private var dismiss
-    let model: AppearanceModel
+    @ObservedObject var model: AppearanceModel
     @State private var draft: ThemeEditorDraft
     @State private var confirmsCancel = false
     @State private var selectedTab = ThemeEditorTab.general

--- a/platforms/ios/Funput/Appearance/ThemeEditorPages.swift
+++ b/platforms/ios/Funput/Appearance/ThemeEditorPages.swift
@@ -65,8 +65,10 @@ private struct ThemeResetButton: View {
     @Binding var draft: ThemeEditorDraft
 
     var body: some View {
-        Button("Khôi phục theme gốc", systemImage: "arrow.counterclockwise") {
+        Button {
             draft.resetToBase()
+        } label: {
+            Label("Khôi phục theme gốc", systemImage: "arrow.counterclockwise")
         }
         .buttonStyle(.bordered)
         .frame(maxWidth: .infinity)

--- a/platforms/ios/Funput/Appearance/ThemeEditorPreview.swift
+++ b/platforms/ios/Funput/Appearance/ThemeEditorPreview.swift
@@ -29,7 +29,7 @@ struct ThemeEditorPreview: View {
             )
             .id(draft.previewMode)
             .frame(height: previewHeight)
-            .clipShape(.rect(cornerRadius: 18))
+            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
             .shadow(color: .black.opacity(0.14), radius: 12, y: 6)
             .accessibilityIdentifier("themeEditor.preview")
         }

--- a/platforms/ios/Funput/Appearance/ThemeGallery.swift
+++ b/platforms/ios/Funput/Appearance/ThemeGallery.swift
@@ -1,10 +1,11 @@
+import Combine
 import KeyboardRenderer
 import SwiftUI
 import ThemeRuntime
 import ThemeSchema
 
 struct ThemeGallery: View {
-    let model: AppearanceModel
+    @ObservedObject var model: AppearanceModel
     let onEdit: (String) -> Void
     let onDelete: (String) -> Void
 
@@ -46,6 +47,7 @@ struct ThemeGallery: View {
         }
     }
 
+    @ViewBuilder
     private func scroller(
         themes: [KeyboardTheme],
         isCustom: Bool,
@@ -55,10 +57,10 @@ struct ThemeGallery: View {
             LazyHStack(spacing: 16) {
                 ForEach(themes) { theme in themeCard(theme, isCustom: isCustom) }
             }
-            .scrollTargetLayout()
             .padding(.vertical, 4)
+            .modifier(ThemeGallerySnapContent())
         }
-        .scrollTargetBehavior(.viewAligned)
+        .modifier(ThemeGallerySnapContainer())
         .accessibilityIdentifier("appearance.carousel.\(identifier)")
     }
 
@@ -76,6 +78,26 @@ struct ThemeGallery: View {
             deleteAction: { onDelete(theme.id) }
         ) {
             withAnimation(.easeInOut(duration: 0.2)) { model.selectTheme(theme.id) }
+        }
+    }
+}
+
+private struct ThemeGallerySnapContent: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 17, *) {
+            content.scrollTargetLayout()
+        } else {
+            content
+        }
+    }
+}
+
+private struct ThemeGallerySnapContainer: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 17, *) {
+            content.scrollTargetBehavior(.viewAligned)
+        } else {
+            content
         }
     }
 }

--- a/platforms/ios/Funput/Appearance/ThemeGeometryControls.swift
+++ b/platforms/ios/Funput/Appearance/ThemeGeometryControls.swift
@@ -10,8 +10,16 @@ struct ThemeEditorNameCard: View {
             TextField("Tên theme", text: $name)
                 .textFieldStyle(.roundedBorder)
                 .accessibilityIdentifier("themeEditor.name")
-                .onChange(of: name) { _, value in
-                    if value.count > 40 { name = String(value.prefix(40)) }
+                .background {
+                    if #available(iOS 17, *) {
+                        Color.clear.onChange(of: name) { _, value in
+                            if value.count > 40 { name = String(value.prefix(40)) }
+                        }
+                    } else {
+                        Color.clear.onChange(of: name) { value in
+                            if value.count > 40 { name = String(value.prefix(40)) }
+                        }
+                    }
                 }
         }
     }

--- a/platforms/ios/Funput/Appearance/ThemeImageControls.swift
+++ b/platforms/ios/Funput/Appearance/ThemeImageControls.swift
@@ -15,21 +15,26 @@ struct ThemeImageControls: View {
             Text("Ảnh nền").font(.headline)
             if let data = draft.renderedImageData, let image = UIImage(data: data) {
                 Image(uiImage: image).resizable().scaledToFill()
-                    .frame(height: 110).clipShape(.rect(cornerRadius: 12))
+                    .frame(height: 110).clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                 HStack {
                     picker("Đổi ảnh")
-                    Button("Điều chỉnh khung", systemImage: "crop") {
+                    Button {
                         cropRequest = ThemeCropRequest()
+                    } label: {
+                        Label("Điều chỉnh khung", systemImage: "crop")
                     }
                         .accessibilityIdentifier("themeEditor.imageCrop")
                 }
-                Button("Xóa ảnh", systemImage: "trash", role: .destructive) {
+                Button(role: .destructive) {
                     confirmsDelete = true
+                } label: {
+                    Label("Xóa ảnh", systemImage: "trash")
                 }
                 .accessibilityIdentifier("themeEditor.imageDelete")
                 blurSlider
             } else {
-                ContentUnavailableView("Chưa có ảnh", systemImage: "photo")
+                Label("Chưa có ảnh", systemImage: "photo")
+                    .foregroundStyle(.secondary)
                 picker("Chọn ảnh")
                 Text("Hãy chọn ảnh để có thể lưu theme ở chế độ Ảnh.")
                     .font(.caption).foregroundStyle(.secondary)
@@ -41,7 +46,13 @@ struct ThemeImageControls: View {
         .confirmationDialog("Xóa ảnh nền?", isPresented: $confirmsDelete) {
             Button("Xóa ảnh", role: .destructive) { draft.removeImage() }
         }
-        .onChange(of: selection) { _, item in load(item) }
+        .background {
+            if #available(iOS 17, *) {
+                Color.clear.onChange(of: selection) { _, item in load(item) }
+            } else {
+                Color.clear.onChange(of: selection) { item in load(item) }
+            }
+        }
         .onDisappear { processingTask?.cancel() }
     }
 

--- a/platforms/ios/Funput/Appearance/ThemeImageCropEditor.swift
+++ b/platforms/ios/Funput/Appearance/ThemeImageCropEditor.swift
@@ -22,7 +22,7 @@ struct ThemeImageCropEditor: View {
                     cropImage(size: proxy.size)
                 }
                 .aspectRatio(1.29, contentMode: .fit)
-                .clipShape(.rect(cornerRadius: 18))
+                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
                 .overlay { RoundedRectangle(cornerRadius: 18).stroke(.white.opacity(0.7)) }
                 ThemeMetricSlider(
                     title: "Phóng to",
@@ -65,7 +65,7 @@ struct ThemeImageCropEditor: View {
                 )
                 .frame(width: size.width, height: size.height)
                 .clipped()
-                .contentShape(.rect)
+                .contentShape(Rectangle())
                 .gesture(dragGesture(overflow: overflow))
                 .simultaneousGesture(magnificationGesture)
         }

--- a/platforms/ios/Funput/Components/FunputIdentityView.swift
+++ b/platforms/ios/Funput/Components/FunputIdentityView.swift
@@ -41,14 +41,17 @@ struct FunputIdentityView: View {
             Image(uiImage: image)
                 .resizable()
                 .scaledToFit()
-                .clipShape(.rect(cornerRadius: iconCornerRadius))
+                .clipShape(RoundedRectangle(cornerRadius: iconCornerRadius, style: .continuous))
                 .frame(width: iconSize, height: iconSize)
         } else {
             Image(systemName: "keyboard.fill")
                 .font(.system(size: iconSize * 0.44, weight: .semibold))
                 .foregroundStyle(.tint)
                 .frame(width: iconSize, height: iconSize)
-                .background(.tint.opacity(0.12), in: .rect(cornerRadius: iconCornerRadius))
+                .background(
+                    .tint.opacity(0.12),
+                    in: RoundedRectangle(cornerRadius: iconCornerRadius, style: .continuous)
+                )
         }
     }
 

--- a/platforms/ios/Funput/Settings/KeyboardSetupCard.swift
+++ b/platforms/ios/Funput/Settings/KeyboardSetupCard.swift
@@ -17,7 +17,9 @@ struct KeyboardSetupCard: View {
             } else {
                 setupSteps
                 privacyNotice
-                Button("Mở Cài đặt", systemImage: "gear", action: openSettings)
+                Button(action: openSettings) {
+                    Label("Mở Cài đặt", systemImage: "gear")
+                }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -69,7 +71,7 @@ struct KeyboardSetupCard: View {
                 .font(.caption.bold())
                 .foregroundStyle(.tint)
                 .frame(width: 24, height: 24)
-                .background(.tint.opacity(0.12), in: .circle)
+                .background(.tint.opacity(0.12), in: Circle())
             VStack(alignment: .leading, spacing: 2) {
                 Text(title).font(.subheadline.weight(.semibold))
                 Text(detail).font(.caption).foregroundStyle(.secondary)

--- a/platforms/ios/Funput/Settings/SettingsModel.swift
+++ b/platforms/ios/Funput/Settings/SettingsModel.swift
@@ -1,13 +1,13 @@
+import Combine
 import FunputShared
 import KeyboardLayout
-import Observation
 import SwiftUI
 
-@MainActor @Observable
-final class SettingsModel {
-    private(set) var configuration: FunputConfiguration
-    private(set) var hasFullAccess: Bool
-    var showsSaveError = false
+@MainActor
+final class SettingsModel: ObservableObject {
+    @Published private(set) var configuration: FunputConfiguration
+    @Published private(set) var hasFullAccess: Bool
+    @Published var showsSaveError = false
     private let store: any FunputConfigurationStoring
     private let customStore: any CustomThemeStoring
     private let bootstrap: any KeyboardBootstrapSynchronizing

--- a/platforms/ios/Funput/Settings/SettingsRows.swift
+++ b/platforms/ios/Funput/Settings/SettingsRows.swift
@@ -20,7 +20,7 @@ struct SettingsSelectionRow: View {
                 Image(systemName: "chevron.right").font(.caption.bold()).foregroundStyle(.tertiary)
             }
             .padding(.vertical, 12)
-            .contentShape(.rect)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel("\(option.title), \(value)")

--- a/platforms/ios/Funput/Settings/SettingsScreen.swift
+++ b/platforms/ios/Funput/Settings/SettingsScreen.swift
@@ -1,3 +1,4 @@
+import Combine
 import FunputShared
 import SwiftUI
 import ThemeRuntime
@@ -6,7 +7,7 @@ import UIKit
 struct SettingsScreen: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.openURL) private var openURL
-    @State private var model: SettingsModel
+    @StateObject private var model: SettingsModel
     @State private var picker: SettingsPicker?
     @State private var requestsHapticAccess = false
     @State private var requestsSoundAccess = false
@@ -16,7 +17,7 @@ struct SettingsScreen: View {
         customStore: any CustomThemeStoring = CustomThemeStore(),
         bootstrap: any KeyboardBootstrapSynchronizing = KeyboardBootstrapSynchronizer()
     ) {
-        _model = State(initialValue: SettingsModel(
+        _model = StateObject(wrappedValue: SettingsModel(
             store: store,
             customStore: customStore,
             bootstrap: bootstrap
@@ -110,8 +111,12 @@ struct SettingsScreen: View {
         } message: {
             Text("Để phát âm thanh khi gõ, hãy mở Funput trong Cài đặt, chọn Bàn phím và bật Cho phép truy cập đầy đủ.")
         }
-        .onChange(of: scenePhase) { _, phase in
-            if phase == .active { model.reload() }
+        .background {
+            if #available(iOS 17, *) {
+                Color.clear.onChange(of: scenePhase) { _, p in if p == .active { model.reload() } }
+            } else {
+                Color.clear.onChange(of: scenePhase) { p in if p == .active { model.reload() } }
+            }
         }
     }
 }

--- a/platforms/ios/Funput/Settings/SettingsSelectionSheet.swift
+++ b/platforms/ios/Funput/Settings/SettingsSelectionSheet.swift
@@ -1,9 +1,10 @@
+import Combine
 import SwiftUI
 
 struct SettingsSelectionSheet: View {
     @Environment(\.dismiss) private var dismiss
     let picker: SettingsPicker
-    let model: SettingsModel
+    @ObservedObject var model: SettingsModel
 
     var body: some View {
         NavigationStack {
@@ -49,7 +50,7 @@ struct SettingsSelectionSheet: View {
                 }
             }
             .padding(.vertical, 14)
-            .contentShape(.rect)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel(choice.title)

--- a/platforms/ios/FunputTests/Keyboard/KeyboardMetricsScaleTests.swift
+++ b/platforms/ios/FunputTests/Keyboard/KeyboardMetricsScaleTests.swift
@@ -35,9 +35,9 @@ struct KeyboardMetricsScaleTests {
         idiom: UIUserInterfaceIdiom,
         vertical: UIUserInterfaceSizeClass
     ) -> UITraitCollection {
-        UITraitCollection { traits in
-            traits.userInterfaceIdiom = idiom
-            traits.verticalSizeClass = vertical
-        }
+        UITraitCollection(traitsFrom: [
+            UITraitCollection(userInterfaceIdiom: idiom),
+            UITraitCollection(verticalSizeClass: vertical),
+        ])
     }
 }

--- a/platforms/ios/Keyboard/Controller/KeyboardViewController+Traits.swift
+++ b/platforms/ios/Keyboard/Controller/KeyboardViewController+Traits.swift
@@ -8,6 +8,11 @@ extension KeyboardViewController {
         activateKeyboardForAppearance()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #unavailable(iOS 17) { updatePreferredHeight() }
+    }
+
     override func textWillChange(_ textInput: (any UITextInput)?) {
         super.textWillChange(textInput)
         updateTextInputTraits()

--- a/platforms/ios/Keyboard/Controller/KeyboardViewController.swift
+++ b/platforms/ios/Keyboard/Controller/KeyboardViewController.swift
@@ -71,9 +71,11 @@ final class KeyboardViewController: UIInputViewController {
         heightController.install(on: view)
         // The height only tracks the size class, and `viewWillTransition` alone misses
         // every change that is not a rotation of an already-visible keyboard.
-        registerForTraitChanges([UITraitVerticalSizeClass.self]) {
-            (controller: KeyboardViewController, _) in
-            controller.updatePreferredHeight()
+        if #available(iOS 17, *) {
+            registerForTraitChanges([UITraitVerticalSizeClass.self]) {
+                (controller: KeyboardViewController, _) in
+                controller.updatePreferredHeight()
+            }
         }
         bootstrapKeyboard()
         launchTrace.endViewDidLoad()

--- a/platforms/ios/Packages/FunputKit/Package.swift
+++ b/platforms/ios/Packages/FunputKit/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "FunputKit",
-    platforms: [.iOS(.v18)],
+    platforms: [.iOS(.v16)],
     products: [
         .library(name: "FunputEngine", targets: ["FunputEngine"]),
         .library(name: "PersonalSuggestions", targets: ["PersonalSuggestions"]),

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Clipboard/ClipboardKeyboardView+Presentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Clipboard/ClipboardKeyboardView+Presentation.swift
@@ -28,8 +28,10 @@ extension ClipboardKeyboardView {
     }
 
     func configureView() {
-        registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: Self, _) in
-            view.applyPresentation()
+        if #available(iOS 17, *) {
+            registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: Self, _) in
+                view.applyPresentation()
+            }
         }
         clipsToBounds = true
         backgroundColor = .clear
@@ -83,6 +85,11 @@ extension ClipboardKeyboardView {
 
     @objc private func accessibilityAppearanceDidChange() {
         applyPresentation()
+    }
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #unavailable(iOS 17) { applyPresentation() }
     }
 
     /// A list layout purely for the swipe actions it brings: separators and

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Emoji/Browser/EmojiKeyboardView+Presentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Emoji/Browser/EmojiKeyboardView+Presentation.swift
@@ -21,8 +21,10 @@ extension EmojiKeyboardView {
     }
 
     func configureView() {
-        registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: Self, _) in
-            view.applyPresentation()
+        if #available(iOS 17, *) {
+            registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: Self, _) in
+                view.applyPresentation()
+            }
         }
         clipsToBounds = true
         backgroundColor = .clear
@@ -96,6 +98,11 @@ extension EmojiKeyboardView {
 
     @objc private func accessibilityAppearanceDidChange() {
         applyPresentation()
+    }
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #unavailable(iOS 17) { applyPresentation() }
     }
 
     static func makeLayout() -> UICollectionViewLayout {

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Feedback/KeyboardHaptics.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Feedback/KeyboardHaptics.swift
@@ -10,11 +10,19 @@ final class KeyboardHaptics {
     private let repeatSelection: UISelectionFeedbackGenerator
 
     init(view: UIView) {
-        light = UIImpactFeedbackGenerator(style: .light, view: view)
-        soft = UIImpactFeedbackGenerator(style: .soft, view: view)
-        rigid = UIImpactFeedbackGenerator(style: .rigid, view: view)
-        medium = UIImpactFeedbackGenerator(style: .medium, view: view)
-        repeatSelection = UISelectionFeedbackGenerator(view: view)
+        if #available(iOS 17.5, *) {
+            light = UIImpactFeedbackGenerator(style: .light, view: view)
+            soft = UIImpactFeedbackGenerator(style: .soft, view: view)
+            rigid = UIImpactFeedbackGenerator(style: .rigid, view: view)
+            medium = UIImpactFeedbackGenerator(style: .medium, view: view)
+            repeatSelection = UISelectionFeedbackGenerator(view: view)
+        } else {
+            light = UIImpactFeedbackGenerator(style: .light)
+            soft = UIImpactFeedbackGenerator(style: .soft)
+            rigid = UIImpactFeedbackGenerator(style: .rigid)
+            medium = UIImpactFeedbackGenerator(style: .medium)
+            repeatSelection = UISelectionFeedbackGenerator()
+        }
     }
 
     func prepare() {

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Kaomoji/Browser/KaomojiKeyboardView+Presentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Kaomoji/Browser/KaomojiKeyboardView+Presentation.swift
@@ -21,8 +21,10 @@ extension KaomojiKeyboardView {
     }
 
     func configureView() {
-        registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: Self, _) in
-            view.applyPresentation()
+        if #available(iOS 17, *) {
+            registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: Self, _) in
+                view.applyPresentation()
+            }
         }
         clipsToBounds = true
         backgroundColor = .clear
@@ -80,6 +82,11 @@ extension KaomojiKeyboardView {
 
     @objc private func accessibilityAppearanceDidChange() {
         applyPresentation()
+    }
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #unavailable(iOS 17) { applyPresentation() }
     }
 
     static func makeLayout() -> UICollectionViewLayout {

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView+Configuration.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView+Configuration.swift
@@ -3,8 +3,10 @@ import UIKit
 
 extension KeyboardSurfaceView {
     func configureView() {
-        registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: Self, _) in
-            view.applyPresentation()
+        if #available(iOS 17, *) {
+            registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: Self, _) in
+                view.applyPresentation()
+            }
         }
         isMultipleTouchEnabled = true
         contentHost.isMultipleTouchEnabled = true
@@ -47,6 +49,11 @@ extension KeyboardSurfaceView {
             interactionController.performSuggestionFeedback(presentation: presentation)
             onClipboardPaste?(text)
         }
+    }
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #unavailable(iOS 17) { applyPresentation() }
     }
 }
 #endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardMetricsTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/KeyboardMetricsTests.swift
@@ -110,10 +110,10 @@ struct KeyboardMetricsTests {
         idiom: UIUserInterfaceIdiom,
         verticalSizeClass: UIUserInterfaceSizeClass
     ) -> UITraitCollection {
-        UITraitCollection { traits in
-            traits.userInterfaceIdiom = idiom
-            traits.verticalSizeClass = verticalSizeClass
-        }
+        UITraitCollection(traitsFrom: [
+            UITraitCollection(userInterfaceIdiom: idiom),
+            UITraitCollection(verticalSizeClass: verticalSizeClass),
+        ])
     }
 
     private func expectHeight(

--- a/platforms/ios/README.md
+++ b/platforms/ios/README.md
@@ -54,19 +54,19 @@
 
 | | |
 |---|---|
-| **Hệ điều hành tối thiểu** | **iOS / iPadOS 18.6** trở lên |
+| **Hệ điều hành tối thiểu** | **iOS / iPadOS 16** trở lên |
 | **Thiết bị** | iPhone và iPad |
 | **Cài đặt** | Miễn phí trên [App Store](https://apps.apple.com/vn/app/id6788829996) |
 | **Quyền** | Cần bật **Cho phép truy cập đầy đủ** — [xem vì sao](#vì-sao-cần-cho-phép-truy-cập-đầy-đủ) |
 
 > [!IMPORTANT]
-> **iOS 18.6 là sàn cứng.** Cả app lẫn tiện ích bàn phím đều khai `MinimumOSVersion` là `18.6`
+> **iOS 16 là sàn cứng.** Cả app lẫn tiện ích bàn phím đều khai `MinimumOSVersion` là `16.0`
 > *(kiểm chứng được trong chính bản đã đóng gói)*, nên App Store sẽ không cho cài trên máy chạy
 > iOS thấp hơn.
 >
 > Kiểm tra máy bạn: **Cài đặt → Cài đặt chung → Giới thiệu → Phiên bản phần mềm**.
 >
-> Giao diện **Liquid Glass cần iOS 26**. Trên iOS 18–25 bàn phím vẫn chạy đầy đủ, chỉ là các
+> Giao diện **Liquid Glass cần iOS 26**. Trên iOS 16–25 bàn phím vẫn chạy đầy đủ, chỉ là các
 > theme kính đổi sang nền đặc tương đương.
 
 ## Cài đặt
@@ -207,16 +207,15 @@ platforms/ios/
 | | |
 |---|---|
 | Swift | `6.3`, Swift language mode 6 · SwiftUI *(app)* + UIKit *(bàn phím)* |
-| Deployment target | **`18.6`** cho cả app, bàn phím và test target |
+| Deployment target | **`16.0`** cho cả app, bàn phím và test target |
 | Engine | [`funput-ffi`](../../crates/funput-ffi) đóng thành `FunputCore.xcframework`, link tĩnh |
 | Cấu hình chia sẻ | App Group `group.app.funput.funput` + `UserDefaults(suiteName:)` |
 | Phát hành | App Store Connect → TestFlight → App Store |
 
 > [!WARNING]
-> **Cài đặt cấp project là `IPHONEOS_DEPLOYMENT_TARGET = 26.5`, không phải 18.6.** Mọi target hiện
-> có đều ghi đè xuống 18.6 nên giá trị đó vô hại — nhưng một target **mới** thêm vào mà quên đặt
-> giá trị riêng sẽ âm thầm thừa kế 26.5, tức là loại bỏ gần hết thiết bị người dùng. Đặt
-> `IPHONEOS_DEPLOYMENT_TARGET` một cách tường minh cho mọi target mới.
+> **Cài đặt cấp project là `IPHONEOS_DEPLOYMENT_TARGET = 16.0`.** Mọi target hiện có đều ghi đè
+> cùng giá trị đó. Vẫn đặt `IPHONEOS_DEPLOYMENT_TARGET` tường minh cho mọi target mới, để một
+> lần Xcode tự điền SDK version vào cấp project không âm thầm nâng sàn.
 
 ### Build
 

--- a/platforms/ios/docs/ARCHITECTURE.md
+++ b/platforms/ios/docs/ARCHITECTURE.md
@@ -31,7 +31,7 @@ Funput iOS sử dụng kiến trúc **hybrid native**: giao diện và tích h�
 - **Swift:** 6.3, Swift language mode 6
 - **iOS SDK:** 26.4
 - **Rust:** 1.97 stable, edition 2024
-- **Minimum deployment:** iOS 18.6 — giá trị `IPHONEOS_DEPLOYMENT_TARGET` của mọi target trong `Funput.xcodeproj`, và là `MinimumOSVersion` của cả `.app` lẫn `.appex` khi đóng gói. Lưu ý cài đặt **cấp project** là 26.5: mọi target hiện có đều ghi đè xuống 18.6, nhưng một target mới quên đặt giá trị riêng sẽ âm thầm thừa kế 26.5
+- **Minimum deployment:** iOS 16.0 — giá trị `IPHONEOS_DEPLOYMENT_TARGET` của mọi target trong `Funput.xcodeproj`, và là `MinimumOSVersion` của cả `.app` lẫn `.appex` khi đóng gói. Cài đặt cấp project cũng là 16.0; vẫn ghi đè tường minh trên từng target để Xcode không âm thầm nâng sàn khi tạo target mới.
 - **Giao diện mục tiêu chính:** iOS/iPadOS 26.4
 
 Không đóng băng toolchain vĩnh viễn. Khi bắt đầu một milestone mới, cập nhật lên bản stable mới nhất sau khi CI và test thiết bị đã xanh.
@@ -392,7 +392,7 @@ phải giới hạn nền tảng**.
 > marked-text API tương đương macOS IMKit". Khẳng định đó **sai**. Không được dùng nó làm
 > tiền đề cho bất kỳ quyết định kiến trúc nào.
 
-`UITextDocumentProxy` có marked-text API từ **iOS 13** — thấp hơn deployment target iOS 18 của
+`UITextDocumentProxy` có marked-text API từ **iOS 13** — thấp hơn deployment target iOS 16 của
 dự án, nên dùng được vô điều kiện, không cần `@available`:
 
 ```swift
@@ -743,7 +743,7 @@ App Store yêu cầu keyboard vẫn hoạt động khi không có Full Access. V
 - Light/dark mode.
 - Reduce Transparency/Reduce Motion/Increase Contrast.
 - Dynamic Type và VoiceOver.
-- iOS 18 fallback và iOS 26 Liquid Glass.
+- iOS 16 fallback và iOS 26 Liquid Glass.
 
 ### Các chỉ số cần theo dõi
 
@@ -804,7 +804,7 @@ trước package resolution và `xcodebuild`.
 - `ThemeSchema`, `ThemeRuntime` và bundled themes.
 - Renderer dùng chung giữa preview và extension.
 - App Group synchronization và fallback không Full Access.
-- Liquid Glass trên iOS 26, fallback trên iOS 18–25.
+- Liquid Glass trên iOS 26, fallback trên iOS 16–25.
 
 ### Giai đoạn 4 — User-created themes
 
@@ -845,7 +845,7 @@ trước package resolution và `xcodebuild`.
 - [ ] Renderer preview và renderer extension là cùng implementation.
 - [ ] App và extension không link module không cần thiết.
 - [ ] Build chạy trên device ARM64 và Apple Silicon simulator.
-- [ ] Test iOS 18 fallback và iOS 26 Liquid Glass.
+- [ ] Test iOS 16 fallback và iOS 26 Liquid Glass.
 - [ ] Test iPhone/iPad, portrait/landscape và floating keyboard.
 - [ ] Test VoiceOver và các accessibility appearance settings.
 - [ ] Instruments không cho thấy allocation bất thường trên key hot path.


### PR DESCRIPTION
## Summary
- Lower the iOS deployment target from 18.6 to 16.0 for the app, keyboard extension, and FunputKit, including the project-level default so new targets cannot inherit 26.5.
- Keep iOS 18+ and Liquid Glass (iOS 26) on their current APIs behind `#available`; older SwiftUI/UIKit paths are only used below those versions.
- Verified with `xcodebuild` (no Swift warnings) and on a physical iOS 27 device.

## Test plan
- [x] Install on iOS 18.6+ (or 26/27): settings, appearance, and typing still match the current flow.
- [x] On iOS 16/17 if a runtime is available: app launches, tabs work, keyboard appears, haptics do not crash.
- [x] Theme editor empty-image and gallery scroll still usable.


Made with [Cursor](https://cursor.com)