### PR TITLE
feat: add the casing axis to the Chuyển mã window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,17 @@ jobs:
       - name: Test (funput-ffi with convert)
         run: cargo test -p funput-ffi --features convert
 
+      # `textcase` is default-off and nothing enables it: the workspace steps do not
+      # resolve it, and the mobile-shape steps are its off shape by construction. So
+      # this pair is the only place the module is built at all — and it is the shape
+      # a keyboard would ask for one day, textcase on with charset off, which no
+      # other step here resolves.
+      - name: Clippy (textcase, no charset)
+        run: cargo clippy -p funput-core --features textcase --all-targets -- -D warnings
+
+      - name: Test (textcase, no charset)
+        run: cargo test -p funput-core --features textcase
+
       # Compiling proves charset-off still builds; it does not prove the mobile
       # artifacts are free of it. Two different ways that can go wrong, so two checks.
       #

--- a/crates/funput-cli/Cargo.toml
+++ b/crates/funput-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "funput"
 path = "src/main.rs"
 
 [dependencies]
-funput-core = { path = "../funput-core", features = ["charset"] }
+funput-core = { path = "../funput-core", features = ["charset", "textcase"] }
 funput-engine = { path = "../funput-engine" }
 funput-term = { path = "../funput-term" }
 clap = { version = "4.6.1", features = ["derive"] }

--- a/crates/funput-cli/README.en.md
+++ b/crates/funput-cli/README.en.md
@@ -87,6 +87,28 @@ holds; writing it as UTF-8 would produce a file Word cannot read.
 No charset is named in the code here: `--to tcvn3` is matched against `funput_core::charset::ALL`
 by slug, so implementing VISCII is one PR in core and this command picks it up.
 
+## Usage — `funput case`
+
+Change the case of **text that already exists**: UPPERCASE, lowercase, bỏ dấu, sentence case,
+Title Case. The rules are `funput_core::textcase`'s — see `docs/features/text-case.md`.
+
+```bash
+funput case upper vanban.txt                  # one transform, from a file
+funput case title < ghichu.txt                # or from standard input
+funput case lower,title vanban.txt            # stacked, in the order typed
+funput case no-diacritics --keep-d            # `đẹp` → `đep` rather than `dep`
+funput case title --flatten-caps < tt.txt     # `TP. HCM` → `Tp. Hcm`
+```
+
+Stacking takes **one comma-separated token** (`lower,title`) so the file stays the second
+positional argument, as in `funput convert`. Order matters: `lower,title` gives `Gửi Về Tp. Hcm`,
+while `title` alone leaves `TP. HCM` standing — which is what it is for.
+
+A legacy-charset file is **refused rather than mangled**: uppercasing TCVN3 bytes produces a
+document nothing can read, and doing it properly means decode → transform → re-encode, where the
+last step can lose letters. That warning belongs to the converter window, so this command says
+what the file looks like and points at `funput convert`.
+
 ## Platform simulation (`dev/sim.rs` — the heart; pure, tested)
 
 `simulate(method, input) -> Simulation { app_text, steps }` does **exactly** what a platform shell
@@ -117,6 +139,9 @@ src/
 ├── convert/       # `funput convert` — the charset-conversion tool
 │   ├── mod.rs     # args + the flow: read → identify → convert → write
 │   └── report.rs  # --list, --detect, loss warnings (all to stderr)
+├── case/          # `funput case` — changing the case of a document
+│   ├── mod.rs     # the flow: read → refuse legacy → stack transforms → write
+│   └── args.rs    # CaseArgs + TransformArg(→textcase::Transform), two switches
 └── dev/
     ├── mod.rs     # args + dispatch for `funput dev` (run/repl/coverage)
     ├── sim.rs     # simulate() — platform simulation; pure, tested

--- a/crates/funput-cli/README.en.md
+++ b/crates/funput-cli/README.en.md
@@ -111,10 +111,11 @@ src/
 ├── cli.rs         # Cli, Command{Term, Dev}, MethodArg(→InputMethod), CliError/CliResult
 ├── term/
 │   └── mod.rs     # args + handler for `funput term` (wrapper via funput-term + install)
+├── io/            # the two ends every text-transforming command shares
+│   ├── source.rs  # bytes → text + charset (two doors: UTF-8 or byte-oriented)
+│   └── sink.rs    # writes **bytes** to stdout, not text
 ├── convert/       # `funput convert` — the charset-conversion tool
 │   ├── mod.rs     # args + the flow: read → identify → convert → write
-│   ├── source.rs  # bytes → text + charset (two doors: UTF-8 or byte-oriented)
-│   ├── sink.rs    # writes **bytes** to stdout, not text
 │   └── report.rs  # --list, --detect, loss warnings (all to stderr)
 └── dev/
     ├── mod.rs     # args + dispatch for `funput dev` (run/repl/coverage)

--- a/crates/funput-cli/README.md
+++ b/crates/funput-cli/README.md
@@ -85,6 +85,28 @@ Không bảng mã nào bị gọi tên trong code ở đây: `--to tcvn3` đối
 `funput_core::charset::ALL` bằng slug, nên thêm VISCII là một PR trong core và lệnh này hưởng miễn
 phí.
 
+## Dùng — `funput case`
+
+Đổi kiểu chữ của **văn bản đã có**: CHỮ HOA, chữ thường, bỏ dấu, viết hoa đầu câu, Viết Hoa Đầu
+Mỗi Từ. Luật nằm ở `funput_core::textcase`, xem `docs/features/text-case.md`.
+
+```bash
+funput case upper vanban.txt                  # một phép, từ tệp
+funput case title < ghichu.txt                # hoặc từ stdin
+funput case lower,title vanban.txt            # cộng dồn, đúng thứ tự đã gõ
+funput case no-diacritics --keep-d            # `đẹp` → `đep` thay vì `dep`
+funput case title --flatten-caps < tt.txt     # `TP. HCM` → `Tp. Hcm`
+```
+
+Cộng dồn dùng **một token, ngăn bằng dấu phẩy** (`lower,title`), để tên tệp vẫn là tham số vị trí
+thứ hai như `funput convert`. Thứ tự có nghĩa: `lower,title` cho `Gửi Về Tp. Hcm`, còn `title` một
+mình giữ nguyên `TP. HCM` — đó là việc của nó.
+
+Tệp bảng mã cũ bị **từ chối chứ không bị làm hỏng**: viết hoa byte TCVN3 sẽ ra tài liệu không ai
+đọc được, mà làm đúng thì phải giải mã → đổi kiểu chữ → mã hoá lại, và bước cuối có thể mất chữ.
+Đường cảnh báo đó thuộc về cửa sổ Chuyển mã, nên ở đây lệnh nói tệp trông như bảng mã gì rồi chỉ
+sang `funput convert`.
+
 ## Mô phỏng platform (`dev/sim.rs` — trái tim, thuần, có test)
 
 `simulate(method, input) -> Simulation { app_text, steps }` làm **đúng** việc một platform shell làm:
@@ -115,6 +137,9 @@ src/
 ├── convert/       # `funput convert` — công cụ chuyển mã
 │   ├── mod.rs     # args + luồng: đọc → nhận diện → chuyển → ghi
 │   └── report.rs  # --list, --detect, cảnh báo mất mát (đều ra stderr)
+├── case/          # `funput case` — đổi kiểu chữ
+│   ├── mod.rs     # luồng: đọc → chặn bảng mã cũ → cộng dồn các phép → ghi
+│   └── args.rs    # CaseArgs + TransformArg(→textcase::Transform), hai công tắc
 └── dev/
     ├── mod.rs     # args + dispatch `funput dev` (run/repl/coverage)
     ├── sim.rs     # simulate() — mô phỏng platform, thuần, có test

--- a/crates/funput-cli/README.md
+++ b/crates/funput-cli/README.md
@@ -109,10 +109,11 @@ src/
 ├── cli.rs         # Cli, Command{Term, Dev}, MethodArg(→InputMethod), CliError/CliResult
 ├── term/
 │   └── mod.rs     # args + handler `funput term` (wrapper qua funput-term + install)
+├── io/            # hai đầu dùng chung của mọi lệnh biến đổi văn bản
+│   ├── source.rs  # bytes → text + bảng mã (hai cửa: UTF-8 hay theo byte)
+│   └── sink.rs    # ghi **bytes** ra stdout (không phải text)
 ├── convert/       # `funput convert` — công cụ chuyển mã
 │   ├── mod.rs     # args + luồng: đọc → nhận diện → chuyển → ghi
-│   ├── source.rs  # bytes → text + bảng mã (hai cửa: UTF-8 hay theo byte)
-│   ├── sink.rs    # ghi **bytes** ra stdout (không phải text)
 │   └── report.rs  # --list, --detect, cảnh báo mất mát (đều ra stderr)
 └── dev/
     ├── mod.rs     # args + dispatch `funput dev` (run/repl/coverage)

--- a/crates/funput-cli/src/case/args.rs
+++ b/crates/funput-cli/src/case/args.rs
@@ -1,0 +1,85 @@
+//! What `funput case` takes on the command line.
+//!
+//! `TransformArg` lives here rather than in [`crate::cli`], where `MethodArg` is:
+//! that one is up there because more than one command family takes an input method,
+//! and this one belongs to a single command. Either way the clap type stays at the
+//! CLI layer, so `funput-core` need not depend on clap.
+
+use std::path::PathBuf;
+
+use clap::{Args, ValueEnum};
+
+use funput_core::textcase::{Options, Transform};
+
+#[derive(Debug, Args)]
+pub struct CaseArgs {
+    /// Transforms to run, comma-separated and in order: `lower,title`.
+    // The doc comment above is the help text, so the reason for the explicit action
+    // is a plain comment: a `Vec` field derives `Append` with `num_args(1..)`, which
+    // is greedy — it would swallow the file name after it, leaving `[FILE]` an
+    // argument clap can never reach. `Cli::command().debug_assert()` says so out
+    // loud, and `cli.rs` runs it in a test.
+    #[arg(
+        value_enum,
+        required = true,
+        value_delimiter = ',',
+        num_args = 1,
+        action = clap::ArgAction::Set
+    )]
+    pub transforms: Vec<TransformArg>,
+
+    /// File to transform. Reads standard input when omitted.
+    pub file: Option<PathBuf>,
+
+    /// Keep đ and Đ instead of writing d and D (affects `no-diacritics`).
+    #[arg(long)]
+    pub keep_d: bool,
+
+    /// Also lowercase words that are already all-caps — `TP. HCM` becomes `Tp. Hcm`
+    /// (affects `title`).
+    #[arg(long)]
+    pub flatten_caps: bool,
+}
+
+impl CaseArgs {
+    /// The switches, as core takes them.
+    ///
+    /// Neither switch conflicts with a transform that does not read it. Several
+    /// transforms can run in one command, so `--keep-d` beside `lower,no-diacritics`
+    /// is a sensible thing to type, and refusing it would be a rule the user has to
+    /// learn for nothing.
+    pub(super) fn options(&self) -> Options {
+        Options {
+            d_to_ascii: !self.keep_d,
+            keep_all_caps: !self.flatten_caps,
+        }
+    }
+}
+
+/// The five transforms, as words on the command line. clap spells the variants in
+/// kebab-case, so this is `upper`, `lower`, `no-diacritics`, `sentence`, `title`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum TransformArg {
+    /// UPPERCASE.
+    Upper,
+    /// lowercase.
+    Lower,
+    /// Bỏ dấu tiếng Việt.
+    NoDiacritics,
+    /// Capitalise the first letter of each sentence.
+    Sentence,
+    /// Capitalise The First Letter Of Each Word.
+    Title,
+}
+
+impl From<TransformArg> for Transform {
+    fn from(arg: TransformArg) -> Self {
+        match arg {
+            TransformArg::Upper => Transform::Upper,
+            TransformArg::Lower => Transform::Lower,
+            TransformArg::NoDiacritics => Transform::NoDiacritics,
+            TransformArg::Sentence => Transform::Sentence,
+            TransformArg::Title => Transform::Title,
+        }
+    }
+}

--- a/crates/funput-cli/src/case/mod.rs
+++ b/crates/funput-cli/src/case/mod.rs
@@ -1,0 +1,76 @@
+//! `funput case`: changing the case of a document (chuyển đổi kiểu chữ).
+//!
+//! Five transforms over text that already exists — UPPERCASE, lowercase, bỏ dấu,
+//! sentence case, title case — as a filter: a file or standard input goes in, the
+//! transformed text comes out, and everything else goes to standard error. The
+//! rules are `funput_core::textcase`'s; see `docs/features/text-case.md`.
+//!
+//! **Transforms stack, in the order they are typed.** `lower,title` is how a user
+//! reaches `Gửi Về Tp. Hcm` from `GỬI VỀ TP. HCM`, because title case on its own
+//! protects words that are already all-caps — that is what it is for. The same
+//! stacking is what the converter window offers with two button presses.
+//!
+//! **Legacy charsets are refused rather than mangled.** A `.VnTime` document is not
+//! Unicode text: it is code points `U+0020..=U+00FF` standing in for TCVN3 bytes,
+//! and uppercasing those would produce a document nothing can read. Doing it
+//! properly means decoding, transforming and re-encoding — and re-encoding can lose
+//! letters, because TCVN3 has no room for uppercase toned vowels. That warning
+//! belongs to a window with somewhere to show it, not to a command whose standard
+//! output is the document. So this says what the file looks like and points at
+//! `funput convert`.
+
+mod args;
+
+use std::process::ExitCode;
+
+use funput_core::charset::{self, Charset, document::Document};
+use funput_core::textcase::apply;
+
+use crate::cli::{CliError, CliResult};
+use crate::io::{read, write};
+
+pub use args::CaseArgs;
+
+/// Run `funput case`.
+pub fn run(args: CaseArgs) -> CliResult {
+    let text = readable(read(args.file.as_deref())?)?;
+    let options = args.options();
+    let transformed = args
+        .transforms
+        .iter()
+        .fold(text, |text, &arg| apply(&text, arg.into(), options));
+    write(transformed.as_bytes())?;
+    Ok(ExitCode::SUCCESS)
+}
+
+/// The text of a document this command is willing to touch.
+///
+/// The charset is asked about rather than assumed: `read` already worked it out, so
+/// refusing costs one question and saves a user from a file full of mojibake.
+fn readable(document: Document) -> Result<String, CliError> {
+    match document.charset {
+        Some(charset) if charset::is_byte_oriented(charset) => Err(CliError::Msg(legacy(charset))),
+        Some(_) => Ok(document.text),
+        None => Err(CliError::Msg(UNREADABLE.to_string())),
+    }
+}
+
+/// What to say when the bytes are not text at all.
+const UNREADABLE: &str =
+    "cannot read this as text: not UTF-8, and no charset explains the bytes either";
+
+/// What to say about a document that is text, but not Unicode.
+///
+/// Names the charset it looks like, because the next command needs it — and the
+/// user may disagree with the guess, which `funput convert --from` lets them say.
+fn legacy(charset: Charset) -> String {
+    format!(
+        "this looks like {} ({}), not Unicode — convert it first:\n  \
+         funput convert <file> --to unicode | funput case …",
+        charset.name(),
+        charset.slug()
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/funput-cli/src/case/tests.rs
+++ b/crates/funput-cli/src/case/tests.rs
@@ -1,0 +1,117 @@
+use funput_core::charset::document;
+use funput_core::textcase::Options;
+
+use super::args::TransformArg;
+use super::*;
+
+/// Everything `run` does between reading and writing, with the I/O left out — the
+/// same shape as `convert`'s tests, and for the same reason: the interesting part is
+/// the decision, not the file handle.
+fn pipeline(
+    bytes: &[u8],
+    transforms: &[TransformArg],
+    options: Options,
+) -> Result<String, CliError> {
+    let document = document::read(bytes.to_vec()).expect("well-formed fixture");
+    let text = readable(document)?;
+    Ok(transforms
+        .iter()
+        .fold(text, |text, &arg| apply(&text, arg.into(), options)))
+}
+
+fn run_one(bytes: &[u8], transform: TransformArg) -> String {
+    pipeline(bytes, &[transform], Options::default()).expect("fixture is Unicode")
+}
+
+#[test]
+fn one_transform_end_to_end() {
+    assert_eq!(
+        run_one("Tiếng Việt rất đẹp".as_bytes(), TransformArg::NoDiacritics),
+        "Tieng Viet rat dep"
+    );
+    assert_eq!(
+        run_one("bàn phím tiếng Việt".as_bytes(), TransformArg::Title),
+        "Bàn Phím Tiếng Việt"
+    );
+}
+
+/// The reason stacking is offered at all, and the reason the order is the typed one.
+#[test]
+fn transforms_stack_in_the_order_given() {
+    let shouting = "GỬI VỀ TP. HCM".as_bytes();
+    let options = Options::default();
+
+    let lower_then_title = [TransformArg::Lower, TransformArg::Title];
+    assert_eq!(
+        pipeline(shouting, &lower_then_title, options).unwrap(),
+        "Gửi Về Tp. Hcm"
+    );
+
+    let title_then_lower = [TransformArg::Title, TransformArg::Lower];
+    assert_eq!(
+        pipeline(shouting, &title_then_lower, options).unwrap(),
+        "gửi về tp. hcm"
+    );
+}
+
+#[test]
+fn keep_d_leaves_the_stroke_alone() {
+    let options = Options {
+        d_to_ascii: false,
+        ..Options::default()
+    };
+    let kept = pipeline("đẹp".as_bytes(), &[TransformArg::NoDiacritics], options).unwrap();
+    assert_eq!(kept, "đep");
+}
+
+#[test]
+fn flatten_caps_stops_title_case_protecting_a_shout() {
+    let options = Options {
+        keep_all_caps: false,
+        ..Options::default()
+    };
+    let flattened = pipeline("gửi về TP. HCM".as_bytes(), &[TransformArg::Title], options).unwrap();
+    assert_eq!(flattened, "Gửi Về Tp. Hcm");
+}
+
+/// A `.VnTime` document — the fixture `convert`'s tests use, which converts cleanly
+/// there and must be refused here.
+#[test]
+fn a_legacy_document_is_refused_by_name() {
+    let err = pipeline(
+        b"vi\xD6t nam h\xB5 n\xE9i",
+        &[TransformArg::Upper],
+        Options::default(),
+    )
+    .expect_err("TCVN3 is not Unicode");
+    let CliError::Msg(message) = err else {
+        panic!("expected a message, not an io error");
+    };
+    assert!(message.contains("tcvn3"), "{message}");
+    assert!(message.contains("funput convert"), "{message}");
+}
+
+#[test]
+fn bytes_that_are_not_text_are_refused_rather_than_guessed_at() {
+    let err = pipeline(
+        &[0xFF, 0x00, 0xFE],
+        &[TransformArg::Upper],
+        Options::default(),
+    )
+    .expect_err("not text");
+    assert!(matches!(err, CliError::Msg(_)));
+}
+
+/// Reading goes through `charset::document`, so a byte-order mark and UTF-16 are
+/// already handled. Pinned here so nobody simplifies it into `String::from_utf8`.
+#[test]
+fn a_utf16_file_with_a_mark_is_read_not_refused() {
+    let mut bytes = vec![0xFF, 0xFE];
+    for unit in "Tiếng Việt".encode_utf16() {
+        bytes.extend_from_slice(&unit.to_le_bytes());
+    }
+    assert_eq!(
+        pipeline(&bytes, &[TransformArg::NoDiacritics], Options::default()).unwrap(),
+        "Tieng Viet"
+    );
+}

--- a/crates/funput-cli/src/cli.rs
+++ b/crates/funput-cli/src/cli.rs
@@ -11,6 +11,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 use funput_core::InputMethod;
 
+use crate::case::CaseArgs;
 use crate::convert::ConvertArgs;
 use crate::dev::DevArgs;
 use crate::term::TermArgs;
@@ -34,6 +35,8 @@ pub enum Command {
     Dev(DevArgs),
     /// Convert Vietnamese text between Unicode and the legacy charsets.
     Convert(ConvertArgs),
+    /// Change the case of Vietnamese text, or strip its diacritics.
+    Case(CaseArgs),
 }
 
 /// Input method as selected on the command line. Kept at the CLI layer (a clap
@@ -78,5 +81,43 @@ impl std::error::Error for CliError {}
 impl From<std::io::Error> for CliError {
     fn from(e: std::io::Error) -> Self {
         CliError::Io(e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+
+    use super::*;
+
+    /// clap's own audit of the argument tree: conflicting ids, impossible
+    /// `num_args`, a positional that can never be reached. Cheap, and it is what
+    /// catches a greedy positional swallowing the argument after it — `funput case`
+    /// takes its transforms as one comma-separated value for exactly that reason.
+    #[test]
+    fn the_argument_tree_is_well_formed() {
+        Cli::command().debug_assert();
+    }
+
+    /// The shape the README promises: transforms first, then the file.
+    #[test]
+    fn case_takes_stacked_transforms_and_still_sees_the_file() {
+        let cli = Cli::try_parse_from(["funput", "case", "lower,title", "vanban.txt"])
+            .expect("valid invocation");
+        let Command::Case(args) = cli.command else {
+            panic!("expected the case command");
+        };
+        assert_eq!(args.transforms.len(), 2);
+        assert_eq!(
+            args.file.as_deref(),
+            Some(std::path::Path::new("vanban.txt"))
+        );
+    }
+
+    /// A transform is required: `funput case vanban.txt` would otherwise read the
+    /// file name as a transform and fail with a worse message.
+    #[test]
+    fn case_without_a_transform_is_rejected() {
+        assert!(Cli::try_parse_from(["funput", "case"]).is_err());
     }
 }

--- a/crates/funput-cli/src/convert/mod.rs
+++ b/crates/funput-cli/src/convert/mod.rs
@@ -5,10 +5,8 @@
 //! text that already exists; typing in a legacy charset is not offered and is not
 //! planned — see `docs/features/charset.md`.
 //!
-//! - [`source`] — turning an argument or standard input into text, and working out
-//!   what charset spelled it.
-//! - [`sink`] — writing the result back out, as bytes when the target is a legacy
-//!   charset and as UTF-8 when it is not.
+//! - [`crate::io`] — turning an argument or standard input into text and writing the
+//!   result back out, shared with `funput case`.
 //! - [`report`] — everything printed to standard error: the charset table, the
 //!   detected name, and the warning when something could not be represented.
 //!
@@ -17,8 +15,6 @@
 //! there and this command picks it up.
 
 mod report;
-mod sink;
-mod source;
 
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -28,6 +24,7 @@ use clap::Args;
 use funput_core::charset::{self, Charset};
 
 use crate::cli::{CliError, CliResult};
+use crate::io::{read, write};
 
 #[derive(Debug, Args)]
 pub struct ConvertArgs {
@@ -63,7 +60,7 @@ pub fn run(args: ConvertArgs) -> CliResult {
     let to = args.to.as_deref().map(by_slug).transpose()?;
     let declared = args.from.as_deref().map(by_slug).transpose()?;
 
-    let input = source::read(args.file.as_deref())?;
+    let input = read(args.file.as_deref())?;
     // A charset the user named beats one that was worked out: they are looking at
     // the document, and the detector is looking at statistics.
     let Some(from) = declared.or(input.charset) else {
@@ -82,7 +79,7 @@ pub fn run(args: ConvertArgs) -> CliResult {
     // The same two calls the converter windows make, so a document converted here
     // and a document converted there cannot come out differently.
     let rendered = charset::render(&charset::read(&input.text, from), to);
-    sink::write(&rendered.bytes)?;
+    write(&rendered.bytes)?;
     report::losses(&rendered.cost);
     Ok(ExitCode::SUCCESS)
 }

--- a/crates/funput-cli/src/io/mod.rs
+++ b/crates/funput-cli/src/io/mod.rs
@@ -1,0 +1,14 @@
+//! The two ends of a command that transforms a document: getting the bytes in, and
+//! writing the bytes out.
+//!
+//! Shared rather than owned by one command, because `funput convert` and
+//! `funput case` need the same two things and would otherwise answer the same
+//! questions twice — what a byte-order mark means, whether a closed pipe is a
+//! failure. Reaching into another command's module for them would say that one
+//! command owns the other's plumbing, which is not true of either.
+
+mod sink;
+mod source;
+
+pub(crate) use sink::write;
+pub(crate) use source::read;

--- a/crates/funput-cli/src/io/sink.rs
+++ b/crates/funput-cli/src/io/sink.rs
@@ -13,7 +13,7 @@ use crate::cli::CliError;
 ///
 /// A closed pipe is not an error. `funput convert … | head` closes the pipe as soon
 /// as it has enough, and reporting that as a failure would make the exit code lie.
-pub(super) fn write(bytes: &[u8]) -> Result<(), CliError> {
+pub(crate) fn write(bytes: &[u8]) -> Result<(), CliError> {
     let mut out = std::io::stdout().lock();
     match out.write_all(bytes).and_then(|()| out.flush()) {
         Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),

--- a/crates/funput-cli/src/io/source.rs
+++ b/crates/funput-cli/src/io/source.rs
@@ -13,7 +13,7 @@ use funput_core::charset::document::{self, Document};
 use crate::cli::CliError;
 
 /// Read `path`, or standard input when it is `None`, and say what it holds.
-pub(super) fn read(path: Option<&Path>) -> Result<Document, CliError> {
+pub(crate) fn read(path: Option<&Path>) -> Result<Document, CliError> {
     let bytes = match path {
         Some(path) => std::fs::read(path)
             .map_err(|e| CliError::Msg(format!("cannot read {}: {e}", path.display())))?,

--- a/crates/funput-cli/src/main.rs
+++ b/crates/funput-cli/src/main.rs
@@ -12,6 +12,7 @@
 mod cli;
 mod convert;
 mod dev;
+mod io;
 mod term;
 
 use std::process::ExitCode;

--- a/crates/funput-cli/src/main.rs
+++ b/crates/funput-cli/src/main.rs
@@ -8,7 +8,9 @@
 //!   platform shell would show, for quick checks, debugging, and CI.
 //! - `funput convert …` — turn a document between Unicode and the legacy charsets
 //!   Vietnamese government paperwork still arrives in (TCVN3, VNI-Windows).
+//! - `funput case …` — change the case of a document, or take its diacritics off.
 
+mod case;
 mod cli;
 mod convert;
 mod dev;
@@ -26,6 +28,7 @@ fn main() -> ExitCode {
         Command::Term(args) => term::run(args),
         Command::Dev(args) => dev::run(args),
         Command::Convert(args) => convert::run(args),
+        Command::Case(args) => case::run(args),
     };
     match result {
         Ok(code) => code,

--- a/crates/funput-convert/Cargo.toml
+++ b/crates/funput-convert/Cargo.toml
@@ -13,4 +13,4 @@ workspace = true
 # Every decision here is expressed in `Charset` terms, and the charset names the
 # warnings quote come from `Charset::name()` — the one place they are written, so
 # a menu on Windows and a menu on Linux cannot drift apart.
-funput-core = { path = "../funput-core", features = ["charset"] }
+funput-core = { path = "../funput-core", features = ["charset", "textcase"] }

--- a/crates/funput-convert/src/batch/write.rs
+++ b/crates/funput-convert/src/batch/write.rs
@@ -8,7 +8,9 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use funput_core::charset::{Charset, read, render};
+use funput_core::charset::Charset;
+
+use crate::casing::{self, Casing};
 
 use super::Entry;
 
@@ -31,7 +33,7 @@ pub struct Outcome {
 ///
 /// A file with no charset is *skipped*, not guessed at — the row is still on screen
 /// with its own picker, and the user can settle it and run again.
-pub fn write_all(entries: &[Entry], target: Charset) -> Outcome {
+pub fn write_all(entries: &[Entry], casing: &Casing, target: Charset) -> Outcome {
     let mut outcome = Outcome {
         written: 0,
         skipped: 0,
@@ -48,11 +50,9 @@ pub fn write_all(entries: &[Entry], target: Charset) -> Outcome {
             outcome.skipped += 1;
             continue;
         };
-        // The same two steps every consumer takes, and the same call: read the
-        // document, then render it. `render` is what makes a legacy target one byte
-        // per letter rather than two — and what makes these bytes the ones the
-        // window promised in its preview pane.
-        let bytes = render(&read(&entry.text, from), target).bytes;
+        // The same call every consumer takes, which is what makes these bytes the
+        // ones the window promised in its preview pane — charset and case both.
+        let bytes = casing::render(&entry.text, from, casing, target).bytes;
         match destination(&entry.path, &mut taken)
             .and_then(|path| std::fs::write(path, &bytes).ok())
         {
@@ -142,7 +142,7 @@ mod tests {
     fn the_original_is_left_exactly_as_it_was() {
         let dir = scratch("keeps-original");
         let entries = [entry(&dir, "vanban.txt", "Việt", Some(Charset::Unicode))];
-        let outcome = write_all(&entries, Charset::Tcvn3);
+        let outcome = write_all(&entries, &Casing::default(), Charset::Tcvn3);
 
         assert_eq!(outcome.written, 1);
         assert_eq!(
@@ -161,8 +161,8 @@ mod tests {
     fn a_second_run_does_not_overwrite_the_first() {
         let dir = scratch("second-run");
         let entries = [entry(&dir, "vanban.txt", "Việt", Some(Charset::Unicode))];
-        write_all(&entries, Charset::Tcvn3);
-        write_all(&entries, Charset::VniWindows);
+        write_all(&entries, &Casing::default(), Charset::Tcvn3);
+        write_all(&entries, &Casing::default(), Charset::VniWindows);
 
         let out = dir.join(OUT_DIR);
         assert_eq!(std::fs::read(out.join("vanban.txt")).unwrap(), b"Vi\xD6t");
@@ -201,7 +201,7 @@ mod tests {
             entry(&dir, "known.txt", "Việt", Some(Charset::Unicode)),
             entry(&dir, "mystery.txt", "????", None),
         ];
-        let outcome = write_all(&entries, Charset::Tcvn3);
+        let outcome = write_all(&entries, &Casing::default(), Charset::Tcvn3);
 
         assert_eq!((outcome.written, outcome.skipped), (1, 1));
         assert!(!dir.join(OUT_DIR).join("mystery.txt").exists());

--- a/crates/funput-convert/src/casing.rs
+++ b/crates/funput-convert/src/casing.rs
@@ -1,0 +1,201 @@
+//! The second axis: what the window does to a document besides re-spelling it.
+//!
+//! Changing a charset and changing the case are two independent choices about one
+//! document, and a window offers both at once. Keeping them in one pipeline is what
+//! makes them agree — see [`render`], which is the only place either happens.
+//!
+//! The transforms themselves are `funput_core::textcase`'s. What is here is what a
+//! *window* needs on top of them: an order to show them in, a name for each, and a
+//! record of which ones the user has pressed so far.
+//!
+//! **Why the names are here rather than in core.** They are interface text, in the
+//! same language as the loss warning and the `N chữ sẽ mất` note next door. Core
+//! spells `Charset::name` because a charset's name is its name in any language; a
+//! button's label is not that. `funput case` never needs one — clap writes English
+//! help — so core would carry Vietnamese for a single caller.
+
+use funput_core::charset::{self, Charset, Rendered};
+use funput_core::textcase::{Options, Transform, apply};
+
+/// The five transforms, in the order a window offers them.
+///
+/// Ordered like `charset::ALL` and used the same way: a shell builds its menu from
+/// this and hands back a position. Append-only, for the same reason — a stored
+/// index has to keep meaning the same thing across releases.
+pub const ALL: [Transform; 5] = [
+    Transform::Upper,
+    Transform::Lower,
+    Transform::NoDiacritics,
+    Transform::Sentence,
+    Transform::Title,
+];
+
+/// What to call each transform, in the language of the window.
+///
+/// `Transform` is exhaustive on purpose, so a sixth one makes this a compile error
+/// rather than a button with no label.
+pub fn name(transform: Transform) -> &'static str {
+    match transform {
+        Transform::Upper => "CHỮ HOA",
+        Transform::Lower => "chữ thường",
+        Transform::NoDiacritics => "Bỏ dấu tiếng Việt",
+        Transform::Sentence => "Viết hoa đầu câu",
+        Transform::Title => "Viết Hoa Đầu Mỗi Từ",
+    }
+}
+
+/// The transform a menu position names, clamped — the rule [`crate::at`] follows for
+/// charsets, and for the same reason: an index can only come from a menu built out
+/// of [`ALL`], so clamping keeps a future mistake a wrong entry rather than a panic.
+pub fn at(index: usize) -> Transform {
+    ALL[index.min(ALL.len() - 1)]
+}
+
+/// A menu position that exists.
+pub fn index_of(transform: Transform) -> Option<usize> {
+    ALL.iter().position(|&t| t == transform)
+}
+
+/// The transforms a document is under, in the order they were pressed.
+///
+/// **A list rather than an edited document.** The window lets a user press one
+/// transform after another, and undo the last one; replaying a list from the
+/// original text is what makes that possible without ever writing back into the
+/// paragraph the user pasted — which would send their caret home, and which GTK
+/// reads as a fresh paste that forgets the charset it had detected.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Casing {
+    transforms: Vec<Transform>,
+    options: Options,
+}
+
+impl Casing {
+    /// Press a transform.
+    ///
+    /// Pressing the one already on top does nothing: every transform is idempotent
+    /// — core has a property test saying so — so a second press cannot change the
+    /// document, and letting it grow the list would only make undo feel broken.
+    pub fn push(&mut self, transform: Transform) {
+        if self.transforms.last() != Some(&transform) {
+            self.transforms.push(transform);
+        }
+    }
+
+    /// Undo the last transform. Does nothing when there is none.
+    pub fn undo(&mut self) {
+        self.transforms.pop();
+    }
+
+    /// Back to the document as it arrived.
+    pub fn clear(&mut self) {
+        self.transforms.clear();
+    }
+
+    pub fn options(&self) -> Options {
+        self.options
+    }
+
+    pub fn set_options(&mut self, options: Options) {
+        self.options = options;
+    }
+
+    /// The list as menu positions, for a shell to show what is applied.
+    pub(crate) fn indices(&self) -> Vec<usize> {
+        self.transforms
+            .iter()
+            .copied()
+            .filter_map(index_of)
+            .collect()
+    }
+
+    fn run(&self, text: &str) -> String {
+        self.transforms
+            .iter()
+            .fold(text.to_string(), |text, &transform| {
+                apply(&text, transform, self.options)
+            })
+    }
+}
+
+/// Read a document, change its case, and write it out as `to` spells it.
+///
+/// **The only place a conversion happens in this crate.** Four callers need the same
+/// answer — the preview pane, the clipboard, the bytes a file receives, and the
+/// `N chữ sẽ mất` note on a batch row — and the note is the one that proves why:
+/// UPPERCASE makes letters TCVN3 has no room for, so a note counted before the
+/// transform would promise a cost the file will not keep to.
+pub(crate) fn render(text: &str, from: Charset, casing: &Casing, to: Charset) -> Rendered {
+    let mut pivoted = charset::read(text, from);
+    if !casing.transforms.is_empty() {
+        // Assigned rather than rebuilt: `Pivoted` is `#[non_exhaustive]`, and the two
+        // counters beside the text describe the *reading* — how much of the source
+        // charset was undefined, how much it respelled — which changing the case
+        // neither adds to nor excuses.
+        pivoted.text = casing.run(&pivoted.text);
+    }
+    charset::render(&pivoted, to)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A shell stores a menu position, so every position has to mean one transform
+    /// and keep meaning it. This is `charset::ALL`'s contract, in the same shape.
+    #[test]
+    fn every_position_names_one_transform_and_survives_a_round_trip() {
+        for (index, transform) in ALL.into_iter().enumerate() {
+            assert_eq!(at(index), transform);
+            assert_eq!(index_of(transform), Some(index));
+            assert!(!name(transform).is_empty());
+        }
+    }
+
+    /// Out of range is a wrong entry, never a panic — a stored index can outlive the
+    /// menu it came from.
+    #[test]
+    fn a_position_from_a_longer_menu_is_clamped() {
+        assert_eq!(at(usize::MAX), ALL[ALL.len() - 1]);
+    }
+
+    /// The list is what the user pressed, and pressing the same button twice is not
+    /// two presses worth of document.
+    #[test]
+    fn the_list_records_presses_in_order_and_ignores_a_repeat() {
+        let mut casing = Casing::default();
+        casing.push(Transform::Lower);
+        casing.push(Transform::Lower);
+        casing.push(Transform::Title);
+        assert_eq!(
+            casing.indices(),
+            vec![
+                index_of(Transform::Lower).unwrap(),
+                index_of(Transform::Title).unwrap()
+            ]
+        );
+
+        casing.undo();
+        assert_eq!(casing.indices(), vec![index_of(Transform::Lower).unwrap()]);
+        casing.clear();
+        assert!(casing.indices().is_empty());
+    }
+
+    /// Reading counts describe the read, so they have to survive the transform —
+    /// a document that was half-undefined does not become clean by being uppercased.
+    #[test]
+    fn the_reading_counts_are_not_disturbed_by_a_transform() {
+        let mut casing = Casing::default();
+        casing.push(Transform::Upper);
+        let plain = render(
+            "việt nam",
+            Charset::Unicode,
+            &Casing::default(),
+            Charset::Unicode,
+        );
+        let cased = render("việt nam", Charset::Unicode, &casing, Charset::Unicode);
+
+        assert_eq!(cased.text, "VIỆT NAM");
+        assert_eq!(cased.cost.undefined, plain.cost.undefined);
+        assert_eq!(cased.cost.normalized, plain.cost.normalized);
+    }
+}

--- a/crates/funput-convert/src/lib.rs
+++ b/crates/funput-convert/src/lib.rs
@@ -23,9 +23,13 @@
 //! whatever that platform does to get work off its UI thread. Those differ per
 //! platform by nature; nothing below does.
 //!
+//! - [`casing`] — the second axis: the transforms a window offers besides the
+//!   charset, and the one place either is applied.
 //! - [`text`] — a paragraph: what it becomes, and what it costs.
 //! - [`batch`] — a drop: what each file turned out to be.
 //! - [`write`] — the copies, written beside the originals and never over them.
+
+pub mod casing;
 
 mod batch;
 mod session;

--- a/crates/funput-convert/src/session.rs
+++ b/crates/funput-convert/src/session.rs
@@ -20,11 +20,13 @@
 //! Charsets are **indices into [`charset::ALL`]** — see [`index`].
 
 mod act;
+mod casing;
 mod job;
 mod query;
 mod view;
 
 use crate::batch::Entry;
+use crate::casing::Casing;
 use crate::{at, clamp};
 
 pub use job::Job;
@@ -40,6 +42,7 @@ pub struct Session {
     pub(super) files: Vec<Entry>,
     pub(super) unreadable: Vec<Unreadable>,
     pub(super) window: (usize, usize),
+    pub(super) casing: Casing,
     view: View,
 }
 
@@ -60,6 +63,7 @@ impl Session {
             files: Vec::new(),
             unreadable: Vec::new(),
             window: (0, WINDOW),
+            casing: Casing::default(),
             view: View::default(),
         }
     }
@@ -69,6 +73,9 @@ impl Session {
     pub fn set_input(&mut self, text: String) {
         self.input = text;
         self.source = None;
+        // A new document is not the old one under a different name: the transforms
+        // pressed on the last paragraph belong to it, exactly as its charset did.
+        self.casing.clear();
     }
 
     /// Clamped on the way in, not on the way out: [`View::target`] is a position a
@@ -107,6 +114,7 @@ impl Session {
     pub fn adopt(&mut self, scan: crate::Scan) {
         self.input.clear();
         self.source = None;
+        self.casing.clear();
         self.files = scan.entries;
         self.unreadable = scan.unreadable;
         self.window = (0, WINDOW);

--- a/crates/funput-convert/src/session.rs
+++ b/crates/funput-convert/src/session.rs
@@ -117,7 +117,9 @@ impl Session {
         self.casing.clear();
         self.files = scan.entries;
         self.unreadable = scan.unreadable;
-        self.window = (0, WINDOW);
+        // Back to the top of the list, but the cap the shell asked for survives: how
+        // many rows it can build is the toolkit's business, not this document's.
+        self.window = (0, self.window.1);
     }
 
     pub fn set_row_window(&mut self, first: usize, len: usize) {

--- a/crates/funput-convert/src/session.rs
+++ b/crates/funput-convert/src/session.rs
@@ -25,7 +25,7 @@ mod query;
 mod view;
 
 use crate::batch::Entry;
-use crate::{at, clamp, index_of};
+use crate::{at, clamp};
 
 pub use job::Job;
 pub use view::{Mode, Row, Unreadable, View};

--- a/crates/funput-convert/src/session/act.rs
+++ b/crates/funput-convert/src/session/act.rs
@@ -5,7 +5,7 @@
 //! is being converted. That rule used to exist in three places in the Windows shell
 //! and was wrong in one of them.
 
-use funput_core::charset;
+use crate::casing;
 
 use super::Session;
 
@@ -14,13 +14,13 @@ impl Session {
     /// which would hand over a document with its tail quietly missing.
     pub fn result_text(&self) -> Option<String> {
         self.conversion()
-            .map(|(text, from, to)| charset::render(&charset::read(text, from), to).text)
+            .map(|(text, from, to)| casing::render(text, from, &self.casing, to).text)
     }
 
     /// The bytes to save. A legacy target stores one byte per letter, and writing the
     /// same characters as UTF-8 would produce a file `.VnTime` cannot read back.
     pub fn save_bytes(&self) -> Option<Vec<u8>> {
         self.conversion()
-            .map(|(text, from, to)| charset::render(&charset::read(text, from), to).bytes)
+            .map(|(text, from, to)| casing::render(text, from, &self.casing, to).bytes)
     }
 }

--- a/crates/funput-convert/src/session/casing.rs
+++ b/crates/funput-convert/src/session/casing.rs
@@ -1,0 +1,47 @@
+//! The buttons of the second axis.
+//!
+//! Commands, not queries: each one changes what the window will produce, and none
+//! of them touches the document. What the user pasted stays exactly as they pasted
+//! it — see [`crate::casing::Casing`] for why that matters — and the list of
+//! presses is replayed on every [`Session::refresh`].
+
+use crate::casing;
+
+use super::Session;
+
+impl Session {
+    /// A transform button was pressed, by menu position.
+    pub fn apply_transform(&mut self, index: usize) {
+        self.casing.push(casing::at(index));
+    }
+
+    /// Undo, which takes off the last transform rather than all of them: pressing a
+    /// third one by mistake should not cost the two before it.
+    pub fn undo_transform(&mut self) {
+        self.casing.undo();
+    }
+
+    /// Back to the document as it arrived.
+    pub fn clear_transforms(&mut self) {
+        self.casing.clear();
+    }
+
+    /// Keep `đ` and `Đ` instead of writing `d` and `D`.
+    ///
+    /// Named for the switch rather than for the field it sets, so that **off is the
+    /// default** — the same way `funput case --keep-d` reads, and the reason
+    /// [`crate::View`] can keep deriving `Default`.
+    pub fn set_keep_d(&mut self, on: bool) {
+        let mut options = self.casing.options();
+        options.d_to_ascii = !on;
+        self.casing.set_options(options);
+    }
+
+    /// Also lowercase words that are already all-caps, so `TP. HCM` becomes
+    /// `Tp. Hcm` under title case.
+    pub fn set_flatten_caps(&mut self, on: bool) {
+        let mut options = self.casing.options();
+        options.keep_all_caps = !on;
+        self.casing.set_options(options);
+    }
+}

--- a/crates/funput-convert/src/session/job.rs
+++ b/crates/funput-convert/src/session/job.rs
@@ -8,18 +8,20 @@
 use funput_core::charset::Charset;
 
 use crate::batch::{self, Entry, Outcome};
+use crate::casing::Casing;
 
 use super::{Session, at};
 
 /// A batch, ready to be written on whatever thread the shell picks.
 pub struct Job {
     entries: Vec<Entry>,
+    casing: Casing,
     target: Charset,
 }
 
 impl Job {
     pub fn run(self) -> Outcome {
-        batch::write_all(&self.entries, self.target)
+        batch::write_all(&self.entries, &self.casing, self.target)
     }
 }
 
@@ -28,6 +30,7 @@ impl Session {
     pub fn batch_job(&self) -> Job {
         Job {
             entries: self.files.clone(),
+            casing: self.casing.clone(),
             target: at(self.target),
         }
     }

--- a/crates/funput-convert/src/session/tests.rs
+++ b/crates/funput-convert/src/session/tests.rs
@@ -113,8 +113,38 @@ fn the_row_window_does_not_change_the_counts() {
     assert_eq!(view.ready, 7, "every file was identified");
 }
 
+/// How many rows a shell can build is the **toolkit's** business, not the document's:
+/// a GTK `ListBox` builds every row it is handed whatever is in it, which is why the
+/// cap exists at all. So a new batch starts at the top of the list without forgetting
+/// how long the list may be — the same distinction the destination charset gets one
+/// test down, where it survives as a tool preference.
+///
+/// Before this was true, the Windows window asked for two thousand rows once when it
+/// opened and then silently drew five hundred for every batch anyone dropped, with the
+/// button above still offering to convert all of them.
 #[test]
-fn adopting_files_replaces_the_previous_document_and_row_window() {
+fn adopting_files_keeps_the_row_cap_the_shell_asked_for() {
+    let (dir, mut session) = batch("keep-cap", 4);
+    session.set_row_window(0, 2);
+    session.refresh();
+    assert_eq!(session.view().rows.len(), 2, "the shell asked for two");
+
+    let paths: Vec<_> = (0..4).map(|i| dir.join(format!("{i}.txt"))).collect();
+    session.adopt(crate::scan(&paths));
+    session.refresh();
+
+    let view = session.view();
+    assert_eq!(view.rows_total, 4, "the whole batch is still counted");
+    assert_eq!(view.rows_first, 0, "a new batch starts at the top");
+    assert_eq!(
+        view.rows.len(),
+        2,
+        "and the cap the shell asked for survives"
+    );
+}
+
+#[test]
+fn adopting_files_replaces_the_previous_document_and_the_row_position() {
     let (_dir, mut session) = batch("fresh-adopt", 2);
     session.set_input("nội dung cũ".to_string());
     session.pick_source(Some(2));

--- a/crates/funput-convert/src/session/tests.rs
+++ b/crates/funput-convert/src/session/tests.rs
@@ -217,3 +217,193 @@ fn a_view_is_never_stale_after_a_refresh() {
         assert_eq!(&once, session.view(), "step {step} left something behind");
     }
 }
+
+/// A pasted paragraph with its charset settled, so what follows is about the second
+/// axis rather than about detection. Unicode is picked rather than detected on
+/// purpose: `detect` places `việt nam` but not `GỬI VỀ TP. HCM`, and a test of
+/// transforms should not turn on that.
+fn pasted(text: &str) -> Session {
+    let mut session = Session::new();
+    session.set_input(text.to_string());
+    session.pick_source(index_of(Charset::Unicode));
+    session
+}
+
+/// Menu positions for the two transforms most of these tests press.
+fn transform(t: funput_core::textcase::Transform) -> usize {
+    crate::casing::index_of(t).expect("every transform has a position")
+}
+
+fn lower() -> usize {
+    transform(funput_core::textcase::Transform::Lower)
+}
+
+fn title() -> usize {
+    transform(funput_core::textcase::Transform::Title)
+}
+
+fn upper() -> usize {
+    transform(funput_core::textcase::Transform::Upper)
+}
+
+/// Two presses, and which came first decides the answer. If the session collapsed
+/// them into a set, or replayed them in menu order, this is the test that says so.
+#[test]
+fn the_order_the_transforms_were_pressed_in_is_the_order_they_run() {
+    let mut lower_then_title = pasted("GỬI VỀ TP. HCM");
+    lower_then_title.apply_transform(lower());
+    lower_then_title.apply_transform(title());
+    lower_then_title.refresh();
+
+    let mut title_then_lower = pasted("GỬI VỀ TP. HCM");
+    title_then_lower.apply_transform(title());
+    title_then_lower.apply_transform(lower());
+    title_then_lower.refresh();
+
+    assert_eq!(lower_then_title.view().output_preview, "Gửi Về Tp. Hcm");
+    assert_eq!(title_then_lower.view().output_preview, "gửi về tp. hcm");
+}
+
+/// Undo takes off the last press, not all of them: pressing a third by mistake
+/// should not cost the two before it.
+#[test]
+fn undo_takes_off_one_transform_and_leaves_the_rest() {
+    let mut session = pasted("GỬI VỀ TP. HCM");
+    session.apply_transform(lower());
+    session.refresh();
+    let after_one = session.view().output_preview.clone();
+
+    session.apply_transform(title());
+    session.refresh();
+    assert_ne!(session.view().output_preview, after_one);
+
+    session.undo_transform();
+    session.refresh();
+    assert_eq!(session.view().output_preview, after_one);
+    assert_eq!(session.view().transforms, vec![lower()]);
+}
+
+/// Every transform is idempotent, so a second press cannot change the document —
+/// and a list that grew anyway would make undo feel broken.
+#[test]
+fn pressing_the_same_transform_twice_does_not_grow_the_list() {
+    let mut session = Session::new();
+    session.set_input("việt nam".to_string());
+    session.apply_transform(upper());
+    session.apply_transform(upper());
+    session.refresh();
+
+    assert_eq!(session.view().transforms, vec![upper()]);
+}
+
+/// The transforms belonged to the document they were pressed on, exactly as the
+/// charset did.
+#[test]
+fn a_fresh_document_arrives_with_no_transforms_on_it() {
+    let mut session = Session::new();
+    session.set_input("việt nam".to_string());
+    session.apply_transform(upper());
+    session.refresh();
+    session.set_input("hà nội".to_string());
+    session.refresh();
+
+    assert!(session.view().transforms.is_empty());
+    assert_eq!(session.view().output_preview, "hà nội");
+
+    session.apply_transform(upper());
+    session.refresh();
+    let (dir, mut dropped) = batch("casing-adopt", 2);
+    dropped.set_input("việt nam".to_string());
+    dropped.apply_transform(upper());
+    dropped.adopt(crate::scan(&[dir.join("0.txt")]));
+    dropped.refresh();
+    assert!(dropped.view().transforms.is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// **The four doors.** The pane, the clipboard, the saved bytes and the file a batch
+/// writes all have to say the same thing about the same document; they used to be
+/// three separate call sites, and one of them was wrong.
+#[test]
+fn the_preview_the_clipboard_and_the_saved_bytes_agree() {
+    let mut session = pasted("tiếng việt");
+    session.apply_transform(title());
+    session.refresh();
+
+    let expected = "Tiếng Việt";
+    assert_eq!(session.view().output_preview, expected);
+    assert_eq!(session.result_text().as_deref(), Some(expected));
+    assert_eq!(
+        session.save_bytes().map(|b| String::from_utf8(b).unwrap()),
+        Some(expected.to_string())
+    );
+}
+
+/// And the fourth door, which goes to disk on another thread.
+#[test]
+fn a_batch_writes_the_transformed_document() {
+    let (dir, mut session) = batch("casing-batch", 2);
+    session.apply_transform(upper());
+    session.refresh();
+
+    let outcome = session.batch_job().run();
+    assert_eq!(outcome.written, 2);
+    let written = std::fs::read_to_string(dir.join(crate::OUT_DIR).join("0.txt")).expect("copy");
+    assert_eq!(written, "VIỆT NAM");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The note on a row is a promise about what that file will cost, so it has to be
+/// counted after the transform: TCVN3 has no room for uppercase toned vowels, and a
+/// count taken before UPPERCASE would understate what the batch is about to lose.
+#[test]
+fn a_row_counts_what_the_transform_will_cost_not_what_the_document_costs_now() {
+    let (dir, mut session) = batch("casing-note", 2);
+    session.set_target(index_of(Charset::Tcvn3).unwrap());
+    session.refresh();
+    assert_eq!(session.view().rows[0].note, "", "lowercase fits TCVN3");
+
+    session.apply_transform(upper());
+    session.refresh();
+    assert!(
+        !session.view().rows[0].note.is_empty(),
+        "uppercase toned vowels do not fit TCVN3, and the row should say so"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The switches reach core, and a fresh window has both of them off.
+#[test]
+fn the_switches_travel_with_the_transform() {
+    let mut session = pasted("đẹp");
+    session.apply_transform(transform(funput_core::textcase::Transform::NoDiacritics));
+    session.refresh();
+    assert_eq!(session.view().output_preview, "dep");
+    assert!(!session.view().keep_d);
+
+    session.set_keep_d(true);
+    session.refresh();
+    assert_eq!(session.view().output_preview, "đep");
+    assert!(session.view().keep_d);
+}
+
+/// A document nothing could explain is not converted, and for the same reason it is
+/// not transformed either: one rule, not two.
+///
+/// The fixture is a real one — `detect` places `việt nam` but has nothing to go on
+/// in an all-caps line, which is exactly when the window asks the user instead.
+#[test]
+fn a_document_with_no_charset_is_left_alone_by_both_axes() {
+    let mut session = Session::new();
+    session.set_input("GỬI VỀ TP. HCM".to_string());
+    session.apply_transform(upper());
+    session.refresh();
+
+    assert_eq!(
+        session.view().source,
+        None,
+        "fixture is meant to be unplaceable"
+    );
+    assert_eq!(session.view().output_preview, "GỬI VỀ TP. HCM");
+    assert_eq!(session.result_text(), None);
+}

--- a/crates/funput-convert/src/session/view.rs
+++ b/crates/funput-convert/src/session/view.rs
@@ -7,9 +7,8 @@
 //!
 //! Charsets are indices; paths are names. Both for the same reason.
 
-use funput_core::charset;
-
 use crate::batch;
+use crate::casing;
 use crate::text;
 
 use super::{Session, at};
@@ -71,13 +70,20 @@ pub struct View {
     pub out_dir: String,
     /// How many files a charset was settled for, over the **whole** batch.
     pub ready: usize,
+    /// The transforms pressed so far, in order, as positions in `casing::ALL`.
+    /// Empty means the document is going out as it came in.
+    pub transforms: Vec<usize>,
+    /// The two switches, named so that **off is what a fresh window means** — which
+    /// is what lets this struct keep deriving `Default`.
+    pub keep_d: bool,
+    pub flatten_caps: bool,
     pub unreadable: Vec<Unreadable>,
 }
 
 pub(super) fn build(session: &Session) -> View {
     let target = at(session.target);
     let (text, rendered) = match session.conversion() {
-        Some((text, from, to)) => (text, Some(charset::render(&charset::read(text, from), to))),
+        Some((text, from, to)) => (text, Some(casing::render(text, from, &session.casing, to))),
         None => (session.text(), None),
     };
     let single = session.files.len() == 1;
@@ -102,6 +108,9 @@ pub(super) fn build(session: &Session) -> View {
         rows_total: session.files.len(),
         out_dir: batch::out_dir_label(&session.files),
         ready: batch::ready(&session.files),
+        transforms: session.casing.indices(),
+        keep_d: !session.casing.options().d_to_ascii,
+        flatten_caps: !session.casing.options().keep_all_caps,
         unreadable: session.unreadable.clone(),
     }
 }

--- a/crates/funput-convert/src/session/view.rs
+++ b/crates/funput-convert/src/session/view.rs
@@ -12,7 +12,11 @@ use funput_core::charset;
 use crate::batch;
 use crate::text;
 
-use super::{Session, at, index_of};
+use super::{Session, at};
+
+mod rows;
+
+pub use rows::Row;
 
 /// Which of the three shapes the window is in.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -27,17 +31,6 @@ pub enum Mode {
     /// Two or more files: a table, because the interesting thing is that the rows
     /// differ.
     Files,
-}
-
-/// One file's row in the batch table.
-#[non_exhaustive]
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct Row {
-    pub name: String,
-    /// Index into `charset::ALL`, or `None` when nothing explained the file.
-    pub charset: Option<usize>,
-    /// "N chữ sẽ mất", or empty.
-    pub note: String,
 }
 
 /// A file that could not be read, and why.
@@ -104,41 +97,11 @@ pub(super) fn build(session: &Session) -> View {
             (Some(r), Some((_, from, _))) => text::warning(&r.cost, from, target),
             _ => String::new(),
         },
-        rows: rows(session, target),
+        rows: rows::rows(session, target),
         rows_first: session.window.0,
         rows_total: session.files.len(),
         out_dir: batch::out_dir_label(&session.files),
         ready: batch::ready(&session.files),
         unreadable: session.unreadable.clone(),
     }
-}
-
-/// Rows for the window only — but every count above runs over the whole batch, so a
-/// capped list stays honest. Rebuilding two thousand of them on every target change
-/// is what the window exists to avoid.
-fn rows(session: &Session, target: charset::Charset) -> Vec<Row> {
-    let (first, len) = session.window;
-    session
-        .files
-        .iter()
-        .skip(first)
-        .take(len)
-        .map(|entry| Row {
-            name: entry.name(),
-            charset: entry.charset.and_then(index_of),
-            note: match entry.charset {
-                Some(from) => {
-                    let lost = charset::render(&charset::read(&entry.text, from), target)
-                        .cost
-                        .unrepresentable;
-                    if lost > 0 {
-                        format!("{lost} chữ sẽ mất")
-                    } else {
-                        String::new()
-                    }
-                }
-                None => String::new(),
-            },
-        })
-        .collect()
 }

--- a/crates/funput-convert/src/session/view/rows.rs
+++ b/crates/funput-convert/src/session/view/rows.rs
@@ -1,0 +1,55 @@
+//! One row per file, and what it will cost.
+//!
+//! Split out of [`super`] rather than sitting beside it because the two answer
+//! different questions: the view is what the window shows *about the document*, and
+//! this is what it shows *about each file in a batch*. They also grow for different
+//! reasons — a new field on the view, a new column here — and this crate's files run
+//! close enough to the line budget that sharing one would make the next addition a
+//! refactor instead of an addition.
+
+use funput_core::charset;
+
+use crate::index_of;
+
+use super::Session;
+
+/// One file's row in the batch table.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Row {
+    pub name: String,
+    /// Index into `charset::ALL`, or `None` when nothing explained the file.
+    pub charset: Option<usize>,
+    /// "N chữ sẽ mất", or empty.
+    pub note: String,
+}
+
+/// Rows for the window only — but every count above runs over the whole batch, so a
+/// capped list stays honest. Rebuilding two thousand of them on every target change
+/// is what the window exists to avoid.
+pub(super) fn rows(session: &Session, target: charset::Charset) -> Vec<Row> {
+    let (first, len) = session.window;
+    session
+        .files
+        .iter()
+        .skip(first)
+        .take(len)
+        .map(|entry| Row {
+            name: entry.name(),
+            charset: entry.charset.and_then(index_of),
+            note: match entry.charset {
+                Some(from) => {
+                    let lost = charset::render(&charset::read(&entry.text, from), target)
+                        .cost
+                        .unrepresentable;
+                    if lost > 0 {
+                        format!("{lost} chữ sẽ mất")
+                    } else {
+                        String::new()
+                    }
+                }
+                None => String::new(),
+            },
+        })
+        .collect()
+}

--- a/crates/funput-convert/src/session/view/rows.rs
+++ b/crates/funput-convert/src/session/view/rows.rs
@@ -9,6 +9,7 @@
 
 use funput_core::charset;
 
+use crate::casing;
 use crate::index_of;
 
 use super::Session;
@@ -39,7 +40,10 @@ pub(super) fn rows(session: &Session, target: charset::Charset) -> Vec<Row> {
             charset: entry.charset.and_then(index_of),
             note: match entry.charset {
                 Some(from) => {
-                    let lost = charset::render(&charset::read(&entry.text, from), target)
+                    // Through `casing::render`, so the count is what this file will
+                    // actually cost: UPPERCASE makes letters TCVN3 has no room for,
+                    // and a note taken before the transform would understate it.
+                    let lost = casing::render(&entry.text, from, &session.casing, target)
                         .cost
                         .unrepresentable;
                     if lost > 0 {

--- a/crates/funput-convert/tests/c_host.rs
+++ b/crates/funput-convert/tests/c_host.rs
@@ -216,3 +216,55 @@ fn the_work_a_shell_hands_off_can_leave_the_thread() {
     assert_send::<Scan>();
     assert_send::<Job>();
 }
+
+/// The second axis, driven the same way: a menu read by index, presses recorded as
+/// positions, and two switches that are plain booleans on the way across.
+#[test]
+fn a_host_can_drive_the_casing_axis_by_index() {
+    use funput_convert::casing;
+
+    // The menu a host builds: count, then a name per index. No `Transform` crosses.
+    let menu: Vec<String> = (0..casing::ALL.len())
+        .map(|index| read_text(casing::name(casing::at(index))))
+        .collect();
+    assert_eq!(menu.len(), casing::ALL.len());
+    assert!(menu.iter().all(|name| !name.is_empty()));
+
+    let position_of = |label: &str| menu.iter().position(|name| name == label).expect(label);
+
+    let mut session = Session::new();
+    session.set_input("GỬI VỀ TP. HCM".to_string());
+    session.pick_source(Some(0));
+    session.apply_transform(position_of("chữ thường"));
+    session.apply_transform(position_of("Viết Hoa Đầu Mỗi Từ"));
+    session.refresh();
+
+    // Read back the way a host reads every other list here: a count, then indices.
+    let applied: Vec<i32> = (0..session.view().transforms.len())
+        .map(|index| position(session.view().transforms.get(index).copied()))
+        .collect();
+    assert_eq!(
+        applied,
+        vec![
+            position(Some(position_of("chữ thường"))),
+            position(Some(position_of("Viết Hoa Đầu Mỗi Từ")))
+        ]
+    );
+    assert_eq!(read_text(&session.view().output_preview), "Gửi Về Tp. Hcm");
+    assert!(!session.view().keep_d && !session.view().flatten_caps);
+
+    // A press a host made up is answered rather than fatal, like every other index
+    // on this door: it clamps to the last menu entry.
+    session.apply_transform(usize::MAX);
+    session.refresh();
+    assert_eq!(
+        session.view().transforms.last().copied(),
+        Some(menu.len() - 1),
+        "a made-up position should clamp to the last entry, not panic"
+    );
+
+    session.clear_transforms();
+    session.refresh();
+    assert!(session.view().transforms.is_empty());
+    assert_eq!(read_text(&session.view().output_preview), "GỬI VỀ TP. HCM");
+}

--- a/crates/funput-core/Cargo.toml
+++ b/crates/funput-core/Cargo.toml
@@ -16,6 +16,13 @@ workspace = true
 [features]
 default = []
 charset = []
+# Changing the case of existing text (chuyển đổi kiểu chữ). Off by default for the
+# same reason as `charset`, but deliberately *separate* from it: a keyboard may one
+# day want bỏ dấu on the selected text — iOS and Android can both read it — and
+# folding the two together would make that cost the four charset codecs. The
+# converse holds too: `funput-config` enables `charset` to read a UniKey macro file
+# and has no use for this. Adds no dependencies either.
+textcase = []
 
 [dependencies]
 

--- a/crates/funput-core/src/charset/codecs/combining/marks.rs
+++ b/crates/funput-core/src/charset/codecs/combining/marks.rs
@@ -1,13 +1,16 @@
-//! The eight combining marks this charset reads, and the five it writes.
+//! What each of the eight combining marks means to this charset.
 //!
-//! Code points checked against the canonical NFD of the whole Vietnamese
-//! inventory, taken from a Unicode normalizer rather than from memory.
+//! The code points themselves live in [`crate::unicode::combining`]: they are a fact
+//! about the language, and this codec is one reader of them rather than their owner.
+//! What is here is the part that *is* about the encoding — [`Mark`], which says what
+//! a mark adds to the letter before it, and the asymmetry below.
 //!
 //! Tones are read *and* written. Shapes are **read only**: the UniKey convention
 //! keeps `ă â ê ô ơ ư` precomposed, so [`super::encode`] never emits one. They are
-//! listed here because real NFD text — from a macOS filesystem, from a web form —
+//! still read because real NFD text — from a macOS filesystem, from a web form —
 //! does contain them, and refusing to read it would help nobody.
 
+use crate::unicode::combining;
 use crate::unicode::marks::Tone;
 use crate::unicode::shapes::VowelShape;
 
@@ -18,35 +21,19 @@ pub(super) enum Mark {
     Shape(VowelShape),
 }
 
-/// Tone marks, in the inventory's own order: sắc, huyền, hỏi, ngã, nặng.
-const TONES: [(char, Tone); 5] = [
-    ('\u{301}', Tone::Sac),
-    ('\u{300}', Tone::Huyen),
-    ('\u{309}', Tone::Hoi),
-    ('\u{303}', Tone::Nga),
-    ('\u{323}', Tone::Nang),
-];
-
-/// Shape marks. Read-only — see the module doc.
-const SHAPES: [(char, VowelShape); 3] = [
-    ('\u{302}', VowelShape::Circumflex),
-    ('\u{306}', VowelShape::Breve),
-    ('\u{31B}', VowelShape::Horn),
-];
-
 /// What `c` adds to the letter before it, or `None` when it is not one of the
 /// eight — in which case it is a letter in its own right, not a mark.
 pub(super) fn mark_of(c: char) -> Option<Mark> {
-    if let Some(&(_, tone)) = TONES.iter().find(|&&(mark, _)| mark == c) {
+    if let Some(&(_, tone)) = combining::TONES.iter().find(|&&(mark, _)| mark == c) {
         return Some(Mark::Tone(tone));
     }
-    let &(_, shape) = SHAPES.iter().find(|&&(mark, _)| mark == c)?;
+    let &(_, shape) = combining::SHAPES.iter().find(|&&(mark, _)| mark == c)?;
     Some(Mark::Shape(shape))
 }
 
 /// The mark that writes `tone`.
 pub(super) fn tone_mark(tone: Tone) -> char {
-    TONES
+    combining::TONES
         .iter()
         .find(|&&(_, candidate)| candidate == tone)
         .map(|&(mark, _)| mark)
@@ -59,41 +46,32 @@ pub(super) fn tone_mark(tone: Tone) -> char {
 /// letter before it: writing a bare `U+0301` after an `a` produces text that reads
 /// back as `á`, which is a different string.
 pub(super) fn is_mark(c: char) -> bool {
-    mark_of(c).is_some()
+    combining::is_mark(c)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// A transcribed code point is invisible to the eye, so pin the whole map:
-    /// every tone and every shape is present exactly once, and no code point does
-    /// double duty.
+    /// A transcribed code point is invisible to the eye, and [`mark_of`] is what
+    /// turns one into meaning, so pin the whole map: every tone and every shape
+    /// round-trips through it. That the eight code points are distinct is the
+    /// tables' own business, and tested where they live.
     #[test]
-    fn the_map_covers_every_tone_and_shape_exactly_once() {
+    fn the_map_covers_every_tone_and_shape() {
         for tone in [Tone::Sac, Tone::Huyen, Tone::Hoi, Tone::Nga, Tone::Nang] {
             assert_eq!(mark_of(tone_mark(tone)), Some(Mark::Tone(tone)));
         }
-        for shape in [VowelShape::Circumflex, VowelShape::Breve, VowelShape::Horn] {
-            let found = SHAPES.iter().filter(|&&(_, s)| s == shape).count();
-            assert_eq!(found, 1, "{shape:?}");
+        for (mark, shape) in combining::SHAPES {
+            assert_eq!(mark_of(mark), Some(Mark::Shape(shape)));
         }
-
-        let mut points: Vec<char> = TONES
-            .iter()
-            .map(|&(mark, _)| mark)
-            .chain(SHAPES.iter().map(|&(mark, _)| mark))
-            .collect();
-        assert_eq!(points.len(), 8);
-        points.sort_unstable();
-        points.dedup();
-        assert_eq!(points.len(), 8, "two marks share a code point");
     }
 
     #[test]
     fn a_letter_is_not_a_mark() {
         for c in ['a', 'â', 'ơ', 'đ', 'Đ', '₫', ' '] {
             assert!(!is_mark(c), "{c}");
+            assert_eq!(mark_of(c), None, "{c}");
         }
     }
 }

--- a/crates/funput-core/src/lib.rs
+++ b/crates/funput-core/src/lib.rs
@@ -20,9 +20,9 @@
 //! exception to the boundary check).
 //! Breaking changes require semver coordination with the engine.
 //!
-//! That list stays complete for the default build. [`charset`] is additive, keeps
-//! to its own namespace, and re-exports nothing here, so the engine's view of this
-//! crate is the same with the feature on or off.
+//! That list stays complete for the default build. [`charset`] and [`textcase`] are
+//! additive, keep to their own namespaces, and re-export nothing here, so the
+//! engine's view of this crate is the same with either feature on or off.
 //!
 //! # Contract
 //!
@@ -38,6 +38,8 @@ mod composition;
 mod input_method;
 mod options;
 mod orthography;
+#[cfg(feature = "textcase")]
+pub mod textcase;
 mod unicode;
 mod validation;
 

--- a/crates/funput-core/src/textcase/case.rs
+++ b/crates/funput-core/src/textcase/case.rs
@@ -1,0 +1,88 @@
+//! UPPERCASE and lowercase.
+//!
+//! Thin on purpose. `str::to_uppercase` is already the right answer for
+//! Vietnamese, and the reasons are worth writing down once rather than
+//! rediscovering them in a shell:
+//!
+//! - It is **locale-independent** — full Unicode case mapping, no tailoring. The
+//!   famous counter-example is Turkish dotless `ı`, and there is no Vietnamese
+//!   equivalent: every letter here maps the same way in every locale.
+//! - It works on the **string**, not on each `char`. Case mapping is allowed to
+//!   change how many characters a word takes, so a `chars().map()` version would be
+//!   wrong in general even though it happens to work on the Vietnamese inventory.
+//! - It handles **both Unicode forms**. Precomposed `ế` has an uppercase mapping of
+//!   its own; in the combining form the mark is caseless and simply rides along on
+//!   the uppercased base letter. Either way the output keeps the form it arrived
+//!   in, which is what a user who pasted one of them expects to get back.
+//!
+//! So what is actually here is the decision to use them, and the tests that hold
+//! that decision to the Vietnamese inventory.
+
+use super::Options;
+
+/// `Xin chào Việt Nam` → `XIN CHÀO VIỆT NAM`.
+pub(super) fn upper(text: &str, _: Options) -> String {
+    text.to_uppercase()
+}
+
+/// `Xin Chào Việt Nam` → `xin chào việt nam`.
+pub(super) fn lower(text: &str, _: Options) -> String {
+    text.to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The combining spelling of `Tiếng Việt`: every tone and shape as its own
+    /// code point, the way NFD text from a macOS filesystem or a web form arrives.
+    const COMBINING: &str = "Tie\u{302}\u{301}ng Vie\u{323}\u{302}t";
+    const COMBINING_UPPER: &str = "TIE\u{302}\u{301}NG VIE\u{323}\u{302}T";
+    const COMBINING_LOWER: &str = "tie\u{302}\u{301}ng vie\u{323}\u{302}t";
+
+    fn opts() -> Options {
+        Options::default()
+    }
+
+    #[test]
+    fn the_documented_examples() {
+        assert_eq!(upper("Xin chào Việt Nam", opts()), "XIN CHÀO VIỆT NAM");
+        assert_eq!(lower("Xin Chào Việt Nam", opts()), "xin chào việt nam");
+    }
+
+    #[test]
+    fn every_vowel_and_the_stroke_survive_a_round_trip() {
+        let all = "aăâeêioôơuưy áắấéếíóốớúứý ạặậẹệịọộợụựỵ đ";
+        assert_eq!(lower(&upper(all, opts()), opts()), all);
+    }
+
+    #[test]
+    fn stroke_d_has_an_uppercase() {
+        assert_eq!(upper("đẹp", opts()), "ĐẸP");
+        assert_eq!(lower("ĐẸP", opts()), "đẹp");
+    }
+
+    #[test]
+    fn the_combining_form_is_not_precomposed_on_the_way_out() {
+        assert_eq!(upper(COMBINING, opts()), COMBINING_UPPER);
+        assert_eq!(lower(COMBINING, opts()), COMBINING_LOWER);
+        // The point of the test: the marks stay separate. A caller who pasted NFD
+        // gets NFD back, so nothing downstream has to re-detect the form.
+        assert_ne!(upper(COMBINING, opts()), "TIẾNG VIỆT");
+    }
+
+    #[test]
+    fn text_that_has_no_case_is_left_alone() {
+        for text in ["こんにちは", "🎉 1.5 —", ""] {
+            assert_eq!(upper(text, opts()), text);
+            assert_eq!(lower(text, opts()), text);
+        }
+    }
+
+    #[test]
+    fn both_are_idempotent() {
+        let text = "Xin chào Việt Nam";
+        assert_eq!(upper(&upper(text, opts()), opts()), upper(text, opts()));
+        assert_eq!(lower(&lower(text, opts()), opts()), lower(text, opts()));
+    }
+}

--- a/crates/funput-core/src/textcase/diacritics.rs
+++ b/crates/funput-core/src/textcase/diacritics.rs
@@ -1,0 +1,118 @@
+//! Bỏ dấu tiếng Việt.
+//!
+//! Three kinds of character and one switch. A vowel loses its tone and its shape
+//! (`ế` → `e`, `ơ` → `o`, `Ữ` → `U`); a combining mark is dropped, which is how the
+//! same word spelled in NFD arrives at the same answer; `đ` is asked about, because
+//! it is a letter of the alphabet and not a `d` carrying something. Everything else
+//! is passed through untouched.
+//!
+//! **Why there is no table here.** [`shapes::base_vowel`] already strips tone and
+//! shape while keeping case, over the whole precomposed inventory — it is what the
+//! typing engine consults to decide whether a shape key should switch a vowel. A
+//! `family → ASCII` table would be a second copy of that answer, and the second
+//! copy is the one that goes stale.
+//!
+//! **Two things it cannot do, both inherent.** `é` is one code point whether it was
+//! typed for Vietnamese or for French, so `café` becomes `cafe`; a transform that
+//! works on letters cannot know which language meant them. And a combining mark is
+//! dropped whoever put it there, so NFD `ñ` comes out as `n` — while precomposed
+//! `ñ`, `ü`, `ç`, `ß` and anything outside the inventory keep everything they have.
+//! Both are tested below so that they stay decisions rather than surprises.
+
+use crate::unicode::{combining, marks, shapes};
+
+use super::Options;
+
+/// `Tiếng Việt rất đẹp` → `Tieng Viet rat dep`.
+pub(super) fn strip(text: &str, options: Options) -> String {
+    // Never longer than the input in bytes: every replacement is ASCII, and the
+    // only other outcomes are a passthrough and a deletion.
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        if combining::is_mark(c) {
+            continue;
+        }
+        if let Some(base) = shapes::base_vowel(c) {
+            out.push(base);
+        } else if let Some(d) = marks::unstroke_d(c).filter(|_| options.d_to_ascii) {
+            out.push(d);
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Tiếng Việt` with every tone and shape as its own code point.
+    const COMBINING: &str = "Tie\u{302}\u{301}ng Vie\u{323}\u{302}t";
+
+    fn opts() -> Options {
+        Options::default()
+    }
+
+    fn keeping_d() -> Options {
+        Options {
+            d_to_ascii: false,
+            ..Options::default()
+        }
+    }
+
+    #[test]
+    fn the_documented_example() {
+        assert_eq!(strip("Tiếng Việt rất đẹp", opts()), "Tieng Viet rat dep");
+    }
+
+    #[test]
+    fn the_whole_inventory_becomes_ascii() {
+        let all = "aăâeêioôơuưy áắấéếíóốớúứý ạặậẹệịọộợụựỵ ÁẮẤÉẾÍÓỐỚÚỨÝ đĐ";
+        let bare = strip(all, opts());
+        assert!(bare.is_ascii(), "{bare}");
+        assert_eq!(
+            bare,
+            "aaaeeiooouuy aaaeeiooouuy aaaeeiooouuy AAAEEIOOOUUY dD"
+        );
+    }
+
+    #[test]
+    fn case_survives() {
+        assert_eq!(strip("ĐẸP Ữ Ế", opts()), "DEP U E");
+    }
+
+    #[test]
+    fn the_stroke_is_a_switch_and_the_tones_are_not() {
+        assert_eq!(strip("đẹp", keeping_d()), "đep");
+        assert_eq!(strip("ĐẸP", keeping_d()), "ĐEP");
+    }
+
+    #[test]
+    fn both_unicode_forms_reach_the_same_answer() {
+        assert_eq!(strip(COMBINING, opts()), strip("Tiếng Việt", opts()));
+        assert_eq!(strip(COMBINING, opts()), "Tieng Viet");
+    }
+
+    /// Not a bug list — the module doc explains why a letter-level transform cannot
+    /// do better, and these hold the behaviour still.
+    #[test]
+    fn what_it_cannot_separate() {
+        assert_eq!(strip("café", opts()), "cafe");
+        assert_eq!(strip("n\u{303}", opts()), "n");
+        assert_eq!(strip("ñ ü ç ß", opts()), "ñ ü ç ß");
+    }
+
+    #[test]
+    fn everything_else_is_passed_through() {
+        for text in ["こんにちは 🎉", "1.5 — TP. HCM", ""] {
+            assert_eq!(strip(text, opts()), text);
+        }
+    }
+
+    #[test]
+    fn stripping_twice_changes_nothing() {
+        let once = strip("Tiếng Việt rất đẹp", opts());
+        assert_eq!(strip(&once, opts()), once);
+    }
+}

--- a/crates/funput-core/src/textcase/mod.rs
+++ b/crates/funput-core/src/textcase/mod.rs
@@ -25,6 +25,7 @@
 mod case;
 mod diacritics;
 mod sentence;
+mod title;
 
 /// Which transform to run.
 ///
@@ -41,6 +42,8 @@ pub enum Transform {
     NoDiacritics,
     /// `xin chào. hôm nay trời đẹp.` → `Xin chào. Hôm nay trời đẹp.`
     Sentence,
+    /// `bàn phím tiếng Việt` → `Bàn Phím Tiếng Việt`.
+    Title,
 }
 
 /// The switches a transform reads.
@@ -81,6 +84,7 @@ pub fn apply(text: &str, transform: Transform, options: Options) -> String {
         Transform::Lower => case::lower(text, options),
         Transform::NoDiacritics => diacritics::strip(text, options),
         Transform::Sentence => sentence::capitalize(text, options),
+        Transform::Title => title::capitalize(text, options),
     }
 }
 

--- a/crates/funput-core/src/textcase/mod.rs
+++ b/crates/funput-core/src/textcase/mod.rs
@@ -1,0 +1,96 @@
+//! Changing the case of text that already exists.
+//!
+//! Five transforms a person runs over a paragraph they have already typed:
+//! UPPERCASE, lowercase, bỏ dấu, sentence case and title case. None of them belongs
+//! to the typing engine — no keystroke reaches this module, nothing here keeps
+//! state, and the whole surface is [`apply`].
+//!
+//! **Why core rather than a shell.** The Chuyển mã window will offer these on three
+//! platforms and `funput case` offers them everywhere else. What counts as the end
+//! of a sentence, and which letters lose their diacritics, then has to be one copy
+//! or it drifts — the same argument that put [`crate::charset`] here rather than in
+//! the windows that draw it. The decisions themselves live in
+//! `docs/features/text-case.md`.
+//!
+//! **Why its own feature and not `charset`'s.** A keyboard has no use for the
+//! legacy charset tables, but it may well want bỏ dấu one day: iOS and Android can
+//! both read the selected text, which is the one place a case transform needs no
+//! permission at all. Folding the two features together would make that choice cost
+//! four codecs. Going the other way, `funput-config` enables `charset` only to read
+//! a UniKey macro file and never changes anyone's case.
+//!
+//! [`Transform`] grows one variant per transform as each is implemented, so that a
+//! shell matching on it cannot compile against a variant that does nothing yet.
+
+mod case;
+
+/// Which transform to run.
+///
+/// Not `#[non_exhaustive]` on purpose: a shell that matches every variant should
+/// stop compiling when a new one arrives, because a new transform means a new menu
+/// entry for it to draw.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Transform {
+    /// `Xin chào Việt Nam` → `XIN CHÀO VIỆT NAM`.
+    Upper,
+    /// `Xin Chào Việt Nam` → `xin chào việt nam`.
+    Lower,
+}
+
+/// The switches a transform reads.
+///
+/// One struct for all five rather than an argument list per transform: a shell
+/// stores these next to the window and hands the same value over whichever button
+/// the user pressed, and a new switch then costs no signature change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Options {
+    /// Whether bỏ dấu also unstrokes `đ`/`Đ` into `d`/`D`.
+    ///
+    /// On by default: `dep` is what nearly everyone means by bỏ dấu. Off keeps the
+    /// stroke, for a filename on a system that accepts it.
+    pub d_to_ascii: bool,
+    /// Whether title case leaves a word that is already all-caps alone.
+    ///
+    /// On by default, so `TP. HCM` does not become `Tp. Hcm`.
+    pub keep_all_caps: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            d_to_ascii: true,
+            keep_all_caps: true,
+        }
+    }
+}
+
+/// Run `transform` over `text`.
+///
+/// Returns a fresh `String` rather than editing in place: a transform can change
+/// how many bytes a character takes, and the caller is a window showing the before
+/// and the after side by side.
+pub fn apply(text: &str, transform: Transform, options: Options) -> String {
+    match transform {
+        Transform::Upper => case::upper(text, options),
+        Transform::Lower => case::lower(text, options),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_default_to_the_common_answer() {
+        let options = Options::default();
+        assert!(options.d_to_ascii);
+        assert!(options.keep_all_caps);
+    }
+
+    #[test]
+    fn apply_dispatches() {
+        let options = Options::default();
+        assert_eq!(apply("Việt", Transform::Upper, options), "VIỆT");
+        assert_eq!(apply("Việt", Transform::Lower, options), "việt");
+    }
+}

--- a/crates/funput-core/src/textcase/mod.rs
+++ b/crates/funput-core/src/textcase/mod.rs
@@ -23,6 +23,7 @@
 //! shell matching on it cannot compile against a variant that does nothing yet.
 
 mod case;
+mod diacritics;
 
 /// Which transform to run.
 ///
@@ -35,6 +36,8 @@ pub enum Transform {
     Upper,
     /// `Xin Chào Việt Nam` → `xin chào việt nam`.
     Lower,
+    /// `Tiếng Việt rất đẹp` → `Tieng Viet rat dep`.
+    NoDiacritics,
 }
 
 /// The switches a transform reads.
@@ -73,6 +76,7 @@ pub fn apply(text: &str, transform: Transform, options: Options) -> String {
     match transform {
         Transform::Upper => case::upper(text, options),
         Transform::Lower => case::lower(text, options),
+        Transform::NoDiacritics => diacritics::strip(text, options),
     }
 }
 

--- a/crates/funput-core/src/textcase/mod.rs
+++ b/crates/funput-core/src/textcase/mod.rs
@@ -24,6 +24,7 @@
 
 mod case;
 mod diacritics;
+mod sentence;
 
 /// Which transform to run.
 ///
@@ -38,6 +39,8 @@ pub enum Transform {
     Lower,
     /// `Tiếng Việt rất đẹp` → `Tieng Viet rat dep`.
     NoDiacritics,
+    /// `xin chào. hôm nay trời đẹp.` → `Xin chào. Hôm nay trời đẹp.`
+    Sentence,
 }
 
 /// The switches a transform reads.
@@ -77,6 +80,7 @@ pub fn apply(text: &str, transform: Transform, options: Options) -> String {
         Transform::Upper => case::upper(text, options),
         Transform::Lower => case::lower(text, options),
         Transform::NoDiacritics => diacritics::strip(text, options),
+        Transform::Sentence => sentence::capitalize(text, options),
     }
 }
 

--- a/crates/funput-core/src/textcase/sentence.rs
+++ b/crates/funput-core/src/textcase/sentence.rs
@@ -1,0 +1,138 @@
+//! Viết hoa đầu câu.
+//!
+//! Capitalises the first letter of each sentence and **leaves the rest alone**.
+//! Lowercasing the rest first was considered and rejected: it would flatten
+//! `TP. HCM`, proper nouns, and anything capitalised on purpose, and a user who
+//! wants that can press lowercase and then this.
+//!
+//! A sentence begins at the start of the text, after a newline, and after one of
+//! `.` `!` `?` `…` **followed by whitespace**. Two rules fall out of that shape
+//! rather than being written down separately: `1.5` keeps its `.` because a digit
+//! follows it rather than a space, and a run of `...` or `?!` ends one sentence
+//! rather than several.
+//!
+//! A newline counts even with no punctuation before it, because the text this
+//! transform is pointed at is usually a list, a subtitle file, or notes — places
+//! where nobody punctuates the ends of lines.
+//!
+//! **Where the first letter is.** Openers are skipped, so `"xin chào"` and
+//! `(xin chào)` both get their `x`. Digits are not: a sentence that opens with a
+//! number has already begun, and skipping past it would turn `3 con mèo` into
+//! `3 Con mèo`. So the search stops at the first letter *or* digit, and only a
+//! letter is changed.
+//!
+//! **The known limitation.** An abbreviation's full stop is indistinguishable from
+//! the end of a sentence — `v.v. nhé` becomes `V.v. Nhé`, `TS. nguyễn` becomes
+//! `TS. Nguyễn`. A list of Vietnamese abbreviations was considered and left out of
+//! `docs/features/text-case.md` on purpose: no list is ever complete, and its
+//! mistakes are harder to predict than this one rule, which a user sees in the
+//! preview. The tests below pin the behaviour so it stays a decision.
+
+use super::Options;
+
+/// The characters that can end a sentence.
+const TERMINATORS: [char; 4] = ['.', '!', '?', '…'];
+
+/// `xin chào. hôm nay trời đẹp.` → `Xin chào. Hôm nay trời đẹp.`
+pub(super) fn capitalize(text: &str, _: Options) -> String {
+    let mut out = String::with_capacity(text.len());
+    // The start of the text is the start of a sentence.
+    let mut awaiting = true;
+    // A terminator has been seen and is waiting for the whitespace that confirms it.
+    let mut terminated = false;
+
+    for c in text.chars() {
+        if awaiting && c.is_alphabetic() {
+            out.extend(c.to_uppercase());
+            awaiting = false;
+            terminated = false;
+            continue;
+        }
+        out.push(c);
+        match c {
+            '\n' => {
+                awaiting = true;
+                terminated = false;
+            }
+            c if TERMINATORS.contains(&c) => terminated = true,
+            c if c.is_whitespace() => {
+                awaiting = awaiting || terminated;
+                terminated = false;
+            }
+            c => {
+                // A digit ends the search for a first letter; punctuation does not.
+                awaiting = awaiting && !c.is_alphanumeric();
+                terminated = false;
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts() -> Options {
+        Options::default()
+    }
+
+    #[test]
+    fn the_documented_example() {
+        assert_eq!(
+            capitalize("xin chào. hôm nay trời đẹp.", opts()),
+            "Xin chào. Hôm nay trời đẹp."
+        );
+    }
+
+    #[test]
+    fn the_rest_of_the_sentence_is_untouched() {
+        assert_eq!(capitalize("xin CHÀO. hôm nay", opts()), "Xin CHÀO. Hôm nay");
+        assert_eq!(capitalize("gửi về TP. hcm", opts()), "Gửi về TP. Hcm");
+    }
+
+    #[test]
+    fn a_newline_is_a_boundary_without_punctuation() {
+        assert_eq!(capitalize("một\nhai\n\nba", opts()), "Một\nHai\n\nBa");
+    }
+
+    #[test]
+    fn an_opener_is_skipped_but_a_digit_is_not() {
+        assert_eq!(capitalize("\"xin chào\"", opts()), "\"Xin chào\"");
+        assert_eq!(capitalize("(xin chào)", opts()), "(Xin chào)");
+        assert_eq!(capitalize("— xin chào", opts()), "— Xin chào");
+        assert_eq!(
+            capitalize("3 con mèo. 5 con chó.", opts()),
+            "3 con mèo. 5 con chó."
+        );
+    }
+
+    #[test]
+    fn a_terminator_needs_whitespace_after_it() {
+        assert_eq!(capitalize("giá 1.5 triệu", opts()), "Giá 1.5 triệu");
+        assert_eq!(capitalize("thật?! không tin", opts()), "Thật?! Không tin");
+        assert_eq!(capitalize("rồi… thôi", opts()), "Rồi… Thôi");
+    }
+
+    /// Not a bug list: the module doc says why a rule beats a list of abbreviations.
+    #[test]
+    fn an_abbreviation_reads_as_the_end_of_a_sentence() {
+        assert_eq!(capitalize("giấy tờ v.v. nhé", opts()), "Giấy tờ v.v. Nhé");
+        assert_eq!(capitalize("TS. nguyễn", opts()), "TS. Nguyễn");
+    }
+
+    #[test]
+    fn the_combining_form_capitalizes_its_base_letter() {
+        assert_eq!(
+            capitalize("vie\u{323}\u{302}t nam", opts()),
+            "Vie\u{323}\u{302}t nam"
+        );
+    }
+
+    #[test]
+    fn text_with_no_letters_is_left_alone() {
+        for text in ["", "… !? 1.5", "🎉", "こんにちは"] {
+            assert_eq!(capitalize(text, opts()), text);
+        }
+    }
+}

--- a/crates/funput-core/src/textcase/title.rs
+++ b/crates/funput-core/src/textcase/title.rs
@@ -1,0 +1,164 @@
+//! Viết Hoa Đầu Mỗi Từ.
+//!
+//! Capitalises the first letter of each word and lowercases the rest of it, with one
+//! exception: a word that is already all-caps is left exactly as it is, so `TP. HCM`
+//! does not become `Tp. Hcm`. That exception is [`Options::keep_all_caps`], on by
+//! default and switchable, because a document shouting in capitals is the one case
+//! where a user does want them flattened.
+//!
+//! No list of little words. Vietnamese has no title-case convention that keeps `của`
+//! or `và` lowercase — that is an English rule — so every word is capitalised and
+//! nothing has to guess.
+//!
+//! **What separates two words: whitespace, or ASCII punctuation.** `bàn-phím` becomes
+//! `Bàn-Phím` and `e-mail` becomes `E-Mail`, which is what every tool of this kind
+//! does and what users expect. The apostrophe is the one exception, so `don't` stays
+//! `Don't` rather than becoming `Don'T`.
+//!
+//! Keeping the separators ASCII buys a guarantee worth more than the edge cases it
+//! costs: **a word can never be split inside a grapheme cluster**, because every
+//! combining mark is non-ASCII. `Tiếng Việt` spelled in NFD stays two words, where a
+//! rule of "split on anything that is not a letter" would cut each vowel off from its
+//! own tone mark and capitalise the fragment after it. The cost is that unspaced
+//! non-ASCII punctuation does not split a word — `xin…chào` capitalises only the `x` —
+//! which is cosmetic, and rare in the text this transform is pointed at.
+//!
+//! Because a word may open with something that has no case, the search is for the
+//! first *letter* in the word: `"xin` and `(xin` get their `x`, and `5g` becomes `5G`.
+//!
+//! **The known limitation** is the mirror of the all-caps exception: a word with a
+//! capital inside it loses it, so `iPhone` becomes `Iphone`. Preserving interior
+//! capitals would mean not lowercasing the rest of a word, which is the whole job.
+
+use super::Options;
+
+/// `bàn phím tiếng Việt` → `Bàn Phím Tiếng Việt`.
+pub(super) fn capitalize(text: &str, options: Options) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut word = String::new();
+    for c in text.chars() {
+        if separates(c) {
+            flush(&mut word, &mut out, options);
+            out.push(c);
+        } else {
+            word.push(c);
+        }
+    }
+    flush(&mut word, &mut out, options);
+    out
+}
+
+/// Whether `c` ends the word before it. ASCII only — see the module doc.
+fn separates(c: char) -> bool {
+    c.is_whitespace() || (c.is_ascii_punctuation() && c != '\'')
+}
+
+/// Write `word` in its title-case form and empty it.
+fn flush(word: &mut String, out: &mut String, options: Options) {
+    if word.is_empty() {
+        return;
+    }
+    if options.keep_all_caps && is_all_caps(word) {
+        out.push_str(word);
+    } else {
+        let mut seen_letter = false;
+        for c in word.chars() {
+            match (seen_letter, c.is_alphabetic()) {
+                (false, true) => {
+                    out.extend(c.to_uppercase());
+                    seen_letter = true;
+                }
+                (true, _) => out.extend(c.to_lowercase()),
+                // Before the first letter — digits, a leading mark — nothing to case.
+                (false, false) => out.push(c),
+            }
+        }
+    }
+    word.clear();
+}
+
+/// Whether `word` holds at least one letter and none of them are lowercase.
+///
+/// A script with no case at all (Japanese, digits alone) answers yes for the letters
+/// it has, which costs nothing: the alternative branch would leave it unchanged too.
+fn is_all_caps(word: &str) -> bool {
+    let mut letters = word.chars().filter(|c| c.is_alphabetic()).peekable();
+    letters.peek().is_some() && !letters.any(char::is_lowercase)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts() -> Options {
+        Options::default()
+    }
+
+    fn flattening() -> Options {
+        Options {
+            keep_all_caps: false,
+            ..Options::default()
+        }
+    }
+
+    #[test]
+    fn the_documented_example() {
+        assert_eq!(
+            capitalize("bàn phím tiếng Việt", opts()),
+            "Bàn Phím Tiếng Việt"
+        );
+    }
+
+    #[test]
+    fn an_all_caps_word_is_left_alone_unless_the_switch_is_off() {
+        assert_eq!(capitalize("gửi về TP. HCM", opts()), "Gửi Về TP. HCM");
+        assert_eq!(capitalize("gửi về TP. HCM", flattening()), "Gửi Về Tp. Hcm");
+    }
+
+    #[test]
+    fn the_rest_of_a_word_is_lowercased() {
+        assert_eq!(capitalize("xIN cHÀO", opts()), "Xin Chào");
+        assert_eq!(capitalize("ĐẸP quá", flattening()), "Đẹp Quá");
+    }
+
+    #[test]
+    fn ascii_punctuation_splits_words_and_the_apostrophe_does_not() {
+        assert_eq!(
+            capitalize("bàn-phím tiếng việt", opts()),
+            "Bàn-Phím Tiếng Việt"
+        );
+        assert_eq!(capitalize("e-mail", opts()), "E-Mail");
+        assert_eq!(capitalize("don't", opts()), "Don't");
+        assert_eq!(capitalize("\"xin chào\"", opts()), "\"Xin Chào\"");
+        assert_eq!(capitalize("(xin chào)", opts()), "(Xin Chào)");
+    }
+
+    #[test]
+    fn the_search_is_for_the_first_letter_not_the_first_character() {
+        assert_eq!(capitalize("5g covid19", opts()), "5G Covid19");
+        assert_eq!(capitalize("giá 1.5 triệu", opts()), "Giá 1.5 Triệu");
+    }
+
+    /// The guarantee the ASCII-only separator rule buys: NFD text keeps its words.
+    #[test]
+    fn a_word_is_never_split_inside_a_grapheme_cluster() {
+        assert_eq!(
+            capitalize("tie\u{302}\u{301}ng vie\u{323}\u{302}t", opts()),
+            "Tie\u{302}\u{301}ng Vie\u{323}\u{302}t"
+        );
+    }
+
+    /// Not a bug list: the module doc says why interior capitals cannot survive a
+    /// transform whose job is to lowercase the rest of the word.
+    #[test]
+    fn an_interior_capital_is_lost() {
+        assert_eq!(capitalize("iPhone", opts()), "Iphone");
+    }
+
+    #[test]
+    fn text_with_no_letters_is_left_alone() {
+        for text in ["", "… !? 1.5", "🎉", "こんにちは"] {
+            assert_eq!(capitalize(text, opts()), text);
+        }
+    }
+}

--- a/crates/funput-core/src/unicode/combining.rs
+++ b/crates/funput-core/src/unicode/combining.rs
@@ -1,0 +1,94 @@
+//! The eight combining marks, and the one question every reader asks of them.
+//!
+//! Vietnamese has two ways to spell the same letter. `ế` is one code point in the
+//! precomposed form that every modern system uses, and in the combining form it is
+//! `e` followed by `U+0302` and `U+0301` — which is what NFD text from a macOS
+//! filesystem or a web form actually contains. The inventory in [`super::vowels`]
+//! covers the first spelling; these eight code points are the second.
+//!
+//! **Why they are here and not in the codec that reads them.** They are a fact about
+//! the language, not about an encoding: NFD text turns up whether or not anyone is
+//! converting a charset. The charset codec that decodes Unicode tổ hợp is one reader
+//! of them, and `textcase` is another — bỏ dấu drops a mark without knowing what a
+//! charset is. A copy per reader would put the eight code points in two places, and
+//! the second place is the one that goes stale.
+//!
+//! Code points checked against the canonical NFD of the whole Vietnamese inventory,
+//! taken from a Unicode normalizer rather than from memory.
+//!
+//! What is *not* here is what a mark means to a particular encoding: whether it can
+//! be written as well as read, and what it does to the letter before it. That stays
+//! with each reader, because the answers differ — the UniKey convention keeps
+//! `ă â ê ô ơ ư` precomposed, so the charset codec reads the three shape marks and
+//! never emits one.
+
+use super::marks::Tone;
+use super::shapes::VowelShape;
+
+/// The combining code point that writes each tone, in the inventory's own order:
+/// sắc, huyền, hỏi, ngã, nặng.
+pub(crate) const TONES: [(char, Tone); 5] = [
+    ('\u{301}', Tone::Sac),
+    ('\u{300}', Tone::Huyen),
+    ('\u{309}', Tone::Hoi),
+    ('\u{303}', Tone::Nga),
+    ('\u{323}', Tone::Nang),
+];
+
+/// The combining code point that writes each vowel shape.
+pub(crate) const SHAPES: [(char, VowelShape); 3] = [
+    ('\u{302}', VowelShape::Circumflex),
+    ('\u{306}', VowelShape::Breve),
+    ('\u{31B}', VowelShape::Horn),
+];
+
+/// Whether `c` is one of the eight — a mark that modifies the letter before it
+/// instead of being a letter in its own right.
+pub(crate) fn is_mark(c: char) -> bool {
+    TONES.iter().any(|&(mark, _)| mark == c) || SHAPES.iter().any(|&(mark, _)| mark == c)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A transcribed code point is invisible to the eye, so pin the tables: every
+    /// tone and every shape appears exactly once, and no two marks share a code
+    /// point. What each mark *means* to a charset is tested with the codec that
+    /// reads them.
+    #[test]
+    fn the_eight_marks_are_distinct_and_complete() {
+        for tone in [Tone::Sac, Tone::Huyen, Tone::Hoi, Tone::Nga, Tone::Nang] {
+            assert_eq!(
+                TONES.iter().filter(|&&(_, t)| t == tone).count(),
+                1,
+                "{tone:?}"
+            );
+        }
+        for shape in [VowelShape::Circumflex, VowelShape::Breve, VowelShape::Horn] {
+            assert_eq!(
+                SHAPES.iter().filter(|&&(_, s)| s == shape).count(),
+                1,
+                "{shape:?}"
+            );
+        }
+
+        let mut points: Vec<char> = TONES
+            .iter()
+            .map(|&(mark, _)| mark)
+            .chain(SHAPES.iter().map(|&(mark, _)| mark))
+            .collect();
+        assert_eq!(points.len(), 8);
+        points.sort_unstable();
+        points.dedup();
+        assert_eq!(points.len(), 8, "two marks share a code point");
+        assert!(points.iter().copied().all(is_mark));
+    }
+
+    #[test]
+    fn a_letter_is_not_a_mark() {
+        for c in ['a', 'â', 'ơ', 'đ', 'Đ', '₫', ' '] {
+            assert!(!is_mark(c), "{c}");
+        }
+    }
+}

--- a/crates/funput-core/src/unicode/marks.rs
+++ b/crates/funput-core/src/unicode/marks.rs
@@ -56,6 +56,22 @@ pub fn stroke_d(c: char) -> Option<char> {
     }
 }
 
+/// Convert đ/Đ back to d/D — the inverse of [`stroke_d`].
+///
+/// A separate question from the combining marks, and from the vowels: `đ` is a
+/// letter of the alphabet rather than a `d` carrying something, so bỏ dấu has to
+/// decide about it rather than derive it. That decision is a switch, because the
+/// answer differs between "make this typeable on a US keyboard" and "just take the
+/// tones off".
+#[cfg(feature = "textcase")]
+pub(crate) fn unstroke_d(c: char) -> Option<char> {
+    match c {
+        'đ' => Some('d'),
+        'Đ' => Some('D'),
+        _ => None,
+    }
+}
+
 /// Returns true if `c` is a vowel (ASCII or precomposed Vietnamese).
 pub fn is_vowel(c: char) -> bool {
     vowels::is_vowel(c)

--- a/crates/funput-core/src/unicode/mod.rs
+++ b/crates/funput-core/src/unicode/mod.rs
@@ -1,7 +1,9 @@
 // The eight combining marks are a fact about the language rather than about any
-// encoding, so they live here with one reader today and a second one coming. Gated
-// because nothing in the default keyboard build spells a letter that way.
-#[cfg(feature = "charset")]
+// encoding, so they live here rather than in either reader: the charset codec that
+// decodes Unicode tổ hợp, and `textcase`, where bỏ dấu drops a mark without knowing
+// what a charset is. Gated because nothing in the default keyboard build spells a
+// letter that way.
+#[cfg(any(feature = "charset", feature = "textcase"))]
 pub(crate) mod combining;
 pub mod marks;
 pub mod shapes;

--- a/crates/funput-core/src/unicode/mod.rs
+++ b/crates/funput-core/src/unicode/mod.rs
@@ -1,3 +1,8 @@
+// The eight combining marks are a fact about the language rather than about any
+// encoding, so they live here with one reader today and a second one coming. Gated
+// because nothing in the default keyboard build spells a letter that way.
+#[cfg(feature = "charset")]
+pub(crate) mod combining;
 pub mod marks;
 pub mod shapes;
 // `charset` reads the vowel inventory through the accessors in `vowels` rather

--- a/crates/funput-core/tests/textcase.rs
+++ b/crates/funput-core/tests/textcase.rs
@@ -1,0 +1,15 @@
+// Gated here, as an inner attribute on the crate root, for the reason spelled out
+// in `charset.rs`: a per-`mod` gate would still let the crate root name
+// `funput_core::textcase` and fail when the feature is off. Please do not "fix" it
+// into per-module attributes.
+#![cfg(feature = "textcase")]
+
+//! Chuyển đổi kiểu chữ integration suite — one binary, modules under
+//! `tests/textcase/`. `#[path]` is required because a `tests/*.rs` crate root looks
+//! up plain `mod` in `tests/`, not a subdirectory.
+//!
+//! These use only the public API, which is also how they check that the public API
+//! is enough: a shell has `Transform`, `Options` and `apply`, and nothing else.
+
+#[path = "textcase/properties.rs"]
+mod properties;

--- a/crates/funput-core/tests/textcase.rs
+++ b/crates/funput-core/tests/textcase.rs
@@ -11,5 +11,7 @@
 //! These use only the public API, which is also how they check that the public API
 //! is enough: a shell has `Transform`, `Options` and `apply`, and nothing else.
 
+#[path = "textcase/cases.rs"]
+mod cases;
 #[path = "textcase/properties.rs"]
 mod properties;

--- a/crates/funput-core/tests/textcase/cases.rs
+++ b/crates/funput-core/tests/textcase/cases.rs
@@ -1,0 +1,85 @@
+//! The examples `docs/features/text-case.md` promises, through the public API.
+//!
+//! Every other test in this feature reaches inside a module. These five are the
+//! contract a reader of the doc is owed, and they are checked the way a shell will
+//! call them: one `apply`, one `Transform`, default `Options`.
+
+use funput_core::textcase::{Options, Transform, apply};
+
+/// One row per line of the table at the top of the design doc.
+const DOCUMENTED: [(Transform, &str, &str); 5] = [
+    (Transform::Upper, "Xin chào Việt Nam", "XIN CHÀO VIỆT NAM"),
+    (Transform::Lower, "Xin Chào Việt Nam", "xin chào việt nam"),
+    (
+        Transform::NoDiacritics,
+        "Tiếng Việt rất đẹp",
+        "Tieng Viet rat dep",
+    ),
+    (
+        Transform::Sentence,
+        "xin chào. hôm nay trời đẹp.",
+        "Xin chào. Hôm nay trời đẹp.",
+    ),
+    (
+        Transform::Title,
+        "bàn phím tiếng Việt",
+        "Bàn Phím Tiếng Việt",
+    ),
+];
+
+#[test]
+fn the_design_doc_examples_hold() {
+    for (transform, input, expected) in DOCUMENTED {
+        assert_eq!(
+            apply(input, transform, Options::default()),
+            expected,
+            "{transform:?} on {input:?}"
+        );
+    }
+}
+
+/// `Tiếng Việt` in the combining spelling, and where each transform takes it. Written
+/// out by hand because core carries no normalizer — that is the point of having it
+/// here: a transform that quietly assumed precomposed input would fail this test and
+/// pass every other one.
+const COMBINING: &str = "Tie\u{302}\u{301}ng Vie\u{323}\u{302}t";
+
+#[test]
+fn the_combining_spelling_is_handled_without_being_normalized_away() {
+    let options = Options::default();
+    assert_eq!(
+        apply(COMBINING, Transform::Upper, options),
+        "TIE\u{302}\u{301}NG VIE\u{323}\u{302}T"
+    );
+    assert_eq!(
+        apply(COMBINING, Transform::Lower, options),
+        "tie\u{302}\u{301}ng vie\u{323}\u{302}t"
+    );
+    // Only bỏ dấu is allowed to collapse the two spellings, because ASCII has one.
+    assert_eq!(
+        apply(COMBINING, Transform::NoDiacritics, options),
+        apply("Tiếng Việt", Transform::NoDiacritics, options)
+    );
+    assert_eq!(
+        apply(COMBINING, Transform::Title, options),
+        "Tie\u{302}\u{301}ng Vie\u{323}\u{302}t"
+    );
+}
+
+/// The window lets a user press one transform and then another, so the interesting
+/// pairs are the ones where the order changes the answer.
+#[test]
+fn transforms_stack() {
+    let options = Options::default();
+    let shouting = "GỬI VỀ TP. HCM";
+
+    // Title case alone protects the all-caps words — that is what it is for — so
+    // flattening first is how a user reaches the other answer.
+    assert_eq!(apply(shouting, Transform::Title, options), shouting);
+    let lowered = apply(shouting, Transform::Lower, options);
+    assert_eq!(apply(&lowered, Transform::Title, options), "Gửi Về Tp. Hcm");
+
+    // Bỏ dấu then UPPERCASE is the filename case, and it must not resurrect a tone.
+    let bare = apply("Tiếng Việt", Transform::NoDiacritics, options);
+    assert_eq!(apply(&bare, Transform::Upper, options), "TIENG VIET");
+}

--- a/crates/funput-core/tests/textcase/properties.rs
+++ b/crates/funput-core/tests/textcase/properties.rs
@@ -1,0 +1,84 @@
+//! Properties that must hold for text no fixture would think to write down —
+//! arbitrary Unicode, lone combining marks, scripts with no case at all.
+
+use funput_core::textcase::{Options, Transform, apply};
+use proptest::prelude::*;
+
+/// Every transform there is. A wildcard is not available here — `Transform` is
+/// exhaustive on purpose — so a new variant makes this array a compile error until
+/// somebody decides which properties it has to satisfy.
+const ALL: [Transform; 3] = [Transform::Upper, Transform::Lower, Transform::NoDiacritics];
+
+/// Vietnamese as it is actually stored: precomposed letters, the stroke, the eight
+/// combining marks, and the punctuation that decides a sentence boundary. A plain
+/// `any::<String>()` would almost never produce a toned vowel, so a property run
+/// over it would be checking nothing about Vietnamese.
+const VIETNAMESE: &str = "[a-zA-Z0-9 .!?\\n\
+    aăâeêioôơuưyđAĂÂEÊIOÔƠUƯYĐ\
+    áàảãạắằẳẵặấầẩẫậéèẻẽẹếềểễệíìỉĩịóòỏõọốồổỗộớờởỡợúùủũụứừửữựýỳỷỹỵ\
+    ÁÀẢÃẠẾỆỐỚỮ\
+    \\x{300}\\x{301}\\x{303}\\x{309}\\x{323}\\x{302}\\x{306}\\x{31B}]{0,48}";
+
+proptest! {
+    /// No transform panics, and none of them grows the text. Case mapping is
+    /// allowed to add characters in general (`ß` → `SS`), but no Vietnamese letter
+    /// does, and bỏ dấu only ever removes.
+    #[test]
+    fn never_panics_and_never_grows(text in VIETNAMESE) {
+        for transform in ALL {
+            let out = apply(&text, transform, Options::default());
+            prop_assert!(
+                out.chars().count() <= text.chars().count(),
+                "{transform:?} grew {text:?} into {out:?}"
+            );
+        }
+    }
+
+    /// Arbitrary Unicode — emoji, unassigned code points, lone marks, right-to-left
+    /// text — reaches the same code and must not panic there either.
+    #[test]
+    fn arbitrary_unicode_is_survivable(text in any::<String>()) {
+        for transform in ALL {
+            let _ = apply(&text, transform, Options::default());
+        }
+    }
+
+    /// Running a transform on its own output changes nothing. The one that would be
+    /// easy to get wrong is bỏ dấu in the combining form: drop the mark but leave
+    /// the base letter respelled, and a second pass would keep finding work.
+    #[test]
+    fn every_transform_is_idempotent(text in VIETNAMESE) {
+        for transform in ALL {
+            let once = apply(&text, transform, Options::default());
+            prop_assert_eq!(
+                apply(&once, transform, Options::default()),
+                once.clone(),
+                "{:?} is not idempotent on {:?}",
+                transform,
+                text
+            );
+        }
+    }
+
+    /// Vietnamese in, ASCII out — the property the whole transform exists for, and
+    /// the one a `family → ASCII` table would have been at risk of missing a row of.
+    #[test]
+    fn bo_dau_leaves_only_ascii(text in VIETNAMESE) {
+        let bare = apply(&text, Transform::NoDiacritics, Options::default());
+        prop_assert!(bare.is_ascii(), "{text:?} left {bare:?}");
+    }
+
+    /// With the switch off, the stroke is the *only* thing that may survive.
+    #[test]
+    fn keeping_the_stroke_keeps_nothing_else(text in VIETNAMESE) {
+        let options = Options {
+            d_to_ascii: false,
+            ..Options::default()
+        };
+        let bare = apply(&text, Transform::NoDiacritics, options);
+        prop_assert!(
+            bare.chars().all(|c| c.is_ascii() || c == 'đ' || c == 'Đ'),
+            "{text:?} left {bare:?}"
+        );
+    }
+}

--- a/crates/funput-core/tests/textcase/properties.rs
+++ b/crates/funput-core/tests/textcase/properties.rs
@@ -7,7 +7,12 @@ use proptest::prelude::*;
 /// Every transform there is. A wildcard is not available here — `Transform` is
 /// exhaustive on purpose — so a new variant makes this array a compile error until
 /// somebody decides which properties it has to satisfy.
-const ALL: [Transform; 3] = [Transform::Upper, Transform::Lower, Transform::NoDiacritics];
+const ALL: [Transform; 4] = [
+    Transform::Upper,
+    Transform::Lower,
+    Transform::NoDiacritics,
+    Transform::Sentence,
+];
 
 /// Vietnamese as it is actually stored: precomposed letters, the stroke, the eight
 /// combining marks, and the punctuation that decides a sentence boundary. A plain
@@ -54,6 +59,24 @@ proptest! {
                 apply(&once, transform, Options::default()),
                 once.clone(),
                 "{:?} is not idempotent on {:?}",
+                transform,
+                text
+            );
+        }
+    }
+
+    /// The case transforms change only case, so lowercasing the result gives the
+    /// same text as lowercasing the input. This is the property that catches a
+    /// scanner losing, duplicating or reordering a character while it looks for a
+    /// sentence boundary — a diff in the output alone would not say which.
+    #[test]
+    fn the_case_transforms_change_only_case(text in VIETNAMESE) {
+        for transform in [Transform::Upper, Transform::Lower, Transform::Sentence] {
+            let out = apply(&text, transform, Options::default());
+            prop_assert_eq!(
+                out.to_lowercase(),
+                text.to_lowercase(),
+                "{:?} changed more than case in {:?}",
                 transform,
                 text
             );

--- a/crates/funput-core/tests/textcase/properties.rs
+++ b/crates/funput-core/tests/textcase/properties.rs
@@ -7,11 +7,12 @@ use proptest::prelude::*;
 /// Every transform there is. A wildcard is not available here — `Transform` is
 /// exhaustive on purpose — so a new variant makes this array a compile error until
 /// somebody decides which properties it has to satisfy.
-const ALL: [Transform; 4] = [
+const ALL: [Transform; 5] = [
     Transform::Upper,
     Transform::Lower,
     Transform::NoDiacritics,
     Transform::Sentence,
+    Transform::Title,
 ];
 
 /// Vietnamese as it is actually stored: precomposed letters, the stroke, the eight
@@ -71,7 +72,12 @@ proptest! {
     /// sentence boundary — a diff in the output alone would not say which.
     #[test]
     fn the_case_transforms_change_only_case(text in VIETNAMESE) {
-        for transform in [Transform::Upper, Transform::Lower, Transform::Sentence] {
+        for transform in [
+            Transform::Upper,
+            Transform::Lower,
+            Transform::Sentence,
+            Transform::Title,
+        ] {
             let out = apply(&text, transform, Options::default());
             prop_assert_eq!(
                 out.to_lowercase(),

--- a/crates/funput-ffi/cbindgen.toml
+++ b/crates/funput-ffi/cbindgen.toml
@@ -10,6 +10,7 @@ style = "type"
 include = [
     "FunputConfig",
     "FunputConversion",
+    "FunputConvertCasing",
     "FunputConvertRow",
     "FunputConvertView",
     "FunputResult",

--- a/crates/funput-ffi/include/funput.h
+++ b/crates/funput-ffi/include/funput.h
@@ -146,6 +146,24 @@ typedef struct {
 #endif
 
 #if defined(FUNPUT_CONVERT)
+/**
+ * What the second axis is doing, as scalars.
+ */
+typedef struct {
+    /**
+     * How many transforms are applied. Read them with
+     * [`funput_convert_session_applied_transform`].
+     */
+    uintptr_t count;
+    /**
+     * Named for what it turns **on**, so a fresh session is all-false.
+     */
+    bool keep_d;
+    bool flatten_caps;
+} FunputConvertCasing;
+#endif
+
+#if defined(FUNPUT_CONVERT)
 typedef struct {
     uint8_t mode;
     uintptr_t target;
@@ -377,6 +395,83 @@ FunputConversion funput_charset_convert(const uint32_t *text,
  * `text` must point to at least `text_len` readable `u32` values, or be null.
  */
 int32_t funput_charset_detect(const uint32_t *text, uintptr_t text_len);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * Press the transform at `index` in the menu. Out of range clamps, as everywhere
+ * else a menu position crosses this door.
+ */
+void funput_convert_session_apply_transform(FunputConvertSession *session, uintptr_t index);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * Take off the last transform. A session with none is a no-op, not an error.
+ */
+void funput_convert_session_undo_transform(FunputConvertSession *session);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * Back to the document as it arrived.
+ */
+void funput_convert_session_clear_transforms(FunputConvertSession *session);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * Keep `đ` and `Đ` instead of writing `d` and `D` (bỏ dấu).
+ */
+void funput_convert_session_set_keep_d(FunputConvertSession *session, bool on);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * Also lowercase words that are already all-caps (title case).
+ */
+void funput_convert_session_set_flatten_caps(FunputConvertSession *session, bool on);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * The axis as of the last refresh. Null gives the all-false snapshot.
+ */
+FunputConvertCasing funput_convert_session_casing(const FunputConvertSession *session);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * The menu position of the `index`-th transform applied, in the order pressed, or
+ * [`FUNPUT_CONVERT_UNKNOWN`] when there is no such press.
+ */
+int32_t funput_convert_session_applied_transform(const FunputConvertSession *session,
+                                                 uintptr_t index);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * How many transforms there are. Valid indices run
+ * `0..funput_convert_transform_count()`.
+ */
+uintptr_t funput_convert_transform_count(void);
+#endif
+
+#if defined(FUNPUT_CONVERT)
+/**
+ * Write the label of the transform at `index` into `out` as UTF-32, returning its
+ * length in codepoints. An index out of range gives 0.
+ *
+ * The label comes from `funput-convert` so that three platforms' menus cannot drift
+ * apart, and it is interface text — Vietnamese, like the loss warning beside it.
+ *
+ * Sizing works as everywhere else on this door: the length comes back whether or
+ * not it fit, and nothing is written unless all of it fits.
+ *
+ * # Safety
+ * `out` must point to at least `cap` writable `u32` values, or be null.
+ */
+uintptr_t funput_convert_transform_name(uintptr_t index, uint32_t *out, uintptr_t cap);
 #endif
 
 #if defined(FUNPUT_CONVERT)

--- a/crates/funput-ffi/src/convert/casing/menu.rs
+++ b/crates/funput-ffi/src/convert/casing/menu.rs
@@ -1,0 +1,48 @@
+//! The transform menu: what a shell offers, and what to call each entry.
+//!
+//! The same contract as the charset menu in [`crate::charset`], for the same reason.
+//! A transform is an **index into `funput_convert::casing::ALL`**, never a name the
+//! host spells for itself: a host writing its own list would silently miss a
+//! transform added later, and these two calls are between them enough to build the
+//! menu without one.
+//!
+//! **That list is append-only, and it is what makes the index an identity.** A host
+//! may store the index — as a remembered last choice, or as the list of what the
+//! user has applied — so reordering would quietly turn a saved `CHỮ HOA` into
+//! `chữ thường`.
+
+use funput_convert::casing;
+
+use crate::abi::{safe, write_text};
+
+/// How many transforms there are. Valid indices run
+/// `0..funput_convert_transform_count()`.
+#[unsafe(no_mangle)]
+pub extern "C" fn funput_convert_transform_count() -> usize {
+    casing::ALL.len()
+}
+
+/// Write the label of the transform at `index` into `out` as UTF-32, returning its
+/// length in codepoints. An index out of range gives 0.
+///
+/// The label comes from `funput-convert` so that three platforms' menus cannot drift
+/// apart, and it is interface text — Vietnamese, like the loss warning beside it.
+///
+/// Sizing works as everywhere else on this door: the length comes back whether or
+/// not it fit, and nothing is written unless all of it fits.
+///
+/// # Safety
+/// `out` must point to at least `cap` writable `u32` values, or be null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_transform_name(
+    index: usize,
+    out: *mut u32,
+    cap: usize,
+) -> usize {
+    safe(0, || {
+        let Some(&transform) = casing::ALL.get(index) else {
+            return 0;
+        };
+        unsafe { write_text(casing::name(transform), out, cap) }
+    })
+}

--- a/crates/funput-ffi/src/convert/casing/mod.rs
+++ b/crates/funput-ffi/src/convert/casing/mod.rs
@@ -1,0 +1,113 @@
+//! The second axis over the C door: which transforms are applied, and the two
+//! switches they read.
+//!
+//! Every call here is a thin marshalling of `funput_convert`'s own commands. What is
+//! worth saying is the shape, because an ABI is append-only and a shape settled
+//! wrongly is settled forever:
+//!
+//! - **The transforms are a list the user built**, not a single choice. A press is
+//!   [`funput_convert_session_apply_transform`], undo takes the last one off, and the
+//!   list is read back the way every other collection on this door is read: a count
+//!   in the snapshot, then one accessor per index.
+//! - **The axis has a snapshot of its own.** `FunputConvertView` does not grow a tail
+//!   of fields that only some hosts read, and a third axis — if one ever arrives —
+//!   gets its own struct rather than lengthening a struct everyone reads.
+//! - **Each switch is a named call.** The two are not a homogeneous list: one belongs
+//!   to bỏ dấu and the other to title case, so a `set_option(index, on)` would be a
+//!   false uniformity. A third switch costs one more export, which is what an
+//!   append-only door is for.
+
+mod menu;
+
+pub use menu::{funput_convert_transform_count, funput_convert_transform_name};
+
+use crate::abi::safe;
+
+use super::FUNPUT_CONVERT_UNKNOWN;
+use super::handle::{FunputConvertSession, with_mut, with_ref};
+
+/// What the second axis is doing, as scalars.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct FunputConvertCasing {
+    /// How many transforms are applied. Read them with
+    /// [`funput_convert_session_applied_transform`].
+    pub count: usize,
+    /// Named for what it turns **on**, so a fresh session is all-false.
+    pub keep_d: bool,
+    pub flatten_caps: bool,
+}
+
+/// Press the transform at `index` in the menu. Out of range clamps, as everywhere
+/// else a menu position crosses this door.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_session_apply_transform(
+    session: *mut FunputConvertSession,
+    index: usize,
+) {
+    unsafe { with_mut(session, |value| value.apply_transform(index)) };
+}
+
+/// Take off the last transform. A session with none is a no-op, not an error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_session_undo_transform(session: *mut FunputConvertSession) {
+    unsafe { with_mut(session, funput_convert::Session::undo_transform) };
+}
+
+/// Back to the document as it arrived.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_session_clear_transforms(
+    session: *mut FunputConvertSession,
+) {
+    unsafe { with_mut(session, funput_convert::Session::clear_transforms) };
+}
+
+/// Keep `đ` and `Đ` instead of writing `d` and `D` (bỏ dấu).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_session_set_keep_d(
+    session: *mut FunputConvertSession,
+    on: bool,
+) {
+    unsafe { with_mut(session, |value| value.set_keep_d(on)) };
+}
+
+/// Also lowercase words that are already all-caps (title case).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_session_set_flatten_caps(
+    session: *mut FunputConvertSession,
+    on: bool,
+) {
+    unsafe { with_mut(session, |value| value.set_flatten_caps(on)) };
+}
+
+/// The axis as of the last refresh. Null gives the all-false snapshot.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_session_casing(
+    session: *const FunputConvertSession,
+) -> FunputConvertCasing {
+    unsafe { with_ref(session, snapshot) }
+}
+
+fn snapshot(session: &funput_convert::Session) -> FunputConvertCasing {
+    let view = session.view();
+    FunputConvertCasing {
+        count: view.transforms.len(),
+        keep_d: view.keep_d,
+        flatten_caps: view.flatten_caps,
+    }
+}
+
+/// The menu position of the `index`-th transform applied, in the order pressed, or
+/// [`FUNPUT_CONVERT_UNKNOWN`] when there is no such press.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn funput_convert_session_applied_transform(
+    session: *const FunputConvertSession,
+    index: usize,
+) -> i32 {
+    safe(FUNPUT_CONVERT_UNKNOWN, || {
+        unsafe { session.as_ref() }
+            .and_then(|s| s.inner.view().transforms.get(index).copied())
+            .and_then(|position| i32::try_from(position).ok())
+            .unwrap_or(FUNPUT_CONVERT_UNKNOWN)
+    })
+}

--- a/crates/funput-ffi/src/convert/mod.rs
+++ b/crates/funput-ffi/src/convert/mod.rs
@@ -10,11 +10,13 @@
     reason = "the common ABI safety contract is documented once above"
 )]
 
+mod casing;
 mod handle;
 mod state;
 mod text;
 mod work;
 
+pub use casing::*;
 pub use handle::{FunputConvertSession, funput_convert_session_free, funput_convert_session_new};
 pub use state::*;
 pub use text::*;

--- a/crates/funput-ffi/src/convert/tests/mod.rs
+++ b/crates/funput-ffi/src/convert/tests/mod.rs
@@ -85,3 +85,152 @@ fn all_convert_handles_are_null_safe() {
         funput_convert_job_free(ptr::null_mut());
     }
 }
+
+/// Menu positions for the transforms these tests press, found the way a host finds
+/// them — by reading the menu, not by writing the list down again.
+fn position(label: &str) -> usize {
+    (0..funput_convert_transform_count())
+        .find(|&index| unsafe {
+            text(|out, cap| funput_convert_transform_name(index, out, cap)) == label
+        })
+        .unwrap_or_else(|| panic!("no transform called {label}"))
+}
+
+/// The whole axis over the door: press, read back, undo, clear — and the result text
+/// changing at each step, because that is the only proof the presses reached core.
+#[test]
+fn transforms_apply_in_order_and_come_back_off_one_at_a_time() {
+    let session = funput_convert_session_new();
+    let input: Vec<u32> = "GỬI VỀ TP. HCM".chars().map(u32::from).collect();
+    let (lower, title) = (position("chữ thường"), position("Viết Hoa Đầu Mỗi Từ"));
+    unsafe {
+        funput_convert_session_set_input(session, input.as_ptr(), input.len());
+        funput_convert_session_pick_source(session, 0);
+        funput_convert_session_apply_transform(session, lower);
+        funput_convert_session_apply_transform(session, title);
+        funput_convert_session_refresh(session);
+
+        let casing = funput_convert_session_casing(session);
+        assert_eq!(casing.count, 2);
+        assert!(!casing.keep_d && !casing.flatten_caps, "fresh session");
+        assert_eq!(
+            funput_convert_session_applied_transform(session, 0),
+            i32::try_from(lower).unwrap()
+        );
+        assert_eq!(
+            funput_convert_session_applied_transform(session, 1),
+            i32::try_from(title).unwrap()
+        );
+        assert_eq!(
+            text(|out, cap| funput_convert_session_result_text(session, out, cap)),
+            "Gửi Về Tp. Hcm"
+        );
+
+        funput_convert_session_undo_transform(session);
+        funput_convert_session_refresh(session);
+        assert_eq!(funput_convert_session_casing(session).count, 1);
+        assert_eq!(
+            text(|out, cap| funput_convert_session_result_text(session, out, cap)),
+            "gửi về tp. hcm"
+        );
+
+        funput_convert_session_clear_transforms(session);
+        funput_convert_session_refresh(session);
+        assert_eq!(funput_convert_session_casing(session).count, 0);
+        assert_eq!(
+            text(|out, cap| funput_convert_session_result_text(session, out, cap)),
+            "GỬI VỀ TP. HCM"
+        );
+        funput_convert_session_free(session);
+    }
+}
+
+/// A switch has to reach core, not just the snapshot.
+#[test]
+fn a_switch_changes_what_the_door_hands_back() {
+    let session = funput_convert_session_new();
+    let input: Vec<u32> = "đẹp".chars().map(u32::from).collect();
+    let bo_dau = position("Bỏ dấu tiếng Việt");
+    unsafe {
+        funput_convert_session_set_input(session, input.as_ptr(), input.len());
+        funput_convert_session_pick_source(session, 0);
+        funput_convert_session_apply_transform(session, bo_dau);
+        funput_convert_session_refresh(session);
+        assert_eq!(
+            text(|out, cap| funput_convert_session_result_text(session, out, cap)),
+            "dep"
+        );
+
+        funput_convert_session_set_keep_d(session, true);
+        funput_convert_session_refresh(session);
+        assert!(funput_convert_session_casing(session).keep_d);
+        assert_eq!(
+            text(|out, cap| funput_convert_session_result_text(session, out, cap)),
+            "đep"
+        );
+        funput_convert_session_free(session);
+    }
+}
+
+/// The menu is the host's only list, so it has to be complete, named, and sized the
+/// way every other text on this door is sized.
+#[test]
+fn the_transform_menu_is_complete_and_sizes_like_the_rest_of_the_door() {
+    assert_eq!(
+        funput_convert_transform_count(),
+        funput_convert::casing::ALL.len(),
+        "the door and the table disagree about how many transforms there are"
+    );
+    unsafe {
+        for index in 0..funput_convert_transform_count() {
+            let needed = funput_convert_transform_name(index, ptr::null_mut(), 0);
+            assert!(needed > 0, "transform {index} has no name");
+
+            // One short of enough writes nothing and still reports the length.
+            let mut small = vec![0u32; needed - 1];
+            assert_eq!(
+                funput_convert_transform_name(index, small.as_mut_ptr(), small.len()),
+                needed
+            );
+            assert!(small.iter().all(|&slot| slot == 0), "wrote a partial name");
+
+            assert_eq!(
+                text(|out, cap| funput_convert_transform_name(index, out, cap))
+                    .chars()
+                    .count(),
+                needed
+            );
+        }
+        assert_eq!(funput_convert_transform_name(999, ptr::null_mut(), 0), 0);
+    }
+}
+
+/// Out of range and never-pressed both answer, rather than panicking or inventing.
+#[test]
+fn an_empty_session_answers_every_question_about_the_axis() {
+    let session = funput_convert_session_new();
+    unsafe {
+        let casing = funput_convert_session_casing(session);
+        assert_eq!(casing.count, 0);
+        assert_eq!(
+            funput_convert_session_applied_transform(session, 0),
+            FUNPUT_CONVERT_UNKNOWN
+        );
+        assert_eq!(
+            funput_convert_session_applied_transform(session, 999),
+            FUNPUT_CONVERT_UNKNOWN
+        );
+        // Null is a no-op everywhere else on this door, and here too.
+        funput_convert_session_apply_transform(ptr::null_mut(), 0);
+        funput_convert_session_undo_transform(ptr::null_mut());
+        funput_convert_session_clear_transforms(ptr::null_mut());
+        funput_convert_session_set_keep_d(ptr::null_mut(), true);
+        funput_convert_session_set_flatten_caps(ptr::null_mut(), true);
+        assert_eq!(funput_convert_session_casing(ptr::null()).count, 0);
+        assert_eq!(
+            funput_convert_session_applied_transform(ptr::null(), 0),
+            FUNPUT_CONVERT_UNKNOWN
+        );
+        funput_convert_session_free(session);
+    }
+}

--- a/docs/features/text-case.md
+++ b/docs/features/text-case.md
@@ -2,12 +2,12 @@
 
 ## Trạng thái
 
-**Còn lại một cửa sổ.** `funput_core::textcase` sau cargo feature `textcase` có cả
-năm phép, kèm corpus và property test; `funput-convert` mang trục thứ hai của
-`Session`; `funput-ffi` mở cửa C cho nó; và **`funput case`** trong CLI, **macOS**
-(`ConvertCasingBar.swift`) cùng **Windows** (`ui/convert/casing.slint`) đều đã gọi
-tới. Chưa nối: cửa sổ GTK trên Linux — mọi thứ nó cần đã có sẵn trong `Session` và
-`View`, đúng như hai shell kia đã dùng.
+**V1 đã xong.** `funput_core::textcase` sau cargo feature `textcase` có cả năm phép,
+kèm corpus và property test; `funput-convert` mang trục thứ hai của `Session`;
+`funput-ffi` mở cửa C cho nó; và cả bốn bề mặt đều đã gọi tới: **`funput case`** trong
+CLI, **macOS** (`ConvertCasingBar.swift`), **Windows** (`ui/convert/casing.slint`) và
+**Linux** (`settings-gtk/src/convert/ui/casing.rs`). Không shell nào tự quyết định gì
+— cả ba đọc cùng `View` và gọi cùng `Session`.
 
 Tài liệu này chốt mô hình trước khi có code, như [charset.md](charset.md) đã làm, và là
 nơi mọi quyết định thiết kế sống — mỗi thay đổi cập nhật lại nó trong cùng PR.
@@ -249,7 +249,10 @@ trước/sau:
 - Hai công tắc, đặt tên theo thứ chúng **bật lên** nên cả hai **mặc định tắt**:
   **Giữ đ/Đ** (tắt = `đ → d`) và **Hạ chữ viết hoa** (tắt = giữ nguyên từ viết HOA).
   Mỗi công tắc chỉ hiện **khi phép sở hữu nó đang được áp** — ngoài lúc đó nó không có
-  gì để nói, và hiện ở đó là cách dạy phép nào sở hữu nó.
+  gì để nói, và hiện ở đó là cách dạy phép nào sở hữu nó. Trên GTK là `gtk::Switch`
+  kèm nhãn, không phải `adw::SwitchRow`: `SwitchRow` là một `ActionRow`, đặt vào thanh
+  ngang sẽ ra một hàng full-width có nền riêng. Giá phải trả là công tắc trần không có
+  tên cho screen reader, nên mỗi cái được trỏ về nhãn của nó bằng `LabelledBy`.
 - Dòng cảnh báo dùng chung với Chuyển mã, chỉ hiện khi encode ngược mất chữ.
 - Nút **Hoàn tác** gỡ **phép cuối cùng** chứ không phải tất cả — bấm nhầm phép thứ ba
   không nên mất hai phép trước nó — và **Bỏ hết** trả về nguyên bản.
@@ -264,6 +267,30 @@ trước/sau:
 
 Một file thả vào vẫn rơi vào `Mode::Text` như hiện tại. Nhiều file là batch —
 **không thuộc V1**, nhưng bảng `Row` không cần đổi khi tới lượt.
+
+### Ba chỗ mỗi shell tự quyết, và đã quyết khác nhau
+
+Hợp đồng ở trên là chung; cách vẽ ra thì theo idiom của nền tảng, và ba chỗ dưới đây
+là nơi ba shell không giống nhau. Ghi lại để lần sau không ai "sửa" chúng cho khớp.
+
+- **Hình dạng chip.** macOS dùng capsule `glassEffect`, Windows vẽ capsule 28px trong
+  Slint. GTK dùng **nút thường trong `gtk::FlowBox`**, không dùng class `pill` của
+  libadwaita: `.pill` là `padding: 10px 32px`, và năm nhãn kèm padding đó vượt cả
+  `default_width` 880 lẫn `width_request` 640 của cửa sổ — GTK nâng minimum của cửa sổ
+  cho vừa con nó, nên capsule sẽ khiến Chuyển mã không co lại được. Đo được: thanh có
+  min 496px, natural 778px, nên vừa một hàng ở kích thước mặc định và xuống dòng khi
+  người dùng thu nhỏ. Mỗi chip `halign: Start` để một chip không đổi kích thước tuỳ
+  theo hàng có xuống dòng hay chưa. `adw::WrapBox` là container đúng hơn nhưng có từ
+  libadwaita 1.7, còn crate nhắm 1.5.
+- **Dấu tick.** GTK dùng `object-select-symbolic`, vì nó nằm trong chính gresource của
+  GTK4 lẫn theme Adwaita hệ thống; `check-plain-symbolic` và `emblem-ok-symbolic`
+  không có trong Adwaita trên 24.04 và sẽ ra ô ảnh thiếu.
+- **Thanh lúc batch đang chạy.** macOS tắt thanh (`!isBusy && …`); Windows và Linux để
+  nguyên, đúng câu chữ ở trên — chỉ tắt khi chưa đoán được bảng mã. Để nguyên là an
+  toàn vì `Session::batch_job` chụp `casing` trước khi việc rời luồng, nên phép bấm
+  giữa lúc chạy không đổi được file đang ghi; giá phải trả thuần hiển thị là cột
+  `N chữ sẽ mất` tính lại theo phép mà job đang chạy không có. Đây là lệch thật giữa
+  ba shell, không phải lỗi của shell nào.
 
 ## Lộ trình sau V1
 

--- a/docs/features/text-case.md
+++ b/docs/features/text-case.md
@@ -2,14 +2,17 @@
 
 ## Trạng thái
 
-**Tầng core đã xong**: `funput_core::textcase` sau cargo feature `textcase`, cả năm
-phép, kèm corpus và property test, và **`funput case`** trong CLI đã gọi tới nó. Còn
-lại: `funput-convert` và ba cửa sổ.
+**Còn lại một cửa sổ.** `funput_core::textcase` sau cargo feature `textcase` có cả
+năm phép, kèm corpus và property test; `funput-convert` mang trục thứ hai của
+`Session`; `funput-ffi` mở cửa C cho nó; và **`funput case`** trong CLI, **macOS**
+(`ConvertCasingBar.swift`) cùng **Windows** (`ui/convert/casing.slint`) đều đã gọi
+tới. Chưa nối: cửa sổ GTK trên Linux — mọi thứ nó cần đã có sẵn trong `Session` và
+`View`, đúng như hai shell kia đã dùng.
 
 Tài liệu này chốt mô hình trước khi có code, như [charset.md](charset.md) đã làm, và là
 nơi mọi quyết định thiết kế sống — mỗi thay đổi cập nhật lại nó trong cùng PR.
 
-Phạm vi **V1 đã chốt: một tab trong cửa sổ Chuyển mã**, ba nền tảng desktop, cộng
+Phạm vi **V1 đã chốt: một thanh trong cửa sổ Chuyển mã**, ba nền tảng desktop, cộng
 `funput case` trong CLI. Không hotkey, không đụng vùng bôi đen, không nghe clipboard. Những thứ đó nằm ở
 [Lộ trình sau V1](#lộ-trình-sau-v1) và có tài liệu riêng khi tới lượt.
 
@@ -80,8 +83,9 @@ thứ hai của cùng câu trả lời, và bản thứ hai là bản sẽ lệc
 cách lọc tám dấu rời, danh sách lấy từ `unicode::combining`.
 
 **Tuỳ chọn `đ → d`**: mặc định **bật**. Người cần giữ `đ` (đặt tên file cho hệ thống
-chấp nhận nó, hoặc chỉ muốn bỏ thanh) tắt được trong cùng tab. Đây là tuỳ chọn duy
-nhất của phép này.
+chấp nhận nó, hoặc chỉ muốn bỏ thanh) tắt được bằng công tắc **Giữ đ/Đ** trên cùng
+thanh — công tắc đặt tên theo thứ nó bật lên, nên mặc định của phép hiện ra ở UI là
+công tắc **tắt**. Đây là tuỳ chọn duy nhất của phép này.
 
 Hai điều phép này **không làm được**, và đều là bản chất chứ không phải thiếu sót.
 `é` chỉ có một code point dù người gõ nó cho tiếng Việt hay tiếng Pháp, nên `café`
@@ -128,8 +132,9 @@ bàn phím tiếng Việt   →  Bàn Phím Tiếng Việt
 gửi về TP. HCM        →  Gửi Về TP. HCM        (không phải "Tp. Hcm")
 ```
 
-Ngoại lệ ALL-CAPS bật mặc định, tắt được. Từ một chữ cái (`A`) coi như ALL-CAPS —
-vô hại, vì kết quả hai đường như nhau.
+Ngoại lệ ALL-CAPS bật mặc định, tắt được bằng công tắc **Hạ chữ viết hoa** — đặt tên
+theo thứ nó bật lên, nên cũng mặc định **tắt** như công tắc kia. Từ một chữ cái (`A`)
+coi như ALL-CAPS — vô hại, vì kết quả hai đường như nhau.
 
 Ranh giới từ là **khoảng trắng hoặc dấu câu ASCII**; `bàn-phím` thành `Bàn-Phím`,
 `e-mail` thành `E-Mail` — quy ước của mọi công cụ cùng loại. Dấu nháy đơn là ngoại lệ,
@@ -154,7 +159,7 @@ quy ước title case như tiếng Anh, và đoán sẽ sai nhiều hơn đúng.
 
 ## Bảng mã cũ là ca biên thật sự
 
-Cửa sổ Chuyển mã làm việc với TCVN3 và VNI-Windows, nên tab mới **bắt buộc** phải trả
+Cửa sổ Chuyển mã làm việc với TCVN3 và VNI-Windows, nên trục mới **bắt buộc** phải trả
 lời câu hỏi: viết hoa một đoạn TCVN3 thì sao?
 
 Viết hoa từng `char` của chuỗi TCVN3 là **sai**, vì `char` ở đó không phải chữ cái —
@@ -182,7 +187,7 @@ không dùng đường cảnh báo.
 | --- | --- |
 | `funput-core::textcase` | Năm phép biến đổi thuần, không phụ thuộc, không alloc ngoài chuỗi kết quả, và không bảng dữ liệu mới nào. Sau cargo feature riêng, **mặc định tắt** như `charset` — iOS/Android không bao giờ biên dịch nó |
 | `funput-convert` | Trục thứ hai của `Session`: "đổi bảng mã" và "đổi kiểu chữ" dùng chung một `Session`, một `View`, một đường cảnh báo |
-| Ba shell | Chỉ tab, nút, và preview. Không quyết định gì — đúng hợp đồng `refresh()` / `view()` hiện tại |
+| Ba shell | Chỉ thanh, nút, và preview. Không quyết định gì — đúng hợp đồng `refresh()` / `view()` hiện tại |
 | `funput-cli` | `funput case --upper|--lower|--no-diacritics|--sentence|--title` đọc stdin. Rẻ, và là bề mặt test tốt nhất |
 
 **Vì sao mở rộng `Session` chứ không dựng session thứ hai.** Lý do `funput-convert`
@@ -228,15 +233,34 @@ Hai chi tiết bắt buộc khi hiện thực:
 
 ## Giao diện V1
 
-Tab thứ hai trong cửa sổ Chuyển mã, cùng vùng dán và cùng cặp khung trước/sau:
+**Một thanh luôn hiện, không phải một tab.** Đã cân nhắc tab và **loại**: đổi bảng mã
+và đổi kiểu chữ là hai lựa chọn về cùng một văn bản và chúng **cộng dồn** — một đoạn
+đọc ra từ TCVN3 vẫn viết hoa đầu mỗi từ được — nên cả hai ở trên màn hình cùng lúc.
+Một tab sẽ nói rằng người dùng phải chọn một trong hai.
 
-- Năm nút phép biến đổi (chọn một), áp dụng ngay lên preview.
-- Hai công tắc: **đ → d** (mặc định bật) và **giữ nguyên từ viết HOA** (mặc định bật),
-  chỉ hiện khi liên quan tới phép đang chọn.
+Thanh nằm ngay dưới hàng chọn bảng mã ở hình dạng văn bản, và dưới header ở hình dạng
+batch; hình dạng rỗng (vùng thả tệp) không có nó. Cùng vùng dán và cùng cặp khung
+trước/sau:
+
+- Năm nút phép biến đổi, áp dụng ngay lên preview. Phép đang áp có **nền accent và
+  dấu tick** — chỉ đổi màu là tín hiệu mà người mù màu không nhận được.
+- Dòng **`Đang áp: chữ thường → Viết Hoa Đầu Mỗi Từ`** viết rõ thứ tự, vì thứ tự ra
+  văn bản khác nhau. Chỉ hiện khi có phép đang áp.
+- Hai công tắc, đặt tên theo thứ chúng **bật lên** nên cả hai **mặc định tắt**:
+  **Giữ đ/Đ** (tắt = `đ → d`) và **Hạ chữ viết hoa** (tắt = giữ nguyên từ viết HOA).
+  Mỗi công tắc chỉ hiện **khi phép sở hữu nó đang được áp** — ngoài lúc đó nó không có
+  gì để nói, và hiện ở đó là cách dạy phép nào sở hữu nó.
 - Dòng cảnh báo dùng chung với Chuyển mã, chỉ hiện khi encode ngược mất chữ.
-- Nút **Sao chép kết quả**, và **Hoàn tác** trả về nguyên bản.
+- Nút **Hoàn tác** gỡ **phép cuối cùng** chứ không phải tất cả — bấm nhầm phép thứ ba
+  không nên mất hai phép trước nó — và **Bỏ hết** trả về nguyên bản.
 - Phép biến đổi **cộng dồn được**: bấm "chữ thường" rồi "Viết Hoa Đầu Mỗi Từ" cho kết
-  quả của cả hai. Nguyên bản luôn giữ để hoàn tác về một bước.
+  quả của cả hai. Bấm lại đúng phép đang ở đỉnh là **không làm gì**, vì mọi phép đều
+  idempotent nên lần bấm thứ hai không đổi được văn bản. Nguyên bản luôn giữ: danh
+  sách phép được phát lại từ đầu ở mỗi lần dựng preview, không bao giờ ghi đè lên
+  đoạn người dùng đã dán.
+- Thanh **mờ và không bấm được** khi chưa có bảng mã nào giải thích được văn bản: văn
+  bản đó không được chuyển mã, và cũng không được đổi kiểu chữ — một quy tắc, không
+  phải hai. Batch mang bảng mã theo từng dòng nên không bao giờ bị chặn.
 
 Một file thả vào vẫn rơi vào `Mode::Text` như hiện tại. Nhiều file là batch —
 **không thuộc V1**, nhưng bảng `Row` không cần đổi khi tới lượt.
@@ -278,7 +302,7 @@ Windows), và không đụng clipboard ở đó.
 
 ## Cấu hình
 
-V1 **không thêm khoá nào vào file cấu hình**. Hai công tắc của tab là lựa chọn của
+V1 **không thêm khoá nào vào file cấu hình**. Hai công tắc của thanh là lựa chọn của
 phiên làm việc, lưu cùng chỗ cửa sổ Chuyển mã lưu trạng thái của nó.
 
 Từ V3 trở đi mới cần hotkey, và hotkey là khối **theo từng nền tảng** trong
@@ -303,12 +327,18 @@ không đoán trước.
 
 ### Kiểm tra thủ công
 
-1. Mở Chuyển mã → tab Kiểu chữ, dán `xin chào. hôm nay trời đẹp.` rồi thử lần lượt
+1. Mở Chuyển mã → thanh Kiểu chữ, dán `xin chào. hôm nay trời đẹp.` rồi thử lần lượt
    năm nút; kiểm tra preview trước/sau khớp với bảng ở đầu tài liệu.
 2. Dán đoạn có `TP. HCM` và một dòng xuống dòng không chấm câu: kiểm tra ngoại lệ
    ALL-CAPS và ranh giới dòng.
-3. Tắt công tắc `đ → d`, bỏ dấu `đẹp` → `đep`.
-4. Dán một đoạn TCVN3 (copy từ Word font `.VnTime`), bấm CHỮ HOA: phải thấy dòng cảnh
-   báo nêu tên ký tự sẽ mất.
-5. Bấm chồng hai phép rồi Hoàn tác: phải về đúng nguyên bản, một bước.
-6. `echo "Tiếng Việt" | funput case --no-diacritics` cho `Tieng Viet`.
+3. Bật công tắc **Giữ đ/Đ**, bỏ dấu `đẹp` → `đep`. Nó chỉ hiện khi `Bỏ dấu tiếng Việt`
+   đang áp; **Hạ chữ viết hoa** cũng vậy với `Viết Hoa Đầu Mỗi Từ`.
+4. Đặt đích TCVN3 rồi bấm CHỮ HOA: phải thấy dòng cảnh báo **nêu tên** ký tự sẽ mất —
+   phép biến đổi chạy trước khi tính giá, nên chữ hoa TCVN3 không có chỗ mới lộ ra ở
+   đây. Ở hình dạng batch, cột `N chữ sẽ mất` của từng dòng phải đổi theo.
+5. Bấm chồng hai phép: dòng `Đang áp` phải viết đúng thứ tự đã bấm, và đổi thứ tự phải
+   cho văn bản khác. **Hoàn tác** gỡ đúng phép cuối; **Bỏ hết** về nguyên bản.
+6. Dán chuỗi không đoán được bảng mã (`hello world`): cả thanh phải mờ và không bấm
+   được.
+7. `echo "Tiếng Việt" | funput case --no-diacritics` cho `Tieng Viet` — CLI và ba cửa
+   sổ gọi cùng một hàm, nên lệch nhau ở đây là lỗi nối dây của shell.

--- a/docs/features/text-case.md
+++ b/docs/features/text-case.md
@@ -3,8 +3,8 @@
 ## Trạng thái
 
 **Tầng core đã xong**: `funput_core::textcase` sau cargo feature `textcase`, cả năm
-phép, kèm corpus và property test. Chưa có người dùng nào — `funput-convert`, ba shell
-và `funput case` là các bước tiếp theo.
+phép, kèm corpus và property test, và **`funput case`** trong CLI đã gọi tới nó. Còn
+lại: `funput-convert` và ba cửa sổ.
 
 Tài liệu này chốt mô hình trước khi có code, như [charset.md](charset.md) đã làm, và là
 nơi mọi quyết định thiết kế sống — mỗi thay đổi cập nhật lại nó trong cùng PR.

--- a/docs/features/text-case.md
+++ b/docs/features/text-case.md
@@ -1,0 +1,287 @@
+# Chuyển đổi kiểu chữ
+
+## Trạng thái
+
+**Chưa có code.** Tài liệu này chốt mô hình trước, như [charset.md](charset.md) đã làm,
+và là nơi mọi quyết định thiết kế sống — mỗi phép biến đổi mới cập nhật lại nó trong
+cùng PR.
+
+Phạm vi **V1 đã chốt: một tab trong cửa sổ Chuyển mã**, ba nền tảng desktop, cộng
+`funput case` trong CLI. Không hotkey, không đụng vùng bôi đen, không nghe clipboard. Những thứ đó nằm ở
+[Lộ trình sau V1](#lộ-trình-sau-v1) và có tài liệu riêng khi tới lượt.
+
+## Mục tiêu
+
+Đổi **kiểu chữ của văn bản có sẵn**, năm phép:
+
+| Phép | Ví dụ |
+| --- | --- |
+| CHỮ HOA | `Xin chào Việt Nam` → `XIN CHÀO VIỆT NAM` |
+| chữ thường | `Xin Chào Việt Nam` → `xin chào việt nam` |
+| Bỏ dấu tiếng Việt | `Tiếng Việt rất đẹp` → `Tieng Viet rat dep` |
+| Viết hoa đầu câu | `xin chào. hôm nay trời đẹp.` → `Xin chào. Hôm nay trời đẹp.` |
+| Viết Hoa Đầu Mỗi Từ | `bàn phím tiếng Việt` → `Bàn Phím Tiếng Việt` |
+
+Đây là tính năng của **người soạn thảo**, không phải của bộ gõ: nó chạy trên đoạn văn
+đã có, không can thiệp vào phím đang gõ. Vì vậy nó ở cạnh Chuyển mã chứ không ở cạnh
+engine.
+
+## Không thuộc phạm vi
+
+- **Sửa ngữ nghĩa.** `chữ thường` sẽ phá `Việt Nam` thành `việt nam`, và đó là đúng
+  yêu cầu. Không có danh sách tên riêng, không đoán, không "thông minh". Cách chữa
+  duy nhất là **hoàn tác**, nên hoàn tác phải rẻ và luôn có.
+- **Danh sách viết tắt cho "đầu câu".** `v.v.`, `TS.`, `Th.S` sẽ bị coi là hết câu và
+  chữ sau đó bị viết hoa. Đã cân nhắc và **cố ý không làm**: một danh sách viết tắt
+  tiếng Việt không bao giờ đủ, và sai sót của nó khó đoán hơn là một quy tắc đơn giản
+  mà người dùng nhìn preview là thấy ngay. Ghi vào phần giới hạn đã biết ở UI.
+- **Chế độ slug** (`tieng-viet`) và **bỏ dấu giữ dấu kiểu Telex** (`đẹp` → `depj`).
+  Có thể thêm sau; không thuộc V1.
+- Chuyển đổi trên vùng bôi đen, hotkey toàn cục, clipboard tự động — xem lộ trình.
+- Wayland: mọi đường đi qua vùng bôi đen đều không khả thi, và tài liệu sẽ nói thẳng
+  như vậy thay vì hứa.
+
+## Năm phép biến đổi, chính xác đến ca biên
+
+### Chung cho cả năm
+
+Hàm nhận `&str`, trả `String`. **Không phải phép ánh xạ từng `char`**: `char`
+tiếng Việt viết hoa có thể dài hơn nguyên bản ở dạng tổ hợp, nên lõi làm việc trên
+chuỗi. Dùng `to_uppercase`/`to_lowercase` của Rust ở mức chuỗi (không phụ thuộc
+locale — tiếng Việt không có ca biên kiểu `i` của tiếng Thổ).
+
+Chuỗi vào có thể ở **Unicode dựng sẵn hoặc tổ hợp**. Cả năm phép phải cho cùng kết
+quả ở hai dạng, và **giữ nguyên dạng của đầu vào** — không tự dựng sẵn hoá một tài
+liệu tổ hợp, vì người dùng chỉ xin đổi kiểu chữ.
+
+### CHỮ HOA / chữ thường
+
+Thẳng. Ca biên duy nhất đáng nói nằm ở [bảng mã cũ](#bảng-mã-cũ-là-ca-biên-thật-sự).
+
+### Bỏ dấu tiếng Việt
+
+Bỏ **cả thanh điệu lẫn dấu phụ của nguyên âm**, giữ chữ cái ASCII:
+
+```
+ế → e     ơ → o     ă → a     ữ → u     Ề → E
+đ → d     Đ → D                (mặc định; xem tuỳ chọn bên dưới)
+```
+
+Không dùng crate normalization: `funput-core` có **bất biến không phụ thuộc runtime**
+(`[dependencies]` rỗng), và phá nó cho một tính năng desktop là cái giá sai. Bảng có
+sẵn đã đủ gần: `unicode::vowels::vowel_stem` bỏ thanh nhưng **giữ hình** (`ấ` → `â`),
+nên còn thiếu một bảng `family → chữ cái ASCII` 12 dòng dựng cạnh
+`vowels::table::VOWEL_FAMILIES`. Chữ tổ hợp xử lý bằng cách lọc các dấu thanh rời
+(`U+0300`, `U+0301`, `U+0303`, `U+0309`, `U+0323`) và dấu mũ/móc/trăng rời, sau khi
+đã quy chữ nền về ASCII.
+
+**Tuỳ chọn `đ → d`**: mặc định **bật**. Người cần giữ `đ` (đặt tên file cho hệ thống
+chấp nhận nó, hoặc chỉ muốn bỏ thanh) tắt được trong cùng tab. Đây là tuỳ chọn duy
+nhất của phép này.
+
+Ký tự không phải tiếng Việt (chữ Nhật, emoji, `é` của tiếng Pháp) **giữ nguyên**:
+tính năng tên là "bỏ dấu tiếng Việt", không phải "ASCII hoá".
+
+### Viết hoa đầu câu
+
+Viết hoa chữ cái đầu của mỗi câu, **giữ nguyên phần còn lại**:
+
+```
+xin CHÀO. hôm nay trời đẹp.  →  Xin CHÀO. Hôm nay trời đẹp.
+```
+
+Đã cân nhắc phương án "hạ thường tất cả rồi mới viết hoa" và **không chọn**: nó phá
+`TP. HCM`, phá tên riêng, phá chữ viết hoa cố ý, trong khi người dùng muốn cả hai việc
+đó thì đã có "chữ thường" rồi bấm tiếp "đầu câu".
+
+Ranh giới câu:
+
+| Là ranh giới | Không là ranh giới |
+| --- | --- |
+| `.` `!` `?` `…` kèm khoảng trắng sau | `.` giữa số (`1.5`) |
+| **Xuống dòng** (`\n`), kể cả khi dòng trước không có dấu chấm | dấu `.` của viết tắt (`v.v.`, `TS.`) — giới hạn đã biết |
+| Đầu văn bản | |
+
+Xuống dòng là ranh giới vì đầu vào thật của tính năng này thường là danh sách, phụ đề
+`.srt`, ghi chú — nơi không ai chấm câu.
+
+Chữ cái đầu có thể không phải chữ cái: `"xin chào"` và `(xin chào)` phải viết hoa
+`x`, không bỏ qua vì gặp dấu nháy. Quy tắc: bỏ qua mọi ký tự không phải chữ cái cho
+tới chữ cái đầu tiên của câu.
+
+### Viết Hoa Đầu Mỗi Từ
+
+Viết hoa chữ cái đầu mỗi từ, hạ thường phần còn lại của từ — **trừ từ đang viết HOA
+toàn bộ, giữ nguyên**:
+
+```
+bàn phím tiếng Việt   →  Bàn Phím Tiếng Việt
+gửi về TP. HCM        →  Gửi Về TP. HCM        (không phải "Tp. Hcm")
+```
+
+Ngoại lệ ALL-CAPS bật mặc định, tắt được. Từ một chữ cái (`A`) coi như ALL-CAPS —
+vô hại, vì kết quả hai đường như nhau.
+
+Ranh giới từ là khoảng trắng và dấu câu; `bàn-phím` thành `Bàn-Phím`, `e-mail` thành
+`E-Mail`. Đây là quy ước của mọi công cụ cùng loại và người dùng đã quen.
+
+Không có danh sách từ nối ("của", "và", "là" vẫn được viết hoa). Tiếng Việt không có
+quy ước title case như tiếng Anh, và đoán sẽ sai nhiều hơn đúng.
+
+## Bảng mã cũ là ca biên thật sự
+
+Cửa sổ Chuyển mã làm việc với TCVN3 và VNI-Windows, nên tab mới **bắt buộc** phải trả
+lời câu hỏi: viết hoa một đoạn TCVN3 thì sao?
+
+Viết hoa từng `char` của chuỗi TCVN3 là **sai**, vì `char` ở đó không phải chữ cái —
+nó là byte TCVN3 nằm trong `U+0020..U+00FF` mà font `.VnTime` vẽ ra. `to_uppercase`
+của Rust không biết điều đó.
+
+Đường đúng dùng lại nguyên mô hình trục đã có ở [charset.md](charset.md):
+
+```
+văn bản nguồn ──decode──> Unicode dựng sẵn ──đổi kiểu chữ──> ──encode──> bảng mã nguồn
+```
+
+Hệ quả quan trọng: **encode ngược có thể mất chữ**. TCVN3 không đủ chỗ cho nguyên âm
+hoa có dấu, nên viết hoa một văn bản TCVN3 là phép **có mất mát** — đúng loại mất mát
+mà `charset::Cost` và `text::warning` đã được xây để cảnh báo, kể cả việc **nêu tên
+ký tự** bị mất. Tab mới dùng lại y nguyên hai thứ đó, không viết câu cảnh báo thứ hai.
+
+"Bỏ dấu" thì ngược lại: luôn về ASCII, nên không bao giờ mất mát ở bước encode, dù
+bản thân nó là phép mất thông tin — chuyện này nói bằng một dòng ghi chú tĩnh ở UI,
+không dùng đường cảnh báo.
+
+## Nơi đặt code
+
+| Tầng | Nội dung |
+| --- | --- |
+| `funput-core::textcase` | Năm hàm thuần + bảng `family → ASCII`. Không phụ thuộc, không alloc ngoài chuỗi kết quả. Sau cargo feature riêng, **mặc định tắt** như `charset` — iOS/Android không bao giờ biên dịch nó |
+| `funput-convert` | Trục thứ hai của `Session`: "đổi bảng mã" và "đổi kiểu chữ" dùng chung một `Session`, một `View`, một đường cảnh báo |
+| Ba shell | Chỉ tab, nút, và preview. Không quyết định gì — đúng hợp đồng `refresh()` / `view()` hiện tại |
+| `funput-cli` | `funput case --upper|--lower|--no-diacritics|--sentence|--title` đọc stdin. Rẻ, và là bề mặt test tốt nhất |
+
+**Vì sao mở rộng `Session` chứ không dựng session thứ hai.** Lý do `funput-convert`
+tồn tại — ghi ở đầu `lib.rs` — là để câu chữ cảnh báo, quy tắc `vanban (2).txt` và
+tên thư mục đích chỉ có một bản. Một session thứ hai sẽ chép lại đúng những thứ đó.
+Cụ thể: thêm một trường "phép biến đổi" (`None` = chỉ đổi bảng mã) vào `Session`,
+`Mode` giữ nguyên ba hình dạng `Empty`/`Text`/`Files`.
+
+Trần 150 LOC/file vẫn áp dụng: năm phép nhiều khả năng là năm file trong
+`core/src/textcase/`.
+
+### Feature `textcase`, tách khỏi `charset`
+
+**Một cargo feature riêng trong `funput-core`, không phải một crate riêng.**
+
+Feature riêng chứ không gộp vào `charset`, vì hai thứ đó không đi cùng nhau ở cả hai
+đầu: `funput-config` bật `charset` chỉ để giải mã file gõ tắt UniKey và không bao giờ
+đổi kiểu chữ; còn chiều quan trọng hơn là **mobile có thể cần `textcase` mà chắc chắn
+không cần `charset`**. iOS và Android đều đọc được vùng bôi đen từ chính bàn phím, nên
+một phím "bỏ dấu" ngay trên bàn phím là hướng đi hợp lý về sau — và gộp hai feature sẽ
+kéo cả bốn codec bảng mã vào bản build của chúng, đúng thứ mà ghi chú của feature
+`charset` cấm.
+
+Crate riêng thì không, vì phần bỏ dấu **đọc bảng nguyên âm nội bộ của core**
+(`unicode::vowels::table::VOWEL_FAMILIES`, `vowel_stem`). Một crate ngoài chỉ có hai
+đường: chép lại bảng — hai nguồn sự thật cho cùng một dữ liệu — hoặc đổi bảng thành
+`pub`, biến chi tiết nội bộ thành API công khai của core cho đúng một người dùng.
+`funput-convert` là crate riêng vì lý do ngược lại: nó không cần ruột của core, nó cần
+nằm *trong* workspace để `cargo test --workspace` và `check-loc.sh` với tới hai shell
+bị loại khỏi workspace. `textcase` không có vấn đề đó.
+
+Hai chi tiết bắt buộc khi hiện thực:
+
+- `VOWEL_FAMILIES` hiện là `pub(crate)` sau `#[cfg(feature = "charset")]`. Phải nới
+  thành `#[cfg(any(feature = "charset", feature = "textcase"))]` — quên thì lỗi build
+  chỉ hiện ra ở đúng một tổ hợp feature.
+- `funput-ffi` đã có cấu trúc hai tầng sẵn; chỉ thêm `textcase = ["funput-core/textcase"]`
+  và đổi `convert` thành `["charset", "textcase", "dep:funput-convert"]`. Job CI hiện
+  có (`cargo test -p funput-ffi --features convert`) phủ luôn, không cần job mới.
+
+## Giao diện V1
+
+Tab thứ hai trong cửa sổ Chuyển mã, cùng vùng dán và cùng cặp khung trước/sau:
+
+- Năm nút phép biến đổi (chọn một), áp dụng ngay lên preview.
+- Hai công tắc: **đ → d** (mặc định bật) và **giữ nguyên từ viết HOA** (mặc định bật),
+  chỉ hiện khi liên quan tới phép đang chọn.
+- Dòng cảnh báo dùng chung với Chuyển mã, chỉ hiện khi encode ngược mất chữ.
+- Nút **Sao chép kết quả**, và **Hoàn tác** trả về nguyên bản.
+- Phép biến đổi **cộng dồn được**: bấm "chữ thường" rồi "Viết Hoa Đầu Mỗi Từ" cho kết
+  quả của cả hai. Nguyên bản luôn giữ để hoàn tác về một bước.
+
+Một file thả vào vẫn rơi vào `Mode::Text` như hiện tại. Nhiều file là batch —
+**không thuộc V1**, nhưng bảng `Row` không cần đổi khi tới lượt.
+
+## Lộ trình sau V1
+
+| Giai đoạn | Nội dung | Rào cản |
+| --- | --- | --- |
+| V2 | Batch kéo-thả file | Không có; chỉ là nối vào đường batch sẵn có |
+| V3 | Hotkey xử lý clipboard: copy → hotkey → clipboard đã đổi, người dùng tự dán | Không cần quyền hệ thống. Phải sao lưu/khôi phục clipboard đủ kiểu dữ liệu, và từ chối khi clipboard không phải text |
+| V4 | Bôi đen → hotkey → thay tại chỗ, kèm HUD | Quyền và API theo nền tảng, xem dưới |
+| V5 | Đổi kiểu chữ **từ/câu vừa gõ** qua engine, không cần bôi đen | Dùng bộ nhớ văn bản đã gõ sẵn có (`Engine::adopt`, typed-text shadow của Windows) |
+
+### V4: mô hình kích hoạt đã chốt
+
+**Một hotkey, rồi một phím chọn.** Bấm tổ hợp → thanh nhỏ hiện cạnh con trỏ → bấm
+`U` HOA, `T` thường, `D` bỏ dấu, `C` đầu câu, `W` đầu từ, `Esc` thôi. Chỉ tốn một
+keybind, tự dạy người dùng, và có chỗ đặt nút Hoàn tác — thứ bắt buộc phải có vì
+"chữ thường" phá tên riêng.
+
+Đã loại: năm hotkey riêng (không ai nhớ nổi, đụng phím tắt app khác) và một hotkey
+xoay vòng (không với tới bỏ dấu và đầu câu).
+
+### V4: khả thi theo nền tảng
+
+| | Đọc vùng chọn | Ghi đè | Ghi chú |
+| --- | --- | --- | --- |
+| macOS | `AXSelectedText`, hoặc giả lập ⌘C | AX set, hoặc giả lập ⌘V | Cần quyền Accessibility. **NSServices** là đường thứ hai: hệ thống tự đưa text và tự thay lại, không cần quyền, hiện sẵn trong menu chuột phải |
+| Windows | UIA `TextPattern`, hoặc giả lập Ctrl+C | Ctrl+V hoặc inject | Đường inject đã có sẵn |
+| Linux X11 | PRIMARY selection — đọc được **không cần Ctrl+C** | XTEST | OK |
+| Linux Wayland | ✗ | ✗ | Không hỗ trợ, nói thẳng |
+
+Đường "giả lập phím copy" là **fallback, không phải đường chính**: phải chờ
+`changeCount` đổi chứ không ngủ một khoảng đoán mò, và nó sai trong terminal, nơi
+⌘C/Ctrl+C là ngắt tiến trình chứ không phải copy.
+
+An toàn: không chạy trong ô mật khẩu (secure input trên macOS, cờ ô nhập trên
+Windows), và không đụng clipboard ở đó.
+
+## Cấu hình
+
+V1 **không thêm khoá nào vào file cấu hình**. Hai công tắc của tab là lựa chọn của
+phiên làm việc, lưu cùng chỗ cửa sổ Chuyển mã lưu trạng thái của nó.
+
+Từ V3 trở đi mới cần hotkey, và hotkey là khối **theo từng nền tảng** trong
+[CONFIG_FORMAT.md](../../platforms/CONFIG_FORMAT.md) — Windows và Linux dùng preset
+giống nhau nhưng mỗi bên chỉ đọc khối của mình. Đặt tên khoá khi tới giai đoạn đó,
+không đoán trước.
+
+## Kiểm thử
+
+- **Corpus vàng** cho cả năm phép, chạy ở cả Unicode dựng sẵn và tổ hợp, cho cùng kết
+  quả.
+- **Property** (`proptest` đã có sẵn trong dev-dependencies):
+  - viết HOA và viết thường là idempotent;
+  - bỏ dấu cho kết quả chỉ chứa ASCII với mọi đầu vào tiếng Việt;
+  - bỏ dấu là idempotent;
+  - đổi kiểu chữ rồi encode về TCVN3 không bao giờ panic, chỉ báo `Cost`.
+- **Roundtrip bảng mã**: viết HOA một đoạn TCVN3 rồi đọc lại phải ra đúng chữ hoa
+  tương ứng, hoặc báo mất chữ có nêu tên — không có đường thứ ba.
+- Ca biên phải có test riêng: `TP. HCM`, `1.5`, `v.v.` (test **khoá giới hạn đã
+  biết**, không phải test đòi nó đúng), chuỗi rỗng, chỉ dấu câu, emoji, chữ Nhật lẫn
+  trong câu.
+
+### Kiểm tra thủ công
+
+1. Mở Chuyển mã → tab Kiểu chữ, dán `xin chào. hôm nay trời đẹp.` rồi thử lần lượt
+   năm nút; kiểm tra preview trước/sau khớp với bảng ở đầu tài liệu.
+2. Dán đoạn có `TP. HCM` và một dòng xuống dòng không chấm câu: kiểm tra ngoại lệ
+   ALL-CAPS và ranh giới dòng.
+3. Tắt công tắc `đ → d`, bỏ dấu `đẹp` → `đep`.
+4. Dán một đoạn TCVN3 (copy từ Word font `.VnTime`), bấm CHỮ HOA: phải thấy dòng cảnh
+   báo nêu tên ký tự sẽ mất.
+5. Bấm chồng hai phép rồi Hoàn tác: phải về đúng nguyên bản, một bước.
+6. `echo "Tiếng Việt" | funput case --no-diacritics` cho `Tieng Viet`.

--- a/docs/features/text-case.md
+++ b/docs/features/text-case.md
@@ -2,9 +2,12 @@
 
 ## Trạng thái
 
-**Chưa có code.** Tài liệu này chốt mô hình trước, như [charset.md](charset.md) đã làm,
-và là nơi mọi quyết định thiết kế sống — mỗi phép biến đổi mới cập nhật lại nó trong
-cùng PR.
+**Tầng core đã xong**: `funput_core::textcase` sau cargo feature `textcase`, cả năm
+phép, kèm corpus và property test. Chưa có người dùng nào — `funput-convert`, ba shell
+và `funput case` là các bước tiếp theo.
+
+Tài liệu này chốt mô hình trước khi có code, như [charset.md](charset.md) đã làm, và là
+nơi mọi quyết định thiết kế sống — mỗi thay đổi cập nhật lại nó trong cùng PR.
 
 Phạm vi **V1 đã chốt: một tab trong cửa sổ Chuyển mã**, ba nền tảng desktop, cộng
 `funput case` trong CLI. Không hotkey, không đụng vùng bôi đen, không nghe clipboard. Những thứ đó nằm ở
@@ -111,8 +114,9 @@ Xuống dòng là ranh giới vì đầu vào thật của tính năng này thư
 `.srt`, ghi chú — nơi không ai chấm câu.
 
 Chữ cái đầu có thể không phải chữ cái: `"xin chào"` và `(xin chào)` phải viết hoa
-`x`, không bỏ qua vì gặp dấu nháy. Quy tắc: bỏ qua mọi ký tự không phải chữ cái cho
-tới chữ cái đầu tiên của câu.
+`x`, không bỏ qua vì gặp dấu nháy. Nhưng **chữ số thì chặn**: câu mở đầu bằng số là câu
+đã bắt đầu, nên `3 con mèo` không được thành `3 Con mèo`. Quy tắc: đi qua dấu mở, dừng
+ở chữ cái **hoặc** chữ số đầu tiên, và chỉ chữ cái mới được đổi.
 
 ### Viết Hoa Đầu Mỗi Từ
 
@@ -127,11 +131,26 @@ gửi về TP. HCM        →  Gửi Về TP. HCM        (không phải "Tp. Hcm
 Ngoại lệ ALL-CAPS bật mặc định, tắt được. Từ một chữ cái (`A`) coi như ALL-CAPS —
 vô hại, vì kết quả hai đường như nhau.
 
-Ranh giới từ là khoảng trắng và dấu câu; `bàn-phím` thành `Bàn-Phím`, `e-mail` thành
-`E-Mail`. Đây là quy ước của mọi công cụ cùng loại và người dùng đã quen.
+Ranh giới từ là **khoảng trắng hoặc dấu câu ASCII**; `bàn-phím` thành `Bàn-Phím`,
+`e-mail` thành `E-Mail` — quy ước của mọi công cụ cùng loại. Dấu nháy đơn là ngoại lệ,
+để `don't` không thành `Don'T`.
+
+Giữ tập ranh giới trong ASCII mua được một bảo đảm đáng giá hơn những ca biên nó bỏ
+lỡ: **không bao giờ cắt một từ ở giữa một grapheme cluster**, vì mọi dấu tổ hợp đều
+ngoài ASCII. `Tiếng Việt` viết dạng tổ hợp vẫn là hai từ, trong khi quy tắc "cắt ở mọi
+ký tự không phải chữ cái" sẽ cắt từng nguyên âm khỏi dấu của nó rồi viết hoa mảnh vụn
+phía sau. Giá phải trả: dấu câu ngoài ASCII không có khoảng trắng thì không tách từ
+(`xin…chào` chỉ viết hoa `x`) — thuần thẩm mỹ, và hiếm trong loại văn bản này.
+
+Vì một từ có thể mở đầu bằng thứ không có hoa/thường, phép này tìm **chữ cái đầu tiên
+trong từ**: `"xin` được viết hoa, và `5g` thành `5G`.
 
 Không có danh sách từ nối ("của", "và", "là" vẫn được viết hoa). Tiếng Việt không có
 quy ước title case như tiếng Anh, và đoán sẽ sai nhiều hơn đúng.
+
+**Giới hạn đã biết**, đối xứng với ngoại lệ ALL-CAPS: chữ hoa nằm giữa từ sẽ mất, nên
+`iPhone` thành `Iphone`. Giữ được nó nghĩa là không hạ thường phần còn lại của từ, mà
+đó chính là việc của phép này.
 
 ## Bảng mã cũ là ca biên thật sự
 

--- a/docs/features/text-case.md
+++ b/docs/features/text-case.md
@@ -188,7 +188,7 @@ không dùng đường cảnh báo.
 | `funput-core::textcase` | Năm phép biến đổi thuần, không phụ thuộc, không alloc ngoài chuỗi kết quả, và không bảng dữ liệu mới nào. Sau cargo feature riêng, **mặc định tắt** như `charset` — iOS/Android không bao giờ biên dịch nó |
 | `funput-convert` | Trục thứ hai của `Session`: "đổi bảng mã" và "đổi kiểu chữ" dùng chung một `Session`, một `View`, một đường cảnh báo |
 | Ba shell | Chỉ thanh, nút, và preview. Không quyết định gì — đúng hợp đồng `refresh()` / `view()` hiện tại |
-| `funput-cli` | `funput case --upper|--lower|--no-diacritics|--sentence|--title` đọc stdin. Rẻ, và là bề mặt test tốt nhất |
+| `funput-cli` | `funput case upper\|lower\|no-diacritics\|sentence\|title` đọc stdin; ghép nhiều phép bằng dấu phẩy (`lower,title`), và hai công tắc là `--keep-d` / `--flatten-caps`. Rẻ, và là bề mặt test tốt nhất |
 
 **Vì sao mở rộng `Session` chứ không dựng session thứ hai.** Lý do `funput-convert`
 tồn tại — ghi ở đầu `lib.rs` — là để câu chữ cảnh báo, quy tắc `vanban (2).txt` và
@@ -367,5 +367,5 @@ không đoán trước.
    cho văn bản khác. **Hoàn tác** gỡ đúng phép cuối; **Bỏ hết** về nguyên bản.
 6. Dán chuỗi không đoán được bảng mã (`hello world`): cả thanh phải mờ và không bấm
    được.
-7. `echo "Tiếng Việt" | funput case --no-diacritics` cho `Tieng Viet` — CLI và ba cửa
+7. `echo "Tiếng Việt" | funput case no-diacritics` cho `Tieng Viet` — CLI và ba cửa
    sổ gọi cùng một hàm, nên lệch nhau ở đây là lỗi nối dây của shell.

--- a/docs/features/text-case.md
+++ b/docs/features/text-case.md
@@ -68,19 +68,24 @@ Bỏ **cả thanh điệu lẫn dấu phụ của nguyên âm**, giữ chữ cá
 ```
 
 Không dùng crate normalization: `funput-core` có **bất biến không phụ thuộc runtime**
-(`[dependencies]` rỗng), và phá nó cho một tính năng desktop là cái giá sai. Bảng có
-sẵn đã đủ gần: `unicode::vowels::vowel_stem` bỏ thanh nhưng **giữ hình** (`ấ` → `â`),
-nên còn thiếu một bảng `family → chữ cái ASCII` 12 dòng dựng cạnh
-`vowels::table::VOWEL_FAMILIES`. Chữ tổ hợp xử lý bằng cách lọc các dấu thanh rời
-(`U+0300`, `U+0301`, `U+0303`, `U+0309`, `U+0323`) và dấu mũ/móc/trăng rời, sau khi
-đã quy chữ nền về ASCII.
+(`[dependencies]` rỗng), và phá nó cho một tính năng desktop là cái giá sai.
+
+Và **không cần bảng mới nào**: `unicode::shapes::base_vowel` đã bỏ cả thanh lẫn hình
+mà giữ hoa/thường, trên toàn bộ bảng chữ dựng sẵn — chính engine dùng nó để quyết định
+phím hình có đổi được nguyên âm hay không. Một bảng `family → ASCII` sẽ là bản copy
+thứ hai của cùng câu trả lời, và bản thứ hai là bản sẽ lệch. Chữ tổ hợp xử lý bằng
+cách lọc tám dấu rời, danh sách lấy từ `unicode::combining`.
 
 **Tuỳ chọn `đ → d`**: mặc định **bật**. Người cần giữ `đ` (đặt tên file cho hệ thống
 chấp nhận nó, hoặc chỉ muốn bỏ thanh) tắt được trong cùng tab. Đây là tuỳ chọn duy
 nhất của phép này.
 
-Ký tự không phải tiếng Việt (chữ Nhật, emoji, `é` của tiếng Pháp) **giữ nguyên**:
-tính năng tên là "bỏ dấu tiếng Việt", không phải "ASCII hoá".
+Hai điều phép này **không làm được**, và đều là bản chất chứ không phải thiếu sót.
+`é` chỉ có một code point dù người gõ nó cho tiếng Việt hay tiếng Pháp, nên `café`
+thành `cafe`: một phép biến đổi trên chữ cái không biết được ai có ý gì. Và dấu tổ hợp
+bị bỏ bất kể ai đặt nó, nên `ñ` ở dạng tổ hợp ra `n` — còn `ñ`, `ü`, `ç`, `ß` dựng sẵn,
+chữ Nhật và emoji thì giữ nguyên mọi thứ. Cả hai đều có test khoá lại để chúng là quyết
+định, không phải điều bất ngờ.
 
 ### Viết hoa đầu câu
 
@@ -156,7 +161,7 @@ không dùng đường cảnh báo.
 
 | Tầng | Nội dung |
 | --- | --- |
-| `funput-core::textcase` | Năm hàm thuần + bảng `family → ASCII`. Không phụ thuộc, không alloc ngoài chuỗi kết quả. Sau cargo feature riêng, **mặc định tắt** như `charset` — iOS/Android không bao giờ biên dịch nó |
+| `funput-core::textcase` | Năm phép biến đổi thuần, không phụ thuộc, không alloc ngoài chuỗi kết quả, và không bảng dữ liệu mới nào. Sau cargo feature riêng, **mặc định tắt** như `charset` — iOS/Android không bao giờ biên dịch nó |
 | `funput-convert` | Trục thứ hai của `Session`: "đổi bảng mã" và "đổi kiểu chữ" dùng chung một `Session`, một `View`, một đường cảnh báo |
 | Ba shell | Chỉ tab, nút, và preview. Không quyết định gì — đúng hợp đồng `refresh()` / `view()` hiện tại |
 | `funput-cli` | `funput case --upper|--lower|--no-diacritics|--sentence|--title` đọc stdin. Rẻ, và là bề mặt test tốt nhất |
@@ -182,19 +187,22 @@ một phím "bỏ dấu" ngay trên bàn phím là hướng đi hợp lý về s
 kéo cả bốn codec bảng mã vào bản build của chúng, đúng thứ mà ghi chú của feature
 `charset` cấm.
 
-Crate riêng thì không, vì phần bỏ dấu **đọc bảng nguyên âm nội bộ của core**
-(`unicode::vowels::table::VOWEL_FAMILIES`, `vowel_stem`). Một crate ngoài chỉ có hai
-đường: chép lại bảng — hai nguồn sự thật cho cùng một dữ liệu — hoặc đổi bảng thành
-`pub`, biến chi tiết nội bộ thành API công khai của core cho đúng một người dùng.
+Crate riêng thì không, vì phần bỏ dấu **đọc thẳng ruột của core**:
+`unicode::shapes::base_vowel` và `unicode::combining::is_mark`, cả hai đều
+`pub(crate)`. Một crate ngoài chỉ có hai đường: chép lại dữ liệu — hai nguồn sự thật
+cho cùng một thứ — hoặc đổi chúng thành `pub`, biến chi tiết nội bộ thành API công khai
+của core cho đúng một người dùng.
 `funput-convert` là crate riêng vì lý do ngược lại: nó không cần ruột của core, nó cần
 nằm *trong* workspace để `cargo test --workspace` và `check-loc.sh` với tới hai shell
 bị loại khỏi workspace. `textcase` không có vấn đề đó.
 
 Hai chi tiết bắt buộc khi hiện thực:
 
-- `VOWEL_FAMILIES` hiện là `pub(crate)` sau `#[cfg(feature = "charset")]`. Phải nới
-  thành `#[cfg(any(feature = "charset", feature = "textcase"))]` — quên thì lỗi build
-  chỉ hiện ra ở đúng một tổ hợp feature.
+- Module `unicode::combining` (tám dấu tổ hợp) nằm sau
+  `#[cfg(any(feature = "charset", feature = "textcase"))]`: nới đúng lúc có người đọc
+  thứ hai, không nới trước — gate rộng hơn số người đọc là dead code, và bước CI
+  textcase-on/charset-off sẽ trượt vì `-D warnings`. Không có gate nào khác phải đổi;
+  `base_vowel` vốn đã `pub(crate)` không gated.
 - `funput-ffi` đã có cấu trúc hai tầng sẵn; chỉ thêm `textcase = ["funput-core/textcase"]`
   và đổi `convert` thành `["charset", "textcase", "dep:funput-convert"]`. Job CI hiện
   có (`cargo test -p funput-ffi --features convert`) phủ luôn, không cần job mới.

--- a/platforms/linux/README.md
+++ b/platforms/linux/README.md
@@ -314,10 +314,13 @@ settings-gtk/           App Cài đặt GTK4 + libadwaita (crate cargo riêng,
   src/settings_window/    mỗi trang preferences một submodule
     shortcuts/              công tắc gõ tắt, các hàng, trạng thái rỗng
   src/convert/            cửa sổ Chuyển mã — xem bên dưới
+    ui/casing/              thanh Kiểu chữ: các chip, và hàng "Đang áp"
 packaging/              hai file .desktop, metadata kho apt/dnf/pacman
 ```
 
 Mỗi thư mục giữ tối đa năm file; vượt quá thì tách theo mối quan tâm chứ không theo kích thước.
+`src/convert/ui/` hiện **đủ năm file**, nên widget tiếp theo của cửa sổ Chuyển mã sẽ phải mở một
+thư mục con chứ không thêm file vào đó.
 Mọi file ở đây bị giới hạn **150 dòng** bởi `scripts/check-loc.sh`, kể cả file test.
 
 ### Build
@@ -417,10 +420,16 @@ trên Windows — cảnh báo mất chữ, luật xử lý hàng loạt, tên th
 trùng tên bằng `vanban (2).txt`. Viết hai lần là cách để hai nền tảng bắt đầu bất đồng về cùng
 một tài liệu. Phần ở lại đây là kéo-thả, clipboard, hộp thoại, và đẩy I/O file ra khỏi luồng UI.
 
-`src/convert/state.rs` là file duy nhất dưới `convert/` có quyết định gì, và cũng là file duy
-nhất có test. Các file `ui/*` đọc state rồi set property, không quyết định gì. Một chốt
-`refreshing` canh mọi tín hiệu mà một lần refresh bắn ra — thiếu nó, refresh set dropdown sẽ tái
-nhập qua `notify::selected` và panic vì `borrow_mut` lồng nhau.
+Không file nào dưới `convert/` quyết định một lần chuyển mã ra sao: các file `ui/*` đọc `View`
+rồi set property, và `crates/funput-convert` giữ toàn bộ phần còn lại. Ngoại lệ duy nhất là
+`ui/casing.rs`, file `ui/*` duy nhất có test — bốn hàm thuần của nó quyết định phần **trình bày**
+của thanh Kiểu chữ (chip nào sáng, dòng `Đang áp` đọc ra sao, công tắc nào đang trên màn hình, và
+thanh có sống hay không), và cả bốn kiểm được mà không cần màn hình.
+
+Một chốt `refreshing` canh mọi tín hiệu mà một lần refresh bắn ra — thiếu nó, refresh set dropdown
+sẽ tái nhập qua `notify::selected` và panic vì `borrow_mut` lồng nhau. `gtk::Switch` của thanh
+Kiểu chữ cũng vậy qua `notify::active`, nên hai công tắc đi qua `widget::connect_switch` chứ không
+tự nối tay. Nút thì không cần: `clicked` không bao giờ nổ vì một lần ghi property.
 
 ### Chế độ không preedit
 

--- a/platforms/linux/settings-gtk/Cargo.lock
+++ b/platforms/linux/settings-gtk/Cargo.lock
@@ -107,6 +107,7 @@ version = "1.2026.1"
 dependencies = [
  "dirs",
  "funput-convert",
+ "funput-core",
  "gtk4",
  "libadwaita",
  "serde",

--- a/platforms/linux/settings-gtk/Cargo.toml
+++ b/platforms/linux/settings-gtk/Cargo.toml
@@ -21,9 +21,17 @@ path = "src/main.rs"
 # The Chuyển mã window's logic — reading a batch file by file, naming what a
 # conversion costs, writing copies beside the originals. Shared with the Windows
 # window so the two cannot drift; see crates/funput-convert/README.md. It re-exports
-# `funput_core::charset`, so this is the only edge needed and the `charset` feature is
-# switched on in exactly one manifest.
+# `funput_core::charset`, so nothing here ever has to name a `Charset` and the
+# `charset` feature stays switched on in exactly one manifest.
 funput-convert = { path = "../../../crates/funput-convert" }
+# Named for one reason: the casing bar decides which switch to show from *which
+# transform* is applied, and asking `casing::index_of(Transform::Title)` is the
+# alternative to writing that transform's position in the menu down as a number.
+# Windows makes the same edge for the same reason. Only `textcase` — the charset side
+# is reached through the re-export above. Considered and rejected: re-exporting
+# `textcase` from funput-convert, which would leave the two shells that mirror each
+# other spelling one type two different ways.
+funput-core = { path = "../../../crates/funput-core", features = ["textcase"] }
 gtk = { package = "gtk4", version = "0.9", features = ["v4_10"] }
 adw = { package = "libadwaita", version = "0.7", features = ["v1_5"] }
 serde = { version = "1", features = ["derive"] }

--- a/platforms/linux/settings-gtk/src/convert/open.rs
+++ b/platforms/linux/settings-gtk/src/convert/open.rs
@@ -83,7 +83,12 @@ fn build(app: &Application) -> Rc<Convert> {
     let weak = Rc::downgrade(&convert);
     convert.restart.connect_clicked(move |_| {
         if let Some(convert) = weak.upgrade() {
-            convert.session.borrow_mut().reset();
+            // A fresh session through the same door `build` used, not `reset()`:
+            // `reset` is `Session::new()`, which takes the row window back to the
+            // crate's own default and drops the cap this shell asked for. The two
+            // numbers agree today; nothing makes them agree tomorrow, and the Windows
+            // window has to re-state its own for exactly this reason.
+            *convert.session.borrow_mut() = session();
             convert.set_progress(String::new());
         }
     });

--- a/platforms/linux/settings-gtk/src/convert/ui.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui.rs
@@ -8,10 +8,14 @@
 //! directly, and [`Panes::refresh`] sets every property it owns rather than the ones
 //! it thinks changed.
 //!
+//! Two of the three shapes carry a [`casing::Bar`] as well, each its own instance —
+//! that file says why one widget could not serve both.
+//!
 //! Two places deviate, and each says why where it happens: the input buffer in
 //! [`text::Pane`], and the batch list in [`files::Pane`], which is the closest thing
 //! GTK has to Slint swapping a model.
 
+mod casing;
 mod empty;
 mod files;
 mod text;

--- a/platforms/linux/settings-gtk/src/convert/ui/casing.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/casing.rs
@@ -1,0 +1,200 @@
+//! The Kiểu chữ bar: five ways to re-case whatever the window is converting.
+//!
+//! The Chuyển mã window's second axis, and a bar rather than a tab because the two axes
+//! **compose** — a paragraph read out of TCVN3 can still be title-cased — so both
+//! choices belong on screen at once. A tab would say the user has to pick one.
+//! `docs/features/text-case.md` is where that decision lives.
+//!
+//! **Two instances, one session.** Slint uses a single `ConvertCasingBar` component in
+//! both shapes because its state arrives through a global; a `GtkWidget` has exactly one
+//! parent, so the text pane and the batch pane each own a [`Bar`]. They cannot disagree:
+//! the hidden pane is never refreshed, which is already how the two target dropdowns
+//! work.
+//!
+//! Nothing here decides what a transform *does*, or what it is called —
+//! `funput_convert::casing` owns the menu, its order, and the Vietnamese names, so the
+//! three shells cannot drift. What this file decides is presentation: which chip is lit,
+//! what the `Đang áp` line reads, which switch is on screen, and whether the bar is live
+//! at all. Those four are pure functions of the view, and the only thing here with
+//! tests.
+
+mod applied;
+mod chips;
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::Convert;
+use funput_convert::{Mode, View, casing};
+use funput_core::textcase::Transform;
+
+pub(in crate::convert) struct Bar {
+    pub(in crate::convert) root: gtk::Box,
+    chips: chips::Chips,
+    applied: applied::Applied,
+}
+
+impl Bar {
+    pub(in crate::convert) fn new() -> Self {
+        let chips = chips::Chips::new();
+        let applied = applied::Applied::new();
+
+        let root = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .spacing(6)
+            .build();
+        root.append(&chips.root);
+        root.append(&applied.root);
+
+        Self {
+            root,
+            chips,
+            applied,
+        }
+    }
+
+    pub(in crate::convert) fn wire(&self, convert: &Rc<Convert>) {
+        self.chips.wire(convert);
+        self.applied.wire(convert);
+    }
+
+    /// Takes no `&Rc<Convert>`, unlike the footer: nothing on this bar reads `is_busy`.
+    /// A batch already running cannot be changed by a press — `Session::batch_job`
+    /// snapshots the casing before the work leaves the thread — so leaving the bar live
+    /// during a run costs only that the `N chữ sẽ mất` column re-costs against a
+    /// transform the running job does not have. Windows makes the same call; macOS dims
+    /// the bar instead, and that difference is noted in the feature document.
+    pub(in crate::convert) fn refresh(&self, view: &View) {
+        // One call, not a hand-written dim as well: GTK fades an insensitive subtree
+        // itself, so there is nothing here to match the `opacity: 0.45` the Slint bar
+        // has to spell out.
+        self.root.set_sensitive(usable(view));
+        self.chips.refresh(&lit(view));
+        self.applied.refresh(view, &applied_line(view));
+    }
+}
+
+/// Which chips are lit — one bool per entry of `casing::ALL`, in menu order.
+fn lit(view: &View) -> Vec<bool> {
+    (0..casing::ALL.len())
+        .map(|index| view.transforms.contains(&index))
+        .collect()
+}
+
+/// The `Đang áp` line, empty when nothing is applied.
+///
+/// Spells the order out because the order changes the text: lowercase then title case
+/// is not title case then lowercase.
+fn applied_line(view: &View) -> String {
+    if view.transforms.is_empty() {
+        return String::new();
+    }
+    let names: Vec<&str> = view
+        .transforms
+        .iter()
+        .map(|&index| casing::name(casing::at(index)))
+        .collect();
+    format!("Đang áp: {}", names.join(" → "))
+}
+
+/// Whether a transform is applied, asked **by name** — so a switch's owner is never
+/// written down as a position in the menu, which is append-only and not ours to count.
+fn applies(view: &View, transform: Transform) -> bool {
+    casing::index_of(transform).is_some_and(|index| view.transforms.contains(&index))
+}
+
+/// Text nothing can read cannot be converted, and cannot be re-cased either: one rule,
+/// not two. A batch carries a charset per row, so it is never blocked.
+fn usable(view: &View) -> bool {
+    view.mode == Mode::Files || view.source.is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use funput_convert::Session;
+
+    /// A settled document with some transforms pressed, in the order given.
+    ///
+    /// Drives a real `Session` because `View` is `#[non_exhaustive]` — the same reason
+    /// the Windows tests do, and the reason these assertions are worth having: they
+    /// check this window against the crate rather than against a fixture of its own.
+    fn viewed(pressed: &[Transform]) -> Session {
+        let mut session = Session::new();
+        session.set_input("Tiếng Việt rất đẹp".to_string());
+        for &transform in pressed {
+            session.apply_transform(casing::index_of(transform).expect("in the menu"));
+        }
+        session.refresh();
+        session
+    }
+
+    #[test]
+    fn the_menu_is_whole_before_anything_is_pressed() {
+        // Load-bearing here in a way it is not in Slint: the chips are built from
+        // `casing::ALL` and refreshed by zipping a slice of bools, so a length that
+        // drifted would quietly stop lighting the last chip rather than fail.
+        let session = viewed(&[]);
+        let lit = lit(session.view());
+        assert_eq!(lit.len(), casing::ALL.len());
+        assert!(lit.iter().all(|on| !on));
+    }
+
+    #[test]
+    fn a_pressed_transform_lights_its_own_chip() {
+        let session = viewed(&[Transform::Lower]);
+        let lower = casing::index_of(Transform::Lower).expect("in the menu");
+        for (index, on) in lit(session.view()).into_iter().enumerate() {
+            assert_eq!(on, index == lower, "chip {index}");
+        }
+    }
+
+    #[test]
+    fn the_applied_line_is_empty_until_something_is_pressed() {
+        assert_eq!(applied_line(viewed(&[]).view()), "");
+    }
+
+    #[test]
+    fn the_applied_line_reads_in_the_order_pressed() {
+        let session = viewed(&[Transform::Lower, Transform::Title]);
+        assert_eq!(
+            applied_line(session.view()),
+            "Đang áp: chữ thường → Viết Hoa Đầu Mỗi Từ"
+        );
+        let session = viewed(&[Transform::Title, Transform::Lower]);
+        assert_eq!(
+            applied_line(session.view()),
+            "Đang áp: Viết Hoa Đầu Mỗi Từ → chữ thường"
+        );
+    }
+
+    #[test]
+    fn a_switch_shows_only_for_the_transform_that_owns_it() {
+        let session = viewed(&[Transform::NoDiacritics]);
+        assert!(applies(session.view(), Transform::NoDiacritics));
+        assert!(!applies(session.view(), Transform::Title));
+    }
+
+    #[test]
+    fn typing_a_new_document_takes_the_transforms_off() {
+        let mut session = viewed(&[Transform::Upper]);
+        session.set_input("Một đoạn khác".to_string());
+        session.refresh();
+        assert_eq!(applied_line(session.view()), "");
+        assert!(lit(session.view()).iter().all(|on| !on));
+    }
+
+    #[test]
+    fn the_bar_is_dead_until_a_charset_explains_the_document() {
+        // The batch arm is not reachable without files on disk; `Mode::Files` carrying
+        // a charset per row is the crate's invariant and is tested there.
+        let mut session = Session::new();
+        session.set_input("hello world".to_string());
+        session.refresh();
+        assert!(!usable(session.view()));
+        session.set_input("Tiếng Việt".to_string());
+        session.refresh();
+        assert!(usable(session.view()));
+    }
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/casing.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/casing.rs
@@ -131,12 +131,13 @@ mod tests {
     }
 
     #[test]
-    fn the_menu_is_whole_before_anything_is_pressed() {
-        // Load-bearing here in a way it is not in Slint: the chips are built from
-        // `casing::ALL` and refreshed by zipping a slice of bools, so a length that
-        // drifted would quietly stop lighting the last chip rather than fail.
-        let session = viewed(&[]);
-        let lit = lit(session.view());
+    fn a_fresh_document_lights_nothing() {
+        // What this locks is that the menu is offered whole with nothing applied — a
+        // press is the only thing that lights a chip. It deliberately does *not* claim
+        // to catch a chip count that drifted from `casing::ALL`: `lit` counts from
+        // `casing::ALL` too, so any length a test could assert here is the same number
+        // twice. That invariant is asserted where the widgets are, in `Chips::refresh`.
+        let lit = lit(viewed(&[]).view());
         assert_eq!(lit.len(), casing::ALL.len());
         assert!(lit.iter().all(|on| !on));
     }

--- a/platforms/linux/settings-gtk/src/convert/ui/casing/applied.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/casing/applied.rs
@@ -1,0 +1,125 @@
+//! The second row: what is applied, the switches that belong to it, and the ways out.
+//!
+//! Shown and hidden as one unit, because with nothing applied there is no `Đang áp` line
+//! to write, neither switch has a transform to belong to, and there is nothing to undo.
+//! Same rule the loss warning follows one pane over: a row that is always there is a row
+//! people stop reading.
+//!
+//! `gtk::Switch` with a label beside it, not `adw::SwitchRow`. A `SwitchRow` is an
+//! `ActionRow` built to sit inside a `.boxed-list`; dropped into a horizontal bar it
+//! renders as a full-width row with its own padding and background. The price of the
+//! bare switch is that it carries no accessible name, so each one is pointed at its own
+//! label — the one thing `SwitchRow` would have given for free.
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::Convert;
+use crate::convert::ui::widget;
+use funput_convert::View;
+use funput_core::textcase::Transform;
+
+pub(super) struct Applied {
+    pub(super) root: gtk::Box,
+    line: gtk::Label,
+    keep_d: Toggle,
+    flatten_caps: Toggle,
+    undo: gtk::Button,
+    clear: gtk::Button,
+}
+
+/// A switch and the label that names it, shown and hidden together.
+struct Toggle {
+    root: gtk::Box,
+    switch: gtk::Switch,
+}
+
+impl Applied {
+    pub(super) fn new() -> Self {
+        let line = widget::caption("");
+        line.set_hexpand(true);
+        line.set_ellipsize(gtk::pango::EllipsizeMode::End);
+
+        // Each switch is named for what it turns *on*, so both read as off by default.
+        // That is the crate's rule, not this window's, which is why neither is given a
+        // starting value here — `refresh` takes both from the view.
+        let keep_d = toggle("Giữ đ/Đ");
+        let flatten_caps = toggle("Hạ chữ viết hoa");
+        // Escape hatches, so no accent: `suggested-action` is spoken for by the one
+        // action each pane exists to perform.
+        let undo = gtk::Button::with_label("Hoàn tác");
+        let clear = gtk::Button::with_label("Bỏ hết");
+
+        let root = gtk::Box::builder().spacing(12).build();
+        root.append(&line);
+        root.append(&keep_d.root);
+        root.append(&flatten_caps.root);
+        root.append(&undo);
+        root.append(&clear);
+
+        Self {
+            root,
+            line,
+            keep_d,
+            flatten_caps,
+            undo,
+            clear,
+        }
+    }
+
+    pub(super) fn wire(&self, convert: &Rc<Convert>) {
+        widget::connect_switch(&self.keep_d.switch, convert, |convert, on| {
+            convert.session.borrow_mut().set_keep_d(on);
+        });
+        widget::connect_switch(&self.flatten_caps.switch, convert, |convert, on| {
+            convert.session.borrow_mut().set_flatten_caps(on);
+        });
+        // Undo removes the **last** transform, not all of them: a mistaken third press
+        // should not cost the two before it. `Bỏ hết` is the one that goes back to the
+        // original.
+        widget::click(&self.undo, convert, |convert| {
+            convert.session.borrow_mut().undo_transform();
+            convert.refresh();
+        });
+        widget::click(&self.clear, convert, |convert| {
+            convert.session.borrow_mut().clear_transforms();
+            convert.refresh();
+        });
+    }
+
+    pub(super) fn refresh(&self, view: &View, line: &str) {
+        self.root.set_visible(!line.is_empty());
+        self.line.set_label(line);
+        // A switch is on screen only while the transform that owns it is applied. Any
+        // other time it has nothing to say, and showing it only then is how the window
+        // teaches which transform owns which.
+        self.keep_d
+            .refresh(super::applies(view, Transform::NoDiacritics), view.keep_d);
+        self.flatten_caps
+            .refresh(super::applies(view, Transform::Title), view.flatten_caps);
+    }
+}
+
+impl Toggle {
+    fn refresh(&self, shown: bool, on: bool) {
+        self.root.set_visible(shown);
+        self.switch.set_active(on);
+    }
+}
+
+fn toggle(label: &str) -> Toggle {
+    let caption = gtk::Label::builder()
+        .label(label)
+        .valign(gtk::Align::Center)
+        .build();
+    let switch = gtk::Switch::builder().valign(gtk::Align::Center).build();
+    switch.update_relation(&[gtk::accessible::Relation::LabelledBy(&[
+        caption.upcast_ref()
+    ])]);
+
+    let root = gtk::Box::builder().spacing(6).build();
+    root.append(&caption);
+    root.append(&switch);
+    Toggle { root, switch }
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/casing/chips.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/casing/chips.rs
@@ -1,0 +1,119 @@
+//! The five transform chips.
+//!
+//! Buttons, not toggles. A press **stacks** a transform onto the list, and pressing the
+//! one already on top is a no-op in the crate because every transform is idempotent. A
+//! toggle would promise that the second click takes it back off — that is `Hoàn tác`'s
+//! job, and not necessarily for the same transform — and it would flip itself before the
+//! refresh flipped it back, which is a re-entrancy hole bought for nothing.
+//!
+//! Plain buttons in a `FlowBox`, not libadwaita's `pill`. The five Vietnamese names come
+//! to roughly 530px of text and `.pill` adds 64px of padding to each, which would put
+//! the row past this window's 880px default and well past its 640px minimum — and GTK
+//! raises a window's minimum to fit its children, so the capsule that looks right on
+//! macOS and Windows would leave Chuyển mã unable to shrink. A `FlowBox` wraps the row
+//! instead, and only when the user makes the window narrow. `adw::WrapBox` is the
+//! better container for this and needs no uniform columns, but it arrived in libadwaita
+//! 1.7 and this crate targets 1.5 — worth revisiting when the floor moves.
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::Convert;
+use crate::convert::ui::widget;
+use funput_convert::casing;
+
+pub(super) struct Chips {
+    pub(super) root: gtk::Box,
+    chips: Vec<Chip>,
+}
+
+struct Chip {
+    button: gtk::Button,
+    tick: gtk::Image,
+}
+
+impl Chips {
+    pub(super) fn new() -> Self {
+        let flow = gtk::FlowBox::builder()
+            .selection_mode(gtk::SelectionMode::None)
+            .min_children_per_line(1)
+            .max_children_per_line(casing::ALL.len() as u32)
+            .homogeneous(false)
+            .row_spacing(6)
+            .column_spacing(6)
+            .accessible_role(gtk::AccessibleRole::Group)
+            .build();
+        let chips: Vec<Chip> = casing::ALL
+            .iter()
+            .map(|&transform| chip(casing::name(transform)))
+            .collect();
+        for chip in &chips {
+            flow.append(&chip.button);
+        }
+
+        // Aligned to the top, not centred: when the row wraps, the label belongs beside
+        // the first line of chips rather than floating between the two.
+        let label = widget::caption("Kiểu chữ");
+        label.set_valign(gtk::Align::Start);
+        label.set_margin_top(8);
+
+        let root = gtk::Box::builder().spacing(8).build();
+        root.append(&label);
+        root.append(&flow);
+        Self { root, chips }
+    }
+
+    pub(super) fn wire(&self, convert: &Rc<Convert>) {
+        for (index, chip) in self.chips.iter().enumerate() {
+            widget::click(&chip.button, convert, move |convert| {
+                convert.session.borrow_mut().apply_transform(index);
+                convert.refresh();
+            });
+        }
+    }
+
+    pub(super) fn refresh(&self, lit: &[bool]) {
+        for (chip, &on) in self.chips.iter().zip(lit) {
+            chip.tick.set_visible(on);
+            // Bound rather than written inline: the two arms are arrays of different
+            // length, and `set_css_classes` wants one slice type.
+            let classes: &[&str] = if on { &["suggested-action"] } else { &[] };
+            chip.button.set_css_classes(classes);
+            // The tick is the cue for someone who cannot read the accent; this is the
+            // one a screen reader reads. Either way, colour alone says nothing.
+            chip.button
+                .update_state(&[gtk::accessible::State::Pressed(if on {
+                    gtk::AccessibleTristate::True
+                } else {
+                    gtk::AccessibleTristate::False
+                })]);
+        }
+    }
+}
+
+/// One chip: a tick that appears once the transform is applied, then its name.
+///
+/// `object-select-symbolic` because it ships inside GTK's own icon resource as well as
+/// in the system Adwaita theme. `check-plain-symbolic` and `emblem-ok-symbolic` are not
+/// in Adwaita on 24.04 and would render as a missing image.
+fn chip(name: &str) -> Chip {
+    let tick = gtk::Image::builder()
+        .icon_name("object-select-symbolic")
+        .pixel_size(12)
+        .visible(false)
+        .build();
+    let content = gtk::Box::builder().spacing(6).build();
+    content.append(&tick);
+    content.append(&gtk::Label::new(Some(name)));
+
+    // `Align::Start` because a `FlowBox` gives every cell in a wrapped row the width of
+    // its widest child. Without this, `CHỮ HOA` would be a wide button at 640px and a
+    // narrow one at 880px — a chip that changes size with the window is a chip that
+    // looks like a different control.
+    let button = gtk::Button::builder()
+        .child(&content)
+        .halign(gtk::Align::Start)
+        .build();
+    Chip { button, tick }
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/casing/chips.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/casing/chips.rs
@@ -6,14 +6,10 @@
 //! job, and not necessarily for the same transform — and it would flip itself before the
 //! refresh flipped it back, which is a re-entrancy hole bought for nothing.
 //!
-//! Plain buttons in a `FlowBox`, not libadwaita's `pill`. The five Vietnamese names come
-//! to roughly 530px of text and `.pill` adds 64px of padding to each, which would put
-//! the row past this window's 880px default and well past its 640px minimum — and GTK
-//! raises a window's minimum to fit its children, so the capsule that looks right on
-//! macOS and Windows would leave Chuyển mã unable to shrink. A `FlowBox` wraps the row
-//! instead, and only when the user makes the window narrow. `adw::WrapBox` is the
-//! better container for this and needs no uniform columns, but it arrived in libadwaita
-//! 1.7 and this crate targets 1.5 — worth revisiting when the floor moves.
+//! Plain buttons in a `FlowBox`, not libadwaita's `pill`, and not `adw::WrapBox` —
+//! `docs/features/text-case.md` carries the measurements behind both, next to the same
+//! call made for the other two shells. What matters here is the consequence: the row
+//! wraps when the window is narrow rather than refusing to be narrow.
 
 use std::rc::Rc;
 
@@ -22,6 +18,10 @@ use adw::prelude::*;
 use crate::convert::Convert;
 use crate::convert::ui::widget;
 use funput_convert::casing;
+
+/// The accent fill an applied chip wears — named so the write and the read-back that
+/// decides whether to write cannot drift apart.
+const ACCENT: &str = "suggested-action";
 
 pub(super) struct Chips {
     pub(super) root: gtk::Box,
@@ -81,10 +81,19 @@ impl Chips {
         // drift — only a live `Chips` knows how many widgets it actually built.
         debug_assert_eq!(self.chips.len(), lit.len(), "a chip per transform");
         for (chip, &on) in self.chips.iter().zip(lit) {
+            // Skip what did not change, as `widget::select` does — this runs on every
+            // keystroke. Read the current state off the chip's own class list, never
+            // from `is_visible`, which answers for the ancestor chain too and would
+            // call every chip off while the pane is hidden — skipping the write that
+            // clears a stale accent. `chip` builds in the `false` state, so the first
+            // refresh has nothing to correct.
+            if chip.button.has_css_class(ACCENT) == on {
+                continue;
+            }
             chip.tick.set_visible(on);
             // Bound rather than written inline: the two arms are arrays of different
             // length, and `set_css_classes` wants one slice type.
-            let classes: &[&str] = if on { &["suggested-action"] } else { &[] };
+            let classes: &[&str] = if on { &[ACCENT] } else { &[] };
             chip.button.set_css_classes(classes);
             // The tick is the cue for someone who cannot read the accent; this is the
             // one a screen reader reads. Either way, colour alone says nothing.
@@ -121,5 +130,11 @@ fn chip(name: &str) -> Chip {
         .child(&content)
         .halign(gtk::Align::Start)
         .build();
+    // Stated here, not left to the first refresh, which skips a chip already in the
+    // state it wants: otherwise a never-pressed chip carries no pressed state while a
+    // cleared one carries `False`, and a screen reader describes them differently.
+    button.update_state(&[gtk::accessible::State::Pressed(
+        gtk::AccessibleTristate::False,
+    )]);
     Chip { button, tick }
 }

--- a/platforms/linux/settings-gtk/src/convert/ui/casing/chips.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/casing/chips.rs
@@ -74,6 +74,12 @@ impl Chips {
     }
 
     pub(super) fn refresh(&self, lit: &[bool]) {
+        // `zip` stops at the shorter side, so a chip count that drifted from the menu
+        // would leave the last chip showing whatever it showed last rather than fail.
+        // The assertion belongs here, not in a test: both sides of the comparison a
+        // test could make are derived from `casing::ALL`, so a test cannot see the
+        // drift — only a live `Chips` knows how many widgets it actually built.
+        debug_assert_eq!(self.chips.len(), lit.len(), "a chip per transform");
         for (chip, &on) in self.chips.iter().zip(lit) {
             chip.tick.set_visible(on);
             // Bound rather than written inline: the two arms are arrays of different

--- a/platforms/linux/settings-gtk/src/convert/ui/files.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/files.rs
@@ -12,6 +12,7 @@
 //! a nasty bug to own, and the boxed list is what the rest of this app looks like.
 
 mod row;
+mod show;
 
 use std::rc::Rc;
 
@@ -19,7 +20,6 @@ use adw::prelude::*;
 
 use crate::convert::ui::widget;
 use crate::convert::{Convert, io};
-use funput_convert::View;
 
 /// How many rows to build at once.
 ///
@@ -97,47 +97,5 @@ impl Pane {
                 io::convert_files(&convert);
             }
         });
-    }
-
-    pub(in crate::convert) fn refresh(&self, convert: &Rc<Convert>, view: &View) {
-        self.count.set_label(&format!("{} tệp", view.rows_total));
-        widget::select(&self.target, Some(view.target));
-
-        while let Some(child) = self.list.first_child() {
-            self.list.remove(&child);
-        }
-        for (offset, row) in view.rows.iter().enumerate() {
-            self.list
-                .append(&row::build(convert, view.rows_first + offset, row));
-        }
-        let shown = view.rows_first + view.rows.len();
-        if shown < view.rows_total {
-            let more = adw::ActionRow::builder()
-                .title(format!("và {} tệp khác", view.rows_total - shown))
-                .css_classes(["dim-label"])
-                .build();
-            self.list.append(&more);
-        }
-
-        // A file nothing explained is skipped, not guessed at, so the button counts
-        // only what is settled — and says so, rather than promising the whole batch.
-        self.action.set_label(&format!("Chuyển {} tệp", view.ready));
-        self.action
-            .set_sensitive(view.ready > 0 && !convert.is_busy());
-
-        // Before a run, the footer is a promise about where the files will land; once
-        // one has happened, it is the report. Never both, and never the promise after.
-        //
-        // A file that could not be read is *named* here rather than counted — a
-        // number cannot answer "which two of my ten".
-        let progress = convert.progress();
-        let footer = if !progress.is_empty() {
-            progress
-        } else if view.unreadable.is_empty() {
-            format!("Lưu vào: {}", view.out_dir)
-        } else {
-            funput_convert::unreadable_line(&view.unreadable)
-        };
-        self.progress.set_label(&footer);
     }
 }

--- a/platforms/linux/settings-gtk/src/convert/ui/files.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/files.rs
@@ -18,7 +18,7 @@ use std::rc::Rc;
 
 use adw::prelude::*;
 
-use crate::convert::ui::widget;
+use crate::convert::ui::{casing, widget};
 use crate::convert::{Convert, io};
 
 /// How many rows to build at once.
@@ -33,6 +33,7 @@ pub(in crate::convert) struct Pane {
     pub(in crate::convert) root: gtk::Box,
     count: gtk::Label,
     target: gtk::DropDown,
+    casing: casing::Bar,
     list: gtk::ListBox,
     progress: gtk::Label,
     action: gtk::Button,
@@ -49,6 +50,7 @@ impl Pane {
         head.append(&widget::caption("Sang"));
         head.append(&target);
 
+        let casing = casing::Bar::new();
         let list = gtk::ListBox::builder()
             .selection_mode(gtk::SelectionMode::None)
             .css_classes(["boxed-list"])
@@ -74,6 +76,9 @@ impl Pane {
             .spacing(12)
             .build();
         root.append(&head);
+        // One transform applies to the whole batch, the way one target charset
+        // does — so it sits in the header, not in every row.
+        root.append(&casing.root);
         root.append(&scroller);
         root.append(&footer);
 
@@ -81,6 +86,7 @@ impl Pane {
             root,
             count,
             target,
+            casing,
             list,
             progress,
             action,
@@ -88,6 +94,7 @@ impl Pane {
     }
 
     pub(in crate::convert) fn wire(&self, convert: &Rc<Convert>) {
+        self.casing.wire(convert);
         widget::connect_dropdown(&self.target, convert, |convert, index| {
             convert.session.borrow_mut().set_target(index);
         });

--- a/platforms/linux/settings-gtk/src/convert/ui/files/show.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/files/show.rs
@@ -1,0 +1,64 @@
+//! Filling the batch pane from the state.
+//!
+//! Split out of [`super`] for the same reason [`crate::convert::ui::text::show`] was:
+//! the pane file holds the skeleton and the wiring, and the redraw is a separate
+//! concern that grows on its own schedule. Batch mode had run out of room in one file
+//! long before the second axis arrived.
+//!
+//! The list is rebuilt rather than updated in place — the reason is in [`super`]'s doc,
+//! and it is the one place in this window that deviates from "set properties, never
+//! build widgets" on purpose.
+
+use std::rc::Rc;
+
+use adw::prelude::*;
+
+use crate::convert::Convert;
+use crate::convert::ui::widget;
+use funput_convert::View;
+
+use super::{Pane, row};
+
+impl Pane {
+    pub(in crate::convert) fn refresh(&self, convert: &Rc<Convert>, view: &View) {
+        self.count.set_label(&format!("{} tệp", view.rows_total));
+        widget::select(&self.target, Some(view.target));
+
+        while let Some(child) = self.list.first_child() {
+            self.list.remove(&child);
+        }
+        for (offset, row) in view.rows.iter().enumerate() {
+            self.list
+                .append(&row::build(convert, view.rows_first + offset, row));
+        }
+        let shown = view.rows_first + view.rows.len();
+        if shown < view.rows_total {
+            let more = adw::ActionRow::builder()
+                .title(format!("và {} tệp khác", view.rows_total - shown))
+                .css_classes(["dim-label"])
+                .build();
+            self.list.append(&more);
+        }
+
+        // A file nothing explained is skipped, not guessed at, so the button counts
+        // only what is settled — and says so, rather than promising the whole batch.
+        self.action.set_label(&format!("Chuyển {} tệp", view.ready));
+        self.action
+            .set_sensitive(view.ready > 0 && !convert.is_busy());
+
+        // Before a run, the footer is a promise about where the files will land; once
+        // one has happened, it is the report. Never both, and never the promise after.
+        //
+        // A file that could not be read is *named* here rather than counted — a
+        // number cannot answer "which two of my ten".
+        let progress = convert.progress();
+        let footer = if !progress.is_empty() {
+            progress
+        } else if view.unreadable.is_empty() {
+            format!("Lưu vào: {}", view.out_dir)
+        } else {
+            funput_convert::unreadable_line(&view.unreadable)
+        };
+        self.progress.set_label(&footer);
+    }
+}

--- a/platforms/linux/settings-gtk/src/convert/ui/files/show.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/files/show.rs
@@ -23,6 +23,7 @@ impl Pane {
     pub(in crate::convert) fn refresh(&self, convert: &Rc<Convert>, view: &View) {
         self.count.set_label(&format!("{} tệp", view.rows_total));
         widget::select(&self.target, Some(view.target));
+        self.casing.refresh(view);
 
         while let Some(child) = self.list.first_child() {
             self.list.remove(&child);

--- a/platforms/linux/settings-gtk/src/convert/ui/text.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/text.rs
@@ -19,7 +19,7 @@ use std::rc::Rc;
 use adw::prelude::*;
 
 use crate::convert::Convert;
-use crate::convert::ui::widget;
+use crate::convert::ui::{casing, widget};
 
 pub(in crate::convert) struct Pane {
     pub(in crate::convert) root: gtk::Box,
@@ -28,6 +28,7 @@ pub(in crate::convert) struct Pane {
     target: gtk::DropDown,
     input: gtk::TextView,
     output: gtk::TextView,
+    casing: casing::Bar,
     loss: gtk::Label,
     footer: footer::Footer,
 }
@@ -63,12 +64,16 @@ impl Pane {
             .css_classes(["warning", "caption"])
             .build();
 
+        let casing = casing::Bar::new();
         let footer = footer::Footer::new();
         let root = gtk::Box::builder()
             .orientation(gtk::Orientation::Vertical)
             .spacing(12)
             .build();
         root.append(&head);
+        // Right under the charset row: changing the charset and changing the case
+        // are two choices about one document, and they add up.
+        root.append(&casing.root);
         root.append(&panes);
         root.append(&loss);
         root.append(&footer.root);
@@ -80,6 +85,7 @@ impl Pane {
             target,
             input,
             output,
+            casing,
             loss,
             footer,
         }
@@ -109,6 +115,7 @@ impl Pane {
         widget::connect_dropdown(&self.target, convert, |convert, index| {
             convert.session.borrow_mut().set_target(index);
         });
+        self.casing.wire(convert);
         self.footer.wire(convert);
     }
 }

--- a/platforms/linux/settings-gtk/src/convert/ui/text/footer.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/text/footer.rs
@@ -52,9 +52,9 @@ impl Footer {
     }
 
     pub(in crate::convert) fn wire(&self, convert: &Rc<Convert>) {
-        click(&self.copy, convert, io::copy_result);
-        click(&self.save, convert, io::save_result);
-        click(&self.convert_file, convert, io::convert_files);
+        widget::click(&self.copy, convert, io::copy_result);
+        widget::click(&self.save, convert, io::save_result);
+        widget::click(&self.convert_file, convert, io::convert_files);
     }
 
     pub(in crate::convert) fn refresh(&self, convert: &Rc<Convert>, view: &View) {
@@ -68,13 +68,4 @@ impl Footer {
         self.convert_file.set_sensitive(ready && !convert.is_busy());
         self.progress.set_label(&convert.progress());
     }
-}
-
-fn click(button: &gtk::Button, convert: &Rc<Convert>, action: fn(&Rc<Convert>)) {
-    let weak = Rc::downgrade(convert);
-    button.connect_clicked(move |_| {
-        if let Some(convert) = weak.upgrade() {
-            action(&convert);
-        }
-    });
 }

--- a/platforms/linux/settings-gtk/src/convert/ui/text/show.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/text/show.rs
@@ -35,6 +35,7 @@ impl Pane {
         if let Some(text) = &view.input_preview {
             self.show_input(text);
         }
+        self.casing.refresh(view);
         self.output.buffer().set_text(&view.output_preview);
         self.loss.set_label(&view.warning);
         self.loss.set_visible(!view.warning.is_empty());

--- a/platforms/linux/settings-gtk/src/convert/ui/widget.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/widget.rs
@@ -84,8 +84,8 @@ pub(in crate::convert) fn connect_dropdown(
 ///
 /// No [`Convert::is_refreshing`] guard, and that is not an oversight: `clicked` is only
 /// ever emitted by a real press, never by a property write, so a refresh cannot come
-/// back in through this door the way it can through [`connect_dropdown`]. Nor does
-/// this call `refresh` for the caller — some actions edit
+/// back in through this door the way it can through [`connect_dropdown`] or
+/// [`connect_switch`]. Nor does this call `refresh` for the caller — some actions edit
 /// the session and want one, others only read it and would redraw for nothing.
 ///
 /// Takes a closure rather than a `fn` pointer so a caller can capture, which is how the
@@ -100,5 +100,30 @@ pub(in crate::convert) fn click(
         if let Some(convert) = weak.upgrade() {
             action(&convert);
         }
+    });
+}
+
+/// Connect a switch to a state edit.
+///
+/// The guard is not optional here the way it is for [`click`]. `set_active` does emit
+/// `notify::active`, so a refresh correcting a stale switch would come straight back in
+/// as the user's own choice and undo the correction. No unchanged-write check like
+/// [`select`]'s is needed: `gtk_switch_set_active` returns early when the value already
+/// matches.
+pub(in crate::convert) fn connect_switch(
+    switch: &gtk::Switch,
+    convert: &Rc<Convert>,
+    edit: impl Fn(&Rc<Convert>, bool) + 'static,
+) {
+    let weak = Rc::downgrade(convert);
+    switch.connect_active_notify(move |switch| {
+        let Some(convert) = weak.upgrade() else {
+            return;
+        };
+        if convert.is_refreshing() {
+            return;
+        }
+        edit(&convert, switch.is_active());
+        convert.refresh();
     });
 }

--- a/platforms/linux/settings-gtk/src/convert/ui/widget.rs
+++ b/platforms/linux/settings-gtk/src/convert/ui/widget.rs
@@ -79,3 +79,26 @@ pub(in crate::convert) fn connect_dropdown(
         convert.refresh();
     });
 }
+
+/// Connect a button to something that reads or edits the state.
+///
+/// No [`Convert::is_refreshing`] guard, and that is not an oversight: `clicked` is only
+/// ever emitted by a real press, never by a property write, so a refresh cannot come
+/// back in through this door the way it can through [`connect_dropdown`]. Nor does
+/// this call `refresh` for the caller — some actions edit
+/// the session and want one, others only read it and would redraw for nothing.
+///
+/// Takes a closure rather than a `fn` pointer so a caller can capture, which is how the
+/// casing chips each know their own position in the menu.
+pub(in crate::convert) fn click(
+    button: &gtk::Button,
+    convert: &Rc<Convert>,
+    action: impl Fn(&Rc<Convert>) + 'static,
+) {
+    let weak = Rc::downgrade(convert);
+    button.connect_clicked(move |_| {
+        if let Some(convert) = weak.upgrade() {
+            action(&convert);
+        }
+    });
+}

--- a/platforms/macos/Funput/Convert/Bridge/ConvertFFI.swift
+++ b/platforms/macos/Funput/Convert/Bridge/ConvertFFI.swift
@@ -31,6 +31,17 @@ nonisolated final class ConvertFFISession: @unchecked Sendable {
         refresh()
     }
 
+    func apply(_ action: ConvertCasingAction) {
+        switch action {
+        case let .apply(index): funput_convert_session_apply_transform(handle, UInt(index))
+        case .undo: funput_convert_session_undo_transform(handle)
+        case .clear: funput_convert_session_clear_transforms(handle)
+        case let .setKeepD(on): funput_convert_session_set_keep_d(handle, on)
+        case let .setFlattenCaps(on): funput_convert_session_set_flatten_caps(handle, on)
+        }
+        refresh()
+    }
+
     func adopt(paths: [String]) -> Bool {
         guard let scan = funput_convert_scan_new() else { return false }
         defer { funput_convert_scan_free(scan) }
@@ -62,9 +73,15 @@ nonisolated final class ConvertFFISession: @unchecked Sendable {
         return Data(bytes)
     }
 
-    func state(input: String, charsets: [ConvertCharset]) -> ConvertScreenState {
+    func state(
+        input: String, charsets: [ConvertCharset], transforms: [ConvertTransform]
+    ) -> ConvertScreenState {
         let view = funput_convert_session_view(handle)
+        let casing = funput_convert_session_casing(handle)
         let rows = (0..<Int(view.rows_count)).map { row(at: $0, first: Int(view.rows_first)) }
+        let applied = (0..<Int(casing.count)).compactMap {
+            optional(funput_convert_session_applied_transform(handle, UInt($0)))
+        }
         return ConvertScreenState(
             mode: mode(view.mode), charsets: charsets, target: Int(view.target),
             source: optional(view.source), fromFile: view.from_file,
@@ -74,7 +91,9 @@ nonisolated final class ConvertFFISession: @unchecked Sendable {
             warning: readText { funput_convert_session_warning(handle, $0, $1) }, files: rows,
             rowsTotal: Int(view.rows_total), outputDirectory: readText { funput_convert_session_out_dir(handle, $0, $1) },
             unreadable: readText { funput_convert_session_unreadable_line(handle, $0, $1) },
-            progress: "", ready: Int(view.ready), isBusy: false, errorMessage: nil
+            progress: "", ready: Int(view.ready), isBusy: false, errorMessage: nil,
+            transforms: transforms, appliedTransforms: applied,
+            keepD: casing.keep_d, flattenCaps: casing.flatten_caps
         )
     }
 
@@ -89,7 +108,7 @@ nonisolated final class ConvertFFISession: @unchecked Sendable {
     private func refreshed() -> Bool { refresh(); return true }
 }
 
-nonisolated private func readText(_ body: (UnsafeMutablePointer<UInt32>?, UInt) -> UInt) -> String {
+nonisolated func readText(_ body: (UnsafeMutablePointer<UInt32>?, UInt) -> UInt) -> String {
     let count = body(nil, 0)
     var values = [UInt32](repeating: 0, count: Int(count))
     values.withUnsafeMutableBufferPointer { _ = body($0.baseAddress, UInt($0.count)) }

--- a/platforms/macos/Funput/Convert/Bridge/ConvertWorker.swift
+++ b/platforms/macos/Funput/Convert/Bridge/ConvertWorker.swift
@@ -3,14 +3,18 @@ import Foundation
 actor ConvertWorker {
     private let session: ConvertFFISession
     let charsets: [ConvertCharset]
+    let transforms: [ConvertTransform]
 
     init?() {
         guard let session = ConvertFFISession() else { return nil }
         self.session = session
         charsets = Self.loadCharsets()
+        transforms = Self.loadTransforms()
     }
 
-    func current(input: String) -> ConvertScreenState { session.state(input: input, charsets: charsets) }
+    func current(input: String) -> ConvertScreenState {
+        session.state(input: input, charsets: charsets, transforms: transforms)
+    }
     func reset() -> ConvertScreenState { session.reset(); return current(input: "") }
     func setInput(_ text: String) -> ConvertScreenState { session.setInput(text); return current(input: text) }
     func setTarget(_ value: Int, input: String) -> ConvertScreenState {
@@ -29,6 +33,9 @@ actor ConvertWorker {
         guard session.adopt(paths: urls.map(\.path)) else { return nil }
         return current(input: "")
     }
+    func casing(_ action: ConvertCasingAction, input: String) -> ConvertScreenState {
+        session.apply(action); return current(input: input)
+    }
     func resultText() -> String { session.resultText() }
     func saveBytes() -> Data { session.saveBytes() }
     func runBatch(input: String) -> (ConvertScreenState, String)? {
@@ -36,17 +43,19 @@ actor ConvertWorker {
         return (current(input: input), report)
     }
 
+    /// Both menus are read the same way — a count, then a name per index — so they
+    /// share `readText` rather than spelling the two-call dance out twice.
     nonisolated static func loadCharsets() -> [ConvertCharset] {
         (0..<Int(funput_charset_count())).map { index in
-            let name = readCharsetName(index)
-            return ConvertCharset(id: index, name: name)
+            ConvertCharset(id: index, name: readText { funput_charset_name(UInt(index), $0, $1) })
         }
     }
-}
 
-nonisolated private func readCharsetName(_ index: Int) -> String {
-    let count = funput_charset_name(UInt(index), nil, 0)
-    var values = [UInt32](repeating: 0, count: Int(count))
-    values.withUnsafeMutableBufferPointer { _ = funput_charset_name(UInt(index), $0.baseAddress, UInt($0.count)) }
-    return String(values.compactMap(UnicodeScalar.init).map(Character.init))
+    nonisolated static func loadTransforms() -> [ConvertTransform] {
+        (0..<Int(funput_convert_transform_count())).map { index in
+            ConvertTransform(
+                id: index, name: readText { funput_convert_transform_name(UInt(index), $0, $1) }
+            )
+        }
+    }
 }

--- a/platforms/macos/Funput/Convert/Casing/ConvertCasingBar.swift
+++ b/platforms/macos/Funput/Convert/Casing/ConvertCasingBar.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+/// The second axis of the Chuyển mã window: five transforms, the order they were
+/// pressed in, and the two switches that belong to them.
+///
+/// Not a tab. Changing a charset and changing the case are two choices about one
+/// document and they compose, so both stay on screen at once; a tab would say the
+/// user has to pick one.
+///
+/// Glass is for the controls only — the chips, Hoàn tác, Bỏ hết. The `Đang áp:`
+/// line is content-layer text and the switches are system controls, so nothing here
+/// nests one glass surface inside another (`docs/LIQUID_GLASS.md`).
+struct ConvertCasingBar: View {
+    let state: ConvertScreenState
+    let dispatch: ConvertDispatch
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            chips
+            if !state.appliedTransforms.isEmpty {
+                applied
+            }
+        }
+        .animation(reduceMotion ? nil : .snappy(duration: 0.28), value: state.appliedTransforms)
+    }
+
+    private var chips: some View {
+        GlassEffectContainer(spacing: Theme.Spacing.sm) {
+            HStack(spacing: Theme.Spacing.sm) {
+                Text("Kiểu chữ").font(.callout).foregroundStyle(.secondary).fixedSize()
+                ForEach(state.transforms) { transform in
+                    chip(transform)
+                }
+                Spacer()
+            }
+        }
+        .disabled(!state.canUseCasing)
+    }
+
+    /// A press appends; pressing the one already on top is a no-op in core, so the
+    /// chip is a button rather than a checkbox. The checkmark is the non-color cue
+    /// the guidelines require — the tint alone would not be one.
+    private func chip(_ transform: ConvertTransform) -> some View {
+        let isApplied = state.appliedTransforms.contains(transform.id)
+        return Button {
+            dispatch(.casing(.apply(transform.id)))
+        } label: {
+            HStack(spacing: Theme.Spacing.xs) {
+                if isApplied {
+                    Image(systemName: "checkmark").font(.caption2.weight(.bold))
+                }
+                Text(transform.name).font(.caption.weight(.semibold))
+            }
+            .lineLimit(1)
+            .padding(.horizontal, Theme.Spacing.sm)
+            .padding(.vertical, 5)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isApplied ? .white : .primary)
+        .glassEffect(
+            .regular.tint(isApplied ? Theme.accent : nil).interactive(),
+            in: .capsule
+        )
+        .accessibilityIdentifier("convert.casing.\(transform.id)")
+        .accessibilityAddTraits(isApplied ? .isSelected : [])
+        .accessibilityValue(isApplied ? "Đã áp" : "Chưa áp")
+    }
+
+    /// The order is the whole point — `chữ thường → Viết Hoa Đầu Mỗi Từ` is a
+    /// different document from the same two reversed — so it is spelled out rather
+    /// than left for the user to infer from which chips are lit.
+    private var applied: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Text("Đang áp: \(state.appliedTransformNames.joined(separator: " → "))")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .accessibilityIdentifier("convert.casing.applied")
+            switches
+            Spacer()
+            GlassEffectContainer(spacing: Theme.Spacing.sm) {
+                HStack(spacing: Theme.Spacing.sm) {
+                    Button("Hoàn tác", systemImage: "arrow.uturn.backward") {
+                        dispatch(.casing(.undo))
+                    }
+                    .buttonStyle(.glass)
+                    .accessibilityIdentifier("convert.casing.undo")
+                    Button("Bỏ hết") { dispatch(.casing(.clear)) }
+                        .buttonStyle(.glass)
+                        .accessibilityIdentifier("convert.casing.clear")
+                }
+            }
+        }
+        .transition(.opacity)
+    }
+
+    /// A switch appears only while the transform it belongs to is applied: it has
+    /// nothing to say otherwise, and showing it there teaches which one owns it.
+    @ViewBuilder private var switches: some View {
+        if state.showsSwitch(for: .noDiacritics) {
+            Toggle("Giữ đ/Đ", isOn: binding(\.keepD) { .setKeepD($0) })
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .accessibilityIdentifier("convert.casing.keepD")
+        }
+        if state.showsSwitch(for: .title) {
+            Toggle("Hạ chữ viết hoa", isOn: binding(\.flattenCaps) { .setFlattenCaps($0) })
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .accessibilityIdentifier("convert.casing.flattenCaps")
+        }
+    }
+
+    private func binding(
+        _ value: KeyPath<ConvertScreenState, Bool>,
+        _ action: @escaping (Bool) -> ConvertCasingAction
+    ) -> Binding<Bool> {
+        Binding(get: { state[keyPath: value] }, set: { dispatch(.casing(action($0))) })
+    }
+}
+
+#Preview("Đã áp hai phép") {
+    ConvertCasingBar(state: ConvertFixtures.cased, dispatch: { _ in })
+        .padding(Theme.Spacing.xl)
+        .frame(width: 920)
+        .background(.windowBackground)
+}

--- a/platforms/macos/Funput/Convert/Casing/ConvertCasingState.swift
+++ b/platforms/macos/Funput/Convert/Casing/ConvertCasingState.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// The second axis gets its own action namespace rather than five more cases on
+/// `ConvertAction`: the store's switch grows by one line instead of five, and it
+/// mirrors how the Rust and C layers keep the axis in a module of its own.
+enum ConvertCasingAction: Equatable {
+    case apply(Int)
+    case undo
+    case clear
+    case setKeepD(Bool)
+    case setFlattenCaps(Bool)
+}
+
+/// The two transforms that own a switch, by their fixed position in core's
+/// append-only menu (`funput_convert::casing::ALL`).
+enum ConvertTransformKind {
+    case noDiacritics
+    case title
+
+    var position: Int {
+        switch self {
+        case .noDiacritics: 2
+        case .title: 4
+        }
+    }
+}
+
+extension ConvertScreenState {
+    /// Whether the transform buttons do anything yet. A document whose charset
+    /// nothing could place is not converted, and core does not transform it either —
+    /// one rule, not two. A batch carries a charset per row, so it is never blocked.
+    var canUseCasing: Bool {
+        !isBusy && (mode == .files || source != nil)
+    }
+
+    /// The applied transforms as names, for the `Đang áp:` line.
+    var appliedTransformNames: [String] {
+        appliedTransforms.compactMap { position in
+            transforms.first { $0.id == position }?.name
+        }
+    }
+
+    /// A switch is shown only while the transform it belongs to is applied: it has
+    /// nothing to say otherwise, and showing it there teaches which one owns it.
+    func showsSwitch(for transform: ConvertTransformKind) -> Bool {
+        appliedTransforms.contains(transform.position)
+    }
+}

--- a/platforms/macos/Funput/Convert/ConvertFixtures.swift
+++ b/platforms/macos/Funput/Convert/ConvertFixtures.swift
@@ -8,6 +8,14 @@ enum ConvertFixtures {
         ConvertCharset(id: 3, name: "Unicode tổ hợp"),
     ]
 
+    static let transforms = [
+        ConvertTransform(id: 0, name: "CHỮ HOA"),
+        ConvertTransform(id: 1, name: "chữ thường"),
+        ConvertTransform(id: 2, name: "Bỏ dấu tiếng Việt"),
+        ConvertTransform(id: 3, name: "Viết hoa đầu câu"),
+        ConvertTransform(id: 4, name: "Viết Hoa Đầu Mỗi Từ"),
+    ]
+
     static let empty = state(mode: .empty)
 
     static let pasted = state(
@@ -40,6 +48,16 @@ enum ConvertFixtures {
         ready: 3
     )
 
+    /// A paste with two transforms on it, in an order that matters: lowercase then
+    /// title case is `Gửi Về Tp. Hcm`, the other way round is all lowercase.
+    static let cased = state(
+        mode: .text,
+        source: 0,
+        input: "GỬI VỀ TP. HCM",
+        output: "Gửi Về Tp. Hcm",
+        applied: [1, 4]
+    )
+
     static var busyBatch: ConvertScreenState {
         var value = batch
         value.isBusy = true
@@ -51,7 +69,7 @@ enum ConvertFixtures {
         mode: ConvertMode, target: Int = 0, source: Int? = nil, fromFile: Bool = false,
         fileName: String? = nil, input: String = "", output: String = "",
         warning: String = "", files: [ConvertFileRow] = [],
-        outputDirectory: String = "", ready: Int = 0
+        outputDirectory: String = "", ready: Int = 0, applied: [Int] = []
     ) -> ConvertScreenState {
         ConvertScreenState(
             mode: mode, charsets: charsets, target: target, source: source,
@@ -59,7 +77,8 @@ enum ConvertFixtures {
             outputText: output, warning: warning, files: files,
             rowsTotal: files.count, outputDirectory: outputDirectory,
             unreadable: "", progress: "", ready: ready,
-            isBusy: false, errorMessage: nil
+            isBusy: false, errorMessage: nil, transforms: transforms,
+            appliedTransforms: applied, keepD: false, flattenCaps: false
         )
     }
 }

--- a/platforms/macos/Funput/Convert/ConvertState.swift
+++ b/platforms/macos/Funput/Convert/ConvertState.swift
@@ -11,6 +11,12 @@ struct ConvertCharset: Identifiable, Equatable {
     let name: String
 }
 
+/// One entry of the transform menu, named by core so three platforms cannot drift.
+struct ConvertTransform: Identifiable, Equatable {
+    let id: Int
+    let name: String
+}
+
 struct ConvertFileRow: Identifiable, Equatable {
     let id: Int
     let name: String
@@ -36,6 +42,13 @@ struct ConvertScreenState: Equatable {
     var ready: Int
     var isBusy: Bool
     var errorMessage: String?
+    /// The menu, in core's order. A position here is the identity of a transform.
+    var transforms: [ConvertTransform]
+    /// What has been applied, in the order pressed — so `chữ thường → Viết Hoa Đầu
+    /// Mỗi Từ` is a different document from the same two the other way round.
+    var appliedTransforms: [Int]
+    var keepD: Bool
+    var flattenCaps: Bool
 
     var canUseTextResult: Bool {
         source != nil && !isBusy
@@ -52,6 +65,7 @@ struct ConvertScreenState: Equatable {
     var canLoadMore: Bool {
         files.count < rowsTotal && !isBusy
     }
+
 }
 
 enum ConvertAction: Equatable {
@@ -67,18 +81,20 @@ enum ConvertAction: Equatable {
     case convertFiles
     case loadMore
     case receiveFiles([URL])
+    case casing(ConvertCasingAction)
 }
 
 typealias ConvertDispatch = (ConvertAction) -> Void
 
 extension ConvertScreenState {
-    static func empty(charsets: [ConvertCharset]) -> Self {
+    static func empty(charsets: [ConvertCharset], transforms: [ConvertTransform]) -> Self {
         .init(
             mode: .empty, charsets: charsets, target: 0, source: nil,
             fromFile: false, fileName: nil, inputText: "", outputText: "",
             warning: "", files: [], rowsTotal: 0, outputDirectory: "",
             unreadable: "", progress: "", ready: 0, isBusy: false,
-            errorMessage: nil
+            errorMessage: nil, transforms: transforms, appliedTransforms: [],
+            keepD: false, flattenCaps: false
         )
     }
 }

--- a/platforms/macos/Funput/Convert/ConvertStore.swift
+++ b/platforms/macos/Funput/Convert/ConvertStore.swift
@@ -14,7 +14,7 @@ final class ConvertStore {
         let worker = ConvertWorker()
         self.worker = worker
         self.platform = platform ?? ConvertPlatform()
-        state = initialState ?? .empty(charsets: ConvertWorker.loadCharsets())
+        state = initialState ?? .empty(charsets: ConvertWorker.loadCharsets(), transforms: ConvertWorker.loadTransforms())
         if worker == nil { state.errorMessage = "Không khởi tạo được bộ chuyển mã." }
     }
     func send(_ action: ConvertAction) {
@@ -32,6 +32,7 @@ final class ConvertStore {
         case .saveResult: saveResult()
         case .convertFiles: convertFiles()
         case .loadMore: loadMore()
+        case let .casing(action): updateFlushing { await $0.casing(action, input: $1) }
         }
     }
     func dismissError() { state.errorMessage = nil }
@@ -90,7 +91,6 @@ final class ConvertStore {
             state.progress = platform.copy(text) ? "Đã chép kết quả" : "Không chép được kết quả"
         }
     }
-
     private func saveResult() {
         taskFlushing { [weak self] worker, _, token in
             let bytes = await worker.saveBytes()
@@ -99,7 +99,6 @@ final class ConvertStore {
             catch { state.errorMessage = "Không lưu được tệp: \(error.localizedDescription)" }
         }
     }
-
     private func convertFiles() {
         busy("Đang chuyển \(state.ready) tệp…") { worker in
             guard let result = await worker.runBatch(input: self.state.inputText) else { return nil }
@@ -108,7 +107,6 @@ final class ConvertStore {
             return next
         }
     }
-
     private func update(_ operation: @escaping (ConvertWorker) async -> ConvertScreenState) {
         generation += 1; let token = generation
         Task { guard let worker else { return }; let next = await operation(worker)

--- a/platforms/macos/Funput/Convert/Views/ConvertBatchView.swift
+++ b/platforms/macos/Funput/Convert/Views/ConvertBatchView.swift
@@ -7,6 +7,7 @@ struct ConvertBatchView: View {
     var body: some View {
         VStack(spacing: Theme.Spacing.md) {
             header
+            ConvertCasingBar(state: state, dispatch: dispatch)
             Table(state.files) {
                 TableColumn("Tệp") { row in
                     Label(row.name, systemImage: "doc.text")

--- a/platforms/macos/Funput/Convert/Views/ConvertComponents.swift
+++ b/platforms/macos/Funput/Convert/Views/ConvertComponents.swift
@@ -9,7 +9,7 @@ struct ConvertHeader: View {
             VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
                 Text("Chuyển mã")
                     .font(.largeTitle.bold())
-                Text("Chuyển văn bản giữa Unicode và các bảng mã tiếng Việt cũ.")
+                Text("Đổi bảng mã và kiểu chữ của văn bản đã có.")
                     .foregroundStyle(.secondary)
             }
             Spacer()

--- a/platforms/macos/Funput/Convert/Views/ConvertTextView.swift
+++ b/platforms/macos/Funput/Convert/Views/ConvertTextView.swift
@@ -7,6 +7,7 @@ struct ConvertTextView: View {
     var body: some View {
         VStack(spacing: Theme.Spacing.md) {
             selectors
+            ConvertCasingBar(state: state, dispatch: dispatch)
             HStack(spacing: Theme.Spacing.md) {
                 ConvertEditorPane(
                     title: state.fromFile ? state.fileName ?? "Tệp nguồn" : "Đang có",

--- a/platforms/macos/FunputTests/Convert/ConvertBridgeTests.swift
+++ b/platforms/macos/FunputTests/Convert/ConvertBridgeTests.swift
@@ -9,7 +9,10 @@ final class ConvertBridgeTests: XCTestCase {
         bridge.setSource(0)
         bridge.setTarget(1)
 
-        let state = bridge.state(input: "Việt", charsets: ConvertWorker.loadCharsets())
+        let state = bridge.state(
+            input: "Việt", charsets: ConvertWorker.loadCharsets(),
+            transforms: ConvertWorker.loadTransforms()
+        )
 
         XCTAssertEqual(state.mode, .text)
         XCTAssertEqual(state.source, 0)
@@ -26,14 +29,14 @@ final class ConvertBridgeTests: XCTestCase {
         let bridge = try XCTUnwrap(ConvertFFISession())
 
         XCTAssertTrue(bridge.adopt(paths: [directory.path]))
-        let first = bridge.state(input: "", charsets: [])
+        let first = bridge.state(input: "", charsets: [], transforms: [])
         XCTAssertEqual(first.rowsTotal, 501)
         XCTAssertEqual(first.files.count, 500)
         XCTAssertEqual(first.files.first?.id, 0)
         XCTAssertEqual(first.files.last?.id, 499)
 
         bridge.setRowCount(1_000)
-        let expanded = bridge.state(input: "", charsets: [])
+        let expanded = bridge.state(input: "", charsets: [], transforms: [])
         XCTAssertEqual(expanded.files.count, 501)
         XCTAssertEqual(expanded.files.last?.id, 500)
     }
@@ -47,7 +50,7 @@ final class ConvertBridgeTests: XCTestCase {
         bridge.setInput("Nội dung cũ")
 
         XCTAssertTrue(bridge.adopt(paths: [broken.path]))
-        let state = bridge.state(input: "", charsets: [])
+        let state = bridge.state(input: "", charsets: [], transforms: [])
         XCTAssertEqual(state.mode, .empty)
         XCTAssertTrue(state.unreadable.contains("hong.txt"))
     }
@@ -70,6 +73,61 @@ final class ConvertBridgeTests: XCTestCase {
         store.send(.copyResult)
         try await waitUntil { copied == "bản mới" }
         XCTAssertEqual(store.state.progress, "Đã chép kết quả")
+    }
+
+    /// The menu is core's, not a list Swift keeps its own copy of.
+    func testTransformMenuComesFromCore() {
+        let menu = ConvertWorker.loadTransforms()
+
+        XCTAssertEqual(menu.count, 5)
+        XCTAssertEqual(menu.map(\.id), Array(0..<5))
+        XCTAssertEqual(menu[2].name, "Bỏ dấu tiếng Việt")
+        XCTAssertTrue(menu.allSatisfy { !$0.name.isEmpty })
+    }
+
+    /// Through the real door: the order decides the answer, and undo takes off one.
+    func testTransformsStackInOrderAndUndoTakesOffOne() throws {
+        let bridge = try XCTUnwrap(ConvertFFISession())
+        bridge.setInput("GỬI VỀ TP. HCM")
+        bridge.setSource(0)
+
+        bridge.apply(.apply(1))
+        bridge.apply(.apply(4))
+        XCTAssertEqual(bridge.resultText(), "Gửi Về Tp. Hcm")
+
+        let state = bridge.state(
+            input: "GỬI VỀ TP. HCM", charsets: [], transforms: ConvertWorker.loadTransforms()
+        )
+        XCTAssertEqual(state.appliedTransforms, [1, 4])
+
+        bridge.apply(.undo)
+        XCTAssertEqual(bridge.resultText(), "gửi về tp. hcm")
+        bridge.apply(.clear)
+        XCTAssertEqual(bridge.resultText(), "GỬI VỀ TP. HCM")
+    }
+
+    func testKeepDSwitchReachesCore() throws {
+        let bridge = try XCTUnwrap(ConvertFFISession())
+        bridge.setInput("đẹp")
+        bridge.setSource(0)
+        bridge.apply(.apply(2))
+        XCTAssertEqual(bridge.resultText(), "dep")
+
+        bridge.apply(.setKeepD(true))
+        XCTAssertEqual(bridge.resultText(), "đep")
+        XCTAssertTrue(bridge.state(input: "đẹp", charsets: [], transforms: []).keepD)
+    }
+
+    /// Typing is debounced 150 ms. A transform pressed before that lands must still
+    /// run on what was typed — the reason casing goes through `updateFlushing`.
+    func testATransformPressedRightAfterTypingSeesTheTypedText() async throws {
+        let store = ConvertStore()
+
+        store.send(.setInput("tôi yêu tiếng việt"))
+        store.send(.casing(.apply(0)))
+
+        try await waitUntil { store.state.outputText == "TÔI YÊU TIẾNG VIỆT" }
+        XCTAssertEqual(store.state.appliedTransforms, [0])
     }
 
     private func scratchDirectory() throws -> URL {

--- a/platforms/macos/FunputTests/Convert/ConvertStateTests.swift
+++ b/platforms/macos/FunputTests/Convert/ConvertStateTests.swift
@@ -3,7 +3,9 @@ import XCTest
 
 final class ConvertStateTests: XCTestCase {
     func testEmptyStateUsesLiveCharsets() {
-        let state = ConvertScreenState.empty(charsets: ConvertFixtures.charsets)
+        let state = ConvertScreenState.empty(
+            charsets: ConvertFixtures.charsets, transforms: ConvertFixtures.transforms
+        )
 
         XCTAssertEqual(state.mode, .empty)
         XCTAssertEqual(state.charsets, ConvertFixtures.charsets)
@@ -35,6 +37,40 @@ final class ConvertStateTests: XCTestCase {
         XCTAssertEqual(ConvertFixtures.singleFile.textPrimaryAction, "Chuyển tệp")
         XCTAssertEqual(ConvertFixtures.batch.batchAction, "Chuyển 3 tệp")
         XCTAssertEqual(ConvertFixtures.busyBatch.batchAction, "Đang chuyển…")
+    }
+
+    /// The order is the feature: the same two transforms the other way round is a
+    /// different document, so the line the window shows has to keep it.
+    func testAppliedTransformsReadBackInThePressedOrder() {
+        XCTAssertEqual(
+            ConvertFixtures.cased.appliedTransformNames,
+            ["chữ thường", "Viết Hoa Đầu Mỗi Từ"]
+        )
+        XCTAssertTrue(ConvertFixtures.pasted.appliedTransformNames.isEmpty)
+    }
+
+    /// A switch belongs to one transform and only appears while that one is applied.
+    func testSwitchesAppearOnlyWithTheTransformTheyBelongTo() {
+        var state = ConvertFixtures.cased
+
+        XCTAssertTrue(state.showsSwitch(for: .title))
+        XCTAssertFalse(state.showsSwitch(for: .noDiacritics))
+
+        state.appliedTransforms = [ConvertTransformKind.noDiacritics.position]
+        XCTAssertTrue(state.showsSwitch(for: .noDiacritics))
+        XCTAssertFalse(state.showsSwitch(for: .title))
+    }
+
+    /// One rule for both axes: nothing is converted, and nothing is transformed,
+    /// until something explains the document. A batch explains itself per row.
+    func testCasingIsBlockedUntilTheDocumentIsExplained() {
+        var unresolved = ConvertFixtures.pasted
+        unresolved.source = nil
+        XCTAssertFalse(unresolved.canUseCasing)
+
+        XCTAssertTrue(ConvertFixtures.pasted.canUseCasing)
+        XCTAssertTrue(ConvertFixtures.batch.canUseCasing, "a batch carries a charset per row")
+        XCTAssertFalse(ConvertFixtures.busyBatch.canUseCasing)
     }
 
     func testUnknownBatchPlaceholderCannotReplaceASelectedCharset() {

--- a/platforms/macos/README.md
+++ b/platforms/macos/README.md
@@ -47,6 +47,7 @@
 | 🗂️ **Nhớ theo ứng dụng** | Bật tiếng Việt ở Pages, tắt ở Terminal — Funput tự chuyển khi bạn đổi app |
 | ✂️ **Gõ tắt** | Bảng viết tắt tự bung, tuỳ chọn khớp cả hoa lẫn thường |
 | 🔄 **Chuyển mã** | Đổi qua lại giữa Unicode dựng sẵn, Unicode tổ hợp, TCVN3 (ABC) và VNI-Windows |
+| 🔠 **Đổi kiểu chữ** | CHỮ HOA · chữ thường · bỏ dấu · viết hoa đầu câu · Viết Hoa Đầu Mỗi Từ, cộng dồn được, ngay trong cửa sổ Chuyển mã |
 | 💾 **Xuất / nhập cấu hình** | Mang toàn bộ tuỳ chọn và gõ tắt sang máy khác bằng một tệp |
 | 🍎 **Hợp chuẩn macOS 26** | Liquid Glass, thanh menu, khởi động cùng máy |
 

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -62,9 +62,12 @@ ed25519-dalek = "3" # verify the Sparkle-compatible Ed25519 signature
 base64 = "0.23" # decode the public key + signature
 semver = "1" # compare the manifest version against CARGO_PKG_VERSION
 self-replace = "1" # replace the currently running executable (crate `self_replace`)
-# `charset` is spelled out rather than left to feature unification through
-# funput-config: this shell calls it directly, so it should ask for it directly.
-funput-core = { path = "../../crates/funput-core", features = ["charset"] }
+# Both features are spelled out rather than left to feature unification through
+# funput-config and funput-convert: this shell calls each of them directly, so it
+# should ask for each directly. `textcase` is the Chuyển mã window's second axis —
+# the shell names `Transform` to ask core which menu position a switch belongs to,
+# rather than writing the position down as a number of its own.
+funput-core = { path = "../../crates/funput-core", features = ["charset", "textcase"] }
 # The Chuyển mã window's logic, shared with the GTK window on Linux so the two
 # cannot drift — see crates/funput-convert/README.md.
 funput-convert = { path = "../../crates/funput-convert" }

--- a/platforms/windows/README.md
+++ b/platforms/windows/README.md
@@ -47,6 +47,7 @@
 | 🌏 **Tự tắt khi đổi bàn phím** | Chuyển sang EN khi bạn dùng bàn phím tiếng Nhật, Hàn, Trung… |
 | ✂️ **Gõ tắt** | Bảng viết tắt tự bung, khớp cả hoa lẫn thường; nhập được bảng gõ tắt UniKey |
 | 🔄 **Chuyển mã** | Đổi qua lại giữa Unicode dựng sẵn, Unicode tổ hợp, TCVN3 (ABC) và VNI-Windows — dán văn bản hoặc chuyển cả tệp |
+| 🔠 **Đổi kiểu chữ** | CHỮ HOA · chữ thường · bỏ dấu · viết hoa đầu câu · Viết Hoa Đầu Mỗi Từ, cộng dồn được, ngay trong cửa sổ Chuyển mã |
 | 💾 **Xuất / nhập cấu hình** | Mang toàn bộ tuỳ chọn và gõ tắt sang máy khác bằng một tệp |
 | 🚀 **Khởi động cùng Windows** | Tuỳ chọn, ghi vào registry `HKCU\…\Run` |
 

--- a/platforms/windows/src/ui/convert/casing.rs
+++ b/platforms/windows/src/ui/convert/casing.rs
@@ -1,0 +1,155 @@
+//! The second axis: this shell's half of it.
+//!
+//! Nothing here decides anything either. Which transforms exist, what each is
+//! called, what pressing one does to a document and what a second press on the same
+//! one means — all of it lives in [`funput_convert::casing`], shared with the GTK
+//! window on Linux and with macOS through the C door. What is here is the mapping:
+//! a [`View`] poured into the `Casing` global, and five buttons tied back to the
+//! session.
+//!
+//! The one thing this file must not do is write a transform's position down as a
+//! number. A switch belongs to a transform, not to a slot, so it asks
+//! [`funput_convert::casing::index_of`] where that transform sits — appending a
+//! sixth transform in core then moves nothing here.
+
+use funput_convert::{Mode, Session, View, casing};
+use funput_core::textcase::Transform;
+use slint::{ComponentHandle, ModelRc, VecModel};
+
+use crate::{Casing, ConvertWindow, TransformChip};
+
+use super::view::edit;
+
+pub(super) fn wire(window: &ConvertWindow) {
+    let casing = window.global::<Casing>();
+    casing.on_apply(|index| edit(move |s| s.apply_transform(usize::try_from(index).unwrap_or(0))));
+    casing.on_undo(|| edit(Session::undo_transform));
+    casing.on_clear(|| edit(Session::clear_transforms));
+    casing.on_set_keep_d(|on| edit(move |s| s.set_keep_d(on)));
+    casing.on_set_flatten_caps(|on| edit(move |s| s.set_flatten_caps(on)));
+}
+
+pub(super) fn show(window: &ConvertWindow, view: &View) {
+    let casing = window.global::<Casing>();
+    casing.set_transforms(ModelRc::new(VecModel::from(chips(view))));
+    casing.set_applied_line(applied_line(view).into());
+    // A document no charset could explain is not converted, and core does not
+    // transform it either — one rule, not two. A batch carries a charset per row, so
+    // it is never blocked.
+    casing.set_enabled(view.mode == Mode::Files || view.source.is_some());
+    casing.set_keep_d(view.keep_d);
+    casing.set_flatten_caps(view.flatten_caps);
+    casing.set_shows_keep_d(applies(view, Transform::NoDiacritics));
+    casing.set_shows_flatten_caps(applies(view, Transform::Title));
+}
+
+/// The menu, and which of it is on.
+fn chips(view: &View) -> Vec<TransformChip> {
+    casing::ALL
+        .iter()
+        .enumerate()
+        .map(|(index, &transform)| TransformChip {
+            name: casing::name(transform).into(),
+            applied: view.transforms.contains(&index),
+        })
+        .collect()
+}
+
+/// What is applied, in the order pressed.
+///
+/// The order is the whole point — `chữ thường → Viết Hoa Đầu Mỗi Từ` is a different
+/// document from the same two reversed — so it is spelled out rather than left for
+/// the user to infer from which chips are lit. Empty when nothing is applied, which
+/// is what hides the row.
+fn applied_line(view: &View) -> String {
+    if view.transforms.is_empty() {
+        return String::new();
+    }
+    let names: Vec<&str> = view
+        .transforms
+        .iter()
+        .map(|&index| casing::name(casing::at(index)))
+        .collect();
+    format!("Đang áp: {}", names.join(" → "))
+}
+
+/// Whether the transform that owns a switch is applied.
+fn applies(view: &View, transform: Transform) -> bool {
+    casing::index_of(transform).is_some_and(|index| view.transforms.contains(&index))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `View` is `#[non_exhaustive]`, so it cannot be built field by field from out
+    /// here. Driving a real session is the honest way anyway: it locks in what the
+    /// window will actually be handed.
+    fn viewed(pressed: &[Transform]) -> Session {
+        let mut session = Session::new();
+        session.set_input("Tiếng Việt rất đẹp".to_string());
+        for &transform in pressed {
+            session.apply_transform(casing::index_of(transform).expect("in the menu"));
+        }
+        session.refresh();
+        session
+    }
+
+    #[test]
+    fn the_menu_is_whole_before_anything_is_pressed() {
+        let session = viewed(&[]);
+        let chips = chips(session.view());
+        assert_eq!(chips.len(), casing::ALL.len());
+        assert!(chips.iter().all(|chip| !chip.applied));
+        assert_eq!(chips[0].name, casing::name(Transform::Upper));
+    }
+
+    #[test]
+    fn a_pressed_transform_lights_its_own_chip() {
+        let session = viewed(&[Transform::Lower]);
+        let chips = chips(session.view());
+        let lit: Vec<&str> = chips
+            .iter()
+            .filter(|chip| chip.applied)
+            .map(|chip| chip.name.as_str())
+            .collect();
+        assert_eq!(lit, vec![casing::name(Transform::Lower)]);
+    }
+
+    #[test]
+    fn the_applied_line_is_empty_until_something_is_pressed() {
+        assert_eq!(applied_line(viewed(&[]).view()), "");
+    }
+
+    #[test]
+    fn the_applied_line_reads_in_the_order_pressed() {
+        let forward = viewed(&[Transform::Lower, Transform::Title]);
+        let backward = viewed(&[Transform::Title, Transform::Lower]);
+        assert_eq!(
+            applied_line(forward.view()),
+            "Đang áp: chữ thường → Viết Hoa Đầu Mỗi Từ"
+        );
+        assert_eq!(
+            applied_line(backward.view()),
+            "Đang áp: Viết Hoa Đầu Mỗi Từ → chữ thường"
+        );
+    }
+
+    #[test]
+    fn a_switch_shows_only_for_the_transform_that_owns_it() {
+        let session = viewed(&[Transform::NoDiacritics]);
+        assert!(applies(session.view(), Transform::NoDiacritics));
+        assert!(!applies(session.view(), Transform::Title));
+    }
+
+    /// The bar's state comes from the session, so the window empties itself when
+    /// core drops the presses — it has no list of its own to forget to clear.
+    #[test]
+    fn typing_a_new_document_takes_the_transforms_off() {
+        let mut session = viewed(&[Transform::Upper]);
+        session.set_input("xin chào".to_string());
+        session.refresh();
+        assert_eq!(applied_line(session.view()), "");
+        assert!(chips(session.view()).iter().all(|chip| !chip.applied));
+    }
+}

--- a/platforms/windows/src/ui/convert/mod.rs
+++ b/platforms/windows/src/ui/convert/mod.rs
@@ -8,10 +8,12 @@
 //! drift. What is here is this shell's half of it.
 //!
 //! - [`view`] — the session, and everything the window shows from it.
+//! - [`casing`] — the second axis: the transforms, and which of them are applied.
 //! - [`text`] — saving a document through a Save dialog.
 //! - [`files`] — running the batch off the UI thread.
 //! - [`win32`] — the two things Slint cannot do: file drop and clipboard buttons.
 
+mod casing;
 mod files;
 mod text;
 mod view;
@@ -60,6 +62,7 @@ pub(super) fn open() {
 }
 
 fn wire(window: &ConvertWindow) {
+    casing::wire(window);
     window.on_text_changed(|typed| edit(|s| s.set_input(typed.to_string())));
     window.on_pick_source(|index| edit(|s| s.pick_source(usize::try_from(index).ok())));
     window.on_pick_target(|index| edit(|s| s.set_target(usize::try_from(index).unwrap_or(0))));

--- a/platforms/windows/src/ui/convert/view.rs
+++ b/platforms/windows/src/ui/convert/view.rs
@@ -16,7 +16,7 @@ use slint::Weak;
 
 use crate::ConvertWindow;
 
-use super::files;
+use super::{casing, files};
 
 thread_local! {
     pub(super) static WINDOW: RefCell<Option<Weak<ConvertWindow>>> = const { RefCell::new(None) };
@@ -64,6 +64,9 @@ fn show(window: &ConvertWindow, view: &View) {
     if let Some(text) = &view.input_preview {
         window.set_input_text(text.clone().into());
     }
+    // Ahead of the shape, and once for both of them: the bar rides in the text view
+    // and in the batch view, and it reads the same fields either way.
+    casing::show(window, view);
 
     match view.mode {
         Mode::Empty => window.set_mode("empty".into()),

--- a/platforms/windows/ui/app.slint
+++ b/platforms/windows/ui/app.slint
@@ -3,7 +3,7 @@
 import { SettingsWindow } from "shell/settings.slint";
 import { OnboardingWindow } from "onboarding/window.slint";
 import { ControlCenterWindow } from "control_center/window.slint";
-import { ConvertWindow, FileRow } from "convert/window.slint";
+import { ConvertWindow, FileRow, Casing, TransformChip } from "convert/window.slint";
 import { Compose } from "overlays/compose.slint";
 import { ShortcutEntry, Theme } from "theme/mod.slint";
 
@@ -15,5 +15,7 @@ export {
     ControlCenterWindow,
     ConvertWindow,
     FileRow,
+    Casing,
+    TransformChip,
     Theme,
 }

--- a/platforms/windows/ui/convert/casing.slint
+++ b/platforms/windows/ui/convert/casing.slint
@@ -1,0 +1,184 @@
+// The second axis: five transforms, the order they were pressed in, and the two
+// switches that belong to them.
+//
+// Not a tab. Changing a charset and changing the case are two choices about one
+// document and they compose — a paragraph can be read out of TCVN3 *and* put in
+// title case — so both stay on screen at once. A tab would say the user has to
+// pick one.
+//
+// State arrives through a global rather than through properties, because this bar
+// appears in two of the window's three shapes (`text` and `files`) and each of them
+// is a component of its own. Passing seven properties and five callbacks down two
+// separate paths would put the same wiring in `window.slint` twice; a global is the
+// shape `Compose` already uses for the same reason.
+//
+// No transform is named here. The labels come from `funput_convert::casing::name`
+// so that three platforms' menus cannot drift apart, and a chip's position in the
+// list is its identity — implementing a sixth transform in core lengthens this row
+// without a line changing here.
+
+import { Palette } from "std-widgets.slint";
+import { Theme, GhostButton, AccentSwitch } from "../theme/mod.slint";
+
+export struct TransformChip {
+    // From `casing::name`, never written in this package.
+    name: string,
+    applied: bool,
+}
+
+export global Casing {
+    // The menu in core's order; the index is the identity of a transform.
+    in property <[TransformChip]> transforms;
+    // "Đang áp: chữ thường → Viết Hoa Đầu Mỗi Từ", or empty when nothing is applied.
+    in property <string> applied-line;
+    // False while no charset explains the document: it is not being converted, and
+    // core does not transform it either.
+    in property <bool> enabled;
+    in property <bool> shows-keep-d;
+    in property <bool> keep-d;
+    in property <bool> shows-flatten-caps;
+    in property <bool> flatten-caps;
+
+    callback apply(int);
+    callback undo();
+    callback clear();
+    callback set-keep-d(bool);
+    callback set-flatten-caps(bool);
+}
+
+// A press appends, and pressing the one already on top is a no-op in core — so this
+// is a button rather than a checkbox. The tick is the non-colour cue: the accent
+// fill alone would leave the state invisible to a colour-blind user.
+component Chip inherits Rectangle {
+    in property <string> label;
+    in property <bool> applied;
+    in property <bool> enabled;
+    callback clicked;
+
+    height: 28px;
+    border-radius: self.height / 2;
+    background: root.applied
+        ? Theme.accent
+        : (touch.has-hover && root.enabled ? Theme.nav-hover : transparent);
+    border-width: root.applied ? 0px : 1px;
+    border-color: Theme.divider;
+    animate background { duration: 120ms; easing: ease-out; }
+
+    HorizontalLayout {
+        padding-left: 12px;
+        padding-right: 12px;
+        spacing: 6px;
+        if root.applied: VerticalLayout {
+            alignment: center;
+            Image {
+                source: @image-url("../icons/status/check.svg");
+                colorize: Theme.accent-text;
+                width: 11px;
+                height: 11px;
+            }
+        }
+        Text {
+            text: root.label;
+            color: root.applied ? Theme.accent-text : Palette.foreground;
+            font-size: Theme.font-caption;
+            font-weight: 600;
+            vertical-alignment: center;
+        }
+    }
+    touch := TouchArea {
+        mouse-cursor: pointer;
+        clicked => {
+            if root.enabled {
+                root.clicked();
+            }
+        }
+    }
+}
+
+export component ConvertCasingBar inherits VerticalLayout {
+    spacing: Theme.sp-sm;
+
+    HorizontalLayout {
+        spacing: Theme.sp-sm;
+        opacity: Casing.enabled ? 1 : 0.45;
+
+        VerticalLayout {
+            alignment: center;
+            Text {
+                text: "Kiểu chữ";
+                font-size: Theme.font-body;
+                color: Theme.subtle;
+            }
+        }
+        for chip[i] in Casing.transforms: Chip {
+            label: chip.name;
+            applied: chip.applied;
+            enabled: Casing.enabled;
+            clicked => { Casing.apply(i); }
+        }
+        // The row is as wide as its chips; anything left over is empty space rather
+        // than five chips stretched across the window.
+        Rectangle { horizontal-stretch: 1; }
+    }
+
+    // The order is the whole point — `chữ thường → Viết Hoa Đầu Mỗi Từ` is a
+    // different document from the same two reversed — so it is spelled out rather
+    // than left for the user to infer from which chips are lit. Shown only when
+    // there is something to say, the way the loss line is.
+    if Casing.applied-line != "": HorizontalLayout {
+        spacing: Theme.sp-md;
+
+        VerticalLayout {
+            alignment: center;
+            horizontal-stretch: 1;
+            Text {
+                text: Casing.applied-line;
+                font-size: Theme.font-caption;
+                color: Theme.subtle;
+                overflow: elide;
+            }
+        }
+        // A switch appears only while the transform it belongs to is applied: it has
+        // nothing to say otherwise, and showing it there teaches which one owns it.
+        if Casing.shows-keep-d: VerticalLayout {
+            alignment: center;
+            Text {
+                text: "Giữ đ/Đ";
+                font-size: Theme.font-caption;
+                color: Theme.subtle;
+            }
+        }
+        if Casing.shows-keep-d: VerticalLayout {
+            alignment: center;
+            AccentSwitch {
+                checked: Casing.keep-d;
+                toggled => { Casing.set-keep-d(self.checked); }
+            }
+        }
+        if Casing.shows-flatten-caps: VerticalLayout {
+            alignment: center;
+            Text {
+                text: "Hạ chữ viết hoa";
+                font-size: Theme.font-caption;
+                color: Theme.subtle;
+            }
+        }
+        if Casing.shows-flatten-caps: VerticalLayout {
+            alignment: center;
+            AccentSwitch {
+                checked: Casing.flatten-caps;
+                toggled => { Casing.set-flatten-caps(self.checked); }
+            }
+        }
+        // Undo takes off the last transform rather than all of them: pressing a
+        // third one by mistake should not cost the two before it.
+        GhostButton {
+            text: "Hoàn tác";
+            clicked => { Casing.undo(); }
+        }
+        GhostButton {
+            text: "Bỏ hết";
+            clicked => { Casing.clear(); }
+        }
+    }
+}

--- a/platforms/windows/ui/convert/files.slint
+++ b/platforms/windows/ui/convert/files.slint
@@ -8,6 +8,7 @@
 
 import { Palette, ComboBox, ListView } from "std-widgets.slint";
 import { Theme, PrimaryButton } from "../theme/mod.slint";
+import { ConvertCasingBar } from "casing.slint";
 
 export struct FileRow {
     name: string,
@@ -62,6 +63,10 @@ export component ConvertFiles inherits VerticalLayout {
             }
         }
     }
+
+    // One transform applies to the whole batch, the way one target charset does —
+    // so it sits in the header rather than in each row.
+    ConvertCasingBar { }
 
     Rectangle {
         vertical-stretch: 1;

--- a/platforms/windows/ui/convert/text.slint
+++ b/platforms/windows/ui/convert/text.slint
@@ -12,6 +12,7 @@
 
 import { Palette, ComboBox, TextEdit } from "std-widgets.slint";
 import { Theme, PrimaryButton, GhostButton } from "../theme/mod.slint";
+import { ConvertCasingBar } from "casing.slint";
 
 export component ConvertText inherits VerticalLayout {
     in property <[string]> charset-names;
@@ -73,6 +74,10 @@ export component ConvertText inherits VerticalLayout {
             }
         }
     }
+
+    // Under the charsets and above the panes: both rows are choices about the same
+    // document, and the panes below show the result of the two together.
+    ConvertCasingBar { }
 
     HorizontalLayout {
         spacing: Theme.sp-sm;

--- a/platforms/windows/ui/convert/window.slint
+++ b/platforms/windows/ui/convert/window.slint
@@ -12,15 +12,18 @@ import { Theme, PageHeader, GhostButton } from "../theme/mod.slint";
 import { ConvertEmpty } from "empty.slint";
 import { ConvertText } from "text.slint";
 import { ConvertFiles, FileRow } from "files.slint";
+import { Casing, TransformChip } from "casing.slint";
 
-export { FileRow }
+export { FileRow, Casing, TransformChip }
 
 export component ConvertWindow inherits Window {
     title: "Funput — Chuyển mã";
     icon: @image-url("../../../../assets/logo.png");
     preferred-width: 760px;
     preferred-height: 560px;
-    min-width: 640px;
+    // Wide enough for the five transform chips on one row: their labels are whole
+    // Vietnamese phrases ("Viết Hoa Đầu Mỗi Từ"), so they do not shrink.
+    min-width: 720px;
     min-height: 460px;
     default-font-family: "Segoe UI Variable Text";
     background: Theme.mica ? transparent : Theme.window-base;
@@ -75,7 +78,7 @@ export component ConvertWindow inherits Window {
                 PageHeader {
                     title: "Chuyển mã";
                     subtitle: root.mode == "empty"
-                        ? "Chuyển văn bản giữa Unicode và các bảng mã cũ."
+                        ? "Đổi bảng mã và kiểu chữ của văn bản đã có."
                         : "";
                 }
             }


### PR DESCRIPTION
Đổi **kiểu chữ của văn bản có sẵn** — năm phép, ba cửa sổ desktop, cộng CLI. Tính năng của người soạn thảo, không phải của bộ gõ: nó chạy trên đoạn văn đã có và không can thiệp vào phím đang gõ.

## Năm phép

| Phép | Ví dụ |
| --- | --- |
| **CHỮ HOA** | `Xin chào Việt Nam` → `XIN CHÀO VIỆT NAM` |
| **chữ thường** | `Xin Chào Việt Nam` → `xin chào việt nam` |
| **Bỏ dấu tiếng Việt** | `Tiếng Việt rất đẹp` → `Tieng Viet rat dep` |
| **Viết hoa đầu câu** | `xin chào. hôm nay trời đẹp.` → `Xin chào. Hôm nay trời đẹp.` |
| **Viết Hoa Đầu Mỗi Từ** | `bàn phím tiếng Việt` → `Bàn Phím Tiếng Việt` |

## Dùng ở đâu

**Một thanh trong cửa sổ Chuyển mã**, trên **macOS · Windows · Linux**. Không phải một tab: đổi bảng mã và đổi kiểu chữ là hai lựa chọn về cùng một văn bản và chúng **cộng dồn** — một đoạn đọc ra từ TCVN3 vẫn viết hoa đầu mỗi từ được.

Cộng **`funput case`** trong CLI:

```console
$ echo "Tiếng Việt" | funput case no-diacritics
Tieng Viet
$ echo "xin Chào" | funput case lower,title
Xin Chào
```

## Làm được gì trên thanh đó

- Bấm chồng nhiều phép; dòng **`Đang áp: chữ thường → Viết Hoa Đầu Mỗi Từ`** viết rõ thứ tự, vì thứ tự cho ra văn bản khác nhau.
- **Hoàn tác** gỡ *phép cuối*, không phải tất cả. **Bỏ hết** về nguyên bản. Nguyên bản luôn còn — danh sách phép được phát lại từ đầu mỗi lần dựng preview.
- Hai công tắc, mỗi cái chỉ hiện khi phép sở hữu nó đang áp: **Giữ đ/Đ** (`đẹp` → `đep`) và **Hạ chữ viết hoa** (`TP. HCM` → `Tp. Hcm`).
- Chạy được cả trên **một đoạn văn** và trên **cả lô tệp** — cột `N chữ sẽ mất` của từng dòng đổi theo phép đang áp.
- **Bảng mã cũ vẫn đúng.** Viết hoa một đoạn TCVN3 là phép *có mất mát* (TCVN3 không có nguyên âm hoa có dấu), nên cảnh báo **nêu tên** ký tự sẽ mất thay vì âm thầm bỏ.

## Không thuộc phạm vi

Không hotkey, không đụng vùng bôi đen, không nghe clipboard — [lộ trình sau V1](../blob/feature/text-case/docs/features/text-case.md#lộ-trình-sau-v1) có trong tài liệu. Không sửa ngữ nghĩa: `chữ thường` sẽ phá `Việt Nam` thành `việt nam`, và đó là đúng yêu cầu; cách chữa duy nhất là Hoàn tác, nên Hoàn tác luôn có và luôn rẻ.

## Hình dạng

Năm phép thuần nằm trong `funput_core::textcase` sau cargo feature riêng, **mặc định tắt** — iOS và Android không bao giờ biên dịch nó. Luật thì ở `funput-convert`, dùng chung cho cả ba cửa sổ, nên không shell nào tự quyết định gì.

Thiết kế đầy đủ, kèm mọi ca biên và giới hạn đã biết: [`docs/features/text-case.md`](../blob/feature/text-case/docs/features/text-case.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)