### PR TITLE
refactor(core): move the combining-mark tables into unicode

### DIFF
--- a/crates/funput-core/src/charset/codecs/combining/marks.rs
+++ b/crates/funput-core/src/charset/codecs/combining/marks.rs
@@ -1,13 +1,16 @@
-//! The eight combining marks this charset reads, and the five it writes.
+//! What each of the eight combining marks means to this charset.
 //!
-//! Code points checked against the canonical NFD of the whole Vietnamese
-//! inventory, taken from a Unicode normalizer rather than from memory.
+//! The code points themselves live in [`crate::unicode::combining`]: they are a fact
+//! about the language, and this codec is one reader of them rather than their owner.
+//! What is here is the part that *is* about the encoding — [`Mark`], which says what
+//! a mark adds to the letter before it, and the asymmetry below.
 //!
 //! Tones are read *and* written. Shapes are **read only**: the UniKey convention
 //! keeps `ă â ê ô ơ ư` precomposed, so [`super::encode`] never emits one. They are
-//! listed here because real NFD text — from a macOS filesystem, from a web form —
+//! still read because real NFD text — from a macOS filesystem, from a web form —
 //! does contain them, and refusing to read it would help nobody.
 
+use crate::unicode::combining;
 use crate::unicode::marks::Tone;
 use crate::unicode::shapes::VowelShape;
 
@@ -18,35 +21,19 @@ pub(super) enum Mark {
     Shape(VowelShape),
 }
 
-/// Tone marks, in the inventory's own order: sắc, huyền, hỏi, ngã, nặng.
-const TONES: [(char, Tone); 5] = [
-    ('\u{301}', Tone::Sac),
-    ('\u{300}', Tone::Huyen),
-    ('\u{309}', Tone::Hoi),
-    ('\u{303}', Tone::Nga),
-    ('\u{323}', Tone::Nang),
-];
-
-/// Shape marks. Read-only — see the module doc.
-const SHAPES: [(char, VowelShape); 3] = [
-    ('\u{302}', VowelShape::Circumflex),
-    ('\u{306}', VowelShape::Breve),
-    ('\u{31B}', VowelShape::Horn),
-];
-
 /// What `c` adds to the letter before it, or `None` when it is not one of the
 /// eight — in which case it is a letter in its own right, not a mark.
 pub(super) fn mark_of(c: char) -> Option<Mark> {
-    if let Some(&(_, tone)) = TONES.iter().find(|&&(mark, _)| mark == c) {
+    if let Some(&(_, tone)) = combining::TONES.iter().find(|&&(mark, _)| mark == c) {
         return Some(Mark::Tone(tone));
     }
-    let &(_, shape) = SHAPES.iter().find(|&&(mark, _)| mark == c)?;
+    let &(_, shape) = combining::SHAPES.iter().find(|&&(mark, _)| mark == c)?;
     Some(Mark::Shape(shape))
 }
 
 /// The mark that writes `tone`.
 pub(super) fn tone_mark(tone: Tone) -> char {
-    TONES
+    combining::TONES
         .iter()
         .find(|&&(_, candidate)| candidate == tone)
         .map(|&(mark, _)| mark)
@@ -59,41 +46,32 @@ pub(super) fn tone_mark(tone: Tone) -> char {
 /// letter before it: writing a bare `U+0301` after an `a` produces text that reads
 /// back as `á`, which is a different string.
 pub(super) fn is_mark(c: char) -> bool {
-    mark_of(c).is_some()
+    combining::is_mark(c)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// A transcribed code point is invisible to the eye, so pin the whole map:
-    /// every tone and every shape is present exactly once, and no code point does
-    /// double duty.
+    /// A transcribed code point is invisible to the eye, and [`mark_of`] is what
+    /// turns one into meaning, so pin the whole map: every tone and every shape
+    /// round-trips through it. That the eight code points are distinct is the
+    /// tables' own business, and tested where they live.
     #[test]
-    fn the_map_covers_every_tone_and_shape_exactly_once() {
+    fn the_map_covers_every_tone_and_shape() {
         for tone in [Tone::Sac, Tone::Huyen, Tone::Hoi, Tone::Nga, Tone::Nang] {
             assert_eq!(mark_of(tone_mark(tone)), Some(Mark::Tone(tone)));
         }
-        for shape in [VowelShape::Circumflex, VowelShape::Breve, VowelShape::Horn] {
-            let found = SHAPES.iter().filter(|&&(_, s)| s == shape).count();
-            assert_eq!(found, 1, "{shape:?}");
+        for (mark, shape) in combining::SHAPES {
+            assert_eq!(mark_of(mark), Some(Mark::Shape(shape)));
         }
-
-        let mut points: Vec<char> = TONES
-            .iter()
-            .map(|&(mark, _)| mark)
-            .chain(SHAPES.iter().map(|&(mark, _)| mark))
-            .collect();
-        assert_eq!(points.len(), 8);
-        points.sort_unstable();
-        points.dedup();
-        assert_eq!(points.len(), 8, "two marks share a code point");
     }
 
     #[test]
     fn a_letter_is_not_a_mark() {
         for c in ['a', 'â', 'ơ', 'đ', 'Đ', '₫', ' '] {
             assert!(!is_mark(c), "{c}");
+            assert_eq!(mark_of(c), None, "{c}");
         }
     }
 }

--- a/crates/funput-core/src/unicode/combining.rs
+++ b/crates/funput-core/src/unicode/combining.rs
@@ -1,0 +1,94 @@
+//! The eight combining marks, and the one question every reader asks of them.
+//!
+//! Vietnamese has two ways to spell the same letter. `ế` is one code point in the
+//! precomposed form that every modern system uses, and in the combining form it is
+//! `e` followed by `U+0302` and `U+0301` — which is what NFD text from a macOS
+//! filesystem or a web form actually contains. The inventory in [`super::vowels`]
+//! covers the first spelling; these eight code points are the second.
+//!
+//! **Why they are here and not in the codec that reads them.** They are a fact about
+//! the language, not about an encoding: NFD text turns up whether or not anyone is
+//! converting a charset. The charset codec that decodes Unicode tổ hợp is one reader
+//! of them, and `textcase` is another — bỏ dấu drops a mark without knowing what a
+//! charset is. A copy per reader would put the eight code points in two places, and
+//! the second place is the one that goes stale.
+//!
+//! Code points checked against the canonical NFD of the whole Vietnamese inventory,
+//! taken from a Unicode normalizer rather than from memory.
+//!
+//! What is *not* here is what a mark means to a particular encoding: whether it can
+//! be written as well as read, and what it does to the letter before it. That stays
+//! with each reader, because the answers differ — the UniKey convention keeps
+//! `ă â ê ô ơ ư` precomposed, so the charset codec reads the three shape marks and
+//! never emits one.
+
+use super::marks::Tone;
+use super::shapes::VowelShape;
+
+/// The combining code point that writes each tone, in the inventory's own order:
+/// sắc, huyền, hỏi, ngã, nặng.
+pub(crate) const TONES: [(char, Tone); 5] = [
+    ('\u{301}', Tone::Sac),
+    ('\u{300}', Tone::Huyen),
+    ('\u{309}', Tone::Hoi),
+    ('\u{303}', Tone::Nga),
+    ('\u{323}', Tone::Nang),
+];
+
+/// The combining code point that writes each vowel shape.
+pub(crate) const SHAPES: [(char, VowelShape); 3] = [
+    ('\u{302}', VowelShape::Circumflex),
+    ('\u{306}', VowelShape::Breve),
+    ('\u{31B}', VowelShape::Horn),
+];
+
+/// Whether `c` is one of the eight — a mark that modifies the letter before it
+/// instead of being a letter in its own right.
+pub(crate) fn is_mark(c: char) -> bool {
+    TONES.iter().any(|&(mark, _)| mark == c) || SHAPES.iter().any(|&(mark, _)| mark == c)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A transcribed code point is invisible to the eye, so pin the tables: every
+    /// tone and every shape appears exactly once, and no two marks share a code
+    /// point. What each mark *means* to a charset is tested with the codec that
+    /// reads them.
+    #[test]
+    fn the_eight_marks_are_distinct_and_complete() {
+        for tone in [Tone::Sac, Tone::Huyen, Tone::Hoi, Tone::Nga, Tone::Nang] {
+            assert_eq!(
+                TONES.iter().filter(|&&(_, t)| t == tone).count(),
+                1,
+                "{tone:?}"
+            );
+        }
+        for shape in [VowelShape::Circumflex, VowelShape::Breve, VowelShape::Horn] {
+            assert_eq!(
+                SHAPES.iter().filter(|&&(_, s)| s == shape).count(),
+                1,
+                "{shape:?}"
+            );
+        }
+
+        let mut points: Vec<char> = TONES
+            .iter()
+            .map(|&(mark, _)| mark)
+            .chain(SHAPES.iter().map(|&(mark, _)| mark))
+            .collect();
+        assert_eq!(points.len(), 8);
+        points.sort_unstable();
+        points.dedup();
+        assert_eq!(points.len(), 8, "two marks share a code point");
+        assert!(points.iter().copied().all(is_mark));
+    }
+
+    #[test]
+    fn a_letter_is_not_a_mark() {
+        for c in ['a', 'â', 'ơ', 'đ', 'Đ', '₫', ' '] {
+            assert!(!is_mark(c), "{c}");
+        }
+    }
+}

--- a/crates/funput-core/src/unicode/mod.rs
+++ b/crates/funput-core/src/unicode/mod.rs
@@ -1,3 +1,8 @@
+// The eight combining marks are a fact about the language rather than about any
+// encoding, so they live here with one reader today and a second one coming. Gated
+// because nothing in the default keyboard build spells a letter that way.
+#[cfg(feature = "charset")]
+pub(crate) mod combining;
 pub mod marks;
 pub mod shapes;
 // `charset` reads the vowel inventory through the accessors in `vowels` rather


### PR DESCRIPTION
**2 of 5** toward `feature/text-case`. Independent of #367 — it touches no `textcase` file — so it can be reviewed and merged in either order. Draft while #367 is under review.

Pure refactor, no behaviour change. Bỏ dấu has to drop the eight combining marks, and the list of them currently lives inside the charset codec that reads them. Copying it into `textcase` would make the code points two sources of truth, which is the kind of drift `funput-convert` exists to prevent; so the list moves to where it belongs instead.

**Where they belong is `unicode`.** The eight marks are a fact about the language, not about an encoding: NFD text turns up from a macOS filesystem or a web form whether or not anyone is converting a charset. The codec keeps the part that genuinely is about the encoding: `Mark`, and the asymmetry that tones are read *and* written while shapes are only read.

**All eight in one module, `unicode::combining`.** The first version of this PR split them five-and-three, beside `Tone` in `marks.rs` and beside `VowelShape` in `shapes.rs`, on the grounds that each table pairs with its own enum and that `unicode` already splits tone from shape everywhere else. Changed after review, and the review was right: "the eight combining marks" is one concept and deserves one name, each reader then imports one path instead of two, one `cfg` on the module replaces three on the items, and the two files that would have carried them are both already close to the 150-line budget (`marks.rs` 74, `shapes.rs` 109 — untouched by this PR now, where the split took them to 103 and 121).

**Gated on `charset` alone, unchanged from before the move.** The plan for this stack said to widen the gate to `any(charset, textcase)` here; that would be wrong at this point. Nothing reads the tables outside the codec yet, so under a wider gate they would be dead code in the textcase-on charset-off shape that CI builds, and `-D warnings` would fail on it. PR 3 widens the gate in the same commit that gives them their second reader.

## Review

The claim worth checking is "no behaviour change", and it has three parts.

The **data** is byte-identical: the eight code points and their pairings extracted from `main` and from this branch sort to the same eight lines. `mark_of` and `tone_mark` keep their signatures and scan the same arrays from the new home. `is_mark` becomes a delegation to `unicode::combining::is_mark`, which answers the same question from the same two arrays — its doc comment stays behind in the codec, because the reason `encode` needs it is an encoding reason.

The **tests** split along the same line rather than moving wholesale: the half that pinned the tables (every tone and shape present exactly once, no two marks sharing a code point) moves next to the tables, and the half that pins what a mark *means* (`mark_of(tone_mark(tone))` round-trips, a letter is not a mark) stays with the codec that decides it. `a_letter_is_not_a_mark` also gained an assertion on `mark_of`, so both entry points are covered there.

The **existing coverage** is what proves the codec still works: 203 tests in `funput-core --features charset`, including the fifteen `charset::codecs::combining` cases and the `tests/charset.rs` corpus, all green. Plus `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, the mobile shape (`-p funput-core -p funput-ffi`, charset off), and `scripts/check-loc.sh` — the codec's `marks.rs` drops from 64 to 51 budgeted lines, the new `unicode/combining.rs` is 50, and `unicode/marks.rs` and `shapes.rs` are left where they were.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
