### PR TITLE
feat(core): add the viết hoa đầu câu transform

### DIFF
--- a/crates/funput-core/src/textcase/mod.rs
+++ b/crates/funput-core/src/textcase/mod.rs
@@ -24,6 +24,7 @@
 
 mod case;
 mod diacritics;
+mod sentence;
 
 /// Which transform to run.
 ///
@@ -38,6 +39,8 @@ pub enum Transform {
     Lower,
     /// `Tiếng Việt rất đẹp` → `Tieng Viet rat dep`.
     NoDiacritics,
+    /// `xin chào. hôm nay trời đẹp.` → `Xin chào. Hôm nay trời đẹp.`
+    Sentence,
 }
 
 /// The switches a transform reads.
@@ -77,6 +80,7 @@ pub fn apply(text: &str, transform: Transform, options: Options) -> String {
         Transform::Upper => case::upper(text, options),
         Transform::Lower => case::lower(text, options),
         Transform::NoDiacritics => diacritics::strip(text, options),
+        Transform::Sentence => sentence::capitalize(text, options),
     }
 }
 

--- a/crates/funput-core/src/textcase/sentence.rs
+++ b/crates/funput-core/src/textcase/sentence.rs
@@ -1,0 +1,138 @@
+//! Viết hoa đầu câu.
+//!
+//! Capitalises the first letter of each sentence and **leaves the rest alone**.
+//! Lowercasing the rest first was considered and rejected: it would flatten
+//! `TP. HCM`, proper nouns, and anything capitalised on purpose, and a user who
+//! wants that can press lowercase and then this.
+//!
+//! A sentence begins at the start of the text, after a newline, and after one of
+//! `.` `!` `?` `…` **followed by whitespace**. Two rules fall out of that shape
+//! rather than being written down separately: `1.5` keeps its `.` because a digit
+//! follows it rather than a space, and a run of `...` or `?!` ends one sentence
+//! rather than several.
+//!
+//! A newline counts even with no punctuation before it, because the text this
+//! transform is pointed at is usually a list, a subtitle file, or notes — places
+//! where nobody punctuates the ends of lines.
+//!
+//! **Where the first letter is.** Openers are skipped, so `"xin chào"` and
+//! `(xin chào)` both get their `x`. Digits are not: a sentence that opens with a
+//! number has already begun, and skipping past it would turn `3 con mèo` into
+//! `3 Con mèo`. So the search stops at the first letter *or* digit, and only a
+//! letter is changed.
+//!
+//! **The known limitation.** An abbreviation's full stop is indistinguishable from
+//! the end of a sentence — `v.v. nhé` becomes `V.v. Nhé`, `TS. nguyễn` becomes
+//! `TS. Nguyễn`. A list of Vietnamese abbreviations was considered and left out of
+//! `docs/features/text-case.md` on purpose: no list is ever complete, and its
+//! mistakes are harder to predict than this one rule, which a user sees in the
+//! preview. The tests below pin the behaviour so it stays a decision.
+
+use super::Options;
+
+/// The characters that can end a sentence.
+const TERMINATORS: [char; 4] = ['.', '!', '?', '…'];
+
+/// `xin chào. hôm nay trời đẹp.` → `Xin chào. Hôm nay trời đẹp.`
+pub(super) fn capitalize(text: &str, _: Options) -> String {
+    let mut out = String::with_capacity(text.len());
+    // The start of the text is the start of a sentence.
+    let mut awaiting = true;
+    // A terminator has been seen and is waiting for the whitespace that confirms it.
+    let mut terminated = false;
+
+    for c in text.chars() {
+        if awaiting && c.is_alphabetic() {
+            out.extend(c.to_uppercase());
+            awaiting = false;
+            terminated = false;
+            continue;
+        }
+        out.push(c);
+        match c {
+            '\n' => {
+                awaiting = true;
+                terminated = false;
+            }
+            c if TERMINATORS.contains(&c) => terminated = true,
+            c if c.is_whitespace() => {
+                awaiting = awaiting || terminated;
+                terminated = false;
+            }
+            c => {
+                // A digit ends the search for a first letter; punctuation does not.
+                awaiting = awaiting && !c.is_alphanumeric();
+                terminated = false;
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts() -> Options {
+        Options::default()
+    }
+
+    #[test]
+    fn the_documented_example() {
+        assert_eq!(
+            capitalize("xin chào. hôm nay trời đẹp.", opts()),
+            "Xin chào. Hôm nay trời đẹp."
+        );
+    }
+
+    #[test]
+    fn the_rest_of_the_sentence_is_untouched() {
+        assert_eq!(capitalize("xin CHÀO. hôm nay", opts()), "Xin CHÀO. Hôm nay");
+        assert_eq!(capitalize("gửi về TP. hcm", opts()), "Gửi về TP. Hcm");
+    }
+
+    #[test]
+    fn a_newline_is_a_boundary_without_punctuation() {
+        assert_eq!(capitalize("một\nhai\n\nba", opts()), "Một\nHai\n\nBa");
+    }
+
+    #[test]
+    fn an_opener_is_skipped_but_a_digit_is_not() {
+        assert_eq!(capitalize("\"xin chào\"", opts()), "\"Xin chào\"");
+        assert_eq!(capitalize("(xin chào)", opts()), "(Xin chào)");
+        assert_eq!(capitalize("— xin chào", opts()), "— Xin chào");
+        assert_eq!(
+            capitalize("3 con mèo. 5 con chó.", opts()),
+            "3 con mèo. 5 con chó."
+        );
+    }
+
+    #[test]
+    fn a_terminator_needs_whitespace_after_it() {
+        assert_eq!(capitalize("giá 1.5 triệu", opts()), "Giá 1.5 triệu");
+        assert_eq!(capitalize("thật?! không tin", opts()), "Thật?! Không tin");
+        assert_eq!(capitalize("rồi… thôi", opts()), "Rồi… Thôi");
+    }
+
+    /// Not a bug list: the module doc says why a rule beats a list of abbreviations.
+    #[test]
+    fn an_abbreviation_reads_as_the_end_of_a_sentence() {
+        assert_eq!(capitalize("giấy tờ v.v. nhé", opts()), "Giấy tờ v.v. Nhé");
+        assert_eq!(capitalize("TS. nguyễn", opts()), "TS. Nguyễn");
+    }
+
+    #[test]
+    fn the_combining_form_capitalizes_its_base_letter() {
+        assert_eq!(
+            capitalize("vie\u{323}\u{302}t nam", opts()),
+            "Vie\u{323}\u{302}t nam"
+        );
+    }
+
+    #[test]
+    fn text_with_no_letters_is_left_alone() {
+        for text in ["", "… !? 1.5", "🎉", "こんにちは"] {
+            assert_eq!(capitalize(text, opts()), text);
+        }
+    }
+}

--- a/crates/funput-core/tests/textcase/properties.rs
+++ b/crates/funput-core/tests/textcase/properties.rs
@@ -7,7 +7,12 @@ use proptest::prelude::*;
 /// Every transform there is. A wildcard is not available here — `Transform` is
 /// exhaustive on purpose — so a new variant makes this array a compile error until
 /// somebody decides which properties it has to satisfy.
-const ALL: [Transform; 3] = [Transform::Upper, Transform::Lower, Transform::NoDiacritics];
+const ALL: [Transform; 4] = [
+    Transform::Upper,
+    Transform::Lower,
+    Transform::NoDiacritics,
+    Transform::Sentence,
+];
 
 /// Vietnamese as it is actually stored: precomposed letters, the stroke, the eight
 /// combining marks, and the punctuation that decides a sentence boundary. A plain
@@ -54,6 +59,24 @@ proptest! {
                 apply(&once, transform, Options::default()),
                 once.clone(),
                 "{:?} is not idempotent on {:?}",
+                transform,
+                text
+            );
+        }
+    }
+
+    /// The case transforms change only case, so lowercasing the result gives the
+    /// same text as lowercasing the input. This is the property that catches a
+    /// scanner losing, duplicating or reordering a character while it looks for a
+    /// sentence boundary — a diff in the output alone would not say which.
+    #[test]
+    fn the_case_transforms_change_only_case(text in VIETNAMESE) {
+        for transform in [Transform::Upper, Transform::Lower, Transform::Sentence] {
+            let out = apply(&text, transform, Options::default());
+            prop_assert_eq!(
+                out.to_lowercase(),
+                text.to_lowercase(),
+                "{:?} changed more than case in {:?}",
                 transform,
                 text
             );


### PR DESCRIPTION
**4 of 5** toward `feature/text-case`. Base is #369. Draft.

Capitalises the first letter of each sentence and leaves the rest alone. Lowercasing the rest first is rejected in the design doc, and it is worth restating because it is the decision most likely to be questioned: it would flatten `TP. HCM`, proper nouns, and anything capitalised on purpose. A user who wants that presses lowercase and then this — which the window supports, because the transforms stack.

**One definition of a boundary, and two rules fall out of it.** A sentence begins at the start of the text, after a newline, and after one of `. ! ? …` *followed by whitespace*. Because whitespace is what confirms a terminator, `1.5` keeps its stop without a digit rule written anywhere, and a run of `...` or `?!` ends one sentence rather than three. A newline counts with no punctuation before it: the text this transform is actually pointed at is a list, a subtitle file, or notes, where nobody punctuates the ends of lines.

**Where the first letter is.** Openers are skipped, so `"xin chào"` and `(xin chào)` both get their `x`. Digits are not, and this is the one place I went beyond the doc: a sentence opening with a number has already begun, so skipping past it would turn `3 con mèo` into `3 Con mèo`. The search therefore stops at the first letter *or* digit, and only a letter is changed.

## The abbreviation limitation

`giấy tờ v.v. nhé` becomes `Giấy tờ v.v. Nhé`, and `TS. nguyễn` becomes `TS. Nguyễn`. An abbreviation's full stop is indistinguishable from the end of a sentence, and the design doc rules out a list of Vietnamese abbreviations on purpose: no list is ever complete, and its mistakes are harder for a user to predict than one rule they can see in the preview. `an_abbreviation_reads_as_the_end_of_a_sentence` pins it, so it stays a decision rather than drifting into a bug someone "fixes" with a half-finished list.

If you would rather have the short list (`v.v.`, `TS.`, `ThS.`, `PGS.`), say so and it is a small follow-up — but it belongs in its own PR, because it changes the rule rather than extending it.

## Tests

Unit tests cover the documented example, the untouched remainder (`xin CHÀO. hôm nay` → `Xin CHÀO. Hôm nay`), newlines including a blank line, the three opener shapes and the digit case, all three "needs whitespace" cases, both abbreviation shapes, the combining form capitalising its base letter, and text with no letters at all.

The suite gains one property: **the case transforms change only case**, so lowercasing the output gives the same text as lowercasing the input. That is the property that catches a scanner dropping, duplicating or reordering a character while looking for a boundary — a diff of the output alone would show that something is wrong without saying what. It runs over `Upper`, `Lower` and `Sentence`; bỏ dấu is excluded because changing more than case is its job.

`Transform` now has four variants, and `ALL` in the property file is a fixed-size array on purpose: a fifth variant makes it a compile error until somebody decides which properties the new transform has to satisfy.

## Review

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo clippy`/`cargo test -p funput-core --features textcase` (118 unit + 6 property tests), the mobile shape (`-p funput-core -p funput-ffi`, both features off), and `scripts/check-loc.sh` — all green. `sentence.rs` is 71 budgeted lines, `textcase/mod.rs` 86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
