### PR TITLE
feat(convert): add the casing axis

### DIFF
--- a/crates/funput-convert/Cargo.toml
+++ b/crates/funput-convert/Cargo.toml
@@ -13,4 +13,4 @@ workspace = true
 # Every decision here is expressed in `Charset` terms, and the charset names the
 # warnings quote come from `Charset::name()` — the one place they are written, so
 # a menu on Windows and a menu on Linux cannot drift apart.
-funput-core = { path = "../funput-core", features = ["charset"] }
+funput-core = { path = "../funput-core", features = ["charset", "textcase"] }

--- a/crates/funput-convert/src/batch/write.rs
+++ b/crates/funput-convert/src/batch/write.rs
@@ -8,7 +8,9 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use funput_core::charset::{Charset, read, render};
+use funput_core::charset::Charset;
+
+use crate::casing::{self, Casing};
 
 use super::Entry;
 
@@ -31,7 +33,7 @@ pub struct Outcome {
 ///
 /// A file with no charset is *skipped*, not guessed at — the row is still on screen
 /// with its own picker, and the user can settle it and run again.
-pub fn write_all(entries: &[Entry], target: Charset) -> Outcome {
+pub fn write_all(entries: &[Entry], casing: &Casing, target: Charset) -> Outcome {
     let mut outcome = Outcome {
         written: 0,
         skipped: 0,
@@ -48,11 +50,9 @@ pub fn write_all(entries: &[Entry], target: Charset) -> Outcome {
             outcome.skipped += 1;
             continue;
         };
-        // The same two steps every consumer takes, and the same call: read the
-        // document, then render it. `render` is what makes a legacy target one byte
-        // per letter rather than two — and what makes these bytes the ones the
-        // window promised in its preview pane.
-        let bytes = render(&read(&entry.text, from), target).bytes;
+        // The same call every consumer takes, which is what makes these bytes the
+        // ones the window promised in its preview pane — charset and case both.
+        let bytes = casing::render(&entry.text, from, casing, target).bytes;
         match destination(&entry.path, &mut taken)
             .and_then(|path| std::fs::write(path, &bytes).ok())
         {
@@ -142,7 +142,7 @@ mod tests {
     fn the_original_is_left_exactly_as_it_was() {
         let dir = scratch("keeps-original");
         let entries = [entry(&dir, "vanban.txt", "Việt", Some(Charset::Unicode))];
-        let outcome = write_all(&entries, Charset::Tcvn3);
+        let outcome = write_all(&entries, &Casing::default(), Charset::Tcvn3);
 
         assert_eq!(outcome.written, 1);
         assert_eq!(
@@ -161,8 +161,8 @@ mod tests {
     fn a_second_run_does_not_overwrite_the_first() {
         let dir = scratch("second-run");
         let entries = [entry(&dir, "vanban.txt", "Việt", Some(Charset::Unicode))];
-        write_all(&entries, Charset::Tcvn3);
-        write_all(&entries, Charset::VniWindows);
+        write_all(&entries, &Casing::default(), Charset::Tcvn3);
+        write_all(&entries, &Casing::default(), Charset::VniWindows);
 
         let out = dir.join(OUT_DIR);
         assert_eq!(std::fs::read(out.join("vanban.txt")).unwrap(), b"Vi\xD6t");
@@ -201,7 +201,7 @@ mod tests {
             entry(&dir, "known.txt", "Việt", Some(Charset::Unicode)),
             entry(&dir, "mystery.txt", "????", None),
         ];
-        let outcome = write_all(&entries, Charset::Tcvn3);
+        let outcome = write_all(&entries, &Casing::default(), Charset::Tcvn3);
 
         assert_eq!((outcome.written, outcome.skipped), (1, 1));
         assert!(!dir.join(OUT_DIR).join("mystery.txt").exists());

--- a/crates/funput-convert/src/casing.rs
+++ b/crates/funput-convert/src/casing.rs
@@ -1,0 +1,201 @@
+//! The second axis: what the window does to a document besides re-spelling it.
+//!
+//! Changing a charset and changing the case are two independent choices about one
+//! document, and a window offers both at once. Keeping them in one pipeline is what
+//! makes them agree — see [`render`], which is the only place either happens.
+//!
+//! The transforms themselves are `funput_core::textcase`'s. What is here is what a
+//! *window* needs on top of them: an order to show them in, a name for each, and a
+//! record of which ones the user has pressed so far.
+//!
+//! **Why the names are here rather than in core.** They are interface text, in the
+//! same language as the loss warning and the `N chữ sẽ mất` note next door. Core
+//! spells `Charset::name` because a charset's name is its name in any language; a
+//! button's label is not that. `funput case` never needs one — clap writes English
+//! help — so core would carry Vietnamese for a single caller.
+
+use funput_core::charset::{self, Charset, Rendered};
+use funput_core::textcase::{Options, Transform, apply};
+
+/// The five transforms, in the order a window offers them.
+///
+/// Ordered like `charset::ALL` and used the same way: a shell builds its menu from
+/// this and hands back a position. Append-only, for the same reason — a stored
+/// index has to keep meaning the same thing across releases.
+pub const ALL: [Transform; 5] = [
+    Transform::Upper,
+    Transform::Lower,
+    Transform::NoDiacritics,
+    Transform::Sentence,
+    Transform::Title,
+];
+
+/// What to call each transform, in the language of the window.
+///
+/// `Transform` is exhaustive on purpose, so a sixth one makes this a compile error
+/// rather than a button with no label.
+pub fn name(transform: Transform) -> &'static str {
+    match transform {
+        Transform::Upper => "CHỮ HOA",
+        Transform::Lower => "chữ thường",
+        Transform::NoDiacritics => "Bỏ dấu tiếng Việt",
+        Transform::Sentence => "Viết hoa đầu câu",
+        Transform::Title => "Viết Hoa Đầu Mỗi Từ",
+    }
+}
+
+/// The transform a menu position names, clamped — the rule [`crate::at`] follows for
+/// charsets, and for the same reason: an index can only come from a menu built out
+/// of [`ALL`], so clamping keeps a future mistake a wrong entry rather than a panic.
+pub fn at(index: usize) -> Transform {
+    ALL[index.min(ALL.len() - 1)]
+}
+
+/// A menu position that exists.
+pub fn index_of(transform: Transform) -> Option<usize> {
+    ALL.iter().position(|&t| t == transform)
+}
+
+/// The transforms a document is under, in the order they were pressed.
+///
+/// **A list rather than an edited document.** The window lets a user press one
+/// transform after another, and undo the last one; replaying a list from the
+/// original text is what makes that possible without ever writing back into the
+/// paragraph the user pasted — which would send their caret home, and which GTK
+/// reads as a fresh paste that forgets the charset it had detected.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Casing {
+    transforms: Vec<Transform>,
+    options: Options,
+}
+
+impl Casing {
+    /// Press a transform.
+    ///
+    /// Pressing the one already on top does nothing: every transform is idempotent
+    /// — core has a property test saying so — so a second press cannot change the
+    /// document, and letting it grow the list would only make undo feel broken.
+    pub fn push(&mut self, transform: Transform) {
+        if self.transforms.last() != Some(&transform) {
+            self.transforms.push(transform);
+        }
+    }
+
+    /// Undo the last transform. Does nothing when there is none.
+    pub fn undo(&mut self) {
+        self.transforms.pop();
+    }
+
+    /// Back to the document as it arrived.
+    pub fn clear(&mut self) {
+        self.transforms.clear();
+    }
+
+    pub fn options(&self) -> Options {
+        self.options
+    }
+
+    pub fn set_options(&mut self, options: Options) {
+        self.options = options;
+    }
+
+    /// The list as menu positions, for a shell to show what is applied.
+    pub(crate) fn indices(&self) -> Vec<usize> {
+        self.transforms
+            .iter()
+            .copied()
+            .filter_map(index_of)
+            .collect()
+    }
+
+    fn run(&self, text: &str) -> String {
+        self.transforms
+            .iter()
+            .fold(text.to_string(), |text, &transform| {
+                apply(&text, transform, self.options)
+            })
+    }
+}
+
+/// Read a document, change its case, and write it out as `to` spells it.
+///
+/// **The only place a conversion happens in this crate.** Four callers need the same
+/// answer — the preview pane, the clipboard, the bytes a file receives, and the
+/// `N chữ sẽ mất` note on a batch row — and the note is the one that proves why:
+/// UPPERCASE makes letters TCVN3 has no room for, so a note counted before the
+/// transform would promise a cost the file will not keep to.
+pub(crate) fn render(text: &str, from: Charset, casing: &Casing, to: Charset) -> Rendered {
+    let mut pivoted = charset::read(text, from);
+    if !casing.transforms.is_empty() {
+        // Assigned rather than rebuilt: `Pivoted` is `#[non_exhaustive]`, and the two
+        // counters beside the text describe the *reading* — how much of the source
+        // charset was undefined, how much it respelled — which changing the case
+        // neither adds to nor excuses.
+        pivoted.text = casing.run(&pivoted.text);
+    }
+    charset::render(&pivoted, to)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A shell stores a menu position, so every position has to mean one transform
+    /// and keep meaning it. This is `charset::ALL`'s contract, in the same shape.
+    #[test]
+    fn every_position_names_one_transform_and_survives_a_round_trip() {
+        for (index, transform) in ALL.into_iter().enumerate() {
+            assert_eq!(at(index), transform);
+            assert_eq!(index_of(transform), Some(index));
+            assert!(!name(transform).is_empty());
+        }
+    }
+
+    /// Out of range is a wrong entry, never a panic — a stored index can outlive the
+    /// menu it came from.
+    #[test]
+    fn a_position_from_a_longer_menu_is_clamped() {
+        assert_eq!(at(usize::MAX), ALL[ALL.len() - 1]);
+    }
+
+    /// The list is what the user pressed, and pressing the same button twice is not
+    /// two presses worth of document.
+    #[test]
+    fn the_list_records_presses_in_order_and_ignores_a_repeat() {
+        let mut casing = Casing::default();
+        casing.push(Transform::Lower);
+        casing.push(Transform::Lower);
+        casing.push(Transform::Title);
+        assert_eq!(
+            casing.indices(),
+            vec![
+                index_of(Transform::Lower).unwrap(),
+                index_of(Transform::Title).unwrap()
+            ]
+        );
+
+        casing.undo();
+        assert_eq!(casing.indices(), vec![index_of(Transform::Lower).unwrap()]);
+        casing.clear();
+        assert!(casing.indices().is_empty());
+    }
+
+    /// Reading counts describe the read, so they have to survive the transform —
+    /// a document that was half-undefined does not become clean by being uppercased.
+    #[test]
+    fn the_reading_counts_are_not_disturbed_by_a_transform() {
+        let mut casing = Casing::default();
+        casing.push(Transform::Upper);
+        let plain = render(
+            "việt nam",
+            Charset::Unicode,
+            &Casing::default(),
+            Charset::Unicode,
+        );
+        let cased = render("việt nam", Charset::Unicode, &casing, Charset::Unicode);
+
+        assert_eq!(cased.text, "VIỆT NAM");
+        assert_eq!(cased.cost.undefined, plain.cost.undefined);
+        assert_eq!(cased.cost.normalized, plain.cost.normalized);
+    }
+}

--- a/crates/funput-convert/src/lib.rs
+++ b/crates/funput-convert/src/lib.rs
@@ -23,9 +23,13 @@
 //! whatever that platform does to get work off its UI thread. Those differ per
 //! platform by nature; nothing below does.
 //!
+//! - [`casing`] — the second axis: the transforms a window offers besides the
+//!   charset, and the one place either is applied.
 //! - [`text`] — a paragraph: what it becomes, and what it costs.
 //! - [`batch`] — a drop: what each file turned out to be.
 //! - [`write`] — the copies, written beside the originals and never over them.
+
+pub mod casing;
 
 mod batch;
 mod session;

--- a/crates/funput-convert/src/session.rs
+++ b/crates/funput-convert/src/session.rs
@@ -20,11 +20,13 @@
 //! Charsets are **indices into [`charset::ALL`]** — see [`index`].
 
 mod act;
+mod casing;
 mod job;
 mod query;
 mod view;
 
 use crate::batch::Entry;
+use crate::casing::Casing;
 use crate::{at, clamp};
 
 pub use job::Job;
@@ -40,6 +42,7 @@ pub struct Session {
     pub(super) files: Vec<Entry>,
     pub(super) unreadable: Vec<Unreadable>,
     pub(super) window: (usize, usize),
+    pub(super) casing: Casing,
     view: View,
 }
 
@@ -60,6 +63,7 @@ impl Session {
             files: Vec::new(),
             unreadable: Vec::new(),
             window: (0, WINDOW),
+            casing: Casing::default(),
             view: View::default(),
         }
     }
@@ -69,6 +73,9 @@ impl Session {
     pub fn set_input(&mut self, text: String) {
         self.input = text;
         self.source = None;
+        // A new document is not the old one under a different name: the transforms
+        // pressed on the last paragraph belong to it, exactly as its charset did.
+        self.casing.clear();
     }
 
     /// Clamped on the way in, not on the way out: [`View::target`] is a position a
@@ -107,6 +114,7 @@ impl Session {
     pub fn adopt(&mut self, scan: crate::Scan) {
         self.input.clear();
         self.source = None;
+        self.casing.clear();
         self.files = scan.entries;
         self.unreadable = scan.unreadable;
         self.window = (0, WINDOW);

--- a/crates/funput-convert/src/session/act.rs
+++ b/crates/funput-convert/src/session/act.rs
@@ -5,7 +5,7 @@
 //! is being converted. That rule used to exist in three places in the Windows shell
 //! and was wrong in one of them.
 
-use funput_core::charset;
+use crate::casing;
 
 use super::Session;
 
@@ -14,13 +14,13 @@ impl Session {
     /// which would hand over a document with its tail quietly missing.
     pub fn result_text(&self) -> Option<String> {
         self.conversion()
-            .map(|(text, from, to)| charset::render(&charset::read(text, from), to).text)
+            .map(|(text, from, to)| casing::render(text, from, &self.casing, to).text)
     }
 
     /// The bytes to save. A legacy target stores one byte per letter, and writing the
     /// same characters as UTF-8 would produce a file `.VnTime` cannot read back.
     pub fn save_bytes(&self) -> Option<Vec<u8>> {
         self.conversion()
-            .map(|(text, from, to)| charset::render(&charset::read(text, from), to).bytes)
+            .map(|(text, from, to)| casing::render(text, from, &self.casing, to).bytes)
     }
 }

--- a/crates/funput-convert/src/session/casing.rs
+++ b/crates/funput-convert/src/session/casing.rs
@@ -1,0 +1,47 @@
+//! The buttons of the second axis.
+//!
+//! Commands, not queries: each one changes what the window will produce, and none
+//! of them touches the document. What the user pasted stays exactly as they pasted
+//! it — see [`crate::casing::Casing`] for why that matters — and the list of
+//! presses is replayed on every [`Session::refresh`].
+
+use crate::casing;
+
+use super::Session;
+
+impl Session {
+    /// A transform button was pressed, by menu position.
+    pub fn apply_transform(&mut self, index: usize) {
+        self.casing.push(casing::at(index));
+    }
+
+    /// Undo, which takes off the last transform rather than all of them: pressing a
+    /// third one by mistake should not cost the two before it.
+    pub fn undo_transform(&mut self) {
+        self.casing.undo();
+    }
+
+    /// Back to the document as it arrived.
+    pub fn clear_transforms(&mut self) {
+        self.casing.clear();
+    }
+
+    /// Keep `đ` and `Đ` instead of writing `d` and `D`.
+    ///
+    /// Named for the switch rather than for the field it sets, so that **off is the
+    /// default** — the same way `funput case --keep-d` reads, and the reason
+    /// [`crate::View`] can keep deriving `Default`.
+    pub fn set_keep_d(&mut self, on: bool) {
+        let mut options = self.casing.options();
+        options.d_to_ascii = !on;
+        self.casing.set_options(options);
+    }
+
+    /// Also lowercase words that are already all-caps, so `TP. HCM` becomes
+    /// `Tp. Hcm` under title case.
+    pub fn set_flatten_caps(&mut self, on: bool) {
+        let mut options = self.casing.options();
+        options.keep_all_caps = !on;
+        self.casing.set_options(options);
+    }
+}

--- a/crates/funput-convert/src/session/job.rs
+++ b/crates/funput-convert/src/session/job.rs
@@ -8,18 +8,20 @@
 use funput_core::charset::Charset;
 
 use crate::batch::{self, Entry, Outcome};
+use crate::casing::Casing;
 
 use super::{Session, at};
 
 /// A batch, ready to be written on whatever thread the shell picks.
 pub struct Job {
     entries: Vec<Entry>,
+    casing: Casing,
     target: Charset,
 }
 
 impl Job {
     pub fn run(self) -> Outcome {
-        batch::write_all(&self.entries, self.target)
+        batch::write_all(&self.entries, &self.casing, self.target)
     }
 }
 
@@ -28,6 +30,7 @@ impl Session {
     pub fn batch_job(&self) -> Job {
         Job {
             entries: self.files.clone(),
+            casing: self.casing.clone(),
             target: at(self.target),
         }
     }

--- a/crates/funput-convert/src/session/tests.rs
+++ b/crates/funput-convert/src/session/tests.rs
@@ -217,3 +217,193 @@ fn a_view_is_never_stale_after_a_refresh() {
         assert_eq!(&once, session.view(), "step {step} left something behind");
     }
 }
+
+/// A pasted paragraph with its charset settled, so what follows is about the second
+/// axis rather than about detection. Unicode is picked rather than detected on
+/// purpose: `detect` places `việt nam` but not `GỬI VỀ TP. HCM`, and a test of
+/// transforms should not turn on that.
+fn pasted(text: &str) -> Session {
+    let mut session = Session::new();
+    session.set_input(text.to_string());
+    session.pick_source(index_of(Charset::Unicode));
+    session
+}
+
+/// Menu positions for the two transforms most of these tests press.
+fn transform(t: funput_core::textcase::Transform) -> usize {
+    crate::casing::index_of(t).expect("every transform has a position")
+}
+
+fn lower() -> usize {
+    transform(funput_core::textcase::Transform::Lower)
+}
+
+fn title() -> usize {
+    transform(funput_core::textcase::Transform::Title)
+}
+
+fn upper() -> usize {
+    transform(funput_core::textcase::Transform::Upper)
+}
+
+/// Two presses, and which came first decides the answer. If the session collapsed
+/// them into a set, or replayed them in menu order, this is the test that says so.
+#[test]
+fn the_order_the_transforms_were_pressed_in_is_the_order_they_run() {
+    let mut lower_then_title = pasted("GỬI VỀ TP. HCM");
+    lower_then_title.apply_transform(lower());
+    lower_then_title.apply_transform(title());
+    lower_then_title.refresh();
+
+    let mut title_then_lower = pasted("GỬI VỀ TP. HCM");
+    title_then_lower.apply_transform(title());
+    title_then_lower.apply_transform(lower());
+    title_then_lower.refresh();
+
+    assert_eq!(lower_then_title.view().output_preview, "Gửi Về Tp. Hcm");
+    assert_eq!(title_then_lower.view().output_preview, "gửi về tp. hcm");
+}
+
+/// Undo takes off the last press, not all of them: pressing a third by mistake
+/// should not cost the two before it.
+#[test]
+fn undo_takes_off_one_transform_and_leaves_the_rest() {
+    let mut session = pasted("GỬI VỀ TP. HCM");
+    session.apply_transform(lower());
+    session.refresh();
+    let after_one = session.view().output_preview.clone();
+
+    session.apply_transform(title());
+    session.refresh();
+    assert_ne!(session.view().output_preview, after_one);
+
+    session.undo_transform();
+    session.refresh();
+    assert_eq!(session.view().output_preview, after_one);
+    assert_eq!(session.view().transforms, vec![lower()]);
+}
+
+/// Every transform is idempotent, so a second press cannot change the document —
+/// and a list that grew anyway would make undo feel broken.
+#[test]
+fn pressing_the_same_transform_twice_does_not_grow_the_list() {
+    let mut session = Session::new();
+    session.set_input("việt nam".to_string());
+    session.apply_transform(upper());
+    session.apply_transform(upper());
+    session.refresh();
+
+    assert_eq!(session.view().transforms, vec![upper()]);
+}
+
+/// The transforms belonged to the document they were pressed on, exactly as the
+/// charset did.
+#[test]
+fn a_fresh_document_arrives_with_no_transforms_on_it() {
+    let mut session = Session::new();
+    session.set_input("việt nam".to_string());
+    session.apply_transform(upper());
+    session.refresh();
+    session.set_input("hà nội".to_string());
+    session.refresh();
+
+    assert!(session.view().transforms.is_empty());
+    assert_eq!(session.view().output_preview, "hà nội");
+
+    session.apply_transform(upper());
+    session.refresh();
+    let (dir, mut dropped) = batch("casing-adopt", 2);
+    dropped.set_input("việt nam".to_string());
+    dropped.apply_transform(upper());
+    dropped.adopt(crate::scan(&[dir.join("0.txt")]));
+    dropped.refresh();
+    assert!(dropped.view().transforms.is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// **The four doors.** The pane, the clipboard, the saved bytes and the file a batch
+/// writes all have to say the same thing about the same document; they used to be
+/// three separate call sites, and one of them was wrong.
+#[test]
+fn the_preview_the_clipboard_and_the_saved_bytes_agree() {
+    let mut session = pasted("tiếng việt");
+    session.apply_transform(title());
+    session.refresh();
+
+    let expected = "Tiếng Việt";
+    assert_eq!(session.view().output_preview, expected);
+    assert_eq!(session.result_text().as_deref(), Some(expected));
+    assert_eq!(
+        session.save_bytes().map(|b| String::from_utf8(b).unwrap()),
+        Some(expected.to_string())
+    );
+}
+
+/// And the fourth door, which goes to disk on another thread.
+#[test]
+fn a_batch_writes_the_transformed_document() {
+    let (dir, mut session) = batch("casing-batch", 2);
+    session.apply_transform(upper());
+    session.refresh();
+
+    let outcome = session.batch_job().run();
+    assert_eq!(outcome.written, 2);
+    let written = std::fs::read_to_string(dir.join(crate::OUT_DIR).join("0.txt")).expect("copy");
+    assert_eq!(written, "VIỆT NAM");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The note on a row is a promise about what that file will cost, so it has to be
+/// counted after the transform: TCVN3 has no room for uppercase toned vowels, and a
+/// count taken before UPPERCASE would understate what the batch is about to lose.
+#[test]
+fn a_row_counts_what_the_transform_will_cost_not_what_the_document_costs_now() {
+    let (dir, mut session) = batch("casing-note", 2);
+    session.set_target(index_of(Charset::Tcvn3).unwrap());
+    session.refresh();
+    assert_eq!(session.view().rows[0].note, "", "lowercase fits TCVN3");
+
+    session.apply_transform(upper());
+    session.refresh();
+    assert!(
+        !session.view().rows[0].note.is_empty(),
+        "uppercase toned vowels do not fit TCVN3, and the row should say so"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The switches reach core, and a fresh window has both of them off.
+#[test]
+fn the_switches_travel_with_the_transform() {
+    let mut session = pasted("đẹp");
+    session.apply_transform(transform(funput_core::textcase::Transform::NoDiacritics));
+    session.refresh();
+    assert_eq!(session.view().output_preview, "dep");
+    assert!(!session.view().keep_d);
+
+    session.set_keep_d(true);
+    session.refresh();
+    assert_eq!(session.view().output_preview, "đep");
+    assert!(session.view().keep_d);
+}
+
+/// A document nothing could explain is not converted, and for the same reason it is
+/// not transformed either: one rule, not two.
+///
+/// The fixture is a real one — `detect` places `việt nam` but has nothing to go on
+/// in an all-caps line, which is exactly when the window asks the user instead.
+#[test]
+fn a_document_with_no_charset_is_left_alone_by_both_axes() {
+    let mut session = Session::new();
+    session.set_input("GỬI VỀ TP. HCM".to_string());
+    session.apply_transform(upper());
+    session.refresh();
+
+    assert_eq!(
+        session.view().source,
+        None,
+        "fixture is meant to be unplaceable"
+    );
+    assert_eq!(session.view().output_preview, "GỬI VỀ TP. HCM");
+    assert_eq!(session.result_text(), None);
+}

--- a/crates/funput-convert/src/session/view.rs
+++ b/crates/funput-convert/src/session/view.rs
@@ -7,9 +7,8 @@
 //!
 //! Charsets are indices; paths are names. Both for the same reason.
 
-use funput_core::charset;
-
 use crate::batch;
+use crate::casing;
 use crate::text;
 
 use super::{Session, at};
@@ -71,13 +70,20 @@ pub struct View {
     pub out_dir: String,
     /// How many files a charset was settled for, over the **whole** batch.
     pub ready: usize,
+    /// The transforms pressed so far, in order, as positions in `casing::ALL`.
+    /// Empty means the document is going out as it came in.
+    pub transforms: Vec<usize>,
+    /// The two switches, named so that **off is what a fresh window means** — which
+    /// is what lets this struct keep deriving `Default`.
+    pub keep_d: bool,
+    pub flatten_caps: bool,
     pub unreadable: Vec<Unreadable>,
 }
 
 pub(super) fn build(session: &Session) -> View {
     let target = at(session.target);
     let (text, rendered) = match session.conversion() {
-        Some((text, from, to)) => (text, Some(charset::render(&charset::read(text, from), to))),
+        Some((text, from, to)) => (text, Some(casing::render(text, from, &session.casing, to))),
         None => (session.text(), None),
     };
     let single = session.files.len() == 1;
@@ -102,6 +108,9 @@ pub(super) fn build(session: &Session) -> View {
         rows_total: session.files.len(),
         out_dir: batch::out_dir_label(&session.files),
         ready: batch::ready(&session.files),
+        transforms: session.casing.indices(),
+        keep_d: !session.casing.options().d_to_ascii,
+        flatten_caps: !session.casing.options().keep_all_caps,
         unreadable: session.unreadable.clone(),
     }
 }

--- a/crates/funput-convert/src/session/view/rows.rs
+++ b/crates/funput-convert/src/session/view/rows.rs
@@ -9,6 +9,7 @@
 
 use funput_core::charset;
 
+use crate::casing;
 use crate::index_of;
 
 use super::Session;
@@ -39,7 +40,10 @@ pub(super) fn rows(session: &Session, target: charset::Charset) -> Vec<Row> {
             charset: entry.charset.and_then(index_of),
             note: match entry.charset {
                 Some(from) => {
-                    let lost = charset::render(&charset::read(&entry.text, from), target)
+                    // Through `casing::render`, so the count is what this file will
+                    // actually cost: UPPERCASE makes letters TCVN3 has no room for,
+                    // and a note taken before the transform would understate it.
+                    let lost = casing::render(&entry.text, from, &session.casing, target)
                         .cost
                         .unrepresentable;
                     if lost > 0 {


### PR DESCRIPTION
Chặng 2 of 4, part 2 of 2. Base is #373, which made room in `view.rs` for this. Draft.

The window has two independent choices about one document — which charset spells it, and what case it is in. This adds the second, in the crate all three shells draw from, so Windows, Linux and macOS cannot each invent the rules. **No shell changes here**: this is Rust in the workspace, testable without a display, and what chặng 3 (the C ABI) and chặng 4 (the macOS tab) stand on.

## One place converts

`casing::render(text, from, casing, to)` reads, runs the transforms, and writes. Four callers need that same answer:

| Caller | What it produces |
| --- | --- |
| `view::build` | the preview pane |
| `view/rows.rs` | the `N chữ sẽ mất` note on each batch row |
| `act.rs` | the clipboard, and the bytes a file receives |
| `batch/write.rs` | the files a batch actually writes |

The row note is what proves the single call site is not tidiness. **UPPERCASE makes letters TCVN3 has no room for** — it has no uppercase toned vowels — so a note counted before the transform promises a cost the file will not keep to. `a_row_counts_what_the_transform_will_cost_not_what_the_document_costs_now` pins it: the same file shows no note in lowercase and a real one after UPPERCASE. And `act.rs`'s own doc comment already carries the scar from the last time this logic lived in three places, one of them wrong.

## A list of presses, not an edited document

`Session` records which transforms were pressed and replays them from the original on every `refresh`. That is what makes undo take off *one* press — a third button by mistake should not cost the two before it — and it means the paragraph the user pasted is never written back into. Writing it back would send their caret home and, in GTK, read as a fresh paste that forgets the charset it had just detected; `view.rs`'s `input_preview` rule exists because both shells got that wrong once.

Pressing the same transform twice is a no-op: every transform is idempotent — core has a property test saying so — so a second press cannot change the document, and a list that grew anyway would make undo feel broken. A new document clears the list, exactly as `set_input` and `adopt` already clear the charset.

## Smaller decisions worth a look

- **`Pivoted.text` is assigned, not rebuilt.** `Pivoted` is `#[non_exhaustive]`, so this crate cannot construct one — and assigning is the right semantics anyway: `undefined` and `normalized` describe the *reading*, which changing the case neither adds to nor excuses. There is a test that a transform leaves both counters where they were.
- **The names live here, not in core.** `CHỮ HOA`, `Bỏ dấu tiếng Việt` and the rest are interface text, in the same language as the loss warning and the row note next door. Core spells `Charset::name` because a charset's name is its name in any language; a button label is not that, and `funput case` never needs one.
- **`View` gains three fields and changes no signature**, so the Slint and GTK windows — both outside the workspace, neither built by CI — keep compiling untouched. The switches are named for what they turn *on* (`keep_d`, `flatten_caps`), so off is what a fresh window means, which is what lets `View` keep deriving `Default`.
- **One rule, no exception branch**: a document whose charset nothing could place is not converted *and* not transformed. The window already refuses to convert under a guess.

## Tests

Thirteen new ones. The two that earn their keep:

- **The four doors agree** — preview, `result_text`, `save_bytes` and the file a `batch_job` writes all say the same thing about the same document.
- **The row note is counted after the transform** (above).

Plus: order of presses decides the answer (`lower,title` ≠ `title,lower`), undo removes exactly one, a repeat does not grow the list, a fresh paste and an `adopt` both clear it, the switches reach core, menu positions round-trip through `casing::ALL`, and an out-of-range position clamps rather than panicking.

One test fixture is worth flagging: `detect` places `việt nam` but has nothing to go on in an all-caps line like `GỬI VỀ TP. HCM`, so the casing tests settle the charset explicitly rather than depending on detection. That same fixture is what makes the "no charset, no transform either" test deterministic.

## Review

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (41 in `funput-convert` plus its 6 `c_host` tests), and `scripts/check-loc.sh` — all green.

Budgets, in a crate that runs close to the line: `casing.rs` 137, `session.rs` 143, `session/casing.rs` 47, `view.rs` 116, `rows.rs` 59. `batch.rs` was left untouched on purpose — it sits at 149 of 150, so the batch change went into `batch/write.rs` (115).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
