### PR TITLE
refactor(convert): split the row builder out of the view

### DIFF
--- a/crates/funput-convert/src/session.rs
+++ b/crates/funput-convert/src/session.rs
@@ -25,7 +25,7 @@ mod query;
 mod view;
 
 use crate::batch::Entry;
-use crate::{at, clamp, index_of};
+use crate::{at, clamp};
 
 pub use job::Job;
 pub use view::{Mode, Row, Unreadable, View};

--- a/crates/funput-convert/src/session/view.rs
+++ b/crates/funput-convert/src/session/view.rs
@@ -12,7 +12,11 @@ use funput_core::charset;
 use crate::batch;
 use crate::text;
 
-use super::{Session, at, index_of};
+use super::{Session, at};
+
+mod rows;
+
+pub use rows::Row;
 
 /// Which of the three shapes the window is in.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -27,17 +31,6 @@ pub enum Mode {
     /// Two or more files: a table, because the interesting thing is that the rows
     /// differ.
     Files,
-}
-
-/// One file's row in the batch table.
-#[non_exhaustive]
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct Row {
-    pub name: String,
-    /// Index into `charset::ALL`, or `None` when nothing explained the file.
-    pub charset: Option<usize>,
-    /// "N chữ sẽ mất", or empty.
-    pub note: String,
 }
 
 /// A file that could not be read, and why.
@@ -104,41 +97,11 @@ pub(super) fn build(session: &Session) -> View {
             (Some(r), Some((_, from, _))) => text::warning(&r.cost, from, target),
             _ => String::new(),
         },
-        rows: rows(session, target),
+        rows: rows::rows(session, target),
         rows_first: session.window.0,
         rows_total: session.files.len(),
         out_dir: batch::out_dir_label(&session.files),
         ready: batch::ready(&session.files),
         unreadable: session.unreadable.clone(),
     }
-}
-
-/// Rows for the window only — but every count above runs over the whole batch, so a
-/// capped list stays honest. Rebuilding two thousand of them on every target change
-/// is what the window exists to avoid.
-fn rows(session: &Session, target: charset::Charset) -> Vec<Row> {
-    let (first, len) = session.window;
-    session
-        .files
-        .iter()
-        .skip(first)
-        .take(len)
-        .map(|entry| Row {
-            name: entry.name(),
-            charset: entry.charset.and_then(index_of),
-            note: match entry.charset {
-                Some(from) => {
-                    let lost = charset::render(&charset::read(&entry.text, from), target)
-                        .cost
-                        .unrepresentable;
-                    if lost > 0 {
-                        format!("{lost} chữ sẽ mất")
-                    } else {
-                        String::new()
-                    }
-                }
-                None => String::new(),
-            },
-        })
-        .collect()
 }

--- a/crates/funput-convert/src/session/view/rows.rs
+++ b/crates/funput-convert/src/session/view/rows.rs
@@ -1,0 +1,55 @@
+//! One row per file, and what it will cost.
+//!
+//! Split out of [`super`] rather than sitting beside it because the two answer
+//! different questions: the view is what the window shows *about the document*, and
+//! this is what it shows *about each file in a batch*. They also grow for different
+//! reasons — a new field on the view, a new column here — and this crate's files run
+//! close enough to the line budget that sharing one would make the next addition a
+//! refactor instead of an addition.
+
+use funput_core::charset;
+
+use crate::index_of;
+
+use super::Session;
+
+/// One file's row in the batch table.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Row {
+    pub name: String,
+    /// Index into `charset::ALL`, or `None` when nothing explained the file.
+    pub charset: Option<usize>,
+    /// "N chữ sẽ mất", or empty.
+    pub note: String,
+}
+
+/// Rows for the window only — but every count above runs over the whole batch, so a
+/// capped list stays honest. Rebuilding two thousand of them on every target change
+/// is what the window exists to avoid.
+pub(super) fn rows(session: &Session, target: charset::Charset) -> Vec<Row> {
+    let (first, len) = session.window;
+    session
+        .files
+        .iter()
+        .skip(first)
+        .take(len)
+        .map(|entry| Row {
+            name: entry.name(),
+            charset: entry.charset.and_then(index_of),
+            note: match entry.charset {
+                Some(from) => {
+                    let lost = charset::render(&charset::read(&entry.text, from), target)
+                        .cost
+                        .unrepresentable;
+                    if lost > 0 {
+                        format!("{lost} chữ sẽ mất")
+                    } else {
+                        String::new()
+                    }
+                }
+                None => String::new(),
+            },
+        })
+        .collect()
+}


### PR DESCRIPTION
Chặng 2 of 4, part 1 of 2. Groundwork only — the casing axis itself is the next PR, which bases on this one. Draft.

`funput-convert` runs close to the line budget nearly everywhere: `batch.rs` is at **149** of 150, `session/view.rs` was at **144**. Nothing can be added to the view until something leaves it, so this PR is the split on its own, with no feature in it to argue about at the same time.

The two halves answer different questions anyway. The view is what the window shows *about the document* — which mode it is in, the panes, the warning. The rows are what it shows *about each file in a batch*. They also grow for different reasons: a field on the view, a column here.

`Row` and its builder move to `session/view/rows.rs` — the `foo.rs` + `foo/` shape `funput-core` already uses (`unicode/vowels.rs` + `vowels/table.rs`). `view.rs` keeps `pub use rows::Row`, so `lib.rs` and all three shells see no difference at all.

| File | Budgeted lines |
| --- | --- |
| `session/view.rs` | 144 → **107** |
| `session/view/rows.rs` | — → **55** |

`session.rs` also drops `index_of` from its imports: it was there so `view.rs` could reach it through `super`, and `rows.rs` now names `crate::index_of` directly.

## Review

No behaviour change, and the evidence is that `session/tests.rs` is untouched and still passes — the 28 tests in `funput-convert` plus the 6 in its `c_host` suite.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `scripts/check-loc.sh` are all green.

Nothing outside the workspace is affected: the Slint and GTK windows read `View` fields and `Row` by name, and both names resolve exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
