### PR TITLE
feat(core): add the textcase feature with UPPERCASE and lowercase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,17 @@ jobs:
       - name: Test (funput-ffi with convert)
         run: cargo test -p funput-ffi --features convert
 
+      # `textcase` is default-off and nothing enables it: the workspace steps do not
+      # resolve it, and the mobile-shape steps are its off shape by construction. So
+      # this pair is the only place the module is built at all — and it is the shape
+      # a keyboard would ask for one day, textcase on with charset off, which no
+      # other step here resolves.
+      - name: Clippy (textcase, no charset)
+        run: cargo clippy -p funput-core --features textcase --all-targets -- -D warnings
+
+      - name: Test (textcase, no charset)
+        run: cargo test -p funput-core --features textcase
+
       # Compiling proves charset-off still builds; it does not prove the mobile
       # artifacts are free of it. Two different ways that can go wrong, so two checks.
       #

--- a/crates/funput-core/Cargo.toml
+++ b/crates/funput-core/Cargo.toml
@@ -16,6 +16,13 @@ workspace = true
 [features]
 default = []
 charset = []
+# Changing the case of existing text (chuyển đổi kiểu chữ). Off by default for the
+# same reason as `charset`, but deliberately *separate* from it: a keyboard may one
+# day want bỏ dấu on the selected text — iOS and Android can both read it — and
+# folding the two together would make that cost the four charset codecs. The
+# converse holds too: `funput-config` enables `charset` to read a UniKey macro file
+# and has no use for this. Adds no dependencies either.
+textcase = []
 
 [dependencies]
 

--- a/crates/funput-core/src/lib.rs
+++ b/crates/funput-core/src/lib.rs
@@ -20,9 +20,9 @@
 //! exception to the boundary check).
 //! Breaking changes require semver coordination with the engine.
 //!
-//! That list stays complete for the default build. [`charset`] is additive, keeps
-//! to its own namespace, and re-exports nothing here, so the engine's view of this
-//! crate is the same with the feature on or off.
+//! That list stays complete for the default build. [`charset`] and [`textcase`] are
+//! additive, keep to their own namespaces, and re-export nothing here, so the
+//! engine's view of this crate is the same with either feature on or off.
 //!
 //! # Contract
 //!
@@ -38,6 +38,8 @@ mod composition;
 mod input_method;
 mod options;
 mod orthography;
+#[cfg(feature = "textcase")]
+pub mod textcase;
 mod unicode;
 mod validation;
 

--- a/crates/funput-core/src/textcase/case.rs
+++ b/crates/funput-core/src/textcase/case.rs
@@ -1,0 +1,88 @@
+//! UPPERCASE and lowercase.
+//!
+//! Thin on purpose. `str::to_uppercase` is already the right answer for
+//! Vietnamese, and the reasons are worth writing down once rather than
+//! rediscovering them in a shell:
+//!
+//! - It is **locale-independent** — full Unicode case mapping, no tailoring. The
+//!   famous counter-example is Turkish dotless `ı`, and there is no Vietnamese
+//!   equivalent: every letter here maps the same way in every locale.
+//! - It works on the **string**, not on each `char`. Case mapping is allowed to
+//!   change how many characters a word takes, so a `chars().map()` version would be
+//!   wrong in general even though it happens to work on the Vietnamese inventory.
+//! - It handles **both Unicode forms**. Precomposed `ế` has an uppercase mapping of
+//!   its own; in the combining form the mark is caseless and simply rides along on
+//!   the uppercased base letter. Either way the output keeps the form it arrived
+//!   in, which is what a user who pasted one of them expects to get back.
+//!
+//! So what is actually here is the decision to use them, and the tests that hold
+//! that decision to the Vietnamese inventory.
+
+use super::Options;
+
+/// `Xin chào Việt Nam` → `XIN CHÀO VIỆT NAM`.
+pub(super) fn upper(text: &str, _: Options) -> String {
+    text.to_uppercase()
+}
+
+/// `Xin Chào Việt Nam` → `xin chào việt nam`.
+pub(super) fn lower(text: &str, _: Options) -> String {
+    text.to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The combining spelling of `Tiếng Việt`: every tone and shape as its own
+    /// code point, the way NFD text from a macOS filesystem or a web form arrives.
+    const COMBINING: &str = "Tie\u{302}\u{301}ng Vie\u{323}\u{302}t";
+    const COMBINING_UPPER: &str = "TIE\u{302}\u{301}NG VIE\u{323}\u{302}T";
+    const COMBINING_LOWER: &str = "tie\u{302}\u{301}ng vie\u{323}\u{302}t";
+
+    fn opts() -> Options {
+        Options::default()
+    }
+
+    #[test]
+    fn the_documented_examples() {
+        assert_eq!(upper("Xin chào Việt Nam", opts()), "XIN CHÀO VIỆT NAM");
+        assert_eq!(lower("Xin Chào Việt Nam", opts()), "xin chào việt nam");
+    }
+
+    #[test]
+    fn every_vowel_and_the_stroke_survive_a_round_trip() {
+        let all = "aăâeêioôơuưy áắấéếíóốớúứý ạặậẹệịọộợụựỵ đ";
+        assert_eq!(lower(&upper(all, opts()), opts()), all);
+    }
+
+    #[test]
+    fn stroke_d_has_an_uppercase() {
+        assert_eq!(upper("đẹp", opts()), "ĐẸP");
+        assert_eq!(lower("ĐẸP", opts()), "đẹp");
+    }
+
+    #[test]
+    fn the_combining_form_is_not_precomposed_on_the_way_out() {
+        assert_eq!(upper(COMBINING, opts()), COMBINING_UPPER);
+        assert_eq!(lower(COMBINING, opts()), COMBINING_LOWER);
+        // The point of the test: the marks stay separate. A caller who pasted NFD
+        // gets NFD back, so nothing downstream has to re-detect the form.
+        assert_ne!(upper(COMBINING, opts()), "TIẾNG VIỆT");
+    }
+
+    #[test]
+    fn text_that_has_no_case_is_left_alone() {
+        for text in ["こんにちは", "🎉 1.5 —", ""] {
+            assert_eq!(upper(text, opts()), text);
+            assert_eq!(lower(text, opts()), text);
+        }
+    }
+
+    #[test]
+    fn both_are_idempotent() {
+        let text = "Xin chào Việt Nam";
+        assert_eq!(upper(&upper(text, opts()), opts()), upper(text, opts()));
+        assert_eq!(lower(&lower(text, opts()), opts()), lower(text, opts()));
+    }
+}

--- a/crates/funput-core/src/textcase/mod.rs
+++ b/crates/funput-core/src/textcase/mod.rs
@@ -1,0 +1,96 @@
+//! Changing the case of text that already exists.
+//!
+//! Five transforms a person runs over a paragraph they have already typed:
+//! UPPERCASE, lowercase, bỏ dấu, sentence case and title case. None of them belongs
+//! to the typing engine — no keystroke reaches this module, nothing here keeps
+//! state, and the whole surface is [`apply`].
+//!
+//! **Why core rather than a shell.** The Chuyển mã window will offer these on three
+//! platforms and `funput case` offers them everywhere else. What counts as the end
+//! of a sentence, and which letters lose their diacritics, then has to be one copy
+//! or it drifts — the same argument that put [`crate::charset`] here rather than in
+//! the windows that draw it. The decisions themselves live in
+//! `docs/features/text-case.md`.
+//!
+//! **Why its own feature and not `charset`'s.** A keyboard has no use for the
+//! legacy charset tables, but it may well want bỏ dấu one day: iOS and Android can
+//! both read the selected text, which is the one place a case transform needs no
+//! permission at all. Folding the two features together would make that choice cost
+//! four codecs. Going the other way, `funput-config` enables `charset` only to read
+//! a UniKey macro file and never changes anyone's case.
+//!
+//! [`Transform`] grows one variant per transform as each is implemented, so that a
+//! shell matching on it cannot compile against a variant that does nothing yet.
+
+mod case;
+
+/// Which transform to run.
+///
+/// Not `#[non_exhaustive]` on purpose: a shell that matches every variant should
+/// stop compiling when a new one arrives, because a new transform means a new menu
+/// entry for it to draw.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Transform {
+    /// `Xin chào Việt Nam` → `XIN CHÀO VIỆT NAM`.
+    Upper,
+    /// `Xin Chào Việt Nam` → `xin chào việt nam`.
+    Lower,
+}
+
+/// The switches a transform reads.
+///
+/// One struct for all five rather than an argument list per transform: a shell
+/// stores these next to the window and hands the same value over whichever button
+/// the user pressed, and a new switch then costs no signature change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Options {
+    /// Whether bỏ dấu also unstrokes `đ`/`Đ` into `d`/`D`.
+    ///
+    /// On by default: `dep` is what nearly everyone means by bỏ dấu. Off keeps the
+    /// stroke, for a filename on a system that accepts it.
+    pub d_to_ascii: bool,
+    /// Whether title case leaves a word that is already all-caps alone.
+    ///
+    /// On by default, so `TP. HCM` does not become `Tp. Hcm`.
+    pub keep_all_caps: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            d_to_ascii: true,
+            keep_all_caps: true,
+        }
+    }
+}
+
+/// Run `transform` over `text`.
+///
+/// Returns a fresh `String` rather than editing in place: a transform can change
+/// how many bytes a character takes, and the caller is a window showing the before
+/// and the after side by side.
+pub fn apply(text: &str, transform: Transform, options: Options) -> String {
+    match transform {
+        Transform::Upper => case::upper(text, options),
+        Transform::Lower => case::lower(text, options),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_default_to_the_common_answer() {
+        let options = Options::default();
+        assert!(options.d_to_ascii);
+        assert!(options.keep_all_caps);
+    }
+
+    #[test]
+    fn apply_dispatches() {
+        let options = Options::default();
+        assert_eq!(apply("Việt", Transform::Upper, options), "VIỆT");
+        assert_eq!(apply("Việt", Transform::Lower, options), "việt");
+    }
+}

--- a/docs/features/text-case.md
+++ b/docs/features/text-case.md
@@ -1,0 +1,287 @@
+# Chuyển đổi kiểu chữ
+
+## Trạng thái
+
+**Chưa có code.** Tài liệu này chốt mô hình trước, như [charset.md](charset.md) đã làm,
+và là nơi mọi quyết định thiết kế sống — mỗi phép biến đổi mới cập nhật lại nó trong
+cùng PR.
+
+Phạm vi **V1 đã chốt: một tab trong cửa sổ Chuyển mã**, ba nền tảng desktop, cộng
+`funput case` trong CLI. Không hotkey, không đụng vùng bôi đen, không nghe clipboard. Những thứ đó nằm ở
+[Lộ trình sau V1](#lộ-trình-sau-v1) và có tài liệu riêng khi tới lượt.
+
+## Mục tiêu
+
+Đổi **kiểu chữ của văn bản có sẵn**, năm phép:
+
+| Phép | Ví dụ |
+| --- | --- |
+| CHỮ HOA | `Xin chào Việt Nam` → `XIN CHÀO VIỆT NAM` |
+| chữ thường | `Xin Chào Việt Nam` → `xin chào việt nam` |
+| Bỏ dấu tiếng Việt | `Tiếng Việt rất đẹp` → `Tieng Viet rat dep` |
+| Viết hoa đầu câu | `xin chào. hôm nay trời đẹp.` → `Xin chào. Hôm nay trời đẹp.` |
+| Viết Hoa Đầu Mỗi Từ | `bàn phím tiếng Việt` → `Bàn Phím Tiếng Việt` |
+
+Đây là tính năng của **người soạn thảo**, không phải của bộ gõ: nó chạy trên đoạn văn
+đã có, không can thiệp vào phím đang gõ. Vì vậy nó ở cạnh Chuyển mã chứ không ở cạnh
+engine.
+
+## Không thuộc phạm vi
+
+- **Sửa ngữ nghĩa.** `chữ thường` sẽ phá `Việt Nam` thành `việt nam`, và đó là đúng
+  yêu cầu. Không có danh sách tên riêng, không đoán, không "thông minh". Cách chữa
+  duy nhất là **hoàn tác**, nên hoàn tác phải rẻ và luôn có.
+- **Danh sách viết tắt cho "đầu câu".** `v.v.`, `TS.`, `Th.S` sẽ bị coi là hết câu và
+  chữ sau đó bị viết hoa. Đã cân nhắc và **cố ý không làm**: một danh sách viết tắt
+  tiếng Việt không bao giờ đủ, và sai sót của nó khó đoán hơn là một quy tắc đơn giản
+  mà người dùng nhìn preview là thấy ngay. Ghi vào phần giới hạn đã biết ở UI.
+- **Chế độ slug** (`tieng-viet`) và **bỏ dấu giữ dấu kiểu Telex** (`đẹp` → `depj`).
+  Có thể thêm sau; không thuộc V1.
+- Chuyển đổi trên vùng bôi đen, hotkey toàn cục, clipboard tự động — xem lộ trình.
+- Wayland: mọi đường đi qua vùng bôi đen đều không khả thi, và tài liệu sẽ nói thẳng
+  như vậy thay vì hứa.
+
+## Năm phép biến đổi, chính xác đến ca biên
+
+### Chung cho cả năm
+
+Hàm nhận `&str`, trả `String`. **Không phải phép ánh xạ từng `char`**: `char`
+tiếng Việt viết hoa có thể dài hơn nguyên bản ở dạng tổ hợp, nên lõi làm việc trên
+chuỗi. Dùng `to_uppercase`/`to_lowercase` của Rust ở mức chuỗi (không phụ thuộc
+locale — tiếng Việt không có ca biên kiểu `i` của tiếng Thổ).
+
+Chuỗi vào có thể ở **Unicode dựng sẵn hoặc tổ hợp**. Cả năm phép phải cho cùng kết
+quả ở hai dạng, và **giữ nguyên dạng của đầu vào** — không tự dựng sẵn hoá một tài
+liệu tổ hợp, vì người dùng chỉ xin đổi kiểu chữ.
+
+### CHỮ HOA / chữ thường
+
+Thẳng. Ca biên duy nhất đáng nói nằm ở [bảng mã cũ](#bảng-mã-cũ-là-ca-biên-thật-sự).
+
+### Bỏ dấu tiếng Việt
+
+Bỏ **cả thanh điệu lẫn dấu phụ của nguyên âm**, giữ chữ cái ASCII:
+
+```
+ế → e     ơ → o     ă → a     ữ → u     Ề → E
+đ → d     Đ → D                (mặc định; xem tuỳ chọn bên dưới)
+```
+
+Không dùng crate normalization: `funput-core` có **bất biến không phụ thuộc runtime**
+(`[dependencies]` rỗng), và phá nó cho một tính năng desktop là cái giá sai. Bảng có
+sẵn đã đủ gần: `unicode::vowels::vowel_stem` bỏ thanh nhưng **giữ hình** (`ấ` → `â`),
+nên còn thiếu một bảng `family → chữ cái ASCII` 12 dòng dựng cạnh
+`vowels::table::VOWEL_FAMILIES`. Chữ tổ hợp xử lý bằng cách lọc các dấu thanh rời
+(`U+0300`, `U+0301`, `U+0303`, `U+0309`, `U+0323`) và dấu mũ/móc/trăng rời, sau khi
+đã quy chữ nền về ASCII.
+
+**Tuỳ chọn `đ → d`**: mặc định **bật**. Người cần giữ `đ` (đặt tên file cho hệ thống
+chấp nhận nó, hoặc chỉ muốn bỏ thanh) tắt được trong cùng tab. Đây là tuỳ chọn duy
+nhất của phép này.
+
+Ký tự không phải tiếng Việt (chữ Nhật, emoji, `é` của tiếng Pháp) **giữ nguyên**:
+tính năng tên là "bỏ dấu tiếng Việt", không phải "ASCII hoá".
+
+### Viết hoa đầu câu
+
+Viết hoa chữ cái đầu của mỗi câu, **giữ nguyên phần còn lại**:
+
+```
+xin CHÀO. hôm nay trời đẹp.  →  Xin CHÀO. Hôm nay trời đẹp.
+```
+
+Đã cân nhắc phương án "hạ thường tất cả rồi mới viết hoa" và **không chọn**: nó phá
+`TP. HCM`, phá tên riêng, phá chữ viết hoa cố ý, trong khi người dùng muốn cả hai việc
+đó thì đã có "chữ thường" rồi bấm tiếp "đầu câu".
+
+Ranh giới câu:
+
+| Là ranh giới | Không là ranh giới |
+| --- | --- |
+| `.` `!` `?` `…` kèm khoảng trắng sau | `.` giữa số (`1.5`) |
+| **Xuống dòng** (`\n`), kể cả khi dòng trước không có dấu chấm | dấu `.` của viết tắt (`v.v.`, `TS.`) — giới hạn đã biết |
+| Đầu văn bản | |
+
+Xuống dòng là ranh giới vì đầu vào thật của tính năng này thường là danh sách, phụ đề
+`.srt`, ghi chú — nơi không ai chấm câu.
+
+Chữ cái đầu có thể không phải chữ cái: `"xin chào"` và `(xin chào)` phải viết hoa
+`x`, không bỏ qua vì gặp dấu nháy. Quy tắc: bỏ qua mọi ký tự không phải chữ cái cho
+tới chữ cái đầu tiên của câu.
+
+### Viết Hoa Đầu Mỗi Từ
+
+Viết hoa chữ cái đầu mỗi từ, hạ thường phần còn lại của từ — **trừ từ đang viết HOA
+toàn bộ, giữ nguyên**:
+
+```
+bàn phím tiếng Việt   →  Bàn Phím Tiếng Việt
+gửi về TP. HCM        →  Gửi Về TP. HCM        (không phải "Tp. Hcm")
+```
+
+Ngoại lệ ALL-CAPS bật mặc định, tắt được. Từ một chữ cái (`A`) coi như ALL-CAPS —
+vô hại, vì kết quả hai đường như nhau.
+
+Ranh giới từ là khoảng trắng và dấu câu; `bàn-phím` thành `Bàn-Phím`, `e-mail` thành
+`E-Mail`. Đây là quy ước của mọi công cụ cùng loại và người dùng đã quen.
+
+Không có danh sách từ nối ("của", "và", "là" vẫn được viết hoa). Tiếng Việt không có
+quy ước title case như tiếng Anh, và đoán sẽ sai nhiều hơn đúng.
+
+## Bảng mã cũ là ca biên thật sự
+
+Cửa sổ Chuyển mã làm việc với TCVN3 và VNI-Windows, nên tab mới **bắt buộc** phải trả
+lời câu hỏi: viết hoa một đoạn TCVN3 thì sao?
+
+Viết hoa từng `char` của chuỗi TCVN3 là **sai**, vì `char` ở đó không phải chữ cái —
+nó là byte TCVN3 nằm trong `U+0020..U+00FF` mà font `.VnTime` vẽ ra. `to_uppercase`
+của Rust không biết điều đó.
+
+Đường đúng dùng lại nguyên mô hình trục đã có ở [charset.md](charset.md):
+
+```
+văn bản nguồn ──decode──> Unicode dựng sẵn ──đổi kiểu chữ──> ──encode──> bảng mã nguồn
+```
+
+Hệ quả quan trọng: **encode ngược có thể mất chữ**. TCVN3 không đủ chỗ cho nguyên âm
+hoa có dấu, nên viết hoa một văn bản TCVN3 là phép **có mất mát** — đúng loại mất mát
+mà `charset::Cost` và `text::warning` đã được xây để cảnh báo, kể cả việc **nêu tên
+ký tự** bị mất. Tab mới dùng lại y nguyên hai thứ đó, không viết câu cảnh báo thứ hai.
+
+"Bỏ dấu" thì ngược lại: luôn về ASCII, nên không bao giờ mất mát ở bước encode, dù
+bản thân nó là phép mất thông tin — chuyện này nói bằng một dòng ghi chú tĩnh ở UI,
+không dùng đường cảnh báo.
+
+## Nơi đặt code
+
+| Tầng | Nội dung |
+| --- | --- |
+| `funput-core::textcase` | Năm hàm thuần + bảng `family → ASCII`. Không phụ thuộc, không alloc ngoài chuỗi kết quả. Sau cargo feature riêng, **mặc định tắt** như `charset` — iOS/Android không bao giờ biên dịch nó |
+| `funput-convert` | Trục thứ hai của `Session`: "đổi bảng mã" và "đổi kiểu chữ" dùng chung một `Session`, một `View`, một đường cảnh báo |
+| Ba shell | Chỉ tab, nút, và preview. Không quyết định gì — đúng hợp đồng `refresh()` / `view()` hiện tại |
+| `funput-cli` | `funput case --upper|--lower|--no-diacritics|--sentence|--title` đọc stdin. Rẻ, và là bề mặt test tốt nhất |
+
+**Vì sao mở rộng `Session` chứ không dựng session thứ hai.** Lý do `funput-convert`
+tồn tại — ghi ở đầu `lib.rs` — là để câu chữ cảnh báo, quy tắc `vanban (2).txt` và
+tên thư mục đích chỉ có một bản. Một session thứ hai sẽ chép lại đúng những thứ đó.
+Cụ thể: thêm một trường "phép biến đổi" (`None` = chỉ đổi bảng mã) vào `Session`,
+`Mode` giữ nguyên ba hình dạng `Empty`/`Text`/`Files`.
+
+Trần 150 LOC/file vẫn áp dụng: năm phép nhiều khả năng là năm file trong
+`core/src/textcase/`.
+
+### Feature `textcase`, tách khỏi `charset`
+
+**Một cargo feature riêng trong `funput-core`, không phải một crate riêng.**
+
+Feature riêng chứ không gộp vào `charset`, vì hai thứ đó không đi cùng nhau ở cả hai
+đầu: `funput-config` bật `charset` chỉ để giải mã file gõ tắt UniKey và không bao giờ
+đổi kiểu chữ; còn chiều quan trọng hơn là **mobile có thể cần `textcase` mà chắc chắn
+không cần `charset`**. iOS và Android đều đọc được vùng bôi đen từ chính bàn phím, nên
+một phím "bỏ dấu" ngay trên bàn phím là hướng đi hợp lý về sau — và gộp hai feature sẽ
+kéo cả bốn codec bảng mã vào bản build của chúng, đúng thứ mà ghi chú của feature
+`charset` cấm.
+
+Crate riêng thì không, vì phần bỏ dấu **đọc bảng nguyên âm nội bộ của core**
+(`unicode::vowels::table::VOWEL_FAMILIES`, `vowel_stem`). Một crate ngoài chỉ có hai
+đường: chép lại bảng — hai nguồn sự thật cho cùng một dữ liệu — hoặc đổi bảng thành
+`pub`, biến chi tiết nội bộ thành API công khai của core cho đúng một người dùng.
+`funput-convert` là crate riêng vì lý do ngược lại: nó không cần ruột của core, nó cần
+nằm *trong* workspace để `cargo test --workspace` và `check-loc.sh` với tới hai shell
+bị loại khỏi workspace. `textcase` không có vấn đề đó.
+
+Hai chi tiết bắt buộc khi hiện thực:
+
+- `VOWEL_FAMILIES` hiện là `pub(crate)` sau `#[cfg(feature = "charset")]`. Phải nới
+  thành `#[cfg(any(feature = "charset", feature = "textcase"))]` — quên thì lỗi build
+  chỉ hiện ra ở đúng một tổ hợp feature.
+- `funput-ffi` đã có cấu trúc hai tầng sẵn; chỉ thêm `textcase = ["funput-core/textcase"]`
+  và đổi `convert` thành `["charset", "textcase", "dep:funput-convert"]`. Job CI hiện
+  có (`cargo test -p funput-ffi --features convert`) phủ luôn, không cần job mới.
+
+## Giao diện V1
+
+Tab thứ hai trong cửa sổ Chuyển mã, cùng vùng dán và cùng cặp khung trước/sau:
+
+- Năm nút phép biến đổi (chọn một), áp dụng ngay lên preview.
+- Hai công tắc: **đ → d** (mặc định bật) và **giữ nguyên từ viết HOA** (mặc định bật),
+  chỉ hiện khi liên quan tới phép đang chọn.
+- Dòng cảnh báo dùng chung với Chuyển mã, chỉ hiện khi encode ngược mất chữ.
+- Nút **Sao chép kết quả**, và **Hoàn tác** trả về nguyên bản.
+- Phép biến đổi **cộng dồn được**: bấm "chữ thường" rồi "Viết Hoa Đầu Mỗi Từ" cho kết
+  quả của cả hai. Nguyên bản luôn giữ để hoàn tác về một bước.
+
+Một file thả vào vẫn rơi vào `Mode::Text` như hiện tại. Nhiều file là batch —
+**không thuộc V1**, nhưng bảng `Row` không cần đổi khi tới lượt.
+
+## Lộ trình sau V1
+
+| Giai đoạn | Nội dung | Rào cản |
+| --- | --- | --- |
+| V2 | Batch kéo-thả file | Không có; chỉ là nối vào đường batch sẵn có |
+| V3 | Hotkey xử lý clipboard: copy → hotkey → clipboard đã đổi, người dùng tự dán | Không cần quyền hệ thống. Phải sao lưu/khôi phục clipboard đủ kiểu dữ liệu, và từ chối khi clipboard không phải text |
+| V4 | Bôi đen → hotkey → thay tại chỗ, kèm HUD | Quyền và API theo nền tảng, xem dưới |
+| V5 | Đổi kiểu chữ **từ/câu vừa gõ** qua engine, không cần bôi đen | Dùng bộ nhớ văn bản đã gõ sẵn có (`Engine::adopt`, typed-text shadow của Windows) |
+
+### V4: mô hình kích hoạt đã chốt
+
+**Một hotkey, rồi một phím chọn.** Bấm tổ hợp → thanh nhỏ hiện cạnh con trỏ → bấm
+`U` HOA, `T` thường, `D` bỏ dấu, `C` đầu câu, `W` đầu từ, `Esc` thôi. Chỉ tốn một
+keybind, tự dạy người dùng, và có chỗ đặt nút Hoàn tác — thứ bắt buộc phải có vì
+"chữ thường" phá tên riêng.
+
+Đã loại: năm hotkey riêng (không ai nhớ nổi, đụng phím tắt app khác) và một hotkey
+xoay vòng (không với tới bỏ dấu và đầu câu).
+
+### V4: khả thi theo nền tảng
+
+| | Đọc vùng chọn | Ghi đè | Ghi chú |
+| --- | --- | --- | --- |
+| macOS | `AXSelectedText`, hoặc giả lập ⌘C | AX set, hoặc giả lập ⌘V | Cần quyền Accessibility. **NSServices** là đường thứ hai: hệ thống tự đưa text và tự thay lại, không cần quyền, hiện sẵn trong menu chuột phải |
+| Windows | UIA `TextPattern`, hoặc giả lập Ctrl+C | Ctrl+V hoặc inject | Đường inject đã có sẵn |
+| Linux X11 | PRIMARY selection — đọc được **không cần Ctrl+C** | XTEST | OK |
+| Linux Wayland | ✗ | ✗ | Không hỗ trợ, nói thẳng |
+
+Đường "giả lập phím copy" là **fallback, không phải đường chính**: phải chờ
+`changeCount` đổi chứ không ngủ một khoảng đoán mò, và nó sai trong terminal, nơi
+⌘C/Ctrl+C là ngắt tiến trình chứ không phải copy.
+
+An toàn: không chạy trong ô mật khẩu (secure input trên macOS, cờ ô nhập trên
+Windows), và không đụng clipboard ở đó.
+
+## Cấu hình
+
+V1 **không thêm khoá nào vào file cấu hình**. Hai công tắc của tab là lựa chọn của
+phiên làm việc, lưu cùng chỗ cửa sổ Chuyển mã lưu trạng thái của nó.
+
+Từ V3 trở đi mới cần hotkey, và hotkey là khối **theo từng nền tảng** trong
+[CONFIG_FORMAT.md](../../platforms/CONFIG_FORMAT.md) — Windows và Linux dùng preset
+giống nhau nhưng mỗi bên chỉ đọc khối của mình. Đặt tên khoá khi tới giai đoạn đó,
+không đoán trước.
+
+## Kiểm thử
+
+- **Corpus vàng** cho cả năm phép, chạy ở cả Unicode dựng sẵn và tổ hợp, cho cùng kết
+  quả.
+- **Property** (`proptest` đã có sẵn trong dev-dependencies):
+  - viết HOA và viết thường là idempotent;
+  - bỏ dấu cho kết quả chỉ chứa ASCII với mọi đầu vào tiếng Việt;
+  - bỏ dấu là idempotent;
+  - đổi kiểu chữ rồi encode về TCVN3 không bao giờ panic, chỉ báo `Cost`.
+- **Roundtrip bảng mã**: viết HOA một đoạn TCVN3 rồi đọc lại phải ra đúng chữ hoa
+  tương ứng, hoặc báo mất chữ có nêu tên — không có đường thứ ba.
+- Ca biên phải có test riêng: `TP. HCM`, `1.5`, `v.v.` (test **khoá giới hạn đã
+  biết**, không phải test đòi nó đúng), chuỗi rỗng, chỉ dấu câu, emoji, chữ Nhật lẫn
+  trong câu.
+
+### Kiểm tra thủ công
+
+1. Mở Chuyển mã → tab Kiểu chữ, dán `xin chào. hôm nay trời đẹp.` rồi thử lần lượt
+   năm nút; kiểm tra preview trước/sau khớp với bảng ở đầu tài liệu.
+2. Dán đoạn có `TP. HCM` và một dòng xuống dòng không chấm câu: kiểm tra ngoại lệ
+   ALL-CAPS và ranh giới dòng.
+3. Tắt công tắc `đ → d`, bỏ dấu `đẹp` → `đep`.
+4. Dán một đoạn TCVN3 (copy từ Word font `.VnTime`), bấm CHỮ HOA: phải thấy dòng cảnh
+   báo nêu tên ký tự sẽ mất.
+5. Bấm chồng hai phép rồi Hoàn tác: phải về đúng nguyên bản, một bước.
+6. `echo "Tiếng Việt" | funput case --no-diacritics` cho `Tieng Viet`.


### PR DESCRIPTION
**1 of 5** toward `feature/text-case`. Base is that branch, not `main`: the five core PRs land there one at a time and the branch merges into `main` once the module is whole. Draft — the four transforms after this one are not in it yet.

The first commit is the design doc — five transforms over text that already exists, the edge-case rules for each, and why this lands next to Chuyển mã rather than next to the engine. It is written before the code, like `charset.md`, so the decisions can be argued with on their own. The rest of the stack is one transform per PR: the combining-mark refactor, bỏ dấu, viết hoa đầu câu, viết Hoa Đầu Mỗi Từ.

**Its own feature, not `charset`'s.** A keyboard has no use for the legacy charset tables, but it may well want bỏ dấu one day — iOS and Android can both read the selected text, which is the one place a case transform needs no permission at all — and folding the two features together would make that choice cost four codecs. The converse holds too: `funput-config` enables `charset` only to read a UniKey macro file and never changes anyone's case. Not a separate crate either: bỏ dấu reaches the vowel inventory in `unicode`, and a crate outside core would have to either copy that table or make it public for one caller.

**`Transform` grows one variant per PR** rather than arriving with five and three of them dead. `clippy::todo` is denied in this workspace, so a stub arm is not available anyway — but the real reason is that a shell matching on the enum should not be able to draw a menu entry that does nothing. `Options` arrives whole, so the switches the later transforms read cost no signature change, and every transform takes it whether or not it reads one.

The two transforms here are `str::to_uppercase` / `to_lowercase`. What is worth reviewing is not the two lines but the module doc explaining why that is the right answer for Vietnamese — locale-independent (the Turkish dotless `ı` has no Vietnamese counterpart), on the string rather than per `char`, and correct for both Unicode forms without normalizing either of them away — and the tests that hold it to the inventory.

## CI

A step for the feature, because nothing enables it yet: the workspace steps never resolve it, and the mobile-shape steps are its off shape by construction, so without this pair the module would ship unbuilt and unlinted. It is also the textcase-on charset-off shape a keyboard would ask for, which no other step here resolves.

## Review

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo clippy -p funput-core -p funput-ffi --all-targets -- -D warnings` (the mobile shape, feature off), `cargo clippy`/`cargo test -p funput-core --features textcase`, and `scripts/check-loc.sh` — all green. `mod.rs` is 78 of the 150-line budget, `case.rs` 32.

One test was wrong on the first run and is worth naming: it compared `lower` of the uppercase combining string against a constant that still carried capitals. Fixed, and rewritten to assert the thing that actually matters — NFD in, NFD out, with `upper("Tie\u{302}\u{301}ng …")` explicitly *not* equal to `TIẾNG VIỆT`, so nothing downstream has to re-detect the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

