### PR TITLE
feat(cli): add funput case

### DIFF
--- a/crates/funput-cli/Cargo.toml
+++ b/crates/funput-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "funput"
 path = "src/main.rs"
 
 [dependencies]
-funput-core = { path = "../funput-core", features = ["charset"] }
+funput-core = { path = "../funput-core", features = ["charset", "textcase"] }
 funput-engine = { path = "../funput-engine" }
 funput-term = { path = "../funput-term" }
 clap = { version = "4.6.1", features = ["derive"] }

--- a/crates/funput-cli/README.en.md
+++ b/crates/funput-cli/README.en.md
@@ -87,6 +87,28 @@ holds; writing it as UTF-8 would produce a file Word cannot read.
 No charset is named in the code here: `--to tcvn3` is matched against `funput_core::charset::ALL`
 by slug, so implementing VISCII is one PR in core and this command picks it up.
 
+## Usage — `funput case`
+
+Change the case of **text that already exists**: UPPERCASE, lowercase, bỏ dấu, sentence case,
+Title Case. The rules are `funput_core::textcase`'s — see `docs/features/text-case.md`.
+
+```bash
+funput case upper vanban.txt                  # one transform, from a file
+funput case title < ghichu.txt                # or from standard input
+funput case lower,title vanban.txt            # stacked, in the order typed
+funput case no-diacritics --keep-d            # `đẹp` → `đep` rather than `dep`
+funput case title --flatten-caps < tt.txt     # `TP. HCM` → `Tp. Hcm`
+```
+
+Stacking takes **one comma-separated token** (`lower,title`) so the file stays the second
+positional argument, as in `funput convert`. Order matters: `lower,title` gives `Gửi Về Tp. Hcm`,
+while `title` alone leaves `TP. HCM` standing — which is what it is for.
+
+A legacy-charset file is **refused rather than mangled**: uppercasing TCVN3 bytes produces a
+document nothing can read, and doing it properly means decode → transform → re-encode, where the
+last step can lose letters. That warning belongs to the converter window, so this command says
+what the file looks like and points at `funput convert`.
+
 ## Platform simulation (`dev/sim.rs` — the heart; pure, tested)
 
 `simulate(method, input) -> Simulation { app_text, steps }` does **exactly** what a platform shell
@@ -117,6 +139,9 @@ src/
 ├── convert/       # `funput convert` — the charset-conversion tool
 │   ├── mod.rs     # args + the flow: read → identify → convert → write
 │   └── report.rs  # --list, --detect, loss warnings (all to stderr)
+├── case/          # `funput case` — changing the case of a document
+│   ├── mod.rs     # the flow: read → refuse legacy → stack transforms → write
+│   └── args.rs    # CaseArgs + TransformArg(→textcase::Transform), two switches
 └── dev/
     ├── mod.rs     # args + dispatch for `funput dev` (run/repl/coverage)
     ├── sim.rs     # simulate() — platform simulation; pure, tested

--- a/crates/funput-cli/README.en.md
+++ b/crates/funput-cli/README.en.md
@@ -111,10 +111,11 @@ src/
 ├── cli.rs         # Cli, Command{Term, Dev}, MethodArg(→InputMethod), CliError/CliResult
 ├── term/
 │   └── mod.rs     # args + handler for `funput term` (wrapper via funput-term + install)
+├── io/            # the two ends every text-transforming command shares
+│   ├── source.rs  # bytes → text + charset (two doors: UTF-8 or byte-oriented)
+│   └── sink.rs    # writes **bytes** to stdout, not text
 ├── convert/       # `funput convert` — the charset-conversion tool
 │   ├── mod.rs     # args + the flow: read → identify → convert → write
-│   ├── source.rs  # bytes → text + charset (two doors: UTF-8 or byte-oriented)
-│   ├── sink.rs    # writes **bytes** to stdout, not text
 │   └── report.rs  # --list, --detect, loss warnings (all to stderr)
 └── dev/
     ├── mod.rs     # args + dispatch for `funput dev` (run/repl/coverage)

--- a/crates/funput-cli/README.md
+++ b/crates/funput-cli/README.md
@@ -85,6 +85,28 @@ Không bảng mã nào bị gọi tên trong code ở đây: `--to tcvn3` đối
 `funput_core::charset::ALL` bằng slug, nên thêm VISCII là một PR trong core và lệnh này hưởng miễn
 phí.
 
+## Dùng — `funput case`
+
+Đổi kiểu chữ của **văn bản đã có**: CHỮ HOA, chữ thường, bỏ dấu, viết hoa đầu câu, Viết Hoa Đầu
+Mỗi Từ. Luật nằm ở `funput_core::textcase`, xem `docs/features/text-case.md`.
+
+```bash
+funput case upper vanban.txt                  # một phép, từ tệp
+funput case title < ghichu.txt                # hoặc từ stdin
+funput case lower,title vanban.txt            # cộng dồn, đúng thứ tự đã gõ
+funput case no-diacritics --keep-d            # `đẹp` → `đep` thay vì `dep`
+funput case title --flatten-caps < tt.txt     # `TP. HCM` → `Tp. Hcm`
+```
+
+Cộng dồn dùng **một token, ngăn bằng dấu phẩy** (`lower,title`), để tên tệp vẫn là tham số vị trí
+thứ hai như `funput convert`. Thứ tự có nghĩa: `lower,title` cho `Gửi Về Tp. Hcm`, còn `title` một
+mình giữ nguyên `TP. HCM` — đó là việc của nó.
+
+Tệp bảng mã cũ bị **từ chối chứ không bị làm hỏng**: viết hoa byte TCVN3 sẽ ra tài liệu không ai
+đọc được, mà làm đúng thì phải giải mã → đổi kiểu chữ → mã hoá lại, và bước cuối có thể mất chữ.
+Đường cảnh báo đó thuộc về cửa sổ Chuyển mã, nên ở đây lệnh nói tệp trông như bảng mã gì rồi chỉ
+sang `funput convert`.
+
 ## Mô phỏng platform (`dev/sim.rs` — trái tim, thuần, có test)
 
 `simulate(method, input) -> Simulation { app_text, steps }` làm **đúng** việc một platform shell làm:
@@ -115,6 +137,9 @@ src/
 ├── convert/       # `funput convert` — công cụ chuyển mã
 │   ├── mod.rs     # args + luồng: đọc → nhận diện → chuyển → ghi
 │   └── report.rs  # --list, --detect, cảnh báo mất mát (đều ra stderr)
+├── case/          # `funput case` — đổi kiểu chữ
+│   ├── mod.rs     # luồng: đọc → chặn bảng mã cũ → cộng dồn các phép → ghi
+│   └── args.rs    # CaseArgs + TransformArg(→textcase::Transform), hai công tắc
 └── dev/
     ├── mod.rs     # args + dispatch `funput dev` (run/repl/coverage)
     ├── sim.rs     # simulate() — mô phỏng platform, thuần, có test

--- a/crates/funput-cli/README.md
+++ b/crates/funput-cli/README.md
@@ -109,10 +109,11 @@ src/
 ├── cli.rs         # Cli, Command{Term, Dev}, MethodArg(→InputMethod), CliError/CliResult
 ├── term/
 │   └── mod.rs     # args + handler `funput term` (wrapper qua funput-term + install)
+├── io/            # hai đầu dùng chung của mọi lệnh biến đổi văn bản
+│   ├── source.rs  # bytes → text + bảng mã (hai cửa: UTF-8 hay theo byte)
+│   └── sink.rs    # ghi **bytes** ra stdout (không phải text)
 ├── convert/       # `funput convert` — công cụ chuyển mã
 │   ├── mod.rs     # args + luồng: đọc → nhận diện → chuyển → ghi
-│   ├── source.rs  # bytes → text + bảng mã (hai cửa: UTF-8 hay theo byte)
-│   ├── sink.rs    # ghi **bytes** ra stdout (không phải text)
 │   └── report.rs  # --list, --detect, cảnh báo mất mát (đều ra stderr)
 └── dev/
     ├── mod.rs     # args + dispatch `funput dev` (run/repl/coverage)

--- a/crates/funput-cli/src/case/args.rs
+++ b/crates/funput-cli/src/case/args.rs
@@ -1,0 +1,85 @@
+//! What `funput case` takes on the command line.
+//!
+//! `TransformArg` lives here rather than in [`crate::cli`], where `MethodArg` is:
+//! that one is up there because more than one command family takes an input method,
+//! and this one belongs to a single command. Either way the clap type stays at the
+//! CLI layer, so `funput-core` need not depend on clap.
+
+use std::path::PathBuf;
+
+use clap::{Args, ValueEnum};
+
+use funput_core::textcase::{Options, Transform};
+
+#[derive(Debug, Args)]
+pub struct CaseArgs {
+    /// Transforms to run, comma-separated and in order: `lower,title`.
+    // The doc comment above is the help text, so the reason for the explicit action
+    // is a plain comment: a `Vec` field derives `Append` with `num_args(1..)`, which
+    // is greedy — it would swallow the file name after it, leaving `[FILE]` an
+    // argument clap can never reach. `Cli::command().debug_assert()` says so out
+    // loud, and `cli.rs` runs it in a test.
+    #[arg(
+        value_enum,
+        required = true,
+        value_delimiter = ',',
+        num_args = 1,
+        action = clap::ArgAction::Set
+    )]
+    pub transforms: Vec<TransformArg>,
+
+    /// File to transform. Reads standard input when omitted.
+    pub file: Option<PathBuf>,
+
+    /// Keep đ and Đ instead of writing d and D (affects `no-diacritics`).
+    #[arg(long)]
+    pub keep_d: bool,
+
+    /// Also lowercase words that are already all-caps — `TP. HCM` becomes `Tp. Hcm`
+    /// (affects `title`).
+    #[arg(long)]
+    pub flatten_caps: bool,
+}
+
+impl CaseArgs {
+    /// The switches, as core takes them.
+    ///
+    /// Neither switch conflicts with a transform that does not read it. Several
+    /// transforms can run in one command, so `--keep-d` beside `lower,no-diacritics`
+    /// is a sensible thing to type, and refusing it would be a rule the user has to
+    /// learn for nothing.
+    pub(super) fn options(&self) -> Options {
+        Options {
+            d_to_ascii: !self.keep_d,
+            keep_all_caps: !self.flatten_caps,
+        }
+    }
+}
+
+/// The five transforms, as words on the command line. clap spells the variants in
+/// kebab-case, so this is `upper`, `lower`, `no-diacritics`, `sentence`, `title`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum TransformArg {
+    /// UPPERCASE.
+    Upper,
+    /// lowercase.
+    Lower,
+    /// Bỏ dấu tiếng Việt.
+    NoDiacritics,
+    /// Capitalise the first letter of each sentence.
+    Sentence,
+    /// Capitalise The First Letter Of Each Word.
+    Title,
+}
+
+impl From<TransformArg> for Transform {
+    fn from(arg: TransformArg) -> Self {
+        match arg {
+            TransformArg::Upper => Transform::Upper,
+            TransformArg::Lower => Transform::Lower,
+            TransformArg::NoDiacritics => Transform::NoDiacritics,
+            TransformArg::Sentence => Transform::Sentence,
+            TransformArg::Title => Transform::Title,
+        }
+    }
+}

--- a/crates/funput-cli/src/case/mod.rs
+++ b/crates/funput-cli/src/case/mod.rs
@@ -1,0 +1,76 @@
+//! `funput case`: changing the case of a document (chuyển đổi kiểu chữ).
+//!
+//! Five transforms over text that already exists — UPPERCASE, lowercase, bỏ dấu,
+//! sentence case, title case — as a filter: a file or standard input goes in, the
+//! transformed text comes out, and everything else goes to standard error. The
+//! rules are `funput_core::textcase`'s; see `docs/features/text-case.md`.
+//!
+//! **Transforms stack, in the order they are typed.** `lower,title` is how a user
+//! reaches `Gửi Về Tp. Hcm` from `GỬI VỀ TP. HCM`, because title case on its own
+//! protects words that are already all-caps — that is what it is for. The same
+//! stacking is what the converter window offers with two button presses.
+//!
+//! **Legacy charsets are refused rather than mangled.** A `.VnTime` document is not
+//! Unicode text: it is code points `U+0020..=U+00FF` standing in for TCVN3 bytes,
+//! and uppercasing those would produce a document nothing can read. Doing it
+//! properly means decoding, transforming and re-encoding — and re-encoding can lose
+//! letters, because TCVN3 has no room for uppercase toned vowels. That warning
+//! belongs to a window with somewhere to show it, not to a command whose standard
+//! output is the document. So this says what the file looks like and points at
+//! `funput convert`.
+
+mod args;
+
+use std::process::ExitCode;
+
+use funput_core::charset::{self, Charset, document::Document};
+use funput_core::textcase::apply;
+
+use crate::cli::{CliError, CliResult};
+use crate::io::{read, write};
+
+pub use args::CaseArgs;
+
+/// Run `funput case`.
+pub fn run(args: CaseArgs) -> CliResult {
+    let text = readable(read(args.file.as_deref())?)?;
+    let options = args.options();
+    let transformed = args
+        .transforms
+        .iter()
+        .fold(text, |text, &arg| apply(&text, arg.into(), options));
+    write(transformed.as_bytes())?;
+    Ok(ExitCode::SUCCESS)
+}
+
+/// The text of a document this command is willing to touch.
+///
+/// The charset is asked about rather than assumed: `read` already worked it out, so
+/// refusing costs one question and saves a user from a file full of mojibake.
+fn readable(document: Document) -> Result<String, CliError> {
+    match document.charset {
+        Some(charset) if charset::is_byte_oriented(charset) => Err(CliError::Msg(legacy(charset))),
+        Some(_) => Ok(document.text),
+        None => Err(CliError::Msg(UNREADABLE.to_string())),
+    }
+}
+
+/// What to say when the bytes are not text at all.
+const UNREADABLE: &str =
+    "cannot read this as text: not UTF-8, and no charset explains the bytes either";
+
+/// What to say about a document that is text, but not Unicode.
+///
+/// Names the charset it looks like, because the next command needs it — and the
+/// user may disagree with the guess, which `funput convert --from` lets them say.
+fn legacy(charset: Charset) -> String {
+    format!(
+        "this looks like {} ({}), not Unicode — convert it first:\n  \
+         funput convert <file> --to unicode | funput case …",
+        charset.name(),
+        charset.slug()
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/funput-cli/src/case/tests.rs
+++ b/crates/funput-cli/src/case/tests.rs
@@ -1,0 +1,117 @@
+use funput_core::charset::document;
+use funput_core::textcase::Options;
+
+use super::args::TransformArg;
+use super::*;
+
+/// Everything `run` does between reading and writing, with the I/O left out — the
+/// same shape as `convert`'s tests, and for the same reason: the interesting part is
+/// the decision, not the file handle.
+fn pipeline(
+    bytes: &[u8],
+    transforms: &[TransformArg],
+    options: Options,
+) -> Result<String, CliError> {
+    let document = document::read(bytes.to_vec()).expect("well-formed fixture");
+    let text = readable(document)?;
+    Ok(transforms
+        .iter()
+        .fold(text, |text, &arg| apply(&text, arg.into(), options)))
+}
+
+fn run_one(bytes: &[u8], transform: TransformArg) -> String {
+    pipeline(bytes, &[transform], Options::default()).expect("fixture is Unicode")
+}
+
+#[test]
+fn one_transform_end_to_end() {
+    assert_eq!(
+        run_one("Tiếng Việt rất đẹp".as_bytes(), TransformArg::NoDiacritics),
+        "Tieng Viet rat dep"
+    );
+    assert_eq!(
+        run_one("bàn phím tiếng Việt".as_bytes(), TransformArg::Title),
+        "Bàn Phím Tiếng Việt"
+    );
+}
+
+/// The reason stacking is offered at all, and the reason the order is the typed one.
+#[test]
+fn transforms_stack_in_the_order_given() {
+    let shouting = "GỬI VỀ TP. HCM".as_bytes();
+    let options = Options::default();
+
+    let lower_then_title = [TransformArg::Lower, TransformArg::Title];
+    assert_eq!(
+        pipeline(shouting, &lower_then_title, options).unwrap(),
+        "Gửi Về Tp. Hcm"
+    );
+
+    let title_then_lower = [TransformArg::Title, TransformArg::Lower];
+    assert_eq!(
+        pipeline(shouting, &title_then_lower, options).unwrap(),
+        "gửi về tp. hcm"
+    );
+}
+
+#[test]
+fn keep_d_leaves_the_stroke_alone() {
+    let options = Options {
+        d_to_ascii: false,
+        ..Options::default()
+    };
+    let kept = pipeline("đẹp".as_bytes(), &[TransformArg::NoDiacritics], options).unwrap();
+    assert_eq!(kept, "đep");
+}
+
+#[test]
+fn flatten_caps_stops_title_case_protecting_a_shout() {
+    let options = Options {
+        keep_all_caps: false,
+        ..Options::default()
+    };
+    let flattened = pipeline("gửi về TP. HCM".as_bytes(), &[TransformArg::Title], options).unwrap();
+    assert_eq!(flattened, "Gửi Về Tp. Hcm");
+}
+
+/// A `.VnTime` document — the fixture `convert`'s tests use, which converts cleanly
+/// there and must be refused here.
+#[test]
+fn a_legacy_document_is_refused_by_name() {
+    let err = pipeline(
+        b"vi\xD6t nam h\xB5 n\xE9i",
+        &[TransformArg::Upper],
+        Options::default(),
+    )
+    .expect_err("TCVN3 is not Unicode");
+    let CliError::Msg(message) = err else {
+        panic!("expected a message, not an io error");
+    };
+    assert!(message.contains("tcvn3"), "{message}");
+    assert!(message.contains("funput convert"), "{message}");
+}
+
+#[test]
+fn bytes_that_are_not_text_are_refused_rather_than_guessed_at() {
+    let err = pipeline(
+        &[0xFF, 0x00, 0xFE],
+        &[TransformArg::Upper],
+        Options::default(),
+    )
+    .expect_err("not text");
+    assert!(matches!(err, CliError::Msg(_)));
+}
+
+/// Reading goes through `charset::document`, so a byte-order mark and UTF-16 are
+/// already handled. Pinned here so nobody simplifies it into `String::from_utf8`.
+#[test]
+fn a_utf16_file_with_a_mark_is_read_not_refused() {
+    let mut bytes = vec![0xFF, 0xFE];
+    for unit in "Tiếng Việt".encode_utf16() {
+        bytes.extend_from_slice(&unit.to_le_bytes());
+    }
+    assert_eq!(
+        pipeline(&bytes, &[TransformArg::NoDiacritics], Options::default()).unwrap(),
+        "Tieng Viet"
+    );
+}

--- a/crates/funput-cli/src/cli.rs
+++ b/crates/funput-cli/src/cli.rs
@@ -11,6 +11,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 use funput_core::InputMethod;
 
+use crate::case::CaseArgs;
 use crate::convert::ConvertArgs;
 use crate::dev::DevArgs;
 use crate::term::TermArgs;
@@ -34,6 +35,8 @@ pub enum Command {
     Dev(DevArgs),
     /// Convert Vietnamese text between Unicode and the legacy charsets.
     Convert(ConvertArgs),
+    /// Change the case of Vietnamese text, or strip its diacritics.
+    Case(CaseArgs),
 }
 
 /// Input method as selected on the command line. Kept at the CLI layer (a clap
@@ -78,5 +81,43 @@ impl std::error::Error for CliError {}
 impl From<std::io::Error> for CliError {
     fn from(e: std::io::Error) -> Self {
         CliError::Io(e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+
+    use super::*;
+
+    /// clap's own audit of the argument tree: conflicting ids, impossible
+    /// `num_args`, a positional that can never be reached. Cheap, and it is what
+    /// catches a greedy positional swallowing the argument after it — `funput case`
+    /// takes its transforms as one comma-separated value for exactly that reason.
+    #[test]
+    fn the_argument_tree_is_well_formed() {
+        Cli::command().debug_assert();
+    }
+
+    /// The shape the README promises: transforms first, then the file.
+    #[test]
+    fn case_takes_stacked_transforms_and_still_sees_the_file() {
+        let cli = Cli::try_parse_from(["funput", "case", "lower,title", "vanban.txt"])
+            .expect("valid invocation");
+        let Command::Case(args) = cli.command else {
+            panic!("expected the case command");
+        };
+        assert_eq!(args.transforms.len(), 2);
+        assert_eq!(
+            args.file.as_deref(),
+            Some(std::path::Path::new("vanban.txt"))
+        );
+    }
+
+    /// A transform is required: `funput case vanban.txt` would otherwise read the
+    /// file name as a transform and fail with a worse message.
+    #[test]
+    fn case_without_a_transform_is_rejected() {
+        assert!(Cli::try_parse_from(["funput", "case"]).is_err());
     }
 }

--- a/crates/funput-cli/src/convert/mod.rs
+++ b/crates/funput-cli/src/convert/mod.rs
@@ -5,10 +5,8 @@
 //! text that already exists; typing in a legacy charset is not offered and is not
 //! planned — see `docs/features/charset.md`.
 //!
-//! - [`source`] — turning an argument or standard input into text, and working out
-//!   what charset spelled it.
-//! - [`sink`] — writing the result back out, as bytes when the target is a legacy
-//!   charset and as UTF-8 when it is not.
+//! - [`crate::io`] — turning an argument or standard input into text and writing the
+//!   result back out, shared with `funput case`.
 //! - [`report`] — everything printed to standard error: the charset table, the
 //!   detected name, and the warning when something could not be represented.
 //!
@@ -17,8 +15,6 @@
 //! there and this command picks it up.
 
 mod report;
-mod sink;
-mod source;
 
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -28,6 +24,7 @@ use clap::Args;
 use funput_core::charset::{self, Charset};
 
 use crate::cli::{CliError, CliResult};
+use crate::io::{read, write};
 
 #[derive(Debug, Args)]
 pub struct ConvertArgs {
@@ -63,7 +60,7 @@ pub fn run(args: ConvertArgs) -> CliResult {
     let to = args.to.as_deref().map(by_slug).transpose()?;
     let declared = args.from.as_deref().map(by_slug).transpose()?;
 
-    let input = source::read(args.file.as_deref())?;
+    let input = read(args.file.as_deref())?;
     // A charset the user named beats one that was worked out: they are looking at
     // the document, and the detector is looking at statistics.
     let Some(from) = declared.or(input.charset) else {
@@ -82,7 +79,7 @@ pub fn run(args: ConvertArgs) -> CliResult {
     // The same two calls the converter windows make, so a document converted here
     // and a document converted there cannot come out differently.
     let rendered = charset::render(&charset::read(&input.text, from), to);
-    sink::write(&rendered.bytes)?;
+    write(&rendered.bytes)?;
     report::losses(&rendered.cost);
     Ok(ExitCode::SUCCESS)
 }

--- a/crates/funput-cli/src/io/mod.rs
+++ b/crates/funput-cli/src/io/mod.rs
@@ -1,0 +1,14 @@
+//! The two ends of a command that transforms a document: getting the bytes in, and
+//! writing the bytes out.
+//!
+//! Shared rather than owned by one command, because `funput convert` and
+//! `funput case` need the same two things and would otherwise answer the same
+//! questions twice — what a byte-order mark means, whether a closed pipe is a
+//! failure. Reaching into another command's module for them would say that one
+//! command owns the other's plumbing, which is not true of either.
+
+mod sink;
+mod source;
+
+pub(crate) use sink::write;
+pub(crate) use source::read;

--- a/crates/funput-cli/src/io/sink.rs
+++ b/crates/funput-cli/src/io/sink.rs
@@ -13,7 +13,7 @@ use crate::cli::CliError;
 ///
 /// A closed pipe is not an error. `funput convert … | head` closes the pipe as soon
 /// as it has enough, and reporting that as a failure would make the exit code lie.
-pub(super) fn write(bytes: &[u8]) -> Result<(), CliError> {
+pub(crate) fn write(bytes: &[u8]) -> Result<(), CliError> {
     let mut out = std::io::stdout().lock();
     match out.write_all(bytes).and_then(|()| out.flush()) {
         Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),

--- a/crates/funput-cli/src/io/source.rs
+++ b/crates/funput-cli/src/io/source.rs
@@ -13,7 +13,7 @@ use funput_core::charset::document::{self, Document};
 use crate::cli::CliError;
 
 /// Read `path`, or standard input when it is `None`, and say what it holds.
-pub(super) fn read(path: Option<&Path>) -> Result<Document, CliError> {
+pub(crate) fn read(path: Option<&Path>) -> Result<Document, CliError> {
     let bytes = match path {
         Some(path) => std::fs::read(path)
             .map_err(|e| CliError::Msg(format!("cannot read {}: {e}", path.display())))?,

--- a/crates/funput-cli/src/main.rs
+++ b/crates/funput-cli/src/main.rs
@@ -12,6 +12,7 @@
 mod cli;
 mod convert;
 mod dev;
+mod io;
 mod term;
 
 use std::process::ExitCode;

--- a/crates/funput-cli/src/main.rs
+++ b/crates/funput-cli/src/main.rs
@@ -8,7 +8,9 @@
 //!   platform shell would show, for quick checks, debugging, and CI.
 //! - `funput convert …` — turn a document between Unicode and the legacy charsets
 //!   Vietnamese government paperwork still arrives in (TCVN3, VNI-Windows).
+//! - `funput case …` — change the case of a document, or take its diacritics off.
 
+mod case;
 mod cli;
 mod convert;
 mod dev;
@@ -26,6 +28,7 @@ fn main() -> ExitCode {
         Command::Term(args) => term::run(args),
         Command::Dev(args) => dev::run(args),
         Command::Convert(args) => convert::run(args),
+        Command::Case(args) => case::run(args),
     };
     match result {
         Ok(code) => code,

--- a/docs/features/text-case.md
+++ b/docs/features/text-case.md
@@ -3,8 +3,8 @@
 ## Trạng thái
 
 **Tầng core đã xong**: `funput_core::textcase` sau cargo feature `textcase`, cả năm
-phép, kèm corpus và property test. Chưa có người dùng nào — `funput-convert`, ba shell
-và `funput case` là các bước tiếp theo.
+phép, kèm corpus và property test, và **`funput case`** trong CLI đã gọi tới nó. Còn
+lại: `funput-convert` và ba cửa sổ.
 
 Tài liệu này chốt mô hình trước khi có code, như [charset.md](charset.md) đã làm, và là
 nơi mọi quyết định thiết kế sống — mỗi thay đổi cập nhật lại nó trong cùng PR.


### PR DESCRIPTION
Chặng 1 of 4 toward the feature having a user at all. Base is #371, because the five `Transform` variants only all exist there. Draft.

`funput_core::textcase` has been complete since #371 and **nothing calls it**. This is the cheapest caller: no FFI, no UI, and part of V1 in `docs/features/text-case.md`. It also changes what CI covers — `funput-cli` turns on the `textcase` feature, so from here the workspace steps compile the module. The `-p funput-core --features textcase` step added in #367 keeps its other job: guarding the textcase-on charset-off shape a keyboard would ask for.

```bash
funput case upper vanban.txt            # one transform, from a file
funput case title < ghichu.txt          # or from standard input
funput case lower,title vanban.txt      # stacked, in the order typed
funput case no-diacritics --keep-d      # đẹp → đep rather than dep
funput case title --flatten-caps        # TP. HCM → Tp. Hcm
```

## Two commits

**`refactor(cli): move source and sink out of convert`** — `case` needs the same two ends as `convert`: bytes in with the byte-order marks and the charset question already answered, bytes out with a closed pipe not counted as a failure. Reaching into another command's module for them would say one command owns the other's plumbing. The two files move to `src/io/` unedited apart from `pub(super)` → `pub(crate)`; `convert`'s tests are untouched and still pass, which is the evidence.

**`feat(cli): add funput case`** — the command.

## The greedy-positional trap, and how it was caught

`funput case lower title vanban.txt` cannot be parsed: a `Vec` positional derives `Append` with `num_args(1..)`, so it swallows the file name and `[FILE]` becomes an argument clap can never reach. The fix is one comma-separated token (`value_delimiter = ','`, `num_args = 1`, and an explicit `action = Set` — without the action the derive re-imposes `num_args(1..)` and the arg tree is still invalid).

What is worth noting is that **this was found by a test, not by hand**: `Cli::command().debug_assert()` now runs in `cli.rs`, and it failed on the first attempt with the exact diagnosis. Two parse tests sit beside it pinning the shape the README promises.

## Refusing legacy charsets

A `.VnTime` document is not Unicode text — it is code points `U+0020..=U+00FF` standing in for TCVN3 bytes, and uppercasing those produces a file nothing can read. Doing it properly means decode → transform → re-encode, and re-encoding can lose letters, because TCVN3 has no room for uppercase toned vowels. That warning needs somewhere to be shown, and this command's standard output is the document, so the window keeps that job:

```
$ printf 'vi\xD6t nam' | funput case upper
this looks like TCVN3 (ABC) (tcvn3), not Unicode — convert it first:
  funput convert <file> --to unicode | funput case …
$ echo $?
1
```

The check is `charset::is_byte_oriented`, not a hand-written `Tcvn3 | VniWindows` match: `Charset` is `#[non_exhaustive]`, so a match outside core needs a wildcard arm and a third byte-oriented charset would slip through as though it were Unicode. Bytes that are not text at all are refused too, rather than guessed at.

## Tests

`case/tests.rs` follows `convert/tests.rs`: one `pipeline` function doing what `run` does between reading and writing, with the I/O left out.

- One transform end to end, and **stacking order**: `lower,title` on `GỬI VỀ TP. HCM` gives `Gửi Về Tp. Hcm` while `title,lower` gives all lowercase — the order is not decoration.
- Both switches.
- The legacy refusal, using the same `.VnTime` fixture `convert`'s tests convert cleanly — it must name `tcvn3` and point at `funput convert`.
- A UTF-16 file with a byte-order mark is read, not refused. Pinned so nobody simplifies `charset::document::read` into `String::from_utf8`.

## Review

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo clippy -p funput-core -p funput-ffi` (the mobile shape), `cargo test -p funput-core --features textcase`, and `scripts/check-loc.sh` — all green. `case/mod.rs` is 74 budgeted lines and `case/args.rs` 85, against the 150 limit.

Run for real, including the four examples in the design doc plus the refusal and a missing file; `funput case --help` lists the five transforms with their own one-line descriptions, and the parser rationale is a plain comment so it stays out of that help text.

Both crate READMEs (VI and EN) gain a `funput case` section and the new module tree; `docs/features/text-case.md` now says the CLI is done and `funput-convert` plus the three windows are what is left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
