### PR TITLE
feat(core): add the viết Hoa Đầu Mỗi Từ transform

### DIFF
--- a/crates/funput-core/src/textcase/mod.rs
+++ b/crates/funput-core/src/textcase/mod.rs
@@ -25,6 +25,7 @@
 mod case;
 mod diacritics;
 mod sentence;
+mod title;
 
 /// Which transform to run.
 ///
@@ -41,6 +42,8 @@ pub enum Transform {
     NoDiacritics,
     /// `xin chào. hôm nay trời đẹp.` → `Xin chào. Hôm nay trời đẹp.`
     Sentence,
+    /// `bàn phím tiếng Việt` → `Bàn Phím Tiếng Việt`.
+    Title,
 }
 
 /// The switches a transform reads.
@@ -81,6 +84,7 @@ pub fn apply(text: &str, transform: Transform, options: Options) -> String {
         Transform::Lower => case::lower(text, options),
         Transform::NoDiacritics => diacritics::strip(text, options),
         Transform::Sentence => sentence::capitalize(text, options),
+        Transform::Title => title::capitalize(text, options),
     }
 }
 

--- a/crates/funput-core/src/textcase/title.rs
+++ b/crates/funput-core/src/textcase/title.rs
@@ -1,0 +1,164 @@
+//! Viết Hoa Đầu Mỗi Từ.
+//!
+//! Capitalises the first letter of each word and lowercases the rest of it, with one
+//! exception: a word that is already all-caps is left exactly as it is, so `TP. HCM`
+//! does not become `Tp. Hcm`. That exception is [`Options::keep_all_caps`], on by
+//! default and switchable, because a document shouting in capitals is the one case
+//! where a user does want them flattened.
+//!
+//! No list of little words. Vietnamese has no title-case convention that keeps `của`
+//! or `và` lowercase — that is an English rule — so every word is capitalised and
+//! nothing has to guess.
+//!
+//! **What separates two words: whitespace, or ASCII punctuation.** `bàn-phím` becomes
+//! `Bàn-Phím` and `e-mail` becomes `E-Mail`, which is what every tool of this kind
+//! does and what users expect. The apostrophe is the one exception, so `don't` stays
+//! `Don't` rather than becoming `Don'T`.
+//!
+//! Keeping the separators ASCII buys a guarantee worth more than the edge cases it
+//! costs: **a word can never be split inside a grapheme cluster**, because every
+//! combining mark is non-ASCII. `Tiếng Việt` spelled in NFD stays two words, where a
+//! rule of "split on anything that is not a letter" would cut each vowel off from its
+//! own tone mark and capitalise the fragment after it. The cost is that unspaced
+//! non-ASCII punctuation does not split a word — `xin…chào` capitalises only the `x` —
+//! which is cosmetic, and rare in the text this transform is pointed at.
+//!
+//! Because a word may open with something that has no case, the search is for the
+//! first *letter* in the word: `"xin` and `(xin` get their `x`, and `5g` becomes `5G`.
+//!
+//! **The known limitation** is the mirror of the all-caps exception: a word with a
+//! capital inside it loses it, so `iPhone` becomes `Iphone`. Preserving interior
+//! capitals would mean not lowercasing the rest of a word, which is the whole job.
+
+use super::Options;
+
+/// `bàn phím tiếng Việt` → `Bàn Phím Tiếng Việt`.
+pub(super) fn capitalize(text: &str, options: Options) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut word = String::new();
+    for c in text.chars() {
+        if separates(c) {
+            flush(&mut word, &mut out, options);
+            out.push(c);
+        } else {
+            word.push(c);
+        }
+    }
+    flush(&mut word, &mut out, options);
+    out
+}
+
+/// Whether `c` ends the word before it. ASCII only — see the module doc.
+fn separates(c: char) -> bool {
+    c.is_whitespace() || (c.is_ascii_punctuation() && c != '\'')
+}
+
+/// Write `word` in its title-case form and empty it.
+fn flush(word: &mut String, out: &mut String, options: Options) {
+    if word.is_empty() {
+        return;
+    }
+    if options.keep_all_caps && is_all_caps(word) {
+        out.push_str(word);
+    } else {
+        let mut seen_letter = false;
+        for c in word.chars() {
+            match (seen_letter, c.is_alphabetic()) {
+                (false, true) => {
+                    out.extend(c.to_uppercase());
+                    seen_letter = true;
+                }
+                (true, _) => out.extend(c.to_lowercase()),
+                // Before the first letter — digits, a leading mark — nothing to case.
+                (false, false) => out.push(c),
+            }
+        }
+    }
+    word.clear();
+}
+
+/// Whether `word` holds at least one letter and none of them are lowercase.
+///
+/// A script with no case at all (Japanese, digits alone) answers yes for the letters
+/// it has, which costs nothing: the alternative branch would leave it unchanged too.
+fn is_all_caps(word: &str) -> bool {
+    let mut letters = word.chars().filter(|c| c.is_alphabetic()).peekable();
+    letters.peek().is_some() && !letters.any(char::is_lowercase)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts() -> Options {
+        Options::default()
+    }
+
+    fn flattening() -> Options {
+        Options {
+            keep_all_caps: false,
+            ..Options::default()
+        }
+    }
+
+    #[test]
+    fn the_documented_example() {
+        assert_eq!(
+            capitalize("bàn phím tiếng Việt", opts()),
+            "Bàn Phím Tiếng Việt"
+        );
+    }
+
+    #[test]
+    fn an_all_caps_word_is_left_alone_unless_the_switch_is_off() {
+        assert_eq!(capitalize("gửi về TP. HCM", opts()), "Gửi Về TP. HCM");
+        assert_eq!(capitalize("gửi về TP. HCM", flattening()), "Gửi Về Tp. Hcm");
+    }
+
+    #[test]
+    fn the_rest_of_a_word_is_lowercased() {
+        assert_eq!(capitalize("xIN cHÀO", opts()), "Xin Chào");
+        assert_eq!(capitalize("ĐẸP quá", flattening()), "Đẹp Quá");
+    }
+
+    #[test]
+    fn ascii_punctuation_splits_words_and_the_apostrophe_does_not() {
+        assert_eq!(
+            capitalize("bàn-phím tiếng việt", opts()),
+            "Bàn-Phím Tiếng Việt"
+        );
+        assert_eq!(capitalize("e-mail", opts()), "E-Mail");
+        assert_eq!(capitalize("don't", opts()), "Don't");
+        assert_eq!(capitalize("\"xin chào\"", opts()), "\"Xin Chào\"");
+        assert_eq!(capitalize("(xin chào)", opts()), "(Xin Chào)");
+    }
+
+    #[test]
+    fn the_search_is_for_the_first_letter_not_the_first_character() {
+        assert_eq!(capitalize("5g covid19", opts()), "5G Covid19");
+        assert_eq!(capitalize("giá 1.5 triệu", opts()), "Giá 1.5 Triệu");
+    }
+
+    /// The guarantee the ASCII-only separator rule buys: NFD text keeps its words.
+    #[test]
+    fn a_word_is_never_split_inside_a_grapheme_cluster() {
+        assert_eq!(
+            capitalize("tie\u{302}\u{301}ng vie\u{323}\u{302}t", opts()),
+            "Tie\u{302}\u{301}ng Vie\u{323}\u{302}t"
+        );
+    }
+
+    /// Not a bug list: the module doc says why interior capitals cannot survive a
+    /// transform whose job is to lowercase the rest of the word.
+    #[test]
+    fn an_interior_capital_is_lost() {
+        assert_eq!(capitalize("iPhone", opts()), "Iphone");
+    }
+
+    #[test]
+    fn text_with_no_letters_is_left_alone() {
+        for text in ["", "… !? 1.5", "🎉", "こんにちは"] {
+            assert_eq!(capitalize(text, opts()), text);
+        }
+    }
+}

--- a/crates/funput-core/tests/textcase.rs
+++ b/crates/funput-core/tests/textcase.rs
@@ -11,5 +11,7 @@
 //! These use only the public API, which is also how they check that the public API
 //! is enough: a shell has `Transform`, `Options` and `apply`, and nothing else.
 
+#[path = "textcase/cases.rs"]
+mod cases;
 #[path = "textcase/properties.rs"]
 mod properties;

--- a/crates/funput-core/tests/textcase/cases.rs
+++ b/crates/funput-core/tests/textcase/cases.rs
@@ -1,0 +1,85 @@
+//! The examples `docs/features/text-case.md` promises, through the public API.
+//!
+//! Every other test in this feature reaches inside a module. These five are the
+//! contract a reader of the doc is owed, and they are checked the way a shell will
+//! call them: one `apply`, one `Transform`, default `Options`.
+
+use funput_core::textcase::{Options, Transform, apply};
+
+/// One row per line of the table at the top of the design doc.
+const DOCUMENTED: [(Transform, &str, &str); 5] = [
+    (Transform::Upper, "Xin chào Việt Nam", "XIN CHÀO VIỆT NAM"),
+    (Transform::Lower, "Xin Chào Việt Nam", "xin chào việt nam"),
+    (
+        Transform::NoDiacritics,
+        "Tiếng Việt rất đẹp",
+        "Tieng Viet rat dep",
+    ),
+    (
+        Transform::Sentence,
+        "xin chào. hôm nay trời đẹp.",
+        "Xin chào. Hôm nay trời đẹp.",
+    ),
+    (
+        Transform::Title,
+        "bàn phím tiếng Việt",
+        "Bàn Phím Tiếng Việt",
+    ),
+];
+
+#[test]
+fn the_design_doc_examples_hold() {
+    for (transform, input, expected) in DOCUMENTED {
+        assert_eq!(
+            apply(input, transform, Options::default()),
+            expected,
+            "{transform:?} on {input:?}"
+        );
+    }
+}
+
+/// `Tiếng Việt` in the combining spelling, and where each transform takes it. Written
+/// out by hand because core carries no normalizer — that is the point of having it
+/// here: a transform that quietly assumed precomposed input would fail this test and
+/// pass every other one.
+const COMBINING: &str = "Tie\u{302}\u{301}ng Vie\u{323}\u{302}t";
+
+#[test]
+fn the_combining_spelling_is_handled_without_being_normalized_away() {
+    let options = Options::default();
+    assert_eq!(
+        apply(COMBINING, Transform::Upper, options),
+        "TIE\u{302}\u{301}NG VIE\u{323}\u{302}T"
+    );
+    assert_eq!(
+        apply(COMBINING, Transform::Lower, options),
+        "tie\u{302}\u{301}ng vie\u{323}\u{302}t"
+    );
+    // Only bỏ dấu is allowed to collapse the two spellings, because ASCII has one.
+    assert_eq!(
+        apply(COMBINING, Transform::NoDiacritics, options),
+        apply("Tiếng Việt", Transform::NoDiacritics, options)
+    );
+    assert_eq!(
+        apply(COMBINING, Transform::Title, options),
+        "Tie\u{302}\u{301}ng Vie\u{323}\u{302}t"
+    );
+}
+
+/// The window lets a user press one transform and then another, so the interesting
+/// pairs are the ones where the order changes the answer.
+#[test]
+fn transforms_stack() {
+    let options = Options::default();
+    let shouting = "GỬI VỀ TP. HCM";
+
+    // Title case alone protects the all-caps words — that is what it is for — so
+    // flattening first is how a user reaches the other answer.
+    assert_eq!(apply(shouting, Transform::Title, options), shouting);
+    let lowered = apply(shouting, Transform::Lower, options);
+    assert_eq!(apply(&lowered, Transform::Title, options), "Gửi Về Tp. Hcm");
+
+    // Bỏ dấu then UPPERCASE is the filename case, and it must not resurrect a tone.
+    let bare = apply("Tiếng Việt", Transform::NoDiacritics, options);
+    assert_eq!(apply(&bare, Transform::Upper, options), "TIENG VIET");
+}

--- a/crates/funput-core/tests/textcase/properties.rs
+++ b/crates/funput-core/tests/textcase/properties.rs
@@ -7,11 +7,12 @@ use proptest::prelude::*;
 /// Every transform there is. A wildcard is not available here — `Transform` is
 /// exhaustive on purpose — so a new variant makes this array a compile error until
 /// somebody decides which properties it has to satisfy.
-const ALL: [Transform; 4] = [
+const ALL: [Transform; 5] = [
     Transform::Upper,
     Transform::Lower,
     Transform::NoDiacritics,
     Transform::Sentence,
+    Transform::Title,
 ];
 
 /// Vietnamese as it is actually stored: precomposed letters, the stroke, the eight
@@ -71,7 +72,12 @@ proptest! {
     /// sentence boundary — a diff in the output alone would not say which.
     #[test]
     fn the_case_transforms_change_only_case(text in VIETNAMESE) {
-        for transform in [Transform::Upper, Transform::Lower, Transform::Sentence] {
+        for transform in [
+            Transform::Upper,
+            Transform::Lower,
+            Transform::Sentence,
+            Transform::Title,
+        ] {
             let out = apply(&text, transform, Options::default());
             prop_assert_eq!(
                 out.to_lowercase(),

--- a/docs/features/text-case.md
+++ b/docs/features/text-case.md
@@ -2,9 +2,12 @@
 
 ## Trạng thái
 
-**Chưa có code.** Tài liệu này chốt mô hình trước, như [charset.md](charset.md) đã làm,
-và là nơi mọi quyết định thiết kế sống — mỗi phép biến đổi mới cập nhật lại nó trong
-cùng PR.
+**Tầng core đã xong**: `funput_core::textcase` sau cargo feature `textcase`, cả năm
+phép, kèm corpus và property test. Chưa có người dùng nào — `funput-convert`, ba shell
+và `funput case` là các bước tiếp theo.
+
+Tài liệu này chốt mô hình trước khi có code, như [charset.md](charset.md) đã làm, và là
+nơi mọi quyết định thiết kế sống — mỗi thay đổi cập nhật lại nó trong cùng PR.
 
 Phạm vi **V1 đã chốt: một tab trong cửa sổ Chuyển mã**, ba nền tảng desktop, cộng
 `funput case` trong CLI. Không hotkey, không đụng vùng bôi đen, không nghe clipboard. Những thứ đó nằm ở
@@ -111,8 +114,9 @@ Xuống dòng là ranh giới vì đầu vào thật của tính năng này thư
 `.srt`, ghi chú — nơi không ai chấm câu.
 
 Chữ cái đầu có thể không phải chữ cái: `"xin chào"` và `(xin chào)` phải viết hoa
-`x`, không bỏ qua vì gặp dấu nháy. Quy tắc: bỏ qua mọi ký tự không phải chữ cái cho
-tới chữ cái đầu tiên của câu.
+`x`, không bỏ qua vì gặp dấu nháy. Nhưng **chữ số thì chặn**: câu mở đầu bằng số là câu
+đã bắt đầu, nên `3 con mèo` không được thành `3 Con mèo`. Quy tắc: đi qua dấu mở, dừng
+ở chữ cái **hoặc** chữ số đầu tiên, và chỉ chữ cái mới được đổi.
 
 ### Viết Hoa Đầu Mỗi Từ
 
@@ -127,11 +131,26 @@ gửi về TP. HCM        →  Gửi Về TP. HCM        (không phải "Tp. Hcm
 Ngoại lệ ALL-CAPS bật mặc định, tắt được. Từ một chữ cái (`A`) coi như ALL-CAPS —
 vô hại, vì kết quả hai đường như nhau.
 
-Ranh giới từ là khoảng trắng và dấu câu; `bàn-phím` thành `Bàn-Phím`, `e-mail` thành
-`E-Mail`. Đây là quy ước của mọi công cụ cùng loại và người dùng đã quen.
+Ranh giới từ là **khoảng trắng hoặc dấu câu ASCII**; `bàn-phím` thành `Bàn-Phím`,
+`e-mail` thành `E-Mail` — quy ước của mọi công cụ cùng loại. Dấu nháy đơn là ngoại lệ,
+để `don't` không thành `Don'T`.
+
+Giữ tập ranh giới trong ASCII mua được một bảo đảm đáng giá hơn những ca biên nó bỏ
+lỡ: **không bao giờ cắt một từ ở giữa một grapheme cluster**, vì mọi dấu tổ hợp đều
+ngoài ASCII. `Tiếng Việt` viết dạng tổ hợp vẫn là hai từ, trong khi quy tắc "cắt ở mọi
+ký tự không phải chữ cái" sẽ cắt từng nguyên âm khỏi dấu của nó rồi viết hoa mảnh vụn
+phía sau. Giá phải trả: dấu câu ngoài ASCII không có khoảng trắng thì không tách từ
+(`xin…chào` chỉ viết hoa `x`) — thuần thẩm mỹ, và hiếm trong loại văn bản này.
+
+Vì một từ có thể mở đầu bằng thứ không có hoa/thường, phép này tìm **chữ cái đầu tiên
+trong từ**: `"xin` được viết hoa, và `5g` thành `5G`.
 
 Không có danh sách từ nối ("của", "và", "là" vẫn được viết hoa). Tiếng Việt không có
 quy ước title case như tiếng Anh, và đoán sẽ sai nhiều hơn đúng.
+
+**Giới hạn đã biết**, đối xứng với ngoại lệ ALL-CAPS: chữ hoa nằm giữa từ sẽ mất, nên
+`iPhone` thành `Iphone`. Giữ được nó nghĩa là không hạ thường phần còn lại của từ, mà
+đó chính là việc của phép này.
 
 ## Bảng mã cũ là ca biên thật sự
 


### PR DESCRIPTION
**5 of 5** toward `feature/text-case`. Base is #370. With this the core module is whole; nothing has a consumer yet. Draft.

Capitalises the first letter of each word and lowercases the rest, except that a word which is already all-caps is left exactly as it is — `gửi về TP. HCM` → `Gửi Về TP. HCM`, not `Tp. Hcm`. The exception is a switch, on by default, because a document shouting in capitals is the one case where a user does want them flattened; `Options { keep_all_caps: false }` gives `Gửi Về Tp. Hcm`.

No list of little words. Vietnamese has no title-case convention that keeps `của` or `và` lowercase — that is an English rule — so every word is capitalised and nothing guesses.

**The separator rule is where the thought went.** Words split on whitespace or ASCII punctuation, with the apostrophe excepted so `don't` stays `Don't` rather than `Don'T`. Keeping the set inside ASCII buys a guarantee worth more than the edge cases it costs:

> A word can never be split inside a grapheme cluster, because every combining mark is non-ASCII.

The alternative rule — "split on anything that is not a letter or digit" — would cut each vowel of NFD `Tiếng Việt` off from its own tone mark and capitalise the fragment after it, which is a mangling rather than a cosmetic miss. What the ASCII rule costs instead is that unspaced non-ASCII punctuation does not split a word: `xin…chào` capitalises only the `x`. Cosmetic, and rare in the text this is pointed at. `a_word_is_never_split_inside_a_grapheme_cluster` pins the guarantee.

The search inside a word is for the first *letter*, not the first character, so `"xin` gets its `x` and `5g` becomes `5G`.

**Known limitation, and it is the mirror of the all-caps exception:** `iPhone` becomes `Iphone`. Preserving an interior capital means not lowercasing the rest of the word, which is the whole job. Tested, so it stays a decision.

## The golden corpus

The module being complete, the integration suite gains `tests/textcase/cases.rs`:

- **The five examples the design doc promises**, checked through `apply` with default `Options` — the way a shell will call it, and the contract a reader of the doc is owed.
- **The combining spelling of `Tiếng Việt` through every transform**, written out by hand because core carries no normalizer. This is the test that fails if a transform quietly assumes precomposed input while passing everything else. Only bỏ dấu is allowed to collapse the two spellings, because ASCII has one.
- **Stacking**, which the window advertises: title case alone protects `GỬI VỀ TP. HCM`, lowercase-then-title reaches `Gửi Về Tp. Hcm`, and bỏ dấu then UPPERCASE never resurrects a tone.

## Design doc

Catches up with two refinements decided while implementing, both already described above: a digit ends the search for a sentence's first letter (#370), and the word-separator rule here with its guarantee and its limitation. Status section now says the core is done and names what has no consumer yet.

## Review

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo clippy`/`cargo test -p funput-core --features textcase` (126 unit + 9 integration tests), the mobile shape (`-p funput-core -p funput-ffi`, both features off), and `scripts/check-loc.sh` — all green. The module's five files are 32 / 45 / 71 / 88 / 90 budgeted lines against the 150 limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
