### PR TITLE
feat(core): add the bỏ dấu transform

### DIFF
--- a/crates/funput-core/src/textcase/diacritics.rs
+++ b/crates/funput-core/src/textcase/diacritics.rs
@@ -1,0 +1,118 @@
+//! Bỏ dấu tiếng Việt.
+//!
+//! Three kinds of character and one switch. A vowel loses its tone and its shape
+//! (`ế` → `e`, `ơ` → `o`, `Ữ` → `U`); a combining mark is dropped, which is how the
+//! same word spelled in NFD arrives at the same answer; `đ` is asked about, because
+//! it is a letter of the alphabet and not a `d` carrying something. Everything else
+//! is passed through untouched.
+//!
+//! **Why there is no table here.** [`shapes::base_vowel`] already strips tone and
+//! shape while keeping case, over the whole precomposed inventory — it is what the
+//! typing engine consults to decide whether a shape key should switch a vowel. A
+//! `family → ASCII` table would be a second copy of that answer, and the second
+//! copy is the one that goes stale.
+//!
+//! **Two things it cannot do, both inherent.** `é` is one code point whether it was
+//! typed for Vietnamese or for French, so `café` becomes `cafe`; a transform that
+//! works on letters cannot know which language meant them. And a combining mark is
+//! dropped whoever put it there, so NFD `ñ` comes out as `n` — while precomposed
+//! `ñ`, `ü`, `ç`, `ß` and anything outside the inventory keep everything they have.
+//! Both are tested below so that they stay decisions rather than surprises.
+
+use crate::unicode::{combining, marks, shapes};
+
+use super::Options;
+
+/// `Tiếng Việt rất đẹp` → `Tieng Viet rat dep`.
+pub(super) fn strip(text: &str, options: Options) -> String {
+    // Never longer than the input in bytes: every replacement is ASCII, and the
+    // only other outcomes are a passthrough and a deletion.
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        if combining::is_mark(c) {
+            continue;
+        }
+        if let Some(base) = shapes::base_vowel(c) {
+            out.push(base);
+        } else if let Some(d) = marks::unstroke_d(c).filter(|_| options.d_to_ascii) {
+            out.push(d);
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Tiếng Việt` with every tone and shape as its own code point.
+    const COMBINING: &str = "Tie\u{302}\u{301}ng Vie\u{323}\u{302}t";
+
+    fn opts() -> Options {
+        Options::default()
+    }
+
+    fn keeping_d() -> Options {
+        Options {
+            d_to_ascii: false,
+            ..Options::default()
+        }
+    }
+
+    #[test]
+    fn the_documented_example() {
+        assert_eq!(strip("Tiếng Việt rất đẹp", opts()), "Tieng Viet rat dep");
+    }
+
+    #[test]
+    fn the_whole_inventory_becomes_ascii() {
+        let all = "aăâeêioôơuưy áắấéếíóốớúứý ạặậẹệịọộợụựỵ ÁẮẤÉẾÍÓỐỚÚỨÝ đĐ";
+        let bare = strip(all, opts());
+        assert!(bare.is_ascii(), "{bare}");
+        assert_eq!(
+            bare,
+            "aaaeeiooouuy aaaeeiooouuy aaaeeiooouuy AAAEEIOOOUUY dD"
+        );
+    }
+
+    #[test]
+    fn case_survives() {
+        assert_eq!(strip("ĐẸP Ữ Ế", opts()), "DEP U E");
+    }
+
+    #[test]
+    fn the_stroke_is_a_switch_and_the_tones_are_not() {
+        assert_eq!(strip("đẹp", keeping_d()), "đep");
+        assert_eq!(strip("ĐẸP", keeping_d()), "ĐEP");
+    }
+
+    #[test]
+    fn both_unicode_forms_reach_the_same_answer() {
+        assert_eq!(strip(COMBINING, opts()), strip("Tiếng Việt", opts()));
+        assert_eq!(strip(COMBINING, opts()), "Tieng Viet");
+    }
+
+    /// Not a bug list — the module doc explains why a letter-level transform cannot
+    /// do better, and these hold the behaviour still.
+    #[test]
+    fn what_it_cannot_separate() {
+        assert_eq!(strip("café", opts()), "cafe");
+        assert_eq!(strip("n\u{303}", opts()), "n");
+        assert_eq!(strip("ñ ü ç ß", opts()), "ñ ü ç ß");
+    }
+
+    #[test]
+    fn everything_else_is_passed_through() {
+        for text in ["こんにちは 🎉", "1.5 — TP. HCM", ""] {
+            assert_eq!(strip(text, opts()), text);
+        }
+    }
+
+    #[test]
+    fn stripping_twice_changes_nothing() {
+        let once = strip("Tiếng Việt rất đẹp", opts());
+        assert_eq!(strip(&once, opts()), once);
+    }
+}

--- a/crates/funput-core/src/textcase/mod.rs
+++ b/crates/funput-core/src/textcase/mod.rs
@@ -23,6 +23,7 @@
 //! shell matching on it cannot compile against a variant that does nothing yet.
 
 mod case;
+mod diacritics;
 
 /// Which transform to run.
 ///
@@ -35,6 +36,8 @@ pub enum Transform {
     Upper,
     /// `Xin Chào Việt Nam` → `xin chào việt nam`.
     Lower,
+    /// `Tiếng Việt rất đẹp` → `Tieng Viet rat dep`.
+    NoDiacritics,
 }
 
 /// The switches a transform reads.
@@ -73,6 +76,7 @@ pub fn apply(text: &str, transform: Transform, options: Options) -> String {
     match transform {
         Transform::Upper => case::upper(text, options),
         Transform::Lower => case::lower(text, options),
+        Transform::NoDiacritics => diacritics::strip(text, options),
     }
 }
 

--- a/crates/funput-core/src/unicode/marks.rs
+++ b/crates/funput-core/src/unicode/marks.rs
@@ -56,6 +56,22 @@ pub fn stroke_d(c: char) -> Option<char> {
     }
 }
 
+/// Convert đ/Đ back to d/D — the inverse of [`stroke_d`].
+///
+/// A separate question from the combining marks, and from the vowels: `đ` is a
+/// letter of the alphabet rather than a `d` carrying something, so bỏ dấu has to
+/// decide about it rather than derive it. That decision is a switch, because the
+/// answer differs between "make this typeable on a US keyboard" and "just take the
+/// tones off".
+#[cfg(feature = "textcase")]
+pub(crate) fn unstroke_d(c: char) -> Option<char> {
+    match c {
+        'đ' => Some('d'),
+        'Đ' => Some('D'),
+        _ => None,
+    }
+}
+
 /// Returns true if `c` is a vowel (ASCII or precomposed Vietnamese).
 pub fn is_vowel(c: char) -> bool {
     vowels::is_vowel(c)

--- a/crates/funput-core/src/unicode/mod.rs
+++ b/crates/funput-core/src/unicode/mod.rs
@@ -1,7 +1,9 @@
 // The eight combining marks are a fact about the language rather than about any
-// encoding, so they live here with one reader today and a second one coming. Gated
-// because nothing in the default keyboard build spells a letter that way.
-#[cfg(feature = "charset")]
+// encoding, so they live here rather than in either reader: the charset codec that
+// decodes Unicode tổ hợp, and `textcase`, where bỏ dấu drops a mark without knowing
+// what a charset is. Gated because nothing in the default keyboard build spells a
+// letter that way.
+#[cfg(any(feature = "charset", feature = "textcase"))]
 pub(crate) mod combining;
 pub mod marks;
 pub mod shapes;

--- a/crates/funput-core/tests/textcase.rs
+++ b/crates/funput-core/tests/textcase.rs
@@ -1,0 +1,15 @@
+// Gated here, as an inner attribute on the crate root, for the reason spelled out
+// in `charset.rs`: a per-`mod` gate would still let the crate root name
+// `funput_core::textcase` and fail when the feature is off. Please do not "fix" it
+// into per-module attributes.
+#![cfg(feature = "textcase")]
+
+//! Chuyển đổi kiểu chữ integration suite — one binary, modules under
+//! `tests/textcase/`. `#[path]` is required because a `tests/*.rs` crate root looks
+//! up plain `mod` in `tests/`, not a subdirectory.
+//!
+//! These use only the public API, which is also how they check that the public API
+//! is enough: a shell has `Transform`, `Options` and `apply`, and nothing else.
+
+#[path = "textcase/properties.rs"]
+mod properties;

--- a/crates/funput-core/tests/textcase/properties.rs
+++ b/crates/funput-core/tests/textcase/properties.rs
@@ -1,0 +1,84 @@
+//! Properties that must hold for text no fixture would think to write down —
+//! arbitrary Unicode, lone combining marks, scripts with no case at all.
+
+use funput_core::textcase::{Options, Transform, apply};
+use proptest::prelude::*;
+
+/// Every transform there is. A wildcard is not available here — `Transform` is
+/// exhaustive on purpose — so a new variant makes this array a compile error until
+/// somebody decides which properties it has to satisfy.
+const ALL: [Transform; 3] = [Transform::Upper, Transform::Lower, Transform::NoDiacritics];
+
+/// Vietnamese as it is actually stored: precomposed letters, the stroke, the eight
+/// combining marks, and the punctuation that decides a sentence boundary. A plain
+/// `any::<String>()` would almost never produce a toned vowel, so a property run
+/// over it would be checking nothing about Vietnamese.
+const VIETNAMESE: &str = "[a-zA-Z0-9 .!?\\n\
+    aăâeêioôơuưyđAĂÂEÊIOÔƠUƯYĐ\
+    áàảãạắằẳẵặấầẩẫậéèẻẽẹếềểễệíìỉĩịóòỏõọốồổỗộớờởỡợúùủũụứừửữựýỳỷỹỵ\
+    ÁÀẢÃẠẾỆỐỚỮ\
+    \\x{300}\\x{301}\\x{303}\\x{309}\\x{323}\\x{302}\\x{306}\\x{31B}]{0,48}";
+
+proptest! {
+    /// No transform panics, and none of them grows the text. Case mapping is
+    /// allowed to add characters in general (`ß` → `SS`), but no Vietnamese letter
+    /// does, and bỏ dấu only ever removes.
+    #[test]
+    fn never_panics_and_never_grows(text in VIETNAMESE) {
+        for transform in ALL {
+            let out = apply(&text, transform, Options::default());
+            prop_assert!(
+                out.chars().count() <= text.chars().count(),
+                "{transform:?} grew {text:?} into {out:?}"
+            );
+        }
+    }
+
+    /// Arbitrary Unicode — emoji, unassigned code points, lone marks, right-to-left
+    /// text — reaches the same code and must not panic there either.
+    #[test]
+    fn arbitrary_unicode_is_survivable(text in any::<String>()) {
+        for transform in ALL {
+            let _ = apply(&text, transform, Options::default());
+        }
+    }
+
+    /// Running a transform on its own output changes nothing. The one that would be
+    /// easy to get wrong is bỏ dấu in the combining form: drop the mark but leave
+    /// the base letter respelled, and a second pass would keep finding work.
+    #[test]
+    fn every_transform_is_idempotent(text in VIETNAMESE) {
+        for transform in ALL {
+            let once = apply(&text, transform, Options::default());
+            prop_assert_eq!(
+                apply(&once, transform, Options::default()),
+                once.clone(),
+                "{:?} is not idempotent on {:?}",
+                transform,
+                text
+            );
+        }
+    }
+
+    /// Vietnamese in, ASCII out — the property the whole transform exists for, and
+    /// the one a `family → ASCII` table would have been at risk of missing a row of.
+    #[test]
+    fn bo_dau_leaves_only_ascii(text in VIETNAMESE) {
+        let bare = apply(&text, Transform::NoDiacritics, Options::default());
+        prop_assert!(bare.is_ascii(), "{text:?} left {bare:?}");
+    }
+
+    /// With the switch off, the stroke is the *only* thing that may survive.
+    #[test]
+    fn keeping_the_stroke_keeps_nothing_else(text in VIETNAMESE) {
+        let options = Options {
+            d_to_ascii: false,
+            ..Options::default()
+        };
+        let bare = apply(&text, Transform::NoDiacritics, options);
+        prop_assert!(
+            bare.chars().all(|c| c.is_ascii() || c == 'đ' || c == 'Đ'),
+            "{text:?} left {bare:?}"
+        );
+    }
+}

--- a/docs/features/text-case.md
+++ b/docs/features/text-case.md
@@ -68,19 +68,24 @@ Bỏ **cả thanh điệu lẫn dấu phụ của nguyên âm**, giữ chữ cá
 ```
 
 Không dùng crate normalization: `funput-core` có **bất biến không phụ thuộc runtime**
-(`[dependencies]` rỗng), và phá nó cho một tính năng desktop là cái giá sai. Bảng có
-sẵn đã đủ gần: `unicode::vowels::vowel_stem` bỏ thanh nhưng **giữ hình** (`ấ` → `â`),
-nên còn thiếu một bảng `family → chữ cái ASCII` 12 dòng dựng cạnh
-`vowels::table::VOWEL_FAMILIES`. Chữ tổ hợp xử lý bằng cách lọc các dấu thanh rời
-(`U+0300`, `U+0301`, `U+0303`, `U+0309`, `U+0323`) và dấu mũ/móc/trăng rời, sau khi
-đã quy chữ nền về ASCII.
+(`[dependencies]` rỗng), và phá nó cho một tính năng desktop là cái giá sai.
+
+Và **không cần bảng mới nào**: `unicode::shapes::base_vowel` đã bỏ cả thanh lẫn hình
+mà giữ hoa/thường, trên toàn bộ bảng chữ dựng sẵn — chính engine dùng nó để quyết định
+phím hình có đổi được nguyên âm hay không. Một bảng `family → ASCII` sẽ là bản copy
+thứ hai của cùng câu trả lời, và bản thứ hai là bản sẽ lệch. Chữ tổ hợp xử lý bằng
+cách lọc tám dấu rời, danh sách lấy từ `unicode::combining`.
 
 **Tuỳ chọn `đ → d`**: mặc định **bật**. Người cần giữ `đ` (đặt tên file cho hệ thống
 chấp nhận nó, hoặc chỉ muốn bỏ thanh) tắt được trong cùng tab. Đây là tuỳ chọn duy
 nhất của phép này.
 
-Ký tự không phải tiếng Việt (chữ Nhật, emoji, `é` của tiếng Pháp) **giữ nguyên**:
-tính năng tên là "bỏ dấu tiếng Việt", không phải "ASCII hoá".
+Hai điều phép này **không làm được**, và đều là bản chất chứ không phải thiếu sót.
+`é` chỉ có một code point dù người gõ nó cho tiếng Việt hay tiếng Pháp, nên `café`
+thành `cafe`: một phép biến đổi trên chữ cái không biết được ai có ý gì. Và dấu tổ hợp
+bị bỏ bất kể ai đặt nó, nên `ñ` ở dạng tổ hợp ra `n` — còn `ñ`, `ü`, `ç`, `ß` dựng sẵn,
+chữ Nhật và emoji thì giữ nguyên mọi thứ. Cả hai đều có test khoá lại để chúng là quyết
+định, không phải điều bất ngờ.
 
 ### Viết hoa đầu câu
 
@@ -156,7 +161,7 @@ không dùng đường cảnh báo.
 
 | Tầng | Nội dung |
 | --- | --- |
-| `funput-core::textcase` | Năm hàm thuần + bảng `family → ASCII`. Không phụ thuộc, không alloc ngoài chuỗi kết quả. Sau cargo feature riêng, **mặc định tắt** như `charset` — iOS/Android không bao giờ biên dịch nó |
+| `funput-core::textcase` | Năm phép biến đổi thuần, không phụ thuộc, không alloc ngoài chuỗi kết quả, và không bảng dữ liệu mới nào. Sau cargo feature riêng, **mặc định tắt** như `charset` — iOS/Android không bao giờ biên dịch nó |
 | `funput-convert` | Trục thứ hai của `Session`: "đổi bảng mã" và "đổi kiểu chữ" dùng chung một `Session`, một `View`, một đường cảnh báo |
 | Ba shell | Chỉ tab, nút, và preview. Không quyết định gì — đúng hợp đồng `refresh()` / `view()` hiện tại |
 | `funput-cli` | `funput case --upper|--lower|--no-diacritics|--sentence|--title` đọc stdin. Rẻ, và là bề mặt test tốt nhất |
@@ -182,19 +187,22 @@ một phím "bỏ dấu" ngay trên bàn phím là hướng đi hợp lý về s
 kéo cả bốn codec bảng mã vào bản build của chúng, đúng thứ mà ghi chú của feature
 `charset` cấm.
 
-Crate riêng thì không, vì phần bỏ dấu **đọc bảng nguyên âm nội bộ của core**
-(`unicode::vowels::table::VOWEL_FAMILIES`, `vowel_stem`). Một crate ngoài chỉ có hai
-đường: chép lại bảng — hai nguồn sự thật cho cùng một dữ liệu — hoặc đổi bảng thành
-`pub`, biến chi tiết nội bộ thành API công khai của core cho đúng một người dùng.
+Crate riêng thì không, vì phần bỏ dấu **đọc thẳng ruột của core**:
+`unicode::shapes::base_vowel` và `unicode::combining::is_mark`, cả hai đều
+`pub(crate)`. Một crate ngoài chỉ có hai đường: chép lại dữ liệu — hai nguồn sự thật
+cho cùng một thứ — hoặc đổi chúng thành `pub`, biến chi tiết nội bộ thành API công khai
+của core cho đúng một người dùng.
 `funput-convert` là crate riêng vì lý do ngược lại: nó không cần ruột của core, nó cần
 nằm *trong* workspace để `cargo test --workspace` và `check-loc.sh` với tới hai shell
 bị loại khỏi workspace. `textcase` không có vấn đề đó.
 
 Hai chi tiết bắt buộc khi hiện thực:
 
-- `VOWEL_FAMILIES` hiện là `pub(crate)` sau `#[cfg(feature = "charset")]`. Phải nới
-  thành `#[cfg(any(feature = "charset", feature = "textcase"))]` — quên thì lỗi build
-  chỉ hiện ra ở đúng một tổ hợp feature.
+- Module `unicode::combining` (tám dấu tổ hợp) nằm sau
+  `#[cfg(any(feature = "charset", feature = "textcase"))]`: nới đúng lúc có người đọc
+  thứ hai, không nới trước — gate rộng hơn số người đọc là dead code, và bước CI
+  textcase-on/charset-off sẽ trượt vì `-D warnings`. Không có gate nào khác phải đổi;
+  `base_vowel` vốn đã `pub(crate)` không gated.
 - `funput-ffi` đã có cấu trúc hai tầng sẵn; chỉ thêm `textcase = ["funput-core/textcase"]`
   và đổi `convert` thành `["charset", "textcase", "dep:funput-convert"]`. Job CI hiện
   có (`cargo test -p funput-ffi --features convert`) phủ luôn, không cần job mới.


### PR DESCRIPTION
**3 of 5** toward `feature/text-case`. Base is #368, which moved the combining-mark tables this reads. Draft.

**It needs no new table, and that is the finding worth reviewing.** The design doc specified a 12-row `family → ASCII` table next to `VOWEL_FAMILIES`, because `vowel_stem` strips tone but keeps shape (`ấ` → `â`). It turns out `unicode::shapes::base_vowel` already goes the whole way — tone off, shape off, case kept — over the entire precomposed inventory, and it is `pub(crate)` and ungated because the typing engine consults it to decide whether a shape key can switch a vowel. Probed over every letter in the inventory before building anything on it:

```
aăâeêioôơuưy áắấéếíóốớúứý ạặậẹệịọộợụựỵ ÁẮẤÉẾÍÓỐỚÚỨÝ
aaaeeiooouuy aaaeeiooouuy aaaeeiooouuy AAAEEIOOOUUY
```

So the transform is a three-way decision per character with no data of its own, and the table that would have been the second copy of `base_vowel`'s answer — the copy that goes stale — does not exist. The design doc is corrected in this PR to say so.

**The gate widens here, not in #368.** `unicode::combining` goes from `charset` to `any(charset, textcase)` in the same commit that gives the module its second reader, which is why #368 deliberately left it alone: a gate wider than the set of readers is dead code, and the textcase-on charset-off CI step fails on it under `-D warnings`. One gate on the module, because #368 put all eight marks in one place.

`unstroke_d` lands next to `stroke_d` rather than inside `textcase`, because `đ` is a letter of the alphabet and mapping it is a fact about the alphabet. That it is a *switch* is the textcase part: `dep` is what nearly everyone means by bỏ dấu, but "just take the tones off" is a real request too.

## Two limits, tested rather than hidden

`é` is one code point whether it was typed for Vietnamese or for French, so `café` becomes `cafe`. And a combining mark is dropped whoever put it there, so NFD `ñ` comes out `n` — while precomposed `ñ ü ç ß`, Japanese and emoji keep everything they have. A transform that works on letters cannot know which language meant them; both are pinned by `what_it_cannot_separate` so they stay decisions. The design doc previously claimed French `é` would survive, which was simply wrong; also corrected here.

## Tests

The integration suite (`tests/textcase.rs`) starts in this PR, with the properties no fixture can state, over a generator of real Vietnamese storage — precomposed letters, the stroke, the eight combining marks, sentence punctuation — because `any::<String>()` would almost never produce a toned vowel and a property run over it would check nothing about Vietnamese:

- Vietnamese in, ASCII out — the property the whole transform exists for, and the row-by-row risk a hand-written table would have carried.
- With the switch off, the stroke is the only non-ASCII character that may survive.
- No transform grows its input; none panics on `any::<String>()`.
- Every transform is idempotent — the one bỏ dấu could plausibly have failed, by dropping a mark and leaving the base letter respelled so a second pass keeps finding work.

Unit tests cover the documented example, the whole inventory in one string, case (`ĐẸP Ữ Ế` → `DEP U E`), both Unicode forms reaching the same answer, the switch, and passthrough.

## Review

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo clippy`/`cargo test -p funput-core --features textcase` (109 unit + 5 property tests), the mobile shape (`-p funput-core -p funput-ffi`, both features off), and `scripts/check-loc.sh` — all green. `diacritics.rs` is 45 budgeted lines, `textcase/mod.rs` 82, `unicode/marks.rs` 119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
