### PR TITLE
feat(macos): add the casing axis to the Chuyển mã window

### DIFF
--- a/platforms/macos/Funput/Convert/Bridge/ConvertFFI.swift
+++ b/platforms/macos/Funput/Convert/Bridge/ConvertFFI.swift
@@ -31,6 +31,17 @@ nonisolated final class ConvertFFISession: @unchecked Sendable {
         refresh()
     }
 
+    func apply(_ action: ConvertCasingAction) {
+        switch action {
+        case let .apply(index): funput_convert_session_apply_transform(handle, UInt(index))
+        case .undo: funput_convert_session_undo_transform(handle)
+        case .clear: funput_convert_session_clear_transforms(handle)
+        case let .setKeepD(on): funput_convert_session_set_keep_d(handle, on)
+        case let .setFlattenCaps(on): funput_convert_session_set_flatten_caps(handle, on)
+        }
+        refresh()
+    }
+
     func adopt(paths: [String]) -> Bool {
         guard let scan = funput_convert_scan_new() else { return false }
         defer { funput_convert_scan_free(scan) }
@@ -62,9 +73,15 @@ nonisolated final class ConvertFFISession: @unchecked Sendable {
         return Data(bytes)
     }
 
-    func state(input: String, charsets: [ConvertCharset]) -> ConvertScreenState {
+    func state(
+        input: String, charsets: [ConvertCharset], transforms: [ConvertTransform]
+    ) -> ConvertScreenState {
         let view = funput_convert_session_view(handle)
+        let casing = funput_convert_session_casing(handle)
         let rows = (0..<Int(view.rows_count)).map { row(at: $0, first: Int(view.rows_first)) }
+        let applied = (0..<Int(casing.count)).compactMap {
+            optional(funput_convert_session_applied_transform(handle, UInt($0)))
+        }
         return ConvertScreenState(
             mode: mode(view.mode), charsets: charsets, target: Int(view.target),
             source: optional(view.source), fromFile: view.from_file,
@@ -74,7 +91,9 @@ nonisolated final class ConvertFFISession: @unchecked Sendable {
             warning: readText { funput_convert_session_warning(handle, $0, $1) }, files: rows,
             rowsTotal: Int(view.rows_total), outputDirectory: readText { funput_convert_session_out_dir(handle, $0, $1) },
             unreadable: readText { funput_convert_session_unreadable_line(handle, $0, $1) },
-            progress: "", ready: Int(view.ready), isBusy: false, errorMessage: nil
+            progress: "", ready: Int(view.ready), isBusy: false, errorMessage: nil,
+            transforms: transforms, appliedTransforms: applied,
+            keepD: casing.keep_d, flattenCaps: casing.flatten_caps
         )
     }
 
@@ -89,7 +108,7 @@ nonisolated final class ConvertFFISession: @unchecked Sendable {
     private func refreshed() -> Bool { refresh(); return true }
 }
 
-nonisolated private func readText(_ body: (UnsafeMutablePointer<UInt32>?, UInt) -> UInt) -> String {
+nonisolated func readText(_ body: (UnsafeMutablePointer<UInt32>?, UInt) -> UInt) -> String {
     let count = body(nil, 0)
     var values = [UInt32](repeating: 0, count: Int(count))
     values.withUnsafeMutableBufferPointer { _ = body($0.baseAddress, UInt($0.count)) }

--- a/platforms/macos/Funput/Convert/Bridge/ConvertWorker.swift
+++ b/platforms/macos/Funput/Convert/Bridge/ConvertWorker.swift
@@ -3,14 +3,18 @@ import Foundation
 actor ConvertWorker {
     private let session: ConvertFFISession
     let charsets: [ConvertCharset]
+    let transforms: [ConvertTransform]
 
     init?() {
         guard let session = ConvertFFISession() else { return nil }
         self.session = session
         charsets = Self.loadCharsets()
+        transforms = Self.loadTransforms()
     }
 
-    func current(input: String) -> ConvertScreenState { session.state(input: input, charsets: charsets) }
+    func current(input: String) -> ConvertScreenState {
+        session.state(input: input, charsets: charsets, transforms: transforms)
+    }
     func reset() -> ConvertScreenState { session.reset(); return current(input: "") }
     func setInput(_ text: String) -> ConvertScreenState { session.setInput(text); return current(input: text) }
     func setTarget(_ value: Int, input: String) -> ConvertScreenState {
@@ -29,6 +33,9 @@ actor ConvertWorker {
         guard session.adopt(paths: urls.map(\.path)) else { return nil }
         return current(input: "")
     }
+    func casing(_ action: ConvertCasingAction, input: String) -> ConvertScreenState {
+        session.apply(action); return current(input: input)
+    }
     func resultText() -> String { session.resultText() }
     func saveBytes() -> Data { session.saveBytes() }
     func runBatch(input: String) -> (ConvertScreenState, String)? {
@@ -36,17 +43,19 @@ actor ConvertWorker {
         return (current(input: input), report)
     }
 
+    /// Both menus are read the same way — a count, then a name per index — so they
+    /// share `readText` rather than spelling the two-call dance out twice.
     nonisolated static func loadCharsets() -> [ConvertCharset] {
         (0..<Int(funput_charset_count())).map { index in
-            let name = readCharsetName(index)
-            return ConvertCharset(id: index, name: name)
+            ConvertCharset(id: index, name: readText { funput_charset_name(UInt(index), $0, $1) })
         }
     }
-}
 
-nonisolated private func readCharsetName(_ index: Int) -> String {
-    let count = funput_charset_name(UInt(index), nil, 0)
-    var values = [UInt32](repeating: 0, count: Int(count))
-    values.withUnsafeMutableBufferPointer { _ = funput_charset_name(UInt(index), $0.baseAddress, UInt($0.count)) }
-    return String(values.compactMap(UnicodeScalar.init).map(Character.init))
+    nonisolated static func loadTransforms() -> [ConvertTransform] {
+        (0..<Int(funput_convert_transform_count())).map { index in
+            ConvertTransform(
+                id: index, name: readText { funput_convert_transform_name(UInt(index), $0, $1) }
+            )
+        }
+    }
 }

--- a/platforms/macos/Funput/Convert/Casing/ConvertCasingBar.swift
+++ b/platforms/macos/Funput/Convert/Casing/ConvertCasingBar.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+/// The second axis of the Chuyển mã window: five transforms, the order they were
+/// pressed in, and the two switches that belong to them.
+///
+/// Not a tab. Changing a charset and changing the case are two choices about one
+/// document and they compose, so both stay on screen at once; a tab would say the
+/// user has to pick one.
+///
+/// Glass is for the controls only — the chips, Hoàn tác, Bỏ hết. The `Đang áp:`
+/// line is content-layer text and the switches are system controls, so nothing here
+/// nests one glass surface inside another (`docs/LIQUID_GLASS.md`).
+struct ConvertCasingBar: View {
+    let state: ConvertScreenState
+    let dispatch: ConvertDispatch
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            chips
+            if !state.appliedTransforms.isEmpty {
+                applied
+            }
+        }
+        .animation(reduceMotion ? nil : .snappy(duration: 0.28), value: state.appliedTransforms)
+    }
+
+    private var chips: some View {
+        GlassEffectContainer(spacing: Theme.Spacing.sm) {
+            HStack(spacing: Theme.Spacing.sm) {
+                Text("Kiểu chữ").font(.callout).foregroundStyle(.secondary).fixedSize()
+                ForEach(state.transforms) { transform in
+                    chip(transform)
+                }
+                Spacer()
+            }
+        }
+        .disabled(!state.canUseCasing)
+    }
+
+    /// A press appends; pressing the one already on top is a no-op in core, so the
+    /// chip is a button rather than a checkbox. The checkmark is the non-color cue
+    /// the guidelines require — the tint alone would not be one.
+    private func chip(_ transform: ConvertTransform) -> some View {
+        let isApplied = state.appliedTransforms.contains(transform.id)
+        return Button {
+            dispatch(.casing(.apply(transform.id)))
+        } label: {
+            HStack(spacing: Theme.Spacing.xs) {
+                if isApplied {
+                    Image(systemName: "checkmark").font(.caption2.weight(.bold))
+                }
+                Text(transform.name).font(.caption.weight(.semibold))
+            }
+            .lineLimit(1)
+            .padding(.horizontal, Theme.Spacing.sm)
+            .padding(.vertical, 5)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isApplied ? .white : .primary)
+        .glassEffect(
+            .regular.tint(isApplied ? Theme.accent : nil).interactive(),
+            in: .capsule
+        )
+        .accessibilityIdentifier("convert.casing.\(transform.id)")
+        .accessibilityAddTraits(isApplied ? .isSelected : [])
+        .accessibilityValue(isApplied ? "Đã áp" : "Chưa áp")
+    }
+
+    /// The order is the whole point — `chữ thường → Viết Hoa Đầu Mỗi Từ` is a
+    /// different document from the same two reversed — so it is spelled out rather
+    /// than left for the user to infer from which chips are lit.
+    private var applied: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Text("Đang áp: \(state.appliedTransformNames.joined(separator: " → "))")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .accessibilityIdentifier("convert.casing.applied")
+            switches
+            Spacer()
+            GlassEffectContainer(spacing: Theme.Spacing.sm) {
+                HStack(spacing: Theme.Spacing.sm) {
+                    Button("Hoàn tác", systemImage: "arrow.uturn.backward") {
+                        dispatch(.casing(.undo))
+                    }
+                    .buttonStyle(.glass)
+                    .accessibilityIdentifier("convert.casing.undo")
+                    Button("Bỏ hết") { dispatch(.casing(.clear)) }
+                        .buttonStyle(.glass)
+                        .accessibilityIdentifier("convert.casing.clear")
+                }
+            }
+        }
+        .transition(.opacity)
+    }
+
+    /// A switch appears only while the transform it belongs to is applied: it has
+    /// nothing to say otherwise, and showing it there teaches which one owns it.
+    @ViewBuilder private var switches: some View {
+        if state.showsSwitch(for: .noDiacritics) {
+            Toggle("Giữ đ/Đ", isOn: binding(\.keepD) { .setKeepD($0) })
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .accessibilityIdentifier("convert.casing.keepD")
+        }
+        if state.showsSwitch(for: .title) {
+            Toggle("Hạ chữ viết hoa", isOn: binding(\.flattenCaps) { .setFlattenCaps($0) })
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .accessibilityIdentifier("convert.casing.flattenCaps")
+        }
+    }
+
+    private func binding(
+        _ value: KeyPath<ConvertScreenState, Bool>,
+        _ action: @escaping (Bool) -> ConvertCasingAction
+    ) -> Binding<Bool> {
+        Binding(get: { state[keyPath: value] }, set: { dispatch(.casing(action($0))) })
+    }
+}
+
+#Preview("Đã áp hai phép") {
+    ConvertCasingBar(state: ConvertFixtures.cased, dispatch: { _ in })
+        .padding(Theme.Spacing.xl)
+        .frame(width: 920)
+        .background(.windowBackground)
+}

--- a/platforms/macos/Funput/Convert/Casing/ConvertCasingState.swift
+++ b/platforms/macos/Funput/Convert/Casing/ConvertCasingState.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// The second axis gets its own action namespace rather than five more cases on
+/// `ConvertAction`: the store's switch grows by one line instead of five, and it
+/// mirrors how the Rust and C layers keep the axis in a module of its own.
+enum ConvertCasingAction: Equatable {
+    case apply(Int)
+    case undo
+    case clear
+    case setKeepD(Bool)
+    case setFlattenCaps(Bool)
+}
+
+/// The two transforms that own a switch, by their fixed position in core's
+/// append-only menu (`funput_convert::casing::ALL`).
+enum ConvertTransformKind {
+    case noDiacritics
+    case title
+
+    var position: Int {
+        switch self {
+        case .noDiacritics: 2
+        case .title: 4
+        }
+    }
+}
+
+extension ConvertScreenState {
+    /// Whether the transform buttons do anything yet. A document whose charset
+    /// nothing could place is not converted, and core does not transform it either —
+    /// one rule, not two. A batch carries a charset per row, so it is never blocked.
+    var canUseCasing: Bool {
+        !isBusy && (mode == .files || source != nil)
+    }
+
+    /// The applied transforms as names, for the `Đang áp:` line.
+    var appliedTransformNames: [String] {
+        appliedTransforms.compactMap { position in
+            transforms.first { $0.id == position }?.name
+        }
+    }
+
+    /// A switch is shown only while the transform it belongs to is applied: it has
+    /// nothing to say otherwise, and showing it there teaches which one owns it.
+    func showsSwitch(for transform: ConvertTransformKind) -> Bool {
+        appliedTransforms.contains(transform.position)
+    }
+}

--- a/platforms/macos/Funput/Convert/ConvertFixtures.swift
+++ b/platforms/macos/Funput/Convert/ConvertFixtures.swift
@@ -8,6 +8,14 @@ enum ConvertFixtures {
         ConvertCharset(id: 3, name: "Unicode tổ hợp"),
     ]
 
+    static let transforms = [
+        ConvertTransform(id: 0, name: "CHỮ HOA"),
+        ConvertTransform(id: 1, name: "chữ thường"),
+        ConvertTransform(id: 2, name: "Bỏ dấu tiếng Việt"),
+        ConvertTransform(id: 3, name: "Viết hoa đầu câu"),
+        ConvertTransform(id: 4, name: "Viết Hoa Đầu Mỗi Từ"),
+    ]
+
     static let empty = state(mode: .empty)
 
     static let pasted = state(
@@ -40,6 +48,16 @@ enum ConvertFixtures {
         ready: 3
     )
 
+    /// A paste with two transforms on it, in an order that matters: lowercase then
+    /// title case is `Gửi Về Tp. Hcm`, the other way round is all lowercase.
+    static let cased = state(
+        mode: .text,
+        source: 0,
+        input: "GỬI VỀ TP. HCM",
+        output: "Gửi Về Tp. Hcm",
+        applied: [1, 4]
+    )
+
     static var busyBatch: ConvertScreenState {
         var value = batch
         value.isBusy = true
@@ -51,7 +69,7 @@ enum ConvertFixtures {
         mode: ConvertMode, target: Int = 0, source: Int? = nil, fromFile: Bool = false,
         fileName: String? = nil, input: String = "", output: String = "",
         warning: String = "", files: [ConvertFileRow] = [],
-        outputDirectory: String = "", ready: Int = 0
+        outputDirectory: String = "", ready: Int = 0, applied: [Int] = []
     ) -> ConvertScreenState {
         ConvertScreenState(
             mode: mode, charsets: charsets, target: target, source: source,
@@ -59,7 +77,8 @@ enum ConvertFixtures {
             outputText: output, warning: warning, files: files,
             rowsTotal: files.count, outputDirectory: outputDirectory,
             unreadable: "", progress: "", ready: ready,
-            isBusy: false, errorMessage: nil
+            isBusy: false, errorMessage: nil, transforms: transforms,
+            appliedTransforms: applied, keepD: false, flattenCaps: false
         )
     }
 }

--- a/platforms/macos/Funput/Convert/ConvertState.swift
+++ b/platforms/macos/Funput/Convert/ConvertState.swift
@@ -11,6 +11,12 @@ struct ConvertCharset: Identifiable, Equatable {
     let name: String
 }
 
+/// One entry of the transform menu, named by core so three platforms cannot drift.
+struct ConvertTransform: Identifiable, Equatable {
+    let id: Int
+    let name: String
+}
+
 struct ConvertFileRow: Identifiable, Equatable {
     let id: Int
     let name: String
@@ -36,6 +42,13 @@ struct ConvertScreenState: Equatable {
     var ready: Int
     var isBusy: Bool
     var errorMessage: String?
+    /// The menu, in core's order. A position here is the identity of a transform.
+    var transforms: [ConvertTransform]
+    /// What has been applied, in the order pressed — so `chữ thường → Viết Hoa Đầu
+    /// Mỗi Từ` is a different document from the same two the other way round.
+    var appliedTransforms: [Int]
+    var keepD: Bool
+    var flattenCaps: Bool
 
     var canUseTextResult: Bool {
         source != nil && !isBusy
@@ -52,6 +65,7 @@ struct ConvertScreenState: Equatable {
     var canLoadMore: Bool {
         files.count < rowsTotal && !isBusy
     }
+
 }
 
 enum ConvertAction: Equatable {
@@ -67,18 +81,20 @@ enum ConvertAction: Equatable {
     case convertFiles
     case loadMore
     case receiveFiles([URL])
+    case casing(ConvertCasingAction)
 }
 
 typealias ConvertDispatch = (ConvertAction) -> Void
 
 extension ConvertScreenState {
-    static func empty(charsets: [ConvertCharset]) -> Self {
+    static func empty(charsets: [ConvertCharset], transforms: [ConvertTransform]) -> Self {
         .init(
             mode: .empty, charsets: charsets, target: 0, source: nil,
             fromFile: false, fileName: nil, inputText: "", outputText: "",
             warning: "", files: [], rowsTotal: 0, outputDirectory: "",
             unreadable: "", progress: "", ready: 0, isBusy: false,
-            errorMessage: nil
+            errorMessage: nil, transforms: transforms, appliedTransforms: [],
+            keepD: false, flattenCaps: false
         )
     }
 }

--- a/platforms/macos/Funput/Convert/ConvertStore.swift
+++ b/platforms/macos/Funput/Convert/ConvertStore.swift
@@ -14,7 +14,7 @@ final class ConvertStore {
         let worker = ConvertWorker()
         self.worker = worker
         self.platform = platform ?? ConvertPlatform()
-        state = initialState ?? .empty(charsets: ConvertWorker.loadCharsets())
+        state = initialState ?? .empty(charsets: ConvertWorker.loadCharsets(), transforms: ConvertWorker.loadTransforms())
         if worker == nil { state.errorMessage = "Không khởi tạo được bộ chuyển mã." }
     }
     func send(_ action: ConvertAction) {
@@ -32,6 +32,7 @@ final class ConvertStore {
         case .saveResult: saveResult()
         case .convertFiles: convertFiles()
         case .loadMore: loadMore()
+        case let .casing(action): updateFlushing { await $0.casing(action, input: $1) }
         }
     }
     func dismissError() { state.errorMessage = nil }
@@ -90,7 +91,6 @@ final class ConvertStore {
             state.progress = platform.copy(text) ? "Đã chép kết quả" : "Không chép được kết quả"
         }
     }
-
     private func saveResult() {
         taskFlushing { [weak self] worker, _, token in
             let bytes = await worker.saveBytes()
@@ -99,7 +99,6 @@ final class ConvertStore {
             catch { state.errorMessage = "Không lưu được tệp: \(error.localizedDescription)" }
         }
     }
-
     private func convertFiles() {
         busy("Đang chuyển \(state.ready) tệp…") { worker in
             guard let result = await worker.runBatch(input: self.state.inputText) else { return nil }
@@ -108,7 +107,6 @@ final class ConvertStore {
             return next
         }
     }
-
     private func update(_ operation: @escaping (ConvertWorker) async -> ConvertScreenState) {
         generation += 1; let token = generation
         Task { guard let worker else { return }; let next = await operation(worker)

--- a/platforms/macos/Funput/Convert/Views/ConvertBatchView.swift
+++ b/platforms/macos/Funput/Convert/Views/ConvertBatchView.swift
@@ -7,6 +7,7 @@ struct ConvertBatchView: View {
     var body: some View {
         VStack(spacing: Theme.Spacing.md) {
             header
+            ConvertCasingBar(state: state, dispatch: dispatch)
             Table(state.files) {
                 TableColumn("Tệp") { row in
                     Label(row.name, systemImage: "doc.text")

--- a/platforms/macos/Funput/Convert/Views/ConvertComponents.swift
+++ b/platforms/macos/Funput/Convert/Views/ConvertComponents.swift
@@ -9,7 +9,7 @@ struct ConvertHeader: View {
             VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
                 Text("Chuyển mã")
                     .font(.largeTitle.bold())
-                Text("Chuyển văn bản giữa Unicode và các bảng mã tiếng Việt cũ.")
+                Text("Đổi bảng mã và kiểu chữ của văn bản đã có.")
                     .foregroundStyle(.secondary)
             }
             Spacer()

--- a/platforms/macos/Funput/Convert/Views/ConvertTextView.swift
+++ b/platforms/macos/Funput/Convert/Views/ConvertTextView.swift
@@ -7,6 +7,7 @@ struct ConvertTextView: View {
     var body: some View {
         VStack(spacing: Theme.Spacing.md) {
             selectors
+            ConvertCasingBar(state: state, dispatch: dispatch)
             HStack(spacing: Theme.Spacing.md) {
                 ConvertEditorPane(
                     title: state.fromFile ? state.fileName ?? "Tệp nguồn" : "Đang có",

--- a/platforms/macos/FunputTests/Convert/ConvertBridgeTests.swift
+++ b/platforms/macos/FunputTests/Convert/ConvertBridgeTests.swift
@@ -9,7 +9,10 @@ final class ConvertBridgeTests: XCTestCase {
         bridge.setSource(0)
         bridge.setTarget(1)
 
-        let state = bridge.state(input: "Việt", charsets: ConvertWorker.loadCharsets())
+        let state = bridge.state(
+            input: "Việt", charsets: ConvertWorker.loadCharsets(),
+            transforms: ConvertWorker.loadTransforms()
+        )
 
         XCTAssertEqual(state.mode, .text)
         XCTAssertEqual(state.source, 0)
@@ -26,14 +29,14 @@ final class ConvertBridgeTests: XCTestCase {
         let bridge = try XCTUnwrap(ConvertFFISession())
 
         XCTAssertTrue(bridge.adopt(paths: [directory.path]))
-        let first = bridge.state(input: "", charsets: [])
+        let first = bridge.state(input: "", charsets: [], transforms: [])
         XCTAssertEqual(first.rowsTotal, 501)
         XCTAssertEqual(first.files.count, 500)
         XCTAssertEqual(first.files.first?.id, 0)
         XCTAssertEqual(first.files.last?.id, 499)
 
         bridge.setRowCount(1_000)
-        let expanded = bridge.state(input: "", charsets: [])
+        let expanded = bridge.state(input: "", charsets: [], transforms: [])
         XCTAssertEqual(expanded.files.count, 501)
         XCTAssertEqual(expanded.files.last?.id, 500)
     }
@@ -47,7 +50,7 @@ final class ConvertBridgeTests: XCTestCase {
         bridge.setInput("Nội dung cũ")
 
         XCTAssertTrue(bridge.adopt(paths: [broken.path]))
-        let state = bridge.state(input: "", charsets: [])
+        let state = bridge.state(input: "", charsets: [], transforms: [])
         XCTAssertEqual(state.mode, .empty)
         XCTAssertTrue(state.unreadable.contains("hong.txt"))
     }
@@ -70,6 +73,61 @@ final class ConvertBridgeTests: XCTestCase {
         store.send(.copyResult)
         try await waitUntil { copied == "bản mới" }
         XCTAssertEqual(store.state.progress, "Đã chép kết quả")
+    }
+
+    /// The menu is core's, not a list Swift keeps its own copy of.
+    func testTransformMenuComesFromCore() {
+        let menu = ConvertWorker.loadTransforms()
+
+        XCTAssertEqual(menu.count, 5)
+        XCTAssertEqual(menu.map(\.id), Array(0..<5))
+        XCTAssertEqual(menu[2].name, "Bỏ dấu tiếng Việt")
+        XCTAssertTrue(menu.allSatisfy { !$0.name.isEmpty })
+    }
+
+    /// Through the real door: the order decides the answer, and undo takes off one.
+    func testTransformsStackInOrderAndUndoTakesOffOne() throws {
+        let bridge = try XCTUnwrap(ConvertFFISession())
+        bridge.setInput("GỬI VỀ TP. HCM")
+        bridge.setSource(0)
+
+        bridge.apply(.apply(1))
+        bridge.apply(.apply(4))
+        XCTAssertEqual(bridge.resultText(), "Gửi Về Tp. Hcm")
+
+        let state = bridge.state(
+            input: "GỬI VỀ TP. HCM", charsets: [], transforms: ConvertWorker.loadTransforms()
+        )
+        XCTAssertEqual(state.appliedTransforms, [1, 4])
+
+        bridge.apply(.undo)
+        XCTAssertEqual(bridge.resultText(), "gửi về tp. hcm")
+        bridge.apply(.clear)
+        XCTAssertEqual(bridge.resultText(), "GỬI VỀ TP. HCM")
+    }
+
+    func testKeepDSwitchReachesCore() throws {
+        let bridge = try XCTUnwrap(ConvertFFISession())
+        bridge.setInput("đẹp")
+        bridge.setSource(0)
+        bridge.apply(.apply(2))
+        XCTAssertEqual(bridge.resultText(), "dep")
+
+        bridge.apply(.setKeepD(true))
+        XCTAssertEqual(bridge.resultText(), "đep")
+        XCTAssertTrue(bridge.state(input: "đẹp", charsets: [], transforms: []).keepD)
+    }
+
+    /// Typing is debounced 150 ms. A transform pressed before that lands must still
+    /// run on what was typed — the reason casing goes through `updateFlushing`.
+    func testATransformPressedRightAfterTypingSeesTheTypedText() async throws {
+        let store = ConvertStore()
+
+        store.send(.setInput("tôi yêu tiếng việt"))
+        store.send(.casing(.apply(0)))
+
+        try await waitUntil { store.state.outputText == "TÔI YÊU TIẾNG VIỆT" }
+        XCTAssertEqual(store.state.appliedTransforms, [0])
     }
 
     private func scratchDirectory() throws -> URL {

--- a/platforms/macos/FunputTests/Convert/ConvertStateTests.swift
+++ b/platforms/macos/FunputTests/Convert/ConvertStateTests.swift
@@ -3,7 +3,9 @@ import XCTest
 
 final class ConvertStateTests: XCTestCase {
     func testEmptyStateUsesLiveCharsets() {
-        let state = ConvertScreenState.empty(charsets: ConvertFixtures.charsets)
+        let state = ConvertScreenState.empty(
+            charsets: ConvertFixtures.charsets, transforms: ConvertFixtures.transforms
+        )
 
         XCTAssertEqual(state.mode, .empty)
         XCTAssertEqual(state.charsets, ConvertFixtures.charsets)
@@ -35,6 +37,40 @@ final class ConvertStateTests: XCTestCase {
         XCTAssertEqual(ConvertFixtures.singleFile.textPrimaryAction, "Chuyển tệp")
         XCTAssertEqual(ConvertFixtures.batch.batchAction, "Chuyển 3 tệp")
         XCTAssertEqual(ConvertFixtures.busyBatch.batchAction, "Đang chuyển…")
+    }
+
+    /// The order is the feature: the same two transforms the other way round is a
+    /// different document, so the line the window shows has to keep it.
+    func testAppliedTransformsReadBackInThePressedOrder() {
+        XCTAssertEqual(
+            ConvertFixtures.cased.appliedTransformNames,
+            ["chữ thường", "Viết Hoa Đầu Mỗi Từ"]
+        )
+        XCTAssertTrue(ConvertFixtures.pasted.appliedTransformNames.isEmpty)
+    }
+
+    /// A switch belongs to one transform and only appears while that one is applied.
+    func testSwitchesAppearOnlyWithTheTransformTheyBelongTo() {
+        var state = ConvertFixtures.cased
+
+        XCTAssertTrue(state.showsSwitch(for: .title))
+        XCTAssertFalse(state.showsSwitch(for: .noDiacritics))
+
+        state.appliedTransforms = [ConvertTransformKind.noDiacritics.position]
+        XCTAssertTrue(state.showsSwitch(for: .noDiacritics))
+        XCTAssertFalse(state.showsSwitch(for: .title))
+    }
+
+    /// One rule for both axes: nothing is converted, and nothing is transformed,
+    /// until something explains the document. A batch explains itself per row.
+    func testCasingIsBlockedUntilTheDocumentIsExplained() {
+        var unresolved = ConvertFixtures.pasted
+        unresolved.source = nil
+        XCTAssertFalse(unresolved.canUseCasing)
+
+        XCTAssertTrue(ConvertFixtures.pasted.canUseCasing)
+        XCTAssertTrue(ConvertFixtures.batch.canUseCasing, "a batch carries a charset per row")
+        XCTAssertFalse(ConvertFixtures.busyBatch.canUseCasing)
     }
 
     func testUnknownBatchPlaceholderCannotReplaceASelectedCharset() {

--- a/platforms/macos/README.md
+++ b/platforms/macos/README.md
@@ -47,6 +47,7 @@
 | 🗂️ **Nhớ theo ứng dụng** | Bật tiếng Việt ở Pages, tắt ở Terminal — Funput tự chuyển khi bạn đổi app |
 | ✂️ **Gõ tắt** | Bảng viết tắt tự bung, tuỳ chọn khớp cả hoa lẫn thường |
 | 🔄 **Chuyển mã** | Đổi qua lại giữa Unicode dựng sẵn, Unicode tổ hợp, TCVN3 (ABC) và VNI-Windows |
+| 🔠 **Đổi kiểu chữ** | CHỮ HOA · chữ thường · bỏ dấu · viết hoa đầu câu · Viết Hoa Đầu Mỗi Từ, cộng dồn được, ngay trong cửa sổ Chuyển mã |
 | 💾 **Xuất / nhập cấu hình** | Mang toàn bộ tuỳ chọn và gõ tắt sang máy khác bằng một tệp |
 | 🍎 **Hợp chuẩn macOS 26** | Liquid Glass, thanh menu, khởi động cùng máy |
 


### PR DESCRIPTION
Chặng 4 of 4. Base is #375. Draft — **build and tests run locally, but CI does not build macOS on PRs**, so the visual pass is yours.

The first part of this feature a user can see: five transforms as glass chips under the charset row, the order they were pressed spelled out, and the two switches that belong to them.

## Not a tab, and why

`docs/features/text-case.md` said "a second tab". The architecture that grew underneath it is **two axes over one document** — charset and case compose, and the batch row notes answer to both — so a tab would say the user has to pick one. The bar sits in both the text and the batch shapes instead.

In batch mode that pays off immediately: press CHỮ HOA with TCVN3 as the target and the `N chữ sẽ mất` note changes on every row, because TCVN3 has no uppercase toned vowels. That is the most useful thing this window now does, and it cost nothing here — #374 made the note count *after* the transform.

## The order is shown, not implied

`chữ thường → Viết Hoa Đầu Mỗi Từ` is a different document from the same two reversed. So a chip is a **button that appends**, and a line underneath spells the sequence out with **Hoàn tác** taking off the last one and **Bỏ hết** clearing it. Lit chips alone could not express the order, nor a transform pressed twice at two points in the sequence.

**A switch appears only while its transform is applied.** `Giữ đ/Đ` belongs to bỏ dấu, `Hạ chữ viết hoa` to title case; either has nothing to say otherwise, and showing it there is what teaches which one owns it.

## Liquid Glass, per `platforms/macos/docs/LIQUID_GLASS.md`

- Glass is on the controls that float — the chips, and the Hoàn tác/Bỏ hết cluster. The `Đang áp:` line is content-layer text and the switches are system `Toggle`s, so **nothing nests glass inside glass**.
- One `GlassEffectContainer` per adjacent cluster, `spacing:` equal to the stack inside it, as `ConvertTextView` already does twice.
- **No `.glassProminent`** here: the window's primary action is still the footer's, and the rule is one per group.
- No `glassEffectID` — nothing enters or leaves in a coordinated transition.
- An applied chip carries a **checkmark as well as the tint**, because "every selection must have a non-color indicator", plus `.isSelected` and a Vietnamese `accessibilityValue`.
- Animations gated on Reduce Motion; Reduce Transparency left to the framework, as the doc requires.
- Chips use the compact sizing `GlassMethodSelector` already uses for its panel — five Vietnamese labels in one row have to survive the 760pt minimum window.

## Plumbing

- **The menu comes from core** (`funput_convert_transform_count/_name`), never a list Swift keeps its own copy of, so a sixth transform appears here without a line changing. There is a test asserting the door and the table agree.
- **Casing goes through `updateFlushing`, not `update`.** Typing is debounced 150 ms; a transform pressed before that lands must still run on what was typed. `testATransformPressedRightAfterTypingSeesTheTypedText` is exactly that case.
- `ConvertWorker.loadCharsets` was spelling the two-call UTF-32 read out longhand because `readText` was file-private. The transform menu would have been a third copy, so `readText` is now shared — one home for the door's sizing rule.
- `ConvertAction` gains **one** case carrying a `ConvertCasingAction`, not five flat cases. `ConvertStore.swift` sat exactly at the 150-line budget with nothing to spare, and an axis with its own action type mirrors how the Rust and C layers keep it in a module of its own. The store's second half had also picked up three blank lines its first half does not have; making that consistent is where the room for the new case came from.

## Budgets

`platforms/macos/scripts/check-swift-loc.sh` allows 150 lines per file and **5 files per feature directory**. `Convert/` and `Convert/Views/` each had one slot left, so the new code went into a new `Convert/Casing/` folder — mirroring `crates/funput-ffi/src/convert/casing/` — which leaves both of those last slots free and gives the axis three of its own. `ConvertCasingBar.swift` is 128 lines, `ConvertCasingState.swift` 48, `ConvertStore.swift` back down to 148.

## The header now says both

The subtitle promised only half of what the window does — "Chuyển văn bản giữa Unicode và các bảng mã tiếng Việt cũ" — and it is the line a user reads while looking for bỏ dấu. It now reads "Đổi bảng mã và kiểu chữ của văn bản đã có."

The window keeps its name. "Chuyển mã" is the term the people who need it already use (it is what UniKey's toolkit is called), and renaming reaches ten user-facing strings across three platforms plus a `.desktop` entry and a tray menu. A wider name is worth that only when there is a third tool in here to justify it — and at that point `OUT_DIR` ("Đã chuyển mã") should be renamed in the same change, because a batch that only changed case already lands in a folder whose name overstates what happened.

## Verification

```
xcodebuild build … ** BUILD SUCCEEDED **
xcodebuild test  … ** TEST SUCCEEDED **   (7 new: 4 through the live bridge, 3 pure)
bash platforms/macos/scripts/check-swift-loc.sh — passed
```

What I could not check is how it *looks*. Worth a pass over:

1. Paste `GỬI VỀ TP. HCM`, press `chữ thường` then `Viết Hoa Đầu Mỗi Từ` → `Gửi Về Tp. Hcm`; the other order → all lowercase.
2. Press `Bỏ dấu tiếng Việt` → `Giữ đ/Đ` appears; switch it on and `đẹp` stays `đep`.
3. Drop a folder of `.txt`, target TCVN3, press `CHỮ HOA` → the row notes should **grow**.
4. Light/dark, Reduce Motion, Reduce Transparency, Increase Contrast, VoiceOver, and the window pulled down to its 760pt minimum — the chip row is the part I would most expect to need a tweak there.

The design doc's status line is deliberately untouched: #372 rewrote that same paragraph, and this branch predates it. It gets updated when the feature branch lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

