### PR TITLE
fix(windows): the tray toggle is global, and the shell is not an app

### DIFF
--- a/crates/funput-config/src/settings/io.rs
+++ b/crates/funput-config/src/settings/io.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::path::Path;
 
 use super::Settings;
+use super::model;
 use super::model::legacy_tone_style_default;
 
 impl Settings {
@@ -34,7 +35,30 @@ impl Settings {
         };
         let legacy: Vec<_> = std::mem::take(&mut settings.excluded_apps);
         settings.remember_as_english(legacy.into_iter().map(|app| app.id));
+        settings.repair();
         settings
+    }
+
+    /// One-time repairs of documents an earlier build wrote, applied in order and
+    /// counted by [`Settings::schema`] so none of them runs twice.
+    ///
+    /// Like the drain above, re-running a repair before the next write is harmless;
+    /// what the counter buys is that it stops once the user's own choices are on
+    /// disk beside it.
+    fn repair(&mut self) {
+        if self.schema < 1 {
+            // Windows' shell draws the taskbar, the desktop *and* the tray icon, all
+            // from explorer.exe — so a pin there fired on every trip to the tray and
+            // read as Vietnamese switching itself off. Nothing put one there on
+            // purpose: until this release a toggle made in the Control Center was
+            // parked and bound to whichever window took focus next, which after a
+            // tray click is the taskbar. The shell's own surfaces are ignored now
+            // (platforms/windows/.../hook/foreground/window.rs), but the entry that
+            // bug already wrote would outlive the fix, and there is no UI to clear
+            // it with.
+            self.app_language_memory.remove("explorer.exe");
+        }
+        self.schema = model::SCHEMA;
     }
 
     /// Write to `path`, creating its directory. Silent on failure — see above.
@@ -79,6 +103,46 @@ mod tests {
         Settings::default().save_to(&path);
 
         assert!(path.is_file());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    /// The pin the Control Center bug left on Windows' shell. Nobody chose it, it
+    /// fired on every trip to the tray, and there is no UI to clear it with.
+    #[test]
+    fn the_explorer_pin_is_dropped_from_a_document_written_before_the_repair() {
+        let dir = tmp_dir();
+        let path = dir.join("settings.json");
+        let mut json = serde_json::to_value(Settings::default()).unwrap();
+        json["schema"] = serde_json::json!(0);
+        json["appLanguageMemory"] = serde_json::json!({ "explorer.exe": false, "code.exe": false });
+        fs::write(&path, json.to_string()).unwrap();
+
+        let loaded = Settings::load_from(&path);
+        assert_eq!(loaded.app_language_memory.get("explorer.exe"), None);
+        assert_eq!(
+            loaded.app_language_memory.get("code.exe"),
+            Some(&false),
+            "every other pin is the user's and stays"
+        );
+        assert_eq!(loaded.schema, model::SCHEMA);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    /// …and having run, it stops. A File Explorer window is a real app, so someone
+    /// may pin it on purpose afterwards, and a repair that kept firing would delete
+    /// that choice on every launch.
+    #[test]
+    fn a_pin_made_after_the_repair_survives() {
+        let dir = tmp_dir();
+        let path = dir.join("settings.json");
+        let mut settings = Settings::default();
+        settings
+            .app_language_memory
+            .insert("explorer.exe".to_string(), false);
+        settings.save_to(&path);
+
+        let loaded = Settings::load_from(&path);
+        assert_eq!(loaded.app_language_memory.get("explorer.exe"), Some(&false));
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/crates/funput-config/src/settings/model.rs
+++ b/crates/funput-config/src/settings/model.rs
@@ -54,6 +54,15 @@ pub struct Settings {
     /// order — this is rewritten on every focus change that flips VI/EN.
     #[serde(default)]
     pub app_language_memory: BTreeMap<String, bool>,
+    /// How many one-time repairs of this document have been applied — see
+    /// [`Settings::repair`]. A file written before the field existed reads as `0`,
+    /// which is what makes a repair run once; [`Settings::default`] starts at the
+    /// current number, because a document nobody has written yet needs none.
+    ///
+    /// Persisted for one reason only: so a repair cannot keep undoing a choice the
+    /// user makes afterwards.
+    #[serde(default)]
+    pub schema: u32,
     /// **Legacy, read-only.** Drained into `app_language_memory` by
     /// [`Settings::load_from`], so it is always empty afterwards, and never
     /// written back (`skip_serializing`).
@@ -89,21 +98,6 @@ pub struct Settings {
     pub auto_english_on_foreign_layout: bool,
 }
 
-/// The tone placement a file that predates the setting implies: whoever wrote it
-/// has been typing traditional placement, whether they chose it or never looked.
-/// A machine with no file at all is a new install and takes [`Settings::default`].
-pub(super) fn legacy_tone_style_default() -> ToneStyle {
-    ToneStyle::Traditional
-}
-
-/// The default every switch that carries one shares: a file written before the
-/// switch existed must decode as "on" — that is how Funput behaved when it was
-/// written, and an update may not silently take a feature away. Each field says
-/// above why that reasoning holds for it.
-fn default_true() -> bool {
-    true
-}
-
 impl Settings {
     /// Fold legacy "always English" app ids into the per-app memory. An id the
     /// user has since toggled keeps its remembered choice — existing wins, the
@@ -118,32 +112,10 @@ impl Settings {
     }
 }
 
-impl Default for Settings {
-    fn default() -> Self {
-        Self {
-            method: Method::Vni,
-            tone_style: ToneStyle::Modern,
-            enabled: true,
-            smart_restore: true,
-            eager_restore: true,
-            spell_check: false,
-            auto_capitalize: false,
-            toggle_hotkey: Hotkey::CtrlBacktick,
-            toggle_combo: None,
-            flip_hotkey: FlipHotkey::Off,
-            flip_combo: None,
-            launch_at_login: false,
-            has_completed_onboarding: false,
-            app_language_memory: BTreeMap::new(),
-            excluded_apps: Vec::new(),
-            shortcuts: Vec::new(),
-            shortcuts_enabled: true,
-            shortcut_smart_case: true,
-            shortcuts_in_english: true,
-            auto_english_on_foreign_layout: true,
-        }
-    }
-}
+mod defaults;
+
+use defaults::default_true;
+pub(super) use defaults::{SCHEMA, legacy_tone_style_default};
 
 #[cfg(test)]
 mod tests;

--- a/crates/funput-config/src/settings/model/defaults.rs
+++ b/crates/funput-config/src/settings/model/defaults.rs
@@ -1,0 +1,59 @@
+//! What a document reads as when a field — or the whole file — is absent.
+//!
+//! Split from [`super`] so the struct there stays the on-disk contract and nothing
+//! else. Every function here answers one question: what did Funput do before this
+//! field existed? An update may not silently change that answer.
+
+use std::collections::BTreeMap;
+
+use super::super::{FlipHotkey, Hotkey, Method, ToneStyle};
+use super::Settings;
+
+/// How many one-time repairs exist. Bump it in the same commit that adds one to
+/// `Settings::repair`, never on its own.
+pub(in crate::settings) const SCHEMA: u32 = 1;
+
+/// The tone placement a file that predates the setting implies: whoever wrote it
+/// has been typing traditional placement, whether they chose it or never looked.
+/// A machine with no file at all is a new install and takes [`Settings::default`].
+pub(in crate::settings) fn legacy_tone_style_default() -> ToneStyle {
+    ToneStyle::Traditional
+}
+
+/// The default every switch that carries one shares: a file written before the
+/// switch existed must decode as "on" — that is how Funput behaved when it was
+/// written, and an update may not silently take a feature away. Each field says
+/// why that reasoning holds for it.
+pub(super) fn default_true() -> bool {
+    true
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            method: Method::Vni,
+            tone_style: ToneStyle::Modern,
+            enabled: true,
+            smart_restore: true,
+            eager_restore: true,
+            spell_check: false,
+            auto_capitalize: false,
+            toggle_hotkey: Hotkey::CtrlBacktick,
+            toggle_combo: None,
+            flip_hotkey: FlipHotkey::Off,
+            flip_combo: None,
+            launch_at_login: false,
+            has_completed_onboarding: false,
+            app_language_memory: BTreeMap::new(),
+            // A document nobody has written yet needs no repair; only a file
+            // missing the key reads as 0 and gets one.
+            schema: SCHEMA,
+            excluded_apps: Vec::new(),
+            shortcuts: Vec::new(),
+            shortcuts_enabled: true,
+            shortcut_smart_case: true,
+            shortcuts_in_english: true,
+            auto_english_on_foreign_layout: true,
+        }
+    }
+}

--- a/crates/funput-desktop/src/shell/apps.rs
+++ b/crates/funput-desktop/src/shell/apps.rs
@@ -5,10 +5,17 @@
 //! choice then survives leaving, re-focusing, and restarting. An app nobody has
 //! toggled in has no opinion attached, so focusing it changes nothing.
 //!
-//! The awkward part is that both places a user can toggle from — the tray flyout
-//! and the Settings window — *steal foreground themselves*, so the app the choice
-//! is meant for is not focused when the choice is made. That is what
-//! `pending_override` exists for.
+//! **The surface a toggle came from says its scope**, which is what keeps the rule
+//! above true. The hotkey is pressed inside the app it means, so it pins that app.
+//! The tray flyout and the Settings window are Funput's own windows, opened from the
+//! tray with no app in sight, so they move the global default and pin nothing.
+//!
+//! Those two used to park their choice and bind it to whichever app took focus next
+//! — the flyout steals foreground, so there was no app to bind to at the time. That
+//! made turning Vietnamese off in the tray write a permanent entry here for whatever
+//! the user clicked into afterwards: an app they never mentioned, pinned invisibly,
+//! since nothing on Windows displays this map, and still overruling the global switch
+//! long after. A global surface now stays global.
 
 use super::ShellState;
 
@@ -25,8 +32,8 @@ impl ShellState {
     }
 
     /// Flip VI/EN from the keyboard hotkey; returns the new state. Unlike the tray,
-    /// the hotkey fires while the target app is focused, so the choice binds to
-    /// that app immediately and clears any stale pending override.
+    /// the hotkey fires while the target app is focused — so it is the one toggle
+    /// that means "just here", and the only thing that writes this map.
     ///
     /// In memory only. The caller persists with [`Self::save_settings`] once it is
     /// somewhere it can afford to block: on Windows this runs inside the low-level
@@ -46,7 +53,6 @@ impl ShellState {
         if let Some(id) = self.foreground_id().map(str::to_string) {
             self.remember(&id, on);
         }
-        self.pending_override = None;
         on
     }
 
@@ -67,35 +73,23 @@ impl ShellState {
         self.foreground = Some(id);
     }
 
-    /// Decide VI/EN for the newly-focused app:
+    /// Replay the choice remembered for the newly-focused app, if it has one.
     ///
-    /// 1. A pending manual toggle (from the tray / Settings, which steal
-    ///    foreground) binds to this app — the user's choice lands on the app they
-    ///    return to, and is remembered there from now on.
-    /// 2. Otherwise the choice remembered for this app, if it has one.
+    /// An app with none is left alone: it inherits whatever state the previous app
+    /// had, which is what "we only remember what you told us" means — and it is why
+    /// a global toggle reaches every app nobody has pinned without this being told
+    /// anything.
     ///
-    /// An app with neither is left alone: it inherits whatever state the previous
-    /// app had, which is what "we only remember what you told us" means.
+    /// **Reads the map, never writes it.** Only [`Self::toggle_enabled_hotkey`]
+    /// writes, because only the hotkey is pressed inside the app it is about.
     ///
     /// Returns `Some(on)` when it flipped VI/EN (so the caller can refresh its
     /// tray), `None` when nothing changed.
     pub fn apply_for_app(&mut self, id: &str) -> Option<bool> {
-        let mut remembered = false;
-        let target = if let Some(on) = self.pending_override.take() {
-            remembered = self.remember(id, on);
-            on
-        } else {
-            *self.settings.app_language_memory.get(id)?
-        };
-
-        // The map is persisted now, so a choice that binds without flipping the
-        // state still has to reach disk — returning early here would drop it.
+        let target = *self.settings.app_language_memory.get(id)?;
         let before = self.effective_enabled();
-        let flipped = self.settings.enabled != target;
-        if flipped {
+        if self.settings.enabled != target {
             self.set_enabled_state(target);
-        }
-        if flipped || remembered {
             self.save();
         }
         // Reported against what is running: an app remembered as Vietnamese does

--- a/crates/funput-desktop/src/shell/config.rs
+++ b/crates/funput-desktop/src/shell/config.rs
@@ -88,13 +88,9 @@ impl ShellState {
         if self.settings == loaded {
             return false;
         }
-        // A VI/EN flip made in one of those windows parked itself in *their*
-        // `ShellState`, which died with the process — so the app it was meant for
-        // never learned about it. Park it here instead and the next focus change
-        // binds it, exactly as an in-process toggle would.
-        if loaded.enabled != self.settings.enabled {
-            self.pending_override = Some(loaded.enabled);
-        }
+        // A VI/EN flip made in one of those windows arrives as a plain settings
+        // field, and `apply_settings` below pushes it to the engine. Nothing else is
+        // owed: it was a global choice, so it needs no app to land on.
         self.settings = loaded;
         self.apply_settings();
         // The foreign-layout switch may have been the thing that changed, and the

--- a/crates/funput-desktop/src/shell/mod.rs
+++ b/crates/funput-desktop/src/shell/mod.rs
@@ -47,11 +47,6 @@ pub struct ShellState {
     /// The app that currently has focus, fed by the foreground hook. Not
     /// persisted, and `None` until the first focus change.
     foreground: Option<String>,
-    /// A manual toggle whose target app isn't known yet. The tray and the Settings
-    /// window steal foreground, so the choice is parked here and bound to the next
-    /// app the user focuses. Session-only: re-arming a stale choice after a
-    /// restart would be surprising, so it is never persisted.
-    pending_override: Option<bool>,
     /// The keyboard layout handle last judged by [`Self::apply_for_layout`], so an
     /// unchanged layout costs nothing. `0` until the platform reports one.
     last_layout: u32,
@@ -76,7 +71,6 @@ impl ShellState {
             settings: Settings::default(),
             settings_file,
             foreground: None,
-            pending_override: None,
             last_layout: 0,
             layout_suspended: false,
             layout_override: 0,

--- a/crates/funput-desktop/src/shell/options.rs
+++ b/crates/funput-desktop/src/shell/options.rs
@@ -102,11 +102,18 @@ impl ShellState {
     }
 
     /// Flip VI/EN from a Funput window (the Settings pane or the tray flyout).
-    /// That window holds focus while this runs, so the choice is parked and bound
-    /// to the next app the user returns to.
+    ///
+    /// **Global, and it pins nothing.** The surface says the scope: these two are
+    /// Funput's own windows, opened from the tray, with no app in sight — so they
+    /// move the default every app without an opinion follows. The hotkey is the one
+    /// that means "just here", because it is pressed inside the app it means.
+    ///
+    /// This used to park the choice and bind it to whichever app took focus next,
+    /// which wrote a permanent entry into the per-app memory for an app the user
+    /// never mentioned — invisible, since nothing on Windows shows that map, and
+    /// still overruling them a week later. See [`ShellState::apply_for_app`].
     pub fn set_enabled(&mut self, on: bool) {
         self.set_enabled_state(on);
-        self.pending_override = Some(on);
         self.save();
     }
 }

--- a/crates/funput-desktop/src/shell/tests.rs
+++ b/crates/funput-desktop/src/shell/tests.rs
@@ -1,6 +1,6 @@
 //! These exercise rules that were unreachable while the state lived inside a
-//! process-global mutex: which app gets Vietnamese, what a toggle made from the
-//! tray binds to, and when composition is thrown away.
+//! process-global mutex: which app gets Vietnamese, which surface is allowed to
+//! pin one, and when composition is thrown away.
 
 use funput_config::{Method, Settings};
 use funput_engine::{Action, KeySource};
@@ -56,21 +56,60 @@ fn focusing_the_same_app_twice_reports_no_change() {
     assert_eq!(state.apply_for_app("code.exe"), None);
 }
 
-/// The flyout steals foreground, so the toggle cannot bind to the app it was
-/// meant for until the user goes back to it.
+/// The flyout is a global surface — it has no app in front of it, so it pins none.
+/// It used to bind to whatever the user clicked into next, which pinned an app they
+/// had never mentioned.
 #[test]
-fn a_flyout_toggle_binds_to_the_next_app_focused() {
+fn a_flyout_toggle_does_not_pin_the_next_app() {
+    let mut state = shell();
+
+    state.set_enabled(false); // flyout turned Vietnamese off
+    // code.exe has no opinion, so it simply inherits the new default…
+    assert_eq!(state.apply_for_app("code.exe"), None);
+    assert!(!state.enabled());
+    // …and nothing was written down about it.
+    assert!(state.settings().app_language_memory.is_empty());
+}
+
+/// The trade this rule makes, stated as a test rather than left as a surprise: a
+/// global switch does not un-pin an app the user pinned on purpose.
+#[test]
+fn a_pinned_app_keeps_its_pin_when_the_global_switch_moves() {
     let mut state = shell_remembering(&[("notepad.exe", true)]);
 
     state.set_enabled(false); // flyout turned Vietnamese off
-    // notepad.exe is remembered as Vietnamese, which would normally switch it back
-    // on the moment focus lands there; the parked choice has to win instead.
-    assert_eq!(state.apply_for_app("notepad.exe"), None);
-    assert!(!state.enabled());
-    // …and it replaces what notepad.exe used to remember, from now on.
+    assert_eq!(
+        state.apply_for_app("notepad.exe"),
+        Some(true),
+        "the pin wins"
+    );
+    assert!(state.enabled());
+    assert_eq!(
+        state.settings().app_language_memory.get("notepad.exe"),
+        Some(&true),
+        "and it is still the only entry"
+    );
+    assert_eq!(state.settings().app_language_memory.len(), 1);
+}
+
+/// The whole rule in one place: the hotkey is the only writer.
+#[test]
+fn only_the_hotkey_writes_the_memory() {
+    let mut state = shell();
+
+    state.set_enabled(false);
     state.apply_for_app("code.exe");
-    assert_eq!(state.apply_for_app("notepad.exe"), None);
-    assert!(!state.enabled());
+    state.set_enabled(true);
+    state.apply_for_app("notepad.exe");
+    assert!(state.settings().app_language_memory.is_empty());
+
+    state.note_foreground("code.exe".into());
+    state.toggle_enabled_hotkey();
+    assert_eq!(
+        state.settings().app_language_memory.get("code.exe"),
+        Some(&false)
+    );
+    assert_eq!(state.settings().app_language_memory.len(), 1);
 }
 
 /// The hotkey fires while the target app is focused, so it binds immediately.
@@ -87,42 +126,11 @@ fn a_hotkey_toggle_binds_to_the_focused_app() {
     assert_eq!(state.apply_for_app("code.exe"), Some(false), "remembered");
 }
 
+/// The Settings window and the Control Center are their own processes, so their
+/// flip reaches the hook process as a settings file. It is a global default and
+/// arrives as one — no app is pinned on the way in.
 #[test]
-fn a_hotkey_toggle_clears_a_parked_flyout_toggle() {
-    let mut state = shell();
-    state.set_enabled(false); // flyout: parks "off"
-    state.note_foreground("code.exe".into());
-    state.toggle_enabled_hotkey(); // back on, and binds to code.exe
-
-    // The parked choice is gone, so a fresh app has nothing to bind and nothing
-    // remembered — it is left alone.
-    assert_eq!(state.apply_for_app("notepad.exe"), None);
-    assert!(state.enabled());
-    assert!(
-        !state
-            .settings()
-            .app_language_memory
-            .contains_key("notepad.exe")
-    );
-}
-
-/// A parked choice that happens to match the current state still has to be
-/// written down, or it is lost the moment focus moves on.
-#[test]
-fn a_parked_choice_is_remembered_even_when_the_state_does_not_flip() {
-    let mut state = shell();
-    state.set_enabled(true); // Settings window: parks "on", state already on
-    assert_eq!(state.apply_for_app("code.exe"), None, "nothing to flip");
-    assert_eq!(
-        state.settings().app_language_memory.get("code.exe"),
-        Some(&true)
-    );
-}
-
-/// The Settings window and the Control Center are their own processes, so the
-/// choice they parked died with them. Picking their file up has to re-park it.
-#[test]
-fn a_flip_written_by_another_process_binds_to_the_next_app() {
+fn a_flip_written_by_another_process_changes_the_global_state_without_pinning() {
     let dir = std::env::temp_dir().join(format!("funput-reload-{}", std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();
     let path = dir.join("settings.json");
@@ -133,11 +141,11 @@ fn a_flip_written_by_another_process_binds_to_the_next_app() {
     child.set_enabled(false);
 
     assert!(background.reload_settings());
+    assert!(!background.enabled(), "the flip reached this process");
     assert_eq!(background.apply_for_app("code.exe"), None, "already off");
-    assert_eq!(
-        background.settings().app_language_memory.get("code.exe"),
-        Some(&false),
-        "the flyout's choice bound to the app the user returned to"
+    assert!(
+        background.settings().app_language_memory.is_empty(),
+        "and pinned nothing on the way"
     );
     let _ = std::fs::remove_dir_all(dir);
 }
@@ -172,8 +180,10 @@ fn an_empty_app_id_is_ignored() {
     state.note_foreground(String::new());
     assert_eq!(state.foreground_id(), None);
 
-    state.set_enabled(false); // parks a choice with nowhere to land
+    // A window that resolved to no executable must not claim an entry, from either
+    // direction: nothing to replay for it, and a hotkey pressed in it writes nothing.
     assert_eq!(state.apply_for_app(""), None);
+    state.toggle_enabled_hotkey();
     assert!(state.settings().app_language_memory.is_empty());
 }
 

--- a/platforms/windows/src/background/hook/foreground.rs
+++ b/platforms/windows/src/background/hook/foreground.rs
@@ -59,7 +59,8 @@ pub(super) unsafe extern "system" fn win_event_proc(
 
     // A Settings child persists changes to disk. Reload them as soon as focus
     // returns to a regular app, before the next keystroke reaches the engine. A
-    // VI/EN flip made there is parked by the reload and lands on this app below.
+    // VI/EN flip made there arrives as the global default — `apply_for_app` below
+    // can still overrule it, but only for an app the user pinned with the hotkey.
     if shell::reload_settings() {
         tray::sync_from_shell();
     }

--- a/platforms/windows/src/background/hook/foreground/mod.rs
+++ b/platforms/windows/src/background/hook/foreground/mod.rs
@@ -3,25 +3,25 @@
 //! Two things follow from that. The caret is somewhere else entirely, so anything
 //! Funput was composing is stale; and the new app may want a different VI/EN state
 //! (see [`crate::shared::shell`]'s per-app auto-switch).
+//!
+//! Twice over, though, a foreground change is **not** a user switching apps: when
+//! the window is one of Funput's own, and when it is the shell itself — the taskbar,
+//! the desktop, Alt-Tab. Both are turned away here, and [`window`] is where a window
+//! is asked which it is.
 
-use std::sync::OnceLock;
+mod window;
+
 use std::sync::atomic::Ordering;
 
-use windows::Win32::Foundation::{CloseHandle, HWND};
-use windows::Win32::System::Threading::{
-    OpenProcess, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
-};
+use windows::Win32::Foundation::HWND;
 use windows::Win32::UI::Accessibility::HWINEVENTHOOK;
-use windows::Win32::UI::WindowsAndMessaging::{
-    EVENT_SYSTEM_FOREGROUND, GetClassNameW, GetWindowThreadProcessId,
-};
-use windows::core::PWSTR;
+use windows::Win32::UI::WindowsAndMessaging::EVENT_SYSTEM_FOREGROUND;
 
 use super::{FOREGROUND_IS_FUNPUT, toggle};
 use crate::background::{inject, keymap, tray};
 use crate::shared::shell;
 
-static OWN_EXE_ID: OnceLock<String> = OnceLock::new();
+use window::{class_of_window, exe_of_window, is_shell_surface, own_exe_id};
 
 /// Foreground-window changed: record the app and apply its per-app VI/EN default.
 pub(super) unsafe extern "system" fn win_event_proc(
@@ -41,8 +41,9 @@ pub(super) unsafe extern "system" fn win_event_proc(
     // costs — see `inject::send_plan`. Decided from the window's class first, so a
     // window whose process cannot be resolved still updates it rather than leaving
     // the previous app's answer standing.
+    let class = class_of_window(hwnd);
     let id = exe_of_window(hwnd);
-    inject::note_foreground(&class_of_window(hwnd), id.as_deref().unwrap_or_default());
+    inject::note_foreground(&class, id.as_deref().unwrap_or_default());
 
     let Some(id) = id else {
         return;
@@ -53,7 +54,11 @@ pub(super) unsafe extern "system" fn win_event_proc(
     // front of it any more (mirrors the mouse-click flush). Both directions: keys
     // typed into Funput's own windows compose in-process and never reach the engine.
     shell::clear();
-    if is_funput {
+    // Neither of these is somewhere a person is typing, so neither gets to say what
+    // language they are typing in. The shell matters most: the tray icon sits on the
+    // taskbar, so answering for `Shell_TrayWnd` would let a trip to Funput's own
+    // flyout undo the choice the user went there to make.
+    if is_funput || is_shell_surface(&class) {
         return;
     }
 
@@ -78,64 +83,4 @@ pub(super) unsafe extern "system" fn win_event_proc(
         // second one is still true. Keeps the tray icon and tooltip in sync.
         toggle::notify(shell::enabled());
     }
-}
-
-fn own_exe_id() -> &'static String {
-    OWN_EXE_ID.get_or_init(|| {
-        std::env::current_exe()
-            .ok()
-            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_lowercase()))
-            .unwrap_or_else(|| "funput.exe".to_string())
-    })
-}
-
-/// A window's class name — what the toolkit that drew it calls itself, which is how
-/// [`inject::note_foreground`] recognizes a browser engine without knowing the
-/// browser. Empty when the window is gone or has no class, which reads as "not a
-/// browser" and is the safe answer.
-fn class_of_window(hwnd: HWND) -> String {
-    // Class names are capped at 256 characters by `RegisterClass`, so this cannot
-    // truncate one that matters.
-    let mut buf = [0u16; 257];
-    // SAFETY: The API receives a writable slice and handles invalid window handles.
-    let len = unsafe { GetClassNameW(hwnd, &mut buf) };
-    String::from_utf16_lossy(&buf[..len.max(0) as usize])
-}
-
-/// Resolve a window's owning process to its app id — the lowercased exe file name
-/// (e.g. "code.exe"), which is the key the per-app VI/EN memory uses.
-fn exe_of_window(hwnd: HWND) -> Option<String> {
-    if hwnd.0.is_null() {
-        return None;
-    }
-    let mut pid = 0u32;
-    // SAFETY: pid is writable; an invalid or expired window returns failure.
-    unsafe { GetWindowThreadProcessId(hwnd, Some(&mut pid)) };
-    if pid == 0 {
-        return None;
-    }
-    // SAFETY: Request query access only; failure is propagated without using a handle.
-    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }.ok()?;
-
-    let mut buf = [0u16; 260];
-    let mut len = buf.len() as u32;
-    // SAFETY: handle is open and buf has the capacity provided in len.
-    let res = unsafe {
-        QueryFullProcessImageNameW(
-            handle,
-            PROCESS_NAME_WIN32,
-            PWSTR(buf.as_mut_ptr()),
-            &mut len,
-        )
-    };
-    // SAFETY: Release the owned process handle exactly once after its final use.
-    let _ = unsafe { CloseHandle(handle) };
-    res.ok()?;
-
-    let full = String::from_utf16_lossy(&buf[..len as usize]);
-    let file = full.rsplit(['\\', '/']).next().unwrap_or("");
-    if file.is_empty() {
-        return None;
-    }
-    Some(file.to_lowercase())
 }

--- a/platforms/windows/src/background/hook/foreground/window.rs
+++ b/platforms/windows/src/background/hook/foreground/window.rs
@@ -1,0 +1,152 @@
+//! What a window is: which program drew it, what the toolkit calls it, and whether
+//! it is a place a person types at all.
+//!
+//! Split out of [`super`] so the hook proc next door stays a list of decisions
+//! rather than a mix of decisions and Win32 plumbing.
+
+use std::sync::OnceLock;
+
+use windows::Win32::Foundation::{CloseHandle, HWND};
+use windows::Win32::System::Threading::{
+    OpenProcess, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
+};
+use windows::Win32::UI::WindowsAndMessaging::{GetClassNameW, GetWindowThreadProcessId};
+use windows::core::PWSTR;
+
+static OWN_EXE_ID: OnceLock<String> = OnceLock::new();
+
+/// Funput's own app id, so its windows can be told apart from everyone else's.
+pub(super) fn own_exe_id() -> &'static String {
+    OWN_EXE_ID.get_or_init(|| {
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_lowercase()))
+            .unwrap_or_else(|| "funput.exe".to_string())
+    })
+}
+
+/// Window classes that belong to the Windows shell itself rather than to a program
+/// the user switched to.
+///
+/// **The taskbar is the one that matters**, and it is the reason this list exists:
+/// the tray icon lives on it, so every trip to Funput's own flyout goes through a
+/// foreground change to `Shell_TrayWnd` — and if per-app memory answers that, the
+/// user's choice is undone by the act of making it. The desktop is the same story
+/// on a quieter path, and Alt-Tab and Task View flash past between two real windows.
+///
+/// All of them are drawn by `explorer.exe`, which is why this is decided by class
+/// and not by program: a File Explorer window (`CabinetWClass`) is somewhere people
+/// really do type Vietnamese — renaming a file, filling the search box — and it
+/// keeps working like any other app.
+///
+/// A class missing from this list costs what the old behaviour cost, nothing worse,
+/// so add one when a surface turns up rather than guessing at them now.
+const SHELL_SURFACES: [&str; 6] = [
+    // The taskbar, and the same on a second monitor.
+    "Shell_TrayWnd",
+    "Shell_SecondaryTrayWnd",
+    // The desktop: the icon host, and the wallpaper window behind it.
+    "Progman",
+    "WorkerW",
+    // Alt-Tab, and Task View.
+    "ForegroundStaging",
+    "MultitaskingViewFrame",
+];
+
+/// Whether this window is the shell rather than an app.
+pub(super) fn is_shell_surface(class: &str) -> bool {
+    SHELL_SURFACES.contains(&class)
+}
+
+/// A window's class name — what the toolkit that drew it calls itself, which is how
+/// [`crate::background::inject::note_foreground`] recognizes a browser engine
+/// without knowing the browser, and how [`is_shell_surface`] recognizes the taskbar.
+/// Empty when the window is gone or has no class, which reads as "not a browser" and
+/// "not the shell", both of which are the safe answers.
+pub(super) fn class_of_window(hwnd: HWND) -> String {
+    // Class names are capped at 256 characters by `RegisterClass`, so this cannot
+    // truncate one that matters.
+    let mut buf = [0u16; 257];
+    // SAFETY: The API receives a writable slice and handles invalid window handles.
+    let len = unsafe { GetClassNameW(hwnd, &mut buf) };
+    String::from_utf16_lossy(&buf[..len.max(0) as usize])
+}
+
+/// Resolve a window's owning process to its app id — the lowercased exe file name
+/// (e.g. "code.exe"), which is the key the per-app VI/EN memory uses.
+pub(super) fn exe_of_window(hwnd: HWND) -> Option<String> {
+    if hwnd.0.is_null() {
+        return None;
+    }
+    let mut pid = 0u32;
+    // SAFETY: pid is writable; an invalid or expired window returns failure.
+    unsafe { GetWindowThreadProcessId(hwnd, Some(&mut pid)) };
+    if pid == 0 {
+        return None;
+    }
+    // SAFETY: Request query access only; failure is propagated without using a handle.
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }.ok()?;
+
+    let mut buf = [0u16; 260];
+    let mut len = buf.len() as u32;
+    // SAFETY: handle is open and buf has the capacity provided in len.
+    let res = unsafe {
+        QueryFullProcessImageNameW(
+            handle,
+            PROCESS_NAME_WIN32,
+            PWSTR(buf.as_mut_ptr()),
+            &mut len,
+        )
+    };
+    // SAFETY: Release the owned process handle exactly once after its final use.
+    let _ = unsafe { CloseHandle(handle) };
+    res.ok()?;
+
+    let full = String::from_utf16_lossy(&buf[..len as usize]);
+    let file = full.rsplit(['\\', '/']).next().unwrap_or("");
+    if file.is_empty() {
+        return None;
+    }
+    Some(file.to_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Measured on Windows 11: clicking the tray icon puts `Shell_TrayWnd` in the
+    /// foreground, which is the whole reason the guard exists.
+    #[test]
+    fn the_taskbar_is_the_shell() {
+        assert!(is_shell_surface("Shell_TrayWnd"));
+        assert!(is_shell_surface("Shell_SecondaryTrayWnd"));
+    }
+
+    #[test]
+    fn the_desktop_and_the_switchers_are_too() {
+        assert!(is_shell_surface("Progman"));
+        assert!(is_shell_surface("WorkerW"));
+        assert!(is_shell_surface("ForegroundStaging"));
+        assert!(is_shell_surface("MultitaskingViewFrame"));
+    }
+
+    /// The point of deciding by class: explorer.exe also draws real windows, and
+    /// those are apps like any other.
+    #[test]
+    fn a_file_explorer_window_is_an_app() {
+        assert!(!is_shell_surface("CabinetWClass"));
+    }
+
+    #[test]
+    fn ordinary_windows_are_apps() {
+        assert!(!is_shell_surface("Chrome_WidgetWin_1"));
+        assert!(!is_shell_surface("Notepad"));
+    }
+
+    /// A window whose class could not be read must not be mistaken for the shell —
+    /// that would silently stop the per-app switch for a real app.
+    #[test]
+    fn an_unreadable_class_is_not_the_shell() {
+        assert!(!is_shell_surface(""));
+    }
+}


### PR DESCRIPTION
Turning Vietnamese off in the Control Center wrote a permanent per-app pin, and the app it pinned was usually `explorer.exe` — which made the toggle look dead. Two commits, because there are two problems underneath.

## What a user sees

Click the tray, turn Vietnamese on, close the flyout, and it is off again. Measured here, with `explorer.exe` pinned to English:

| Action | `enabled` |
| --- | --- |
| Focus Chrome | `true` |
| **Touch the taskbar** (`Shell_TrayWnd`) | **`false`** |

The tray icon lives on the taskbar, so the trip to the flyout is itself a foreground change to `explorer.exe`. The choice is undone by the act of making it.

## 21de4d5 — the surface says the scope

The flyout and the Settings window steal foreground, so their toggle used to be parked and bound to whichever app took focus next. After a tray click that is the taskbar. The pin was permanent, on an app the user never mentioned, and invisible — nothing on Windows displays `app_language_memory`.

This is also the rule `apps.rs` already stated at the top of the file and broke: *an app gets a state only once a manual toggle happened inside it.*

So the hotkey pins (it is pressed inside the app it means) and the two global surfaces do not. `pending_override` is deleted rather than reworked; `apply_for_app` goes back to reading the map, and `reload_settings` just carries the global flag across from the child process, which `apply_settings` already pushes to the engine.

**The trade, as a test rather than a surprise:** a global switch no longer un-pins an app someone pinned on purpose. Turn VI off in the tray and return to a pinned app and it comes back on — which is what per-app memory means (`a_pinned_app_keeps_its_pin_when_the_global_switch_moves`).

## b07cdce — the shell is not an app

The first commit stops new pins. It does nothing about the pin already in people's files, or about why that pin was so much worse than it looked: `explorer.exe` draws the taskbar, the desktop *and* the tray icon.

- **The foreground hook turns the shell away**, the way it already turns away Funput's own windows. Decided by **window class, not program** — a File Explorer window (`CabinetWClass`) is somewhere people really do type Vietnamese and keeps working like any other app. The list covers the taskbars, the desktop, Alt-Tab and Task View; a class missing from it costs what the old behaviour cost and no more.
- **`settings.json` gains one-time repairs**, counted by a new `schema` field, the first of which drops the `explorer.exe` pin. Nothing put it there on purpose and there is no UI to clear it with. The counter is persisted for one reason: so the repair cannot keep deleting a File Explorer pin someone makes deliberately afterwards. Both directions are tested.

`schema` is additive and `#[serde(default)]`, so an older build reading a newer file ignores it and a newer build reading an older file sees `0` — which is exactly what triggers the repair once.

`foreground.rs` sat at 141 of 150 lines and `hook/` already held five files, so it became `foreground/mod.rs` (the decisions) plus `foreground/window.rs` (what a window is, with the class guard and its tests).

## Windows-only

`funput-desktop` has no other consumer. macOS reaches the same behaviour through `funput-ffi` with its own `pendingVietnameseOverride` and is untouched here — it has the same scope question in principle, worth its own change. Linux dropped per-app memory entirely.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `scripts/check-loc.sh`, and the Windows shell's own fmt + clippy + 69 tests — all green.

Run on Windows 11 against the settings file that reproduced the report:

```
1. toggled VI on in flyout      enabled=True
2. flyout dismissed, Cursor up  enabled=True
3. taskbar touched              enabled=True   <- was False
4. back in Cursor               enabled=True
```

and the next save wrote `"appLanguageMemory": { "chrome.exe": true }, "schema": 1` — the bug's pin gone, the user's own pin untouched.

Not covered: existing pins other than `explorer.exe` that the parking bug may have written (e.g. a pin on whatever app someone happened to click after a tray toggle). Those are indistinguishable from deliberate ones, so they stay. A way to see and clear the map is still missing and deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
