### PR TITLE
feat(windows): add the casing axis to the Chuyển mã window

### DIFF
--- a/docs/features/text-case.md
+++ b/docs/features/text-case.md
@@ -2,14 +2,17 @@
 
 ## Trạng thái
 
-**Tầng core đã xong**: `funput_core::textcase` sau cargo feature `textcase`, cả năm
-phép, kèm corpus và property test, và **`funput case`** trong CLI đã gọi tới nó. Còn
-lại: `funput-convert` và ba cửa sổ.
+**Còn lại một cửa sổ.** `funput_core::textcase` sau cargo feature `textcase` có cả
+năm phép, kèm corpus và property test; `funput-convert` mang trục thứ hai của
+`Session`; `funput-ffi` mở cửa C cho nó; và **`funput case`** trong CLI, **macOS**
+(`ConvertCasingBar.swift`) cùng **Windows** (`ui/convert/casing.slint`) đều đã gọi
+tới. Chưa nối: cửa sổ GTK trên Linux — mọi thứ nó cần đã có sẵn trong `Session` và
+`View`, đúng như hai shell kia đã dùng.
 
 Tài liệu này chốt mô hình trước khi có code, như [charset.md](charset.md) đã làm, và là
 nơi mọi quyết định thiết kế sống — mỗi thay đổi cập nhật lại nó trong cùng PR.
 
-Phạm vi **V1 đã chốt: một tab trong cửa sổ Chuyển mã**, ba nền tảng desktop, cộng
+Phạm vi **V1 đã chốt: một thanh trong cửa sổ Chuyển mã**, ba nền tảng desktop, cộng
 `funput case` trong CLI. Không hotkey, không đụng vùng bôi đen, không nghe clipboard. Những thứ đó nằm ở
 [Lộ trình sau V1](#lộ-trình-sau-v1) và có tài liệu riêng khi tới lượt.
 
@@ -80,8 +83,9 @@ thứ hai của cùng câu trả lời, và bản thứ hai là bản sẽ lệc
 cách lọc tám dấu rời, danh sách lấy từ `unicode::combining`.
 
 **Tuỳ chọn `đ → d`**: mặc định **bật**. Người cần giữ `đ` (đặt tên file cho hệ thống
-chấp nhận nó, hoặc chỉ muốn bỏ thanh) tắt được trong cùng tab. Đây là tuỳ chọn duy
-nhất của phép này.
+chấp nhận nó, hoặc chỉ muốn bỏ thanh) tắt được bằng công tắc **Giữ đ/Đ** trên cùng
+thanh — công tắc đặt tên theo thứ nó bật lên, nên mặc định của phép hiện ra ở UI là
+công tắc **tắt**. Đây là tuỳ chọn duy nhất của phép này.
 
 Hai điều phép này **không làm được**, và đều là bản chất chứ không phải thiếu sót.
 `é` chỉ có một code point dù người gõ nó cho tiếng Việt hay tiếng Pháp, nên `café`
@@ -128,8 +132,9 @@ bàn phím tiếng Việt   →  Bàn Phím Tiếng Việt
 gửi về TP. HCM        →  Gửi Về TP. HCM        (không phải "Tp. Hcm")
 ```
 
-Ngoại lệ ALL-CAPS bật mặc định, tắt được. Từ một chữ cái (`A`) coi như ALL-CAPS —
-vô hại, vì kết quả hai đường như nhau.
+Ngoại lệ ALL-CAPS bật mặc định, tắt được bằng công tắc **Hạ chữ viết hoa** — đặt tên
+theo thứ nó bật lên, nên cũng mặc định **tắt** như công tắc kia. Từ một chữ cái (`A`)
+coi như ALL-CAPS — vô hại, vì kết quả hai đường như nhau.
 
 Ranh giới từ là **khoảng trắng hoặc dấu câu ASCII**; `bàn-phím` thành `Bàn-Phím`,
 `e-mail` thành `E-Mail` — quy ước của mọi công cụ cùng loại. Dấu nháy đơn là ngoại lệ,
@@ -154,7 +159,7 @@ quy ước title case như tiếng Anh, và đoán sẽ sai nhiều hơn đúng.
 
 ## Bảng mã cũ là ca biên thật sự
 
-Cửa sổ Chuyển mã làm việc với TCVN3 và VNI-Windows, nên tab mới **bắt buộc** phải trả
+Cửa sổ Chuyển mã làm việc với TCVN3 và VNI-Windows, nên trục mới **bắt buộc** phải trả
 lời câu hỏi: viết hoa một đoạn TCVN3 thì sao?
 
 Viết hoa từng `char` của chuỗi TCVN3 là **sai**, vì `char` ở đó không phải chữ cái —
@@ -182,7 +187,7 @@ không dùng đường cảnh báo.
 | --- | --- |
 | `funput-core::textcase` | Năm phép biến đổi thuần, không phụ thuộc, không alloc ngoài chuỗi kết quả, và không bảng dữ liệu mới nào. Sau cargo feature riêng, **mặc định tắt** như `charset` — iOS/Android không bao giờ biên dịch nó |
 | `funput-convert` | Trục thứ hai của `Session`: "đổi bảng mã" và "đổi kiểu chữ" dùng chung một `Session`, một `View`, một đường cảnh báo |
-| Ba shell | Chỉ tab, nút, và preview. Không quyết định gì — đúng hợp đồng `refresh()` / `view()` hiện tại |
+| Ba shell | Chỉ thanh, nút, và preview. Không quyết định gì — đúng hợp đồng `refresh()` / `view()` hiện tại |
 | `funput-cli` | `funput case --upper|--lower|--no-diacritics|--sentence|--title` đọc stdin. Rẻ, và là bề mặt test tốt nhất |
 
 **Vì sao mở rộng `Session` chứ không dựng session thứ hai.** Lý do `funput-convert`
@@ -228,15 +233,34 @@ Hai chi tiết bắt buộc khi hiện thực:
 
 ## Giao diện V1
 
-Tab thứ hai trong cửa sổ Chuyển mã, cùng vùng dán và cùng cặp khung trước/sau:
+**Một thanh luôn hiện, không phải một tab.** Đã cân nhắc tab và **loại**: đổi bảng mã
+và đổi kiểu chữ là hai lựa chọn về cùng một văn bản và chúng **cộng dồn** — một đoạn
+đọc ra từ TCVN3 vẫn viết hoa đầu mỗi từ được — nên cả hai ở trên màn hình cùng lúc.
+Một tab sẽ nói rằng người dùng phải chọn một trong hai.
 
-- Năm nút phép biến đổi (chọn một), áp dụng ngay lên preview.
-- Hai công tắc: **đ → d** (mặc định bật) và **giữ nguyên từ viết HOA** (mặc định bật),
-  chỉ hiện khi liên quan tới phép đang chọn.
+Thanh nằm ngay dưới hàng chọn bảng mã ở hình dạng văn bản, và dưới header ở hình dạng
+batch; hình dạng rỗng (vùng thả tệp) không có nó. Cùng vùng dán và cùng cặp khung
+trước/sau:
+
+- Năm nút phép biến đổi, áp dụng ngay lên preview. Phép đang áp có **nền accent và
+  dấu tick** — chỉ đổi màu là tín hiệu mà người mù màu không nhận được.
+- Dòng **`Đang áp: chữ thường → Viết Hoa Đầu Mỗi Từ`** viết rõ thứ tự, vì thứ tự ra
+  văn bản khác nhau. Chỉ hiện khi có phép đang áp.
+- Hai công tắc, đặt tên theo thứ chúng **bật lên** nên cả hai **mặc định tắt**:
+  **Giữ đ/Đ** (tắt = `đ → d`) và **Hạ chữ viết hoa** (tắt = giữ nguyên từ viết HOA).
+  Mỗi công tắc chỉ hiện **khi phép sở hữu nó đang được áp** — ngoài lúc đó nó không có
+  gì để nói, và hiện ở đó là cách dạy phép nào sở hữu nó.
 - Dòng cảnh báo dùng chung với Chuyển mã, chỉ hiện khi encode ngược mất chữ.
-- Nút **Sao chép kết quả**, và **Hoàn tác** trả về nguyên bản.
+- Nút **Hoàn tác** gỡ **phép cuối cùng** chứ không phải tất cả — bấm nhầm phép thứ ba
+  không nên mất hai phép trước nó — và **Bỏ hết** trả về nguyên bản.
 - Phép biến đổi **cộng dồn được**: bấm "chữ thường" rồi "Viết Hoa Đầu Mỗi Từ" cho kết
-  quả của cả hai. Nguyên bản luôn giữ để hoàn tác về một bước.
+  quả của cả hai. Bấm lại đúng phép đang ở đỉnh là **không làm gì**, vì mọi phép đều
+  idempotent nên lần bấm thứ hai không đổi được văn bản. Nguyên bản luôn giữ: danh
+  sách phép được phát lại từ đầu ở mỗi lần dựng preview, không bao giờ ghi đè lên
+  đoạn người dùng đã dán.
+- Thanh **mờ và không bấm được** khi chưa có bảng mã nào giải thích được văn bản: văn
+  bản đó không được chuyển mã, và cũng không được đổi kiểu chữ — một quy tắc, không
+  phải hai. Batch mang bảng mã theo từng dòng nên không bao giờ bị chặn.
 
 Một file thả vào vẫn rơi vào `Mode::Text` như hiện tại. Nhiều file là batch —
 **không thuộc V1**, nhưng bảng `Row` không cần đổi khi tới lượt.
@@ -278,7 +302,7 @@ Windows), và không đụng clipboard ở đó.
 
 ## Cấu hình
 
-V1 **không thêm khoá nào vào file cấu hình**. Hai công tắc của tab là lựa chọn của
+V1 **không thêm khoá nào vào file cấu hình**. Hai công tắc của thanh là lựa chọn của
 phiên làm việc, lưu cùng chỗ cửa sổ Chuyển mã lưu trạng thái của nó.
 
 Từ V3 trở đi mới cần hotkey, và hotkey là khối **theo từng nền tảng** trong
@@ -303,12 +327,18 @@ không đoán trước.
 
 ### Kiểm tra thủ công
 
-1. Mở Chuyển mã → tab Kiểu chữ, dán `xin chào. hôm nay trời đẹp.` rồi thử lần lượt
+1. Mở Chuyển mã → thanh Kiểu chữ, dán `xin chào. hôm nay trời đẹp.` rồi thử lần lượt
    năm nút; kiểm tra preview trước/sau khớp với bảng ở đầu tài liệu.
 2. Dán đoạn có `TP. HCM` và một dòng xuống dòng không chấm câu: kiểm tra ngoại lệ
    ALL-CAPS và ranh giới dòng.
-3. Tắt công tắc `đ → d`, bỏ dấu `đẹp` → `đep`.
-4. Dán một đoạn TCVN3 (copy từ Word font `.VnTime`), bấm CHỮ HOA: phải thấy dòng cảnh
-   báo nêu tên ký tự sẽ mất.
-5. Bấm chồng hai phép rồi Hoàn tác: phải về đúng nguyên bản, một bước.
-6. `echo "Tiếng Việt" | funput case --no-diacritics` cho `Tieng Viet`.
+3. Bật công tắc **Giữ đ/Đ**, bỏ dấu `đẹp` → `đep`. Nó chỉ hiện khi `Bỏ dấu tiếng Việt`
+   đang áp; **Hạ chữ viết hoa** cũng vậy với `Viết Hoa Đầu Mỗi Từ`.
+4. Đặt đích TCVN3 rồi bấm CHỮ HOA: phải thấy dòng cảnh báo **nêu tên** ký tự sẽ mất —
+   phép biến đổi chạy trước khi tính giá, nên chữ hoa TCVN3 không có chỗ mới lộ ra ở
+   đây. Ở hình dạng batch, cột `N chữ sẽ mất` của từng dòng phải đổi theo.
+5. Bấm chồng hai phép: dòng `Đang áp` phải viết đúng thứ tự đã bấm, và đổi thứ tự phải
+   cho văn bản khác. **Hoàn tác** gỡ đúng phép cuối; **Bỏ hết** về nguyên bản.
+6. Dán chuỗi không đoán được bảng mã (`hello world`): cả thanh phải mờ và không bấm
+   được.
+7. `echo "Tiếng Việt" | funput case --no-diacritics` cho `Tieng Viet` — CLI và ba cửa
+   sổ gọi cùng một hàm, nên lệch nhau ở đây là lỗi nối dây của shell.

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -62,9 +62,12 @@ ed25519-dalek = "3" # verify the Sparkle-compatible Ed25519 signature
 base64 = "0.23" # decode the public key + signature
 semver = "1" # compare the manifest version against CARGO_PKG_VERSION
 self-replace = "1" # replace the currently running executable (crate `self_replace`)
-# `charset` is spelled out rather than left to feature unification through
-# funput-config: this shell calls it directly, so it should ask for it directly.
-funput-core = { path = "../../crates/funput-core", features = ["charset"] }
+# Both features are spelled out rather than left to feature unification through
+# funput-config and funput-convert: this shell calls each of them directly, so it
+# should ask for each directly. `textcase` is the Chuyển mã window's second axis —
+# the shell names `Transform` to ask core which menu position a switch belongs to,
+# rather than writing the position down as a number of its own.
+funput-core = { path = "../../crates/funput-core", features = ["charset", "textcase"] }
 # The Chuyển mã window's logic, shared with the GTK window on Linux so the two
 # cannot drift — see crates/funput-convert/README.md.
 funput-convert = { path = "../../crates/funput-convert" }

--- a/platforms/windows/README.md
+++ b/platforms/windows/README.md
@@ -47,6 +47,7 @@
 | 🌏 **Tự tắt khi đổi bàn phím** | Chuyển sang EN khi bạn dùng bàn phím tiếng Nhật, Hàn, Trung… |
 | ✂️ **Gõ tắt** | Bảng viết tắt tự bung, khớp cả hoa lẫn thường; nhập được bảng gõ tắt UniKey |
 | 🔄 **Chuyển mã** | Đổi qua lại giữa Unicode dựng sẵn, Unicode tổ hợp, TCVN3 (ABC) và VNI-Windows — dán văn bản hoặc chuyển cả tệp |
+| 🔠 **Đổi kiểu chữ** | CHỮ HOA · chữ thường · bỏ dấu · viết hoa đầu câu · Viết Hoa Đầu Mỗi Từ, cộng dồn được, ngay trong cửa sổ Chuyển mã |
 | 💾 **Xuất / nhập cấu hình** | Mang toàn bộ tuỳ chọn và gõ tắt sang máy khác bằng một tệp |
 | 🚀 **Khởi động cùng Windows** | Tuỳ chọn, ghi vào registry `HKCU\…\Run` |
 

--- a/platforms/windows/src/ui/convert/casing.rs
+++ b/platforms/windows/src/ui/convert/casing.rs
@@ -1,0 +1,155 @@
+//! The second axis: this shell's half of it.
+//!
+//! Nothing here decides anything either. Which transforms exist, what each is
+//! called, what pressing one does to a document and what a second press on the same
+//! one means — all of it lives in [`funput_convert::casing`], shared with the GTK
+//! window on Linux and with macOS through the C door. What is here is the mapping:
+//! a [`View`] poured into the `Casing` global, and five buttons tied back to the
+//! session.
+//!
+//! The one thing this file must not do is write a transform's position down as a
+//! number. A switch belongs to a transform, not to a slot, so it asks
+//! [`funput_convert::casing::index_of`] where that transform sits — appending a
+//! sixth transform in core then moves nothing here.
+
+use funput_convert::{Mode, Session, View, casing};
+use funput_core::textcase::Transform;
+use slint::{ComponentHandle, ModelRc, VecModel};
+
+use crate::{Casing, ConvertWindow, TransformChip};
+
+use super::view::edit;
+
+pub(super) fn wire(window: &ConvertWindow) {
+    let casing = window.global::<Casing>();
+    casing.on_apply(|index| edit(move |s| s.apply_transform(usize::try_from(index).unwrap_or(0))));
+    casing.on_undo(|| edit(Session::undo_transform));
+    casing.on_clear(|| edit(Session::clear_transforms));
+    casing.on_set_keep_d(|on| edit(move |s| s.set_keep_d(on)));
+    casing.on_set_flatten_caps(|on| edit(move |s| s.set_flatten_caps(on)));
+}
+
+pub(super) fn show(window: &ConvertWindow, view: &View) {
+    let casing = window.global::<Casing>();
+    casing.set_transforms(ModelRc::new(VecModel::from(chips(view))));
+    casing.set_applied_line(applied_line(view).into());
+    // A document no charset could explain is not converted, and core does not
+    // transform it either — one rule, not two. A batch carries a charset per row, so
+    // it is never blocked.
+    casing.set_enabled(view.mode == Mode::Files || view.source.is_some());
+    casing.set_keep_d(view.keep_d);
+    casing.set_flatten_caps(view.flatten_caps);
+    casing.set_shows_keep_d(applies(view, Transform::NoDiacritics));
+    casing.set_shows_flatten_caps(applies(view, Transform::Title));
+}
+
+/// The menu, and which of it is on.
+fn chips(view: &View) -> Vec<TransformChip> {
+    casing::ALL
+        .iter()
+        .enumerate()
+        .map(|(index, &transform)| TransformChip {
+            name: casing::name(transform).into(),
+            applied: view.transforms.contains(&index),
+        })
+        .collect()
+}
+
+/// What is applied, in the order pressed.
+///
+/// The order is the whole point — `chữ thường → Viết Hoa Đầu Mỗi Từ` is a different
+/// document from the same two reversed — so it is spelled out rather than left for
+/// the user to infer from which chips are lit. Empty when nothing is applied, which
+/// is what hides the row.
+fn applied_line(view: &View) -> String {
+    if view.transforms.is_empty() {
+        return String::new();
+    }
+    let names: Vec<&str> = view
+        .transforms
+        .iter()
+        .map(|&index| casing::name(casing::at(index)))
+        .collect();
+    format!("Đang áp: {}", names.join(" → "))
+}
+
+/// Whether the transform that owns a switch is applied.
+fn applies(view: &View, transform: Transform) -> bool {
+    casing::index_of(transform).is_some_and(|index| view.transforms.contains(&index))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `View` is `#[non_exhaustive]`, so it cannot be built field by field from out
+    /// here. Driving a real session is the honest way anyway: it locks in what the
+    /// window will actually be handed.
+    fn viewed(pressed: &[Transform]) -> Session {
+        let mut session = Session::new();
+        session.set_input("Tiếng Việt rất đẹp".to_string());
+        for &transform in pressed {
+            session.apply_transform(casing::index_of(transform).expect("in the menu"));
+        }
+        session.refresh();
+        session
+    }
+
+    #[test]
+    fn the_menu_is_whole_before_anything_is_pressed() {
+        let session = viewed(&[]);
+        let chips = chips(session.view());
+        assert_eq!(chips.len(), casing::ALL.len());
+        assert!(chips.iter().all(|chip| !chip.applied));
+        assert_eq!(chips[0].name, casing::name(Transform::Upper));
+    }
+
+    #[test]
+    fn a_pressed_transform_lights_its_own_chip() {
+        let session = viewed(&[Transform::Lower]);
+        let chips = chips(session.view());
+        let lit: Vec<&str> = chips
+            .iter()
+            .filter(|chip| chip.applied)
+            .map(|chip| chip.name.as_str())
+            .collect();
+        assert_eq!(lit, vec![casing::name(Transform::Lower)]);
+    }
+
+    #[test]
+    fn the_applied_line_is_empty_until_something_is_pressed() {
+        assert_eq!(applied_line(viewed(&[]).view()), "");
+    }
+
+    #[test]
+    fn the_applied_line_reads_in_the_order_pressed() {
+        let forward = viewed(&[Transform::Lower, Transform::Title]);
+        let backward = viewed(&[Transform::Title, Transform::Lower]);
+        assert_eq!(
+            applied_line(forward.view()),
+            "Đang áp: chữ thường → Viết Hoa Đầu Mỗi Từ"
+        );
+        assert_eq!(
+            applied_line(backward.view()),
+            "Đang áp: Viết Hoa Đầu Mỗi Từ → chữ thường"
+        );
+    }
+
+    #[test]
+    fn a_switch_shows_only_for_the_transform_that_owns_it() {
+        let session = viewed(&[Transform::NoDiacritics]);
+        assert!(applies(session.view(), Transform::NoDiacritics));
+        assert!(!applies(session.view(), Transform::Title));
+    }
+
+    /// The bar's state comes from the session, so the window empties itself when
+    /// core drops the presses — it has no list of its own to forget to clear.
+    #[test]
+    fn typing_a_new_document_takes_the_transforms_off() {
+        let mut session = viewed(&[Transform::Upper]);
+        session.set_input("xin chào".to_string());
+        session.refresh();
+        assert_eq!(applied_line(session.view()), "");
+        assert!(chips(session.view()).iter().all(|chip| !chip.applied));
+    }
+}

--- a/platforms/windows/src/ui/convert/mod.rs
+++ b/platforms/windows/src/ui/convert/mod.rs
@@ -8,10 +8,12 @@
 //! drift. What is here is this shell's half of it.
 //!
 //! - [`view`] — the session, and everything the window shows from it.
+//! - [`casing`] — the second axis: the transforms, and which of them are applied.
 //! - [`text`] — saving a document through a Save dialog.
 //! - [`files`] — running the batch off the UI thread.
 //! - [`win32`] — the two things Slint cannot do: file drop and clipboard buttons.
 
+mod casing;
 mod files;
 mod text;
 mod view;
@@ -60,6 +62,7 @@ pub(super) fn open() {
 }
 
 fn wire(window: &ConvertWindow) {
+    casing::wire(window);
     window.on_text_changed(|typed| edit(|s| s.set_input(typed.to_string())));
     window.on_pick_source(|index| edit(|s| s.pick_source(usize::try_from(index).ok())));
     window.on_pick_target(|index| edit(|s| s.set_target(usize::try_from(index).unwrap_or(0))));

--- a/platforms/windows/src/ui/convert/view.rs
+++ b/platforms/windows/src/ui/convert/view.rs
@@ -16,7 +16,7 @@ use slint::Weak;
 
 use crate::ConvertWindow;
 
-use super::files;
+use super::{casing, files};
 
 thread_local! {
     pub(super) static WINDOW: RefCell<Option<Weak<ConvertWindow>>> = const { RefCell::new(None) };
@@ -64,6 +64,9 @@ fn show(window: &ConvertWindow, view: &View) {
     if let Some(text) = &view.input_preview {
         window.set_input_text(text.clone().into());
     }
+    // Ahead of the shape, and once for both of them: the bar rides in the text view
+    // and in the batch view, and it reads the same fields either way.
+    casing::show(window, view);
 
     match view.mode {
         Mode::Empty => window.set_mode("empty".into()),

--- a/platforms/windows/ui/app.slint
+++ b/platforms/windows/ui/app.slint
@@ -3,7 +3,7 @@
 import { SettingsWindow } from "shell/settings.slint";
 import { OnboardingWindow } from "onboarding/window.slint";
 import { ControlCenterWindow } from "control_center/window.slint";
-import { ConvertWindow, FileRow } from "convert/window.slint";
+import { ConvertWindow, FileRow, Casing, TransformChip } from "convert/window.slint";
 import { Compose } from "overlays/compose.slint";
 import { ShortcutEntry, Theme } from "theme/mod.slint";
 
@@ -15,5 +15,7 @@ export {
     ControlCenterWindow,
     ConvertWindow,
     FileRow,
+    Casing,
+    TransformChip,
     Theme,
 }

--- a/platforms/windows/ui/convert/casing.slint
+++ b/platforms/windows/ui/convert/casing.slint
@@ -1,0 +1,184 @@
+// The second axis: five transforms, the order they were pressed in, and the two
+// switches that belong to them.
+//
+// Not a tab. Changing a charset and changing the case are two choices about one
+// document and they compose — a paragraph can be read out of TCVN3 *and* put in
+// title case — so both stay on screen at once. A tab would say the user has to
+// pick one.
+//
+// State arrives through a global rather than through properties, because this bar
+// appears in two of the window's three shapes (`text` and `files`) and each of them
+// is a component of its own. Passing seven properties and five callbacks down two
+// separate paths would put the same wiring in `window.slint` twice; a global is the
+// shape `Compose` already uses for the same reason.
+//
+// No transform is named here. The labels come from `funput_convert::casing::name`
+// so that three platforms' menus cannot drift apart, and a chip's position in the
+// list is its identity — implementing a sixth transform in core lengthens this row
+// without a line changing here.
+
+import { Palette } from "std-widgets.slint";
+import { Theme, GhostButton, AccentSwitch } from "../theme/mod.slint";
+
+export struct TransformChip {
+    // From `casing::name`, never written in this package.
+    name: string,
+    applied: bool,
+}
+
+export global Casing {
+    // The menu in core's order; the index is the identity of a transform.
+    in property <[TransformChip]> transforms;
+    // "Đang áp: chữ thường → Viết Hoa Đầu Mỗi Từ", or empty when nothing is applied.
+    in property <string> applied-line;
+    // False while no charset explains the document: it is not being converted, and
+    // core does not transform it either.
+    in property <bool> enabled;
+    in property <bool> shows-keep-d;
+    in property <bool> keep-d;
+    in property <bool> shows-flatten-caps;
+    in property <bool> flatten-caps;
+
+    callback apply(int);
+    callback undo();
+    callback clear();
+    callback set-keep-d(bool);
+    callback set-flatten-caps(bool);
+}
+
+// A press appends, and pressing the one already on top is a no-op in core — so this
+// is a button rather than a checkbox. The tick is the non-colour cue: the accent
+// fill alone would leave the state invisible to a colour-blind user.
+component Chip inherits Rectangle {
+    in property <string> label;
+    in property <bool> applied;
+    in property <bool> enabled;
+    callback clicked;
+
+    height: 28px;
+    border-radius: self.height / 2;
+    background: root.applied
+        ? Theme.accent
+        : (touch.has-hover && root.enabled ? Theme.nav-hover : transparent);
+    border-width: root.applied ? 0px : 1px;
+    border-color: Theme.divider;
+    animate background { duration: 120ms; easing: ease-out; }
+
+    HorizontalLayout {
+        padding-left: 12px;
+        padding-right: 12px;
+        spacing: 6px;
+        if root.applied: VerticalLayout {
+            alignment: center;
+            Image {
+                source: @image-url("../icons/status/check.svg");
+                colorize: Theme.accent-text;
+                width: 11px;
+                height: 11px;
+            }
+        }
+        Text {
+            text: root.label;
+            color: root.applied ? Theme.accent-text : Palette.foreground;
+            font-size: Theme.font-caption;
+            font-weight: 600;
+            vertical-alignment: center;
+        }
+    }
+    touch := TouchArea {
+        mouse-cursor: pointer;
+        clicked => {
+            if root.enabled {
+                root.clicked();
+            }
+        }
+    }
+}
+
+export component ConvertCasingBar inherits VerticalLayout {
+    spacing: Theme.sp-sm;
+
+    HorizontalLayout {
+        spacing: Theme.sp-sm;
+        opacity: Casing.enabled ? 1 : 0.45;
+
+        VerticalLayout {
+            alignment: center;
+            Text {
+                text: "Kiểu chữ";
+                font-size: Theme.font-body;
+                color: Theme.subtle;
+            }
+        }
+        for chip[i] in Casing.transforms: Chip {
+            label: chip.name;
+            applied: chip.applied;
+            enabled: Casing.enabled;
+            clicked => { Casing.apply(i); }
+        }
+        // The row is as wide as its chips; anything left over is empty space rather
+        // than five chips stretched across the window.
+        Rectangle { horizontal-stretch: 1; }
+    }
+
+    // The order is the whole point — `chữ thường → Viết Hoa Đầu Mỗi Từ` is a
+    // different document from the same two reversed — so it is spelled out rather
+    // than left for the user to infer from which chips are lit. Shown only when
+    // there is something to say, the way the loss line is.
+    if Casing.applied-line != "": HorizontalLayout {
+        spacing: Theme.sp-md;
+
+        VerticalLayout {
+            alignment: center;
+            horizontal-stretch: 1;
+            Text {
+                text: Casing.applied-line;
+                font-size: Theme.font-caption;
+                color: Theme.subtle;
+                overflow: elide;
+            }
+        }
+        // A switch appears only while the transform it belongs to is applied: it has
+        // nothing to say otherwise, and showing it there teaches which one owns it.
+        if Casing.shows-keep-d: VerticalLayout {
+            alignment: center;
+            Text {
+                text: "Giữ đ/Đ";
+                font-size: Theme.font-caption;
+                color: Theme.subtle;
+            }
+        }
+        if Casing.shows-keep-d: VerticalLayout {
+            alignment: center;
+            AccentSwitch {
+                checked: Casing.keep-d;
+                toggled => { Casing.set-keep-d(self.checked); }
+            }
+        }
+        if Casing.shows-flatten-caps: VerticalLayout {
+            alignment: center;
+            Text {
+                text: "Hạ chữ viết hoa";
+                font-size: Theme.font-caption;
+                color: Theme.subtle;
+            }
+        }
+        if Casing.shows-flatten-caps: VerticalLayout {
+            alignment: center;
+            AccentSwitch {
+                checked: Casing.flatten-caps;
+                toggled => { Casing.set-flatten-caps(self.checked); }
+            }
+        }
+        // Undo takes off the last transform rather than all of them: pressing a
+        // third one by mistake should not cost the two before it.
+        GhostButton {
+            text: "Hoàn tác";
+            clicked => { Casing.undo(); }
+        }
+        GhostButton {
+            text: "Bỏ hết";
+            clicked => { Casing.clear(); }
+        }
+    }
+}

--- a/platforms/windows/ui/convert/files.slint
+++ b/platforms/windows/ui/convert/files.slint
@@ -8,6 +8,7 @@
 
 import { Palette, ComboBox, ListView } from "std-widgets.slint";
 import { Theme, PrimaryButton } from "../theme/mod.slint";
+import { ConvertCasingBar } from "casing.slint";
 
 export struct FileRow {
     name: string,
@@ -62,6 +63,10 @@ export component ConvertFiles inherits VerticalLayout {
             }
         }
     }
+
+    // One transform applies to the whole batch, the way one target charset does —
+    // so it sits in the header rather than in each row.
+    ConvertCasingBar { }
 
     Rectangle {
         vertical-stretch: 1;

--- a/platforms/windows/ui/convert/text.slint
+++ b/platforms/windows/ui/convert/text.slint
@@ -12,6 +12,7 @@
 
 import { Palette, ComboBox, TextEdit } from "std-widgets.slint";
 import { Theme, PrimaryButton, GhostButton } from "../theme/mod.slint";
+import { ConvertCasingBar } from "casing.slint";
 
 export component ConvertText inherits VerticalLayout {
     in property <[string]> charset-names;
@@ -73,6 +74,10 @@ export component ConvertText inherits VerticalLayout {
             }
         }
     }
+
+    // Under the charsets and above the panes: both rows are choices about the same
+    // document, and the panes below show the result of the two together.
+    ConvertCasingBar { }
 
     HorizontalLayout {
         spacing: Theme.sp-sm;

--- a/platforms/windows/ui/convert/window.slint
+++ b/platforms/windows/ui/convert/window.slint
@@ -12,15 +12,18 @@ import { Theme, PageHeader, GhostButton } from "../theme/mod.slint";
 import { ConvertEmpty } from "empty.slint";
 import { ConvertText } from "text.slint";
 import { ConvertFiles, FileRow } from "files.slint";
+import { Casing, TransformChip } from "casing.slint";
 
-export { FileRow }
+export { FileRow, Casing, TransformChip }
 
 export component ConvertWindow inherits Window {
     title: "Funput — Chuyển mã";
     icon: @image-url("../../../../assets/logo.png");
     preferred-width: 760px;
     preferred-height: 560px;
-    min-width: 640px;
+    // Wide enough for the five transform chips on one row: their labels are whole
+    // Vietnamese phrases ("Viết Hoa Đầu Mỗi Từ"), so they do not shrink.
+    min-width: 720px;
     min-height: 460px;
     default-font-family: "Segoe UI Variable Text";
     background: Theme.mica ? transparent : Theme.window-base;
@@ -75,7 +78,7 @@ export component ConvertWindow inherits Window {
                 PageHeader {
                     title: "Chuyển mã";
                     subtitle: root.mode == "empty"
-                        ? "Chuyển văn bản giữa Unicode và các bảng mã cũ."
+                        ? "Đổi bảng mã và kiểu chữ của văn bản đã có."
                         : "";
                 }
             }


### PR DESCRIPTION
The second shell to read the axis, after #376. Base is `feature/text-case`; **nothing in `crates/` changes** — `funput-convert` already carried everything this needed, and Windows links it as plain Rust rather than through the C door.

## What is new

Five transform chips under the charset row, the order they were pressed spelled out, `Hoàn tác` / `Bỏ hết`, and the two switches — same wording and same rules as macOS, so the two windows behave alike.

**State arrives through a Slint global, not properties.** The bar shows in two of the window's three shapes and each is a component of its own, so seven properties and five callbacks would have been threaded down two separate paths — the same wiring in `window.slint` twice. `Compose` already uses a global for that reason.

**No transform's position is written down as a number.** macOS spells `2` and `4` in Swift; here a switch asks `casing::index_of` where its transform sits, so a sixth transform in core moves nothing in this package.

`min-width` goes 640 → 720. Five whole Vietnamese phrases do not shrink, and at 640 the last chip was clipped.

## Docs

`docs/features/text-case.md` still described the interface it was written against — a tab. #376 chose a bar and deliberately; this says so, along with the rest the two shells settled and the document had not caught up with.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (70, six new), `scripts/check-loc.sh`, `cargo test --workspace` — all green. `casing.rs` is 80 code lines; `ui/convert/` goes to 4 of its 5 files.

Run on a real machine, twelve scenarios. The two worth repeating:

1. Target TCVN3, press `CHỮ HOA` → `3 chữ không có trong TCVN3 (ABC): À Ờ Ẹ`. The transform runs before the cost is counted.
2. Drop two files, target TCVN3, press `CHỮ HOA` → every row's `N chữ sẽ mất` note appears.

Not checked here: **light theme** (it would mean changing the whole desktop's theme) and **drag-and-drop** (the `Chọn tệp…` dialog shares the same path, so it is covered indirectly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
