### PR TITLE
feat(linux): add the casing axis to the Chuyển mã window

### DIFF
--- a/docs/features/text-case.md
+++ b/docs/features/text-case.md
@@ -2,12 +2,12 @@
 
 ## Trạng thái
 
-**Còn lại một cửa sổ.** `funput_core::textcase` sau cargo feature `textcase` có cả
-năm phép, kèm corpus và property test; `funput-convert` mang trục thứ hai của
-`Session`; `funput-ffi` mở cửa C cho nó; và **`funput case`** trong CLI, **macOS**
-(`ConvertCasingBar.swift`) cùng **Windows** (`ui/convert/casing.slint`) đều đã gọi
-tới. Chưa nối: cửa sổ GTK trên Linux — mọi thứ nó cần đã có sẵn trong `Session` và
-`View`, đúng như hai shell kia đã dùng.
+**V1 đã xong.** `funput_core::textcase` sau cargo feature `textcase` có cả năm phép,
+kèm corpus và property test; `funput-convert` mang trục thứ hai của `Session`;
+`funput-ffi` mở cửa C cho nó; và cả bốn bề mặt đều đã gọi tới: **`funput case`** trong
+CLI, **macOS** (`ConvertCasingBar.swift`), **Windows** (`ui/convert/casing.slint`) và
+**Linux** (`settings-gtk/src/convert/ui/casing.rs`). Không shell nào tự quyết định gì
+— cả ba đọc cùng `View` và gọi cùng `Session`.
 
 Tài liệu này chốt mô hình trước khi có code, như [charset.md](charset.md) đã làm, và là
 nơi mọi quyết định thiết kế sống — mỗi thay đổi cập nhật lại nó trong cùng PR.
@@ -249,7 +249,10 @@ trước/sau:
 - Hai công tắc, đặt tên theo thứ chúng **bật lên** nên cả hai **mặc định tắt**:
   **Giữ đ/Đ** (tắt = `đ → d`) và **Hạ chữ viết hoa** (tắt = giữ nguyên từ viết HOA).
   Mỗi công tắc chỉ hiện **khi phép sở hữu nó đang được áp** — ngoài lúc đó nó không có
-  gì để nói, và hiện ở đó là cách dạy phép nào sở hữu nó.
+  gì để nói, và hiện ở đó là cách dạy phép nào sở hữu nó. Trên GTK là `gtk::Switch`
+  kèm nhãn, không phải `adw::SwitchRow`: `SwitchRow` là một `ActionRow`, đặt vào thanh
+  ngang sẽ ra một hàng full-width có nền riêng. Giá phải trả là công tắc trần không có
+  tên cho screen reader, nên mỗi cái được trỏ về nhãn của nó bằng `LabelledBy`.
 - Dòng cảnh báo dùng chung với Chuyển mã, chỉ hiện khi encode ngược mất chữ.
 - Nút **Hoàn tác** gỡ **phép cuối cùng** chứ không phải tất cả — bấm nhầm phép thứ ba
   không nên mất hai phép trước nó — và **Bỏ hết** trả về nguyên bản.
@@ -264,6 +267,30 @@ trước/sau:
 
 Một file thả vào vẫn rơi vào `Mode::Text` như hiện tại. Nhiều file là batch —
 **không thuộc V1**, nhưng bảng `Row` không cần đổi khi tới lượt.
+
+### Ba chỗ mỗi shell tự quyết, và đã quyết khác nhau
+
+Hợp đồng ở trên là chung; cách vẽ ra thì theo idiom của nền tảng, và ba chỗ dưới đây
+là nơi ba shell không giống nhau. Ghi lại để lần sau không ai "sửa" chúng cho khớp.
+
+- **Hình dạng chip.** macOS dùng capsule `glassEffect`, Windows vẽ capsule 28px trong
+  Slint. GTK dùng **nút thường trong `gtk::FlowBox`**, không dùng class `pill` của
+  libadwaita: `.pill` là `padding: 10px 32px`, và năm nhãn kèm padding đó vượt cả
+  `default_width` 880 lẫn `width_request` 640 của cửa sổ — GTK nâng minimum của cửa sổ
+  cho vừa con nó, nên capsule sẽ khiến Chuyển mã không co lại được. Đo được: thanh có
+  min 496px, natural 778px, nên vừa một hàng ở kích thước mặc định và xuống dòng khi
+  người dùng thu nhỏ. Mỗi chip `halign: Start` để một chip không đổi kích thước tuỳ
+  theo hàng có xuống dòng hay chưa. `adw::WrapBox` là container đúng hơn nhưng có từ
+  libadwaita 1.7, còn crate nhắm 1.5.
+- **Dấu tick.** GTK dùng `object-select-symbolic`, vì nó nằm trong chính gresource của
+  GTK4 lẫn theme Adwaita hệ thống; `check-plain-symbolic` và `emblem-ok-symbolic`
+  không có trong Adwaita trên 24.04 và sẽ ra ô ảnh thiếu.
+- **Thanh lúc batch đang chạy.** macOS tắt thanh (`!isBusy && …`); Windows và Linux để
+  nguyên, đúng câu chữ ở trên — chỉ tắt khi chưa đoán được bảng mã. Để nguyên là an
+  toàn vì `Session::batch_job` chụp `casing` trước khi việc rời luồng, nên phép bấm
+  giữa lúc chạy không đổi được file đang ghi; giá phải trả thuần hiển thị là cột
+  `N chữ sẽ mất` tính lại theo phép mà job đang chạy không có. Đây là lệch thật giữa
+  ba shell, không phải lỗi của shell nào.
 
 ## Lộ trình sau V1
 

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -314,10 +314,13 @@ settings-gtk/           App Cài đặt GTK4 + libadwaita (crate cargo riêng,
   src/settings_window/    mỗi trang preferences một submodule
     shortcuts/              công tắc gõ tắt, các hàng, trạng thái rỗng
   src/convert/            cửa sổ Chuyển mã — xem bên dưới
+    ui/casing/              thanh Kiểu chữ: các chip, và hàng "Đang áp"
 packaging/              hai file .desktop, metadata kho apt/dnf/pacman
 ```
 
 Mỗi thư mục giữ tối đa năm file; vượt quá thì tách theo mối quan tâm chứ không theo kích thước.
+`src/convert/ui/` hiện **đủ năm file**, nên widget tiếp theo của cửa sổ Chuyển mã sẽ phải mở một
+thư mục con chứ không thêm file vào đó.
 Mọi file ở đây bị giới hạn **150 dòng** bởi `scripts/check-loc.sh`, kể cả file test.
 
 ### Build
@@ -417,10 +420,16 @@ trên Windows — cảnh báo mất chữ, luật xử lý hàng loạt, tên th
 trùng tên bằng `vanban (2).txt`. Viết hai lần là cách để hai nền tảng bắt đầu bất đồng về cùng
 một tài liệu. Phần ở lại đây là kéo-thả, clipboard, hộp thoại, và đẩy I/O file ra khỏi luồng UI.
 
-`src/convert/state.rs` là file duy nhất dưới `convert/` có quyết định gì, và cũng là file duy
-nhất có test. Các file `ui/*` đọc state rồi set property, không quyết định gì. Một chốt
-`refreshing` canh mọi tín hiệu mà một lần refresh bắn ra — thiếu nó, refresh set dropdown sẽ tái
-nhập qua `notify::selected` và panic vì `borrow_mut` lồng nhau.
+Không file nào dưới `convert/` quyết định một lần chuyển mã ra sao: các file `ui/*` đọc `View`
+rồi set property, và `crates/funput-convert` giữ toàn bộ phần còn lại. Ngoại lệ duy nhất là
+`ui/casing.rs`, file `ui/*` duy nhất có test — bốn hàm thuần của nó quyết định phần **trình bày**
+của thanh Kiểu chữ (chip nào sáng, dòng `Đang áp` đọc ra sao, công tắc nào đang trên màn hình, và
+thanh có sống hay không), và cả bốn kiểm được mà không cần màn hình.
+
+Một chốt `refreshing` canh mọi tín hiệu mà một lần refresh bắn ra — thiếu nó, refresh set dropdown
+sẽ tái nhập qua `notify::selected` và panic vì `borrow_mut` lồng nhau. `gtk::Switch` của thanh
+Kiểu chữ cũng vậy qua `notify::active`, nên hai công tắc đi qua `widget::connect_switch` chứ không
+tự nối tay. Nút thì không cần: `clicked` không bao giờ nổ vì một lần ghi property.
 
 ### Chế độ không preedit
 

--- a/platforms/linux/settings-gtk/Cargo.lock
+++ b/platforms/linux/settings-gtk/Cargo.lock
@@ -107,6 +107,7 @@ version = "1.2026.1"
 dependencies = [
  "dirs",
  "funput-convert",
+ "funput-core",
  "gtk4",
  "libadwaita",
  "serde",

--- a/platforms/linux/settings-gtk/Cargo.toml
+++ b/platforms/linux/settings-gtk/Cargo.toml
@@ -21,9 +21,17 @@ path = "src/main.rs"
 # The Chuyển mã window's logic — reading a batch file by file, naming what a
 # conversion costs, writing copies beside the originals. Shared with the Windows
 # window so the two cannot drift; see crates/funput-convert/README.md. It re-exports
-# `funput_core::charset`, so this is the only edge needed and the `charset` feature is
-# switched on in exactly one manifest.
+# `funput_core::charset`, so nothing here ever has to name a `Charset` and the
+# `charset` feature stays switched on in exactly one manifest.
 funput-convert = { path = "../../../crates/funput-convert" }
+# Named for one reason: the casing bar decides which switch to show from *which
+# transform* is applied, and asking `casing::index_of(Transform::Title)` is the
+# alternative to writing that transform's position in the menu down as a number.
+# Windows makes the same edge for the same reason. Only `textcase` — the charset side
+# is reached through the re-export above. Considered and rejected: re-exporting
+# `textcase` from funput-convert, which would leave the two shells that mirror each
+# other spelling one type two different ways.
+funput-core = { path = "../../../crates/funput-core", features = ["textcase"] }
 gtk = { package = "gtk4", version = "0.9", features = ["v4_10"] }
 adw = { package = "libadwaita", version = "0.7", features = ["v1_5"] }
 serde = { version = "1", features = ["derive"] }

--- a/platforms/linux/settings-gtk/src/convert/open.rs
+++ b/platforms/linux/settings-gtk/src/convert/open.rs
@@ -83,7 +83,12 @@ fn build(app: &Application) -> Rc<Convert> {
     let weak = Rc::downgrade(&convert);
     convert.restart.connect_clicked(move |_| {
         if let Some(convert) = weak.upgrade() {
-            convert.session.borrow_mut().reset();
+            // A fresh session through the same door `build` used, not `reset()`:
+            // `reset` is `Session::new()`, which takes the row window back to the
+            // crate's own default and drops the cap this shell asked for. The two
+            // numbers agree today; nothing makes them agree tomorrow, and the Windows
+            // window has to re-state its own for exactly this reason.
+            *convert.session.borrow_mut() = session();
             convert.set_progress(String::new());
         }
     });

--- a/platforms/linux/settings-gtk/src/convert/ui.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui.rs
@@ -8,10 +8,14 @@
 //! directly, and [`Panes::refresh`] sets every property it owns rather than the ones
 //! it thinks changed.
 //!
+//! Two of the three shapes carry a [`casing::Bar`] as well, each its own instance —
+//! that file says why one widget could not serve both.
+//!
 //! Two places deviate, and each says why where it happens: the input buffer in
 //! [`text::Pane`], and the batch list in [`files::Pane`], which is the closest thing
 //! GTK has to Slint swapping a model.
 
+mod casing;
 mod empty;
 mod files;
 mod text;

--- a/platforms/linux/settings-gtk/src/convert/ui/casing.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/casing.rs
@@ -1,0 +1,200 @@
+//! The Kiểu chữ bar: five ways to re-case whatever the window is converting.
+//!
+//! The Chuyển mã window's second axis, and a bar rather than a tab because the two axes
+//! **compose** — a paragraph read out of TCVN3 can still be title-cased — so both
+//! choices belong on screen at once. A tab would say the user has to pick one.
+//! `docs/features/text-case.md` is where that decision lives.
+//!
+//! **Two instances, one session.** Slint uses a single `ConvertCasingBar` component in
+//! both shapes because its state arrives through a global; a `GtkWidget` has exactly one
+//! parent, so the text pane and the batch pane each own a [`Bar`]. They cannot disagree:
+//! the hidden pane is never refreshed, which is already how the two target dropdowns
+//! work.
+//!
+//! Nothing here decides what a transform *does*, or what it is called —
+//! `funput_convert::casing` owns the menu, its order, and the Vietnamese names, so the
+//! three shells cannot drift. What this file decides is presentation: which chip is lit,
+//! what the `Đang áp` line reads, which switch is on screen, and whether the bar is live
+//! at all. Those four are pure functions of the view, and the only thing here with
+//! tests.
+
+mod applied;
+mod chips;
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::Convert;
+use funput_convert::{Mode, View, casing};
+use funput_core::textcase::Transform;
+
+pub(in crate::convert) struct Bar {
+    pub(in crate::convert) root: gtk::Box,
+    chips: chips::Chips,
+    applied: applied::Applied,
+}
+
+impl Bar {
+    pub(in crate::convert) fn new() -> Self {
+        let chips = chips::Chips::new();
+        let applied = applied::Applied::new();
+
+        let root = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .spacing(6)
+            .build();
+        root.append(&chips.root);
+        root.append(&applied.root);
+
+        Self {
+            root,
+            chips,
+            applied,
+        }
+    }
+
+    pub(in crate::convert) fn wire(&self, convert: &Rc<Convert>) {
+        self.chips.wire(convert);
+        self.applied.wire(convert);
+    }
+
+    /// Takes no `&Rc<Convert>`, unlike the footer: nothing on this bar reads `is_busy`.
+    /// A batch already running cannot be changed by a press — `Session::batch_job`
+    /// snapshots the casing before the work leaves the thread — so leaving the bar live
+    /// during a run costs only that the `N chữ sẽ mất` column re-costs against a
+    /// transform the running job does not have. Windows makes the same call; macOS dims
+    /// the bar instead, and that difference is noted in the feature document.
+    pub(in crate::convert) fn refresh(&self, view: &View) {
+        // One call, not a hand-written dim as well: GTK fades an insensitive subtree
+        // itself, so there is nothing here to match the `opacity: 0.45` the Slint bar
+        // has to spell out.
+        self.root.set_sensitive(usable(view));
+        self.chips.refresh(&lit(view));
+        self.applied.refresh(view, &applied_line(view));
+    }
+}
+
+/// Which chips are lit — one bool per entry of `casing::ALL`, in menu order.
+fn lit(view: &View) -> Vec<bool> {
+    (0..casing::ALL.len())
+        .map(|index| view.transforms.contains(&index))
+        .collect()
+}
+
+/// The `Đang áp` line, empty when nothing is applied.
+///
+/// Spells the order out because the order changes the text: lowercase then title case
+/// is not title case then lowercase.
+fn applied_line(view: &View) -> String {
+    if view.transforms.is_empty() {
+        return String::new();
+    }
+    let names: Vec<&str> = view
+        .transforms
+        .iter()
+        .map(|&index| casing::name(casing::at(index)))
+        .collect();
+    format!("Đang áp: {}", names.join(" → "))
+}
+
+/// Whether a transform is applied, asked **by name** — so a switch's owner is never
+/// written down as a position in the menu, which is append-only and not ours to count.
+fn applies(view: &View, transform: Transform) -> bool {
+    casing::index_of(transform).is_some_and(|index| view.transforms.contains(&index))
+}
+
+/// Text nothing can read cannot be converted, and cannot be re-cased either: one rule,
+/// not two. A batch carries a charset per row, so it is never blocked.
+fn usable(view: &View) -> bool {
+    view.mode == Mode::Files || view.source.is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use funput_convert::Session;
+
+    /// A settled document with some transforms pressed, in the order given.
+    ///
+    /// Drives a real `Session` because `View` is `#[non_exhaustive]` — the same reason
+    /// the Windows tests do, and the reason these assertions are worth having: they
+    /// check this window against the crate rather than against a fixture of its own.
+    fn viewed(pressed: &[Transform]) -> Session {
+        let mut session = Session::new();
+        session.set_input("Tiếng Việt rất đẹp".to_string());
+        for &transform in pressed {
+            session.apply_transform(casing::index_of(transform).expect("in the menu"));
+        }
+        session.refresh();
+        session
+    }
+
+    #[test]
+    fn the_menu_is_whole_before_anything_is_pressed() {
+        // Load-bearing here in a way it is not in Slint: the chips are built from
+        // `casing::ALL` and refreshed by zipping a slice of bools, so a length that
+        // drifted would quietly stop lighting the last chip rather than fail.
+        let session = viewed(&[]);
+        let lit = lit(session.view());
+        assert_eq!(lit.len(), casing::ALL.len());
+        assert!(lit.iter().all(|on| !on));
+    }
+
+    #[test]
+    fn a_pressed_transform_lights_its_own_chip() {
+        let session = viewed(&[Transform::Lower]);
+        let lower = casing::index_of(Transform::Lower).expect("in the menu");
+        for (index, on) in lit(session.view()).into_iter().enumerate() {
+            assert_eq!(on, index == lower, "chip {index}");
+        }
+    }
+
+    #[test]
+    fn the_applied_line_is_empty_until_something_is_pressed() {
+        assert_eq!(applied_line(viewed(&[]).view()), "");
+    }
+
+    #[test]
+    fn the_applied_line_reads_in_the_order_pressed() {
+        let session = viewed(&[Transform::Lower, Transform::Title]);
+        assert_eq!(
+            applied_line(session.view()),
+            "Đang áp: chữ thường → Viết Hoa Đầu Mỗi Từ"
+        );
+        let session = viewed(&[Transform::Title, Transform::Lower]);
+        assert_eq!(
+            applied_line(session.view()),
+            "Đang áp: Viết Hoa Đầu Mỗi Từ → chữ thường"
+        );
+    }
+
+    #[test]
+    fn a_switch_shows_only_for_the_transform_that_owns_it() {
+        let session = viewed(&[Transform::NoDiacritics]);
+        assert!(applies(session.view(), Transform::NoDiacritics));
+        assert!(!applies(session.view(), Transform::Title));
+    }
+
+    #[test]
+    fn typing_a_new_document_takes_the_transforms_off() {
+        let mut session = viewed(&[Transform::Upper]);
+        session.set_input("Một đoạn khác".to_string());
+        session.refresh();
+        assert_eq!(applied_line(session.view()), "");
+        assert!(lit(session.view()).iter().all(|on| !on));
+    }
+
+    #[test]
+    fn the_bar_is_dead_until_a_charset_explains_the_document() {
+        // The batch arm is not reachable without files on disk; `Mode::Files` carrying
+        // a charset per row is the crate's invariant and is tested there.
+        let mut session = Session::new();
+        session.set_input("hello world".to_string());
+        session.refresh();
+        assert!(!usable(session.view()));
+        session.set_input("Tiếng Việt".to_string());
+        session.refresh();
+        assert!(usable(session.view()));
+    }
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/casing.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/casing.rs
@@ -131,12 +131,13 @@ mod tests {
     }
 
     #[test]
-    fn the_menu_is_whole_before_anything_is_pressed() {
-        // Load-bearing here in a way it is not in Slint: the chips are built from
-        // `casing::ALL` and refreshed by zipping a slice of bools, so a length that
-        // drifted would quietly stop lighting the last chip rather than fail.
-        let session = viewed(&[]);
-        let lit = lit(session.view());
+    fn a_fresh_document_lights_nothing() {
+        // What this locks is that the menu is offered whole with nothing applied — a
+        // press is the only thing that lights a chip. It deliberately does *not* claim
+        // to catch a chip count that drifted from `casing::ALL`: `lit` counts from
+        // `casing::ALL` too, so any length a test could assert here is the same number
+        // twice. That invariant is asserted where the widgets are, in `Chips::refresh`.
+        let lit = lit(viewed(&[]).view());
         assert_eq!(lit.len(), casing::ALL.len());
         assert!(lit.iter().all(|on| !on));
     }

--- a/platforms/linux/settings-gtk/src/convert/ui/casing/applied.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/casing/applied.rs
@@ -1,0 +1,125 @@
+//! The second row: what is applied, the switches that belong to it, and the ways out.
+//!
+//! Shown and hidden as one unit, because with nothing applied there is no `Đang áp` line
+//! to write, neither switch has a transform to belong to, and there is nothing to undo.
+//! Same rule the loss warning follows one pane over: a row that is always there is a row
+//! people stop reading.
+//!
+//! `gtk::Switch` with a label beside it, not `adw::SwitchRow`. A `SwitchRow` is an
+//! `ActionRow` built to sit inside a `.boxed-list`; dropped into a horizontal bar it
+//! renders as a full-width row with its own padding and background. The price of the
+//! bare switch is that it carries no accessible name, so each one is pointed at its own
+//! label — the one thing `SwitchRow` would have given for free.
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::Convert;
+use crate::convert::ui::widget;
+use funput_convert::View;
+use funput_core::textcase::Transform;
+
+pub(super) struct Applied {
+    pub(super) root: gtk::Box,
+    line: gtk::Label,
+    keep_d: Toggle,
+    flatten_caps: Toggle,
+    undo: gtk::Button,
+    clear: gtk::Button,
+}
+
+/// A switch and the label that names it, shown and hidden together.
+struct Toggle {
+    root: gtk::Box,
+    switch: gtk::Switch,
+}
+
+impl Applied {
+    pub(super) fn new() -> Self {
+        let line = widget::caption("");
+        line.set_hexpand(true);
+        line.set_ellipsize(gtk::pango::EllipsizeMode::End);
+
+        // Each switch is named for what it turns *on*, so both read as off by default.
+        // That is the crate's rule, not this window's, which is why neither is given a
+        // starting value here — `refresh` takes both from the view.
+        let keep_d = toggle("Giữ đ/Đ");
+        let flatten_caps = toggle("Hạ chữ viết hoa");
+        // Escape hatches, so no accent: `suggested-action` is spoken for by the one
+        // action each pane exists to perform.
+        let undo = gtk::Button::with_label("Hoàn tác");
+        let clear = gtk::Button::with_label("Bỏ hết");
+
+        let root = gtk::Box::builder().spacing(12).build();
+        root.append(&line);
+        root.append(&keep_d.root);
+        root.append(&flatten_caps.root);
+        root.append(&undo);
+        root.append(&clear);
+
+        Self {
+            root,
+            line,
+            keep_d,
+            flatten_caps,
+            undo,
+            clear,
+        }
+    }
+
+    pub(super) fn wire(&self, convert: &Rc<Convert>) {
+        widget::connect_switch(&self.keep_d.switch, convert, |convert, on| {
+            convert.session.borrow_mut().set_keep_d(on);
+        });
+        widget::connect_switch(&self.flatten_caps.switch, convert, |convert, on| {
+            convert.session.borrow_mut().set_flatten_caps(on);
+        });
+        // Undo removes the **last** transform, not all of them: a mistaken third press
+        // should not cost the two before it. `Bỏ hết` is the one that goes back to the
+        // original.
+        widget::click(&self.undo, convert, |convert| {
+            convert.session.borrow_mut().undo_transform();
+            convert.refresh();
+        });
+        widget::click(&self.clear, convert, |convert| {
+            convert.session.borrow_mut().clear_transforms();
+            convert.refresh();
+        });
+    }
+
+    pub(super) fn refresh(&self, view: &View, line: &str) {
+        self.root.set_visible(!line.is_empty());
+        self.line.set_label(line);
+        // A switch is on screen only while the transform that owns it is applied. Any
+        // other time it has nothing to say, and showing it only then is how the window
+        // teaches which transform owns which.
+        self.keep_d
+            .refresh(super::applies(view, Transform::NoDiacritics), view.keep_d);
+        self.flatten_caps
+            .refresh(super::applies(view, Transform::Title), view.flatten_caps);
+    }
+}
+
+impl Toggle {
+    fn refresh(&self, shown: bool, on: bool) {
+        self.root.set_visible(shown);
+        self.switch.set_active(on);
+    }
+}
+
+fn toggle(label: &str) -> Toggle {
+    let caption = gtk::Label::builder()
+        .label(label)
+        .valign(gtk::Align::Center)
+        .build();
+    let switch = gtk::Switch::builder().valign(gtk::Align::Center).build();
+    switch.update_relation(&[gtk::accessible::Relation::LabelledBy(&[
+        caption.upcast_ref()
+    ])]);
+
+    let root = gtk::Box::builder().spacing(6).build();
+    root.append(&caption);
+    root.append(&switch);
+    Toggle { root, switch }
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/casing/chips.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/casing/chips.rs
@@ -1,0 +1,119 @@
+//! The five transform chips.
+//!
+//! Buttons, not toggles. A press **stacks** a transform onto the list, and pressing the
+//! one already on top is a no-op in the crate because every transform is idempotent. A
+//! toggle would promise that the second click takes it back off — that is `Hoàn tác`'s
+//! job, and not necessarily for the same transform — and it would flip itself before the
+//! refresh flipped it back, which is a re-entrancy hole bought for nothing.
+//!
+//! Plain buttons in a `FlowBox`, not libadwaita's `pill`. The five Vietnamese names come
+//! to roughly 530px of text and `.pill` adds 64px of padding to each, which would put
+//! the row past this window's 880px default and well past its 640px minimum — and GTK
+//! raises a window's minimum to fit its children, so the capsule that looks right on
+//! macOS and Windows would leave Chuyển mã unable to shrink. A `FlowBox` wraps the row
+//! instead, and only when the user makes the window narrow. `adw::WrapBox` is the
+//! better container for this and needs no uniform columns, but it arrived in libadwaita
+//! 1.7 and this crate targets 1.5 — worth revisiting when the floor moves.
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::Convert;
+use crate::convert::ui::widget;
+use funput_convert::casing;
+
+pub(super) struct Chips {
+    pub(super) root: gtk::Box,
+    chips: Vec<Chip>,
+}
+
+struct Chip {
+    button: gtk::Button,
+    tick: gtk::Image,
+}
+
+impl Chips {
+    pub(super) fn new() -> Self {
+        let flow = gtk::FlowBox::builder()
+            .selection_mode(gtk::SelectionMode::None)
+            .min_children_per_line(1)
+            .max_children_per_line(casing::ALL.len() as u32)
+            .homogeneous(false)
+            .row_spacing(6)
+            .column_spacing(6)
+            .accessible_role(gtk::AccessibleRole::Group)
+            .build();
+        let chips: Vec<Chip> = casing::ALL
+            .iter()
+            .map(|&transform| chip(casing::name(transform)))
+            .collect();
+        for chip in &chips {
+            flow.append(&chip.button);
+        }
+
+        // Aligned to the top, not centred: when the row wraps, the label belongs beside
+        // the first line of chips rather than floating between the two.
+        let label = widget::caption("Kiểu chữ");
+        label.set_valign(gtk::Align::Start);
+        label.set_margin_top(8);
+
+        let root = gtk::Box::builder().spacing(8).build();
+        root.append(&label);
+        root.append(&flow);
+        Self { root, chips }
+    }
+
+    pub(super) fn wire(&self, convert: &Rc<Convert>) {
+        for (index, chip) in self.chips.iter().enumerate() {
+            widget::click(&chip.button, convert, move |convert| {
+                convert.session.borrow_mut().apply_transform(index);
+                convert.refresh();
+            });
+        }
+    }
+
+    pub(super) fn refresh(&self, lit: &[bool]) {
+        for (chip, &on) in self.chips.iter().zip(lit) {
+            chip.tick.set_visible(on);
+            // Bound rather than written inline: the two arms are arrays of different
+            // length, and `set_css_classes` wants one slice type.
+            let classes: &[&str] = if on { &["suggested-action"] } else { &[] };
+            chip.button.set_css_classes(classes);
+            // The tick is the cue for someone who cannot read the accent; this is the
+            // one a screen reader reads. Either way, colour alone says nothing.
+            chip.button
+                .update_state(&[gtk::accessible::State::Pressed(if on {
+                    gtk::AccessibleTristate::True
+                } else {
+                    gtk::AccessibleTristate::False
+                })]);
+        }
+    }
+}
+
+/// One chip: a tick that appears once the transform is applied, then its name.
+///
+/// `object-select-symbolic` because it ships inside GTK's own icon resource as well as
+/// in the system Adwaita theme. `check-plain-symbolic` and `emblem-ok-symbolic` are not
+/// in Adwaita on 24.04 and would render as a missing image.
+fn chip(name: &str) -> Chip {
+    let tick = gtk::Image::builder()
+        .icon_name("object-select-symbolic")
+        .pixel_size(12)
+        .visible(false)
+        .build();
+    let content = gtk::Box::builder().spacing(6).build();
+    content.append(&tick);
+    content.append(&gtk::Label::new(Some(name)));
+
+    // `Align::Start` because a `FlowBox` gives every cell in a wrapped row the width of
+    // its widest child. Without this, `CHỮ HOA` would be a wide button at 640px and a
+    // narrow one at 880px — a chip that changes size with the window is a chip that
+    // looks like a different control.
+    let button = gtk::Button::builder()
+        .child(&content)
+        .halign(gtk::Align::Start)
+        .build();
+    Chip { button, tick }
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/casing/chips.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/casing/chips.rs
@@ -6,14 +6,10 @@
 //! job, and not necessarily for the same transform — and it would flip itself before the
 //! refresh flipped it back, which is a re-entrancy hole bought for nothing.
 //!
-//! Plain buttons in a `FlowBox`, not libadwaita's `pill`. The five Vietnamese names come
-//! to roughly 530px of text and `.pill` adds 64px of padding to each, which would put
-//! the row past this window's 880px default and well past its 640px minimum — and GTK
-//! raises a window's minimum to fit its children, so the capsule that looks right on
-//! macOS and Windows would leave Chuyển mã unable to shrink. A `FlowBox` wraps the row
-//! instead, and only when the user makes the window narrow. `adw::WrapBox` is the
-//! better container for this and needs no uniform columns, but it arrived in libadwaita
-//! 1.7 and this crate targets 1.5 — worth revisiting when the floor moves.
+//! Plain buttons in a `FlowBox`, not libadwaita's `pill`, and not `adw::WrapBox` —
+//! `docs/features/text-case.md` carries the measurements behind both, next to the same
+//! call made for the other two shells. What matters here is the consequence: the row
+//! wraps when the window is narrow rather than refusing to be narrow.
 
 use std::rc::Rc;
 
@@ -22,6 +18,10 @@ use adw::prelude::*;
 use crate::convert::Convert;
 use crate::convert::ui::widget;
 use funput_convert::casing;
+
+/// The accent fill an applied chip wears — named so the write and the read-back that
+/// decides whether to write cannot drift apart.
+const ACCENT: &str = "suggested-action";
 
 pub(super) struct Chips {
     pub(super) root: gtk::Box,
@@ -81,10 +81,19 @@ impl Chips {
         // drift — only a live `Chips` knows how many widgets it actually built.
         debug_assert_eq!(self.chips.len(), lit.len(), "a chip per transform");
         for (chip, &on) in self.chips.iter().zip(lit) {
+            // Skip what did not change, as `widget::select` does — this runs on every
+            // keystroke. Read the current state off the chip's own class list, never
+            // from `is_visible`, which answers for the ancestor chain too and would
+            // call every chip off while the pane is hidden — skipping the write that
+            // clears a stale accent. `chip` builds in the `false` state, so the first
+            // refresh has nothing to correct.
+            if chip.button.has_css_class(ACCENT) == on {
+                continue;
+            }
             chip.tick.set_visible(on);
             // Bound rather than written inline: the two arms are arrays of different
             // length, and `set_css_classes` wants one slice type.
-            let classes: &[&str] = if on { &["suggested-action"] } else { &[] };
+            let classes: &[&str] = if on { &[ACCENT] } else { &[] };
             chip.button.set_css_classes(classes);
             // The tick is the cue for someone who cannot read the accent; this is the
             // one a screen reader reads. Either way, colour alone says nothing.
@@ -121,5 +130,11 @@ fn chip(name: &str) -> Chip {
         .child(&content)
         .halign(gtk::Align::Start)
         .build();
+    // Stated here, not left to the first refresh, which skips a chip already in the
+    // state it wants: otherwise a never-pressed chip carries no pressed state while a
+    // cleared one carries `False`, and a screen reader describes them differently.
+    button.update_state(&[gtk::accessible::State::Pressed(
+        gtk::AccessibleTristate::False,
+    )]);
     Chip { button, tick }
 }

--- a/platforms/linux/settings-gtk/src/convert/ui/casing/chips.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/casing/chips.rs
@@ -74,6 +74,12 @@ impl Chips {
     }
 
     pub(super) fn refresh(&self, lit: &[bool]) {
+        // `zip` stops at the shorter side, so a chip count that drifted from the menu
+        // would leave the last chip showing whatever it showed last rather than fail.
+        // The assertion belongs here, not in a test: both sides of the comparison a
+        // test could make are derived from `casing::ALL`, so a test cannot see the
+        // drift — only a live `Chips` knows how many widgets it actually built.
+        debug_assert_eq!(self.chips.len(), lit.len(), "a chip per transform");
         for (chip, &on) in self.chips.iter().zip(lit) {
             chip.tick.set_visible(on);
             // Bound rather than written inline: the two arms are arrays of different

--- a/platforms/linux/settings-gtk/src/convert/ui/files.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/files.rs
@@ -12,6 +12,7 @@
 //! a nasty bug to own, and the boxed list is what the rest of this app looks like.
 
 mod row;
+mod show;
 
 use std::rc::Rc;
 
@@ -19,7 +20,6 @@ use adw::prelude::*;
 
 use crate::convert::ui::widget;
 use crate::convert::{Convert, io};
-use funput_convert::View;
 
 /// How many rows to build at once.
 ///
@@ -97,47 +97,5 @@ impl Pane {
                 io::convert_files(&convert);
             }
         });
-    }
-
-    pub(in crate::convert) fn refresh(&self, convert: &Rc<Convert>, view: &View) {
-        self.count.set_label(&format!("{} tệp", view.rows_total));
-        widget::select(&self.target, Some(view.target));
-
-        while let Some(child) = self.list.first_child() {
-            self.list.remove(&child);
-        }
-        for (offset, row) in view.rows.iter().enumerate() {
-            self.list
-                .append(&row::build(convert, view.rows_first + offset, row));
-        }
-        let shown = view.rows_first + view.rows.len();
-        if shown < view.rows_total {
-            let more = adw::ActionRow::builder()
-                .title(format!("và {} tệp khác", view.rows_total - shown))
-                .css_classes(["dim-label"])
-                .build();
-            self.list.append(&more);
-        }
-
-        // A file nothing explained is skipped, not guessed at, so the button counts
-        // only what is settled — and says so, rather than promising the whole batch.
-        self.action.set_label(&format!("Chuyển {} tệp", view.ready));
-        self.action
-            .set_sensitive(view.ready > 0 && !convert.is_busy());
-
-        // Before a run, the footer is a promise about where the files will land; once
-        // one has happened, it is the report. Never both, and never the promise after.
-        //
-        // A file that could not be read is *named* here rather than counted — a
-        // number cannot answer "which two of my ten".
-        let progress = convert.progress();
-        let footer = if !progress.is_empty() {
-            progress
-        } else if view.unreadable.is_empty() {
-            format!("Lưu vào: {}", view.out_dir)
-        } else {
-            funput_convert::unreadable_line(&view.unreadable)
-        };
-        self.progress.set_label(&footer);
     }
 }

--- a/platforms/linux/settings-gtk/src/convert/ui/files.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/files.rs
@@ -18,7 +18,7 @@ use std::rc::Rc;
 
 use adw::prelude::*;
 
-use crate::convert::ui::widget;
+use crate::convert::ui::{casing, widget};
 use crate::convert::{Convert, io};
 
 /// How many rows to build at once.
@@ -33,6 +33,7 @@ pub(in crate::convert) struct Pane {
     pub(in crate::convert) root: gtk::Box,
     count: gtk::Label,
     target: gtk::DropDown,
+    casing: casing::Bar,
     list: gtk::ListBox,
     progress: gtk::Label,
     action: gtk::Button,
@@ -49,6 +50,7 @@ impl Pane {
         head.append(&widget::caption("Sang"));
         head.append(&target);
 
+        let casing = casing::Bar::new();
         let list = gtk::ListBox::builder()
             .selection_mode(gtk::SelectionMode::None)
             .css_classes(["boxed-list"])
@@ -74,6 +76,9 @@ impl Pane {
             .spacing(12)
             .build();
         root.append(&head);
+        // One transform applies to the whole batch, the way one target charset
+        // does — so it sits in the header, not in every row.
+        root.append(&casing.root);
         root.append(&scroller);
         root.append(&footer);
 
@@ -81,6 +86,7 @@ impl Pane {
             root,
             count,
             target,
+            casing,
             list,
             progress,
             action,
@@ -88,6 +94,7 @@ impl Pane {
     }
 
     pub(in crate::convert) fn wire(&self, convert: &Rc<Convert>) {
+        self.casing.wire(convert);
         widget::connect_dropdown(&self.target, convert, |convert, index| {
             convert.session.borrow_mut().set_target(index);
         });

--- a/platforms/linux/settings-gtk/src/convert/ui/files/show.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/files/show.rs
@@ -1,0 +1,64 @@
+//! Filling the batch pane from the state.
+//!
+//! Split out of [`super`] for the same reason [`crate::convert::ui::text::show`] was:
+//! the pane file holds the skeleton and the wiring, and the redraw is a separate
+//! concern that grows on its own schedule. Batch mode had run out of room in one file
+//! long before the second axis arrived.
+//!
+//! The list is rebuilt rather than updated in place — the reason is in [`super`]'s doc,
+//! and it is the one place in this window that deviates from "set properties, never
+//! build widgets" on purpose.
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::Convert;
+use crate::convert::ui::widget;
+use funput_convert::View;
+
+use super::{Pane, row};
+
+impl Pane {
+    pub(in crate::convert) fn refresh(&self, convert: &Rc<Convert>, view: &View) {
+        self.count.set_label(&format!("{} tệp", view.rows_total));
+        widget::select(&self.target, Some(view.target));
+
+        while let Some(child) = self.list.first_child() {
+            self.list.remove(&child);
+        }
+        for (offset, row) in view.rows.iter().enumerate() {
+            self.list
+                .append(&row::build(convert, view.rows_first + offset, row));
+        }
+        let shown = view.rows_first + view.rows.len();
+        if shown < view.rows_total {
+            let more = adw::ActionRow::builder()
+                .title(format!("và {} tệp khác", view.rows_total - shown))
+                .css_classes(["dim-label"])
+                .build();
+            self.list.append(&more);
+        }
+
+        // A file nothing explained is skipped, not guessed at, so the button counts
+        // only what is settled — and says so, rather than promising the whole batch.
+        self.action.set_label(&format!("Chuyển {} tệp", view.ready));
+        self.action
+            .set_sensitive(view.ready > 0 && !convert.is_busy());
+
+        // Before a run, the footer is a promise about where the files will land; once
+        // one has happened, it is the report. Never both, and never the promise after.
+        //
+        // A file that could not be read is *named* here rather than counted — a
+        // number cannot answer "which two of my ten".
+        let progress = convert.progress();
+        let footer = if !progress.is_empty() {
+            progress
+        } else if view.unreadable.is_empty() {
+            format!("Lưu vào: {}", view.out_dir)
+        } else {
+            funput_convert::unreadable_line(&view.unreadable)
+        };
+        self.progress.set_label(&footer);
+    }
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/files/show.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/files/show.rs
@@ -23,6 +23,7 @@ impl Pane {
     pub(in crate::convert) fn refresh(&self, convert: &Rc<Convert>, view: &View) {
         self.count.set_label(&format!("{} tệp", view.rows_total));
         widget::select(&self.target, Some(view.target));
+        self.casing.refresh(view);
 
         while let Some(child) = self.list.first_child() {
             self.list.remove(&child);

--- a/platforms/linux/settings-gtk/src/convert/ui/text.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/text.rs
@@ -19,7 +19,7 @@ use std::rc::Rc;
 use adw::prelude::*;
 
 use crate::convert::Convert;
-use crate::convert::ui::widget;
+use crate::convert::ui::{casing, widget};
 
 pub(in crate::convert) struct Pane {
     pub(in crate::convert) root: gtk::Box,
@@ -28,6 +28,7 @@ pub(in crate::convert) struct Pane {
     target: gtk::DropDown,
     input: gtk::TextView,
     output: gtk::TextView,
+    casing: casing::Bar,
     loss: gtk::Label,
     footer: footer::Footer,
 }
@@ -63,12 +64,16 @@ impl Pane {
             .css_classes(["warning", "caption"])
             .build();
 
+        let casing = casing::Bar::new();
         let footer = footer::Footer::new();
         let root = gtk::Box::builder()
             .orientation(gtk::Orientation::Vertical)
             .spacing(12)
             .build();
         root.append(&head);
+        // Right under the charset row: changing the charset and changing the case
+        // are two choices about one document, and they add up.
+        root.append(&casing.root);
         root.append(&panes);
         root.append(&loss);
         root.append(&footer.root);
@@ -80,6 +85,7 @@ impl Pane {
             target,
             input,
             output,
+            casing,
             loss,
             footer,
         }
@@ -109,6 +115,7 @@ impl Pane {
         widget::connect_dropdown(&self.target, convert, |convert, index| {
             convert.session.borrow_mut().set_target(index);
         });
+        self.casing.wire(convert);
         self.footer.wire(convert);
     }
 }

--- a/platforms/linux/settings-gtk/src/convert/ui/text/footer.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/text/footer.rs
@@ -52,9 +52,9 @@ impl Footer {
     }
 
     pub(in crate::convert) fn wire(&self, convert: &Rc<Convert>) {
-        click(&self.copy, convert, io::copy_result);
-        click(&self.save, convert, io::save_result);
-        click(&self.convert_file, convert, io::convert_files);
+        widget::click(&self.copy, convert, io::copy_result);
+        widget::click(&self.save, convert, io::save_result);
+        widget::click(&self.convert_file, convert, io::convert_files);
     }
 
     pub(in crate::convert) fn refresh(&self, convert: &Rc<Convert>, view: &View) {
@@ -68,13 +68,4 @@ impl Footer {
         self.convert_file.set_sensitive(ready && !convert.is_busy());
         self.progress.set_label(&convert.progress());
     }
-}
-
-fn click(button: &gtk::Button, convert: &Rc<Convert>, action: fn(&Rc<Convert>)) {
-    let weak = Rc::downgrade(convert);
-    button.connect_clicked(move |_| {
-        if let Some(convert) = weak.upgrade() {
-            action(&convert);
-        }
-    });
 }

--- a/platforms/linux/settings-gtk/src/convert/ui/text/show.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/text/show.rs
@@ -35,6 +35,7 @@ impl Pane {
         if let Some(text) = &view.input_preview {
             self.show_input(text);
         }
+        self.casing.refresh(view);
         self.output.buffer().set_text(&view.output_preview);
         self.loss.set_label(&view.warning);
         self.loss.set_visible(!view.warning.is_empty());

--- a/platforms/linux/settings-gtk/src/convert/ui/widget.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/widget.rs
@@ -84,8 +84,8 @@ pub(in crate::convert) fn connect_dropdown(
 ///
 /// No [`Convert::is_refreshing`] guard, and that is not an oversight: `clicked` is only
 /// ever emitted by a real press, never by a property write, so a refresh cannot come
-/// back in through this door the way it can through [`connect_dropdown`]. Nor does
-/// this call `refresh` for the caller — some actions edit
+/// back in through this door the way it can through [`connect_dropdown`] or
+/// [`connect_switch`]. Nor does this call `refresh` for the caller — some actions edit
 /// the session and want one, others only read it and would redraw for nothing.
 ///
 /// Takes a closure rather than a `fn` pointer so a caller can capture, which is how the
@@ -100,5 +100,30 @@ pub(in crate::convert) fn click(
         if let Some(convert) = weak.upgrade() {
             action(&convert);
         }
+    });
+}
+
+/// Connect a switch to a state edit.
+///
+/// The guard is not optional here the way it is for [`click`]. `set_active` does emit
+/// `notify::active`, so a refresh correcting a stale switch would come straight back in
+/// as the user's own choice and undo the correction. No unchanged-write check like
+/// [`select`]'s is needed: `gtk_switch_set_active` returns early when the value already
+/// matches.
+pub(in crate::convert) fn connect_switch(
+    switch: &gtk::Switch,
+    convert: &Rc<Convert>,
+    edit: impl Fn(&Rc<Convert>, bool) + 'static,
+) {
+    let weak = Rc::downgrade(convert);
+    switch.connect_active_notify(move |switch| {
+        let Some(convert) = weak.upgrade() else {
+            return;
+        };
+        if convert.is_refreshing() {
+            return;
+        }
+        edit(&convert, switch.is_active());
+        convert.refresh();
     });
 }

--- a/platforms/linux/settings-gtk/src/convert/ui/widget.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/widget.rs
@@ -79,3 +79,26 @@ pub(in crate::convert) fn connect_dropdown(
         convert.refresh();
     });
 }
+
+/// Connect a button to something that reads or edits the state.
+///
+/// No [`Convert::is_refreshing`] guard, and that is not an oversight: `clicked` is only
+/// ever emitted by a real press, never by a property write, so a refresh cannot come
+/// back in through this door the way it can through [`connect_dropdown`]. Nor does
+/// this call `refresh` for the caller — some actions edit
+/// the session and want one, others only read it and would redraw for nothing.
+///
+/// Takes a closure rather than a `fn` pointer so a caller can capture, which is how the
+/// casing chips each know their own position in the menu.
+pub(in crate::convert) fn click(
+    button: &gtk::Button,
+    convert: &Rc<Convert>,
+    action: impl Fn(&Rc<Convert>) + 'static,
+) {
+    let weak = Rc::downgrade(convert);
+    button.connect_clicked(move |_| {
+        if let Some(convert) = weak.upgrade() {
+            action(&convert);
+        }
+    });
+}


### PR DESCRIPTION
Shell thứ ba và cuối cùng đọc trục này, sau #376 và #379. Base là `feature/text-case`; **không có gì trong `crates/` đổi** — `funput-convert` đã mang danh sách phép, hai tuỳ chọn và thứ tự `Đang áp` từ lúc macOS vào, còn app GTK link nó như Rust thuần chứ không qua cửa C. Đây là một view và phần nối dây của nó.

## Có gì mới

Năm chip phép biến đổi, dưới hàng chọn bảng mã ở hình dạng văn bản và dưới header ở hình dạng batch, thứ tự đã bấm viết rõ ra, `Hoàn tác` / `Bỏ hết`, và hai công tắc chỉ hiện khi phép sở hữu chúng đang được áp — cùng câu chữ và cùng luật với hai cửa sổ kia.

**Hai instance `Bar`, không phải một component dùng hai lần.** Slint dùng lại `ConvertCasingBar` được vì state của nó tới qua một global; một `GtkWidget` chỉ có đúng một parent, nên pane văn bản và pane batch mỗi bên sở hữu một thanh. Chúng không thể bất đồng: pane đang ẩn không bao giờ được refresh, đúng như hai dropdown đích vốn đã làm.

**Không viết vị trí của phép nào thành một con số**, giống Windows: một công tắc hỏi `casing::index_of` xem phép của nó nằm ở đâu, nên thêm phép thứ sáu vào core không phải sửa gì ở đây. Đó cũng là thứ duy nhất package này cần một cạnh mới — `funput-core` với **chỉ** `textcase`, vì shell này chưa bao giờ gọi tên một `Charset` (nó hỏi `funput_convert::charset_names()`), nên luật `charset` chỉ bật ở đúng một manifest vẫn đúng.

## Ba chỗ GTK phải tự quyết

Đo, không đoán. Cả ba giờ đã được ghi vào `text-case.md` để sau này không ai "sửa" chúng cho khớp hai shell kia.

**Nút thường trong `FlowBox`, không dùng class `pill` của libadwaita.** `.pill` là `padding: 10px 32px`. Năm cụm từ tiếng Việt đầy đủ cộng 64px mỗi chip sẽ đẩy hàng vượt `default_width` 880 và vượt xa `width_request` 640 của cửa sổ này — mà GTK nâng minimum của cửa sổ cho vừa con nó, nên capsule vốn vừa trên macOS và Windows sẽ khiến Chuyển mã không co lại được. Windows chữa được bằng cách nâng `min-width` lên 720; cửa sổ GTK thì không, vì cửa sổ Cài đặt dùng chung cái sàn đó. Đo bằng `gtk_widget_measure`: thanh có **min 496px, natural 778px** — một hàng ở kích thước mặc định, chỉ xuống dòng khi người dùng thu nhỏ cửa sổ. Mỗi chip `halign: Start`, vì `FlowBox` cho mọi cell trong một hàng đã xuống dòng cùng bề rộng với con rộng nhất; thiếu nó thì `CHỮ HOA` là nút to ở 640px và nút nhỏ ở 880px. `adw::WrapBox` là container đúng hơn và không cần chỗ nào trong đoạn này, nhưng nó có từ libadwaita 1.7 còn crate nhắm 1.5.

**`set_sensitive`, và không gì khác.** GTK tự làm mờ một cây widget insensitive — đo được mức giảm 27% luminance trung bình trên dải chip (65.2 → 47.3) — nên ở đây không cần `opacity: 0.45` mà thanh Slint phải viết tay, và một lời gọi thì không thể để thanh mờ mà vẫn bấm được.

**`gtk::Switch` kèm nhãn, không phải `adw::SwitchRow`.** `SwitchRow` là một `ActionRow` dựng cho `.boxed-list`; đặt vào thanh ngang nó ra một hàng full-width có padding và nền riêng. Giá phải trả là công tắc trần không mang tên cho screen reader, nên mỗi cái được trỏ về nhãn của chính nó bằng `Relation::LabelledBy` — đúng thứ `SwitchRow` cho không, và module doc nói thẳng như vậy.

Ngoài màu, một chip nói nó đang được áp bằng ba cách: nền accent, một dấu tick (`object-select-symbolic`, chọn vì nó nằm trong chính gresource của GTK4 *và* theme Adwaita hệ thống — `check-plain-symbolic` và `emblem-ok-symbolic` không có trong Adwaita trên 24.04 và sẽ ra ô ảnh thiếu), và `accessible::State::Pressed`.

## Bẫy re-entrancy cửa sổ này vốn đã có

`widget::connect_switch` vào cạnh `connect_dropdown` thay vì mỗi công tắc tự nối tay. `gtk::Switch::set_active` bắn `notify::active`, nên thiếu guard `is_refreshing()` thì một lần refresh đang sửa công tắc lệch sẽ tái nhập ngay thành lựa chọn của người dùng và tự hoàn tác phần sửa đó. Nút không cần guard và không được cấp: `clicked` không bao giờ nổ vì một lần ghi property, và nói điều đó ở một chỗ thì rẻ hơn để người đọc tự hỏi sao hai helper lại khác nhau.

## Hai commit dọn đường trước

`refactor(linux)` không đổi hành vi và tách riêng có chủ ý. `ui/files.rs` đang ở **143 trong 150** dòng mà `check-loc.sh` cho phép; sáu dòng máy móc để gắn một thanh vào header cộng comment mà codebase này đòi sẽ đưa nó lên đúng 150, để lại phần refactor cho người sau làm dưới áp lực thời gian. `files::Pane::refresh` chuyển sang `files/show.rs`, việc này cũng làm hình dạng batch soi gương đúng hình dạng văn bản vốn đã có. `click` được nâng từ `text/footer.rs` lên `widget.rs` và nới từ con trỏ `fn` thành `impl Fn`, vì mỗi chip phải nhớ vị trí của riêng nó trong menu.

## Hai việc từ vòng review

`Chips::refresh` đang ghi lại class list và trạng thái accessible của cả năm chip mỗi lần refresh — tức mỗi ký tự gõ vào khung nhập — trong khi `widget::select` và `show_input` ngay cạnh đều bỏ qua lệnh ghi trùng. Giờ nó đọc trạng thái hiện tại của chip lại từ class list của chính chip đó và bỏ qua cái không đổi.

Phần đọc lại là chỗ có bẫy, và cách hiển nhiên nhất thì sai: `is_visible` trên dấu tick trả lời cho cả chuỗi ancestor, nên khi pane đang ẩn thì mọi chip báo là off, và một chip đi từ đang-áp sang không-áp sẽ bị bỏ qua rồi **giữ nguyên nền accent**. `has_css_class` hỏi đúng widget đó. Tên class là một `const` để lệnh ghi và lệnh đọc-lại không lệch nhau. Và vì refresh đầu tiên giờ bỏ qua chip đã ở trạng thái nó muốn, `chip` nêu `Pressed(False)` ngay lúc dựng — không thì chip chưa từng bấm mang trạng thái pressed rỗng còn chip đã xoá mang `False`, và screen reader đọc hai chip y hệt nhau thành hai thứ khác nhau. Kiểm bằng cách render **chuỗi chuyển trạng thái** chứ không phải từng trạng thái rời: áp hai phép rồi xoá thì không còn accent sót, và Upper→Lower tắt một chip đúng lúc bật chip khác.

`Bắt đầu lại` gọi `Session::reset`, tức `Session::new()`, làm row window về mặc định của crate và bỏ mất cái cap mà shell này đã khai trong `session()`. Hai con số đều là 500 nên hiện chưa thấy gì sai — nhưng không có gì giữ chúng bằng nhau, và cửa sổ Windows khai lại cap của nó sau `reset` đúng vì lý do này. Đi qua `session()` thì cap chỉ có một chỗ viết.

**Một lỗi tìm được khi lần theo việc trên, cố ý không sửa trong PR này:** `Session::adopt` (`crates/funput-convert/src/session.rs:120`) cũng xoá row window, và Windows chỉ khai lại sau `reset`, không khai lại sau `adopt` — nên thả tệp trên Windows làm window tụt từ `ROWS = 2_000` xuống 500, thấy được khi batch quá 500 tệp. Sửa đúng là giữ *độ dài* window qua `reset`/`adopt` trong crate và chỉ đưa *vị trí* về 0; test `adopting_files_replaces_the_previous_document_and_row_window` chỉ assert `rows_first == 0` nên vẫn xanh, và chính nó đã phân biệt "tool preference" với state của tài liệu. Để ngoài PR này vì nó đổi hành vi cho hai shell đã merge nên cần review riêng, và `session.rs` đang ở 145/150 dòng nên phải dọn chỗ trước.

## Tài liệu

Phần Trạng thái của `text-case.md` vẫn đang gọi cửa sổ GTK là thứ duy nhất còn lại. Nó cũng được thêm một mục cho ba chỗ lệch ở trên — trong đó có một chỗ có trước PR này và đáng nói thẳng: **macOS tắt thanh trong lúc batch chạy (`!isBusy && …`), Windows và Linux thì không.** Để nguyên là an toàn vì `Session::batch_job` chụp `casing` trước khi việc rời luồng, nên một cú bấm giữa lúc chạy không đổi được file đang được ghi; giá phải trả thuần hiển thị là cột `N chữ sẽ mất` tính lại theo phép mà job đang chạy không có. Ở đây theo Windows chứ không dựng ra hành vi thứ ba, và tài liệu giờ nói vậy thay vì ngụ ý cả ba giống nhau.

`platforms/linux/README.md` đã sai sẵn trước nhánh này: nó mô tả một `src/convert/state.rs` đã thôi tồn tại từ khi phần logic đó thành `crates/funput-convert`, và nói không file `ui/*` nào có test. Sửa cả hai ở đây, thêm một câu rằng `ui/` giờ đủ trần năm file nên widget tiếp theo phải mở thư mục con, và mở rộng đoạn về `refreshing` để kể cả `notify::active`.

## Kiểm chứng

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (18, **bảy test mới**), `scripts/check-loc.sh` — xanh hết, và `cargo build --release` chạy sạch không có GTK critical nào.

Bảy test là những test đầu tiên dưới `src/convert/`, và làm `ui/casing.rs` thành file `ui/*` đầu tiên có test. Chúng phủ bốn quyết định trình bày mà file này sở hữu — chip nào sáng, dòng `Đang áp` đọc ra sao, công tắc nào thuộc phép nào, thanh có sống hay không — đối chiếu với một `Session` thật, vì `View` là `#[non_exhaustive]`.

Một điều bản nháp đầu của PR này nói sai, và commit cuối sửa: `Chips::refresh` ghép chip với `lit` bằng `zip`, mà `zip` dừng ở bên ngắn hơn, nên số chip lệch khỏi `casing::ALL` sẽ âm thầm để chip cuối giữ nguyên nền accent và dấu tick nó có lần trước. **Một test không thấy được chuyện đó**: `lit` cũng đếm từ `casing::ALL`, nên mọi độ dài mà test có thể assert là cùng một con số hai lần — assertion cũ không thể fail dù `Chips::new` dựng ra bao nhiêu widget. Chỉ một `Chips` sống mới biết nó dựng thật mấy cái, nên bất biến chuyển về đó thành `debug_assert_eq!` (nổ dưới `cargo test` và dev build). Test giữ phần nó thật sự khoá — chỉ một cú bấm mới thắp được chip — và tên nó giờ nói vậy.

Ngân sách: file lớn nhất là `widget.rs` 129 dòng code; `casing.rs` 112, `applied.rs` 125, `chips.rs` 119, `text.rs` 121, `files.rs` 108 (từ 143). `src/convert/ui/` lên **5 trong 5** file, còn `casing/`, `files/` và `text/` mỗi thư mục 2 file.

`Cargo.lock` thêm đúng một dòng — một cạnh path tới `funput-core`, thứ vốn đã có trong graph theo đường gián tiếp. Không crate registry nào mới, nên `cargo-deny` không có gì mới để xét.

## Chưa kiểm ở đây

**Phần kiểm bằng mắt và bằng tay là của bạn.** Session Wayland này không có tool chụp màn hình hay inject input, nên bảy tình huống thủ công ở cuối `text-case.md` — dán văn bản, chồng hai phép, dòng cảnh báo TCVN3 nêu tên ký tự sẽ mất, thả tệp rồi xem note từng dòng đổi theo — chưa được bấm tay. Phần kiểm được mà không cần con trỏ thì tôi đã làm: thanh được render qua `GskRenderer` ở bốn trạng thái (hai phép đang áp, không phép nào, xuống dòng ở bề rộng nội dung 604px, và mờ chết khi không đoán được bảng mã) và được đo bằng `gtk_widget_measure` — đó là nguồn của mọi con số ở trên.

Cũng chưa kiểm: **theme sáng**, và việc máy này chạy GTK 4.22 / libadwaita 1.9 trong khi manifest nhắm 4.14 / 1.5. Mọi API dùng ở đây đều từ 4.10 trở về trước nên biên dịch đúng dưới gate đã khai, nhưng số đo stylesheet đến từ 1.9 — `.pill` *nhỏ hơn* ở 1.5, điều này chỉ củng cố quyết định loại nó, còn metric của nút stock thì ổn định. Đáng nhìn một lần trên máy 24.04 thật trước khi phát hành; CI chỉ biên dịch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
