### PR TITLE
fix(android): align symbol key order with Gboard

### DIFF
--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/SymbolPageContent.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/SymbolPageContent.kt
@@ -4,16 +4,16 @@ package app.funput.funput.keyboard.layout
  * Symbol key labels grouped by page and row for the 5-row Samsung-style grid.
  *
  * Rows keep a 10 / 10 / 7 shape so every key shares one width (the bottom row also
- * carries the 1.5-weight page-switch and backspace keys). Page 1 holds the everyday
- * symbols for fast access; page 2 holds technical, foreign-currency and math glyphs.
+ * carries the 1.5-weight page-switch and backspace keys). Symbols shared with Gboard
+ * follow its page order; Funput-only glyphs fill the remaining trailing positions.
  * No glyph is repeated across the two pages.
  */
 internal object SymbolPageContent {
-    val primaryRow1 = listOf("@", "#", "₫", "$", "%", "&", "*", "+", "=", "/")
-    val primaryRow2 = listOf("(", ")", "-", "_", ":", ";", "'", "\"", "!", "?")
-    val primaryRow3 = listOf("~", "•", "…", "°", "×", "÷", "^")
+    val primaryRow1 = listOf("@", "#", "₫", "_", "&", "-", "+", "(", ")", "/")
+    val primaryRow2 = listOf("*", "\"", "'", ":", ";", "!", "?", "…", "<", ">")
+    val primaryRow3 = listOf("¥", "¶", "·", "≠", "±", "≈", "≤")
 
-    val secondaryRow1 = listOf("[", "]", "{", "}", "<", ">", "\\", "|", "`", "§")
-    val secondaryRow2 = listOf("€", "£", "¥", "¢", "©", "®", "™", "¶", "·", "✓")
-    val secondaryRow3 = listOf("≠", "±", "≈", "≤", "≥", "√", "∞")
+    val secondaryRow1 = listOf("~", "`", "|", "•", "√", "÷", "×", "§", "£", "€")
+    val secondaryRow2 = listOf("$", "¢", "^", "°", "=", "{", "}", "\\", "%", "©")
+    val secondaryRow3 = listOf("®", "™", "✓", "[", "]", "≥", "∞")
 }

--- a/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/symbols/CompactSymbolPageContent.kt
+++ b/platforms/android/keyboard-renderer/src/main/java/app/funput/funput/keyboard/layout/symbols/CompactSymbolPageContent.kt
@@ -1,10 +1,10 @@
 package app.funput.funput.keyboard.layout.symbols
 
-/** Symbol labels for Telex compact layouts, mirrored from iOS CompactSymbolPageContent. */
+/** Gboard-ordered symbol labels for Telex compact layouts, followed by Funput-only glyphs. */
 internal object CompactSymbolPageContent {
-    val primaryMiddle = listOf("@", "#", "₫", "$", "%", "&", "*", "+", "=", "/")
-    val primaryBottom = listOf("(", ")", "-", "_", ":", "!", "?")
-    val secondaryTop = listOf(";", "'", "\"", "~", "•", "…", "°", "×", "÷", "^")
-    val secondaryMiddle = listOf("[", "]", "{", "}", "<", ">", "\\", "|", "`", "€")
-    val secondaryBottom = listOf("£", "¥", "©", "≠", "±", "≤", "≥")
+    val primaryMiddle = listOf("@", "#", "₫", "_", "&", "-", "+", "(", ")", "/")
+    val primaryBottom = listOf("*", "\"", "'", ":", ";", "!", "?")
+    val secondaryTop = listOf("~", "`", "|", "•", "÷", "×", "£", "€", "$", "^")
+    val secondaryMiddle = listOf("°", "=", "{", "}", "\\", "%", "©", "[", "]", "…")
+    val secondaryBottom = listOf("<", ">", "¥", "≠", "±", "≤", "≥")
 }

--- a/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/SymbolLayoutsTest.kt
+++ b/platforms/android/keyboard-renderer/src/test/java/app/funput/funput/keyboard/layout/SymbolLayoutsTest.kt
@@ -4,6 +4,7 @@ import app.funput.funput.keyboard.model.KeyRole
 import app.funput.funput.keyboard.model.KeySpec
 import app.funput.funput.keyboard.model.KeyboardInputMethod
 import app.funput.funput.keyboard.model.KeyboardEditorMode
+import app.funput.funput.keyboard.model.KeyboardLayout
 import app.funput.funput.keyboard.model.KeySwipeAction
 import app.funput.funput.keyboard.model.KeyboardLayoutMode
 import app.funput.funput.keyboard.model.KeyboardRow
@@ -15,7 +16,7 @@ import org.junit.Test
 
 class SymbolLayoutsTest {
     @Test
-    fun `primary page uses five rows with common symbols`() {
+    fun `primary page follows Gboard order before Funput-only symbols`() {
         val layout = KeyboardLayoutResolver.resolve(
             KeyboardInputMethod.TELEX,
             KeyboardLayoutMode.SYMBOLS_PRIMARY,
@@ -25,21 +26,25 @@ class SymbolLayoutsTest {
         assertEquals("1234567890", labels(layout.rows[0].keys))
         assertTrue(layout.rows[0].keys.all { key -> key.role == KeyRole.PUNCTUATION })
         assertTrue(layout.rows[0].keys.all { key -> key.secondaryLabel == null })
-        assertEquals("@#₫", labels(layout.rows[1].keys).take(3))
-        assertEquals("()-", labels(layout.rows[2].keys).take(3))
+        assertEquals(listOf("@", "#", "₫", "_", "&", "-", "+", "(", ")", "/"), keyLabels(layout, 1))
+        assertEquals(listOf("*", "\"", "'", ":", ";", "!", "?", "…", "<", ">"), keyLabels(layout, 2))
+        assertEquals(listOf("=\\<", "¥", "¶", "·", "≠", "±", "≈", "≤", ""), keyLabels(layout, 3))
         assertTrue(layout.rows.flattenedKeys().any { it.label == "₫" })
         assertTrue(layout.rows.flattenedKeys().any { it.role == KeyRole.MORE_SYMBOLS })
         assertTrue(layout.rows.flattenedKeys().any { it.role == KeyRole.LETTERS })
     }
 
     @Test
-    fun `secondary page uses five rows with less common symbols`() {
+    fun `secondary page follows Gboard order before Funput-only symbols`() {
         val layout = KeyboardLayoutResolver.resolve(
             KeyboardInputMethod.VNI,
             KeyboardLayoutMode.SYMBOLS_SECONDARY,
         )
 
         assertEquals(5, layout.rows.size)
+        assertEquals(listOf("~", "`", "|", "•", "√", "÷", "×", "§", "£", "€"), keyLabels(layout, 1))
+        assertEquals(listOf("$", "¢", "^", "°", "=", "{", "}", "\\", "%", "©"), keyLabels(layout, 2))
+        assertEquals(listOf("?123", "®", "™", "✓", "[", "]", "≥", "∞", ""), keyLabels(layout, 3))
         assertTrue(layout.rows.flattenedKeys().any { it.role == KeyRole.SYMBOLS && it.label == "?123" })
         assertTrue(layout.rows.flattenedKeys().any { it.label == "€" })
         assertTrue(layout.rows.flattenedKeys().none { it.role == KeyRole.PLACEHOLDER })
@@ -84,6 +89,28 @@ class SymbolLayoutsTest {
 
         assertEquals(glyphs.size, glyphs.distinct().size)
     }
+
+    @Test
+    fun `compact pages follow Gboard order before Funput-only symbols`() {
+        val primary = compact(KeyboardLayoutMode.SYMBOLS_PRIMARY)
+        val secondary = compact(KeyboardLayoutMode.SYMBOLS_SECONDARY)
+
+        assertEquals(listOf("@", "#", "₫", "_", "&", "-", "+", "(", ")", "/"), keyLabels(primary, 1))
+        assertEquals(listOf("=\\<", "*", "\"", "'", ":", ";", "!", "?", ""), keyLabels(primary, 2))
+        assertEquals(listOf("~", "`", "|", "•", "÷", "×", "£", "€", "$", "^"), keyLabels(secondary, 0))
+        assertEquals(listOf("°", "=", "{", "}", "\\", "%", "©", "[", "]", "…"), keyLabels(secondary, 1))
+        assertEquals(listOf("?123", "<", ">", "¥", "≠", "±", "≤", "≥", ""), keyLabels(secondary, 2))
+    }
+
+    private fun compact(mode: KeyboardLayoutMode) = KeyboardLayoutResolver.resolve(
+        inputMethod = KeyboardInputMethod.TELEX,
+        mode = mode,
+        editorMode = KeyboardEditorMode.SEARCH,
+        showsNumberRow = false,
+    )
+
+    private fun keyLabels(layout: KeyboardLayout, row: Int) =
+        layout.rows[row].keys.map { it.label }
 
     private fun labels(keys: List<KeySpec>) = keys.joinToString("") { it.label }
 


### PR DESCRIPTION
## Summary

- reorder standard Android symbol pages to follow the supplied Gboard layout
- reorder compact symbol pages while preserving their existing geometry and glyph set
- add exact row-order coverage for both symbol layout variants

## Test plan

- `./gradlew testDebugUnitTest --console=plain`
- `bash scripts/check-kotlin-loc.sh`
- `bash scripts/check-kotlin-layout.sh`
- `./gradlew :app:assembleDebug --console=plain`