### PR TITLE
fix(convert): a new batch keeps the row cap the shell asked for

### DIFF
--- a/crates/funput-convert/src/session.rs
+++ b/crates/funput-convert/src/session.rs
@@ -117,7 +117,9 @@ impl Session {
         self.casing.clear();
         self.files = scan.entries;
         self.unreadable = scan.unreadable;
-        self.window = (0, WINDOW);
+        // Back to the top of the list, but the cap the shell asked for survives: how
+        // many rows it can build is the toolkit's business, not this document's.
+        self.window = (0, self.window.1);
     }
 
     pub fn set_row_window(&mut self, first: usize, len: usize) {

--- a/crates/funput-convert/src/session/tests.rs
+++ b/crates/funput-convert/src/session/tests.rs
@@ -113,8 +113,38 @@ fn the_row_window_does_not_change_the_counts() {
     assert_eq!(view.ready, 7, "every file was identified");
 }
 
+/// How many rows a shell can build is the **toolkit's** business, not the document's:
+/// a GTK `ListBox` builds every row it is handed whatever is in it, which is why the
+/// cap exists at all. So a new batch starts at the top of the list without forgetting
+/// how long the list may be — the same distinction the destination charset gets one
+/// test down, where it survives as a tool preference.
+///
+/// Before this was true, the Windows window asked for two thousand rows once when it
+/// opened and then silently drew five hundred for every batch anyone dropped, with the
+/// button above still offering to convert all of them.
 #[test]
-fn adopting_files_replaces_the_previous_document_and_row_window() {
+fn adopting_files_keeps_the_row_cap_the_shell_asked_for() {
+    let (dir, mut session) = batch("keep-cap", 4);
+    session.set_row_window(0, 2);
+    session.refresh();
+    assert_eq!(session.view().rows.len(), 2, "the shell asked for two");
+
+    let paths: Vec<_> = (0..4).map(|i| dir.join(format!("{i}.txt"))).collect();
+    session.adopt(crate::scan(&paths));
+    session.refresh();
+
+    let view = session.view();
+    assert_eq!(view.rows_total, 4, "the whole batch is still counted");
+    assert_eq!(view.rows_first, 0, "a new batch starts at the top");
+    assert_eq!(
+        view.rows.len(),
+        2,
+        "and the cap the shell asked for survives"
+    );
+}
+
+#[test]
+fn adopting_files_replaces_the_previous_document_and_the_row_position() {
     let (_dir, mut session) = batch("fresh-adopt", 2);
     session.set_input("nội dung cũ".to_string());
     session.pick_source(Some(2));


### PR DESCRIPTION
Lỗi tìm được khi review #382, để riêng ra vì nó nằm trong crate dùng chung và ảnh hưởng Windows chứ không phải Linux. Base là `feature/text-case`, cùng chỗ #382 vừa vào.

## Lỗi

`adopt` đưa row window về mặc định của crate, tức bỏ mất cái cap mà shell đã khai:

```rust
self.window = (0, WINDOW);   // WINDOW = 500
```

Cửa sổ Windows khai `set_row_window(0, 2_000)` **đúng một lần** lúc dựng cửa sổ (`platforms/windows/src/ui/convert/mod.rs:61`), lúc đó chưa có tệp nào. Sau đó mọi lần thả tệp đều đi qua `adopt` và xoá nó về 500. Nên con số 2 000 của Windows **chưa bao giờ có hiệu lực với một batch thật** — nó chỉ đang có hiệu lực đúng lúc không có gì để vẽ.

Thả 800 tệp trên Windows, trước PR này:

| | |
| --- | --- |
| Danh sách hiện | **500 hàng** |
| Nút ghi | **"Chuyển 800 tệp"** (`ready` đếm cả batch) |
| Bấm vào chuyển | **800 tệp** — đúng |
| Giải thích 300 hàng còn lại | **không có gì** |

Chỗ này Windows đau hơn GTK: `platforms/windows/src/ui/convert/files/rows.rs` map thẳng `view.rows` vào model Slint và **không bao giờ đọc `rows_total`**, nên nó không có dòng `và N tệp khác` mà cửa sổ GTK dùng để nói ra cái cap. Trên Linux lỗi này vô hình vì `WINDOW` của crate và `ui::ROWS` của shell tình cờ đều là 500 — latent, không chảy máu.

**Không có tệp nào bị bỏ chuyển, ở cả hai nền tảng.** `batch_job` clone toàn bộ `self.files`, `write_all` lặp qua mọi entry, và `rows_total`/`ready` đếm trên cả batch — window chỉ là ngân sách *vẽ*. Test `the_row_window_does_not_change_the_counts` đã khoá điều đó từ trước.

## Sửa

```rust
self.window = (0, self.window.1);
```

Danh sách về đầu, nhưng cap thì giữ. Shell dựng nổi bao nhiêu hàng là chuyện của **toolkit**, không phải của tài liệu — một `ListBox` của GTK dựng *mọi* hàng nó được đưa, và đó là toàn bộ lý do cái cap tồn tại. Đây đúng là phân biệt mà `adopt` vốn đã áp cho bảng mã đích: đích sống sót vì nó là tuỳ chọn của công cụ, còn nguồn thì phải nhận dạng lại vì nó thuộc tài liệu.

**`reset` cố ý để nguyên.** Nó nghĩa là `Session::new()` và nói thẳng như vậy, và mọi caller đều đã tự khai lại cap sau đó (`mod.rs:105` bên Windows) hoặc đi qua constructor riêng (`session()` bên Linux, sau #382). Không có chỗ nào chảy máu ở đó, nên mở rộng phạm vi sang `reset` chỉ thêm bề mặt để review mà không sửa được gì.

Cũng vì vậy **PR này không đụng một dòng nào trong `platforms/`** — dòng `set_row_window` sau `reset` của Windows vẫn đang làm việc thật, không phải code chết.

## Test

`adopting_files_keeps_the_row_cap_the_shell_asked_for`: batch 4 tệp, shell xin cap 2, adopt một batch 4 tệp khác → `rows_total` vẫn 4, `rows_first` về 0, `rows.len()` vẫn **2**.

Test cũ tên là `adopting_files_replaces_the_previous_document_and_row_window` nhưng chỉ assert *vị trí* — điều vẫn đúng. Đổi tên thành `..._and_the_row_position` cho khớp thứ nó thật sự khoá, thay vì để cái tên hứa nhiều hơn nội dung.

## Kiểm chứng

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo clippy -p funput-ffi --features convert --all-targets -- -D warnings`, `cargo test -p funput-ffi --features convert`, `scripts/check-loc.sh`, và cây `settings-gtk` riêng — xanh hết. `session.rs` ở 145/150 dòng.

Không đổi chữ ký FFI nào, nên `include/funput.h` không cần sinh lại.

## Chưa kiểm

Shell Windows **có** được CI biên dịch và chạy test trên PR này: bộ lọc `changes` trong `ci.yml` coi `crates/**` là trigger dùng chung — "crates/ is the ROOT of the dependency graph — both shells consume it by path" — nên job `windows` chạy trên runner `windows-latest` với `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` và `cargo test` trong `platforms/windows`, và xanh. Job `android` cũng vậy, cùng lý do.

Còn lại là **phần tương tác**: chưa ai thả một thư mục hơn 500 tệp vào cửa sổ Chuyển mã trên Windows để thấy 2 000 hàng thật sự tới. Máy làm việc ở đây là Linux. Và phần mô tả hành vi Windows ở trên là đọc code (`mod.rs:61`, `mod.rs:105`, `files/rows.rs`), không phải quan sát trực tiếp — cái CI chứng minh là nó biên dịch và test xanh, không phải là nó vẽ đúng 2 000 hàng.

## Ngoài phạm vi

`crates/funput-convert/README.md` phác `View` mà thiếu ba trường của trục kiểu chữ (`transforms`, `keep_d`, `flatten_caps`) — khoảng trống có từ các PR casing trước, không phải PR này mở ra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
