### PR TITLE
feat(ios): auto-save copied text while the keyboard is open

### DIFF
--- a/platforms/ios/Funput/App/TypingHarness/ClipboardHarnessControls.swift
+++ b/platforms/ios/Funput/App/TypingHarness/ClipboardHarnessControls.swift
@@ -1,0 +1,23 @@
+#if DEBUG
+import FunputShared
+import SwiftUI
+import UIKit
+
+/// A host-process copy while the real extension stays visible. Only enabled by
+/// the clipboard UI test launch argument; the status reads the shared history.
+struct ClipboardHarnessControls: View {
+    private let text = ProcessInfo.processInfo.environment["CLIPBOARD_TEST_TEXT"] ?? "Clipboard test"
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Button("Copy test text") { UIPasteboard.general.string = text }
+                .accessibilityIdentifier("clipboardHarness.copy")
+            TimelineView(.periodic(from: .now, by: 0.2)) { _ in
+                Text(ClipboardStore().load().contains { $0.text == text } ? "Saved" : "Waiting")
+                    .accessibilityIdentifier("clipboardHarness.status")
+            }
+        }
+        .padding()
+    }
+}
+#endif

--- a/platforms/ios/Funput/App/TypingHarness/TypingHarnessView.swift
+++ b/platforms/ios/Funput/App/TypingHarness/TypingHarnessView.swift
@@ -14,6 +14,11 @@ struct TypingHarnessView: View {
         HarnessTextView()
             .ignoresSafeArea(.container, edges: .bottom)
             .onAppear(perform: Self.forceDeterministicConfiguration)
+            .overlay(alignment: .topLeading) {
+                if ProcessInfo.processInfo.arguments.contains("-uitest-clipboard") {
+                    ClipboardHarnessControls()
+                }
+            }
             .overlay(alignment: .topTrailing) {
                 if ProcessInfo.processInfo.arguments.contains("-uitest-warm-toolbar-refresh") {
                     Button("Ẩn toolbar", action: Self.applyToolbarlessConfiguration)

--- a/platforms/ios/Funput/Settings/ClipboardSettingsCard.swift
+++ b/platforms/ios/Funput/Settings/ClipboardSettingsCard.swift
@@ -4,6 +4,7 @@ struct ClipboardSettingsCard: View {
     @Binding var isEnabled: Bool
     let expiryLabel: String
     let selectExpiry: () -> Void
+    let openSettings: () -> Void
     let clear: () -> Void
 
     @State private var confirmsClear = false
@@ -14,9 +15,12 @@ struct ClipboardSettingsCard: View {
                 title: "Lưu lịch sử clipboard",
                 // The one place a user with existing entries will actually read this:
                 // the empty state that explains it is, by definition, never shown to them.
-                summary: "Chỉ lưu những gì bạn đã dán qua Funput, trên thiết bị.",
+                summary: "Tự lưu văn bản đã sao chép khi Funput hoạt động, trên thiết bị. Cần cho phép đọc clipboard.",
                 isOn: $isEnabled
             )
+            if isEnabled {
+                pastePermissionGuide
+            }
             SettingsSelectionRow(option: .clipboardExpiry, value: expiryLabel, action: selectExpiry)
             Button("Xoá tất cả", role: .destructive) { confirmsClear = true }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -35,5 +39,29 @@ struct ClipboardSettingsCard: View {
                     Text("Xoá ngay lập tức, kể cả những mục đã ghim.")
                 }
         }
+    }
+
+    /// iOS asks for permission once per copied item, so without this setting the
+    /// feature works but greets every copy with an alert. There is no API to read the
+    /// current choice, so the guidance is always offered rather than hidden once granted.
+    private var pastePermissionGuide: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label {
+                Text("Để Funput tự lưu mà không hỏi lại sau mỗi lần sao chép, đặt **Dán từ ứng dụng khác** thành **Cho phép**.")
+            } icon: {
+                Image(systemName: "doc.on.clipboard").foregroundStyle(.tint)
+            }
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            Button(action: openSettings) {
+                Label("Mở Cài đặt", systemImage: "gear")
+            }
+            .buttonStyle(.bordered)
+            .accessibilityHint("Mở cài đặt của Funput để cho phép dán từ ứng dụng khác")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.bottom, 10)
+        .accessibilityElement(children: .contain)
     }
 }

--- a/platforms/ios/Funput/Settings/SettingsScreen.swift
+++ b/platforms/ios/Funput/Settings/SettingsScreen.swift
@@ -72,6 +72,7 @@ struct SettingsScreen: View {
                 isEnabled: model.boolBinding(\.clipboardEnabled),
                 expiryLabel: model.clipboardExpiryLabel,
                 selectExpiry: { picker = .clipboardExpiry },
+                openSettings: { openURL(URL(string: UIApplication.openSettingsURLString)!) },
                 clear: { model.clearClipboardHistory() }
             )
             FeedbackSettingsCard(

--- a/platforms/ios/FunputUITests/ClipboardCaptureUITests.swift
+++ b/platforms/ios/FunputUITests/ClipboardCaptureUITests.swift
@@ -1,0 +1,61 @@
+import XCTest
+
+/// Requires Funput enabled with Full Access on the selected simulator/device.
+final class ClipboardCaptureUITests: XCTestCase {
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws { continueAfterFailure = false }
+
+    override func tearDownWithError() throws {
+        app?.terminate()
+        let cleanup = XCUIApplication()
+        cleanup.launchArguments = ["-uitest-clear-configuration-override"]
+        cleanup.launch()
+        cleanup.terminate()
+    }
+
+    @MainActor
+    func testCopyWhileKeyboardOpenSavesBeforePaste() throws {
+        app = XCUIApplication()
+        let text = "Clipboard " + UUID().uuidString
+        app.launchArguments = ["-uitest-typing-harness", "-uitest-clipboard"]
+        app.launchEnvironment["CLIPBOARD_TEST_TEXT"] = text
+        addUIInterruptionMonitor(withDescription: "Clipboard permission") { alert in
+            let allow = alert.buttons.matching(
+                NSPredicate(format: "label IN %@", ["Allow Paste", "Cho phép dán"])
+            ).firstMatch
+            guard allow.exists else { return false }
+            allow.tap()
+            return true
+        }
+        app.launch()
+        let field = app.textViews["typingHarness.field"]
+        XCTAssertTrue(field.waitForExistence(timeout: 10))
+        XCTAssertTrue(FunputKeyboardDriver.switchToFunputKeyboard(app))
+        allowClipboardPrompt()
+        app.buttons["clipboardHarness.copy"].tap()
+        allowClipboardPrompt()
+        let saved = app.staticTexts["clipboardHarness.status"]
+        let ready = NSPredicate(format: "label == 'Saved'")
+        XCTAssertEqual(XCTWaiter.wait(
+            for: [XCTNSPredicateExpectation(predicate: ready, object: saved)], timeout: 10
+        ), .completed, "Text must be saved before tapping Paste; check clipboard permissions")
+        XCTAssertEqual(field.value as? String, "")
+        let paste = app.buttons["funput.clipboard.paste"]
+        XCTAssertTrue(paste.waitForExistence(timeout: 3))
+        XCTAssertTrue(paste.isEnabled)
+        paste.tap()
+        let inserted = NSPredicate(format: "value == %@", text)
+        XCTAssertEqual(XCTWaiter.wait(
+            for: [XCTNSPredicateExpectation(predicate: inserted, object: field)], timeout: 5
+        ), .completed)
+    }
+
+    @MainActor
+    private func allowClipboardPrompt() {
+        let allow = app.alerts.buttons.matching(
+            NSPredicate(format: "label IN %@", ["Allow Paste", "Cho phép dán"])
+        ).firstMatch
+        if allow.waitForExistence(timeout: 2) { allow.tap() }
+    }
+}

--- a/platforms/ios/Keyboard/Clipboard/KeyboardViewController+Clipboard.swift
+++ b/platforms/ios/Keyboard/Clipboard/KeyboardViewController+Clipboard.swift
@@ -16,7 +16,7 @@ extension KeyboardViewController {
     ///
     /// Reads pasteboard **metadata only** — `changeCount`, `hasStrings`, `hasURLs` —
     /// which raises no paste alert. The contents are never read here; they arrive
-    /// only through the user's tap on the chip's `UIPasteControl`.
+    /// through the capture controller or the chip's `UIPasteControl`.
     ///
     /// Deliberately not called from `updateInputPresentation()`: that runs on every
     /// keystroke that moves the shift state, and the typing hot path stays free of
@@ -49,7 +49,7 @@ extension KeyboardViewController {
 
         let offer = ClipboardOfferPolicy.offer(
             snapshot: snapshot,
-            lastCapturedChangeCount: clipboardStore.lastCapturedChangeCount(),
+            lastPastedChangeCount: clipboardCapture.lastPastedChangeCount,
             context: context
         )
         keyboardView.updateClipboardHint(offer.map(Self.hint))
@@ -86,18 +86,10 @@ extension KeyboardViewController {
         }
     }
 
-    private func pasteFromClipboard(_ text: String) {
-        guard !text.isEmpty else { return }
-        let effects = inputCoordinator.insertLiteral(text, writer: makeDocumentWriter())
-        // Stamped with the live `changeCount` rather than the one the offer was built
-        // from: the text just handed over is whatever is on the pasteboard now.
-        // The panel can already be open when the switch is turned off, so the write
-        // is guarded here and not only where the chip is offered.
-        if configuration.clipboardEnabled {
-            clipboardStore.record(
-                ClipboardItem(text: text, sourceChangeCount: UIPasteboard.general.changeCount)
-            )
-        }
+    private func pasteFromClipboard(_ paste: KeyboardClipboardPaste) {
+        guard activationState.isActive, !paste.text.isEmpty else { return }
+        let effects = inputCoordinator.insertLiteral(paste.text, writer: makeDocumentWriter())
+        clipboardCapture.didPaste(paste.text, changeCount: paste.changeCount)
         refreshClipboardOffer()
         applyPostCommitEffects(effects)
     }

--- a/platforms/ios/Keyboard/Clipboard/KeyboardViewController+ClipboardCapture.swift
+++ b/platforms/ios/Keyboard/Clipboard/KeyboardViewController+ClipboardCapture.swift
@@ -1,0 +1,51 @@
+import FunputShared
+import KeyboardConfiguration
+import KeyboardInput
+import KeyboardLayout
+import UIKit
+
+extension KeyboardViewController {
+    var allowsClipboardCapture: Bool {
+        activationState.isActive && hasFullAccess && configuration.clipboardEnabled
+            && !inputCoordinator.state.editorMode.isPassword
+    }
+
+    func makeClipboardCapture() -> ClipboardCaptureController {
+        ClipboardCaptureController(
+            gateway: SystemClipboardGateway(),
+            allowsCapture: { [weak self] in self?.allowsClipboardCapture == true },
+            save: { [weak self] item in self?.clipboardStore.capture(item) == true },
+            // Resolved through `self`, not captured: activation replaces the store,
+            // and `ClipboardStore` is a struct, so a copy taken here would freeze.
+            marks: KeyboardClipboardMarks { [weak self] in self?.clipboardStore },
+            onUpdate: { [weak self] in self?.refreshClipboardPanel() }
+        )
+    }
+
+    func startClipboardMonitoring() {
+        clipboardCapture.begin()
+        refreshClipboardOffer()
+        clipboardChangeMonitor.start(
+            readSnapshot: { [weak self] in
+                guard self?.allowsClipboardCapture == true else { return nil }
+                return ClipboardSnapshot(.general)
+            },
+            onChange: { [weak self] in
+                self?.refreshClipboardOffer()
+                self?.clipboardCapture.synchronize()
+            }
+        )
+    }
+}
+
+/// Reaches the controller's current ``ClipboardStore`` rather than a copy of
+/// whichever one existed when the capture controller was built.
+struct KeyboardClipboardMarks: ClipboardSessionMarkStoring {
+    let store: () -> ClipboardStore?
+
+    func lastCapturedChangeCount() -> Int? { store()?.lastCapturedChangeCount() }
+    func lastPastedChangeCount() -> Int? { store()?.lastPastedChangeCount() }
+
+    @discardableResult
+    func markPasted(_ changeCount: Int) -> Bool { store()?.markPasted(changeCount) == true }
+}

--- a/platforms/ios/Keyboard/Clipboard/KeyboardViewController+ClipboardPanel.swift
+++ b/platforms/ios/Keyboard/Clipboard/KeyboardViewController+ClipboardPanel.swift
@@ -11,6 +11,10 @@ extension KeyboardViewController {
             return clipboardPanelView
         }
         let clipboardPanelView = KeyboardLaunchTrace.makePanel(.clipboard, ClipboardKeyboardView())
+        clipboardPanelView.onRetry = { [weak self] in
+            self?.clipboardCapture.synchronize(retry: true)
+            self?.refreshClipboardPanel()
+        }
         clipboardPanelView.onSelect = { [weak self] entry in
             self?.pasteFromHistory(entry)
         }
@@ -43,6 +47,7 @@ extension KeyboardViewController {
         ensureClipboardPanelView()
         inputCoordinator.prepareForLiteralInput()
         clearPersonalSuggestions()
+        clipboardCapture.synchronize()
         refreshClipboardPanel()
         switchSurface(to: .clipboard)
     }
@@ -51,7 +56,8 @@ extension KeyboardViewController {
         clipboardPanelView?.apply(
             presentation: currentPresentation,
             entries: clipboardStore.load().map(Self.entry),
-            hasFullAccess: hasFullAccess
+            hasFullAccess: hasFullAccess,
+            needsRetry: clipboardCapture.needsRetry
         )
     }
 
@@ -73,10 +79,12 @@ extension KeyboardViewController {
         applyPostCommitEffects(effects)
     }
 
-    /// Wiping the history also clears the captured change count, so whatever is still
-    /// on the pasteboard is offered again — after an explicit wipe the user should be
-    /// able to start over rather than face a keyboard that has quietly written it off.
+    /// Wiping the history suppresses the clipboard that is still on the pasteboard for
+    /// the rest of the session: capture would otherwise re-import, within half a
+    /// second, exactly what the user just asked to be rid of. The next session syncs
+    /// it again, as opening the keyboard always does.
     private func clearClipboardHistory() {
+        clipboardCapture.suppressCurrentAfterClear()
         clipboardStore.clear()
         refreshClipboardPanel()
         refreshClipboardOffer()

--- a/platforms/ios/Keyboard/Controller/KeyboardViewController.swift
+++ b/platforms/ios/Keyboard/Controller/KeyboardViewController.swift
@@ -37,6 +37,8 @@ final class KeyboardViewController: UIInputViewController {
     let backgroundImageCache = KeyboardBackgroundAssetCache<UIImage>()
     let bootstrapSnapshotStore = KeyboardBootstrapSnapshotStore()
     var clipboardRetryTask: Task<Void, Never>?
+    let clipboardChangeMonitor = ClipboardChangeMonitor()
+    lazy var clipboardCapture = makeClipboardCapture()
     var pendingBootstrapRepair: KeyboardBootstrapSnapshot?
     var adoptedIdentity: KeyboardActivationIdentity?
     var resolvedBackgroundRequest: KeyboardBackgroundRequest?
@@ -88,7 +90,7 @@ final class KeyboardViewController: UIInputViewController {
 #if DEBUG
         touchDiagnosticsReporter.startIfAvailable(hasFullAccess: hasFullAccess)
 #endif
-        refreshClipboardOffer()
+        startClipboardMonitoring()
         repairBootstrapSnapshotIfNeeded()
     }
 

--- a/platforms/ios/Keyboard/Suggestions/KeyboardViewController+SuggestionLifecycle.swift
+++ b/platforms/ios/Keyboard/Suggestions/KeyboardViewController+SuggestionLifecycle.swift
@@ -1,9 +1,12 @@
+import FunputShared
 import KeyboardConfiguration
 import UIKit
 
 extension KeyboardViewController {
     override func viewWillDisappear(_ animated: Bool) {
         activationState.end()
+        clipboardChangeMonitor.stop()
+        clipboardCapture.end()
         cancelClipboardRetry()
         markPreferredHeightHidden()
         super.viewWillDisappear(animated)

--- a/platforms/ios/Packages/FunputKit/Package.swift
+++ b/platforms/ios/Packages/FunputKit/Package.swift
@@ -91,7 +91,7 @@ let package = Package(
         ),
         .testTarget(
             name: "KeyboardRendererTests",
-            dependencies: ["KeyboardLayout", "KeyboardRenderer", "ThemeSchema"]
+            dependencies: ["KeyboardLayout", "KeyboardRenderer", "ThemeSchema", "FunputShared"]
         ),
         .testTarget(
             name: "ThemeRuntimeTests",

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardBootTime.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardBootTime.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// When this device last booted, as seconds since the epoch.
+///
+/// `UIPasteboard.changeCount` restarts at boot, so a change count remembered on disk
+/// only means something within the boot that wrote it. Pairing the two is what lets
+/// the keyboard trust a remembered generation instead of re-reading the pasteboard —
+/// and a pasteboard read is user-visible, so trusting it is the whole point.
+///
+/// The clock can shift this by a second or two after a time sync. That direction is
+/// safe: the marks are simply treated as another boot's and re-read once.
+public enum ClipboardBootTime {
+    /// nil when the kernel would not say. Failing safe matters more than answering:
+    /// a sentinel could equal one stored by an earlier failed probe, which would make
+    /// another boot's marks look current and skip a clipboard the user did copy.
+    public static var current: Int? {
+        var boot = timeval()
+        var size = MemoryLayout<timeval>.stride
+        var mib: [Int32] = [CTL_KERN, KERN_BOOTTIME]
+        guard sysctl(&mib, 2, &boot, &size, nil, 0) == 0 else { return nil }
+        return Int(boot.tv_sec)
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardCaptureController.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardCaptureController.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Coordinates one active keyboard session. A failed content read pauses automatic
+/// capture until an explicit retry; metadata monitoring and manual Paste still work.
+@MainActor
+public final class ClipboardCaptureController {
+    public private(set) var needsRetry = false
+    public private(set) var lastPastedChangeCount: Int?
+    private var processed: Int?
+    private var suppressed: Int?
+    private var isReading = false
+    private var pending = false
+    private var resampleTask: Task<Void, Never>?
+    private var generation = 0
+    private var active = false
+    private let gateway: any ClipboardGateway
+    private let allowsCapture: () -> Bool
+    private let save: (ClipboardItem) -> Bool
+    private let marks: any ClipboardSessionMarkStoring
+    private let onUpdate: () -> Void
+
+    public init(
+        gateway: any ClipboardGateway,
+        allowsCapture: @escaping () -> Bool,
+        save: @escaping (ClipboardItem) -> Bool,
+        marks: any ClipboardSessionMarkStoring,
+        onUpdate: @escaping () -> Void
+    ) {
+        self.gateway = gateway
+        self.allowsCapture = allowsCapture
+        self.save = save
+        self.marks = marks
+        self.onUpdate = onUpdate
+    }
+
+    /// A new session inherits what the last one already learned about this
+    /// pasteboard. The keyboard is torn down and rebuilt in every app it appears in,
+    /// so starting blank meant re-reading the same clipboard — and every read shows
+    /// the user a system paste banner — and re-offering text they had already pasted.
+    public func begin() {
+        generation += 1
+        active = true
+        processed = marks.lastCapturedChangeCount()
+        suppressed = nil
+        lastPastedChangeCount = marks.lastPastedChangeCount()
+    }
+
+    public func end() {
+        generation += 1
+        active = false
+        pending = false
+        resampleTask?.cancel()
+        resampleTask = nil
+    }
+
+    public func synchronize(retry: Bool = false) {
+        guard active, allowsCapture() else { return }
+        guard !isReading else { pending = true; return }
+        if retry { needsRetry = false; processed = nil }
+        guard !needsRetry else { return }
+        let before = gateway.snapshot()
+        guard !before.isIndeterminate, before.hasStrings,
+              before.changeCount != processed, before.changeCount != suppressed else { return }
+        isReading = true
+        defer {
+            isReading = false
+            schedulePendingRead()
+        }
+        let session = generation
+        let text = gateway.readText()
+        guard active, session == generation, allowsCapture() else { return }
+        // Do not label an old provider result with a newer clipboard generation.
+        guard gateway.snapshot().changeCount == before.changeCount else { pending = true; return }
+        guard let text else { fail(); return }
+        guard !text.isEmpty else { processed = before.changeCount; return }
+        if save(ClipboardItem(text: text, sourceChangeCount: before.changeCount)) {
+            processed = before.changeCount
+            onUpdate()
+        } else { fail() }
+    }
+
+    /// nil means the provider could not establish a stable clipboard generation.
+    /// -1 is reserved for such manual pastes and never suppresses a live offer.
+    public func didPaste(_ text: String, changeCount: Int?) {
+        guard active, !text.isEmpty else { return }
+        let current = gateway.snapshot()
+        let stable = changeCount == current.changeCount ? changeCount : nil
+        lastPastedChangeCount = stable
+        if let stable { marks.markPasted(stable) }
+        guard allowsCapture() else { return }
+        if stable != nil, stable == processed { return }
+        if save(ClipboardItem(text: text, sourceChangeCount: stable ?? -1)) {
+            if let stable { processed = stable }
+            onUpdate()
+        } else { fail() }
+    }
+
+    public func suppressCurrentAfterClear() {
+        guard active, allowsCapture() else { return }
+        suppressed = gateway.snapshot().changeCount
+        processed = suppressed
+    }
+
+    private func fail() {
+        needsRetry = true
+        onUpdate()
+    }
+
+    private func schedulePendingRead() {
+        guard pending, active else { return }
+        pending = false
+        let session = generation
+        resampleTask?.cancel()
+        resampleTask = Task { @MainActor [weak self] in
+            await Task.yield()
+            guard !Task.isCancelled, let self, generation == session else { return }
+            resampleTask = nil
+            synchronize()
+        }
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardChangeMonitor.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardChangeMonitor.swift
@@ -1,0 +1,67 @@
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Samples metadata while a keyboard is visible, including changes made by its host
+/// process. No clipboard contents or history files are read by the monitor.
+@MainActor
+public final class ClipboardChangeMonitor: NSObject {
+    private var task: Task<Void, Never>?
+    private var previous: ClipboardSnapshot?
+    private var readSnapshot: (() -> ClipboardSnapshot?)?
+    private var onChange: (() -> Void)?
+
+    public override init() { super.init() }
+
+    deinit { task?.cancel(); NotificationCenter.default.removeObserver(self) }
+
+    public func start(
+        readSnapshot: @escaping () -> ClipboardSnapshot?,
+        onChange: @escaping () -> Void
+    ) {
+        stop()
+        self.readSnapshot = readSnapshot
+        self.onChange = onChange
+#if canImport(UIKit)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(clipboardChanged),
+            name: UIPasteboard.changedNotification, object: nil
+        )
+#endif
+        sample()
+        task = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                do { try await Task.sleep(for: .milliseconds(500)) }
+                catch { return }
+                guard !Task.isCancelled else { return }
+                self?.sample()
+            }
+        }
+    }
+
+    public func stop() {
+        NotificationCenter.default.removeObserver(self)
+        task?.cancel()
+        task = nil
+        previous = nil
+        readSnapshot = nil
+        onChange = nil
+    }
+
+    public func refresh() { sample() }
+
+    @objc nonisolated private func clipboardChanged() {
+        Task { @MainActor [weak self] in self?.sample() }
+    }
+
+    func sample() {
+        guard let snapshot = readSnapshot?() else {
+            previous = nil
+            return
+        }
+        guard snapshot != previous else { return }
+        previous = snapshot
+        onChange?()
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardGateway.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardGateway.swift
@@ -1,0 +1,19 @@
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+@MainActor
+public protocol ClipboardGateway {
+    func snapshot() -> ClipboardSnapshot
+    func readText() -> String?
+}
+
+#if canImport(UIKit)
+@MainActor
+public struct SystemClipboardGateway: ClipboardGateway {
+    public init() {}
+    public func snapshot() -> ClipboardSnapshot { ClipboardSnapshot(.general) }
+    public func readText() -> String? { UIPasteboard.general.string }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardOfferPolicy.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardOfferPolicy.swift
@@ -46,14 +46,14 @@ public enum ClipboardOfferPolicy {
 
     public static func offer(
         snapshot: ClipboardSnapshot,
-        lastCapturedChangeCount: Int?,
+        lastPastedChangeCount: Int?,
         context: Context
     ) -> ClipboardOffer? {
         guard allowsOffer(context: context) else { return nil }
         // v1 is text only: an image-only pasteboard stays silent.
         guard snapshot.hasStrings else { return nil }
-        // Already captured — do not invite the user to paste the same thing twice.
-        guard snapshot.changeCount != lastCapturedChangeCount else { return nil }
+        // Already pasted — do not invite the user to paste the same thing twice.
+        guard snapshot.changeCount != lastPastedChangeCount else { return nil }
 
         return ClipboardOffer(
             kind: snapshot.hasURLs ? .link : .text,

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardSessionMarks.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardSessionMarks.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// What a new keyboard session inherits from the previous one.
+///
+/// Split from the capture controller because the lifetime is the point: the
+/// controller is rebuilt whenever the keyboard appears in another app, while these
+/// answers have to outlive it. Three calls, so a test can stand in for the store.
+public protocol ClipboardSessionMarkStoring {
+    /// nil means "read the pasteboard to find out", which costs the user a banner.
+    func lastCapturedChangeCount() -> Int?
+    func lastPastedChangeCount() -> Int?
+    @discardableResult
+    func markPasted(_ changeCount: Int) -> Bool
+}
+
+extension ClipboardStore: ClipboardSessionMarkStoring {}

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardStore.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardStore.swift
@@ -9,11 +9,34 @@ import Foundation
 public struct ClipboardStore {
     public static let limit = 50
 
-    private struct Payload: Codable {
+    /// The change-count marks and the boot they belong to. On disk, not in the
+    /// session: the keyboard is rebuilt in every app it appears in.
+    struct Payload: Codable {
+        var bootTime: Int?
         var lastCapturedChangeCount: Int?
+        var lastPastedChangeCount: Int?
         var items: [ClipboardItem]
 
-        static let empty = Payload(lastCapturedChangeCount: nil, items: [])
+        static let empty = Payload(
+            bootTime: nil, lastCapturedChangeCount: nil, lastPastedChangeCount: nil, items: []
+        )
+
+        /// Claims the marks for this boot, dropping any the previous boot left: their
+        /// change counts name generations that no longer exist and could collide.
+        mutating func stampThisBoot() {
+            if !marksAreCurrent {
+                lastCapturedChangeCount = nil
+                lastPastedChangeCount = nil
+            }
+            bootTime = ClipboardBootTime.current
+        }
+
+        /// Change counts restart at boot, so marks written before this one name
+        /// generations that no longer exist.
+        var marksAreCurrent: Bool {
+            guard let bootTime, let current = ClipboardBootTime.current else { return false }
+            return bootTime == current
+        }
     }
 
     private let fileURL: URL?
@@ -34,24 +57,9 @@ public struct ClipboardStore {
     }
 
     /// Entries still worth showing. Pruning happens in memory: reading should not
-    /// have the side effect of writing.
+    /// write.
     public func load(now: Date = Date()) -> [ClipboardItem] {
         prune(read().items, now: now)
-    }
-
-    /// The pasteboard generation whose text is already stored, so the keyboard does
-    /// not offer the same item twice. Survives the item being deleted or expiring.
-    public func lastCapturedChangeCount() -> Int? {
-        read().lastCapturedChangeCount
-    }
-
-    @discardableResult
-    public func record(_ item: ClipboardItem, now: Date = Date()) -> [ClipboardItem] {
-        var payload = read()
-        payload.lastCapturedChangeCount = item.sourceChangeCount
-        payload.items = prune([item] + payload.items.filter { $0.text != item.text }, now: now)
-        write(payload)
-        return payload.items
     }
 
     @discardableResult
@@ -74,15 +82,15 @@ public struct ClipboardStore {
         return payload.items
     }
 
-    /// Drops every entry, pinned included. `lastCapturedChangeCount` is cleared too,
-    /// so whatever is still on the pasteboard can be offered again — after an
-    /// explicit wipe the user should be able to start over.
+    /// Drops every entry, pinned included, and both change-count marks with them:
+    /// after a wipe nothing on disk claims to have seen this pasteboard. Not
+    /// re-importing it is the running session's job, not the store's.
     public func clear() {
         write(.empty)
     }
 
-    /// Newest first. Expired unpinned entries go, then the oldest unpinned entries
-    /// go until the list fits; pinned entries are never evicted.
+    /// Newest first. Expired unpinned entries go, then the oldest unpinned ones until
+    /// the list fits; pinned entries are never evicted.
     private func prune(_ items: [ClipboardItem], now: Date) -> [ClipboardItem] {
         let live = items.filter { $0.isPinned || now.timeIntervalSince($0.capturedAt) < expiry }
         guard live.count > Self.limit else { return live }
@@ -98,16 +106,43 @@ public struct ClipboardStore {
         return Array(kept.reversed())
     }
 
-    private func read() -> Payload {
+    /// Idempotent for an unchanged clipboard, including a reopened keyboard.
+    public func capture(_ item: ClipboardItem, now: Date = Date()) -> Bool {
+        var payload = read()
+        let known = payload.items.contains {
+            $0.text == item.text && $0.sourceChangeCount == item.sourceChangeCount
+        }
+        // Re-stamp even for text already held: the mark is what spares the next
+        // session a pasteboard read, and after a boot it has to be earned again.
+        guard !known || !payload.marksAreCurrent
+            || payload.lastCapturedChangeCount != item.sourceChangeCount else { return true }
+        payload.stampThisBoot()
+        payload.lastCapturedChangeCount = item.sourceChangeCount
+        guard !known else { return write(payload) }
+        payload.items = merged(item, into: payload.items, now: now)
+        return write(payload)
+    }
+
+    private func merged(_ item: ClipboardItem, into items: [ClipboardItem], now: Date) -> [ClipboardItem] {
+        let old = items.first { $0.text == item.text }
+        let updated = ClipboardItem(
+            id: old?.id ?? item.id, text: item.text, capturedAt: item.capturedAt,
+            isPinned: old?.isPinned ?? item.isPinned, sourceChangeCount: item.sourceChangeCount
+        )
+        return prune([updated] + items.filter { $0.text != item.text }, now: now)
+    }
+
+    func read() -> Payload {
         guard let fileURL, let data = try? Data(contentsOf: fileURL) else { return .empty }
         return (try? JSONDecoder().decode(Payload.self, from: data)) ?? .empty
     }
 
-    private func write(_ payload: Payload) {
-        guard let fileURL, let data = try? JSONEncoder().encode(payload) else { return }
-        try? data.write(
-            to: fileURL,
-            options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication]
-        )
+    @discardableResult
+    func write(_ payload: Payload) -> Bool {
+        guard let fileURL, let data = try? JSONEncoder().encode(payload) else { return false }
+        do {
+            try data.write(to: fileURL, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+            return true
+        } catch { return false }
     }
 }

--- a/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardStoreMarks.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/FunputShared/Clipboard/ClipboardStoreMarks.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// What the keyboard remembers about the *current* pasteboard between sessions.
+///
+/// Kept apart from the history itself because the lifetime differs: entries are the
+/// user's data, while these two numbers exist only to spare the next session work
+/// the user would notice — a pasteboard read raises a system paste banner, and the
+/// keyboard is rebuilt in every app it appears in.
+public extension ClipboardStore {
+    /// The generation whose text is already stored, so reopening the keyboard on an
+    /// unchanged pasteboard reads nothing. Survives the entry expiring or being
+    /// deleted; does not survive a reboot, where the number means something else.
+    func lastCapturedChangeCount() -> Int? {
+        let payload = read()
+        return payload.marksAreCurrent ? payload.lastCapturedChangeCount : nil
+    }
+
+    /// Already pasted: the offer stays down until the user copies something else.
+    /// Pasting the same thing again is what the history panel is for.
+    func lastPastedChangeCount() -> Int? {
+        let payload = read()
+        return payload.marksAreCurrent ? payload.lastPastedChangeCount : nil
+    }
+
+    @discardableResult
+    func markPasted(_ changeCount: Int) -> Bool {
+        var payload = read()
+        guard !payload.marksAreCurrent || payload.lastPastedChangeCount != changeCount else {
+            return true
+        }
+        payload.stampThisBoot()
+        payload.lastPastedChangeCount = changeCount
+        return write(payload)
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Clipboard/ClipboardKeyboardView+Presentation.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Clipboard/ClipboardKeyboardView+Presentation.swift
@@ -7,8 +7,11 @@ extension ClipboardKeyboardView {
         presentation: KeyboardPresentation,
         entries: [KeyboardClipboardEntry],
         hasFullAccess: Bool,
+        needsRetry: Bool = false,
         now: Date = Date()
     ) {
+        retryBanner.isHidden = !hasFullAccess || !needsRetry
+        setNeedsLayout()
         self.presentation = presentation
         self.now = now
         emptyState = hasFullAccess ? .nothingSaved : .needsFullAccess
@@ -39,7 +42,9 @@ extension ClipboardKeyboardView {
         bottomBar.onReturn = { [weak self] in self?.onReturn?() }
         bottomBar.onDelete = { [weak self] in self?.onDelete?() }
         bottomBar.onClearAll = { [weak self] in self?.onClearAll?() }
-        [backdropView, collectionView, emptyStateView, bottomBar].forEach(addSubview)
+        retryBanner.isHidden = true
+        retryBanner.onRetry = { [weak self] in self?.onRetry?() }
+        [backdropView, collectionView, emptyStateView, bottomBar, retryBanner].forEach(addSubview)
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(accessibilityAppearanceDidChange),
@@ -62,6 +67,7 @@ extension ClipboardKeyboardView {
         collectionView.isHidden = isEmpty
         emptyStateView.apply(state: emptyState, theme: theme, traits: traitCollection)
         bottomBar.apply(color: label, canClear: !isEmpty)
+        retryBanner.tintColor = label
         collectionView.reloadData()
     }
 

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Clipboard/ClipboardKeyboardView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Clipboard/ClipboardKeyboardView.swift
@@ -2,7 +2,7 @@
 import ThemeSchema
 import UIKit
 
-/// Panel listing what the user has pasted through Funput.
+/// Panel listing text captured by Funput.
 ///
 /// Built on the same bones as ``KaomojiKeyboardView`` — `KeyboardBackdropView` for
 /// the background, a collection above a 46pt bottom bar — so every theme, image
@@ -20,9 +20,12 @@ public final class ClipboardKeyboardView: UIView {
     public var onClearAll: (() -> Void)?
     public var onDelete: (() -> Void)?
     public var onReturn: (() -> Void)?
+    public var onRetry: (() -> Void)?
 
     static let bottomBarHeight: CGFloat = 46
+    static let retryBannerHeight: CGFloat = 52
 
+    let retryBanner = ClipboardRetryBanner()
     let backdropView = KeyboardBackdropView()
     let collectionView: UICollectionView
     let bottomBar = ClipboardBottomBar()
@@ -54,8 +57,10 @@ public final class ClipboardKeyboardView: UIView {
     public override func layoutSubviews() {
         super.layoutSubviews()
         backdropView.frame = bounds
-        let listHeight = max(0, bounds.height - Self.bottomBarHeight)
-        collectionView.frame = CGRect(x: 0, y: 0, width: bounds.width, height: listHeight)
+        let retryHeight = retryBanner.isHidden ? 0 : Self.retryBannerHeight
+        retryBanner.frame = CGRect(x: 0, y: 0, width: bounds.width, height: retryHeight)
+        let listHeight = max(0, bounds.height - Self.bottomBarHeight - retryHeight)
+        collectionView.frame = CGRect(x: 0, y: retryHeight, width: bounds.width, height: listHeight)
         emptyStateView.frame = collectionView.frame
         bottomBar.frame = CGRect(
             x: 0, y: bounds.height - Self.bottomBarHeight,

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Clipboard/Components/ClipboardEmptyStateView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Clipboard/Components/ClipboardEmptyStateView.swift
@@ -23,10 +23,7 @@ public enum ClipboardEmptyState: Equatable, Sendable {
         case .needsFullAccess:
             "Bật trong Cài đặt › Bàn phím › Funput để dùng lịch sử clipboard."
         case .nothingSaved:
-            // The limit of never reading the pasteboard behind the user's back: only
-            // what they pasted through Funput can be here. Better said up front than
-            // discovered as a missing feature.
-            "Sao chép văn bản rồi chạm nút Dán trên thanh công cụ. Lịch sử chỉ lưu những gì bạn đã dán qua Funput."
+            "Sao chép văn bản khi Funput đang mở. Khi được phép đọc clipboard, Funput tự lưu vào lịch sử mà không cần bấm Dán."
         }
     }
 }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Clipboard/Components/ClipboardRetryBanner.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Clipboard/Components/ClipboardRetryBanner.swift
@@ -1,0 +1,31 @@
+#if canImport(UIKit)
+import UIKit
+
+@MainActor
+final class ClipboardRetryBanner: UIView {
+    var onRetry: (() -> Void)?
+    private let label = UILabel()
+    let button = UIButton(type: .system)
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        label.text = "Chưa đọc được clipboard"
+        label.font = .preferredFont(forTextStyle: .caption1)
+        label.adjustsFontSizeToFitWidth = true
+        button.setTitle("Thử lại", for: .normal)
+        button.accessibilityLabel = "Thử đọc và lưu clipboard lại"
+        button.addAction(UIAction { [weak self] _ in self?.onRetry?() }, for: .touchUpInside)
+        [label, button].forEach(addSubview)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        label.textColor = tintColor
+        label.frame = CGRect(x: 12, y: 0, width: max(0, bounds.width - 104), height: bounds.height)
+        button.frame = CGRect(x: bounds.width - 84, y: 0, width: 72, height: bounds.height)
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Surface/Core/KeyboardSurfaceView.swift
@@ -28,7 +28,7 @@ public final class KeyboardSurfaceView: UIView {
     }
     public var onKeyEvent: ((KeyboardKeyEvent) -> Void)?
     public var onSuggestionSelected: ((KeyboardSuggestionCandidate) -> Void)?
-    public var onClipboardPaste: ((String) -> Void)?
+    public var onClipboardPaste: ((KeyboardClipboardPaste) -> Void)?
     public var onOverlayPadChanged: ((CGFloat) -> Void)?
     var overlayPadTop: CGFloat = 0
     var keyboardSize: CGSize {

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Toolbar/KeyboardClipboardChipView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Toolbar/KeyboardClipboardChipView.swift
@@ -10,7 +10,7 @@ import UIKit
 /// delivers its provider in ~29ms.
 @MainActor
 final class KeyboardClipboardChipView: UIView {
-    var onPaste: ((String) -> Void)?
+    var onPaste: ((KeyboardClipboardPaste) -> Void)?
 
     private let hintLabel = UILabel()
     private var pasteControl: UIPasteControl?
@@ -88,6 +88,7 @@ final class KeyboardClipboardChipView: UIView {
         configuration.baseBackgroundColor = accent
         configuration.baseForegroundColor = foreground
         let control = UIPasteControl(configuration: configuration)
+        control.accessibilityIdentifier = "funput.clipboard.paste"
         control.target = self
         addSubview(control)
         pasteControl = control
@@ -98,9 +99,13 @@ final class KeyboardClipboardChipView: UIView {
         guard let provider = itemProviders.first(where: {
             $0.canLoadObject(ofClass: NSString.self)
         }) else { return }
+        let changeCount = UIPasteboard.general.changeCount
         _ = provider.loadObject(ofClass: NSString.self) { [weak self] object, _ in
             guard let text = (object as? NSString) as String? else { return }
-            Task { @MainActor in self?.onPaste?(text) }
+            Task { @MainActor in
+                let stable = UIPasteboard.general.changeCount == changeCount ? changeCount : nil
+                self?.onPaste?(KeyboardClipboardPaste(text: text, changeCount: stable))
+            }
         }
     }
 }

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Toolbar/KeyboardClipboardPaste.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Toolbar/KeyboardClipboardPaste.swift
@@ -1,0 +1,9 @@
+public struct KeyboardClipboardPaste: Sendable {
+    public let text: String
+    public let changeCount: Int?
+
+    public init(text: String, changeCount: Int?) {
+        self.text = text
+        self.changeCount = changeCount
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Toolbar/KeyboardToolbarView.swift
+++ b/platforms/ios/Packages/FunputKit/Sources/KeyboardRenderer/Toolbar/KeyboardToolbarView.swift
@@ -7,7 +7,7 @@ import UIKit
 final class KeyboardToolbarView: UIView {
     var onEvent: ((KeyboardKeyEvent) -> Void)?
     var onSuggestionSelected: ((KeyboardSuggestionCandidate) -> Void)?
-    var onClipboardPaste: ((String) -> Void)?
+    var onClipboardPaste: ((KeyboardClipboardPaste) -> Void)?
 
     // Laid out across the band by `layoutContents()` in KeyboardToolbarView+Layout.
     let logoView = KeyboardBrandLogoView()
@@ -18,6 +18,8 @@ final class KeyboardToolbarView: UIView {
     private var clipboardHint: KeyboardClipboardHint?
     private var hasSuggestions = false
     private var allowsClipboardKey = true
+    /// Whether the offer arrived since the user last typed. See `arbitrateContentRegion`.
+    private var pasteOfferIsNew = false
     private var allowsEmojiKey = true
     var spec: KeyboardToolbarSpec?
 
@@ -72,6 +74,9 @@ final class KeyboardToolbarView: UIView {
     func updateSuggestions(_ candidates: [KeyboardSuggestionCandidate]) {
         suggestionBar.update(candidates)
         hasSuggestions = !candidates.isEmpty
+        // The user has typed since the offer arrived, so it is no longer the newest
+        // thing in the band and stops holding the region.
+        pasteOfferIsNew = false
         arbitrateContentRegion()
     }
 
@@ -86,17 +91,23 @@ final class KeyboardToolbarView: UIView {
     }
 
     func updateClipboardHint(_ hint: KeyboardClipboardHint?) {
+        pasteOfferIsNew = hint != nil && hint != clipboardHint
         clipboardHint = hint
         clipboardChip.update(hint: hint)
         arbitrateContentRegion()
     }
 
-    /// Suggestions win the shared region: they are about what the user is typing
-    /// right now, while the clipboard chip is a standing offer they can also reach
-    /// from the clipboard panel.
+    /// Both want the one shared region, and each is right at a different moment.
+    ///
+    /// Copying while typing must expose Paste, or the offer is swallowed by the
+    /// candidates and the user never learns it was there. But the offer stands until
+    /// they paste or copy again, so letting it hold the region would cost them every
+    /// suggestion for the rest of the session. It holds until the next keystroke and
+    /// then steps aside; the clipboard key and the history panel still reach it.
     private func arbitrateContentRegion() {
-        suggestionBar.isHidden = !hasSuggestions
-        clipboardChip.isHidden = hasSuggestions || clipboardHint == nil
+        let pasteWins = clipboardHint != nil && (!hasSuggestions || pasteOfferIsNew)
+        suggestionBar.isHidden = !hasSuggestions || pasteWins
+        clipboardChip.isHidden = !pasteWins
         // The clipboard key yields its slot too: while the user is typing, the whole
         // toolbar belongs to suggestions.
         clipboardButton.isHidden = hasSuggestions || !allowsClipboardKey

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardCaptureControllerTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardCaptureControllerTests.swift
@@ -1,0 +1,68 @@
+import FunputShared
+import Testing
+
+@MainActor
+struct ClipboardCaptureControllerTests {
+    @Test func capturesBeforePasteWithoutChangingText() {
+        let f = CaptureFixture()
+        f.controller.synchronize()
+        #expect(f.saved.map(\.text) == ["  Tiếng Việt\n🙂  "])
+        #expect(f.updates == 1)
+        #expect(f.controller.lastPastedChangeCount == nil)
+        for _ in 0..<1_000 { f.controller.synchronize() }
+        #expect(f.gateway.reads == 1)
+        #expect(f.saved.count == 1)
+        f.gateway.copy("new")
+        f.controller.synchronize()
+        #expect(f.saved.count == 2)
+    }
+
+    @Test func copyDuringReadDiscardsUnstableResult() {
+        let f = CaptureFixture()
+        f.gateway.duringRead = { f.gateway.copy("new") }
+        f.controller.synchronize()
+        #expect(f.saved.isEmpty)
+        f.gateway.duringRead = nil
+        f.controller.synchronize()
+        #expect(f.saved.first?.text == "new")
+        #expect(f.saved.first?.sourceChangeCount == 2)
+    }
+
+    @Test func captureDoesNotSuppressPasteOffer() {
+        let f = CaptureFixture()
+        f.controller.synchronize()
+        let context = ClipboardOfferPolicy.Context(
+            editorMode: .text, hasToolbar: true, hasFullAccess: true
+        )
+        #expect(ClipboardOfferPolicy.offer(
+            snapshot: f.gateway.metadata,
+            lastPastedChangeCount: f.controller.lastPastedChangeCount, context: context
+        ) != nil)
+        f.controller.didPaste(f.gateway.text!, changeCount: 1)
+        #expect(f.saved.count == 1)
+        #expect(ClipboardOfferPolicy.offer(
+            snapshot: f.gateway.metadata,
+            lastPastedChangeCount: f.controller.lastPastedChangeCount, context: context
+        ) == nil)
+    }
+
+    @Test func lateManualPasteDoesNotSuppressOrClaimNewClipboard() {
+        let f = CaptureFixture()
+        f.gateway.copy("new")
+        f.controller.didPaste("old", changeCount: 1)
+        #expect(f.saved.first?.sourceChangeCount == -1)
+        #expect(f.controller.lastPastedChangeCount == nil)
+        f.controller.synchronize()
+        #expect(f.saved.last?.text == "new")
+    }
+
+    @Test func ignoresEmptyTextAndImages() {
+        let f = CaptureFixture()
+        f.gateway.copy("")
+        f.controller.synchronize()
+        f.gateway.copy(nil)
+        f.controller.synchronize()
+        #expect(f.saved.isEmpty)
+        #expect(!f.controller.needsRetry)
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardCaptureFixture.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardCaptureFixture.swift
@@ -1,0 +1,52 @@
+import FunputShared
+
+@MainActor
+final class CaptureGateway: ClipboardGateway {
+    var metadata = ClipboardSnapshot(changeCount: 1, hasStrings: true, hasURLs: false)
+    var text: String? = "  Tiếng Việt\n🙂  "
+    var reads = 0
+    var duringRead: (() -> Void)?
+    func snapshot() -> ClipboardSnapshot { metadata }
+    func readText() -> String? { reads += 1; duringRead?(); return text }
+    func copy(_ text: String?) {
+        self.text = text
+        metadata = ClipboardSnapshot(
+            changeCount: metadata.changeCount + 1, hasStrings: text != nil, hasURLs: false
+        )
+    }
+}
+
+/// Stands in for the on-disk marks, so a test can end one session and start another
+/// the way switching apps does.
+final class SessionMarkSpy: ClipboardSessionMarkStoring {
+    var captured: Int?
+    private var pasted: Int?
+    func lastCapturedChangeCount() -> Int? { captured }
+    func lastPastedChangeCount() -> Int? { pasted }
+    @discardableResult
+    func markPasted(_ changeCount: Int) -> Bool {
+        pasted = changeCount
+        return true
+    }
+}
+
+@MainActor
+final class CaptureFixture {
+    let gateway = CaptureGateway()
+    let marks = SessionMarkSpy()
+    var allowed = true
+    var writesSucceed = true
+    var saved: [ClipboardItem] = []
+    var updates = 0
+    lazy var controller = ClipboardCaptureController(
+        gateway: gateway, allowsCapture: { [unowned self] in allowed },
+        save: { [unowned self] item in
+            guard writesSucceed else { return false }
+            saved.append(item)
+            return true
+        },
+        marks: marks,
+        onUpdate: { [unowned self] in updates += 1 }
+    )
+    init() { controller.begin() }
+}

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardCaptureLifecycleTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardCaptureLifecycleTests.swift
@@ -1,0 +1,115 @@
+import FunputShared
+import Testing
+
+@MainActor
+struct ClipboardCaptureLifecycleTests {
+    @Test func deniedReadsPauseUntilExplicitRetryEvenAcrossNewCopies() {
+        let f = CaptureFixture()
+        f.gateway.text = nil
+        f.controller.synchronize()
+        #expect(f.controller.needsRetry)
+        f.gateway.copy("allowed now")
+        f.controller.synchronize()
+        f.controller.end()
+        f.controller.begin()
+        f.controller.synchronize()
+        #expect(f.gateway.reads == 1)
+        #expect(f.saved.isEmpty)
+        f.controller.synchronize(retry: true)
+        #expect(f.saved.first?.text == "allowed now")
+        #expect(!f.controller.needsRetry)
+    }
+
+    @Test func writeFailureIsNotMarkedCaptured() {
+        let f = CaptureFixture()
+        f.writesSucceed = false
+        f.controller.synchronize()
+        #expect(f.controller.needsRetry)
+        f.writesSucceed = true
+        f.controller.synchronize(retry: true)
+        #expect(f.saved.count == 1)
+    }
+
+    @Test func lostAccessOrClosedSessionCannotSaveAnInFlightRead() {
+        for close in [false, true] {
+            let f = CaptureFixture()
+            f.gateway.duringRead = {
+                if close { f.controller.end() } else { f.allowed = false }
+            }
+            f.controller.synchronize()
+            #expect(f.saved.isEmpty)
+            f.controller.synchronize()
+            #expect(f.gateway.reads == 1)
+        }
+    }
+
+    @Test func clearingSuppressesSameClipboardUntilNextSession() {
+        let f = CaptureFixture()
+        f.controller.synchronize()
+        f.controller.suppressCurrentAfterClear()
+        f.saved = []
+        f.controller.synchronize(retry: true)
+        #expect(f.saved.isEmpty)
+        f.controller.end()
+        f.controller.begin()
+        f.controller.synchronize()
+        #expect(f.saved.count == 1)
+    }
+
+    /// Every pasteboard read shows the user a system banner, so reopening the
+    /// keyboard on a clipboard the previous session already captured must read
+    /// nothing at all.
+    @Test func reopeningOnAnUnchangedClipboardReadsNothing() {
+        let f = CaptureFixture()
+        f.controller.synchronize()
+        #expect(f.gateway.reads == 1)
+        f.marks.captured = f.gateway.metadata.changeCount
+
+        for _ in 0..<5 {
+            f.controller.end()
+            f.controller.begin()
+            f.controller.synchronize()
+        }
+        #expect(f.gateway.reads == 1)
+        #expect(f.saved.count == 1)
+
+        // A copy made while the keyboard was away is still picked up on reopening.
+        f.gateway.copy("trong luc dong")
+        f.controller.end()
+        f.controller.begin()
+        f.controller.synchronize()
+        #expect(f.gateway.reads == 2)
+        #expect(f.saved.map(\.text) == ["  Tiếng Việt\n🙂  ", "trong luc dong"])
+    }
+
+    /// Switching apps rebuilds the keyboard. The offer must not come back with it.
+    @Test func pasteSurvivesTheSessionAndOnlyANewCopyBringsTheOfferBack() {
+        let f = CaptureFixture()
+        f.controller.didPaste(f.gateway.text!, changeCount: 1)
+        #expect(f.controller.lastPastedChangeCount == 1)
+
+        f.controller.end()
+        f.controller.begin()
+        #expect(f.controller.lastPastedChangeCount == 1)
+
+        f.gateway.copy("thu hai")
+        f.controller.end()
+        f.controller.begin()
+        #expect(f.controller.lastPastedChangeCount == 1)
+        #expect(ClipboardOfferPolicy.offer(
+            snapshot: f.gateway.metadata,
+            lastPastedChangeCount: f.controller.lastPastedChangeCount,
+            context: ClipboardOfferPolicy.Context(
+                editorMode: .text, hasToolbar: true, hasFullAccess: true
+            )
+        ) != nil)
+    }
+
+    @Test func reentrantNotificationDoesNotStartAnotherRead() {
+        let f = CaptureFixture()
+        f.gateway.duringRead = { f.controller.synchronize() }
+        f.controller.synchronize()
+        #expect(f.gateway.reads == 1)
+        #expect(f.saved.count == 1)
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardCaptureStoreTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardCaptureStoreTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import FunputShared
+import Testing
+
+struct ClipboardCaptureStoreTests {
+    @Test func recopyKeepsIdentityAndPinAndMovesToFront() throws {
+        let dir = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = ClipboardStore(directory: dir)
+        let pinned = ClipboardItem(text: "pin", isPinned: true, sourceChangeCount: 1)
+        #expect(store.capture(pinned))
+        #expect(store.capture(ClipboardItem(text: "other", sourceChangeCount: 2)))
+        #expect(store.capture(ClipboardItem(text: "pin", sourceChangeCount: 3)))
+        let items = store.load()
+        #expect(items.map(\.text) == ["pin", "other"])
+        #expect(items.first?.id == pinned.id)
+        #expect(items.first?.isPinned == true)
+        let bytes = try Data(contentsOf: dir.appendingPathComponent("clipboard.json"))
+        #expect(store.capture(ClipboardItem(text: "pin", sourceChangeCount: 3)))
+        #expect(try Data(contentsOf: dir.appendingPathComponent("clipboard.json")) == bytes)
+    }
+
+    @Test func sameCountWithDifferentTextAfterRestartIsNotSuppressed() throws {
+        let dir = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = ClipboardStore(directory: dir)
+        #expect(store.capture(ClipboardItem(text: "before reboot", sourceChangeCount: 1)))
+        #expect(store.capture(ClipboardItem(text: "after reboot", sourceChangeCount: 1)))
+        #expect(store.load().count == 2)
+    }
+
+    /// History written before automatic capture shipped: the same file, but every
+    /// change count in it belongs to a previous boot.
+    @Test func historyWrittenByAnOlderBuildStillLoadsAndAcceptsCapture() throws {
+        let dir = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let legacy = """
+        {"lastCapturedChangeCount":4,"items":[{"id":"\(UUID())","text":"ghim cu",\
+        "capturedAt":0,"isPinned":true,"sourceChangeCount":4}]}
+        """
+        try Data(legacy.utf8).write(to: dir.appendingPathComponent("clipboard.json"))
+        let store = ClipboardStore(directory: dir, expiry: .week)
+        let loaded = store.load(now: Date(timeIntervalSinceReferenceDate: 60))
+        #expect(loaded.map(\.text) == ["ghim cu"])
+        #expect(loaded.first?.isPinned == true)
+        // A fresh boot can hand out a change count the old file already used.
+        #expect(store.capture(ClipboardItem(text: "moi", sourceChangeCount: 4)))
+        #expect(store.load().map(\.text) == ["moi", "ghim cu"])
+    }
+
+    /// The marks are what keep the next session from re-reading the pasteboard,
+    /// which the user sees as a system paste banner in every app.
+    @Test func marksSurviveTheSessionAndSpareTheNextOneARead() throws {
+        let dir = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = ClipboardStore(directory: dir)
+        #expect(store.capture(ClipboardItem(text: "da dan", sourceChangeCount: 7)))
+        #expect(store.markPasted(7))
+        #expect(ClipboardStore(directory: dir).lastCapturedChangeCount() == 7)
+        #expect(ClipboardStore(directory: dir).lastPastedChangeCount() == 7)
+    }
+
+    /// Change counts restart at boot, so a mark written before it names a generation
+    /// that no longer exists: the keyboard has to read once and earn the mark again.
+    @Test func marksFromAnotherBootAreNotTrusted() throws {
+        let dir = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let stale = """
+        {"bootTime":1,"lastCapturedChangeCount":7,"lastPastedChangeCount":7,"items":[]}
+        """
+        try Data(stale.utf8).write(to: dir.appendingPathComponent("clipboard.json"))
+        let store = ClipboardStore(directory: dir)
+        #expect(store.lastCapturedChangeCount() == nil)
+        #expect(store.lastPastedChangeCount() == nil)
+
+        // Re-reading text the file already holds must still re-stamp the mark,
+        // otherwise every session after a reboot reads the pasteboard again.
+        #expect(store.capture(ClipboardItem(text: "cu", sourceChangeCount: 7)))
+        #expect(store.lastCapturedChangeCount() == 7)
+        #expect(store.lastPastedChangeCount() == nil)
+    }
+
+    @Test func clearingHistoryDropsBothMarks() throws {
+        let dir = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = ClipboardStore(directory: dir)
+        #expect(store.capture(ClipboardItem(text: "bi mat", sourceChangeCount: 3)))
+        #expect(store.markPasted(3))
+        store.clear()
+        #expect(store.lastPastedChangeCount() == nil)
+        #expect(store.lastCapturedChangeCount() == nil)
+    }
+
+    @Test func missingContainerReportsFailure() {
+        #expect(!ClipboardStore(directory: nil).capture(ClipboardItem(text: "text", sourceChangeCount: 1)))
+    }
+
+    private func makeDirectory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardChangeMonitorTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardChangeMonitorTests.swift
@@ -1,0 +1,82 @@
+@testable import FunputShared
+import Testing
+
+@MainActor
+@Suite("Clipboard changes during a keyboard session")
+struct ClipboardChangeMonitorTests {
+    @Test("The running monitor detects a copy without a keyboard callback")
+    func automaticSampling() async throws {
+        let monitor = ClipboardChangeMonitor()
+        defer { monitor.stop() }
+        var snapshot = ClipboardSnapshot(changeCount: 1, hasStrings: false, hasURLs: false)
+        var changes = 0
+        monitor.start(readSnapshot: { snapshot }, onChange: { changes += 1 })
+        snapshot = ClipboardSnapshot(changeCount: 2, hasStrings: true, hasURLs: false)
+        for _ in 0..<100 {
+            if changes == 2 { break }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(changes == 2)
+    }
+
+    @Test("Copy, replacement and clearing are detected without reopening the keyboard")
+    func changesDuringSession() {
+        let monitor = ClipboardChangeMonitor()
+        defer { monitor.stop() }
+        var snapshot = ClipboardSnapshot(changeCount: 1, hasStrings: false, hasURLs: false)
+        var changes = 0
+        monitor.start(readSnapshot: { snapshot }, onChange: { changes += 1 })
+        #expect(changes == 1)
+        monitor.sample()
+        #expect(changes == 1)
+
+        snapshot = ClipboardSnapshot(changeCount: 2, hasStrings: true, hasURLs: false)
+        monitor.sample()
+        #expect(changes == 2)
+        snapshot = ClipboardSnapshot(changeCount: 3, hasStrings: true, hasURLs: false)
+        monitor.sample()
+        #expect(changes == 3)
+        snapshot = ClipboardSnapshot(changeCount: 4, hasStrings: false, hasURLs: false)
+        monitor.sample()
+        #expect(changes == 4)
+    }
+
+    @Test("Hidden keyboards stop sampling and reopening refreshes unchanged metadata")
+    func lifecycle() {
+        let monitor = ClipboardChangeMonitor()
+        defer { monitor.stop() }
+        var reads = 0
+        var changes = 0
+        let read = {
+            reads += 1
+            return ClipboardSnapshot(changeCount: 5, hasStrings: true, hasURLs: false)
+        }
+        monitor.start(readSnapshot: read, onChange: { changes += 1 })
+        monitor.stop()
+        monitor.sample()
+        #expect(reads == 1)
+        #expect(changes == 1)
+        monitor.start(readSnapshot: read, onChange: { changes += 1 })
+        #expect(changes == 2)
+    }
+
+    @Test("Recovering access or an indeterminate read refreshes the offer")
+    func recovery() {
+        let monitor = ClipboardChangeMonitor()
+        defer { monitor.stop() }
+        var snapshot: ClipboardSnapshot?
+        var changes = 0
+        monitor.start(readSnapshot: { snapshot }, onChange: { changes += 1 })
+        #expect(changes == 0)
+        snapshot = ClipboardSnapshot(changeCount: 0, hasStrings: false, hasURLs: false)
+        monitor.sample()
+        snapshot = ClipboardSnapshot(changeCount: 9, hasStrings: true, hasURLs: false)
+        monitor.sample()
+        #expect(changes == 2)
+        snapshot = nil
+        monitor.sample()
+        snapshot = ClipboardSnapshot(changeCount: 9, hasStrings: true, hasURLs: false)
+        monitor.sample()
+        #expect(changes == 3)
+    }
+}

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardNotificationTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardNotificationTests.swift
@@ -1,0 +1,31 @@
+#if canImport(UIKit)
+@testable import FunputShared
+import Testing
+import UIKit
+
+@MainActor
+struct ClipboardNotificationTests {
+    @Test func notificationsAndPollingShareOneChangeAndStopTogether() async throws {
+        let monitor = ClipboardChangeMonitor()
+        var count = 1
+        var reads = 0
+        var changes = 0
+        monitor.start(readSnapshot: {
+            reads += 1
+            return ClipboardSnapshot(changeCount: count, hasStrings: true, hasURLs: false)
+        }, onChange: { changes += 1 })
+        count = 2
+        NotificationCenter.default.post(name: UIPasteboard.changedNotification, object: nil)
+        // Yield to the notification's MainActor handoff, without waiting for polling.
+        for _ in 0..<100 where changes != 2 { await Task.yield() }
+        #expect(changes == 2)
+        monitor.sample()
+        #expect(changes == 2)
+        monitor.stop()
+        let stoppedReads = reads
+        NotificationCenter.default.post(name: UIPasteboard.changedNotification, object: nil)
+        try await Task.sleep(for: .milliseconds(550))
+        #expect(reads == stoppedReads)
+    }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardOfferPolicyTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardOfferPolicyTests.swift
@@ -10,7 +10,7 @@ struct ClipboardOfferPolicyTests {
     func offersText() {
         #expect(
             ClipboardOfferPolicy.offer(
-                snapshot: text, lastCapturedChangeCount: 41, context: context()
+                snapshot: text, lastPastedChangeCount: 41, context: context()
             ) == ClipboardOffer(kind: .text, changeCount: 42)
         )
     }
@@ -20,7 +20,7 @@ struct ClipboardOfferPolicyTests {
         let snapshot = ClipboardSnapshot(changeCount: 7, hasStrings: true, hasURLs: true)
         #expect(
             ClipboardOfferPolicy.offer(
-                snapshot: snapshot, lastCapturedChangeCount: nil, context: context()
+                snapshot: snapshot, lastPastedChangeCount: nil, context: context()
             )?.kind == .link
         )
     }
@@ -29,7 +29,7 @@ struct ClipboardOfferPolicyTests {
     func noHistory() {
         #expect(
             ClipboardOfferPolicy.offer(
-                snapshot: text, lastCapturedChangeCount: nil, context: context()
+                snapshot: text, lastPastedChangeCount: nil, context: context()
             ) != nil
         )
     }
@@ -42,7 +42,7 @@ struct ClipboardOfferPolicyTests {
         #expect(
             ClipboardOfferPolicy.offer(
                 snapshot: text,
-                lastCapturedChangeCount: nil,
+                lastPastedChangeCount: nil,
                 context: context(editorMode: mode)
             ) == nil
         )
@@ -53,7 +53,7 @@ struct ClipboardOfferPolicyTests {
         #expect(
             ClipboardOfferPolicy.offer(
                 snapshot: text,
-                lastCapturedChangeCount: nil,
+                lastPastedChangeCount: nil,
                 context: context(hasFullAccess: false)
             ) == nil
         )
@@ -64,7 +64,7 @@ struct ClipboardOfferPolicyTests {
         #expect(
             ClipboardOfferPolicy.offer(
                 snapshot: text,
-                lastCapturedChangeCount: nil,
+                lastPastedChangeCount: nil,
                 context: context(hasToolbar: false)
             ) == nil
         )
@@ -75,16 +75,16 @@ struct ClipboardOfferPolicyTests {
         let snapshot = ClipboardSnapshot(changeCount: 9, hasStrings: false, hasURLs: false)
         #expect(
             ClipboardOfferPolicy.offer(
-                snapshot: snapshot, lastCapturedChangeCount: nil, context: context()
+                snapshot: snapshot, lastPastedChangeCount: nil, context: context()
             ) == nil
         )
     }
 
     @Test("The same pasteboard generation is never offered twice")
-    func alreadyCaptured() {
+    func alreadyPasted() {
         #expect(
             ClipboardOfferPolicy.offer(
-                snapshot: text, lastCapturedChangeCount: 42, context: context()
+                snapshot: text, lastPastedChangeCount: 42, context: context()
             ) == nil
         )
     }

--- a/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardStoreTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/FunputSharedTests/Clipboard/ClipboardStoreTests.swift
@@ -9,20 +9,20 @@ struct ClipboardStoreTests {
     @Test("Records newest first and de-duplicates by text")
     func recording() throws {
         let store = try makeStore()
-        store.record(item("một", at: epoch), now: epoch)
-        store.record(item("hai", at: epoch), now: epoch)
-        store.record(item("một", at: epoch), now: epoch)
+        _ = store.capture(item("một", at: epoch, changeCount: 1), now: epoch)
+        _ = store.capture(item("hai", at: epoch, changeCount: 2), now: epoch)
+        _ = store.capture(item("một", at: epoch, changeCount: 3), now: epoch)
         #expect(store.load(now: epoch).map(\.text) == ["một", "hai"])
     }
 
     @Test("Unpinned entries expire, pinned entries survive")
     func expiry() throws {
         let store = try makeStore()
-        store.record(item("tạm", at: epoch), now: epoch)
+        _ = store.capture(item("tạm", at: epoch), now: epoch)
         let pinned = ClipboardItem(
             text: "giữ", capturedAt: epoch, isPinned: true, sourceChangeCount: 2
         )
-        store.record(pinned, now: epoch)
+        _ = store.capture(pinned, now: epoch)
 
         let later = epoch.addingTimeInterval(ClipboardExpiry.hour.interval + 1)
         #expect(store.load(now: epoch).count == 2)
@@ -35,7 +35,7 @@ struct ClipboardStoreTests {
     func configurableExpiry() throws {
         let directory = try makeDirectory()
         let entry = item("tạm", at: epoch)
-        ClipboardStore(directory: directory, expiry: .week).record(entry, now: epoch)
+        _ = ClipboardStore(directory: directory, expiry: .week).capture(entry, now: epoch)
 
         let later = epoch.addingTimeInterval(ClipboardExpiry.hour.interval + 1)
         #expect(ClipboardStore(directory: directory, expiry: .hour).load(now: later).isEmpty)
@@ -48,9 +48,9 @@ struct ClipboardStoreTests {
         let oldestPinned = ClipboardItem(
             text: "ghim", capturedAt: epoch, isPinned: true, sourceChangeCount: 0
         )
-        store.record(oldestPinned, now: epoch)
+        _ = store.capture(oldestPinned, now: epoch)
         for index in 0...ClipboardStore.limit {
-            store.record(item("mục\(index)", at: epoch, changeCount: index + 1), now: epoch)
+            _ = store.capture(item("mục\(index)", at: epoch, changeCount: index + 1), now: epoch)
         }
         let stored = store.load(now: epoch)
         #expect(stored.count == ClipboardStore.limit)
@@ -62,7 +62,7 @@ struct ClipboardStoreTests {
     func changeCountSurvivesDeletion() throws {
         let store = try makeStore()
         let entry = item("xin chào", at: epoch, changeCount: 77)
-        store.record(entry, now: epoch)
+        _ = store.capture(entry, now: epoch)
         store.remove(id: entry.id, now: epoch)
         #expect(store.load(now: epoch).isEmpty)
         #expect(store.lastCapturedChangeCount() == 77)
@@ -72,7 +72,7 @@ struct ClipboardStoreTests {
     func pinning() throws {
         let directory = try makeDirectory()
         let entry = item("ghim tôi", at: epoch)
-        ClipboardStore(directory: directory).record(entry, now: epoch)
+        _ = ClipboardStore(directory: directory).capture(entry, now: epoch)
         ClipboardStore(directory: directory).setPinned(true, id: entry.id, now: epoch)
         #expect(ClipboardStore(directory: directory).load(now: epoch).first?.isPinned == true)
     }
@@ -80,7 +80,7 @@ struct ClipboardStoreTests {
     @Test("clear wipes the entries and the captured change count")
     func clearing() throws {
         let store = try makeStore()
-        store.record(item("bí mật", at: epoch, changeCount: 5), now: epoch)
+        _ = store.capture(item("bí mật", at: epoch, changeCount: 5), now: epoch)
         store.clear()
         #expect(store.load(now: epoch).isEmpty)
         #expect(store.lastCapturedChangeCount() == nil)
@@ -89,7 +89,7 @@ struct ClipboardStoreTests {
     @Test("A missing container degrades to an empty store instead of crashing")
     func withoutContainer() {
         let store = ClipboardStore(directory: nil)
-        store.record(item("rơi", at: epoch), now: epoch)
+        _ = store.capture(item("rơi", at: epoch), now: epoch)
         #expect(store.load(now: epoch).isEmpty)
     }
 

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Clipboard/ClipboardCapturePresentationTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/Clipboard/ClipboardCapturePresentationTests.swift
@@ -1,0 +1,68 @@
+#if canImport(UIKit)
+import Foundation
+import FunputShared
+@testable import KeyboardRenderer
+import KeyboardLayout
+import Testing
+import UIKit
+
+@MainActor
+struct ClipboardCapturePresentationTests {
+    @Test func savingUpdatesOpenPanelAndKeepsPasteVisible() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = ClipboardStore(directory: directory)
+        let gateway = PresentationGateway()
+        let panel = ClipboardKeyboardView()
+        let toolbar = KeyboardToolbarView()
+        toolbar.updateSuggestions([KeyboardSuggestionCandidate(text: "gõ", generation: 1)])
+        let controller = ClipboardCaptureController(
+            gateway: gateway, allowsCapture: { true }, save: { store.capture($0) },
+            marks: store,
+            onUpdate: {
+                panel.apply(presentation: KeyboardPresentation(), entries: store.load().map {
+                    KeyboardClipboardEntry(
+                        id: $0.id, text: $0.text, capturedAt: $0.capturedAt, isPinned: $0.isPinned
+                    )
+                }, hasFullAccess: true)
+            }
+        )
+        controller.begin()
+        controller.synchronize()
+        let context = ClipboardOfferPolicy.Context(
+            editorMode: .text, hasToolbar: true, hasFullAccess: true
+        )
+        let offer = ClipboardOfferPolicy.offer(
+            snapshot: gateway.snapshot(), lastPastedChangeCount: controller.lastPastedChangeCount,
+            context: context
+        )
+        toolbar.updateClipboardHint(offer == nil ? nil : .text)
+        #expect(store.load().map(\.text) == ["copied"])
+        #expect(panel.entry(at: IndexPath(item: 0, section: 0))?.text == "copied")
+        #expect(!toolbar.clipboardChip.isHidden)
+        #expect(toolbar.suggestionBar.isHidden)
+    }
+
+    @Test func retryBannerDoesNotHideExistingHistory() {
+        let panel = ClipboardKeyboardView()
+        let entry = KeyboardClipboardEntry(id: UUID(), text: "saved", capturedAt: Date(), isPinned: false)
+        panel.apply(
+            presentation: KeyboardPresentation(), entries: [entry], hasFullAccess: true, needsRetry: true
+        )
+        #expect(!panel.retryBanner.isHidden)
+        #expect(!panel.collectionView.isHidden)
+        #expect(panel.retryBanner.button.isEnabled)
+        panel.apply(presentation: KeyboardPresentation(), entries: [entry], hasFullAccess: true)
+        #expect(panel.retryBanner.isHidden)
+    }
+}
+
+@MainActor
+private struct PresentationGateway: ClipboardGateway {
+    func snapshot() -> ClipboardSnapshot {
+        ClipboardSnapshot(changeCount: 1, hasStrings: true, hasURLs: false)
+    }
+    func readText() -> String? { "copied" }
+}
+#endif

--- a/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/ClipboardChipToolbarTests.swift
+++ b/platforms/ios/Packages/FunputKit/Tests/KeyboardRendererTests/ClipboardChipToolbarTests.swift
@@ -16,13 +16,28 @@ struct ClipboardChipToolbarTests {
         #expect(try #require(chip(in: toolbar)).isHidden == false)
     }
 
-    @Test("Suggestions win the shared region, and give it back when they clear")
-    func suggestionsWin() throws {
+    @Test("Copying while suggestions are visible exposes Paste")
+    func pasteWinsOnArrival() throws {
         let toolbar = makeToolbar()
-        toolbar.updateClipboardHint(.link)
         toolbar.updateSuggestions([KeyboardSuggestionCandidate(text: "chào", generation: 1)])
-        #expect(try #require(chip(in: toolbar)).isHidden == true)
+        toolbar.updateClipboardHint(.link)
+        #expect(try #require(chip(in: toolbar)).isHidden == false)
+        #expect(toolbar.suggestionBar.isHidden)
+    }
 
+    /// The offer stands until the user pastes or copies again, so holding the region
+    /// would cost them every suggestion for the rest of the session.
+    @Test("The next keystroke takes the region back for suggestions")
+    func pasteYieldsOnceTypingContinues() throws {
+        let toolbar = makeToolbar()
+        toolbar.updateSuggestions([KeyboardSuggestionCandidate(text: "chào", generation: 1)])
+        toolbar.updateClipboardHint(.link)
+
+        toolbar.updateSuggestions([KeyboardSuggestionCandidate(text: "chào", generation: 2)])
+        #expect(try #require(chip(in: toolbar)).isHidden)
+        #expect(!toolbar.suggestionBar.isHidden)
+
+        // Still offered the moment the candidates clear.
         toolbar.updateSuggestions([])
         #expect(try #require(chip(in: toolbar)).isHidden == false)
     }


### PR DESCRIPTION
## Summary

Copying text no longer needs a tap on **Dán** to reach the clipboard history: while the
keyboard is open, Funput notices the copy, stores it, and offers Paste. Three commits —
the capture path, the settings guidance for the system paste permission, and a device UI
test. Based on `feat/ios-min-16`, so the diff is only the clipboard work.

The design constraint that shapes everything here: reading pasteboard **contents** is
user-visible (an alert, or a "Funput đã dán từ…" banner once the user allows pasting),
while reading **metadata** is free and silent. So the pasteboard is read at most once per
copy, and never on reopening a clipboard already captured.

## Detection and capture

- `ClipboardChangeMonitor` samples metadata every 0.5s while the keyboard is visible and
  also observes `UIPasteboard.changedNotification`. Both paths go through one `sample()`,
  so a notification that coincides with a poll does not process the copy twice.
  Polling is not optional: `changedNotification` is only delivered for changes made in the
  same process, and the copy happens in the host app.
- `ClipboardGateway` is the only place UIKit is touched, so every rule below is testable
  without a device. `ClipboardCaptureController` owns the reading/processed/retry state.
- Contents are read only when the generation changed. `changeCount` is re-checked after the
  read and a mismatched result is discarded rather than filed under the wrong generation.
- A failed read never writes an empty entry or marks anything captured: it pauses automatic
  reading and surfaces "Chưa đọc được clipboard" with **Thử lại** in the panel, rather than
  assuming every failure is a denied permission.
- Capture is decoupled from having a toolbar (layouts without one still save) but stays
  blocked in password and PIN fields.

## What a new session inherits

The keyboard is torn down and rebuilt in **every app it appears in**, so anything kept only
in the session resets on an app switch. Two facts now live next to the history:

- `lastPastedChangeCount` — the offer stays down until the user copies something else.
  Without it, Paste came back for text they had already pasted the moment they switched apps.
- `lastCapturedChangeCount` — reopening on an unchanged clipboard reads nothing at all.
  Without it, every keyboard appearance re-read the same clipboard, and every read shows the
  user a system paste banner.

Both are stamped with `KERN_BOOTTIME`. Change counts restart at boot, so marks from an
earlier one name generations that no longer exist and are dropped rather than trusted — this
is what lets a remembered generation be believed without re-reading to confirm it. A failed
`sysctl` answers `nil`, which fails safe toward one extra read.

## Toolbar arbitration

Suggestions and the Paste chip want the same region. The chip takes it when an offer
*arrives* — otherwise copying while typing is swallowed by the candidates and the user never
learns the offer was there — and hands it back at the next keystroke. The offer itself stands
until they paste or copy again, so letting it hold the region would cost every word
suggestion for the rest of the session; the clipboard key and the history panel still reach it.

## Settings

iOS asks for permission once per copied item, so automatic saving works but greets every copy
with an alert until **Cài đặt › Funput › Dán từ ứng dụng khác › Cho phép**. No API reports
that choice, so the card explains it whenever clipboard history is on and offers a button to
Funput's own settings page. Verified on device (iOS 27): with the setting on, capture is
silent and automatic.

## Tests

- Capture controller with a fake gateway: new copy, duplicate copy, notification racing the
  poll, clipboard changed mid-read, lost access, read/write failure, retry, and session
  close/open — including the app-switch case (`end()` then `begin()`) that both bugs above
  hid behind.
- Store: re-copy keeps id and pin and moves to the front, expiry, clear, history written by
  an older build still loads, no file write when the clipboard is unchanged, marks from
  another boot are not trusted.
- Renderer: an open panel receives the new item, Paste survives capture, the chip yields the
  region once typing continues.
- `Scripts/test-funput-kit.sh` green, app + keyboard extension build clean,
  `Scripts/check-swift-loc.sh` green (every file, tests included, ≤150 lines).

## Still to verify on hardware

`FunputUITests/ClipboardCaptureUITests` needs Funput enabled **with Full Access** on the
target, so it stays out of the package suite CI runs and must be started by hand. CPU,
memory and read/write counts under idle, repeated copying and open/close have not been
measured yet; nothing here allocates per poll, but the numbers are not in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
