### PR TITLE
feat(ffi): add the casing axis to the convert door

### DIFF
--- a/crates/funput-convert/tests/c_host.rs
+++ b/crates/funput-convert/tests/c_host.rs
@@ -216,3 +216,55 @@ fn the_work_a_shell_hands_off_can_leave_the_thread() {
     assert_send::<Scan>();
     assert_send::<Job>();
 }
+
+/// The second axis, driven the same way: a menu read by index, presses recorded as
+/// positions, and two switches that are plain booleans on the way across.
+#[test]
+fn a_host_can_drive_the_casing_axis_by_index() {
+    use funput_convert::casing;
+
+    // The menu a host builds: count, then a name per index. No `Transform` crosses.
+    let menu: Vec<String> = (0..casing::ALL.len())
+        .map(|index| read_text(casing::name(casing::at(index))))
+        .collect();
+    assert_eq!(menu.len(), casing::ALL.len());
+    assert!(menu.iter().all(|name| !name.is_empty()));
+
+    let position_of = |label: &str| menu.iter().position(|name| name == label).expect(label);
+
+    let mut session = Session::new();
+    session.set_input("GỬI VỀ TP. HCM".to_string());
+    session.pick_source(Some(0));
+    session.apply_transform(position_of("chữ thường"));
+    session.apply_transform(position_of("Viết Hoa Đầu Mỗi Từ"));
+    session.refresh();
+
+    // Read back the way a host reads every other list here: a count, then indices.
+    let applied: Vec<i32> = (0..session.view().transforms.len())
+        .map(|index| position(session.view().transforms.get(index).copied()))
+        .collect();
+    assert_eq!(
+        applied,
+        vec![
+            position(Some(position_of("chữ thường"))),
+            position(Some(position_of("Viết Hoa Đầu Mỗi Từ")))
+        ]
+    );
+    assert_eq!(read_text(&session.view().output_preview), "Gửi Về Tp. Hcm");
+    assert!(!session.view().keep_d && !session.view().flatten_caps);
+
+    // A press a host made up is answered rather than fatal, like every other index
+    // on this door: it clamps to the last menu entry.
+    session.apply_transform(usize::MAX);
+    session.refresh();
+    assert_eq!(
+        session.view().transforms.last().copied(),
+        Some(menu.len() - 1),
+        "a made-up position should clamp to the last entry, not panic"
+    );
+
+    session.clear_transforms();
+    session.refresh();
+    assert!(session.view().transforms.is_empty());
+    assert_eq!(read_text(&session.view().output_preview), "GỬI VỀ TP. HCM");
+}

--- a/crates/funput-ffi/cbindgen.toml
+++ b/crates/funput-ffi/cbindgen.toml
@@ -10,6 +10,7 @@ style = "type"
 include = [
     "FunputConfig",
     "FunputConversion",
+    "FunputConvertCasing",
     "FunputConvertRow",
     "FunputConvertView",
     "FunputResult",

--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -146,6 +146,24 @@ typedef struct {
 #endif
 
 #if defined(FUNPUT_CONVERT)
+/**
+ * What the second axis is doing, as scalars.
+ */
+typedef struct {
+    /**
+     * How many transforms are applied. Read them with
+     * [`funput_convert_session_applied_transform`].
+     */
+    uintptr_t count;
+    /**
+     * Named for what it turns **on**, so a fresh session is all-false.
+     */
+    bool keep_d;
+    bool flatten_caps;
+} FunputConvertCasing;
+#endif
+
+#if defined(FUNPUT_CONVERT)
 typedef struct {
     uint8_t mode;
     uintptr_t target;
@@ -377,6 +395,83 @@ FunputConversion funput_charset_convert(const uint32_t *text,
  * `text` must point to at least `text_len` readable `u32` values, or be null.
  */
 int32_t funput_charset_detect(const uint32_t *text, uintptr_t text_len);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * Press the transform at `index` in the menu. Out of range clamps, as everywhere
+ * else a menu position crosses this door.
+ */
+void funput_convert_session_apply_transform(FunputConvertSession *session, uintptr_t index);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * Take off the last transform. A session with none is a no-op, not an error.
+ */
+void funput_convert_session_undo_transform(FunputConvertSession *session);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * Back to the document as it arrived.
+ */
+void funput_convert_session_clear_transforms(FunputConvertSession *session);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * Keep `đ` and `Đ` instead of writing `d` and `D` (bỏ dấu).
+ */
+void funput_convert_session_set_keep_d(FunputConvertSession *session, bool on);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * Also lowercase words that are already all-caps (title case).
+ */
+void funput_convert_session_set_flatten_caps(FunputConvertSession *session, bool on);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * The axis as of the last refresh. Null gives the all-false snapshot.
+ */
+FunputConvertCasing funput_convert_session_casing(const FunputConvertSession *session);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * The menu position of the `index`-th transform applied, in the order pressed, or
+ * [`FUNPUT_CONVERT_UNKNOWN`] when there is no such press.
+ */
+int32_t funput_convert_session_applied_transform(const FunputConvertSession *session,
+                                                 uintptr_t index);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * How many transforms there are. Valid indices run
+ * `0..funput_convert_transform_count()`.
+ */
+uintptr_t funput_convert_transform_count(void);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * Write the label of the transform at `index` into `out` as UTF-32, returning its
+ * length in codepoints. An index out of range gives 0.
+ *
+ * The label comes from `funput-convert` so that three platforms' menus cannot drift
+ * apart, and it is interface text — Vietnamese, like the loss warning beside it.
+ *
+ * Sizing works as everywhere else on this door: the length comes back whether or
+ * not it fit, and nothing is written unless all of it fits.
+ *
+ * # Safety
+ * `out` must point to at least `cap` writable `u32` values, or be null.
+ */
+uintptr_t funput_convert_transform_name(uintptr_t index, uint32_t *out, uintptr_t cap);
 #endif
 
 #if defined(FUNPUT_CONVERT)

--- a/crates/funput-ffi/src/convert/casing/menu.rs
+++ b/crates/funput-ffi/src/convert/casing/menu.rs
@@ -1,0 +1,48 @@
+//! The transform menu: what a shell offers, and what to call each entry.
+//!
+//! The same contract as the charset menu in [`crate::charset`], for the same reason.
+//! A transform is an **index into `funput_convert::casing::ALL`**, never a name the
+//! host spells for itself: a host writing its own list would silently miss a
+//! transform added later, and these two calls are between them enough to build the
+//! menu without one.
+//!
+//! **That list is append-only, and it is what makes the index an identity.** A host
+//! may store the index — as a remembered last choice, or as the list of what the
+//! user has applied — so reordering would quietly turn a saved `CHỮ HOA` into
+//! `chữ thường`.
+
+use funput_convert::casing;
+
+use crate::abi::{safe, write_text};
+
+/// How many transforms there are. Valid indices run
+/// `0..funput_convert_transform_count()`.
+#[unsafe(no_mangle)]
+pub extern "C" fn funput_convert_transform_count() -> usize {
+    casing::ALL.len()
+}
+
+/// Write the label of the transform at `index` into `out` as UTF-32, returning its
+/// length in codepoints. An index out of range gives 0.
+///
+/// The label comes from `funput-convert` so that three platforms' menus cannot drift
+/// apart, and it is interface text — Vietnamese, like the loss warning beside it.
+///
+/// Sizing works as everywhere else on this door: the length comes back whether or
+/// not it fit, and nothing is written unless all of it fits.
+///
+/// # Safety
+/// `out` must point to at least `cap` writable `u32` values, or be null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_transform_name(
+    index: usize,
+    out: *mut u32,
+    cap: usize,
+) -> usize {
+    safe(0, || {
+        let Some(&transform) = casing::ALL.get(index) else {
+            return 0;
+        };
+        unsafe { write_text(casing::name(transform), out, cap) }
+    })
+}

--- a/crates/funput-ffi/src/convert/casing/mod.rs
+++ b/crates/funput-ffi/src/convert/casing/mod.rs
@@ -1,0 +1,113 @@
+//! The second axis over the C door: which transforms are applied, and the two
+//! switches they read.
+//!
+//! Every call here is a thin marshalling of `funput_convert`'s own commands. What is
+//! worth saying is the shape, because an ABI is append-only and a shape settled
+//! wrongly is settled forever:
+//!
+//! - **The transforms are a list the user built**, not a single choice. A press is
+//!   [`funput_convert_session_apply_transform`], undo takes the last one off, and the
+//!   list is read back the way every other collection on this door is read: a count
+//!   in the snapshot, then one accessor per index.
+//! - **The axis has a snapshot of its own.** `FunputConvertView` does not grow a tail
+//!   of fields that only some hosts read, and a third axis — if one ever arrives —
+//!   gets its own struct rather than lengthening a struct everyone reads.
+//! - **Each switch is a named call.** The two are not a homogeneous list: one belongs
+//!   to bỏ dấu and the other to title case, so a `set_option(index, on)` would be a
+//!   false uniformity. A third switch costs one more export, which is what an
+//!   append-only door is for.
+
+mod menu;
+
+pub use menu::{funput_convert_transform_count, funput_convert_transform_name};
+
+use crate::abi::safe;
+
+use super::FUNPUT_CONVERT_UNKNOWN;
+use super::handle::{FunputConvertSession, with_mut, with_ref};
+
+/// What the second axis is doing, as scalars.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct FunputConvertCasing {
+    /// How many transforms are applied. Read them with
+    /// [`funput_convert_session_applied_transform`].
+    pub count: usize,
+    /// Named for what it turns **on**, so a fresh session is all-false.
+    pub keep_d: bool,
+    pub flatten_caps: bool,
+}
+
+/// Press the transform at `index` in the menu. Out of range clamps, as everywhere
+/// else a menu position crosses this door.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_session_apply_transform(
+    session: *mut FunputConvertSession,
+    index: usize,
+) {
+    unsafe { with_mut(session, |value| value.apply_transform(index)) };
+}
+
+/// Take off the last transform. A session with none is a no-op, not an error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_session_undo_transform(session: *mut FunputConvertSession) {
+    unsafe { with_mut(session, funput_convert::Session::undo_transform) };
+}
+
+/// Back to the document as it arrived.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_session_clear_transforms(
+    session: *mut FunputConvertSession,
+) {
+    unsafe { with_mut(session, funput_convert::Session::clear_transforms) };
+}
+
+/// Keep `đ` and `Đ` instead of writing `d` and `D` (bỏ dấu).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_session_set_keep_d(
+    session: *mut FunputConvertSession,
+    on: bool,
+) {
+    unsafe { with_mut(session, |value| value.set_keep_d(on)) };
+}
+
+/// Also lowercase words that are already all-caps (title case).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_session_set_flatten_caps(
+    session: *mut FunputConvertSession,
+    on: bool,
+) {
+    unsafe { with_mut(session, |value| value.set_flatten_caps(on)) };
+}
+
+/// The axis as of the last refresh. Null gives the all-false snapshot.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_session_casing(
+    session: *const FunputConvertSession,
+) -> FunputConvertCasing {
+    unsafe { with_ref(session, snapshot) }
+}
+
+fn snapshot(session: &funput_convert::Session) -> FunputConvertCasing {
+    let view = session.view();
+    FunputConvertCasing {
+        count: view.transforms.len(),
+        keep_d: view.keep_d,
+        flatten_caps: view.flatten_caps,
+    }
+}
+
+/// The menu position of the `index`-th transform applied, in the order pressed, or
+/// [`FUNPUT_CONVERT_UNKNOWN`] when there is no such press.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_session_applied_transform(
+    session: *const FunputConvertSession,
+    index: usize,
+) -> i32 {
+    safe(FUNPUT_CONVERT_UNKNOWN, || {
+        unsafe { session.as_ref() }
+            .and_then(|s| s.inner.view().transforms.get(index).copied())
+            .and_then(|position| i32::try_from(position).ok())
+            .unwrap_or(FUNPUT_CONVERT_UNKNOWN)
+    })
+}

--- a/crates/funput-ffi/src/convert/mod.rs
+++ b/crates/funput-ffi/src/convert/mod.rs
@@ -10,11 +10,13 @@
     reason = "the common ABI safety contract is documented once above"
 )]
 
+mod casing;
 mod handle;
 mod state;
 mod text;
 mod work;
 
+pub use casing::*;
 pub use handle::{FunputConvertSession, funput_convert_session_free, funput_convert_session_new};
 pub use state::*;
 pub use text::*;

--- a/crates/funput-ffi/src/convert/tests/mod.rs
+++ b/crates/funput-ffi/src/convert/tests/mod.rs
@@ -85,3 +85,152 @@ fn all_convert_handles_are_null_safe() {
         funput_convert_job_free(ptr::null_mut());
     }
 }
+
+/// Menu positions for the transforms these tests press, found the way a host finds
+/// them — by reading the menu, not by writing the list down again.
+fn position(label: &str) -> usize {
+    (0..funput_convert_transform_count())
+        .find(|&index| unsafe {
+            text(|out, cap| funput_convert_transform_name(index, out, cap)) == label
+        })
+        .unwrap_or_else(|| panic!("no transform called {label}"))
+}
+
+/// The whole axis over the door: press, read back, undo, clear — and the result text
+/// changing at each step, because that is the only proof the presses reached core.
+#[test]
+fn transforms_apply_in_order_and_come_back_off_one_at_a_time() {
+    let session = funput_convert_session_new();
+    let input: Vec<u32> = "GỬI VỀ TP. HCM".chars().map(u32::from).collect();
+    let (lower, title) = (position("chữ thường"), position("Viết Hoa Đầu Mỗi Từ"));
+    unsafe {
+        funput_convert_session_set_input(session, input.as_ptr(), input.len());
+        funput_convert_session_pick_source(session, 0);
+        funput_convert_session_apply_transform(session, lower);
+        funput_convert_session_apply_transform(session, title);
+        funput_convert_session_refresh(session);
+
+        let casing = funput_convert_session_casing(session);
+        assert_eq!(casing.count, 2);
+        assert!(!casing.keep_d && !casing.flatten_caps, "fresh session");
+        assert_eq!(
+            funput_convert_session_applied_transform(session, 0),
+            i32::try_from(lower).unwrap()
+        );
+        assert_eq!(
+            funput_convert_session_applied_transform(session, 1),
+            i32::try_from(title).unwrap()
+        );
+        assert_eq!(
+            text(|out, cap| funput_convert_session_result_text(session, out, cap)),
+            "Gửi Về Tp. Hcm"
+        );
+
+        funput_convert_session_undo_transform(session);
+        funput_convert_session_refresh(session);
+        assert_eq!(funput_convert_session_casing(session).count, 1);
+        assert_eq!(
+            text(|out, cap| funput_convert_session_result_text(session, out, cap)),
+            "gửi về tp. hcm"
+        );
+
+        funput_convert_session_clear_transforms(session);
+        funput_convert_session_refresh(session);
+        assert_eq!(funput_convert_session_casing(session).count, 0);
+        assert_eq!(
+            text(|out, cap| funput_convert_session_result_text(session, out, cap)),
+            "GỬI VỀ TP. HCM"
+        );
+        funput_convert_session_free(session);
+    }
+}
+
+/// A switch has to reach core, not just the snapshot.
+#[test]
+fn a_switch_changes_what_the_door_hands_back() {
+    let session = funput_convert_session_new();
+    let input: Vec<u32> = "đẹp".chars().map(u32::from).collect();
+    let bo_dau = position("Bỏ dấu tiếng Việt");
+    unsafe {
+        funput_convert_session_set_input(session, input.as_ptr(), input.len());
+        funput_convert_session_pick_source(session, 0);
+        funput_convert_session_apply_transform(session, bo_dau);
+        funput_convert_session_refresh(session);
+        assert_eq!(
+            text(|out, cap| funput_convert_session_result_text(session, out, cap)),
+            "dep"
+        );
+
+        funput_convert_session_set_keep_d(session, true);
+        funput_convert_session_refresh(session);
+        assert!(funput_convert_session_casing(session).keep_d);
+        assert_eq!(
+            text(|out, cap| funput_convert_session_result_text(session, out, cap)),
+            "đep"
+        );
+        funput_convert_session_free(session);
+    }
+}
+
+/// The menu is the host's only list, so it has to be complete, named, and sized the
+/// way every other text on this door is sized.
+#[test]
+fn the_transform_menu_is_complete_and_sizes_like_the_rest_of_the_door() {
+    assert_eq!(
+        funput_convert_transform_count(),
+        funput_convert::casing::ALL.len(),
+        "the door and the table disagree about how many transforms there are"
+    );
+    unsafe {
+        for index in 0..funput_convert_transform_count() {
+            let needed = funput_convert_transform_name(index, ptr::null_mut(), 0);
+            assert!(needed > 0, "transform {index} has no name");
+
+            // One short of enough writes nothing and still reports the length.
+            let mut small = vec![0u32; needed - 1];
+            assert_eq!(
+                funput_convert_transform_name(index, small.as_mut_ptr(), small.len()),
+                needed
+            );
+            assert!(small.iter().all(|&slot| slot == 0), "wrote a partial name");
+
+            assert_eq!(
+                text(|out, cap| funput_convert_transform_name(index, out, cap))
+                    .chars()
+                    .count(),
+                needed
+            );
+        }
+        assert_eq!(funput_convert_transform_name(999, ptr::null_mut(), 0), 0);
+    }
+}
+
+/// Out of range and never-pressed both answer, rather than panicking or inventing.
+#[test]
+fn an_empty_session_answers_every_question_about_the_axis() {
+    let session = funput_convert_session_new();
+    unsafe {
+        let casing = funput_convert_session_casing(session);
+        assert_eq!(casing.count, 0);
+        assert_eq!(
+            funput_convert_session_applied_transform(session, 0),
+            FUNPUT_CONVERT_UNKNOWN
+        );
+        assert_eq!(
+            funput_convert_session_applied_transform(session, 999),
+            FUNPUT_CONVERT_UNKNOWN
+        );
+        // Null is a no-op everywhere else on this door, and here too.
+        funput_convert_session_apply_transform(ptr::null_mut(), 0);
+        funput_convert_session_undo_transform(ptr::null_mut());
+        funput_convert_session_clear_transforms(ptr::null_mut());
+        funput_convert_session_set_keep_d(ptr::null_mut(), true);
+        funput_convert_session_set_flatten_caps(ptr::null_mut(), true);
+        assert_eq!(funput_convert_session_casing(ptr::null()).count, 0);
+        assert_eq!(
+            funput_convert_session_applied_transform(ptr::null(), 0),
+            FUNPUT_CONVERT_UNKNOWN
+        );
+        funput_convert_session_free(session);
+    }
+}


### PR DESCRIPTION
Chặng 3 of 4. Base is #374. Draft.

Windows and Linux link `funput-convert` directly and have had the second axis since it landed there. macOS is Swift and cannot, so this opens the C door — and only the door: no Swift, no UI, nothing drawn.

Everything here follows the conventions the convert door already keeps, because an ABI is append-only: a shape settled wrongly is settled forever.

## Three shapes, chosen for what comes next

**The menu is read, never written down by the host.** `funput_convert_transform_count()` and `funput_convert_transform_name(index, …)` are between them enough to build it — the contract the charset door already spells out for charsets. A sixth transform appended to `casing::ALL` turns up in all three menus **without a line changing here**. That is also why the list has to stay append-only, and the module doc says so: a host may store the index as a remembered choice, and as the record of what the user applied.

**The axis gets a snapshot of its own.** `FunputConvertCasing { count, keep_d, flatten_caps }` rather than a tail of fields on `FunputConvertView`, so a host that does not care reads nothing new, and a third axis takes its own struct instead of lengthening one everybody reads. Note `cbindgen.toml` lists exported structs explicitly — without that line the struct is simply **absent from the generated header**, with no error anywhere.

**Each switch is a named call.** `set_keep_d` and `set_flatten_caps`. The two are not a homogeneous list — one belongs to bỏ dấu, the other to title case — so `set_option(index, on)` would be a false uniformity that reads worse from Swift. A third switch costs one export, which is what an append-only door is for.

The applied transforms are read like every other collection here: a count in the snapshot, then one accessor per index, with the door's existing `-1` (`FUNPUT_CONVERT_UNKNOWN`) for "no such entry". Commands go through the existing `with_mut` / `with_ref` / `safe`, so null stays a no-op and no panic crosses.

## Where the files went

`convert/` already held the five `.rs` files `scripts/check-loc.sh` allows per directory under it, so a sixth would have failed CI on its own. The new code is `convert/casing/mod.rs` (113 budgeted lines) and `convert/casing/menu.rs` (48) — a subfolder counted separately, with room for three more as the axis grows.

## Tests

Against the real door, not a model of it:

- Press two transforms, read `casing()` and `applied_transform(0|1)` back, then undo one at a time and clear — with `result_text` checked at every step, since that is the only proof the presses reached core (`GỬI VỀ TP. HCM` → `Gửi Về Tp. Hcm` → `gửi về tp. hcm` → back).
- `set_keep_d(true)` turns `dep` into `đep` **through the door**, and shows up in the snapshot.
- The menu: `transform_count()` equals `casing::ALL.len()` so the door and the table cannot drift; every entry has a name; and sizing follows the door's all-or-nothing rule — one slot short of enough **writes nothing** and still reports the length.
- Out of range and never-pressed both answer: `transform_name(999)` is 0, `applied_transform(999)` is `-1`, an empty session answers everything, and every new command is null-safe.

The tests find their transform by reading the menu for a label rather than hard-coding a position — the way a host will.

`funput-convert/tests/c_host.rs`, the no-unsafe rehearsal that predates this door, gains the axis too: it is the file that documents these conventions, and a rehearsal that stops covering the door stops being one.

## Review

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo clippy`/`cargo test -p funput-ffi --features convert`, `bash scripts/check-loc.sh`, and — the one that is easiest to forget — `crates/funput-ffi/scripts/gen-header.sh --check`, since `include/funput.h` is generated but committed and CI checks it. All green; the regenerated header is in the diff (+95 lines, all inside `#if defined(FUNPUT_CONVERT)`).

No new CI job. `cargo test -p funput-ffi --features convert` already exists, and the guard keeping charset and convert symbols out of the mobile library matches on the `funput_convert` prefix, so the new exports are already inside its net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
