### PR TITLE
docs(features): write funput case the way it is actually invoked

### DIFF
--- a/docs/features/text-case.md
+++ b/docs/features/text-case.md
@@ -188,7 +188,7 @@ không dùng đường cảnh báo.
 | `funput-core::textcase` | Năm phép biến đổi thuần, không phụ thuộc, không alloc ngoài chuỗi kết quả, và không bảng dữ liệu mới nào. Sau cargo feature riêng, **mặc định tắt** như `charset` — iOS/Android không bao giờ biên dịch nó |
 | `funput-convert` | Trục thứ hai của `Session`: "đổi bảng mã" và "đổi kiểu chữ" dùng chung một `Session`, một `View`, một đường cảnh báo |
 | Ba shell | Chỉ thanh, nút, và preview. Không quyết định gì — đúng hợp đồng `refresh()` / `view()` hiện tại |
-| `funput-cli` | `funput case --upper|--lower|--no-diacritics|--sentence|--title` đọc stdin. Rẻ, và là bề mặt test tốt nhất |
+| `funput-cli` | `funput case upper\|lower\|no-diacritics\|sentence\|title` đọc stdin; ghép nhiều phép bằng dấu phẩy (`lower,title`), và hai công tắc là `--keep-d` / `--flatten-caps`. Rẻ, và là bề mặt test tốt nhất |
 
 **Vì sao mở rộng `Session` chứ không dựng session thứ hai.** Lý do `funput-convert`
 tồn tại — ghi ở đầu `lib.rs` — là để câu chữ cảnh báo, quy tắc `vanban (2).txt` và
@@ -367,5 +367,5 @@ không đoán trước.
    cho văn bản khác. **Hoàn tác** gỡ đúng phép cuối; **Bỏ hết** về nguyên bản.
 6. Dán chuỗi không đoán được bảng mã (`hello world`): cả thanh phải mờ và không bấm
    được.
-7. `echo "Tiếng Việt" | funput case --no-diacritics` cho `Tieng Viet` — CLI và ba cửa
+7. `echo "Tiếng Việt" | funput case no-diacritics` cho `Tieng Viet` — CLI và ba cửa
    sổ gọi cùng một hàm, nên lệch nhau ở đây là lỗi nối dây của shell.


### PR DESCRIPTION
Tài liệu ghi `funput case` bằng flag từ trước khi có lệnh này. `CaseArgs` nhận các phép làm **positional value list**, nên dòng trong bảng kiểm tra thủ công không chạy được:

```console
$ echo "Tiếng Việt" | funput case --no-diacritics
error: unexpected argument '--no-diacritics' found
```

Ai làm theo bước 7 để đối chiếu CLI với ba cửa sổ sẽ kết luận CLI hỏng. Sửa cả hai chỗ (`text-case.md:191` và `:370`), và nói ra hai điều mà cách viết bằng flag đã che: các phép **ghép bằng dấu phẩy**, và `--keep-d` / `--flatten-caps` mới là flag thật.

Mọi dạng tài liệu hiện ghi đều đã chạy thật:

| Lệnh | Ra |
| --- | --- |
| `funput case upper` | `TIẾNG VIỆT RẤT ĐẸP. XIN CHÀO` |
| `funput case lower` | `tiếng việt rất đẹp. xin chào` |
| `funput case no-diacritics` | `Tieng Viet rat dep. xin chao` |
| `funput case sentence` | `Tiếng Việt rất đẹp. Xin chào` |
| `funput case title` | `Tiếng Việt Rất Đẹp. Xin Chào` |
| `funput case title` trên `gửi về TP. HCM` | `Gửi Về TP. HCM` |
| `… --flatten-caps` | `Gửi Về Tp. Hcm` |
| `funput case no-diacritics` trên `đẹp` | `dep` |
| `… --keep-d` | `đep` |
| `funput case lower,title` trên `xin Chào` | `Xin Chào` |

Chỉ đổi tài liệu, không đổi code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)